### PR TITLE
Fix for crash on startup for M1 macs

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/shadowUtil.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/shadowUtil.glsl
@@ -59,12 +59,12 @@ float pcfShadow(sampler2DShadow shadowMap, vec3 norm, vec4 stc, float bias_mul, 
     stc.xyz /= stc.w;
     stc.z += offset * 2.0;
     stc.x = floor(stc.x*shadow_res.x + fract(pos_screen.y*shadow_res.y))/shadow_res.x; // add some chaotic jitter to X sample pos according to Y to disguise the snapping going on here
-    float cs = texture(shadowMap, stc.xyz).x;
+    float cs = texture(shadowMap, stc.xyz);
     float shadow = cs * 4.0;
-    shadow += texture(shadowMap, stc.xyz+vec3( 1.5/shadow_res.x,  0.5/shadow_res.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3( 0.5/shadow_res.x, -1.5/shadow_res.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3(-1.5/shadow_res.x, -0.5/shadow_res.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3(-0.5/shadow_res.x,  1.5/shadow_res.y, 0.0)).x;
+    shadow += texture(shadowMap, stc.xyz+vec3( 1.5/shadow_res.x,  0.5/shadow_res.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3( 0.5/shadow_res.x, -1.5/shadow_res.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3(-1.5/shadow_res.x, -0.5/shadow_res.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3(-0.5/shadow_res.x,  1.5/shadow_res.y, 0.0));
     return clamp(shadow * 0.125, 0.0, 1.0);
 #else
     return 1.0;
@@ -78,16 +78,16 @@ float pcfSpotShadow(sampler2DShadow shadowMap, vec4 stc, float bias_scale, vec2 
     stc.z += spot_shadow_bias * bias_scale;
     stc.x = floor(proj_shadow_res.x * stc.x + fract(pos_screen.y*0.666666666)) / proj_shadow_res.x; // snap
 
-    float cs = texture(shadowMap, stc.xyz).x;
+    float cs = texture(shadowMap, stc.xyz);
     float shadow = cs;
 
     vec2 off = 1.0/proj_shadow_res;
     off.y *= 1.5;
     
-    shadow += texture(shadowMap, stc.xyz+vec3(off.x*2.0, off.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3(off.x, -off.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3(-off.x, off.y, 0.0)).x;
-    shadow += texture(shadowMap, stc.xyz+vec3(-off.x*2.0, -off.y, 0.0)).x;
+    shadow += texture(shadowMap, stc.xyz+vec3(off.x*2.0, off.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3(off.x, -off.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3(-off.x, off.y, 0.0));
+    shadow += texture(shadowMap, stc.xyz+vec3(-off.x*2.0, -off.y, 0.0));
     return shadow*0.2;
 #else
     return 1.0;


### PR DESCRIPTION
Looks like on M1 (and potentially Apple Silicon generally) - texture when sampling a shadow map implicitly returns a float causing the GLSL compiler to choke on startup on shadowUtil.