### PR TITLE
Update glext package in attempt to fix DRTVWR-559 viewer readiness report

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" ?>
-<llsd><map>
+<llsd>
+<map>
     <key>installables</key>
     <map>
       <key>SDL</key>
@@ -773,9 +774,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>4f8dc85863fec36e8d872c31f4abcd05</string>
+              <string>7cc58b3acb230a7e65ea5f0ff800be393eb4aa1b</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
               <key>url</key>
-              <string>https://automated-builds-secondlife-com.s3.amazonaws.com/ct2/101480/892402/glext-68-common-572829.tar.bz2</string>
+              <string>https://github.com/secondlife/3p-glext/releases/download/v69/glext-68-common-685b36e.tar.zst</string>
             </map>
             <key>name</key>
             <string>common</string>
@@ -3511,4 +3514,5 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
     <string>autobuild</string>
     <key>version</key>
     <string>1.3</string>
-  </map></llsd>
+  </map>
+</llsd>


### PR DESCRIPTION
This updates the glext package to correct a misconfigured canonical_url.  However the new package is built with Github Actions which now packages things using zstd compression.  All developers will need autobuild >= 3.5 for this.

see https://github.com/secondlife/3p-glext/releases/tag/v69 