### PR TITLE
SL-18839: Add basic windows build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,93 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main, contribute]
+    tags: ["*"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        runner: [windows-large]
+        configuration: [ReleaseOS]
+        addrsize: [64]
+        include:
+          - runner: windows-large
+            configuration: ReleaseOS
+            addrsize: 32
+    runs-on: ${{ matrix.runner }}
+    env:
+      AUTOBUILD_CONFIGURATION: ${{ matrix.configuration }}
+      AUTOBUILD_ADDRSIZE: ${{ matrix.addrsize }}
+      AUTOBUILD_INSTALLABLE_CACHE: ${{ github.workspace }}/.autobuild-installables
+      AUTOBUILD_VARIABLES_FILE: ${{ github.workspace }}/.build-variables/variables
+      AUTOBUILD_VSVER: "170" # vs2k22
+      LOGFAIL: debug # Show details when tests fail
+      GIT_REF: ${{ github.head_ref || github.ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Checkout build variables
+        uses: actions/checkout@v3
+        with:
+          repository: secondlife/build-variables
+          ref: viewer
+          path: .build-variables
+
+      - name: Install autobuild and python dependencies
+        run: pip3 install autobuild llbase
+
+      - name: Cache autobuild packages
+        uses: actions/cache@v3
+        id: cache-installables
+        with:
+          path: .autobuild-installables
+          key: ${{ runner.os }}-${{ matrix.addrsize }}-${{ matrix.configuration }}-${{ hashFiles('autobuild.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.addrsize }}-${{ matrix.configuration }}-
+            ${{ runner.os }}-${{ matrix.addrsize }}-
+
+      - name: Install windows dependencies
+        if: runner.os == 'Windows'
+        run: choco install nsis-unicode
+
+      - name: Build
+        id: build
+        shell: bash
+        env:
+          RUNNER_OS: ${{ runner.os }}
+        run: |
+          # On windows we need to point the build to the correct python
+          # as neither CMake's FindPython nor our custom Python.cmake module
+          # will resolve the correct interpreter location.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            export PYTHON="$(cygpath -m "$(which python)")"
+            echo "Python location: $PYTHON"
+          fi
+          
+          autobuild configure -- -DVIEWER_CHANNEL="Second Life Test ${GIT_REF##*/}"
+          autobuild  build --no-configure
+
+          # Find artifacts
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            installer_path=$(find ./build-*/newview/ | grep '_Setup\.exe')
+            installer_name="$(basename $installer_path)"
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            installer_path=$(find ./build-*/newview/ | grep '\.dmg')
+            installer_name="$(basename $installer_path)"
+          fi
+
+          echo "installer_path=$installer_path" >> $GITHUB_OUTPUT
+          echo "installer_name=$installer_name" >> $GITHUB_OUTPUT
+      
+      - name: Upload installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build.outputs.installer_name }}
+          path: ${{ steps.build.outputs.installer_path }}

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -3403,7 +3403,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/t:Build</string>
                   <string>/p:useenv=true</string>
                   <string>/verbosity:minimal</string>
-                  <string>/toolsversion:4.0</string>
                   <string>/p:VCBuildAdditionalOptions= /incremental</string>
                 </array>
               </map>
@@ -3477,7 +3476,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
                   <string>/t:Build</string>
                   <string>/p:useenv=true</string>
                   <string>/verbosity:minimal</string>
-                  <string>/toolsversion:4.0</string>
                   <string>/p:VCBuildAdditionalOptions= /incremental</string>
                 </array>
               </map>

--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -61,7 +61,7 @@ if (WINDOWS)
   # CP changed to only append the flag for 32bit builds - on 64bit builds,
   # locally at least, the build output is spammed with 1000s of 'D9002'
   # warnings about this switch being ignored.
-  if( ADDRESS_SIZE EQUAL 32 )
+  if(ADDRESS_SIZE EQUAL 32 AND DEFINED ENV{"TEAMCITY_PROJECT_NAME"})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /p:PreferredToolArchitecture=x64")  
   endif()
   # zlib has assembly-language object files incompatible with SAFESEH

--- a/indra/cmake/Python.cmake
+++ b/indra/cmake/Python.cmake
@@ -2,7 +2,11 @@
 
 set(PYTHONINTERP_FOUND)
 
-if (WINDOWS)
+if (DEFINED ENV{PYTHON})
+  # Allow python executable to be explicitly set
+  set(python "$ENV{PYTHON}")
+  set(PYTHONINTERP_FOUND ON)
+elseif (WINDOWS)
   # On Windows, explicitly avoid Cygwin Python.
 
   # if the user has their own version of Python installed, prefer that
@@ -43,7 +47,7 @@ else()
   if (python)
     set(PYTHONINTERP_FOUND ON)
   endif (python)
-endif (WINDOWS)
+endif (DEFINED ENV{PYTHON})
 
 if (NOT python)
   message(FATAL_ERROR "No Python interpreter found")

--- a/indra/newview/installers/windows/installer_template.nsi
+++ b/indra/newview/installers/windows/installer_template.nsi
@@ -26,7 +26,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Compiler flags
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-Unicode true
 SetOverwrite on				# Overwrite files
 SetCompress auto			# Compress if saves space
 SetCompressor /solid lzma	# Compress whole installer as one block

--- a/indra/newview/installers/windows/installer_template.nsi
+++ b/indra/newview/installers/windows/installer_template.nsi
@@ -26,6 +26,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Compiler flags
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+Unicode true
 SetOverwrite on				# Overwrite files
 SetCompress auto			# Compress if saves space
 SetCompressor /solid lzma	# Compress whole installer as one block
@@ -523,6 +524,7 @@ FunctionEnd
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Make sure the user can uninstall
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+/* Unused
 Function un.CheckIfAdministrator
     DetailPrint $(CheckAdministratorUnInstDP)
     UserInfo::GetAccountType
@@ -534,6 +536,7 @@ lbl_is_admin:
     Return
 
 FunctionEnd
+*/
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Function CheckWillUninstallV2               

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -790,27 +790,15 @@ class WindowsManifest(ViewerManifest):
             
         # Check two paths, one for Program Files, and one for Program Files (x86).
         # Yay 64bit windows.
-        for ProgramFiles in 'ProgramFiles', 'ProgramFiles(x86)':
-            NSIS_path = os.path.expandvars(r'${%s}\NSIS\makensis.exe' % ProgramFiles)
-            if os.path.exists(NSIS_path):
-                break
-        installer_created=False
-        nsis_attempts=3
-        nsis_retry_wait=15
-        for attempt in range(nsis_attempts):
-            try:
-                self.run_command([NSIS_path, '/V2', self.dst_path_of(tempfile)])
-            except ManifestError as err:
-                if attempt+1 < nsis_attempts:
-                    print("nsis failed, waiting %d seconds before retrying" % nsis_retry_wait, file=sys.stderr)
-                    time.sleep(nsis_retry_wait)
-                    nsis_retry_wait*=2
-            else:
-                # NSIS worked! Done!
-                break
-        else:
-            print("Maximum nsis attempts exceeded; giving up", file=sys.stderr)
-            raise
+        nsis_path = "makensis.exe"
+        for program_files in '${programfiles}', '${programfiles(x86)}':
+            for nesis_path in 'NSIS', 'NSIS\\Unicode':
+                possible_path = os.path.expandvars(f"{program_files}\\{nesis_path}\\makensis.exe")
+                if os.path.exists(possible_path):
+                    nsis_path = possible_path
+                    break
+
+        self.run_command([possible_path, '/V2', self.dst_path_of(tempfile)])
 
         self.sign(installer_file)
         self.created_path(self.dst_path_of(installer_file))


### PR DESCRIPTION
Add basic builds for win32 and win64 using Github actions. This is a foundation for additional work, and should be able to run in parallel with our existing TeamCity configurations. See an example run [here](https://github.com/secondlife/viewer/actions/runs/4579252214).

<img width="713" alt="Screenshot 2023-03-31 150055" src="https://user-images.githubusercontent.com/151138/229241229-8eaf2319-3e4d-4feb-8448-3909322d8a81.png">

## Limitations

- Windows only
- ReleaseOS configuration
- Channel is not baked into resulting installable
- Not signed
- Installers are zipped
- Build artifacts last 90 days (by default)

At a minimum, this changeset allows us to verify PRs/commits to shared branches such as `contribute` do not break the build. It also allows builds to be manually triggered, which may be useful for producing regular/periodic downloads for projects.

## Future work

There's a lot of work remaining here. This PR is a first step that gives us some initial useful value.

### macOS

We need to get some dedicated macOS hosts set up so that darwin builds don't take an eternity --at least until Github releases more[ powerful macOS managed runners](https://github.blog/2023-03-01-github-actions-introducing-faster-github-hosted-x64-macos-runners/).

### Proprietary libs

We also need to move all proprietary autobuild dependencies from our internal artifact server which requires VPN access to Github release artifacts so that we can use Github credentials to download 3p deps like fmod.

### Releases

Ideally the Second Life viewer release process will incorporate Github Releases in the future. These could be used to help publish changenotes and permanently host project viewer releases, including project viewer nightlies. Publishing files through releases would mean that we can provide installation artifacts that are not wrapped in a zip archive, and can have no shelf life.