### PR TITLE
DRTVWR-558: Fix TC unit tests; make Xcode 14.2 compatible

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -166,7 +166,7 @@ pre_build()
      -DGRID:STRING="\"$viewer_grid\"" \
      -DHAVOK:BOOL="$HAVOK" \
      -DPACKAGE:BOOL=ON \
-     -DPYTHON_EXECUTABLE:FILEPATH="$PYTHON_COMMAND" \
+     -DPYTHON_EXECUTABLE:FILEPATH="$(native_path "$PYTHON_COMMAND")" \
      -DRELEASE_CRASH_REPORTING:BOOL="$RELEASE_CRASH_REPORTING" \
      -DTEMPLATE_VERIFIER_OPTIONS:STRING="$template_verifier_options" $template_verifier_master_url \
      -DVIEWER_CHANNEL:STRING="${viewer_channel}" \

--- a/build.sh
+++ b/build.sh
@@ -158,16 +158,19 @@ pre_build()
     # honor autobuild_configure_parameters same as sling-buildscripts
     eval_autobuild_configure_parameters=$(eval $(echo echo $autobuild_configure_parameters))
 
+    # Set PYTHON_EXECUTABLE: it's important to use the virtualenv created by
+    # sling-buildscripts build.sh.
     "$autobuild" configure --quiet -c $variant \
      ${eval_autobuild_configure_parameters:---} \
-     -DPACKAGE:BOOL=ON \
-     -DHAVOK:BOOL="$HAVOK" \
-     -DRELEASE_CRASH_REPORTING:BOOL="$RELEASE_CRASH_REPORTING" \
-     -DVIEWER_SYMBOL_FILE:STRING="${VIEWER_SYMBOL_FILE:-}" \
      -DBUGSPLAT_DB:STRING="${BUGSPLAT_DB:-}" \
-     -DVIEWER_CHANNEL:STRING="${viewer_channel}" \
      -DGRID:STRING="\"$viewer_grid\"" \
+     -DHAVOK:BOOL="$HAVOK" \
+     -DPACKAGE:BOOL=ON \
+     -DPYTHON_EXECUTABLE:FILEPATH="$PYTHON_COMMAND" \
+     -DRELEASE_CRASH_REPORTING:BOOL="$RELEASE_CRASH_REPORTING" \
      -DTEMPLATE_VERIFIER_OPTIONS:STRING="$template_verifier_options" $template_verifier_master_url \
+     -DVIEWER_CHANNEL:STRING="${viewer_channel}" \
+     -DVIEWER_SYMBOL_FILE:STRING="${VIEWER_SYMBOL_FILE:-}" \
      "${SIGNING[@]}" \
     || fatal "$variant configuration failed"
 

--- a/indra/llcharacter/llik.cpp
+++ b/indra/llcharacter/llik.cpp
@@ -45,14 +45,14 @@
 
 namespace
 {
-    constexpr char *NULL_CONSTRAINT_NAME                  ("NULL_CONSTRAINT");
-    constexpr char *UNKNOWN_CONSTRAINT_NAME               ("UNKNOWN_CONSTRAINT");
-    constexpr char *SIMPLE_CONE_CONSTRAINT_NAME           ("SIMPLE_CONE");
-    constexpr char *TWIST_LIMITED_CONE_CONSTRAINT_NAME    ("TWIST_LIMITED_CONE");
-    constexpr char *ELBOW_CONSTRAINT_NAME                 ("ELBOW");
-    constexpr char *KNEE_CONSTRAINT_NAME                  ("KNEE");
-    constexpr char *ACUTE_ELLIPSOIDAL_CONE_CONSTRAINT_NAME("ACUTE_ELLIPSOIDAL_CONE");
-    constexpr char *DOUBLE_LIMITED_HINGE_CONSTRAINT_NAME  ("DOUBLE_LIMITED_HINGE");
+    constexpr const char *NULL_CONSTRAINT_NAME                  ("NULL_CONSTRAINT");
+    constexpr const char *UNKNOWN_CONSTRAINT_NAME               ("UNKNOWN_CONSTRAINT");
+    constexpr const char *SIMPLE_CONE_CONSTRAINT_NAME           ("SIMPLE_CONE");
+    constexpr const char *TWIST_LIMITED_CONE_CONSTRAINT_NAME    ("TWIST_LIMITED_CONE");
+    constexpr const char *ELBOW_CONSTRAINT_NAME                 ("ELBOW");
+    constexpr const char *KNEE_CONSTRAINT_NAME                  ("KNEE");
+    constexpr const char *ACUTE_ELLIPSOIDAL_CONE_CONSTRAINT_NAME("ACUTE_ELLIPSOIDAL_CONE");
+    constexpr const char *DOUBLE_LIMITED_HINGE_CONSTRAINT_NAME  ("DOUBLE_LIMITED_HINGE");
 
     std::string constraint_type_to_name(LLIK::Constraint::ConstraintType type)
     {
@@ -72,6 +72,8 @@ namespace
             return ACUTE_ELLIPSOIDAL_CONE_CONSTRAINT_NAME;
         case LLIK::Constraint::DOUBLE_LIMITED_HINGE_CONSTRAINT:
             return DOUBLE_LIMITED_HINGE_CONSTRAINT_NAME;
+        default:
+            return UNKNOWN_CONSTRAINT_NAME;
         }
         return std::string();
     }
