### PR TITLE
Stream all animations through puppetry channel

### DIFF
--- a/indra/llappearance/llavatarappearance.h
+++ b/indra/llappearance/llavatarappearance.h
@@ -133,7 +133,7 @@ protected:
 
 public:
 	F32					getPelvisToFoot() const { return mPelvisToFoot; }
-	/*virtual*/ LLJoint*	getRootJoint() { return mRoot; }
+	LLJoint*	        getRootJoint() override { return mRoot; }
 
 	LLVector3			mHeadOffset; // current head position
 	LLAvatarJoint		*mRoot;

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -591,6 +591,7 @@ set(viewer_SOURCE_FILES
     llstartup.cpp
     llstartuplistener.cpp
     llstatusbar.cpp
+    llstreamingmotion.cpp
     llstylemap.cpp
     llsurface.cpp
     llsurfacepatch.cpp
@@ -1224,6 +1225,7 @@ set(viewer_HEADER_FILES
     llstartup.h
     llstartuplistener.h
     llstatusbar.h
+    llstreamingmotion.h
     llstylemap.h
     llsurface.h
     llsurfacepatch.h

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -3181,7 +3181,13 @@ LLQuaternion LLAgent::getHeadRotation()
 
 void LLAgent::sendAnimationRequests(const std::vector<LLUUID> &anim_ids, EAnimRequest request)
 {
-	if (LLStreamingMotion::GetIsSendingAnimationStream() || gAgentID.isNull())
+    // Note: we continue to send animation requests
+    // for any viewers lacking puppetry support
+    // however if animation-streaming works great in the end
+    // and is adopted everywhere...
+    // then we could purge this logic.
+
+	if (gAgentID.isNull())
 	{
 		return;
 	}

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -72,6 +72,7 @@
 #include "llsmoothstep.h"
 #include "llstartup.h"
 #include "llstatusbar.h"
+#include "llstreamingmotion.h"
 #include "llteleportflags.h"
 #include "lltool.h"
 #include "lltoolbarview.h"
@@ -3180,7 +3181,7 @@ LLQuaternion LLAgent::getHeadRotation()
 
 void LLAgent::sendAnimationRequests(const std::vector<LLUUID> &anim_ids, EAnimRequest request)
 {
-	if (gAgentID.isNull())
+	if (LLStreamingMotion::GetIsSendingAnimationStream() || gAgentID.isNull())
 	{
 		return;
 	}

--- a/indra/newview/llpuppetevent.cpp
+++ b/indra/newview/llpuppetevent.cpp
@@ -42,7 +42,7 @@ U8      PUPPET_WRITE_BUFFER[PUPPET_MAX_EVENT_BYTES]; //HACK move this somewhere 
 
 // Helper function
 // Note that the passed in vector is quantized
-size_t pack_vec3(U8* wptr, LLVector3 &vec)
+size_t LLIK::pack_vec3(U8* wptr, LLVector3 vec)
 {
     size_t offset(0);
 
@@ -65,7 +65,7 @@ size_t pack_vec3(U8* wptr, LLVector3 &vec)
 
 // Helper function
 // Note that the passed in quaternion is quantized and possibly negated
-size_t pack_quat(U8* wptr, LLQuaternion& quat)
+size_t LLIK::pack_quat(U8* wptr, LLQuaternion quat)
 {
     // A Quaternion is a 4D object but the group isomorphic with rotations is
     // limited to the surface of the unit hypersphere (radius = 1). Consequently
@@ -232,15 +232,15 @@ size_t LLPuppetJointEvent::pack(U8* wptr)
     //Pack these into the buffer in the same order as the flags.
     if (mMask & LLIK::MASK_ROT)
     {
-        offset += pack_quat(wptr + offset, mRotation);
+        offset += LLIK::pack_quat(wptr + offset, mRotation);
     }
     if (mMask & LLIK::MASK_POS)
     {
-        offset += pack_vec3(wptr+offset, mPosition);
+        offset += LLIK::pack_vec3(wptr + offset, mPosition);
     }
     if (mMask & LLIK::CONFIG_FLAG_LOCAL_SCALE)
     {
-        offset += pack_vec3(wptr+offset, mScale);
+        offset += LLIK::pack_vec3(wptr + offset, mScale);
     }
 
     LL_DEBUGS("PUPPET_SPAM_PACK") << "Packed event for joint " << mJointID << " with flags 0x" << std::hex << static_cast<S32>(mMask) << std::dec << " into " << offset << " bytes.";

--- a/indra/newview/llpuppetevent.h
+++ b/indra/newview/llpuppetevent.h
@@ -40,6 +40,11 @@
 #include "v3math.h"
 #include "llframetimer.h"
 
+namespace LLIK {
+    size_t pack_vec3(U8* wptr, LLVector3 vec);
+    size_t pack_quat(U8* wptr, LLQuaternion quat);
+};
+
 class LLPuppetJointEvent
 {
     //Information about an expression event that we want to broadcast
@@ -81,7 +86,7 @@ private:
     LLQuaternion mRotation;
     LLVector3 mPosition;
     LLVector3 mScale;
-    U16 mJointID = -1;
+    S16 mJointID = -1;
     U8 mMask = 0x0;
 };
 

--- a/indra/newview/llpuppetmodule.cpp
+++ b/indra/newview/llpuppetmodule.cpp
@@ -41,6 +41,7 @@
 #include "llleap.h"
 #include "llpuppetmotion.h"
 #include "llsdutil.h"
+#include "llstreamingmotion.h"
 #include "llviewercontrol.h"    // gSavedSettings
 #include "llviewerobjectlist.h" //gObjectList
 #include "llviewerregion.h"
@@ -583,7 +584,15 @@ void LLPuppetModule::setPuppetryOptions(LLSD options)
 void LLPuppetModule::parsePuppetryResponse(LLSD response)
 {
     mPlayServerEcho = response["echo_back"].asBoolean();
-    mIsSending = response["transmit"].asBoolean();
+
+    // HACK: streaming animations is tied to whether "puppetry sending" is enabled.
+    bool is_sending = response["transmit"].asBoolean();
+    if (is_sending != mIsSending)
+    {
+        mIsSending = is_sending;
+        LLStreamingMotion::SetIsSendingAnimationStream(is_sending);
+        LLStreamingMotion::SetIsSendingAnimationStream(is_sending);
+    }
     mIsReceiving = response["receive"].asBoolean();
     mRange = response["range"].asReal();
 

--- a/indra/newview/llpuppetmodule.cpp
+++ b/indra/newview/llpuppetmodule.cpp
@@ -584,12 +584,7 @@ void LLPuppetModule::setPuppetryOptions(LLSD options)
 void LLPuppetModule::parsePuppetryResponse(LLSD response)
 {
     mPlayServerEcho = response["echo_back"].asBoolean();
-
-    bool is_sending = response["transmit"].asBoolean();
-    if (is_sending != mIsSending)
-    {
-        mIsSending = is_sending;
-    }
+    mIsSending = is_sending = response["transmit"].asBoolean();
     mIsReceiving = response["receive"].asBoolean();
     mRange = response["range"].asReal();
 

--- a/indra/newview/llpuppetmodule.cpp
+++ b/indra/newview/llpuppetmodule.cpp
@@ -585,13 +585,10 @@ void LLPuppetModule::parsePuppetryResponse(LLSD response)
 {
     mPlayServerEcho = response["echo_back"].asBoolean();
 
-    // HACK: streaming animations is tied to whether "puppetry sending" is enabled.
     bool is_sending = response["transmit"].asBoolean();
     if (is_sending != mIsSending)
     {
         mIsSending = is_sending;
-        LLStreamingMotion::SetIsSendingAnimationStream(is_sending);
-        LLStreamingMotion::SetIsSendingAnimationStream(is_sending);
     }
     mIsReceiving = response["receive"].asBoolean();
     mRange = response["range"].asReal();

--- a/indra/newview/llpuppetmodule.h
+++ b/indra/newview/llpuppetmodule.h
@@ -104,7 +104,11 @@ public:
     const active_joint_map_t & getActiveJoints() const { return mActiveJoints; }
 
     void parsePuppetryResponse(LLSD response);
+
+    void pumpOutgoingEvents();
 private:
+
+    void packEvents();
 
     virtual ~LLPuppetModule()
     {
@@ -125,6 +129,8 @@ private:
     bool mIsReceiving = true;     // true when getting stream from simulator
     LLSD mSkeletonData;           // Send to the expression module on request.
     F32  mRange = 25.0f;
+
+    U64 mBroadcastExpiry = 0;
 };
 
 #endif

--- a/indra/newview/llstreamingmotion.cpp
+++ b/indra/newview/llstreamingmotion.cpp
@@ -1,0 +1,393 @@
+/**
+ * @file llstreamingmotion.cpp
+ * @brief LLStreamingMotion is an LLMotion which plays animation stream from server
+ *
+ * $LicenseInfo:firstyear=2023&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2023, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "llviewerprecompiledheaders.h"
+
+#include <set>
+#include <limits>
+
+#include "llagent.h"
+#include "llagentcamera.h"
+#include "llagentdata.h"
+#include "llcharacter.h"
+#include "lldatapacker.h"
+#include "llframetimer.h"
+#include "llstreamingmotion.h"
+#include "llpuppetmodule.h"
+#include "llviewerregion.h"
+#include "llvoavatar.h"
+#include "v3dmath.h"
+#include "llsdutil_math.h"        //For ll_sd_from_vector3
+
+#include "llvoavatarself.h"
+
+#define ENABLE_RIGHT_CONSTRAINTS
+
+// BEGIN_HACK : hard-coded joint_ids
+//constexpr U16 PELVIS_ID = 0;
+constexpr U16 TORSO_ID = 3;
+constexpr U16 CHEST_ID = 6;
+constexpr U16 NECK_ID = 7;
+constexpr U16 HEAD_ID = 8;
+constexpr S16 COLLAR_LEFT_ID = 58;
+constexpr S16 SHOULDER_LEFT_ID = 59;
+constexpr S16 ELBOW_LEFT_ID = 60;
+constexpr S16 WRIST_LEFT_ID = 61;
+
+constexpr S16 HAND_MIDDLE_LEFT_1_ID = 62;
+constexpr S16 HAND_MIDDLE_LEFT_2_ID = 63;
+constexpr S16 HAND_MIDDLE_LEFT_3_ID = 64;
+constexpr S16 HAND_INDEX_LEFT_1_ID = 65;
+constexpr S16 HAND_INDEX_LEFT_2_ID = 66;
+constexpr S16 HAND_INDEX_LEFT_3_ID = 67;
+constexpr S16 HAND_RING_LEFT_1_ID = 68;
+constexpr S16 HAND_RING_LEFT_2_ID = 69;
+constexpr S16 HAND_RING_LEFT_3_ID = 70;
+constexpr S16 HAND_PINKY_LEFT_1_ID = 71;
+constexpr S16 HAND_PINKY_LEFT_2_ID = 72;
+constexpr S16 HAND_PINKY_LEFT_3_ID = 73;
+constexpr S16 HAND_THUMB_LEFT_1_ID = 74;
+constexpr S16 HAND_THUMB_LEFT_2_ID = 75;
+constexpr S16 HAND_THUMB_LEFT_3_ID = 76;
+
+#ifdef ENABLE_RIGHT_CONSTRAINTS
+constexpr S16 COLLAR_RIGHT_ID = 77;
+constexpr S16 SHOULDER_RIGHT_ID = 78;
+constexpr S16 ELBOW_RIGHT_ID = 79;
+constexpr S16 WRIST_RIGHT_ID = 80;
+constexpr S16 HAND_MIDDLE_RIGHT_1_ID = 81;
+constexpr S16 HAND_MIDDLE_RIGHT_2_ID = 82;
+constexpr S16 HAND_MIDDLE_RIGHT_3_ID = 83;
+constexpr S16 HAND_INDEX_RIGHT_1_ID = 84;
+constexpr S16 HAND_INDEX_RIGHT_2_ID = 85;
+constexpr S16 HAND_INDEX_RIGHT_3_ID = 86;
+constexpr S16 HAND_RING_RIGHT_1_ID = 87;
+constexpr S16 HAND_RING_RIGHT_2_ID = 88;
+constexpr S16 HAND_RING_RIGHT_3_ID = 89;
+constexpr S16 HAND_PINKY_RIGHT_1_ID = 90;
+constexpr S16 HAND_PINKY_RIGHT_2_ID = 91;
+constexpr S16 HAND_PINKY_RIGHT_3_ID = 92;
+constexpr S16 HAND_THUMB_RIGHT_1_ID = 93;
+constexpr S16 HAND_THUMB_RIGHT_2_ID = 94;
+constexpr S16 HAND_THUMB_RIGHT_3_ID = 95;
+#endif //ENABLE_RIGHT_CONSTRAINTS
+
+namespace
+{
+    constexpr U32 PUPPET_MAX_MSG_BYTES = 255;  // This is the largest possible size event
+}
+
+bool gIsSendingAnimationStream = false;
+
+void LLStreamingMotion::SetIsSendingAnimationStream(bool is_sending)
+{
+    gIsSendingAnimationStream = is_sending;
+}
+
+bool LLStreamingMotion::GetIsSendingAnimationStream()
+{
+    return gIsSendingAnimationStream;
+}
+
+void LLStreamingMotion::DelayedEventQueue::addEvent(
+        Timestamp remote_timestamp,
+        Timestamp local_timestamp,
+        const LLPuppetJointEvent& event)
+{
+    if (mLastRemoteTimestamp != -1)
+    {
+        // dynamically measure mEventPeriod and mEventJitter
+        constexpr F32 DEL = 0.1f;
+        Timestamp this_period = remote_timestamp - mLastRemoteTimestamp;
+        mEventJitter = (1.0f - DEL) * mEventJitter + DEL * std::abs(mEventPeriod - (F32)this_period);
+
+        // mEventPeriod is a running average of the period between events
+        mEventPeriod = (1.0f - DEL) * mEventPeriod + DEL * this_period;
+    }
+    mLastRemoteTimestamp = remote_timestamp;
+
+    // we push event into the future so we have something to interpolate toward
+    // while we wait for the next
+    Timestamp delayed_timestamp = local_timestamp + (Timestamp)(mEventPeriod + mEventJitter);
+    mQueue.push_back({delayed_timestamp, event});
+}
+
+LLStreamingMotion::LLStreamingMotion(const LLUUID &id) :
+    LLMotion(id)
+{
+    mName = "streaming_motion";
+    mRemoteToLocalClockOffset = std::numeric_limits<F32>::min();
+}
+
+void LLStreamingMotion::collectJoints(LLJoint* joint)
+{
+    // rather than maintain a map<name, LLJointState>
+    // we use a vector<JointState> so joints can be looked up by index
+    // which means we must collect ALL the bone joints
+    if (!joint->isBone() || !joint->getParent())
+    {
+        return;
+    }
+
+    LLPointer<LLJointState> joint_state = new LLJointState(joint);
+    S16 joint_id = joint->getJointNum();
+    mJointStates[joint_id] = joint_state;
+
+    // Recurse through the children of this joint and add them to our joint control list
+    for (LLJoint::joints_t::iterator itr = joint->mChildren.begin();
+         itr != joint->mChildren.end(); ++itr)
+    {
+        collectJoints(*itr);
+    }
+}
+
+// override
+bool LLStreamingMotion::needsUpdate() const
+{
+    return !mEventQueues.empty() || LLMotion::needsUpdate();
+}
+
+F32 LLStreamingMotion::getEaseInDuration()
+{
+    return 1.0f;
+}
+
+F32 LLStreamingMotion::getEaseOutDuration()
+{
+    return 1.0f;
+}
+
+LLJoint::JointPriority LLStreamingMotion::getPriority()
+{
+    // Note: getPriority() is only used to delegate motion-wide priority
+    // to LLJointStates added to mPose in LLMotion::addJointState()...
+    // when they have LLJoint::USE_MOTION_PRIORITY.
+    return LLJoint::PUPPET_PRIORITY;
+}
+
+LLMotion::LLMotionInitStatus LLStreamingMotion::onInitialize(LLCharacter *character)
+{
+    assert(character);
+    constexpr size_t NUM_JOINTS = 133;
+    mJointStates.resize(NUM_JOINTS);
+    LLJoint* root_joint = character->getJoint("mPelvis");
+    assert(root_joint);
+    assert(root_joint->isBone());
+    collectJoints(root_joint);
+    return STATUS_SUCCESS;
+}
+
+void LLStreamingMotion::applyEvent(const LLPuppetJointEvent& event, Timestamp now)
+{
+    S16 joint_id = event.getJointID();
+    if (joint_id > 0 && joint_id < mJointStates.size())
+    {
+        LLPointer<LLJointState> joint_state = mJointStates[joint_id];
+        if (!joint_state)
+        {
+            return;
+        }
+        U8 flags = event.getMask();
+        joint_state->setUsage((U32)(flags & LLIK::MASK_JOINT_STATE_USAGE));
+        if (flags & LLIK::CONFIG_FLAG_LOCAL_POS)
+        {
+            // we expect received position to be scaled correctly
+            // so it can be applied without modification
+            joint_state->setPosition(event.getPosition());
+        }
+        if (flags & LLIK::CONFIG_FLAG_LOCAL_ROT)
+        {
+            joint_state->setRotation(event.getRotation());
+        }
+        if (flags & LLIK::CONFIG_FLAG_LOCAL_SCALE)
+        {
+            joint_state->setScale(event.getScale());
+        }
+        addJointState(joint_state);
+    }
+}
+
+void LLStreamingMotion::updateFromQueues(Timestamp now)
+{
+    // We walk the queue looking for the two bounding events: the last previous
+    // and the next pending: we will interpolate between them.  If we don't
+    // find bounding events we'll use whatever we've got.
+    auto queue_itr = mEventQueues.begin();
+    while (queue_itr != mEventQueues.end())
+    {
+        auto& queue = queue_itr->second.getEventQueue();
+        auto event_itr = queue.begin();
+        while (event_itr != queue.end())
+        {
+            Timestamp timestamp = event_itr->first;
+            const LLPuppetJointEvent& event = event_itr->second;
+            if (timestamp > now)
+            {
+                // first available event is in the future
+                // we have no choice but to apply what we have
+                applyEvent(event, now);
+                break;
+            }
+
+            // event is in the past --> check next event
+            ++event_itr;
+            if (event_itr == queue.end())
+            {
+                // we're at the end of the queue
+                constexpr Timestamp STALE_QUEUE_DURATION = 3 * MSEC_PER_SEC;
+                if (timestamp < now - STALE_QUEUE_DURATION)
+                {
+                    // this queue is stale
+                    // the "remembered pose" will be purged elewhere
+                    queue.clear();
+                }
+                else
+                {
+                    // presumeably we already interpolated close to this event
+                    // but just in case we didn't quite reach it yet: apply
+                    applyEvent(event, now);
+                }
+                break;
+            }
+
+            Timestamp next_timestamp = event_itr->first;
+            if (next_timestamp < now)
+            {
+                // event is stale --> drop it
+                queue.pop_front();
+                event_itr = queue.begin();
+                continue;
+            }
+
+            // next event is in the future
+            // which means we've found the two events that straddle 'now'
+            // --> create an interpolated event and apply that
+            F32 del = (F32)(now - timestamp) / (F32)(next_timestamp - timestamp);
+            LLPuppetJointEvent interpolated_event;
+            const LLPuppetJointEvent& next_event = event_itr->second;
+            interpolated_event.interpolate(del, event, next_event);
+            applyEvent(interpolated_event, now);
+            break;
+        }
+        if (queue.empty())
+        {
+            queue_itr = mEventQueues.erase(queue_itr);
+        }
+        else
+        {
+            ++queue_itr;
+        }
+    }
+}
+
+void LLStreamingMotion::queueEvent(const LLPuppetEvent& puppet_event)
+{
+    // adjust the timestamp for local clock
+    // and push into the future to allow interpolation
+    Timestamp remote_timestamp = puppet_event.getTimestamp();
+    Timestamp now = (S32)(LLFrameTimer::getElapsedSeconds() * MSEC_PER_SEC);
+    Timestamp clock_skew = now - remote_timestamp;
+    if (std::numeric_limits<F32>::min() == mRemoteToLocalClockOffset)
+    {
+        mRemoteToLocalClockOffset = (F32)(clock_skew);
+    }
+    else
+    {
+        // compute a running average
+        constexpr F32 DEL = 0.05f;
+        mRemoteToLocalClockOffset = (1.0 - DEL) * mRemoteToLocalClockOffset + DEL * clock_skew;
+    }
+    Timestamp local_timestamp = remote_timestamp + (Timestamp)(mRemoteToLocalClockOffset);
+
+    // split puppet_event into joint-specific streams
+    for (const auto& joint_event : puppet_event.mJointEvents)
+    {
+        S16 joint_id = joint_event.getJointID();
+        if (joint_id > 0 && joint_id < mJointStates.size() && mJointStates[joint_id])
+        {
+            DelayedEventQueue& queue = mEventQueues[joint_id];
+            queue.addEvent(remote_timestamp, local_timestamp, joint_event);
+        }
+    }
+}
+
+BOOL LLStreamingMotion::onUpdate(F32 time, U8* joint_mask)
+{
+    if (mJointStates.empty())
+    {
+        return FALSE;
+    }
+
+    Timestamp now = (S32)(LLFrameTimer::getElapsedSeconds() * MSEC_PER_SEC);
+    updateFromQueues(now);
+
+    // We must return TRUE else LLMotionController will stop and purge this motion.
+    //
+    // TODO?: figure out when to return FALSE so that LLMotionController can
+    // reduce its idle load.
+    return TRUE;
+}
+
+BOOL LLStreamingMotion::onActivate()
+{
+    // LLMotionController calls this when it adds this motion
+    // to its active list.  As of 2022.04.21 the return value
+    // is never checked.
+    return TRUE;
+}
+
+void LLStreamingMotion::onDeactivate()
+{
+    // LLMotionController calls this when it removes
+    // this motion from its active list.
+    mPose.removeAllJointStates();
+    for (auto& joint_state: mJointStates)
+    {
+        joint_state->setUsage(0);
+    }
+}
+
+void LLStreamingMotion::unpackEvents(LLMessageSystem *mesgsys,int blocknum)
+{
+    std::array<U8, PUPPET_MAX_MSG_BYTES> puppet_pack_buffer;
+
+    LLDataPackerBinaryBuffer dataPacker( puppet_pack_buffer.data(), PUPPET_MAX_MSG_BYTES );
+    dataPacker.reset();
+
+    S32 data_size = mesgsys->getSizeFast(_PREHASH_PhysicalAvatarEventList, blocknum, _PREHASH_TypeData);
+    mesgsys->getBinaryDataFast(_PREHASH_PhysicalAvatarEventList, _PREHASH_TypeData, puppet_pack_buffer.data(), data_size , blocknum,PUPPET_MAX_MSG_BYTES);
+
+    LLPuppetEvent event;
+    if (event.unpack(dataPacker))
+    {
+        queueEvent(event);
+    }
+    else
+    {
+        LL_WARNS_ONCE("Puppet") << "Reject invalid animation data" << LL_ENDL;
+    }
+}
+

--- a/indra/newview/llstreamingmotion.cpp
+++ b/indra/newview/llstreamingmotion.cpp
@@ -100,18 +100,6 @@ namespace
     constexpr U32 PUPPET_MAX_MSG_BYTES = 255;  // This is the largest possible size event
 }
 
-bool gIsSendingAnimationStream = false;
-
-void LLStreamingMotion::SetIsSendingAnimationStream(bool is_sending)
-{
-    gIsSendingAnimationStream = is_sending;
-}
-
-bool LLStreamingMotion::GetIsSendingAnimationStream()
-{
-    return gIsSendingAnimationStream;
-}
-
 void LLStreamingMotion::DelayedEventQueue::addEvent(
         Timestamp remote_timestamp,
         Timestamp local_timestamp,

--- a/indra/newview/llstreamingmotion.cpp
+++ b/indra/newview/llstreamingmotion.cpp
@@ -46,55 +46,6 @@
 
 #define ENABLE_RIGHT_CONSTRAINTS
 
-// BEGIN_HACK : hard-coded joint_ids
-//constexpr U16 PELVIS_ID = 0;
-constexpr U16 TORSO_ID = 3;
-constexpr U16 CHEST_ID = 6;
-constexpr U16 NECK_ID = 7;
-constexpr U16 HEAD_ID = 8;
-constexpr S16 COLLAR_LEFT_ID = 58;
-constexpr S16 SHOULDER_LEFT_ID = 59;
-constexpr S16 ELBOW_LEFT_ID = 60;
-constexpr S16 WRIST_LEFT_ID = 61;
-
-constexpr S16 HAND_MIDDLE_LEFT_1_ID = 62;
-constexpr S16 HAND_MIDDLE_LEFT_2_ID = 63;
-constexpr S16 HAND_MIDDLE_LEFT_3_ID = 64;
-constexpr S16 HAND_INDEX_LEFT_1_ID = 65;
-constexpr S16 HAND_INDEX_LEFT_2_ID = 66;
-constexpr S16 HAND_INDEX_LEFT_3_ID = 67;
-constexpr S16 HAND_RING_LEFT_1_ID = 68;
-constexpr S16 HAND_RING_LEFT_2_ID = 69;
-constexpr S16 HAND_RING_LEFT_3_ID = 70;
-constexpr S16 HAND_PINKY_LEFT_1_ID = 71;
-constexpr S16 HAND_PINKY_LEFT_2_ID = 72;
-constexpr S16 HAND_PINKY_LEFT_3_ID = 73;
-constexpr S16 HAND_THUMB_LEFT_1_ID = 74;
-constexpr S16 HAND_THUMB_LEFT_2_ID = 75;
-constexpr S16 HAND_THUMB_LEFT_3_ID = 76;
-
-#ifdef ENABLE_RIGHT_CONSTRAINTS
-constexpr S16 COLLAR_RIGHT_ID = 77;
-constexpr S16 SHOULDER_RIGHT_ID = 78;
-constexpr S16 ELBOW_RIGHT_ID = 79;
-constexpr S16 WRIST_RIGHT_ID = 80;
-constexpr S16 HAND_MIDDLE_RIGHT_1_ID = 81;
-constexpr S16 HAND_MIDDLE_RIGHT_2_ID = 82;
-constexpr S16 HAND_MIDDLE_RIGHT_3_ID = 83;
-constexpr S16 HAND_INDEX_RIGHT_1_ID = 84;
-constexpr S16 HAND_INDEX_RIGHT_2_ID = 85;
-constexpr S16 HAND_INDEX_RIGHT_3_ID = 86;
-constexpr S16 HAND_RING_RIGHT_1_ID = 87;
-constexpr S16 HAND_RING_RIGHT_2_ID = 88;
-constexpr S16 HAND_RING_RIGHT_3_ID = 89;
-constexpr S16 HAND_PINKY_RIGHT_1_ID = 90;
-constexpr S16 HAND_PINKY_RIGHT_2_ID = 91;
-constexpr S16 HAND_PINKY_RIGHT_3_ID = 92;
-constexpr S16 HAND_THUMB_RIGHT_1_ID = 93;
-constexpr S16 HAND_THUMB_RIGHT_2_ID = 94;
-constexpr S16 HAND_THUMB_RIGHT_3_ID = 95;
-#endif //ENABLE_RIGHT_CONSTRAINTS
-
 namespace
 {
     constexpr U32 PUPPET_MAX_MSG_BYTES = 255;  // This is the largest possible size event

--- a/indra/newview/llstreamingmotion.h
+++ b/indra/newview/llstreamingmotion.h
@@ -41,8 +41,6 @@ class LLStreamingMotion :
     public LLMotion
 {
 public:
-    static void SetIsSendingAnimationStream(bool is_sending);
-    static bool GetIsSendingAnimationStream();
 
     //using state_map_t = std::map <S16, LLPointer<LLJointState>>;
     using state_vector_t = std::vector< LLPointer<LLJointState> >;

--- a/indra/newview/llstreamingmotion.h
+++ b/indra/newview/llstreamingmotion.h
@@ -42,11 +42,7 @@ class LLStreamingMotion :
 {
 public:
 
-    //using state_map_t = std::map <S16, LLPointer<LLJointState>>;
     using state_vector_t = std::vector< LLPointer<LLJointState> >;
-    //using jointid_vec_t = std::vector<S16>;
-    //using update_deq_t = std::deque<LLPuppetEvent>;
-    //using joint_events_t = std::vector<LLPuppetJointEvent>;
     using ptr_t = std::shared_ptr<LLStreamingMotion>;
     using Timestamp = S32;
 
@@ -67,14 +63,11 @@ public:
     };
     using EventQueues = std::map<S16, DelayedEventQueue>;
 
-    // Constructor
     LLStreamingMotion(const LLUUID &id);
+    virtual ~LLStreamingMotion() {}
 
     void collectJoints(LLJoint* joint);
     bool needsUpdate() const override;
-
-    // Destructor
-    virtual ~LLStreamingMotion() {}
 
     void unpackEvents(LLMessageSystem *mesgsys,int blocknum);
 

--- a/indra/newview/llstreamingmotion.h
+++ b/indra/newview/llstreamingmotion.h
@@ -1,0 +1,138 @@
+/**
+ * @file llstreamingmotion.h
+ * @brief LLStreamingMotion is an LLMotion which plays animation stream from server
+ *
+ * $LicenseInfo:firstyear=2023&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2023, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#pragma once
+
+//#include <deque>
+//#include <vector>
+#include "llmotion.h"
+#include "m3math.h"
+#include "v3dmath.h"
+#include "llpuppetevent.h"
+
+constexpr F32 MIN_REQUIRED_PIXEL_AREA_STREAMING = 100.f;
+
+class LLCharacter;
+
+class LLStreamingMotion :
+    public LLMotion
+{
+public:
+    static void SetIsSendingAnimationStream(bool is_sending);
+    static bool GetIsSendingAnimationStream();
+
+    //using state_map_t = std::map <S16, LLPointer<LLJointState>>;
+    using state_vector_t = std::vector< LLPointer<LLJointState> >;
+    //using jointid_vec_t = std::vector<S16>;
+    //using update_deq_t = std::deque<LLPuppetEvent>;
+    //using joint_events_t = std::vector<LLPuppetJointEvent>;
+    using ptr_t = std::shared_ptr<LLStreamingMotion>;
+    using Timestamp = S32;
+
+public:
+    using EventQueue = std::deque< std::pair<Timestamp, LLPuppetJointEvent> >;
+    class DelayedEventQueue
+    {
+    public:
+        void addEvent(Timestamp remote_timestamp, Timestamp local_timestamp, const LLPuppetJointEvent& event);
+        EventQueue& getEventQueue() { return mQueue; }
+    private:
+        EventQueue mQueue;
+        Timestamp mLastRemoteTimestamp = -1; // msec
+        // EventPeriod and Jitter are dynamically updated
+        // but we start with these optimistic guesses
+        F32 mEventPeriod = 100.0f; // msec
+        F32 mEventJitter = 50.0f; // msec
+    };
+    using EventQueues = std::map<S16, DelayedEventQueue>;
+
+    // Constructor
+    LLStreamingMotion(const LLUUID &id);
+
+    void collectJoints(LLJoint* joint);
+    bool needsUpdate() const override;
+
+    // Destructor
+    virtual ~LLStreamingMotion() {}
+
+    void unpackEvents(LLMessageSystem *mesgsys,int blocknum);
+
+public:
+    // LLMotion subclasses must implement create() factory method
+    static LLMotion::ptr_t create(const LLUUID &id) { return std::make_shared<LLStreamingMotion>(id); }
+
+public:
+    // required overrides
+
+    // motions must specify whether or not they loop
+    virtual BOOL getLoop() override { return FALSE; }
+
+    // motions must report their total duration
+    virtual F32 getDuration() override { return 0.0f; }
+
+    // motions must report their "ease in" duration
+    virtual F32 getEaseInDuration() override;
+
+    // motions must report their "ease out" duration.
+    virtual F32 getEaseOutDuration() override;
+
+    // motions must report their priority
+    virtual LLJoint::JointPriority getPriority() override;
+
+    virtual LLMotionBlendType getBlendType() override { return NORMAL_BLEND; }
+
+    // called to determine when a motion should be activated/deactivated based on avatar pixel coverage
+    virtual F32 getMinPixelArea() override { return MIN_REQUIRED_PIXEL_AREA_STREAMING; }
+
+    // run-time (post constructor) initialization,
+    // called after parameters have been set
+    // must return true to indicate success and be available for activation
+    virtual LLMotionInitStatus onInitialize(LLCharacter* character) override;
+
+    virtual BOOL onActivate() override;
+
+    // called per time step
+    // must return TRUE while it is active, and
+    // must return FALSE when the motion is completed.
+    virtual BOOL onUpdate(F32 time, U8* joint_mask) override;
+
+    virtual void onDeactivate() override;
+
+    BOOL canDeprecate() override { return FALSE; }
+
+private:
+    void queueEvent(const LLPuppetEvent& event);
+    void applyEvent(const LLPuppetJointEvent& event, Timestamp now);
+
+    void updateFromQueues(Timestamp now);
+
+private:
+    state_vector_t mJointStates;
+    EventQueues mEventQueues;
+    LLCharacter* mCharacter;
+    F32 mRemoteToLocalClockOffset; // msec
+};
+

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -2735,10 +2735,9 @@ class LLAdvancedPuppetryEnableSend : public view_listener_t
     {   // Must have a loaded module
         bool have_module = LLPuppetModule::instance().havePuppetModule();
         LL_DEBUGS("PuppetMenu") << "Enable send " << (have_module ? "true" : "false") << LL_ENDL;
-        return (LLPuppetModule::instance().havePuppetModule());
+        return have_module;
     }
 };
-
 
 class LLAdvancedPuppetryCheckReceive : public view_listener_t
 {

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4059,7 +4059,9 @@ void process_sim_stats(LLMessageSystem *msg, void **user_data)
 // Common code to extract puppetry data from an avatar animation message
 static void  handle_streaming_animation_data(LLMessageSystem * mesgsys, LLVOAvatar * avatarp, S32 num_physav_blocks)
 {
-    if (!avatarp->isReceivingAnimationStream())
+    if (num_physav_blocks > 0
+            && !avatarp->isReceivingAnimationStream()
+            && mesgsys->getSizeFast(_PREHASH_PhysicalAvatarEventList, 0, _PREHASH_TypeData) > 0)
     {
         avatarp->enableStreamingMotion();
     }

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4061,6 +4061,7 @@ static void  handle_streaming_animation_data(LLMessageSystem * mesgsys, LLVOAvat
 {
     if (num_physav_blocks > 0
             && !avatarp->isReceivingAnimationStream()
+            && LLPuppetModule::instance().isReceiving()
             && mesgsys->getSizeFast(_PREHASH_PhysicalAvatarEventList, 0, _PREHASH_TypeData) > 0)
     {
         avatarp->enableStreamingMotion();

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -3749,6 +3749,17 @@ void LLVOAvatar::enableStreamingMotion()
     }
 }
 
+void LLVOAvatar::disableStreamingMotion()
+{
+    // TODO?: implement this?
+    // Might be necessary when this avatar moves out of region with puppetry support.
+    //
+    // Note: ATM mIsReceivingAnimationStream is initialized to 'false',
+    // is set 'true' as soon as it receives any animation-stream data,
+    // and can never be set 'false' again.  This animation stream stuff
+    // is still experimental.
+}
+
 void LLVOAvatar::slamPosition()
 {
 	gAgent.setPositionAgent(getPositionAgent());
@@ -5893,6 +5904,9 @@ const LLUUID& LLVOAvatar::getStepSound() const
 //-----------------------------------------------------------------------------
 void LLVOAvatar::processAnimationStateChanges()
 {
+    // Note: if this other-avatar is receiving an animation stream
+    // then we don't bother processing animation state changes
+    // since the stream should represent the final animation state
     if (!isSelf() && mIsReceivingAnimationStream)
     {
         return;

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -1223,29 +1223,29 @@ void LLVOAvatar::initInstance()
         registerMotion( ANIM_AGENT_PUPPET_MOTION,           LLPuppetMotion::create );
         registerMotion( ANIM_AGENT_STREAMING_MOTION,        LLStreamingMotion::create );
 	}
-	
+
 	LLAvatarAppearance::initInstance();
-	
+
 	// preload specific motions here
 
 	createMotion( ANIM_AGENT_CUSTOMIZE);
 	createMotion( ANIM_AGENT_CUSTOMIZE_DONE);
-    if (isSelf())
-    {
-	    createMotion(ANIM_AGENT_PUPPET_MOTION);
-    }
+	if (isSelf())
+	{
+		createMotion(ANIM_AGENT_PUPPET_MOTION);
+	}
 
 	LLPuppetMotion::ptr_t puppet_motion = getPuppetMotion();
-    if (puppet_motion)
-    {
+	if (puppet_motion)
+	{
 		puppet_motion->setAvatar(this);
-    }
+	}
 	else
 	{
 		LL_WARNS("Puppet") << "Missing puppet motion when initializing avatar" << LL_ENDL;
 	}
 	//VTPause();  // VTune
-	
+
 	mVoiceVisualizer->setVoiceEnabled( LLVoiceClient::getInstance()->getVoiceEnabled( mID ) );
 
     mInitFlags |= 1<<1;
@@ -3716,11 +3716,11 @@ void LLVOAvatar::enableStreamingMotion()
         // stop all non-streaming animations
         bool found_streaming_motion = false;
         LLMotionController::motion_list_t motions_to_stop;
-	    for (LLMotionController::motion_list_t::iterator iter = mMotionController.getActiveMotions().begin();
-		    iter != mMotionController.getActiveMotions().end(); ++iter)
-	    {
-		    LLMotion::ptr_t motionp = *iter;
-		    if (motionp->getID() == ANIM_AGENT_STREAMING_MOTION)
+        for (LLMotionController::motion_list_t::iterator iter = mMotionController.getActiveMotions().begin();
+            iter != mMotionController.getActiveMotions().end(); ++iter)
+        {
+            LLMotion::ptr_t motionp = *iter;
+            if (motionp->getID() == ANIM_AGENT_STREAMING_MOTION)
             {
                 found_streaming_motion = true;
             }
@@ -3740,10 +3740,10 @@ void LLVOAvatar::enableStreamingMotion()
             LLMotion::ptr_t motionp = mMotionController.findMotion(ANIM_AGENT_STREAMING_MOTION);
             if (!motionp)
             {
-	            createMotion(ANIM_AGENT_STREAMING_MOTION);
+                createMotion(ANIM_AGENT_STREAMING_MOTION);
             }
         }
-	    startMotion(ANIM_AGENT_STREAMING_MOTION);
+        startMotion(ANIM_AGENT_STREAMING_MOTION);
         mIsReceivingAnimationStream = true;
         mEnableDefaultMotions = false;
     }
@@ -5904,13 +5904,13 @@ const LLUUID& LLVOAvatar::getStepSound() const
 //-----------------------------------------------------------------------------
 void LLVOAvatar::processAnimationStateChanges()
 {
-    // Note: if this other-avatar is receiving an animation stream
-    // then we don't bother processing animation state changes
-    // since the stream should represent the final animation state
-    if (!isSelf() && mIsReceivingAnimationStream)
-    {
-        return;
-    }
+	// Note: if this other-avatar is receiving an animation stream
+	// then we don't bother processing animation state changes
+	// since the stream should represent the final animation state
+	if (!isSelf() && mIsReceivingAnimationStream)
+	{
+		return;
+	}
 
 	if ( isAnyAnimationSignaled(AGENT_WALK_ANIMS, NUM_AGENT_WALK_ANIMS) )
 	{
@@ -5920,10 +5920,10 @@ void LLVOAvatar::processAnimationStateChanges()
 	else if (mInAir && !isSitting())
 	{
 		stopMotion(ANIM_AGENT_WALK_ADJUST);
-        if (mEnableDefaultMotions)
-        {
+		if (mEnableDefaultMotions)
+		{
 		    startMotion(ANIM_AGENT_FLY_ADJUST);
-	    }
+		}
 	}
 	else
 	{
@@ -5933,17 +5933,17 @@ void LLVOAvatar::processAnimationStateChanges()
 
 	if ( isAnyAnimationSignaled(AGENT_GUN_AIM_ANIMS, NUM_AGENT_GUN_AIM_ANIMS) )
 	{
-        if (mEnableDefaultMotions)
-        {
+		if (mEnableDefaultMotions)
+		{
 			startMotion(ANIM_AGENT_TARGET);
-        }
+		}
 		stopMotion(ANIM_AGENT_BODY_NOISE);
 	}
 	else
 	{
 		stopMotion(ANIM_AGENT_TARGET);
-        if (mEnableDefaultMotions)
-        {
+		if (mEnableDefaultMotions)
+		{
 			startMotion(ANIM_AGENT_BODY_NOISE);
 		}
 	}
@@ -5970,7 +5970,7 @@ void LLVOAvatar::processAnimationStateChanges()
 	{
 		mPlayingAnimations.clear();
 	}
-	
+
 	// start up all new anims
 	if (getOverallAppearance() == AOA_NORMAL)
 	{

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -254,7 +254,7 @@ public:
 
 	virtual bool 	        isControlAvatar() const { return mIsControlAvatar; } // True if this avatar is a control av (no associated user)
 	virtual bool 	        isUIAvatar() const { return mIsUIAvatar; } // True if this avatar is a supplemental av used in some UI views (no associated user)
-    bool isReceivingAnimationStream() const { return mIsReceivingAnimationStream; }
+	bool isReceivingAnimationStream() const { return mIsReceivingAnimationStream; }
 
 	// If this is an attachment, return the avatar it is attached to. Otherwise NULL.
 	virtual const LLVOAvatar *getAttachedAvatar() const { return NULL; }
@@ -318,8 +318,8 @@ public:
 
 	void 			idleUpdateBelowWater();
 
-    void enableStreamingMotion();
-    void disableStreamingMotion();
+	void enableStreamingMotion();
+	void disableStreamingMotion();
 
 	//--------------------------------------------------------------------
 	// Static preferences (controlled by user settings/menus)
@@ -395,7 +395,7 @@ private:
 	LLColor4		mMutedAVColor;
 	LLFrameTimer	mFullyLoadedTimer;
 	LLFrameTimer	mRuthTimer;
-    bool            mIsReceivingAnimationStream;
+	bool			mIsReceivingAnimationStream;
 
 private:
 	LLViewerStats::PhaseMap mPhases;

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -67,6 +67,7 @@ extern const LLUUID ANIM_AGENT_PELVIS_FIX;
 extern const LLUUID ANIM_AGENT_TARGET;
 extern const LLUUID ANIM_AGENT_WALK_ADJUST;
 extern const LLUUID ANIM_AGENT_PUPPET_MOTION;
+extern const LLUUID ANIM_AGENT_STREAMING_MOTION;
 
 class LLViewerWearable;
 class LLVoiceVisualizer;
@@ -253,6 +254,7 @@ public:
 
 	virtual bool 	        isControlAvatar() const { return mIsControlAvatar; } // True if this avatar is a control av (no associated user)
 	virtual bool 	        isUIAvatar() const { return mIsUIAvatar; } // True if this avatar is a supplemental av used in some UI views (no associated user)
+    bool isReceivingAnimationStream() const { return mIsReceivingAnimationStream; }
 
 	// If this is an attachment, return the avatar it is attached to. Otherwise NULL.
 	virtual const LLVOAvatar *getAttachedAvatar() const { return NULL; }
@@ -315,6 +317,8 @@ public:
 	static void     updateImpostorRendering(U32 newMaxNonImpostorsValue);
 
 	void 			idleUpdateBelowWater();
+
+    void enableStreamingMotion();
 
 	//--------------------------------------------------------------------
 	// Static preferences (controlled by user settings/menus)
@@ -390,6 +394,7 @@ private:
 	LLColor4		mMutedAVColor;
 	LLFrameTimer	mFullyLoadedTimer;
 	LLFrameTimer	mRuthTimer;
+    bool            mIsReceivingAnimationStream;
 
 private:
 	LLViewerStats::PhaseMap mPhases;

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -319,6 +319,7 @@ public:
 	void 			idleUpdateBelowWater();
 
     void enableStreamingMotion();
+    void disableStreamingMotion();
 
 	//--------------------------------------------------------------------
 	// Static preferences (controlled by user settings/menus)

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -1366,7 +1366,7 @@ void LLVOAvatarSelf::sendAttachmentUpdate(U64 now)
 
 void LLVOAvatarSelf::sendAnimationStream(U64 now)
 {
-    if (!LLStreamingMotion::GetIsSendingAnimationStream() || now < mAnimationStreamExpiry)
+    if (!LLPuppetModule::instance().isSending() || now < mAnimationStreamExpiry)
     {
         return;
     }

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -320,14 +320,23 @@ private:
     void sendAnimationStream(U64 now);
 
 private:
+    // We keep track of last-streamed joint data
     std::vector<LLQuaternion> mLastJointRotation;
     std::vector<LLVector3> mLastJointPosition;
     std::vector<LLVector3> mLastJointScale;
-    bool                mAttachmentUpdateEnabled;
+
+    // The animation stream sends fresh changes, but also resends old
+    // changes that haven't been sent in a while.  This because otherwise
+    // it is possible for a new viewer to arrive mid-stream and never
+    // receive an update for some joint that changed once but stopped changing.
+    std::vector<S32> mJointResendExpiries;
+    std::vector<U8> mLastMask;
+
     U64                 mAttachmentUpdatePeriod; // usec
     U64                 mAttachmentUpdateExpiry; // usec
     U64                 mAnimationStreamPeriod; // usec
     U64                 mAnimationStreamExpiry; // usec
+    bool                mAttachmentUpdateEnabled;
 
  /**                   ANIMATIONS
   **                                                                            **

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -316,9 +316,18 @@ public:
     bool                getAttachmentUpdateEnabled() const { return mAttachmentUpdateEnabled; }
 
 private:
+    void sendAttachmentUpdate(U64 now);
+    void sendAnimationStream(U64 now);
+
+private:
+    std::vector<LLQuaternion> mLastJointRotation;
+    std::vector<LLVector3> mLastJointPosition;
+    std::vector<LLVector3> mLastJointScale;
     bool                mAttachmentUpdateEnabled;
     U64                 mAttachmentUpdatePeriod; // usec
     U64                 mAttachmentUpdateExpiry; // usec
+    U64                 mAnimationStreamPeriod; // usec
+    U64                 mAnimationStreamExpiry; // usec
 
  /**                   ANIMATIONS
   **                                                                            **


### PR DESCRIPTION
This PR introduces an experiment where the local Viewer computes the final animation state and streams ALL joints through the puppetry relay of the server.  Remote Viewers will receive the stream and just play it, instead of mixing various animation assets.