### PR TITLE
SL-18740: Fix texture animations not working for GLTF materials

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/pbralphaV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbralphaV.glsl
@@ -36,6 +36,7 @@ mat4 getObjectSkinnedTransform();
 uniform mat3 normal_matrix;
 uniform mat4 modelview_projection_matrix;
 #endif
+uniform mat4 texture_matrix0;
 
 #if (DIFFUSE_ALPHA_MODE == DIFFUSE_ALPHA_MODE_BLEND)
   #if !defined(HAS_SKIN)
@@ -92,10 +93,10 @@ void main()
     vary_fragcoord.xyz = vert.xyz + vec3(0,0,near_clip);
 #endif
 
-	basecolor_texcoord = (texture_basecolor_matrix * vec3(texcoord0,1)).xy;
-	normal_texcoord = (texture_normal_matrix * vec3(texcoord0,1)).xy;
-	metallic_roughness_texcoord = (texture_metallic_roughness_matrix * vec3(texcoord0,1)).xy;
-	emissive_texcoord = (texture_emissive_matrix * vec3(texcoord0,1)).xy;
+	basecolor_texcoord = (texture_matrix0 * vec4(texture_basecolor_matrix * vec3(texcoord0,1), 1)).xy;
+	normal_texcoord = (texture_matrix0 * vec4(texture_normal_matrix * vec3(texcoord0,1), 1)).xy;
+	metallic_roughness_texcoord = (texture_matrix0 * vec4(texture_metallic_roughness_matrix * vec3(texcoord0,1), 1)).xy;
+	emissive_texcoord = (texture_matrix0 * vec4(texture_emissive_matrix * vec3(texcoord0,1), 1)).xy;
 
 #ifdef HAS_SKIN
 	vec3 n = (mat*vec4(normal.xyz+position.xyz,1.0)).xyz-pos.xyz;

--- a/indra/newview/app_settings/shaders/class1/deferred/pbropaqueV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbropaqueV.glsl
@@ -36,6 +36,7 @@ mat4 getObjectSkinnedTransform();
 uniform mat3 normal_matrix;
 uniform mat4 modelview_projection_matrix;
 #endif
+uniform mat4 texture_matrix0;
 
 uniform mat3 texture_basecolor_matrix;
 uniform mat3 texture_normal_matrix;
@@ -75,10 +76,10 @@ void main()
 	gl_Position = modelview_projection_matrix * vec4(position.xyz, 1.0); 
 #endif
 	
-	basecolor_texcoord = (texture_basecolor_matrix * vec3(texcoord0,1)).xy;
-	normal_texcoord = (texture_normal_matrix * vec3(texcoord0,1)).xy;
-	metallic_roughness_texcoord = (texture_metallic_roughness_matrix * vec3(texcoord0,1)).xy;
-	emissive_texcoord = (texture_emissive_matrix * vec3(texcoord0,1)).xy;
+	basecolor_texcoord = (texture_matrix0 * vec4(texture_basecolor_matrix * vec3(texcoord0,1), 1)).xy;
+	normal_texcoord = (texture_matrix0 * vec4(texture_normal_matrix * vec3(texcoord0,1), 1)).xy;
+	metallic_roughness_texcoord = (texture_matrix0 * vec4(texture_metallic_roughness_matrix * vec3(texcoord0,1), 1)).xy;
+	emissive_texcoord = (texture_matrix0 * vec4(texture_emissive_matrix * vec3(texcoord0,1), 1)).xy;
 
 #ifdef HAS_SKIN
 	vec3 n = (mat*vec4(normal.xyz+position.xyz,1.0)).xyz-pos.xyz;


### PR DESCRIPTION
After some testing, I have concluded that pre-PBR texture animations are weird, but to the best of my knowledge, just multiplying the texture animation matrix seems to do the right thing for GLTF materials, minus the weird pre-PBR legacy animation quirks.