### PR TITLE
Faster and simpler inventory category hashing.

### DIFF
--- a/indra/llappearance/llwearable.h
+++ b/indra/llappearance/llwearable.h
@@ -32,7 +32,6 @@
 #include "llsaleinfo.h"
 #include "llwearabletype.h"
 
-class LLMD5;
 class LLVisualParam;
 class LLTexGlobalColorInfo;
 class LLTexGlobalColor;
@@ -109,9 +108,6 @@ public:
 
 	// Something happened that requires the wearable to be updated (e.g. worn/unworn).
 	virtual void		setUpdated() const = 0;
-
-	// Update the baked texture hash.
-	virtual void		addToBakedTextureHash(LLMD5& hash) const = 0;
 
 	typedef std::map<S32, LLVisualParam *>    visual_param_index_map_t;
 	visual_param_index_map_t mVisualParamIndexMap;

--- a/indra/llappearance/llwearabledata.cpp
+++ b/indra/llappearance/llwearabledata.cpp
@@ -31,7 +31,6 @@
 #include "llavatarappearance.h"
 #include "llavatarappearancedefines.h"
 #include "lldriverparam.h"
-#include "llmd5.h"
 
 LLWearableData::LLWearableData() :
 	mAvatarAppearance(NULL)
@@ -343,42 +342,3 @@ U32 LLWearableData::getWearableCount(const U32 tex_index) const
 	const LLWearableType::EType wearable_type = LLAvatarAppearance::getDictionary()->getTEWearableType((LLAvatarAppearanceDefines::ETextureIndex)tex_index);
 	return getWearableCount(wearable_type);
 }
-
-LLUUID LLWearableData::computeBakedTextureHash(LLAvatarAppearanceDefines::EBakedTextureIndex baked_index,
-												 BOOL generate_valid_hash) // Set to false if you want to upload the baked texture w/o putting it in the cache
-{
-	LLUUID hash_id;
-	bool hash_computed = false;
-	LLMD5 hash;
-	const LLAvatarAppearanceDictionary::BakedEntry *baked_dict = LLAvatarAppearance::getDictionary()->getBakedTexture(baked_index);
-
-	for (U8 i=0; i < baked_dict->mWearables.size(); i++)
-	{
-		const LLWearableType::EType baked_type = baked_dict->mWearables[i];
-		const U32 num_wearables = getWearableCount(baked_type);
-		for (U32 index = 0; index < num_wearables; ++index)
-		{
-			const LLWearable* wearable = getWearable(baked_type,index);
-			if (wearable)
-			{
-				wearable->addToBakedTextureHash(hash);
-				hash_computed = true;
-			}
-		}
-	}
-	if (hash_computed)
-	{
-		hash.update((const unsigned char*)baked_dict->mWearablesHashID.mData, UUID_BYTES);
-
-		if (!generate_valid_hash)
-		{
-			invalidateBakedTextureHash(hash);
-		}
-		hash.finalize();
-		hash.raw_digest(hash_id.mData);
-	}
-
-	return hash_id;
-}
-
-

--- a/indra/llappearance/llwearabledata.h
+++ b/indra/llappearance/llwearabledata.h
@@ -86,15 +86,6 @@ private:
 	void			pullCrossWearableValues(const LLWearableType::EType type);
 
 	//--------------------------------------------------------------------
-	// Server Communication
-	//--------------------------------------------------------------------
-public:
-	LLUUID			computeBakedTextureHash(LLAvatarAppearanceDefines::EBakedTextureIndex baked_index,
-											BOOL generate_valid_hash = TRUE);
-protected:
-	virtual void	invalidateBakedTextureHash(LLMD5& hash) const {}
-
-	//--------------------------------------------------------------------
 	// Member variables
 	//--------------------------------------------------------------------
 protected:

--- a/indra/newview/llagentwearables.cpp
+++ b/indra/newview/llagentwearables.cpp
@@ -41,7 +41,6 @@
 #include "llinventoryobserver.h"
 #include "llinventorypanel.h"
 #include "lllocaltextureobject.h"
-#include "llmd5.h"
 #include "llnotificationsutil.h"
 #include "lloutfitobserver.h"
 #include "llsidepanelappearance.h"

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -452,7 +452,7 @@ void LLInventoryModel::getDirectDescendentsOf(const LLUUID& cat_id,
 	items = get_ptr_in_map(mParentChildItemTree, cat_id);
 }
 
