### PR TITLE
SL-15752 Reduce default graphical quality on machines with little memory

### DIFF
--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -490,6 +490,18 @@ bool LLFeatureManager::loadGPUClass()
 		{
 			mGPUClass = GPU_CLASS_5;
 		}
+
+    #if LL_WINDOWS
+        const F32Gigabytes MIN_PHYSICAL_MEMORY(2);
+
+        LLMemory::updateMemoryInfo();
+        F32Gigabytes physical_mem = LLMemory::getMaxMemKB();
+        if (MIN_PHYSICAL_MEMORY > physical_mem && mGPUClass > GPU_CLASS_1)
+        {
+            // reduce quality on systems that don't have enough memory
+            mGPUClass = (EGPUClass)(mGPUClass - 1);
+        }
+    #endif //LL_WINDOWS
 	} //end if benchmark
 	else
 	{


### PR DESCRIPTION
Try to reduce 'class' if reported physical memory (which is more often page size and not actual memory) is below 2Gb.