@@ -3271,7 +3273,7 @@ void LLIKConstraintFactory::initSingleton()
     // so introduces an unnecessary dependency on LLDir into the unit tests.
 #ifndef LL_TEST
     // Load the default constraints and mappings from config file.
-    constexpr char *constraint_file_base("avatar_constraint.llsd");
+    constexpr const char *constraint_file_base("avatar_constraint.llsd");
 
     std::string constraint_file (gDirUtilp->getExpandedFilename(LL_PATH_CHARACTER, constraint_file_base));
     if (constraint_file.empty())

--- a/indra/llcommon/tests/llleap_test.cpp
+++ b/indra/llcommon/tests/llleap_test.cpp
@@ -115,7 +115,7 @@ namespace tut
                    "    import llsd\n"
                    "except ImportError:\n"
                    // older llbase.llsd module
-                   "    from llbase import llsd\n"
+                   "    raise\n"
                    "\n"
                    "class ProtocolError(Exception):\n"
                    "    def __init__(self, msg, data):\n"

--- a/indra/llcommon/tests/llsdserialize_test.cpp
+++ b/indra/llcommon/tests/llsdserialize_test.cpp
@@ -1801,7 +1801,7 @@ namespace tut
                                    "    import llsd\n"
                                    "except ImportError:\n"
                                    // older llbase.llsd module
-                                   "    from llbase import llsd\n");
+                                   "    raise\n");
 
     // helper for TestPythonCompatible
     template <typename CONTENT>

--- a/indra/llcorehttp/tests/test_llcorehttp_peer.py
+++ b/indra/llcorehttp/tests/test_llcorehttp_peer.py
@@ -39,7 +39,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
 from llbase.fastest_elementtree import parse as xml_parse
-from llbase import llsd
+import llsd
 
 # we're in llcorehttp/tests ; testrunner.py is found in llmessage/tests
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,

--- a/indra/llmath/v3math.h
+++ b/indra/llmath/v3math.h
@@ -612,6 +612,7 @@ inline std::ostream& operator<<(std::ostream& s, const LLVector3 &a)
 }
 
 template <>
