### PR TITLE
puppetry: cleanup IK algorithm invocation

### DIFF
--- a/indra/llcharacter/llik.cpp
+++ b/indra/llcharacter/llik.cpp
@@ -2848,9 +2848,9 @@ F32 LLIK::Solver::solve()
 F32 LLIK::Solver::solveOnce()
 {
     // Special experimental IK logic
-    bool enforce_constraints = false;
-    bool drop_elbow = false;
-    bool untwist = false;
+    bool enforce_constraints = true;
+    bool drop_elbow = true;
+    bool untwist = true;
     // uncomment the selected IK algorithm below:
 
     // CCD

--- a/indra/llcharacter/llik.cpp
+++ b/indra/llcharacter/llik.cpp
@@ -2775,6 +2775,15 @@ F32 LLIK::Solver::solve()
 {
     rebuildAllChains();
 
+    // Before each solve: we relax a fraction toward the reset pose.
+    // This provides return pressure that removes floating-point drift that would
+    // otherwise wander around within the valid zones of the constraints.
+    constexpr F32 INITIAL_RELAXATION_FACTOR = 0.25f;
+    for (auto& root : mActiveRoots)
+    {
+        root->relaxRotationsRecursively(INITIAL_RELAXATION_FACTOR);
+    }
+
 #ifdef DEBUG_LLIK_UNIT_TESTS
     if (mDebugEnabled)
     {
@@ -2809,15 +2818,6 @@ F32 LLIK::Solver::solve()
         }
     }
 #endif
-
-    // Before each solve: we relax a fraction toward the reset pose.
-    // This provides return pressure that removes floating-point drift that would
-    // otherwise wander around within the valid zones of the constraints.
-    constexpr F32 INITIAL_RELAXATION_FACTOR = 0.25f;
-    for (auto& root : mActiveRoots)
-    {
-        root->relaxRotationsRecursively(INITIAL_RELAXATION_FACTOR);
-    }
 
     constexpr U32 MAX_FABRIK_ITERATIONS = 16;
     constexpr U32 MIN_FABRIK_ITERATIONS = 4;

--- a/indra/llcharacter/llik.h
+++ b/indra/llcharacter/llik.h
@@ -659,7 +659,8 @@ private:
     F32 solveOnce();
 
     // experimental solver methods
-    void executeFabrikWithDroppedElbow(bool enable_constraints=true, bool untwist=true);
+    void executeFabrik(bool enforce_constraints=false, bool drop_elbow=false, bool untwist=false);
+    void executeCcd(bool enforce_constraints=false, bool drop_elbow=false, bool untwist=false);
 
     bool isSubBase(S16 joint_id) const;
     bool isSubRoot(S16 joint_id) const;
@@ -672,8 +673,8 @@ private:
     void shiftChainToBase(const joint_list_t& chain);
     void executeFabrikPass();
     void enforceConstraintsOutward();
-    void executeCcdPass(); // EXPERIMENTAL
-    void executeCcdInward(const joint_list_t& chain);
+    void executeCcdPass(bool enforce_constraints); // EXPERIMENTAL
+    void executeCcdInward(const joint_list_t& chain, bool enforce_constraints);
     void untwistChain(const joint_list_t& chain);
     F32 measureMaxError();
 

--- a/indra/llcharacter/llik.h
+++ b/indra/llcharacter/llik.h
@@ -638,7 +638,6 @@ public:
     LLQuaternion getJointLocalRot(S16 joint_id) const;
     LLVector3 getJointLocalPos(S16 joint_id) const;
     bool getJointLocalTransform(S16 joint_id, LLVector3& pos, LLQuaternion& rot) const;
-    LLVector3 getJointWorldTipPos(S16 joint_id) const;
     LLVector3 getJointWorldEndPos(S16 joint_id) const;
     LLQuaternion getJointWorldRot(S16 joint_id) const;
 
@@ -657,6 +656,11 @@ public:
     void setAcceptableError(F32 slop) { mAcceptableError = slop; }
 
 private:
+    F32 solveOnce();
+
+    // experimental solver methods
+    void executeFabrikWithDroppedElbow(bool enable_constraints=true, bool untwist=true);
+
     bool isSubBase(S16 joint_id) const;
     bool isSubRoot(S16 joint_id) const;
     //void adjustTargets(joint_config_map_t& targets); // EXPERIMENTAL: keep this

--- a/indra/llcharacter/tests/llik_test.cpp
+++ b/indra/llcharacter/tests/llik_test.cpp
@@ -1240,7 +1240,6 @@ namespace tut
         }
     }
 
-#ifdef ENABLE_FAILING_UNIT_TESTS
     // These hard-coded indices and constraints for a simplified two-fingered arm:
     //
     // chest   collar  shoulder   elbow    wrist (5)--(6)--(7)-. index
@@ -1387,6 +1386,48 @@ namespace tut
         //                                           (8)--(9)--(10)-. ring     /|
         //                                                                    Z X
         //
+        std::vector<std::string> names = {
+            "mChest",
+            "mCollar",
+            "mShoulder",
+            "mElbow",
+            "mWrist",
+            "mIndex1",
+            "mIndex2",
+            "mIndex3",
+            "mRing1",
+            "mRing2",
+            "mRing3"
+        };
+
+        std::vector<LLVector3> local_positions = {
+            {0.0f, 0.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {-0.2f, 0.5f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.2f, 0.5f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f}
+        };
+
+        std::vector<LLVector3> end_positions = {
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 1.0f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f},
+            {0.0f, 0.3f, 0.0f}
+        };
+
         // We try to bend the elbow near PI/2 by setting fingertip targets
         // in the positive X-direction:
         //
