### PR TITLE
SL-19121: Add some override tests

### DIFF
--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -31,14 +31,14 @@
 // NOTE -- this should be the one and only place tiny_gltf.h is included
 #include "tinygltf/tiny_gltf.h"
 
-const char* LLGLTFMaterial::ASSET_VERSION = "1.1";
-const char* LLGLTFMaterial::ASSET_TYPE = "GLTF 2.0";
+const char* const LLGLTFMaterial::ASSET_VERSION = "1.1";
+const char* const LLGLTFMaterial::ASSET_TYPE = "GLTF 2.0";
 const std::array<std::string, 2> LLGLTFMaterial::ACCEPTED_ASSET_VERSIONS = { "1.0", "1.1" };
 
-const char* GLTF_FILE_EXTENSION_TRANSFORM = "KHR_texture_transform";
-const char* GLTF_FILE_EXTENSION_TRANSFORM_SCALE = "scale";
-const char* GLTF_FILE_EXTENSION_TRANSFORM_OFFSET = "offset";
-const char* GLTF_FILE_EXTENSION_TRANSFORM_ROTATION = "rotation";
+const char* const GLTF_FILE_EXTENSION_TRANSFORM = "KHR_texture_transform";
+const char* const GLTF_FILE_EXTENSION_TRANSFORM_SCALE = "scale";
+const char* const GLTF_FILE_EXTENSION_TRANSFORM_OFFSET = "offset";
+const char* const GLTF_FILE_EXTENSION_TRANSFORM_ROTATION = "rotation";
 
 // special UUID that indicates a null UUID in override data
 static const LLUUID GLTF_OVERRIDE_NULL_UUID = LLUUID("ffffffff-ffff-ffff-ffff-ffffffffffff");

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -49,8 +49,8 @@ public:
     // default material for reference
     static const LLGLTFMaterial sDefault;
 
-    static const char* ASSET_VERSION;
-    static const char* ASSET_TYPE;
+    static const char* const ASSET_VERSION;
+    static const char* const ASSET_TYPE;
     static const std::array<std::string, 2> ACCEPTED_ASSET_VERSIONS;
     static bool isAcceptedVersion(const std::string& version) { return std::find(ACCEPTED_ASSET_VERSIONS.cbegin(), ACCEPTED_ASSET_VERSIONS.cend(), version) != ACCEPTED_ASSET_VERSIONS.cend(); }
 

--- a/indra/llprimitive/tests/llgltfmaterial_test.cpp
+++ b/indra/llprimitive/tests/llgltfmaterial_test.cpp
@@ -339,4 +339,31 @@ namespace tut
             }
         }
     }
+
+    // Test non-persistence of default value flags in overrides
+    template<> template<>
+    void llgltfmaterial_object_t::test<11>()
+    {
+        const S32 non_default_alpha_modes[] = { LLGLTFMaterial::ALPHA_MODE_BLEND, LLGLTFMaterial::ALPHA_MODE_MASK };
+        for (S32 non_default_alpha_mode : non_default_alpha_modes)
+        {
+            LLGLTFMaterial material;
+            // Set default alpha mode
+            material.setAlphaMode(LLGLTFMaterial::ALPHA_MODE_OPAQUE, true);
+            ensure_equals("LLGLTFMaterial: alpha mode override flag set", material.mOverrideAlphaMode, true);
+            // Set non-default alpha mode
+            material.setAlphaMode(non_default_alpha_mode, true);
+            ensure_equals("LLGLTFMaterial: alpha mode override flag unset", material.mOverrideAlphaMode, false);
+        }
+
+        {
+            // Set default double sided
+            LLGLTFMaterial material;
+            material.setDoubleSided(false, true);
+            ensure_equals("LLGLTFMaterial: double sided override flag set", material.mOverrideDoubleSided, true);
+            // Set non-default double sided
+            material.setDoubleSided(true, true);
+            ensure_equals("LLGLTFMaterial: double sided override flag unset", material.mOverrideDoubleSided, false);
+        }
+    }
 }

--- a/indra/llprimitive/tests/llgltfmaterial_test.cpp
+++ b/indra/llprimitive/tests/llgltfmaterial_test.cpp
@@ -139,14 +139,13 @@ namespace tut
     template<> template<>
     void llgltfmaterial_object_t::test<1>()
     {
-        if (sizeof(void*) > 4) // Don't bother running this test for 32-bit systems
-        {
-            // If any fields are added/changed, these tests should be updated (consider also updating ASSET_VERSION in LLGLTFMaterial)
-            // This test result will vary between compilers, so only test a single platform
+#if ADDRESS_SIZE != 32
 #if LL_WINDOWS
-            ensure_equals("fields supported for GLTF (sizeof check)", sizeof(LLGLTFMaterial), 216);
+        // If any fields are added/changed, these tests should be updated (consider also updating ASSET_VERSION in LLGLTFMaterial)
+        // This test result will vary between compilers, so only test a single platform
+        ensure_equals("fields supported for GLTF (sizeof check)", sizeof(LLGLTFMaterial), 216);
 #endif
-        }
+#endif
         ensure_equals("LLGLTFMaterial texture info count", (U32)LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT, 4);
     }
 


### PR DESCRIPTION
These tests confirm material overrides behave as expected for a few select cases.

For merge convenience, these are built on top of [SL-19080](https://jira.secondlife.com/browse/SL-19080), which is delayed by server changes. This PR will reviewed/merged after SL-19080 .