### PR TITLE
SL-14399: Ditch overflow queue LLViewerAssetStorage::mCoroWaitList.

### DIFF
--- a/indra/llmessage/llcoproceduremanager.cpp
+++ b/indra/llmessage/llcoproceduremanager.cpp
@@ -47,7 +47,10 @@ static const std::map<std::string, U32> DefaultPoolSizes{
 };
 
 static const U32 DEFAULT_POOL_SIZE = 5;
-const U32 LLCoprocedureManager::DEFAULT_QUEUE_SIZE = 4096;
+// SL-14399: When we teleport to a brand-new simulator, the coprocedure queue
+// gets absolutely slammed with fetch requests. Make this queue effectively
+// unlimited.
+const U32 LLCoprocedureManager::DEFAULT_QUEUE_SIZE = 1024*1024;
 
 //=========================================================================
 class LLCoprocedurePool: private boost::noncopyable

--- a/indra/newview/llviewerassetstorage.h
+++ b/indra/newview/llviewerassetstorage.h
@@ -65,8 +65,6 @@ public:
 		bool user_waiting=FALSE,
 		F64Seconds timeout=LL_ASSET_STORAGE_TIMEOUT) override;
 
-    void checkForTimeouts() override;
-
 protected:
 	void _queueDataRequest(const LLUUID& uuid,
 						   LLAssetType::EType type,
@@ -118,8 +116,6 @@ protected:
         LLGetAssetCallback mCallback;
         void *mUserData;
     };
-    typedef std::list<CoroWaitList> wait_list_t;
-    wait_list_t mCoroWaitList;
 
     std::string mViewerAssetUrl;
     S32 mCountRequests;


### PR DESCRIPTION
mCoroWaitList was introduced to prevent an assertion failure crash: LLCoprocedureManager never expects to fill its LLCoprocedurePool::mPendingCoprocs queue. The queue limit was arbitrarily set to 4096 some years ago, but in practice LLViewerAssetStorage can post way more requests than that.

LLViewerAssetStorage checked whether the target LLCoprocedureManager pool's queue looked close to full, and if so posted the pending request to its mCoroWaitList instead. But then it had to override the base LLAssetStorage method checkForTimeouts() to continually check whether pending tasks could be moved from mCoroWaitList to LLCoprocedureManager.

A simpler solution is to enlarge LLCorpocedureManager::DEFAULT_QUEUE_SIZE, the upper limit on mPendingCoprocs. Since mCoroWaitList was an unlimited queue, making DEFAULT_QUEUE_SIZE "very large" does not increase the risk of runaway memory consumption.