### PR TITLE
Load correct localized version of emoji dictionary and guard against access violation exception

### DIFF
--- a/indra/llui/llemojidictionary.cpp
+++ b/indra/llui/llemojidictionary.cpp
@@ -141,7 +141,13 @@ void LLEmojiDictionary::initClass()
 
 	LLSD data;
 
-	const std::string filename = gDirUtilp->findSkinnedFilenames(LLDir::XUI, SKINNED_EMOJI_FILENAME, LLDir::CURRENT_SKIN).front();
+	auto filenames = gDirUtilp->findSkinnedFilenames(LLDir::XUI, SKINNED_EMOJI_FILENAME, LLDir::CURRENT_SKIN);
+	if (filenames.empty())
+	{
+		LL_WARNS() << "Emoji file characters not found" << LL_ENDL;
+		return;
+	}
+	const std::string filename = filenames.back();
 	llifstream file(filename.c_str());
 	if (file.is_open())
 	{


### PR DESCRIPTION
findSkinnedFilenames() will return a vector with English always being the first item. Localized versions will get appended, thus we need to use the last item in the vector for the correct file.