### PR TITLE
SL-20066 Add debug setting for animation import viewer diagnostics

### DIFF
--- a/indra/llcharacter/llbvhloader.h
+++ b/indra/llcharacter/llbvhloader.h
@@ -199,7 +199,7 @@ class LLBVHLoader
 	friend class LLKeyframeMotion;
 public:
 	// Constructor
-    LLBVHLoader();
+    LLBVHLoader(bool save_diagnostic_files);
 	~LLBVHLoader();
 
     void loadAnimationData(const char* buffer,
@@ -323,6 +323,8 @@ protected:
     std::string         mFilenameAndPath;   // Source file (bvh)
     Assimp::Importer *  mAssimpImporter;    // Main assimp library object
     const aiScene *     mAssimpScene;       // scene data after reading a file
+
+    bool mSaveDiagnosticFiles;                // Flag to save extra logging data during import
 };
 
 #endif // LL_LLBVHLOADER_H

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -17113,5 +17113,16 @@
     <key>Value</key>
     <integer>2</integer>
   </map>
+  <key>AnimationImportDiagnosticFiles</key>
+  <map>
+    <key>Comment</key>
+    <string>Save diagnostic files when importing animations</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
 </map>
 </llsd>


### PR DESCRIPTION
This implements SL-20066 so by default extra logs are not saved, but if needed we can enable them and get better information about why an animation import might fail.