### PR TITLE
SL-19676 - more IL control, added Reset Interest List Debug menu command

### DIFF
--- a/indra/llmessage/llcorehttputil.cpp
+++ b/indra/llmessage/llcorehttputil.cpp
@@ -1336,6 +1336,48 @@ void HttpCoroutineAdapter::trivialPostCoro(std::string url, LLCore::HttpRequest:
 }
 
 
+/*static*/
+void HttpCoroutineAdapter::callbackHttpDel(const std::string &url, LLCore::HttpRequest::policy_t policyId, completionCallback_t success,
+                                           completionCallback_t failure)
+{
+    LLCoros::instance().launch("HttpCoroutineAdapter::genericDelCoro",
+                               boost::bind(&HttpCoroutineAdapter::trivialDelCoro, url, policyId, success, failure));
+}
+
+/*static*/
+void HttpCoroutineAdapter::trivialDelCoro(std::string url, LLCore::HttpRequest::policy_t policyId, completionCallback_t success,
+                                          completionCallback_t failure)
+{
+    LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t httpAdapter(new LLCoreHttpUtil::HttpCoroutineAdapter("genericDelCoro", policyId));
+    LLCore::HttpRequest::ptr_t                  httpRequest(new LLCore::HttpRequest);
+    LLCore::HttpOptions::ptr_t                  httpOpts(new LLCore::HttpOptions);
+
+    httpOpts->setWantHeaders(true);
+
+    LL_INFOS("HttpCoroutineAdapter", "genericDelCoro") << "Generic DEL for " << url << LL_ENDL;
+
+    LLSD result = httpAdapter->deleteAndSuspend(httpRequest, url, httpOpts);
+
+    LLSD               httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
+    LLCore::HttpStatus status      = LLCoreHttpUtil::HttpCoroutineAdapter::getStatusFromLLSD(httpResults);
+
+    if (!status)
+    {
+        if (failure)
+        {
+            failure(httpResults);
+        }
+    }
+    else
+    {
+        if (success)
+        {
+            success(result);
+        }
+    }
+}
+
+
 
 } // end namespace LLCoreHttpUtil
 

--- a/indra/llmessage/llcorehttputil.h
+++ b/indra/llmessage/llcorehttputil.h
@@ -608,6 +608,9 @@ public:
         callbackHttpPost(url, LLCore::HttpRequest::DEFAULT_POLICY_ID, postData, success, failure);
     }
 
+    static void callbackHttpDel(const std::string &url, LLCore::HttpRequest::policy_t policyId, completionCallback_t success = NULL,
+                            completionCallback_t failure = NULL);
+
     /// Generic Get and post routines for HTTP via coroutines.
     /// These static methods do all required setup for the GET or POST operation.
     /// When the operation completes successfully they will put the success message in the log at INFO level, 
@@ -669,6 +672,7 @@ private:
 
     static void trivialGetCoro(std::string url, LLCore::HttpRequest::policy_t policyId, completionCallback_t success, completionCallback_t failure);
     static void trivialPostCoro(std::string url, LLCore::HttpRequest::policy_t policyId, LLSD postData, completionCallback_t success, completionCallback_t failure);
+    static void trivialDelCoro(std::string url, LLCore::HttpRequest::policy_t policyId, completionCallback_t success, completionCallback_t failure);
 
     void checkDefaultHeaders(LLCore::HttpHeaders::ptr_t &headers);
 

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -122,6 +122,7 @@
 #include "llviewerstatsrecorder.h"
 #include "llvoavatarself.h"
 #include "llvoicevivox.h"
+#include "llworld.h"
 #include "llworldmap.h"
 #include "pipeline.h"
 #include "llviewerjoystick.h"
@@ -333,6 +334,7 @@ void handle_debug_avatar_textures(void*);
 void handle_grab_baked_texture(void*);
 BOOL enable_grab_baked_texture(void*);
 void handle_dump_region_object_cache(void*);
+void handle_reset_interest_lists(void *);
 
 BOOL enable_save_into_task_inventory(void*);
 
@@ -1346,6 +1348,14 @@ class LLAdvancedCheckStatsRecorder : public view_listener_t
     }
 };
 
+class LLAdvancedResetInterestLists : public view_listener_t
+{
+    bool handleEvent(const LLSD &userdata)
+    {	// Reset all region interest lists
+        handle_reset_interest_lists(NULL);
+        return true;
+    }
+};
 
 
 class LLAdvancedBuyCurrencyTest : public view_listener_t
@@ -3891,6 +3901,22 @@ void handle_dump_region_object_cache(void*)
 		regionp->dumpCache();
 	}
 }
