### PR TITLE
Sl 18820: Build floater should preserve GLTF transforms when changing the PBR material

### DIFF
--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -392,9 +392,21 @@ bool LLGLTFMaterial::setBaseMaterial()
 {
     const LLGLTFMaterial old_override = *this;
     *this = sDefault;
-    // Preserve the texture transforms
-    mTextureTransform = old_override.mTextureTransform;
+    setBaseMaterial(old_override);
     return *this != old_override;
+}
+
+bool LLGLTFMaterial::isClearedForBaseMaterial()
+{
+    LLGLTFMaterial cleared_override = sDefault;
+    cleared_override.setBaseMaterial(*this);
+    return *this == cleared_override;
+}
+
+// For material overrides only. Copies transforms from the old override.
+void LLGLTFMaterial::setBaseMaterial(const LLGLTFMaterial& old_override_mat)
+{
+    mTextureTransform = old_override_mat.mTextureTransform;
 }
 
 

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -98,6 +98,29 @@ LLGLTFMaterial& LLGLTFMaterial::operator=(const LLGLTFMaterial& rhs)
     return *this;
 }
 
+bool LLGLTFMaterial::operator==(const LLGLTFMaterial& rhs) const
+{
+    return mBaseColorId == rhs.mBaseColorId &&
+        mNormalId == rhs.mNormalId &&
+        mMetallicRoughnessId == rhs.mMetallicRoughnessId &&
+        mEmissiveId == rhs.mEmissiveId &&
+
+        mBaseColor == rhs.mBaseColor &&
+        mEmissiveColor == rhs.mEmissiveColor &&
+        
+        mMetallicFactor == rhs.mMetallicFactor &&
+        mRoughnessFactor == rhs.mRoughnessFactor &&
+        mAlphaCutoff == rhs.mAlphaCutoff &&
+
+        mDoubleSided == rhs.mDoubleSided &&
+        mAlphaMode == rhs.mAlphaMode &&
+
+        mTextureTransform == rhs.mTextureTransform &&
+
+        mOverrideDoubleSided == rhs.mOverrideDoubleSided &&
+        mOverrideAlphaMode == rhs.mOverrideAlphaMode;
+}
+
 bool LLGLTFMaterial::fromJSON(const std::string& json, std::string& warn_msg, std::string& error_msg)
 {
     LL_PROFILE_ZONE_SCOPED;
@@ -364,6 +387,16 @@ void LLGLTFMaterial::writeToTexture(tinygltf::Model& model, T& texture_info, Tex
     transform_map[GLTF_FILE_EXTENSION_TRANSFORM_ROTATION] = tinygltf::Value(transform.mRotation);
     texture_info.extensions[GLTF_FILE_EXTENSION_TRANSFORM] = tinygltf::Value(transform_map);
 }
+
+bool LLGLTFMaterial::setBaseMaterial()
+{
+    const LLGLTFMaterial old_override = *this;
+    *this = sDefault;
+    // Preserve the texture transforms
+    mTextureTransform = old_override.mTextureTransform;
+    return *this != old_override;
+}
+
 
 // static
 void LLGLTFMaterial::hackOverrideUUID(LLUUID& id)

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -185,6 +185,8 @@ public:
     // For material overrides only. Clears most properties to
     // default/fallthrough, but preserves the transforms.
     bool setBaseMaterial();
+    // True if setBaseMaterial() was just called
+    bool isClearedForBaseMaterial();
 
 private:
 
@@ -193,5 +195,7 @@ private:
 
     template<typename T>
     void writeToTexture(tinygltf::Model& model, T& texture_info, TextureInfo texture_info_id, const LLUUID& texture_id) const;
+
+    void setBaseMaterial(const LLGLTFMaterial& old_override_mat);
 };
 

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -71,6 +71,8 @@ public:
     LLGLTFMaterial(const LLGLTFMaterial& rhs);
 
     LLGLTFMaterial& operator=(const LLGLTFMaterial& rhs);
+    bool operator==(const LLGLTFMaterial& rhs) const;
+    bool operator!=(const LLGLTFMaterial& rhs) const { return !(*this == rhs); }
 
     LLUUID mBaseColorId;
     LLUUID mNormalId;
@@ -101,7 +103,6 @@ public:
         md5.finalize();
         LLUUID id;
         md5.raw_digest(id.mData);
-        // *TODO: Hash the overrides
         return id;
     }
 
@@ -180,6 +181,10 @@ public:
     void writeToModel(tinygltf::Model& model, S32 mat_index) const;
 
     void applyOverride(const LLGLTFMaterial& override_mat);
+
+    // For material overrides only. Clears most properties to
+    // default/fallthrough, but preserves the transforms.
+    bool setBaseMaterial();
 
 private:
 

--- a/indra/llprimitive/lltextureentry.h
+++ b/indra/llprimitive/lltextureentry.h
@@ -195,12 +195,16 @@ public:
 	enum { MF_NONE = 0x0, MF_HAS_MEDIA = 0x1 };
 
     // GLTF asset
-    void setGLTFMaterial(LLGLTFMaterial* material);
+    void setGLTFMaterial(LLGLTFMaterial* material, bool local_origin = true);
     LLGLTFMaterial* getGLTFMaterial() const { return mGLTFMaterial; }
 
     // GLTF override
     LLGLTFMaterial* getGLTFMaterialOverride() const { return mGLTFMaterialOverrides; }
     void setGLTFMaterialOverride(LLGLTFMaterial* mat);
