### PR TITLE
Unload avatar and group icons from memory when not visible to reduce video ram usage

### DIFF
--- a/indra/llui/lliconctrl.cpp
+++ b/indra/llui/lliconctrl.cpp
@@ -37,6 +37,8 @@
 #include "lluiimage.h"
 #include "llwindow.h"
 
+#include "llgltexture.h"
+
 static LLDefaultChildRegistry::Register<LLIconCtrl> r("icon");
 
 LLIconCtrl::Params::Params()
@@ -94,6 +96,22 @@ BOOL LLIconCtrl::handleHover(S32 x, S32 y, MASK mask)
     return LLUICtrl::handleHover(x, y, mask);
 }
 
+void LLIconCtrl::onVisibilityChange(BOOL new_visibility)
+{
+	LLUICtrl::onVisibilityChange(new_visibility);
+	if (mPriority == LLGLTexture::BOOST_ICON)
+	{
+		if (new_visibility)
+		{
+			loadImage(getValue(), mPriority);
+		}
+		else
+		{
+			mImagep = nullptr;
+		}
+	}
+}
+
 // virtual
 // value might be a string or a UUID
 void LLIconCtrl::setValue(const LLSD& value)
@@ -110,6 +128,14 @@ void LLIconCtrl::setValue(const LLSD& value, S32 priority)
 		tvalue = LLSD(LLUUID(value.asString()));
 	}
 	LLUICtrl::setValue(tvalue);
+
+	loadImage(tvalue, priority);
+}
+
+void LLIconCtrl::loadImage(const LLSD& tvalue, S32 priority)
+{
+	if(mPriority == LLGLTexture::BOOST_ICON && !getVisible()) return;
+
 	if (tvalue.isUUID())
 	{
         mImagep = LLUI::getUIImageByID(tvalue.asUUID(), priority);

--- a/indra/llui/lliconctrl.h
+++ b/indra/llui/lliconctrl.h
@@ -72,6 +72,7 @@ public:
     virtual BOOL handleHover(S32 x, S32 y, MASK mask);
 
 	// lluictrl overrides
+	void onVisibilityChange(BOOL new_visibility);
 	virtual void	setValue(const LLSD& value );
 
 	std::string	getImageName() const;
@@ -95,6 +96,8 @@ protected:
     bool mInteractable;
 
 private:
+	void loadImage(const LLSD& value, S32 priority);
+
 	LLUIColor mColor;
 	LLPointer<LLUIImage> mImagep;
 };

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1350,9 +1350,9 @@ void LLTextBase::draw()
 		drawCursor();
 	}
  
-	mDocumentView->setVisible(FALSE);
+	mDocumentView->setVisibleDirect(FALSE);
 	LLUICtrl::draw();
-	mDocumentView->setVisible(TRUE);
+	mDocumentView->setVisibleDirect(TRUE);
 }
 
 

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -287,6 +287,7 @@ public:
 	void 	setAllChildrenEnabled(BOOL b);
 
 	virtual void	setVisible(BOOL visible);
+	void			setVisibleDirect(BOOL visible) { mVisible = visible; }
 	const BOOL&		getVisible() const			{ return mVisible; }
 	virtual void	setEnabled(BOOL enabled);
 	BOOL			getEnabled() const			{ return mEnabled; }


### PR DESCRIPTION
This unloads avatar icons when they're made non-visible as well as fixes a storm of visibility changes during text draw for anything in a text segment.