### PR TITLE
SL-18159 Windows' mouse emulation causes pointer to jump around the screen.

### DIFF
--- a/indra/newview/llagentcamera.h
+++ b/indra/newview/llagentcamera.h
@@ -167,7 +167,6 @@ private:
 	// Follow
 	//--------------------------------------------------------------------
 public:
-	void			setUsingFollowCam(bool using_follow_cam);
 	bool 			isfollowCamLocked();
 private:
 	LLFollowCam 	mFollowCam; 			// Ventrella

--- a/indra/newview/lltoolfocus.cpp
+++ b/indra/newview/lltoolfocus.cpp
@@ -75,6 +75,7 @@ LLToolCamera::LLToolCamera()
 	mOutsideSlopX(FALSE),
 	mOutsideSlopY(FALSE),
 	mValidClickPoint(FALSE),
+    mClickPickPending(false),
 	mValidSelection(FALSE),
 	mMouseSteering(FALSE),
 	mMouseUpX(0),
@@ -127,6 +128,11 @@ BOOL LLToolCamera::handleMouseDown(S32 x, S32 y, MASK mask)
 
 	mValidClickPoint = FALSE;
 
+    // Sometimes Windows issues down and up events near simultaneously
+    // without giving async pick a chance to trigged
+    // Ex: mouse from numlock emulation
+    mClickPickPending = true;
+
 	// If mouse capture gets ripped away, claim we moused up
 	// at the point we moused down. JC
 	mMouseUpX = x;
@@ -142,13 +148,15 @@ BOOL LLToolCamera::handleMouseDown(S32 x, S32 y, MASK mask)
 
 void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
 {
-	if (!LLToolCamera::getInstance()->hasMouseCapture())
+    LLToolCamera* camera = LLToolCamera::getInstance();
+	if (!camera->mClickPickPending)
 	{
 		return;
 	}
+    camera->mClickPickPending = false;
 
-	LLToolCamera::getInstance()->mMouseDownX = pick_info.mMousePt.mX;
-	LLToolCamera::getInstance()->mMouseDownY = pick_info.mMousePt.mY;
+    camera->mMouseDownX = pick_info.mMousePt.mX;
+    camera->mMouseDownY = pick_info.mMousePt.mY;
 
 	gViewerWindow->moveCursorToCenter();
 
@@ -158,7 +166,7 @@ void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
 	// Check for hit the sky, or some other invalid point
 	if (!hit_obj && pick_info.mPosGlobal.isExactlyZero())
 	{
-		LLToolCamera::getInstance()->mValidClickPoint = FALSE;
+        camera->mValidClickPoint = FALSE;
 		return;
 	}
 
@@ -168,7 +176,7 @@ void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
 		LLObjectSelectionHandle selection = LLSelectMgr::getInstance()->getSelection();
 		if (!selection->getObjectCount() || selection->getSelectType() != SELECT_TYPE_HUD)
 		{
-			LLToolCamera::getInstance()->mValidClickPoint = FALSE;
+            camera->mValidClickPoint = FALSE;
 			return;
 		}
 	}
@@ -192,7 +200,7 @@ void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
 
 		if( !good_customize_avatar_hit )
 		{
-			LLToolCamera::getInstance()->mValidClickPoint = FALSE;
+            camera->mValidClickPoint = FALSE;
 			return;
 		}
 
@@ -237,7 +245,7 @@ void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
 
 	}
 
-	LLToolCamera::getInstance()->mValidClickPoint = TRUE;
+    camera->mValidClickPoint = TRUE;
 
 	if( CAMERA_MODE_CUSTOMIZE_AVATAR == gAgentCamera.getCameraMode() )
 	{
@@ -284,32 +292,36 @@ BOOL LLToolCamera::handleMouseUp(S32 x, S32 y, MASK mask)
 
 	if (hasMouseCapture())
 	{
-		if (mValidClickPoint)
-		{
-			if( CAMERA_MODE_CUSTOMIZE_AVATAR == gAgentCamera.getCameraMode() )
-			{
-				LLCoordGL mouse_pos;
-				LLVector3 focus_pos = gAgent.getPosAgentFromGlobal(gAgentCamera.getFocusGlobal());
-				BOOL success = LLViewerCamera::getInstance()->projectPosAgentToScreen(focus_pos, mouse_pos);
-				if (success)
-				{
-					LLUI::getInstance()->setMousePositionScreen(mouse_pos.mX, mouse_pos.mY);
-				}
-			}
-			else if (mMouseSteering)
-			{
-				LLUI::getInstance()->setMousePositionScreen(mMouseDownX, mMouseDownY);
-			}
-			else
-			{
-				gViewerWindow->moveCursorToCenter();
-			}
-		}
-		else
-		{
-			// not a valid zoomable object
-			LLUI::getInstance()->setMousePositionScreen(mMouseDownX, mMouseDownY);
-		}
+        // Do not move camera if we haven't gotten a pick
+        if (!mClickPickPending)
+        {
+            if (mValidClickPoint)
+            {
+                if (CAMERA_MODE_CUSTOMIZE_AVATAR == gAgentCamera.getCameraMode())
+                {
+                    LLCoordGL mouse_pos;
+                    LLVector3 focus_pos = gAgent.getPosAgentFromGlobal(gAgentCamera.getFocusGlobal());
+                    BOOL success = LLViewerCamera::getInstance()->projectPosAgentToScreen(focus_pos, mouse_pos);
+                    if (success)
+                    {
+                        LLUI::getInstance()->setMousePositionScreen(mouse_pos.mX, mouse_pos.mY);
+                    }
+                }
+                else if (mMouseSteering)
+                {
+                    LLUI::getInstance()->setMousePositionScreen(mMouseDownX, mMouseDownY);
+                }
+                else
+                {
+                    gViewerWindow->moveCursorToCenter();
+                }
+            }
+            else
+            {
+                // not a valid zoomable object
+                LLUI::getInstance()->setMousePositionScreen(mMouseDownX, mMouseDownY);
+            }
+        }
 
 		// calls releaseMouse() internally
 		setMouseCapture(FALSE);

--- a/indra/newview/lltoolfocus.h
+++ b/indra/newview/lltoolfocus.h
@@ -65,6 +65,7 @@ protected:
 	BOOL	mOutsideSlopX;
 	BOOL	mOutsideSlopY;
 	BOOL	mValidClickPoint;
+    bool	mClickPickPending;
 	BOOL	mValidSelection;
 	BOOL	mMouseSteering;
 	S32		mMouseUpX;	// needed for releaseMouse()


### PR DESCRIPTION
Emulated mouse trigers "not a valid zoomable object" case due to triggering 'up' event too early, forcing mouse to jump to garbage mMouseDownX/Y.