### PR TITLE
SL-20090 BugSplat Crash: LLViewerFetchedTexture::updateFetch(2099)

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -2365,7 +2365,8 @@ bool LLViewerFetchedTexture::updateFetch()
 		}
 	}
 	
-	llassert_always(mRawImage.notNull() || (!mNeedsCreateTexture && !mIsRawImageValid));
+	llassert_always(mRawImage.notNull() || !mIsRawImageValid);
+	llassert_always(mRawImage.notNull() || !mNeedsCreateTexture);
 	
 	return mIsFetching ? true : false;
 }


### PR DESCRIPTION
Split the assertion into 2 separate checks
This will highlight the root cause when re-reporting the issue