### PR TITLE
SL-20078 Remove Google Translation UI (just fix error processing)

### DIFF
--- a/indra/newview/lltranslate.cpp
+++ b/indra/newview/lltranslate.cpp
@@ -253,7 +253,7 @@ void LLTranslationAPIHandler::translateMessageCoro(LanguagePair_t fromTo, std::s
 
     try
     {
-        res = this->parseResponse(httpResults, parseResult, body, translation, detected_lang, err_msg);
+        res = parseResponse(httpResults, parseResult, body, translation, detected_lang, err_msg);
     }
     catch (std::out_of_range&)
     {
@@ -293,8 +293,6 @@ void LLTranslationAPIHandler::translateMessageCoro(LanguagePair_t fromTo, std::s
         if (!failure.empty())
             failure(status, err_msg);
     }
-
-
 }
 
 //=========================================================================
@@ -353,7 +351,6 @@ private:
         std::string& translation,
         std::string& detected_lang);
     static std::string getAPIKey();
-
 };
 
 //-------------------------------------------------------------------------
@@ -391,36 +388,37 @@ bool LLGoogleTranslationHandler::checkVerificationResponse(
 
 // virtual
 bool LLGoogleTranslationHandler::parseResponse(
-    const LLSD& http_response,
+	const LLSD& http_response,
 	int& status,
 	const std::string& body,
 	std::string& translation,
 	std::string& detected_lang,
 	std::string& err_msg) const
 {
+	const std::string& text = !body.empty() ? body : http_response["error_body"].asStringRef();
+
 	Json::Value root;
 	Json::Reader reader;
 
-	if (!reader.parse(body, root))
+	if (reader.parse(text, root))
 	{
+		if (root.isObject())
+		{
+			// Request succeeded, extract translation from the XML body.
+			if (parseTranslation(root, translation, detected_lang))
+				return true;
+
+			// Request failed. Extract error message from the XML body.
+			parseErrorResponse(root, status, err_msg);
+		}
+	}
+	else
+	{
+		// XML parsing failed. Extract error message from the XML parser.
 		err_msg = reader.getFormatedErrorMessages();
-		return false;
 	}
 
-	if (!root.isObject()) // empty response? should not happen
-	{
-		return false;
-	}
-
-	if (status != HTTP_OK)
-	{
-		// Request failed. Extract error message from the response.
-		parseErrorResponse(root, status, err_msg);
-		return false;
-	}
-
-	// Request succeeded, extract translation from the response.
-	return parseTranslation(root, translation, detected_lang);
+	return false;
 }
 
 // virtual
@@ -493,7 +491,7 @@ void LLGoogleTranslationHandler::verifyKey(const LLSD &key, LLTranslate::KeyVeri
 /*virtual*/
 void LLGoogleTranslationHandler::initHttpHeader(LLCore::HttpHeaders::ptr_t headers, const std::string& user_agent) const
 {
-    headers->append(HTTP_OUT_HEADER_ACCEPT, HTTP_CONTENT_TEXT_PLAIN);
+    headers->append(HTTP_OUT_HEADER_ACCEPT, HTTP_CONTENT_JSON);
     headers->append(HTTP_OUT_HEADER_USER_AGENT, user_agent);
 }
 
@@ -503,8 +501,7 @@ void LLGoogleTranslationHandler::initHttpHeader(
     const std::string& user_agent,
     const LLSD &key) const
 {
-    headers->append(HTTP_OUT_HEADER_ACCEPT, HTTP_CONTENT_TEXT_PLAIN);
-    headers->append(HTTP_OUT_HEADER_USER_AGENT, user_agent);
+    initHttpHeader(headers, user_agent);
 }
 
 LLSD LLGoogleTranslationHandler::sendMessageAndSuspend(LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t adapter,
@@ -1314,5 +1311,4 @@ LLTranslationAPIHandler& LLTranslate::getHandler(EService service)
     }
 
     return azure;
-
 }


### PR DESCRIPTION
Before this change (incorrect error message):
![image](https://github.com/secondlife/viewer/assets/124201357/6a22a09e-a836-4958-9344-fda1327e7440)

After this change (correct error message):
![image](https://github.com/secondlife/viewer/assets/124201357/e1a91ab9-1fd6-41e3-82a2-6399d56c2cb8)

Using my own API key (no error message):
![image](https://github.com/secondlife/viewer/assets/124201357/322ea32a-5ea6-447a-8b37-1cb222665071)

No needs to remove Google Tranclation API, it works well
All we need is correct API key and correct error processing