### PR TITLE
Close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,24 @@
+name: Stale PRs 
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * *
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        id: stale
+        with:
+          stale-pr-message: This pull request is stale because it has been open 60 days with no activity. Remove stale label or comment or it will be closed in 7 days
+          days-before-stale: 60
+          days-before-close: 7 
+          exempt-pr-labels: blocked,must,should,keep
+          stale-pr-label: stale
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Mark PRs as stale after 60 days, close them automatically if no response after 7 days.