### PR TITLE
sl-19676 - more loading stats and 360 Interest List mode work

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16964,17 +16964,6 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-  <key>360CaptureUseInterestListCap</key>
-  <map>
-    <key>Comment</key>
-    <string>Flag if set, uses the new InterestList cap to ask the simulator for full content</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Boolean</string>
-    <key>Value</key>
-    <integer>1</integer>
-  </map>
   <key>360CaptureJPEGEncodeQuality</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -295,13 +295,14 @@ public:
 	void                            removeRegionChangedCallback(boost::signals2::connection callback);
 
 
-	void changeInterestListMode(bool use_360_mode);
-	bool getInterestList360Mode() const { return mUse360Mode; }
+	void changeInterestListMode(const std::string & new_mode);
+    const std::string & getInterestListMode() const { return mInterestListMode; }
 
 private:
 	LLViewerRegion	*mRegionp;
 	region_changed_signal_t		            mRegionChangedSignal;
-	bool                                    mUse360Mode;
+
+    std::string								mInterestListMode;	// How agent wants regions to send updates
 
 	//--------------------------------------------------------------------
 	// History

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -294,9 +294,14 @@ public:
 	boost::signals2::connection     addRegionChangedCallback(const region_changed_signal_t::slot_type& cb);
 	void                            removeRegionChangedCallback(boost::signals2::connection callback);
 
+
+	void changeInterestListMode(bool use_360_mode);
+	bool getInterestList360Mode() const { return mUse360Mode; }
+
 private:
 	LLViewerRegion	*mRegionp;
 	region_changed_signal_t		            mRegionChangedSignal;
+	bool                                    mUse360Mode;
 
 	//--------------------------------------------------------------------
 	// History

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -64,12 +64,11 @@ LLFloater360Capture::LLFloater360Capture(const LLSD& key)
     // such time as we ask it not to (the dtor). If we crash or
     // otherwise, exit before this is turned off, the Simulator
     // will take care of cleaning up for us.
-    if (gSavedSettings.getBOOL("360CaptureUseInterestListCap"))
-    {
-        // send everything to us for as long as this floater is open
-        const bool send_everything = true;
-        changeInterestListMode(send_everything);
-    }
+    mWasIn360Mode = gAgent.getInterestList360Mode();
+
+    // send everything to us for as long as this floater is open
+    const bool use_360_mode = true;
+    gAgent.changeInterestListMode(use_360_mode);
 }
 
 LLFloater360Capture::~LLFloater360Capture()
@@ -81,13 +80,15 @@ LLFloater360Capture::~LLFloater360Capture()
         mWebBrowser->unloadMediaSource();
     }
 
-    // Tell the Simulator not to send us everything anymore
-    // and revert to the regular "keyhole" frustum of interest
+    // Restore interest list mode to the state when started
+    // Normally LLFloater360Capture tells the Simulator send everything
+    // and now reverts to the regular "keyhole" frustum of interest
     // list updates.
-    if (!LLApp::isExiting() && gSavedSettings.getBOOL("360CaptureUseInterestListCap"))
+    if (!LLApp::isExiting() && 
+        gSavedSettings.getBOOL("360CaptureUseInterestListCap") &&
+        mWasIn360Mode != gAgent.getInterestList360Mode())
     {
-        const bool send_everything = false;
-        changeInterestListMode(send_everything);
+        gAgent.changeInterestListMode(mWasIn360Mode);
     }
 }
 
@@ -170,49 +171,6 @@ void LLFloater360Capture::onChooseQualityRadioGroup()
     setSourceImageSize();
 }
 
