### PR TITLE
SL-18725 Texture picker should explain why dropping texture isn't allowed

### DIFF
--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -390,10 +390,10 @@ BOOL LLMaterialEditor::postBuild()
     if (!gAgent.isGodlike())
     {
         // Only allow fully permissive textures
-        mBaseColorTextureCtrl->setImmediateFilterPermMask(PERM_ITEM_UNRESTRICTED);
-        mMetallicTextureCtrl->setImmediateFilterPermMask(PERM_ITEM_UNRESTRICTED);
-        mEmissiveTextureCtrl->setImmediateFilterPermMask(PERM_ITEM_UNRESTRICTED);
-        mNormalTextureCtrl->setImmediateFilterPermMask(PERM_ITEM_UNRESTRICTED);
+        mBaseColorTextureCtrl->setImmediateFilterPermMask(PERM_COPY | PERM_TRANSFER);
+        mMetallicTextureCtrl->setImmediateFilterPermMask(PERM_COPY | PERM_TRANSFER);
+        mEmissiveTextureCtrl->setImmediateFilterPermMask(PERM_COPY | PERM_TRANSFER);
+        mNormalTextureCtrl->setImmediateFilterPermMask(PERM_COPY | PERM_TRANSFER);
     }
 
     // Texture callback

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -1800,7 +1800,7 @@ BOOL LLTextureCtrl::handleDragAndDrop(S32 x, S32 y, MASK mask,
         allow_dnd = is_texture || is_mesh || is_material;
     }
 
-	if (getEnabled() && allow_dnd && allowDrop(item))
+	if (getEnabled() && allow_dnd && allowDrop(item, cargo_type, tooltip_msg))
 	{
 		if (drop)
 		{
@@ -1952,7 +1952,7 @@ void LLTextureCtrl::draw()
 	LLUICtrl::draw();
 }
 
-BOOL LLTextureCtrl::allowDrop(LLInventoryItem* item)
+BOOL LLTextureCtrl::allowDrop(LLInventoryItem* item, EDragAndDropType cargo_type, std::string& tooltip_msg)
 {
 	BOOL copy = item->getPermissions().allowCopyBy(gAgent.getID());
 	BOOL mod = item->getPermissions().allowModifyBy(gAgent.getID());
@@ -1978,6 +1978,12 @@ BOOL LLTextureCtrl::allowDrop(LLInventoryItem* item)
 	}
 	else
 	{
+        PermissionMask mask = PERM_COPY | PERM_TRANSFER;
+        if ((filter_perm_mask & mask) == mask
+            && cargo_type == DAD_TEXTURE)
+        {
+            tooltip_msg.assign(LLTrans::getString("TooltipTextureRestrictedDrop"));
+        }
 		return FALSE;
 	}
 }

--- a/indra/newview/lltexturectrl.h
+++ b/indra/newview/lltexturectrl.h
@@ -223,7 +223,7 @@ public:
     EPickInventoryType getInventoryPickType() { return mInventoryPickType; };
 
 private:
-	BOOL allowDrop(LLInventoryItem* item);
+	BOOL allowDrop(LLInventoryItem* item, EDragAndDropType cargo_type, std::string& tooltip_msg);
 	BOOL doDrop(LLInventoryItem* item);
 
 private:

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -319,6 +319,11 @@ Only items with unrestricted
 'next owner' permissions
 can be attached to notecards.
 	</string>
+	<string name="TooltipTextureRestrictedDrop">
+Only textures with unrestricted
+copy and transfer permissions
+are allowed.
+	</string>
 
 	<!-- searching - generic -->
 	<string name="Searching">Searching...</string>


### PR DESCRIPTION
Show a 'missing permissions' tooltip on drag&drop.

Changed permissions from unrestricted to PERM_COPY | PERM_TRANSFER due to 'modify' permission not being relevant and to be in line with other floaters (ex: land textures). 