### PR TITLE
SL-17640 Fix 'Apply now' being enabled when importing

### DIFF
--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -420,6 +420,13 @@ BOOL LLMaterialEditor::postBuild()
         mEmissiveTextureCtrl->setOnSelectCallback(boost::bind(&LLMaterialEditor::onSelectCtrl, this, _1, _2, MATERIAL_EMISIVE_TEX_DIRTY));
         mNormalTextureCtrl->setOnSelectCallback(boost::bind(&LLMaterialEditor::onSelectCtrl, this, _1, _2, MATERIAL_NORMAL_TEX_DIRTY));
     }
+    else
+    {
+        mBaseColorTextureCtrl->setCanApplyImmediately(false);
+        mMetallicTextureCtrl->setCanApplyImmediately(false);
+        mEmissiveTextureCtrl->setCanApplyImmediately(false);
+        mNormalTextureCtrl->setCanApplyImmediately(false);
+    }
 
     if (!mIsOverride)
     {
@@ -461,6 +468,10 @@ BOOL LLMaterialEditor::postBuild()
         mBaseColorCtrl->setOnCancelCallback(boost::bind(&LLMaterialEditor::onCancelCtrl, this, _1, _2, MATERIAL_BASE_COLOR_DIRTY));
         mBaseColorCtrl->setOnSelectCallback(boost::bind(&LLMaterialEditor::onSelectCtrl, this, _1, _2, MATERIAL_BASE_COLOR_DIRTY));
     }
+    else
+    {
+        mBaseColorCtrl->setCanApplyImmediately(false);
+    }
     // transparency is a part of base color
     childSetCommitCallback("transparency", changes_callback, (void*)&MATERIAL_BASE_COLOR_DIRTY);
     childSetCommitCallback("alpha mode", changes_callback, (void*)&MATERIAL_ALPHA_MODE_DIRTY);
@@ -476,6 +487,10 @@ BOOL LLMaterialEditor::postBuild()
     {
         mEmissiveColorCtrl->setOnCancelCallback(boost::bind(&LLMaterialEditor::onCancelCtrl, this, _1, _2, MATERIAL_EMISIVE_COLOR_DIRTY));
         mEmissiveColorCtrl->setOnSelectCallback(boost::bind(&LLMaterialEditor::onSelectCtrl, this, _1, _2, MATERIAL_EMISIVE_COLOR_DIRTY));
+    }
+    else
+    {
+        mEmissiveColorCtrl->setCanApplyImmediately(false);
     }
 
     if (!mIsOverride)

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -251,7 +251,9 @@ void LLFloaterTexturePicker::setCanApplyImmediately(BOOL b)
 {
 	mCanApplyImmediately = b;
 
-	getChild<LLUICtrl>("apply_immediate_check")->setValue(mCanApplyImmediately);
+    LLUICtrl *apply_checkbox = getChild<LLUICtrl>("apply_immediate_check");
+    apply_checkbox->setValue(mCanApplyImmediately && gSavedSettings.getBOOL("TextureLivePreview"));
+    apply_checkbox->setEnabled(mCanApplyImmediately);
 }
 
 void LLFloaterTexturePicker::stopUsingPipette()
@@ -528,7 +530,7 @@ BOOL LLFloaterTexturePicker::postBuild()
 
 	mNoCopyTextureSelected = FALSE;
 
-	getChild<LLUICtrl>("apply_immediate_check")->setValue(gSavedSettings.getBOOL("TextureLivePreview"));
+	getChild<LLUICtrl>("apply_immediate_check")->setValue(mCanApplyImmediately && gSavedSettings.getBOOL("TextureLivePreview"));
 	childSetCommitCallback("apply_immediate_check", onApplyImmediateCheck, this);
     getChildView("apply_immediate_check")->setEnabled(mCanApplyImmediately);
 
@@ -862,7 +864,7 @@ void LLFloaterTexturePicker::onSelectionChange(const std::deque<LLFolderViewItem
 
 			if(!mPreviewSettingChanged)
 			{
-				mCanPreview = gSavedSettings.getBOOL("TextureLivePreview");
+				mCanPreview = mCanApplyImmediately && gSavedSettings.getBOOL("TextureLivePreview");
 			}
 			else
 			{
@@ -1163,7 +1165,7 @@ void LLFloaterTexturePicker::onBakeTextureSelect(LLUICtrl* ctrl, void *user_data
 
 	if (!self->mPreviewSettingChanged)
 	{
-		self->mCanPreview = gSavedSettings.getBOOL("TextureLivePreview");
+		self->mCanPreview = self->mCanApplyImmediately && gSavedSettings.getBOOL("TextureLivePreview");
 	}
 	else
 	{
@@ -1184,7 +1186,7 @@ void LLFloaterTexturePicker::setCanApply(bool can_preview, bool can_apply)
 	getChildRef<LLUICtrl>("apply_immediate_check").setVisible(can_preview);
 
 	mCanApply = can_apply;
-	mCanPreview = can_preview ? gSavedSettings.getBOOL("TextureLivePreview") : false;
+	mCanPreview = can_preview ? (mCanApplyImmediately && gSavedSettings.getBOOL("TextureLivePreview")) : false;
 	mPreviewSettingChanged = true;
 }
 


### PR DESCRIPTION
According to mockup in [SL-17640](https://jira.secondlife.com/browse/SL-17640), 'apply now' shouldn't be enabled when importing material or opening from inventory. "Apply now" does nothing in these to cases.

This commit should:
1. Disable "Apply now" for textures and colors
2. Fix inconsistencies in how texture picker uses mCanApplyImmediately