-// Using a new capability, tell the simulator that we want it to send everything
-// it knows about and not just what is in front of the camera, in its view
-// frustum. We need this feature so that the contents of the region that appears
-// in the 6 snapshots which we cannot see and is normally not "considered", is
-// also rendered. Typically, this is turned on when the 360 capture floater is
-// opened and turned off when it is closed.
-// Note: for this version, we do not have a way to determine when "everything"
-// has arrived and has been rendered so for now, the proposal is that users
-// will need to experiment with the low resolution version and wait for some
-// (hopefully) small period of time while the full contents resolves.
-// Pass in a flag to ask the simulator/interest list to "send everything" or
-// not (the default mode)
-void LLFloater360Capture::changeInterestListMode(bool send_everything)
-{
-    LLSD body;
-
-    if (send_everything)
-    {
-        body["mode"] = LLSD::String("360");
-    }
-    else
-    {
-        body["mode"] = LLSD::String("default");
-    }
-
-    if (gAgent.requestPostCapability("InterestList", body, [](const LLSD & response)
-    {
-        LL_DEBUGS("360Capture") << "InterestList capability responded: \n" <<
-                               ll_pretty_print_sd(response) <<
-                               LL_ENDL;
-    }))
-    {
-        LL_DEBUGS("360Capture") << "Successfully posted an InterestList capability request with payload: \n" <<
-                               ll_pretty_print_sd(body) <<
-                               LL_ENDL;
-    }
-    else
-    {
-        LL_WARNS("360Capture") << "Unable to post an InterestList capability request with payload: \n" <<
-                               ll_pretty_print_sd(body) <<
-                               LL_ENDL;
-    }
-}
 
 // There is is a setting (360CaptureSourceImageSize) that holds the size
 // (width == height since it's a square) of each of the 6 source snapshots.

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -64,11 +64,10 @@ LLFloater360Capture::LLFloater360Capture(const LLSD& key)
     // such time as we ask it not to (the dtor). If we crash or
     // otherwise, exit before this is turned off, the Simulator
     // will take care of cleaning up for us.
-    mWasIn360Mode = gAgent.getInterestList360Mode();
+    mStartILMode = gAgent.getInterestListMode();
 
     // send everything to us for as long as this floater is open
-    const bool use_360_mode = true;
-    gAgent.changeInterestListMode(use_360_mode);
+    gAgent.changeInterestListMode(LLViewerRegion::IL_MODE_360);
 }
 
 LLFloater360Capture::~LLFloater360Capture()
@@ -86,9 +85,9 @@ LLFloater360Capture::~LLFloater360Capture()
     // list updates.
     if (!LLApp::isExiting() && 
         gSavedSettings.getBOOL("360CaptureUseInterestListCap") &&
-        mWasIn360Mode != gAgent.getInterestList360Mode())
+        mStartILMode != gAgent.getInterestListMode())
     {
-        gAgent.changeInterestListMode(mWasIn360Mode);
+        gAgent.changeInterestListMode(mStartILMode);
     }
 }
 

--- a/indra/newview/llfloater360capture.h
+++ b/indra/newview/llfloater360capture.h
@@ -50,8 +50,6 @@ class LLFloater360Capture:
         void onOpen(const LLSD& key) override;
         void handleMediaEvent(LLPluginClassMedia* self, EMediaEvent event) override;
 
-        void changeInterestListMode(bool send_everything);
-
         const std::string getHTMLBaseFolder();
         void capture360Images();
 
@@ -93,6 +91,8 @@ class LLFloater360Capture:
         std::string mImageSaveDir;
 
         LLPointer<LLImageRaw> mRawImages[6];
+
+        bool mWasIn360Mode;
 };
 
 #endif  // LL_FLOATER_360CAPTURE_H

--- a/indra/newview/llfloater360capture.h
+++ b/indra/newview/llfloater360capture.h
@@ -92,7 +92,7 @@ class LLFloater360Capture:
 
         LLPointer<LLImageRaw> mRawImages[6];
 
-        bool mWasIn360Mode;
+        std::string mStartILMode;
 };
 
 #endif  // LL_FLOATER_360CAPTURE_H

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -1301,65 +1301,18 @@ class LLAdvancedToggleInterestList360Mode : public view_listener_t
 public:
     bool handleEvent(const LLSD &userdata)
     {
-        LLSD request;
-        LLSD body;
-
-        // First do a GET to report on current mode and update stats
-        if (gAgent.requestGetCapability("InterestList",
-                                        [](const LLSD &response) {
-                                            LL_DEBUGS("360Capture") << "InterestList capability GET responded: \n"
-                                                                   << ll_pretty_print_sd(response) << LL_ENDL;
-                                        }))
-        {
-            LL_DEBUGS("360Capture") << "Successful GET InterestList capability request with return body: \n"
-                                   << ll_pretty_print_sd(body) << LL_ENDL;
-        }
-        else
-        {
-            LL_WARNS("360Capture") << "Unable to GET InterestList capability request with return body: \n"
-                                   << ll_pretty_print_sd(body) << LL_ENDL;
-        }
-
-        // Now do a POST to change the mode
-        if (sUsing360)
-        {
-            body["mode"] = LLSD::String("default");
-        }
-        else
-        {
-            body["mode"] = LLSD::String("360");
-        }
-        sUsing360 = !sUsing360;
-        LL_INFOS("360Capture") << "Setting InterestList capability mode to " << body["mode"].asString() << LL_ENDL;
-
-        if (gAgent.requestPostCapability("InterestList", body,
-                                         [](const LLSD &response) {
-                                             LL_DEBUGS("360Capture") << "InterestList capability responded: \n"
-                                                                    << ll_pretty_print_sd(response) << LL_ENDL;
-                                         }))
-        {
-            LL_DEBUGS("360Capture") << "Successfully posted an InterestList capability request with payload: \n"
-                                   << ll_pretty_print_sd(body) << LL_ENDL;
-            return true;
-        }
-        else
-        {
-            LL_DEBUGS("360Capture") << "Unable to post an InterestList capability request with payload: \n"
-                                   << ll_pretty_print_sd(body) << LL_ENDL;
-            return false;
-        }
-    };
-
-	static bool sUsing360;
+        // Toggle the mode - regions will get updated
+        bool new_mode = !gAgent.getInterestList360Mode();
+        gAgent.changeInterestListMode(new_mode);
+        return true;
+    }
 };
