### PR TITLE
Faster LLUUID and LLMaterialID hashing for std and boost containers keys

### DIFF
--- a/indra/llappearance/llwearable.h
+++ b/indra/llappearance/llwearable.h
@@ -32,7 +32,6 @@
 #include "llsaleinfo.h"
 #include "llwearabletype.h"
 
-class LLMD5;
 class LLVisualParam;
 class LLTexGlobalColorInfo;
 class LLTexGlobalColor;
@@ -109,9 +108,6 @@ public:
 
 	// Something happened that requires the wearable to be updated (e.g. worn/unworn).
 	virtual void		setUpdated() const = 0;
-
-	// Update the baked texture hash.
-	virtual void		addToBakedTextureHash(LLMD5& hash) const = 0;
 
 	typedef std::map<S32, LLVisualParam *>    visual_param_index_map_t;
 	visual_param_index_map_t mVisualParamIndexMap;

--- a/indra/llappearance/llwearabledata.cpp
+++ b/indra/llappearance/llwearabledata.cpp
@@ -31,7 +31,6 @@
 #include "llavatarappearance.h"
 #include "llavatarappearancedefines.h"
 #include "lldriverparam.h"
-#include "llmd5.h"
 
 LLWearableData::LLWearableData() :
 	mAvatarAppearance(NULL)
@@ -343,42 +342,3 @@ U32 LLWearableData::getWearableCount(const U32 tex_index) const
 	const LLWearableType::EType wearable_type = LLAvatarAppearance::getDictionary()->getTEWearableType((LLAvatarAppearanceDefines::ETextureIndex)tex_index);
 	return getWearableCount(wearable_type);
 }
-
-LLUUID LLWearableData::computeBakedTextureHash(LLAvatarAppearanceDefines::EBakedTextureIndex baked_index,
-												 BOOL generate_valid_hash) // Set to false if you want to upload the baked texture w/o putting it in the cache
-{
-	LLUUID hash_id;
-	bool hash_computed = false;
-	LLMD5 hash;
-	const LLAvatarAppearanceDictionary::BakedEntry *baked_dict = LLAvatarAppearance::getDictionary()->getBakedTexture(baked_index);
-
-	for (U8 i=0; i < baked_dict->mWearables.size(); i++)
-	{
-		const LLWearableType::EType baked_type = baked_dict->mWearables[i];
-		const U32 num_wearables = getWearableCount(baked_type);
-		for (U32 index = 0; index < num_wearables; ++index)
-		{
-			const LLWearable* wearable = getWearable(baked_type,index);
-			if (wearable)
-			{
-				wearable->addToBakedTextureHash(hash);
-				hash_computed = true;
-			}
-		}
-	}
-	if (hash_computed)
-	{
-		hash.update((const unsigned char*)baked_dict->mWearablesHashID.mData, UUID_BYTES);
-
-		if (!generate_valid_hash)
-		{
-			invalidateBakedTextureHash(hash);
-		}
-		hash.finalize();
-		hash.raw_digest(hash_id.mData);
-	}
-
-	return hash_id;
-}
-
-

--- a/indra/llappearance/llwearabledata.h
+++ b/indra/llappearance/llwearabledata.h
@@ -86,15 +86,6 @@ private:
 	void			pullCrossWearableValues(const LLWearableType::EType type);
 
 	//--------------------------------------------------------------------
-	// Server Communication
-	//--------------------------------------------------------------------
-public:
-	LLUUID			computeBakedTextureHash(LLAvatarAppearanceDefines::EBakedTextureIndex baked_index,
-											BOOL generate_valid_hash = TRUE);
-protected:
-	virtual void	invalidateBakedTextureHash(LLMD5& hash) const {}
-
-	//--------------------------------------------------------------------
 	// Member variables
 	//--------------------------------------------------------------------
 protected:

--- a/indra/llcommon/lluuid.cpp
+++ b/indra/llcommon/lluuid.cpp
@@ -878,7 +878,7 @@ U32 LLUUID::getRandomSeed()
    seed[7]=(unsigned char)(pid);
    getSystemTime((uuid_time_t *)(&seed[8]));
 
