### PR TITLE
SL-18448 When initing views and object has pbr, open pbr in texture tab

### DIFF
--- a/indra/newview/lldrawpoolwlsky.cpp
+++ b/indra/newview/lldrawpoolwlsky.cpp
@@ -283,6 +283,11 @@ void LLDrawPoolWLSky::renderStars(const LLVector3& camPosLocal) const
 
 void LLDrawPoolWLSky::renderStarsDeferred(const LLVector3& camPosLocal) const
 {
+    if (!gSky.mVOSkyp)
+    {
+        return;
+    }
+
 	LLGLSPipelineBlendSkyBox gls_sky(true, false);
 
 	gGL.setSceneBlendType(LLRender::BT_ADD_WITH_ALPHA);

--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -996,8 +996,18 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
 		
         if (mComboMatMedia->getCurrentIndex() < MATMEDIA_MATERIAL)
         {
-            mComboMatMedia->selectNthItem(MATMEDIA_MATERIAL);
+            // When selecting an object with a pbr and UI combo is not set,
+            // set to pbr option, otherwise to a texture (material)
+            if (has_pbr_material)
+            {
+                mComboMatMedia->selectNthItem(MATMEDIA_PBR);
+            }
+            else
+            {
+                mComboMatMedia->selectNthItem(MATMEDIA_MATERIAL);
+            }
         }
+
         mComboMatMedia->setEnabled(editable);
 
 		LLRadioGroup* radio_mat_type = getChild<LLRadioGroup>("radio_material_type");


### PR DESCRIPTION
A while back davep requested that if object has pbr, selecting that face should start with a 'pbr' open. Unfortunately it is not entirely practical to do due to rarely knowing the difference between refreshing a selection and selecting a new object or face, nor is practical if user explicitly selected pbr or texture. But in case we are initing views it appears to be practical to jump to pbr directly.