-
-bool LLAdvancedToggleInterestList360Mode::sUsing360 = false;
 
 class LLAdvancedCheckInterestList360Mode : public view_listener_t
 {
 	bool handleEvent(const LLSD& userdata)
 	{
-		return LLAdvancedToggleInterestList360Mode::sUsing360;
+		return gAgent.getInterestList360Mode();
 	}
 };
 

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -1302,8 +1302,14 @@ public:
     bool handleEvent(const LLSD &userdata)
     {
         // Toggle the mode - regions will get updated
-        bool new_mode = !gAgent.getInterestList360Mode();
-        gAgent.changeInterestListMode(new_mode);
+        if (gAgent.getInterestListMode() == LLViewerRegion::IL_MODE_360)
+        {
+			gAgent.changeInterestListMode(LLViewerRegion::IL_MODE_DEFAULT);
+		}
+		else
+		{
+			gAgent.changeInterestListMode(LLViewerRegion::IL_MODE_360);
+		}
         return true;
     }
 };
@@ -1312,7 +1318,7 @@ class LLAdvancedCheckInterestList360Mode : public view_listener_t
 {
 	bool handleEvent(const LLSD& userdata)
 	{
-		return gAgent.getInterestList360Mode();
+		return (gAgent.getInterestListMode() == LLViewerRegion::IL_MODE_360);
 	}
 };
 

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -99,6 +99,7 @@
 #include "llviewerobjectlist.h"
 #include "llviewerparcelmgr.h"
 #include "llviewerstats.h"
+#include "llviewerstatsrecorder.h"
 #include "llviewertexteditor.h"
 #include "llviewerthrottle.h"
 #include "llviewerwindow.h"
@@ -3759,31 +3760,34 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
 			continue;
 		}
 