-   U64 seed64 = HBXXH64((const void*)seed, 16).digest();
+   U64 seed64 = HBXXH64::digest((const void*)seed, 16);
    return U32(seed64) ^ U32(seed64 >> 32);
 }
 

--- a/indra/llcommon/lluuid.h
+++ b/indra/llcommon/lluuid.h
@@ -119,6 +119,14 @@ public:
 	U16 getCRC16() const;
 	U32 getCRC32() const;
 
+	// Returns a 64 bits digest of the UUID, by XORing its two 64 bits long
+	// words. HB
+	inline U64 getDigest64() const
+	{
+		U64* tmp = (U64*)mData;
+		return tmp[0] ^ tmp[1];
+	}
+
 	static BOOL validate(const std::string& in_string); // Validate that the UUID string is legal.
 
 	static const LLUUID null;
@@ -165,36 +173,20 @@ public:
 	LLAssetID makeAssetID(const LLUUID& session) const;
 };
 
-// Generate a hash of an LLUUID object using the boost hash templates. 
-template <>
-struct boost::hash<LLUUID>
-{
-    typedef LLUUID argument_type;
-    typedef std::size_t result_type;
-    result_type operator()(argument_type const& s) const
-    {
-        result_type seed(0);
-
-        for (S32 i = 0; i < UUID_BYTES; ++i)
-        {
-            boost::hash_combine(seed, s.mData[i]);
-        }
-
-        return seed;
-    }
-};
-
-// Adapt boost hash to std hash
+// std::hash implementation for LLUUID
 namespace std
 {
-    template<> struct hash<LLUUID>
-    {
-        std::size_t operator()(LLUUID const& s) const noexcept
-        {
-            return boost::hash<LLUUID>()(s);
-        }
-    };
+	template<> struct hash<LLUUID>
+	{
+		inline size_t operator()(const LLUUID& id) const noexcept
+		{
+			return (size_t)id.getDigest64();
+		}
+	};
 }
-#endif
 
-
+// For use with boost containers.
+inline size_t hash_value(const LLUUID& id) noexcept
+{
+	return (size_t)id.getDigest64();
+}

--- a/indra/llprimitive/llmaterialid.h
+++ b/indra/llprimitive/llmaterialid.h
@@ -66,6 +66,14 @@ public:
 
 	static const LLMaterialID null;
 
+	// Returns a 64 bits digest of the material Id, by XORing its two 64 bits
+	// long words. HB
+	inline U64 getDigest64() const
+	{
+		U64* tmp = (U64*)mID;
+		return tmp[0] ^ tmp[1];
+	}
+
 private:
 	void parseFromBinary(const LLSD::Binary& pMaterialID);
 	void copyFromOtherMaterialID(const LLMaterialID& pOtherMaterialID);
@@ -73,6 +81,24 @@ private:
 
 	U8 mID[MATERIAL_ID_SIZE];
 } ;
+
+// std::hash implementation for LLMaterialID
+namespace std
+{
+	template<> struct hash<LLMaterialID>
+	{
+		inline size_t operator()(const LLMaterialID& id) const noexcept
+		{
+			return (size_t)id.getDigest64();
+		}
+	};
+}
+
+// For use with boost containers.
+inline size_t hash_value(const LLMaterialID& id) noexcept
+{
+	return (size_t)id.getDigest64();
+}
 
 #endif // LL_LLMATERIALID_H
 

--- a/indra/newview/llagentwearables.cpp
+++ b/indra/newview/llagentwearables.cpp
@@ -41,7 +41,6 @@
 #include "llinventoryobserver.h"
 #include "llinventorypanel.h"
 #include "lllocaltextureobject.h"
-#include "llmd5.h"
 #include "llnotificationsutil.h"
 #include "lloutfitobserver.h"
 #include "llsidepanelappearance.h"

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -62,6 +62,7 @@
 #include "bufferarray.h"
 #include "bufferstream.h"
 #include "llcorehttputil.h"
+#include "hbxxh.h"
 
 //#define DIFF_INVENTORY_FILES
 #ifdef DIFF_INVENTORY_FILES