+inline
 void boost::hash_combine(size_t& seed, LLVector3 const& v)
 {
     hash_combine(seed, v.mV[0]);

--- a/indra/llmessage/tests/test_llsdmessage_peer.py
+++ b/indra/llmessage/tests/test_llsdmessage_peer.py
@@ -34,7 +34,7 @@ import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from llbase.fastest_elementtree import parse as xml_parse
-from llbase import llsd
+import llsd
 from testrunner import freeport, run, debug, VERBOSE
 import time
 

--- a/indra/newview/llpuppetmotion.cpp
+++ b/indra/newview/llpuppetmotion.cpp
@@ -46,19 +46,21 @@
 
 #include "llvoavatarself.h"
 
-#define ENABLE_RIGHT_CONSTRAINTS
+//#define ENABLE_RIGHT_CONSTRAINTS
 
 // BEGIN_HACK : hard-coded joint_ids
 //constexpr U16 PELVIS_ID = 0;
-constexpr U16 TORSO_ID = 3;
+//constexpr U16 TORSO_ID = 3;
 constexpr U16 CHEST_ID = 6;
-constexpr U16 NECK_ID = 7;
-constexpr U16 HEAD_ID = 8;
+//constexpr U16 NECK_ID = 7;
+//constexpr U16 HEAD_ID = 8;
+#ifdef ENABLE_LEFT_CONSTRAINTS
 constexpr S16 COLLAR_LEFT_ID = 58;
 constexpr S16 SHOULDER_LEFT_ID = 59;
 constexpr S16 ELBOW_LEFT_ID = 60;
+#endif // ENABLE_LEFT_CONSTRAINTS
 constexpr S16 WRIST_LEFT_ID = 61;
-
+#ifdef ENABLE_LEFT_CONSTRAINTS
 constexpr S16 HAND_MIDDLE_LEFT_1_ID = 62;
 constexpr S16 HAND_MIDDLE_LEFT_2_ID = 63;
 constexpr S16 HAND_MIDDLE_LEFT_3_ID = 64;
@@ -74,12 +76,15 @@ constexpr S16 HAND_PINKY_LEFT_3_ID = 73;
 constexpr S16 HAND_THUMB_LEFT_1_ID = 74;
 constexpr S16 HAND_THUMB_LEFT_2_ID = 75;
 constexpr S16 HAND_THUMB_LEFT_3_ID = 76;
+#endif // ENABLE_LEFT_CONSTRAINTS
 
 #ifdef ENABLE_RIGHT_CONSTRAINTS
 constexpr S16 COLLAR_RIGHT_ID = 77;
 constexpr S16 SHOULDER_RIGHT_ID = 78;
 constexpr S16 ELBOW_RIGHT_ID = 79;
+#endif // ENABLE_RIGHT_CONSTRAINTS
 constexpr S16 WRIST_RIGHT_ID = 80;
+#ifdef ENABLE_RIGHT_CONSTRAINTS
 constexpr S16 HAND_MIDDLE_RIGHT_1_ID = 81;
 constexpr S16 HAND_MIDDLE_RIGHT_2_ID = 82;
 constexpr S16 HAND_MIDDLE_RIGHT_3_ID = 83;

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -49,7 +49,7 @@ viewer_dir = os.path.dirname(__file__)
 # indra.util.llmanifest under their system Python!
 sys.path.insert(0, os.path.join(viewer_dir, os.pardir, "lib", "python"))
 from indra.util.llmanifest import LLManifest, main, path_ancestors, CHANNEL_VENDOR_BASE, RELEASE_CHANNEL, ManifestError, MissingError
-from llbase import llsd
+import llsd
 
 class ViewerManifest(LLManifest):
     def is_packaging_viewer(self):

--- a/scripts/metrics/slp_conv.py
+++ b/scripts/metrics/slp_conv.py
@@ -29,7 +29,7 @@ Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
 $/LicenseInfo$
 """
 
-from llbase import llsd
+import llsd
 import argparse
 
 parser = argparse.ArgumentParser(

--- a/scripts/metrics/viewer_asset_logs.py
+++ b/scripts/metrics/viewer_asset_logs.py
@@ -28,7 +28,7 @@ $/LicenseInfo$
 
 import argparse
 from lxml import etree
-from llbase import llsd
+import llsd
 
 def get_metrics_record(infiles):
     for filename in args.infiles:

--- a/scripts/metrics/viewerstats.py
+++ b/scripts/metrics/viewerstats.py
@@ -31,7 +31,7 @@ import numpy as np
 import pandas as pd
 import json
 from collections import Counter, defaultdict
-from llbase import llsd
+import llsd
 import io
 import re
 import os


### PR DESCRIPTION
The TC unit tests were failing because they were using `llbase.llsd`, whose published version doesn't include recent compatibility fixes. Directly importing standalone `llsd` should help.

Also, some C++ changes were necessary to build with Xcode 14.2. Please carefully look over especially `llpuppetmotion.cpp`, since some of the hard-coded constraints are referenced and others not. There may be better ways to address the resulting errors.