### PR TITLE
SL-19089 Changing UI scale crashes viewer

### DIFF
--- a/indra/llrender/llfontbitmapcache.cpp
+++ b/indra/llrender/llfontbitmapcache.cpp
@@ -92,6 +92,20 @@ BOOL LLFontBitmapCache::nextOpenPos(S32 width, S32& pos_x, S32& pos_y, EFontGlyp
 		{
 			// We're out of space in the current image, or no image
 			// has been allocated yet.  Make a new one.
+            
+            S32 image_width = mMaxCharWidth * 20;
+            S32 pow_iw = 2;
+            while (pow_iw < image_width)
+            {
+                pow_iw *= 2;
+            }
+            image_width = pow_iw;
+            image_width = llmin(512, image_width); // Don't make bigger than 512x512, ever.
+            S32 image_height = image_width;
+            
+            mBitmapWidth = image_width;
+            mBitmapHeight = image_height;
+            
 			S32 num_components = getNumComponents(bitmap_type);
 			mImageRawVec[bitmap_idx].push_back(new LLImageRaw(mBitmapWidth, mBitmapHeight, num_components));
 			bitmap_num = mImageRawVec[bitmap_idx].size() - 1;

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -798,11 +798,11 @@ void LLFontFreetype::setSubImageLuminanceAlpha(U32 x, U32 y, U32 bitmap_num, U32
 
 	llassert(!mIsFallback);
 	llassert(image_raw && (image_raw->getComponents() == 2));
-
 	
 	U8 *target = image_raw->getData();
+    llassert(target);
 
-	if (!data)
+	if (!data || !target)
 	{
 		return;
 	}


### PR DESCRIPTION
This makes no sense, trying to add a glyph in resetBitmapCache will have no width or height set, neither character width or heigh, yet release viewer does that. I doubt we need to add glyph (one will be added after loadface that is about to be called), but fixed code to match release and set width and height despite char width not being up to date.