@@ -451,17 +452,16 @@ void LLInventoryModel::getDirectDescendentsOf(const LLUUID& cat_id,
 	items = get_ptr_in_map(mParentChildItemTree, cat_id);
 }
 
-LLMD5 LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
+LLUUID LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
 {
 	LLInventoryModel::cat_array_t* cat_array;
 	LLInventoryModel::item_array_t* item_array;
 	getDirectDescendentsOf(cat_id,cat_array,item_array);
-	LLMD5 item_name_hash;
 	if (!item_array)
 	{
-		item_name_hash.finalize();
-		return item_name_hash;
+		return LLUUID::null;
 	}
+	HBXXH128 item_name_hash;
 	for (LLInventoryModel::item_array_t::const_iterator iter = item_array->begin();
 		 iter != item_array->end();
 		 iter++)
@@ -471,8 +471,7 @@ LLMD5 LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
 			continue;
 		item_name_hash.update(item->getName());
 	}
-	item_name_hash.finalize();
-	return item_name_hash;
+	return item_name_hash.digest();
 }
 
 // SJB: Added version to lock the arrays to catch potential logic bugs

--- a/indra/newview/llinventorymodel.h
+++ b/indra/newview/llinventorymodel.h
@@ -39,7 +39,6 @@
 #include "llpermissionsflags.h"
 #include "llviewerinventory.h"
 #include "llstring.h"
-#include "llmd5.h"
 #include "httpcommon.h"
 #include "httprequest.h"
 #include "httpoptions.h"
@@ -258,7 +257,7 @@ public:
 								item_array_t*& items) const;
 
 	// Compute a hash of direct descendant names (for detecting child name changes)
-	LLMD5 hashDirectDescendentNames(const LLUUID& cat_id) const;
+	LLUUID hashDirectDescendentNames(const LLUUID& cat_id) const;
 	
 	// Starting with the object specified, add its descendants to the
 	// array provided, but do not add the inventory object specified

--- a/indra/newview/llinventoryobserver.cpp
+++ b/indra/newview/llinventoryobserver.cpp
@@ -640,7 +640,7 @@ void LLInventoryCategoriesObserver::changed(U32 mask)
 		// computed, or (b) a name has changed.
 		if (!cat_data.mIsNameHashInitialized || (mask & LLInventoryObserver::LABEL))
 		{
-			LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			if (cat_data.mItemNameHash != item_name_hash)
 			{
 				cat_data.mIsNameHashInitialized = true;
@@ -701,7 +701,7 @@ bool LLInventoryCategoriesObserver::addCategory(const LLUUID& cat_id, callback_t
 	{
 		if(init_name_hash)
 		{
-			LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			mCategoryMap.insert(category_map_value_t(cat_id,LLCategoryData(cat_id, cb, version, current_num_known_descendents,item_name_hash)));
 		}
 		else
@@ -727,11 +727,10 @@ LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
 	, mDescendentsCount(num_descendents)
 	, mIsNameHashInitialized(false)
 {
-	mItemNameHash.finalize();
 }
 
 LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
-	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, LLMD5 name_hash)
+	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash)
 
 	: mCatID(cat_id)
 	, mCallback(cb)

--- a/indra/newview/llinventoryobserver.h
+++ b/indra/newview/llinventoryobserver.h
@@ -28,7 +28,6 @@
 #define LL_LLINVENTORYOBSERVERS_H
 
 #include "lluuid.h"
-#include "llmd5.h"
 #include <string>
 #include <vector>
 
@@ -274,11 +273,11 @@ protected:
 	struct LLCategoryData
 	{
 		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents);
-		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, LLMD5 name_hash);
+		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash);
 		callback_t	mCallback;
 		S32			mVersion;
 		S32			mDescendentsCount;
-		LLMD5		mItemNameHash;
+		LLUUID		mItemNameHash;
 		bool		mIsNameHashInitialized;
 		LLUUID		mCatID;
 	};

--- a/indra/newview/llmaterialmgr.h
+++ b/indra/newview/llmaterialmgr.h
@@ -102,13 +102,6 @@ private:
 			(lhs.materialID < rhs.materialID);
 	}
 