-LLUUID LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
+LLInventoryModel::digest_t LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
 {
 	LLInventoryModel::cat_array_t* cat_array;
 	LLInventoryModel::item_array_t* item_array;

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -62,6 +62,7 @@
 #include "bufferarray.h"
 #include "bufferstream.h"
 #include "llcorehttputil.h"
+#include "hbxxh.h"
 
 //#define DIFF_INVENTORY_FILES
 #ifdef DIFF_INVENTORY_FILES
@@ -451,17 +452,16 @@ void LLInventoryModel::getDirectDescendentsOf(const LLUUID& cat_id,
 	items = get_ptr_in_map(mParentChildItemTree, cat_id);
 }
 
-LLMD5 LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
+LLUUID LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
 {
 	LLInventoryModel::cat_array_t* cat_array;
 	LLInventoryModel::item_array_t* item_array;
 	getDirectDescendentsOf(cat_id,cat_array,item_array);
-	LLMD5 item_name_hash;
 	if (!item_array)
 	{
-		item_name_hash.finalize();
-		return item_name_hash;
+		return LLUUID::null;
 	}
+	HBXXH128 item_name_hash;
 	for (LLInventoryModel::item_array_t::const_iterator iter = item_array->begin();
 		 iter != item_array->end();
 		 iter++)
@@ -471,8 +471,7 @@ LLMD5 LLInventoryModel::hashDirectDescendentNames(const LLUUID& cat_id) const
 			continue;
 		item_name_hash.update(item->getName());
 	}
-	item_name_hash.finalize();
-	return item_name_hash;
+	return item_name_hash.digest();
 }
 
 // SJB: Added version to lock the arrays to catch potential logic bugs

--- a/indra/newview/llinventorymodel.h
+++ b/indra/newview/llinventorymodel.h
@@ -39,7 +39,6 @@
 #include "llpermissionsflags.h"
 #include "llviewerinventory.h"
 #include "llstring.h"
-#include "llmd5.h"
 #include "httpcommon.h"
 #include "httprequest.h"
 #include "httpoptions.h"
@@ -258,7 +257,7 @@ public:
 								item_array_t*& items) const;
 
 	// Compute a hash of direct descendant names (for detecting child name changes)
-	LLMD5 hashDirectDescendentNames(const LLUUID& cat_id) const;
+	LLUUID hashDirectDescendentNames(const LLUUID& cat_id) const;
 	
 	// Starting with the object specified, add its descendants to the
 	// array provided, but do not add the inventory object specified

--- a/indra/newview/llinventorymodel.h
+++ b/indra/newview/llinventorymodel.h
@@ -256,8 +256,9 @@ public:
 								cat_array_t*& categories,
 								item_array_t*& items) const;
 
+	typedef LLUUID digest_t; // To clarify the actual usage of this "UUID"
 	// Compute a hash of direct descendant names (for detecting child name changes)
-	LLUUID hashDirectDescendentNames(const LLUUID& cat_id) const;
+	digest_t hashDirectDescendentNames(const LLUUID& cat_id) const;
 	
 	// Starting with the object specified, add its descendants to the
 	// array provided, but do not add the inventory object specified

