### PR TITLE
SL-19169 Local material updates aren't applied with non-default transforms

### DIFF
--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -41,6 +41,8 @@ namespace tinygltf
     class Model;
 }
 
+class LLTextureEntry;
+
 class LLGLTFMaterial : public LLRefCount
 {
 public:
@@ -192,6 +194,11 @@ public:
     bool setBaseMaterial();
     // True if setBaseMaterial() was just called
     bool isClearedForBaseMaterial();
+
+    // For local materials, they have to keep track of where
+    // they are assigned to for full updates
+    virtual void addTextureEntry(LLTextureEntry* te) {};
+    virtual void removeTextureEntry(LLTextureEntry* te) {};
 
 private:
     template<typename T>

--- a/indra/llprimitive/lltextureentry.cpp
+++ b/indra/llprimitive/lltextureentry.cpp
@@ -112,7 +112,15 @@ LLTextureEntry &LLTextureEntry::operator=(const LLTextureEntry &rhs)
 
         mMaterialID = rhs.mMaterialID;
 
+        if (mGLTFMaterial)
+        {
+            mGLTFMaterial->removeTextureEntry(this);
+        }
         mGLTFMaterial = rhs.mGLTFMaterial;
+        if (mGLTFMaterial)
+        {
+            mGLTFMaterial->addTextureEntry(this);
+        }
         
         if (rhs.mGLTFMaterialOverrides.notNull())
         {
@@ -155,6 +163,12 @@ LLTextureEntry::~LLTextureEntry()
 		delete mMediaEntry;
 		mMediaEntry = NULL;
 	}
+
+    if (mGLTFMaterial)
+    {
+        mGLTFMaterial->removeTextureEntry(this);
+        mGLTFMaterial = NULL;
+    }
 }
 
 bool LLTextureEntry::operator!=(const LLTextureEntry &rhs) const
@@ -524,7 +538,20 @@ void LLTextureEntry::setGLTFMaterial(LLGLTFMaterial* material, bool local_origin
         // NOTE: if you're hitting this assert, try to make sure calling code is using LLViewerObject::setRenderMaterialID
         llassert(!local_origin || getGLTFMaterialOverride() == nullptr || getGLTFMaterialOverride()->isClearedForBaseMaterial());
 
+        if (mGLTFMaterial)
+        {
+            // Local materials have to keep track
+            // due to update mechanics
+            mGLTFMaterial->removeTextureEntry(this);
+        }
+
         mGLTFMaterial = material;
+
+        if (mGLTFMaterial)
+        {
+            mGLTFMaterial->addTextureEntry(this);
+        }
+
         if (mGLTFMaterial == nullptr)
         {
             setGLTFRenderMaterial(nullptr);

--- a/indra/newview/llfetchedgltfmaterial.cpp
+++ b/indra/newview/llfetchedgltfmaterial.cpp
@@ -46,6 +46,18 @@ LLFetchedGLTFMaterial::~LLFetchedGLTFMaterial()
     
 }
 
+LLFetchedGLTFMaterial& LLFetchedGLTFMaterial::operator=(const LLFetchedGLTFMaterial& rhs)
+{
+    LLGLTFMaterial::operator =(rhs);
+
+    mBaseColorTexture = rhs.mBaseColorTexture;
+    mNormalTexture = rhs.mNormalTexture;
+    mMetallicRoughnessTexture = rhs.mMetallicRoughnessTexture;
+    mEmissiveTexture = rhs.mEmissiveTexture;
+
+    return *this;
+}
+
 void LLFetchedGLTFMaterial::bind(LLViewerTexture* media_tex)
 {
     // glTF 2.0 Specification 3.9.4. Alpha Coverage

--- a/indra/newview/llfetchedgltfmaterial.h
+++ b/indra/newview/llfetchedgltfmaterial.h
@@ -39,6 +39,8 @@ public:
     LLFetchedGLTFMaterial();
     virtual ~LLFetchedGLTFMaterial();
 
+    LLFetchedGLTFMaterial& operator=(const LLFetchedGLTFMaterial& rhs);
+
     // If this material is loaded, fire the given function
     void onMaterialComplete(std::function<void()> material_complete);
 

--- a/indra/newview/lllocalgltfmaterials.h
+++ b/indra/newview/lllocalgltfmaterials.h
@@ -34,6 +34,7 @@
 class LLScrollListCtrl;
 class LLGLTFMaterial;
 class LLViewerObject;
+class LLTextureEntry;
 
 class LLLocalGLTFMaterial : public LLFetchedGLTFMaterial
 {
@@ -47,6 +48,9 @@ public: /* accessors */
     LLUUID		getTrackingID() const;
     LLUUID		getWorldID() const;
     S32			getIndexInFile() const;
+
+    void addTextureEntry(LLTextureEntry* te) override;
+    void removeTextureEntry(LLTextureEntry* te) override;
 
 public:
     bool updateSelf();
@@ -77,6 +81,7 @@ private: /* members */
     ELinkStatus mLinkStatus;
     S32         mUpdateRetries;
     S32         mMaterialIndex; // Single file can have more than one
+    std::set<LLTextureEntry*> mTextureEntires;
 };
 
 class LLLocalGLTFMaterialTimer : public LLEventTimer

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -5368,8 +5368,10 @@ S32 LLViewerObject::setTEGLTFMaterialOverride(U8 te, LLGLTFMaterial* override_ma
 
     LLFetchedGLTFMaterial* src_mat = (LLFetchedGLTFMaterial*) tep->getGLTFMaterial();
 
+    // if override mat exists, we must also have a source mat
     if (!src_mat)
-    { // we can get into this state if an override has arrived before the viewer has
+    {
+        // we can get into this state if an override has arrived before the viewer has
         // received or handled an update, return TEM_CHANGE_NONE to signal to LLGLTFMaterialList that it
         // should queue the update for later
         return retval;
@@ -5383,10 +5385,7 @@ S32 LLViewerObject::setTEGLTFMaterialOverride(U8 te, LLGLTFMaterial* override_ma
 
     tep->setGLTFMaterialOverride(override_mat);
 
-    // if override mat exists, we must also have a source mat
-    llassert(override_mat ? bool(src_mat) : true);
-
-    if (override_mat && src_mat)
+    if (override_mat)
     {
         LLFetchedGLTFMaterial* render_mat = new LLFetchedGLTFMaterial(*src_mat);
         render_mat->applyOverride(*override_mat);

--- a/indra/newview/skins/default/xui/en/floater_material_editor.xml
+++ b/indra/newview/skins/default/xui/en/floater_material_editor.xml
@@ -29,7 +29,6 @@
    color="DkGray2"
    opaque="true"
    tab_stop="true"
-   border="false"
    reserve_scroll_corner="false">
     <panel
      name="panel_material"


### PR DESCRIPTION
Local materials without overrides/transforms modify material pointer which acts as a render pointer and this keeps everything updated. But with overrides or transforms applied there is a separate render pointer which remained unchanged once user updated local material. Since the point is to let user experiment prior to upload we should not drop either overrides or transforms.

Solution: local materials should keep track of render materials and update those as needed.