@@ -1395,7 +1436,7 @@ namespace tut
         //                              |
         //                              |
         //                              |
-        //                             (4)
+        //                             (4) wrist
         //           +--Y               |
         //          /|               (8)|(5)
         //         Z X                |   |
@@ -1404,69 +1445,51 @@ namespace tut
         //                          (10) (7)
         //                            |   |
         //
-        std::vector<LLVector3> local_positions;
-        std::vector<LLVector3> bones;
+        LLJoint* parent_joint = nullptr;
+        LLJoint* wrist_joint = nullptr;
+        std::vector<LLJoint*> joints;
+        for (size_t i = 0; i < local_positions.size(); ++i)
+        {
+            S16 id = (S16)(i);
+            if (id == INDEX_1 || id == RING_1)
+            {
+                parent_joint = wrist_joint;
+            }
+            LLJoint* joint = new LLJoint(names[i], parent_joint);
+            joint->setIsBone(true);
+            joint->setJointNum(id);
+            joint->setPosition(local_positions[i]);
+            joint->setEnd(end_positions[i]);
+            joints.push_back(joint);
 
-        // mChest (the root for this test)
-        local_positions.push_back(LLVector3::zero);
-        bones.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        // mCollarLeft
-        local_positions.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        // mShoulderLeft
-        local_positions.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        // mElbowLeft
-        local_positions.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        // mWristLeft
-        local_positions.push_back(LLVector3(0.0f, 1.0f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.5f, 0.0f));
+            if (id == WRIST)
+            {
+                wrist_joint = joint;
+            }
+            parent_joint = joint;
+        }
 
-        // mHandIndex1Left
-        local_positions.push_back(LLVector3(0.2f, 0.5f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        // mHandIndex2Left
-        local_positions.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        // mHandIndex3Left
-        local_positions.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-
-        // mHandRing1Left
-        local_positions.push_back(LLVector3(-0.2f, 0.5f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        // mHandRing2Left
-        local_positions.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        // mHandRing3Left
-        local_positions.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-        bones.push_back(LLVector3(0.0f, 0.3f, 0.0f));
-
-        LLIKConstraintFactory &factory(LLIKConstraintFactory::instance());
-        LLIK::Constraint::Info info;
-        LLIK::Constraint::ptr_t null_constraint = factory.getConstraint(info);
-
-        S16 joint_id = 0;
         LLIK::Solver solver;
         constexpr F32 ACCEPTABLE_ERROR = 1.0e-3f; // one mm
         solver.setAcceptableError(ACCEPTABLE_ERROR);
-        solver.setRootID(joint_id);
-        for (S32 id = 0; id < (S16)(local_positions.size()); ++id)
+        solver.setRootID(CHEST);
+        LLIKConstraintFactory factory;
+        for (size_t i = 0; i < local_positions.size(); ++i)
         {
+            S16 id = (S16)(i);
             S16 parent_id = id - 1;
             if (id == INDEX_1 || id == RING_1)
             {
                 parent_id = WRIST;
             }
-            LLIK::Constraint::Info info = get_constraint_info(id, local_positions[id]);
+            LLIK::Constraint::Info info = get_constraint_info(id, local_positions[i]);
             LLIK::Constraint::ptr_t constraint = factory.getConstraint(info);
-            solver.addJoint(id, parent_id, local_positions[id], bones[id], constraint);
+            solver.addJoint(id, parent_id, joints[i], constraint);
         }
         std::vector<S16> fingertip_indices = { INDEX_3, RING_3 };
 
         // measure the initial offsets to fingers from elbow_tip
-        LLVector3 elbow_tip = solver.getJointWorldTipPos(ELBOW);
+        LLVector3 elbow_tip = solver.getJointWorldEndPos(ELBOW);
         std::vector<LLVector3> finger_offsets;
         for (auto id : fingertip_indices)
         {
@@ -1494,19 +1517,20 @@ namespace tut
         // solve
         //solver.enableDebugIfPossible();
         solver.updateJointConfigs(configs);
-        F32 max_error = solver.solve();
+        F32 error = solver.solve();
 
         // check results
         // Note; this test does not quite reach ACCEPTABLE_ERROR after 16 iterations
         // however it gets close
-        F32 allowable_error = 0.033f;
-        for (size_t i = 0; i < fingertip_indices.size(); ++i)
+        F32 allowable_error = 0.016f;
+        ensure("LLIK::Solver finger should reach target", error < allowable_error);
+
+        // cleanup LLJoints
+        for (auto joint: joints)
         {
-            F32 error = dist_vec(solver.getJointWorldEndPos(fingertip_indices[i]), finger_target_positions[i]);
-            ensure("LLIK::Solver finger should reach target", error < allowable_error);
+            delete joint;
         }
     }
-#endif // ENABLE_FAILING_UNIT_TESTS
 
     void build_skeleton_arm(std::vector<LLJoint*>& joints, LLIKConstraintFactory& factory, LLIK::Solver& solver, bool with_fingers=true)
 	{


### PR DESCRIPTION
This PR is cleanup around how the IK algorithm is invoked to make it easier to enable/disable algorithm features and to experiment with alternative strategies.