### PR TITLE
SL-17761: Replace 'Grid emergency' message with generic error

### DIFF
--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -126,7 +126,7 @@ http://secondlife.com/download
 
 For more information, see our FAQ below:
 http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginFailed">Grid emergency login failure.
+	<string name="LoginFailed">Login failure.
 If you feel this is an error, please contact support@secondlife.com.</string>
 	<string name="LoginIntermediateOptionalUpdateAvailable">Optional viewer update available: [VERSION]</string>
 	<string name="LoginFailedRequiredUpdate">Required viewer update: [VERSION]</string>


### PR DESCRIPTION
The viewer currently presents a startling "Grid emergency" warning if an unrecognized error is returned from login. Let's tone this down a bit and present the error as it is: an unrecognized login failure rather than SLearth exploding.