-			LLViewerObject *objectp = gObjectList.findObject(id);
-			if (objectp)
+		LLViewerObject *objectp = gObjectList.findObject(id);
+		if (objectp)
+		{
+			// Display green bubble on kill
+			if ( gShowObjectUpdates )
 			{
-				// Display green bubble on kill
-				if ( gShowObjectUpdates )
-				{
-					LLColor4 color(0.f,1.f,0.f,1.f);
-					gPipeline.addDebugBlip(objectp->getPositionAgent(), color);
-					LL_DEBUGS("MessageBlip") << "Kill blip for local " << local_id << " at " << objectp->getPositionAgent() << LL_ENDL;
-				}
-
-				// Do the kill
-				gObjectList.killObject(objectp);
+				LLColor4 color(0.f,1.f,0.f,1.f);
+				gPipeline.addDebugBlip(objectp->getPositionAgent(), color);
+				LL_DEBUGS("MessageBlip") << "Kill blip for local " << local_id << " at " << objectp->getPositionAgent() << LL_ENDL;
 			}
 
-			if(delete_object)
-			{
-				regionp->killCacheEntry(local_id);
+			// Do the kill
+			gObjectList.killObject(objectp);
+		}
+
+		if(delete_object)
+		{
+			regionp->killCacheEntry(local_id);
 		}
 
 		// We should remove the object from selection after it is marked dead by gObjectList to make LLToolGrab,
         // which is using the object, release the mouse capture correctly when the object dies.
         // See LLToolGrab::handleHoverActive() and LLToolGrab::handleHoverNonPhysical().
 		LLSelectMgr::getInstance()->removeObjectFromSelections(id);
-	}
+
+	}	// end for loop
+
+    LLViewerStatsRecorder::instance().recordObjectKills(num_objects);
 }
 
 void process_time_synch(LLMessageSystem *mesgsys, void **user_data)

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -369,7 +369,7 @@ LLViewerObject* LLViewerObjectList::processObjectUpdateFromCache(LLVOCacheEntry*
 		if (!objectp)
 		{
 			LL_INFOS() << "createObject failure for object: " << fullid << LL_ENDL;
-			recorder.objectUpdateFailure(0);
+			recorder.objectUpdateFailure();
 			return NULL;
 		}
 		justCreated = true;
@@ -501,7 +501,7 @@ void LLViewerObjectList::processObjectUpdate(LLMessageSystem *mesgsys,
 						<< " Flags: " << flags
 						<< " Region: " << regionp->getName()
 						<< " Region id: " << regionp->getRegionID() << LL_ENDL;
-					recorder.objectUpdateFailure(msg_size);
+					recorder.objectUpdateFailure();
 					continue;
 				}
 				else if ((flags & FLAGS_TEMPORARY_ON_REZ) == 0)
@@ -612,7 +612,7 @@ void LLViewerObjectList::processObjectUpdate(LLMessageSystem *mesgsys,
 				if (update_type == OUT_TERSE_IMPROVED)
 				{
 					// LL_INFOS() << "terse update for an unknown object (compressed):" << fullid << LL_ENDL;
-					recorder.objectUpdateFailure(msg_size);
+					recorder.objectUpdateFailure();
 					continue;
 				}
 			}
@@ -621,7 +621,7 @@ void LLViewerObjectList::processObjectUpdate(LLMessageSystem *mesgsys,
 				if (update_type != OUT_FULL)
 				{
 					//LL_INFOS() << "terse update for an unknown object:" << fullid << LL_ENDL;
-					recorder.objectUpdateFailure(msg_size);
+					recorder.objectUpdateFailure();
 					continue;
 				}
 
@@ -634,7 +634,7 @@ void LLViewerObjectList::processObjectUpdate(LLMessageSystem *mesgsys,
 			{
 				mNumDeadObjectUpdates++;
 				//LL_INFOS() << "update for a dead object:" << fullid << LL_ENDL;
-				recorder.objectUpdateFailure(msg_size);
+				recorder.objectUpdateFailure();
 				continue;
 			}
 #endif
@@ -647,7 +647,7 @@ void LLViewerObjectList::processObjectUpdate(LLMessageSystem *mesgsys,
 			if (!objectp)
 			{
 				LL_INFOS() << "createObject failure for object: " << fullid << LL_ENDL;
-				recorder.objectUpdateFailure(msg_size);
+				recorder.objectUpdateFailure();
 				continue;
 			}
 

--- a/indra/newview/llviewerregion.h
+++ b/indra/newview/llviewerregion.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <boost/signals2.hpp>
 
+#include "llcorehttputil.h"
 #include "llwind.h"
 #include "v3dmath.h"
 #include "llstring.h"
@@ -278,6 +279,15 @@ public:
 	static bool isSpecialCapabilityName(const std::string &name);
 	void logActiveCapabilities() const;
 
+	// Utilities to post and get via
+    // HTTP using the agent's policy settings and headers.
+    typedef LLCoreHttpUtil::HttpCoroutineAdapter::completionCallback_t httpCallback_t;
+    bool requestPostCapability(const std::string &capName,
+                               LLSD              &postData,
+                               httpCallback_t     cbSuccess = NULL,
+                               httpCallback_t     cbFailure = NULL);
+    bool requestGetCapability(const std::string &capName, httpCallback_t cbSuccess = NULL, httpCallback_t cbFailure = NULL);
+
     /// implements LLCapabilityProvider
 	/*virtual*/ const LLHost& getHost() const;
 	const U64 		&getHandle() const 			{ return mHandle; }
@@ -477,6 +487,11 @@ public:
 	};
 	typedef std::set<LLViewerRegion*, CompareRegionByLastUpdate> region_priority_list_t;
 
+	void setInterestList360Mode(bool use_360_mode);
+	bool getInterestList360Mode() const { return mUse360Mode; }
+
+
+
 private:
 	static S32  sNewObjectCreationThrottle;
 	LLViewerRegionImpl * mImpl;
@@ -574,6 +589,9 @@ private:
 	LLFrameTimer mMaterialsCapThrottleTimer;
 	LLFrameTimer mRenderInfoRequestTimer;
 	LLFrameTimer mRenderInfoReportTimer;
+
+	// how the server interest list works
+    bool mUse360Mode;
 };
 
 inline BOOL LLViewerRegion::getRegionProtocol(U64 protocol) const

--- a/indra/newview/llviewerregion.h
+++ b/indra/newview/llviewerregion.h
@@ -487,12 +487,13 @@ public:
 	};
 	typedef std::set<LLViewerRegion*, CompareRegionByLastUpdate> region_priority_list_t;
 
-	void setInterestList360Mode(bool use_360_mode);
-	bool getInterestList360Mode() const { return mUse360Mode; }
+	void setInterestListMode(const std::string & new_mode);
+    const std::string & getInterestListMode() const { return mInterestListMode; }
 
+	static const std::string IL_MODE_DEFAULT;
+    static const std::string IL_MODE_360;
 
-
-private:
+  private:
 	static S32  sNewObjectCreationThrottle;
 	LLViewerRegionImpl * mImpl;
 	LLFrameTimer         mRegionTimer;
@@ -591,7 +592,7 @@ private:
 	LLFrameTimer mRenderInfoReportTimer;
 
 	// how the server interest list works
-    bool mUse360Mode;
+    std::string mInterestListMode;
 };
 
 inline BOOL LLViewerRegion::getRegionProtocol(U64 protocol) const

