### PR TITLE
SL-18778 Crash at LLVoiceClient::removeObserver

### DIFF
--- a/indra/newview/llspeakingindicatormanager.cpp
+++ b/indra/newview/llspeakingindicatormanager.cpp
@@ -51,6 +51,10 @@ class SpeakingIndicatorManager : public LLSingleton<SpeakingIndicatorManager>, L
 	LLSINGLETON(SpeakingIndicatorManager);
 	~SpeakingIndicatorManager();
 	LOG_CLASS(SpeakingIndicatorManager);
+
+protected:
+    void                cleanupSingleton();
+
 public:
 
 	/**
@@ -183,12 +187,16 @@ SpeakingIndicatorManager::SpeakingIndicatorManager()
 
 SpeakingIndicatorManager::~SpeakingIndicatorManager()
 {
-	// Don't use LLVoiceClient::getInstance() here without check
-	// singleton MAY have already been destroyed.
-	if(LLVoiceClient::instanceExists())
-	{
-		LLVoiceClient::getInstance()->removeObserver(this);
-	}
+}
+
+void SpeakingIndicatorManager::cleanupSingleton()
+{
+    // Don't use LLVoiceClient::getInstance() here without a check,
+    // singleton MAY have already been destroyed.
+    if (LLVoiceClient::instanceExists())
+    {
+        LLVoiceClient::getInstance()->removeObserver(this);
+    }
 }
 
 void SpeakingIndicatorManager::sOnCurrentChannelChanged(const LLUUID& /*session_id*/)

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -797,7 +797,10 @@ void LLVoiceClient::addObserver(LLVoiceClientStatusObserver* observer)
 
 void LLVoiceClient::removeObserver(LLVoiceClientStatusObserver* observer)
 {
-	if (mVoiceModule && mVoiceModule->singletoneInstanceExists()) mVoiceModule->removeObserver(observer);
+    if (mVoiceModule)
+    {
+        mVoiceModule->removeObserver(observer);
+    }
 }
 
 void LLVoiceClient::addObserver(LLFriendObserver* observer)
@@ -807,7 +810,10 @@ void LLVoiceClient::addObserver(LLFriendObserver* observer)
 
 void LLVoiceClient::removeObserver(LLFriendObserver* observer)
 {
-	if (mVoiceModule && mVoiceModule->singletoneInstanceExists()) mVoiceModule->removeObserver(observer);
+    if (mVoiceModule)
+    {
+        mVoiceModule->removeObserver(observer);
+    }
 }
 
 void LLVoiceClient::addObserver(LLVoiceClientParticipantObserver* observer)
@@ -817,7 +823,10 @@ void LLVoiceClient::addObserver(LLVoiceClientParticipantObserver* observer)
 
 void LLVoiceClient::removeObserver(LLVoiceClientParticipantObserver* observer)
 {
-	if (mVoiceModule && mVoiceModule->singletoneInstanceExists()) mVoiceModule->removeObserver(observer);
+    if (mVoiceModule)
+    {
+        mVoiceModule->removeObserver(observer);
+    }
 }
 
 std::string LLVoiceClient::sipURIFromID(const LLUUID &id)

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -122,8 +122,6 @@ public:
 
 	virtual const LLVoiceVersionInfo& getVersion()=0;
 	
-	virtual bool singletoneInstanceExists()=0;
-	
 	/////////////////////
 	/// @name Tuning
 	//@{

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5217,11 +5217,6 @@ void LLVivoxVoiceClient::declineInvite(std::string &sessionHandle)
 	}
 }
 
-bool LLVivoxVoiceClient::singletoneInstanceExists()
-{
-	return LLVivoxVoiceClient::instanceExists();
-}
-
 void LLVivoxVoiceClient::leaveNonSpatialChannel()
 {
     LL_DEBUGS("Voice") << "Request to leave spacial channel." << LL_ENDL;

--- a/indra/newview/llvoicevivox.h
+++ b/indra/newview/llvoicevivox.h
@@ -73,8 +73,6 @@ public:
 
 	// Returns true if vivox has successfully logged in and is not in error state	
 	virtual bool isVoiceWorking() const;
-	
-	virtual bool singletoneInstanceExists();
 
 	/////////////////////
 	/// @name Tuning


### PR DESCRIPTION
Adjusted vlean order.

singletoneInstanceExists() makes no sense to me. It's a non-static member of a potentially dead singleton yet we prod it... invalid_pointer->is_valid()?