-	struct TEMaterialPairHasher
-	{
-		enum { bucket_size = 8 };
-		size_t operator()(const TEMaterialPair& key_value) const { return *((size_t*)key_value.materialID.get());  } // cheesy, but effective
-		bool   operator()(const TEMaterialPair& left, const TEMaterialPair& right) const { return left < right; }
-	};
-
 	typedef std::set<LLMaterialID> material_queue_t;
 	typedef std::map<LLUUID, material_queue_t> get_queue_t;
 	typedef std::pair<const LLUUID, LLMaterialID> pending_material_t;
@@ -116,7 +109,7 @@ private:
 	typedef std::map<LLMaterialID, get_callback_t*> get_callback_map_t;
 
 
-	typedef boost::unordered_map<TEMaterialPair, get_callback_te_t*, TEMaterialPairHasher> get_callback_te_map_t;
+	typedef boost::unordered_map<TEMaterialPair, get_callback_te_t*> get_callback_te_map_t;
 	typedef std::set<LLUUID> getall_queue_t;
 	typedef std::map<LLUUID, F64> getall_pending_map_t;
 	typedef std::map<LLUUID, getall_callback_t*> getall_callback_map_t;
@@ -145,6 +138,24 @@ private:
 
 	U32 getMaxEntries(const LLViewerRegion* regionp);
 };
+
+// std::hash implementation for TEMaterialPair
+namespace std
+{
+	template<> struct hash<LLMaterialMgr::TEMaterialPair>
+	{
+		inline size_t operator()(const LLMaterialMgr::TEMaterialPair& p) const noexcept
+		{
+			return size_t((p.te + 1) * p.materialID.getDigest64());
+		}
+	};
+}
+
+// For use with boost containers.
+inline size_t hash_value(const LLMaterialMgr::TEMaterialPair& p) noexcept
+{
+	return size_t((p.te + 1) * p.materialID.getDigest64());
+}
 
 #endif // LL_LLMATERIALMGR_H
 

--- a/indra/newview/lloutfitobserver.cpp
+++ b/indra/newview/lloutfitobserver.cpp
@@ -34,7 +34,6 @@
 LLOutfitObserver::LLOutfitObserver() :
 	mCOFLastVersion(LLViewerInventoryCategory::VERSION_UNKNOWN)
 {
-	mItemNameHash.finalize();
 	gInventory.addObserver(this);
 }
 
@@ -83,7 +82,7 @@ bool LLOutfitObserver::checkCOF()
 		return false;
 
 	bool cof_changed = false;
-	LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cof);
+	LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cof);
 	if (item_name_hash != mItemNameHash)
 	{
 		cof_changed = true;

--- a/indra/newview/lloutfitobserver.h
+++ b/indra/newview/lloutfitobserver.h
@@ -28,7 +28,6 @@
 #define LL_OUTFITOBSERVER_H
 
 #include "llsingleton.h"
-#include "llmd5.h"
 
 /**
  * Outfit observer facade that provides simple possibility to subscribe on
@@ -78,7 +77,7 @@ protected:
 
 	bool mLastOutfitDirtiness;
 
-	LLMD5 mItemNameHash;
+	LLUUID mItemNameHash;
 
 private:
 	signal_t mBOFReplaced;

--- a/indra/newview/llviewerwearable.h
+++ b/indra/newview/llviewerwearable.h
@@ -93,7 +93,6 @@ public:
 	// the wearable was worn. make sure the name of the wearable object matches the LLViewerInventoryItem,
 	// not the wearable asset itself.
 	void				refreshName();
-	/*virtual*/void		addToBakedTextureHash(LLMD5& hash) const {}
 
 protected:
 	LLAssetID			mAssetID;


### PR DESCRIPTION
LLUUID and LLMaterialID already have an excellent entropy and value dispersion; there is therefore strictly no need to further (slowly) hash their value for use with std and boost libraries containers.

This commit adds a trivial getDigest64() method to both LLUUID and LLMaterialID (which simply returns the XOR of the two 64 bits long words their value is made of), and uses it in std::hash and hash_value() specializations for use with containers.