### PR TITLE
SL-20053: Fix sometimes unable to unset a PBR material on a prim

### DIFF
--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -693,6 +693,11 @@ void LLFloaterTexturePicker::draw()
 
 const LLUUID& LLFloaterTexturePicker::findItemID(const LLUUID& asset_id, BOOL copyable_only, BOOL ignore_library)
 {
+	if (asset_id.isNull())
+	{
+		return LLUUID::null;
+	}
+
 	LLViewerInventoryCategory::cat_array_t cats;
 	LLViewerInventoryItem::item_array_t items;
 	LLAssetIDMatches asset_id_matches(asset_id);


### PR DESCRIPTION
Caused by inventory item asset IDs being null. Seems suspicious. But working around it for now seems best.