### PR TITLE
DRTVWR-587: Use [[noreturn]] attribute on callFail() methods

### DIFF
--- a/indra/llcommon/lleventdispatcher.h
+++ b/indra/llcommon/lleventdispatcher.h
@@ -720,10 +720,6 @@ template <typename Method, typename InstanceGetter>
 LLEventDispatcher::invoker_function
 LLEventDispatcher::make_invoker(Method f, const InstanceGetter& getter)
 {
-    // function_arity<member function> includes its implicit 'this' pointer
-    constexpr auto arity = LL::function_arity<
-        typename std::remove_reference<Method>::type>::value - 1;
-
     return [f, getter](const LLSD& args)
     {
         // always_return<LLSD>() immediately calls the lambda we pass, and
@@ -732,6 +728,10 @@ LLEventDispatcher::make_invoker(Method f, const InstanceGetter& getter)
             [f, getter, args]
             ()
             {
+                // function_arity<member function> includes its implicit 'this' pointer
+                constexpr auto arity = LL::function_arity<
+                    typename std::remove_reference<Method>::type>::value - 1;
+
                 // Use bind_front() to bind the method to (a pointer to) the object
                 // returned by getter(). It's okay to capture and bind a pointer
                 // because this bind_front() object will last only as long as this

--- a/indra/llcommon/lleventdispatcher.h
+++ b/indra/llcommon/lleventdispatcher.h
@@ -475,13 +475,9 @@ private:
         virtual LLSD getMetadata() const = 0;
 
         template <typename... ARGS>
-        LLSD callFail(ARGS&&... args) const
+        [[noreturn]] void callFail(ARGS&&... args) const
         {
             mParent->callFail<LLEventDispatcher::DispatchError>(std::forward<ARGS>(args)...);
-#if _MSC_VER < 1930                 // pre VS 2022
-            // pacify the compiler
-            return {};
-#endif // pre VS 2022
         }
     };
     typedef std::map<std::string, std::unique_ptr<DispatchEntry> > DispatchMap;
@@ -584,9 +580,9 @@ private:
 protected:
     // raise specified EXCEPTION with specified stringize(ARGS)
     template <typename EXCEPTION, typename... ARGS>
-    void callFail(ARGS&&... args) const;
+    [[noreturn]] void callFail(ARGS&&... args) const;
     template <typename EXCEPTION, typename... ARGS>
-    static
+    [[noreturn]] static
     void sCallFail(ARGS&&... args);
 
     // Manage transient state, e.g. which registered callable we're attempting


### PR DESCRIPTION
that unconditionally return. This eliminates the problem of pacifying a compiler that expects a return statement vs. a compiler that detects that callFail() unconditionally throws.

Thanks, Ansariel.