### PR TITLE
Don't hardcode UI text plus layout fixes and removing some needless checks

### DIFF
--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -80,7 +80,7 @@ LLFloaterEmojiPicker* LLFloaterEmojiPicker::getInstance()
 LLFloaterEmojiPicker* LLFloaterEmojiPicker::showInstance(pick_callback_t pick_callback, close_callback_t close_callback)
 {
 	LLFloaterEmojiPicker* floater = getInstance();
-	if (LLFloaterEmojiPicker* floater = getInstance())
+	if (floater)
 		floater->show(pick_callback, close_callback);
 	return floater;
 }
@@ -101,41 +101,31 @@ LLFloaterEmojiPicker::LLFloaterEmojiPicker(const LLSD& key)
 BOOL LLFloaterEmojiPicker::postBuild()
 {
 	// Should be initialized first
-	if ((mPreviewEmoji = getChild<LLButton>("PreviewEmoji")))
-	{
-		mPreviewEmoji->setClickedCallback(boost::bind(&LLFloaterEmojiPicker::onPreviewEmojiClick, this));
-	}
+	mPreviewEmoji = getChild<LLButton>("PreviewEmoji");
+	mPreviewEmoji->setClickedCallback(boost::bind(&LLFloaterEmojiPicker::onPreviewEmojiClick, this));
 
-	if ((mCategory = getChild<LLComboBox>("Category")))
+	mCategory = getChild<LLComboBox>("Category");
+	mCategory->setCommitCallback(boost::bind(&LLFloaterEmojiPicker::onCategoryCommit, this));
+	const auto& cat2Descrs = LLEmojiDictionary::instance().getCategory2Descrs();
+	mCategory->clearRows();
+	for (const auto& item : cat2Descrs)
 	{
-		mCategory->setCommitCallback(boost::bind(&LLFloaterEmojiPicker::onCategoryCommit, this));
-		mCategory->setLabel(LLStringExplicit("Choose a category"));
-		const auto& cat2Descrs = LLEmojiDictionary::instance().getCategory2Descrs();
-		mCategory->clearRows();
-		for (const auto& item : cat2Descrs)
-		{
-			std::string value = item.first;
-			std::string name = value;
-			LLStringUtil::capitalize(name);
-			mCategory->add(name, value);
-		}
-		mCategory->setSelectedByValue(mSelectedCategory, true);
+		std::string value = item.first;
+		std::string name = value;
+		LLStringUtil::capitalize(name);
+		mCategory->add(name, value);
 	}
+	mCategory->setSelectedByValue(mSelectedCategory, true);
 
-	if ((mSearch = getChild<LLLineEditor>("Search")))
-	{
-		mSearch->setKeystrokeCallback(boost::bind(&LLFloaterEmojiPicker::onSearchKeystroke, this, _1, _2), NULL);
-		mSearch->setLabel(LLStringExplicit("Type to search an emoji"));
-		mSearch->setFont(LLViewerChat::getChatFont());
-		mSearch->setText(mSearchPattern);
-	}
+	mSearch = getChild<LLLineEditor>("Search");
+	mSearch->setKeystrokeCallback(boost::bind(&LLFloaterEmojiPicker::onSearchKeystroke, this, _1, _2), NULL);
+	mSearch->setFont(LLViewerChat::getChatFont());
+	mSearch->setText(mSearchPattern);
 
-	if ((mEmojis = getChild<LLScrollListCtrl>("Emojis")))
-	{
-		mEmojis->setCommitCallback(boost::bind(&LLFloaterEmojiPicker::onEmojiSelect, this));
-		mEmojis->setDoubleClickCallback(boost::bind(&LLFloaterEmojiPicker::onEmojiPick, this));
-		fillEmojis();
-	}
+	mEmojis = getChild<LLScrollListCtrl>("Emojis");
+	mEmojis->setCommitCallback(boost::bind(&LLFloaterEmojiPicker::onEmojiSelect, this));
+	mEmojis->setDoubleClickCallback(boost::bind(&LLFloaterEmojiPicker::onEmojiPick, this));
+	fillEmojis();
 
 	return TRUE;
 }

--- a/indra/newview/skins/default/xui/en/floater_emoji_picker.xml
+++ b/indra/newview/skins/default/xui/en/floater_emoji_picker.xml
@@ -11,23 +11,23 @@
     width="200">
   <line_editor
       name="Search"
+      label="Type to search an emoji"
       layout="bottomleft"
       follows="bottom|left|right"
       text_tentative_color="TextFgTentativeColor"
       max_length_bytes="63"
-      left_pad="5"
-	  bottom="14"
-	  left="34"
+	  bottom="5"
+	  left="39"
       height="29"
-      width="162" />
+      width="158" />
   <button
 	  name="PreviewEmoji"
       layout="bottomleft"
       follows="bottom|left"
 	  font="EmojiHuge"
 	  use_font_color="true"
-	  bottom="14"
-	  left="0"
+	  bottom="5"
+	  left="5"
 	  height="29"
 	  width="29" />
   <scroll_list
@@ -39,26 +39,27 @@
 	  commit_on_selection_change="true"
       draw_heading="true"
       heading_height="25"
+	  left="5"
 	  row_padding="0"
 	  top="25"
-	  height="330"
-	  width="200">
+	  height="338"
+	  width="192">
     <columns
         label="Look"
         name="look"
-        width="40" />
+        width="50" />
 	<columns
         label="Name"
         name="name" />
   </scroll_list>
   <combo_box
       name="Category"
+      label="Choose a category"
       layout="topleft"
       follows="top|left|right"
 	  allow_text_entry="true"
-      left_pad="4"
 	  top="0"
-	  left="4"
-      height="27"
+	  left="5"
+      height="25"
       width="192" />
 </floater>


### PR DESCRIPTION
- Labels shouldn't be hardcoded in code
- Optimized layout of emoji picker floater (less wasted space, aligned widgets)
- Removed needless nullpointer checks for getChild (will create a dummy if not present in XUI and will never return nullptr)