--- a/indra/newview/llviewerstatsrecorder.h
+++ b/indra/newview/llviewerstatsrecorder.h
@@ -53,11 +53,11 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
 	bool isEnabled() const { return mEnableStatsRecording; }
 	bool isLogging() const { return mEnableStatsLogging; }
 
-	void objectUpdateFailure(S32 msg_size)
+	void objectUpdateFailure()
     {
         if (mEnableStatsRecording)
         {
-            recordObjectUpdateFailure(msg_size);
+            mObjectUpdateFailures++;
         }
 	}
 
@@ -73,7 +73,7 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
     {
         if (mEnableStatsRecording)
         {
-            recordCacheHitEvent();
+            mObjectCacheHitCount++;
         }
     }
 
@@ -97,7 +97,7 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
 	{
         if (mEnableStatsRecording)
         {
-            recordRequestCacheMissesEvent(count);
+            mObjectCacheMissRequests += count;
         }
 	}
 
@@ -105,7 +105,7 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
 	{
         if (mEnableStatsRecording)
         {
-            recordTextureFetch();
+            mTextureFetchCount += 1;
         }
 	}
 
@@ -113,8 +113,16 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
 	{
 		if (mEnableStatsRecording)
 		{
-			recordMeshLoaded();
+            mMeshLoadedCount += 1;
 		}
+	}
+
+	void recordObjectKills(S32 num_objects)
+	{ 
+		if (mEnableStatsRecording)
+        {
+            mObjectKills += num_objects;
+        }
 	}
 
 	void idle()
@@ -125,14 +133,9 @@ class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
 	F32 getTimeSinceStart();
 
 private:
-	void recordObjectUpdateFailure(S32 msg_size);
 	void recordCacheMissEvent(U8 cache_miss_type);
-	void recordCacheHitEvent();
 	void recordObjectUpdateEvent(const EObjectUpdateType update_type);
 	void recordCacheFullUpdate(LLViewerRegion::eCacheUpdateResult update_result);
-	void recordRequestCacheMissesEvent(S32 count);
-	void recordTextureFetch();
-	void recordMeshLoaded();
 	void writeToLog(F32 interval);
     void closeStatsFile();
 	void makeStatsFileName();
@@ -158,15 +161,14 @@ private:
 	S32			mObjectFullUpdates;
 	S32			mObjectTerseUpdates;
 	S32			mObjectCacheMissRequests;
-	S32			mObjectCacheMissResponses;
 	S32			mObjectCacheUpdateDupes;
 	S32			mObjectCacheUpdateChanges;
 	S32			mObjectCacheUpdateAdds;
 	S32			mObjectCacheUpdateReplacements;
 	S32			mObjectUpdateFailures;
-	S32			mObjectUpdateFailuresSize;
 	S32			mTextureFetchCount;
     S32         mMeshLoadedCount;
+	S32			mObjectKills;
 
 	void	clearStats();
 };


### PR DESCRIPTION
Some refinement with 360 mode Interest List and viewer stats:

- 360 modes is applied to all regions the viewer can see
- if the agent is in 360 interest list mode, it is applied to all new regions they see or visit
- removed obsolete 360CaptureUseInterestListCap Debug setting - all regions support it now.
- shuffled code to use the IL cap into LLViewerRegion
- object kill messages are now counted in the update stats
- object update failures no longer track message size
- mObjectCacheMissResponses from stats removed, it was useless 