--- a/indra/newview/llinventoryobserver.cpp
+++ b/indra/newview/llinventoryobserver.cpp
@@ -640,7 +640,7 @@ void LLInventoryCategoriesObserver::changed(U32 mask)
 		// computed, or (b) a name has changed.
 		if (!cat_data.mIsNameHashInitialized || (mask & LLInventoryObserver::LABEL))
 		{
-			LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			if (cat_data.mItemNameHash != item_name_hash)
 			{
 				cat_data.mIsNameHashInitialized = true;
@@ -701,7 +701,7 @@ bool LLInventoryCategoriesObserver::addCategory(const LLUUID& cat_id, callback_t
 	{
 		if(init_name_hash)
 		{
-			LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			mCategoryMap.insert(category_map_value_t(cat_id,LLCategoryData(cat_id, cb, version, current_num_known_descendents,item_name_hash)));
 		}
 		else
@@ -727,11 +727,10 @@ LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
 	, mDescendentsCount(num_descendents)
 	, mIsNameHashInitialized(false)
 {
-	mItemNameHash.finalize();
 }
 
 LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
-	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, LLMD5 name_hash)
+	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash)
 
 	: mCatID(cat_id)
 	, mCallback(cb)

--- a/indra/newview/llinventoryobserver.cpp
+++ b/indra/newview/llinventoryobserver.cpp
@@ -640,7 +640,7 @@ void LLInventoryCategoriesObserver::changed(U32 mask)
 		// computed, or (b) a name has changed.
 		if (!cat_data.mIsNameHashInitialized || (mask & LLInventoryObserver::LABEL))
 		{
-			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			digest_t item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			if (cat_data.mItemNameHash != item_name_hash)
 			{
 				cat_data.mIsNameHashInitialized = true;
@@ -701,7 +701,7 @@ bool LLInventoryCategoriesObserver::addCategory(const LLUUID& cat_id, callback_t
 	{
 		if(init_name_hash)
 		{
-			LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
+			digest_t item_name_hash = gInventory.hashDirectDescendentNames(cat_id);
 			mCategoryMap.insert(category_map_value_t(cat_id,LLCategoryData(cat_id, cb, version, current_num_known_descendents,item_name_hash)));
 		}
 		else
@@ -730,7 +730,7 @@ LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
 }
 
 LLInventoryCategoriesObserver::LLCategoryData::LLCategoryData(
-	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash)
+	const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const digest_t& name_hash)
 
 	: mCatID(cat_id)
 	, mCallback(cb)

--- a/indra/newview/llinventoryobserver.h
+++ b/indra/newview/llinventoryobserver.h
@@ -270,14 +270,15 @@ public:
 	void removeCategory(const LLUUID& cat_id);
 
 protected:
+	typedef LLUUID digest_t; // To clarify the actual usage of this "UUID"
 	struct LLCategoryData
 	{
 		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents);
-		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash);
+		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const digest_t& name_hash);
 		callback_t	mCallback;
 		S32			mVersion;
 		S32			mDescendentsCount;
-		LLUUID		mItemNameHash;
+		digest_t	mItemNameHash;
 		bool		mIsNameHashInitialized;
 		LLUUID		mCatID;
 	};

--- a/indra/newview/llinventoryobserver.h
+++ b/indra/newview/llinventoryobserver.h
@@ -28,7 +28,6 @@
 #define LL_LLINVENTORYOBSERVERS_H
 
 #include "lluuid.h"
-#include "llmd5.h"
 #include <string>
 #include <vector>
 
@@ -274,11 +273,11 @@ protected:
 	struct LLCategoryData
 	{
 		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents);
-		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, LLMD5 name_hash);
+		LLCategoryData(const LLUUID& cat_id, callback_t cb, S32 version, S32 num_descendents, const LLUUID& name_hash);
 		callback_t	mCallback;
 		S32			mVersion;
 		S32			mDescendentsCount;
-		LLMD5		mItemNameHash;
+		LLUUID		mItemNameHash;
 		bool		mIsNameHashInitialized;
 		LLUUID		mCatID;
 	};

--- a/indra/newview/lloutfitobserver.cpp
+++ b/indra/newview/lloutfitobserver.cpp
@@ -34,7 +34,6 @@
 LLOutfitObserver::LLOutfitObserver() :
 	mCOFLastVersion(LLViewerInventoryCategory::VERSION_UNKNOWN)
 {
-	mItemNameHash.finalize();
 	gInventory.addObserver(this);
 }
 
@@ -83,7 +82,7 @@ bool LLOutfitObserver::checkCOF()
 		return false;
 
 	bool cof_changed = false;
-	LLMD5 item_name_hash = gInventory.hashDirectDescendentNames(cof);
+	LLUUID item_name_hash = gInventory.hashDirectDescendentNames(cof);
 	if (item_name_hash != mItemNameHash)
 	{
 		cof_changed = true;

--- a/indra/newview/lloutfitobserver.h
+++ b/indra/newview/lloutfitobserver.h
@@ -28,7 +28,6 @@
 #define LL_OUTFITOBSERVER_H
 
 #include "llsingleton.h"
-#include "llmd5.h"
 
 /**
  * Outfit observer facade that provides simple possibility to subscribe on
@@ -78,7 +77,7 @@ protected:
 
 	bool mLastOutfitDirtiness;
 
-	LLMD5 mItemNameHash;
+	LLUUID mItemNameHash;
 
 private:
 	signal_t mBOFReplaced;

--- a/indra/newview/llviewerwearable.h
+++ b/indra/newview/llviewerwearable.h
@@ -93,7 +93,6 @@ public:
 	// the wearable was worn. make sure the name of the wearable object matches the LLViewerInventoryItem,
 	// not the wearable asset itself.
 	void				refreshName();
-	/*virtual*/void		addToBakedTextureHash(LLMD5& hash) const {}
 
 protected:
 	LLAssetID			mAssetID;


### PR DESCRIPTION
This commit changes inventory category hashing from slow LLMD5 to fast HBXX128 hashing, and allows to use a simple LLUUID for the hash, instead of an LLMD5 instance. It also removes some old cruft dealing with unused baked texture hashing.