### PR TITLE
SL-18735 Using "Find original" in main inventory tab breaks inventory view

### DIFF
--- a/indra/llcommon/llallocator_heap_profile.cpp
+++ b/indra/llcommon/llallocator_heap_profile.cpp
@@ -130,7 +130,6 @@ void LLAllocatorHeapProfile::parse(std::string const & prof_text)
 
 void LLAllocatorHeapProfile::dump(std::ostream & out) const
 {
-    lines_t::const_iterator i;
 	for (const LLAllocatorHeapProfile::line& line : mLines)
     {
         out << line.mLiveCount << ": " << line.mLiveSize << '[' << line.mTotalCount << ": " << line.mTotalSize << "] @";

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -1646,7 +1646,8 @@ void LLFolderView::update()
     
 	// Clear the modified setting on the filter only if the filter finished after running the filter process
 	// Note: if the filter count has timed out, that means the filter halted before completing the entire set of items
-    if (filter_object.isModified() && (!filter_object.isTimedOut()))
+    bool filter_modified = filter_object.isModified();
+    if (filter_modified && (!filter_object.isTimedOut()))
 	{
 		filter_object.clearModified();
 	}
@@ -1680,7 +1681,7 @@ void LLFolderView::update()
 	BOOL filter_finished = mViewModel->contentsReady()
 							&& (getViewModelItem()->passedFilter()
 								|| ( getViewModelItem()->getLastFilterGeneration() >= filter_object.getFirstSuccessGeneration()
-									&& !filter_object.isModified()));
+									&& !filter_modified));
 	if (filter_finished 
 		|| gFocusMgr.childHasKeyboardFocus(mParentPanel.get())
 		|| gFocusMgr.childHasMouseCapture(mParentPanel.get()))
@@ -1768,13 +1769,26 @@ void LLFolderView::update()
 
 	if (mSelectedItems.size() && mNeedsScroll)
 	{
-		scrollToShowItem(mSelectedItems.back(), constraint_rect);
+        LLFolderViewItem* scroll_to_item = mSelectedItems.back();
+		scrollToShowItem(scroll_to_item, constraint_rect);
 		// continue scrolling until animated layout change is done
-		if (filter_finished
-			&& (!needsArrange() || !is_visible))
-		{
-			mNeedsScroll = FALSE;
-		}
+        bool selected_filter_finished = true;
+        if (scroll_to_item && scroll_to_item->getViewModelItem())
+        {
+            selected_filter_finished = scroll_to_item->getViewModelItem()->getLastFilterGeneration() >= filter_object.getFirstSuccessGeneration();
+        }
+        if (filter_finished && selected_filter_finished)
+        {
+            bool needs_arrange = needsArrange();
+            if (mParentFolder)
+            {
+                needs_arrange |= (bool)mParentFolder->needsArrange();
+            }
+            if (!needs_arrange || !is_visible)
+            {
+                mNeedsScroll = FALSE;
+            }
+        }
 	}
 
 	if (mSignalSelectCallback)

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -335,7 +335,6 @@ protected:
 	F32			mAutoOpenCountdown;
 	S32			mLastArrangeGeneration;
 	S32			mLastCalculatedWidth;
-	bool		mNeedsSort;
 	bool		mIsFolderComplete; // indicates that some children were not loaded/added yet
 	bool		mAreChildrenInited; // indicates that no children were initialized
 

--- a/indra/newview/lleventpoll.cpp
+++ b/indra/newview/lleventpoll.cpp
@@ -247,8 +247,9 @@ namespace Details
             errorCount = 0;
 
             if (!result.isMap() ||
-                !result.get("events") ||
-                !result.get("id"))
+                !result.has("events") ||
+                !result["events"].isArray() ||
+                !result.has("id"))
             {
                 LL_WARNS("LLEventPollImpl") << " <" << counter << "> received event poll with no events or id key: " << result << LL_ENDL;
                 continue;

--- a/indra/newview/llfolderviewmodelinventory.cpp
+++ b/indra/newview/llfolderviewmodelinventory.cpp
@@ -182,11 +182,15 @@ void LLFolderViewModelItemInventory::setPassedFilter(bool passed, S32 filter_gen
 	bool generation_skip = mMarkedDirtyGeneration >= 0
 		&& mPrevPassedAllFilters
 		&& mMarkedDirtyGeneration < mRootViewModel.getFilter().getFirstSuccessGeneration();
+    S32 last_generation = mLastFilterGeneration;
 	LLFolderViewModelItemCommon::setPassedFilter(passed, filter_generation, string_offset, string_size);
 	bool before = mPrevPassedAllFilters;
 	mPrevPassedAllFilters = passedFilter(filter_generation);
 
-	if (before != mPrevPassedAllFilters || generation_skip)
+	if (before != mPrevPassedAllFilters // Change of state
+        || generation_skip // Was marked dirty
+        // Potential change from being in-progress and invisible to visible)
+        || (mPrevPassedAllFilters && last_generation < mRootViewModel.getFilter().getFirstRequiredGeneration()))
 	{
 		// Need to rearrange the folder if the filtered state of the item changed,
 		// previously passed item skipped filter generation changes while being dirty

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -324,6 +324,8 @@ void set_flags_and_update_appearance()
 {
 	LLAppearanceMgr::instance().setAttachmentInvLinkEnable(true);
 	LLAppearanceMgr::instance().updateAppearanceFromCOF(true, true, no_op);
+
+    LLInventoryModelBackgroundFetch::instance().start();
 }
 
 // Returns false to skip other idle processing. Should only return


### PR DESCRIPTION
Fixes folders being invidible (missing arrange)
Fixes sroll to target not working reliably