### PR TITLE
SL-18721: Faster viewer shutdown time since performance improvements can lead to perceived inventory loss due to cache corruption

### DIFF
--- a/indra/llcommon/threadpool.cpp
+++ b/indra/llcommon/threadpool.cpp
@@ -39,6 +39,11 @@ void LL::ThreadPool::start()
                 run(tname);
             });
     }
+
+    // Special workflow for LLWindowWin32Thread - it's close() should be called explicitly
+    if (mExplicitShutdown)
+        return;
+
     // Listen on "LLApp", and when the app is shutting down, close the queue
     // and join the workers.
     LLEventPumps::instance().obtain("LLApp").listen(

--- a/indra/llcommon/threadpool.h
+++ b/indra/llcommon/threadpool.h
@@ -59,6 +59,10 @@ namespace LL
          */
         virtual void run();
 
+    protected:
+        // LLWindowWin32Thread should set this flag to true
+        bool mExplicitShutdown { false };
+
     private:
         void run(const std::string& name);
 

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -4581,6 +4581,9 @@ std::vector<std::string> LLWindowWin32::getDynamicFallbackFontList()
 inline LLWindowWin32::LLWindowWin32Thread::LLWindowWin32Thread()
     : ThreadPool("Window Thread", 1, MAX_QUEUE_SIZE)
 {
+    // Set this flag to true to avoid of implicit call of close() from start()
+    mExplicitShutdown = true;
+
     ThreadPool::start();
 }
 


### PR DESCRIPTION
Make `LLWindowWin32::LLWindowWin32Thread::close()` to be called from the class destructor