### PR TITLE
SL-19549 Add option to show ban lines on collision

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -11316,11 +11316,11 @@
     <key>ShowBanLines</key>
     <map>
       <key>Comment</key>
-      <string>Show in-world ban/access borders</string>
+      <string>Show in-world ban/access borders, 0 - do not show, 1 - show on collision, 2 - show on proximity</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
-      <string>Boolean</string>
+      <string>S32</string>
       <key>Value</key>
       <integer>1</integer>
     </map>

--- a/indra/newview/llglsandbox.cpp
+++ b/indra/newview/llglsandbox.cpp
@@ -741,6 +741,12 @@ void LLViewerParcelMgr::renderCollisionSegments(U8* segments, BOOL use_pass, LLV
 	gGL.end();
 }
 
+void LLViewerParcelMgr::resetCollisionTimer()
+{
+    mCollisionTimer.reset();
+    mRenderCollision = TRUE;
+}
+
 void draw_line_cube(F32 width, const LLVector3& center)
 {
 	width = 0.5f * width;

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -9060,6 +9060,25 @@ class LLWorldPostProcess : public view_listener_t
 	}
 };
 
+class LLWorldCheckBanLines : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        S32 callback_data = userdata.asInteger();
+        return gSavedSettings.getS32("ShowBanLines") == callback_data;
+    }
+};
+
+class LLWorldShowBanLines : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        S32 callback_data = userdata.asInteger();
+        gSavedSettings.setS32("ShowBanLines", callback_data);
+        return true;
+    }
+};
+
 void handle_flush_name_caches()
 {
 	if (gCacheName) gCacheName->clear();
@@ -9349,6 +9368,8 @@ void initialize_menus()
 	view_listener_t::addMenu(new LLWorldEnvPreset(), "World.EnvPreset");
 	view_listener_t::addMenu(new LLWorldEnableEnvPreset(), "World.EnableEnvPreset");
 	view_listener_t::addMenu(new LLWorldPostProcess(), "World.PostProcess");
+    view_listener_t::addMenu(new LLWorldCheckBanLines() , "World.CheckBanLines");
+    view_listener_t::addMenu(new LLWorldShowBanLines() , "World.ShowBanLines");
 
 	// Tools menu
 	view_listener_t::addMenu(new LLToolsSelectTool(), "Tools.SelectTool");

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -5151,6 +5151,7 @@ bool attempt_standard_notification(LLMessageSystem* msgsystem)
 				LandBuyAccessBlocked_AdultsOnlyContent
 			 
 			-----------------------------------------------------------------------*/ 
+            LLViewerParcelMgr::getInstance()->resetCollisionTimer();
 			if (handle_special_notification(notificationID, llsdBlock))
 			{
 				return true;
@@ -5319,6 +5320,11 @@ void process_alert_message(LLMessageSystem *msgsystem, void **user_data)
 	{
 		BOOL modal = FALSE;
 		process_alert_core(message, modal);
+
+        if (message.find("Cannot enter parcel") != std::string::npos)
+        {
+            LLViewerParcelMgr::getInstance()->resetCollisionTimer();
+        }
 	}
 }
 

--- a/indra/newview/llviewerparcelmgr.cpp
+++ b/indra/newview/llviewerparcelmgr.cpp
@@ -72,7 +72,11 @@
 
 #include "llenvironment.h"
 
-const F32 PARCEL_COLLISION_DRAW_SECS = 1.f;
+const F32 PARCEL_BAN_LINES_DRAW_SECS_ON_COLLISION = 10.f;
+const F32 PARCEL_COLLISION_DRAW_SECS_ON_PROXIMITY = 1.f;
+const S32 PARCEL_BAN_LINES_HIDE = 0;
+const S32 PARCEL_BAN_LINES_ON_COLLISION = 1;
+const S32 PARCEL_BAN_LINES_ON_PROXIMITY = 2;
 
 
 // Globals
@@ -892,13 +896,18 @@ void LLViewerParcelMgr::render()
 
 void LLViewerParcelMgr::renderParcelCollision()
 {
+    static LLCachedControl<S32> ban_lines_mode(gSavedSettings , "ShowBanLines" , PARCEL_BAN_LINES_DRAW_SECS_ON_COLLISION);
+
 	// check for expiration
-	if (mCollisionTimer.getElapsedTimeF32() > PARCEL_COLLISION_DRAW_SECS)
+    F32 expiration = (ban_lines_mode == PARCEL_BAN_LINES_ON_PROXIMITY)
+        ? PARCEL_COLLISION_DRAW_SECS_ON_PROXIMITY
+        : PARCEL_BAN_LINES_DRAW_SECS_ON_COLLISION;
+	if (mCollisionTimer.getElapsedTimeF32() > expiration)
 	{
-		mRenderCollision = FALSE;
+		mRenderCollision = false;
 	}
 
-	if (mRenderCollision && gSavedSettings.getBOOL("ShowBanLines"))
+	if (mRenderCollision && ban_lines_mode != PARCEL_BAN_LINES_HIDE)
 	{
 		LLViewerRegion* regionp = gAgent.getRegion();
 		if (regionp)
@@ -1842,8 +1851,11 @@ void LLViewerParcelMgr::processParcelProperties(LLMessageSystem *msg, void **use
 			 sequence_id == COLLISION_BANNED_PARCEL_SEQ_ID)
 	{
 		// We're about to collide with this parcel
-		parcel_mgr.mRenderCollision = TRUE;
-		parcel_mgr.mCollisionTimer.reset();
+        static LLCachedControl<S32> ban_lines_mode(gSavedSettings , "ShowBanLines" , PARCEL_BAN_LINES_DRAW_SECS_ON_COLLISION);
+        if (ban_lines_mode == PARCEL_BAN_LINES_ON_PROXIMITY)
+        {
+            parcel_mgr.resetCollisionTimer();
+        }
 
 		// Differentiate this parcel if we are banned from it.
 		if (sequence_id == COLLISION_BANNED_PARCEL_SEQ_ID)

--- a/indra/newview/llviewerparcelmgr.h
+++ b/indra/newview/llviewerparcelmgr.h
@@ -204,6 +204,7 @@ public:
 	void	renderOneSegment(F32 x1, F32 y1, F32 x2, F32 y2, F32 height, U8 direction, LLViewerRegion* regionp);
 	void	renderHighlightSegments(const U8* segments, LLViewerRegion* regionp);
 	void	renderCollisionSegments(U8* segments, BOOL use_pass, LLViewerRegion* regionp);
+    void	resetCollisionTimer();
 
 	void	sendParcelGodForceOwner(const LLUUID& owner_id);
 
@@ -361,7 +362,7 @@ private:
 	// If it's coming, draw the parcel's boundaries.
 	LLParcel*					mCollisionParcel;
 	U8*							mCollisionSegments;
-	BOOL						mRenderCollision; 
+	bool						mRenderCollision; 
 	BOOL						mRenderSelection;
 	S32							mCollisionBanned;     
 	LLFrameTimer				mCollisionTimer;

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -794,14 +794,36 @@
            name="LandShow"
            tear_off="true">
           <menu_item_check
-             label="Ban Lines"
-             name="Ban Lines">
+             label="Hide Ban Lines"
+             name="Hide Ban Lines">
             <menu_item_check.on_check
-               control="ShowBanLines" />
+             function="World.CheckBanLines"
+             parameter="0" />
             <menu_item_check.on_click
-               function="ToggleControl"
-               parameter="ShowBanLines" />
+             function="World.ShowBanLines"
+             parameter="0" />
           </menu_item_check>
+          <menu_item_check
+             label="Show Ban Lines On Collision"
+             name="Show Ban Lines On Collision">
+            <menu_item_check.on_check
+             function="World.CheckBanLines"
+             parameter="1" />
+            <menu_item_check.on_click
+             function="World.ShowBanLines"
+             parameter="1" />
+          </menu_item_check>
+          <menu_item_check
+             label="Show Ban Lines On Proximity"
+             name="Show Ban Lines On Proximity">
+            <menu_item_check.on_check
+             function="World.CheckBanLines"
+             parameter="2" />
+            <menu_item_check.on_click
+             function="World.ShowBanLines"
+             parameter="2" />
+          </menu_item_check>
+          <menu_item_separator />
            <menu_item_check
                  label="Beacons"
                  name="beacons"


### PR DESCRIPTION
Tracking notifications isn't a nice or correct way to do this, but viewer has no other way to track collisions with ban lines.