### PR TITLE
SL-18911 My Land Holdings floater crashes viewer on the Xcode branch

### DIFF
--- a/indra/llcommon/llsd.h
+++ b/indra/llcommon/llsd.h
@@ -30,7 +30,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <type_traits>
 
 #include "stdtypes.h"
 
@@ -216,21 +215,15 @@ public:
 		void assign(const Date&);
 		void assign(const URI&);
 		void assign(const Binary&);
-
-		// support assignment from size_t et al.
-		template <typename VALUE,
-				  typename std::enable_if<std::is_integral<VALUE>::value &&
-										  ! std::is_same<VALUE, Boolean>::value,
-										  bool>::type = true>
-		void assign(VALUE v) { assign(Integer(narrow(v))); }
-		// support assignment from F32 et al.
-		template <typename VALUE,
-				  typename std::enable_if<std::is_floating_point<VALUE>::value,
-										  bool>::type = true>
-		void assign(VALUE v) { assign(Real(narrow(v))); }
-
-		template <typename VALUE>
-		LLSD& operator=(VALUE v)			{ assign(v); return *this; }
+		
+		LLSD& operator=(Boolean v)			{ assign(v); return *this; }
+		LLSD& operator=(Integer v)			{ assign(v); return *this; }
+		LLSD& operator=(Real v)				{ assign(v); return *this; }
+		LLSD& operator=(const String& v)	{ assign(v); return *this; }
+		LLSD& operator=(const UUID& v)		{ assign(v); return *this; }
+		LLSD& operator=(const Date& v)		{ assign(v); return *this; }
+		LLSD& operator=(const URI& v)		{ assign(v); return *this; }
+		LLSD& operator=(const Binary& v)	{ assign(v); return *this; }
 	//@}
 
 	/**
@@ -292,6 +285,7 @@ public:
 	//@{
 		LLSD(const char*);
 		void assign(const char*);
+		LLSD& operator=(const char* v) { assign(v); return *this; }
 	//@}
 	
 	/** @name Map Values */

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -337,7 +337,7 @@ void LLNotificationForm::addElement(const std::string& type, const std::string& 
 	element["name"] = name;
 	element["text"] = name;
 	element["value"] = value;
-	element["index"] = mFormData.size();
+	element["index"] = LLSD::Integer(mFormData.size());
 	element["enabled"] = enabled;
 	mFormData.append(element);
 }

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -6284,7 +6284,7 @@ bool handle_lure_callback(const LLSD& notification, const LLSD& response)
 		// More than OFFER_RECIPIENT_LIMIT targets will overload the message
 		// producing an llerror.
 		LLSD args;
-		args["OFFERS"] = notification["payload"]["ids"].size();
+		args["OFFERS"] = LLSD::Integer(notification["payload"]["ids"].size());
 		args["LIMIT"] = static_cast<int>(OFFER_RECIPIENT_LIMIT);
 		LLNotificationsUtil::add("TooManyTeleportOffers", args);
 		return false;


### PR DESCRIPTION
Revert part of "DRTVWR-575: Address review comments on Xcode 14.1 type tweaks."

Crash was reproduced when assigning areastr to llsd, but likely present in other cases as well.