+
+void handle_reset_interest_lists(void *)
+{
+    // Check all regions and reset their interest list
+    for (LLWorld::region_list_t::const_iterator iter = LLWorld::getInstance()->getRegionList().begin();
+         iter != LLWorld::getInstance()->getRegionList().end();
+         ++iter)
+    {
+        LLViewerRegion *regionp = *iter;
+        if (regionp && regionp->isAlive() && regionp->capabilitiesReceived())
+        {
+            regionp->resetInterestList();
+        }
+    }
+}
+
 
 void handle_dump_focus()
 {
@@ -9452,10 +9478,11 @@ void initialize_menus()
 	// Advanced > World
 	view_listener_t::addMenu(new LLAdvancedDumpScriptedCamera(), "Advanced.DumpScriptedCamera");
 	view_listener_t::addMenu(new LLAdvancedDumpRegionObjectCache(), "Advanced.DumpRegionObjectCache");
-    view_listener_t::addMenu(new LLAdvancedToggleInterestList360Mode(), "Advanced.ToggleInterestList360Mode");
-    view_listener_t::addMenu(new LLAdvancedCheckInterestList360Mode(), "Advanced.CheckInterestList360Mode");
     view_listener_t::addMenu(new LLAdvancedToggleStatsRecorder(), "Advanced.ToggleStatsRecorder");
     view_listener_t::addMenu(new LLAdvancedCheckStatsRecorder(), "Advanced.CheckStatsRecorder");
+    view_listener_t::addMenu(new LLAdvancedToggleInterestList360Mode(), "Advanced.ToggleInterestList360Mode");
+    view_listener_t::addMenu(new LLAdvancedCheckInterestList360Mode(), "Advanced.CheckInterestList360Mode");
+    view_listener_t::addMenu(new LLAdvancedResetInterestLists(), "Advanced.ResetInterestLists");
 
 	// Advanced > UI
 	commit.add("Advanced.WebBrowserTest", boost::bind(&handle_web_browser_test,	_2));	// sigh! this one opens the MEDIA browser

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -3341,6 +3341,21 @@ bool LLViewerRegion::requestGetCapability(const std::string &capName, httpCallba
     return true;
 }
 
+bool LLViewerRegion::requestDelCapability(const std::string &capName, httpCallback_t cbSuccess, httpCallback_t cbFailure)
+{
+    std::string url;
+
+    url = getCapability(capName);
+
+    if (url.empty())
+    {
+        LL_WARNS("Region") << "Could not retrieve region " << getRegionID() << " DEL capability \"" << capName << "\"" << LL_ENDL;
+        return false;
+    }
+
+    LLCoreHttpUtil::HttpCoroutineAdapter::callbackHttpDel(url, gAgent.getAgentPolicy(), cbSuccess, cbFailure);
+    return true;
+}
 
 void LLViewerRegion::setInterestListMode(const std::string &new_mode)
 {
@@ -3381,6 +3396,20 @@ void LLViewerRegion::setInterestListMode(const std::string &new_mode)
     }
 }
 
+
+void LLViewerRegion::resetInterestList()
+{
+	if (requestDelCapability("InterestList", [](const LLSD &response) {
+							LL_DEBUGS("360Capture") << "InterestList capability DEL responded: \n" << ll_pretty_print_sd(response) << LL_ENDL;
+						}))
+	{
+		LL_DEBUGS("360Capture") << "Region " << getRegionID() << " Successfully reset InterestList capability" << LL_ENDL;
+	}
+	else
+	{
+		LL_WARNS("360Capture") << "Region " << getRegionID() << " Unable to DEL InterestList capability request" << LL_ENDL;
+	}
+}
 
 
 LLSpatialPartition *LLViewerRegion::getSpatialPartition(U32 type)

--- a/indra/newview/llviewerregion.h
+++ b/indra/newview/llviewerregion.h
@@ -287,6 +287,7 @@ public:
                                httpCallback_t     cbSuccess = NULL,
                                httpCallback_t     cbFailure = NULL);
     bool requestGetCapability(const std::string &capName, httpCallback_t cbSuccess = NULL, httpCallback_t cbFailure = NULL);
+    bool requestDelCapability(const std::string &capName, httpCallback_t cbSuccess = NULL, httpCallback_t cbFailure = NULL);
 
     /// implements LLCapabilityProvider
 	/*virtual*/ const LLHost& getHost() const;
@@ -489,6 +490,8 @@ public:
 
 	void setInterestListMode(const std::string & new_mode);
     const std::string & getInterestListMode() const { return mInterestListMode; }
+
+	void resetInterestList();
 
 	static const std::string IL_MODE_DEFAULT;
     static const std::string IL_MODE_360;

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3485,16 +3485,6 @@ function="World.EnvPreset"
                 <menu_item_call.on_click
                  function="Advanced.DumpRegionObjectCache" />
             </menu_item_call>
-
-			<menu_item_check
-			  label="Interest List 360 Mode"
-             name="Interest List: 360 Mode"
-             shortcut="alt|shift|I">
-			   <menu_item_check.on_check
-				function="Advanced.CheckInterestList360Mode" />
-			   <menu_item_check.on_click
-				  function="Advanced.ToggleInterestList360Mode" />
-            </menu_item_check>
 			<menu_item_check
              label="Record Stats to File"
              name="Stats Recorder File">
@@ -3503,7 +3493,22 @@ function="World.EnvPreset"
 				<menu_item_check.on_click
                  function="Advanced.ToggleStatsRecorder" />
 			</menu_item_check>
-        </menu>
+			<menu_item_check
+		     label="Interest Lists 360 Mode"
+             name="Interest List: 360 Mode"
+             shortcut="alt|shift|I">
+			   <menu_item_check.on_check
+				function="Advanced.CheckInterestList360Mode" />
+			   <menu_item_check.on_click
+				  function="Advanced.ToggleInterestList360Mode" />
+            </menu_item_check>
+			<menu_item_call
+             label="Reset Interest Lists"
+             name="Reset Interest Lists">
+				<menu_item_call.on_click
+                 function="Advanced.ResetInterestLists" />
+			</menu_item_call>
+		</menu>
         <menu
          create_jump_keys="true"
          label="UI"


### PR DESCRIPTION
Added new IL reset menu command for Debug menu, tweaked the item order a little to make more sense
Added convenience functions LLViewerRegion::requestDelCapability(), HttpCoroutineAdapter::callbackHttpDel() and   HttpCoroutineAdapter::trivialDelCoro() to follow the same pattern as used by GET and POST for DEL