### PR TITLE
Fix moon texture being incorrectly multiplied by the global light color

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/moonF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/moonF.glsl
@@ -30,7 +30,6 @@
 out vec4 frag_data[4];
 
 uniform vec4 color;
-uniform vec3 moonlight_color;
 uniform vec3 moon_dir;
 uniform float moon_brightness;
 uniform sampler2D diffuseMap;
@@ -53,11 +52,7 @@ void main()
         discard;
     }
 
-
-    c.rgb *= moonlight_color.rgb;
     c.rgb *= moon_brightness;
-
-    c.rgb *= fade;
     c.a   *= fade;
 
     frag_data[0] = vec4(0);


### PR DESCRIPTION
Fixes moon being adjusted by the sunlight/moonlight color resulting in the brightness slider being basically ignored in darker nights.