+    // Clear most overrides so the render material better matches the material
+    // ID (preserve transforms). If the overrides become passthrough, set the
+    // overrides to nullptr.
+    S32 setBaseMaterial();
 
     // GLTF render material
     // nuanced behavior here -- if there is no render material, fall back to getGLTFMaterial, but ONLY for the getter, not the setter

--- a/indra/newview/llgltfmateriallist.h
+++ b/indra/newview/llgltfmateriallist.h
@@ -59,7 +59,7 @@ public:
     //  side - TexureEntry index to modify, or -1 for all sides
     //  mat - material to apply as override, or nullptr to remove existing overrides and revert to asset
     //
-    // NOTE: do not use to revert to asset when applying a new asset id, use queueApplyMaterialAsset below
+    // NOTE: do not use to revert to asset when applying a new asset id, use queueApply below
     static void queueModify(const LLUUID& id, S32 side, const LLGLTFMaterial* mat);
 
     // Queue an application of a material asset we want to send to the simulator.  Call "flushUpdates" to flush pending updates.
@@ -67,8 +67,8 @@ public:
     //  side - TextureEntry index to apply material to, or -1 for all sides
     //  asset_id - ID of material asset to apply, or LLUUID::null to disassociate current material asset
     //
-    // NOTE: implicitly removes any override data if present
-    static void queueApply(const LLUUID& object_id, S32 side, const LLUUID& asset_id);
+    // NOTE: Implicitly clears most override data if present
+    static void queueApply(const LLViewerObject* obj, S32 side, const LLUUID& asset_id);
 
     // flush pending material updates to the simulator
     // Automatically called once per frame, but may be called explicitly
@@ -136,6 +136,7 @@ protected:
         LLUUID object_id;
         S32 side = -1;
         LLUUID asset_id;
+        LLPointer<LLGLTFMaterial> override_data;
     };
 
     typedef std::list<ApplyMaterialAssetData> apply_queue_t;

--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -4527,8 +4527,8 @@ void LLPanelFace::onPasteTexture(LLViewerObject* objectp, S32 te)
                 tep->setGLTFRenderMaterial(nullptr);
                 tep->setGLTFMaterialOverride(nullptr);
 
-                // blank out any override data on the server
-                LLGLTFMaterialList::queueApply(objectp->getID(), te, LLUUID::null);
+                // blank out most override data on the server
+                LLGLTFMaterialList::queueApply(objectp, te, LLUUID::null);
             }
 
             // Texture map

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -1806,11 +1806,9 @@ void LLObjectSelection::applyNoCopyPbrMaterialToTEs(LLViewerInventoryItem* item)
                 }
 
                 // apply texture for the selected faces
+                // blank out most override data on the server
                 //add(LLStatViewer::EDIT_TEXTURE, 1);
-                object->setRenderMaterialID(te, asset_id, false /*will be sent later*/);
-
-                // blank out any override data on the server
-                LLGLTFMaterialList::queueApply(object->getID(), te, asset_id);
+                object->setRenderMaterialID(te, asset_id);
             }
         }
     }
@@ -1949,10 +1947,8 @@ void LLSelectMgr::selectionSetGLTFMaterial(const LLUUID& mat_id)
                 objectp->setParameterEntryInUse(LLNetworkData::PARAMS_RENDER_MATERIAL, TRUE, false /*prevent an update*/);
             }
 
-            objectp->setRenderMaterialID(te, asset_id, false /*prevent an update to prevent a race condition*/);
-
-            // blank out any override data on the server
-            LLGLTFMaterialList::queueApply(objectp->getID(), te, asset_id);
+            // Blank out most override data on the object and send to server
+            objectp->setRenderMaterialID(te, asset_id);
 
             return true;
         }
@@ -2223,17 +2219,12 @@ void LLSelectMgr::selectionRevertGLTFMaterials()
                     && asset_id.notNull())
                 {
                     // Restore overrides
-                    LLSD overrides;
-                    overrides["object_id"] = objectp->getID();
-                    overrides["side"] = te;
-
-                    overrides["gltf_json"] = nodep->mSavedGLTFOverrideMaterials[te]->asJSON();
-                    LLGLTFMaterialList::queueUpdate(overrides);
+                    LLGLTFMaterialList::queueModify(objectp->getID(), te, nodep->mSavedGLTFOverrideMaterials[te]);
                 } 
                 else
                 {
                     //blank override out
-                    LLGLTFMaterialList::queueApply(objectp->getID(), te, asset_id);
+                    LLGLTFMaterialList::queueApply(objectp, te, asset_id);
                 }
 
             }

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -188,7 +188,7 @@ public:
     // set the RenderMaterialID for the given TextureEntry
     // te - TextureEntry index to set, or -1 for all TEs
     // id - asset id of material asset
-    // update_server - if true, will send updates to server
+    // update_server - if true, will send updates to server and clear most overrides
     void setRenderMaterialID(S32 te, const LLUUID& id, bool update_server = true);
     void setRenderMaterialIDs(const LLUUID& id);
 


### PR DESCRIPTION
Requires server changes as well in order to take effect (merge order is unimportant).

This changes the data LLGLTFMaterialList sends over the wire. When LLGLTFMaterialList::queueApply is called, it will send both a material ID and a non-default material override JSON. Previously, it sent an empty string.

Viewer material editing will now always preserves GLTF texture transforms in overrides whenever the render material ID changes, even if the new render material ID is null. This is the current LSL script behavior as well. The code removes overrides when they become sDefault.

LLTextureEntry::setBaseMaterial modifies the material override in-place. Seems reasonable for now, but is there a case in the future where it won't be?
- Ideally overrides would use std::unique_ptr, but that has caveats for how LLRefCount objects are typically used