### PR TITLE
Remove unused counters that cause fatal warnings

### DIFF
--- a/indra/llcharacter/llbvhloader.cpp
+++ b/indra/llcharacter/llbvhloader.cpp
@@ -1352,7 +1352,6 @@ BOOL LLBVHLoader::serialize(LLDataPacker& dp)
 		dp.packS32(joint->mNumRotKeys, "num_rot_keys");
 
 		LLQuaternion::Order order = bvhStringToOrder( joint->mOrder );
-		S32 outcount = 0;
 		S32 frame = 0;
 		for (Key& key : joint->mKeys)
 		{
@@ -1418,7 +1417,6 @@ BOOL LLBVHLoader::serialize(LLDataPacker& dp)
 			dp.packU16(x, "rot_angle_x");
 			dp.packU16(y, "rot_angle_y");
 			dp.packU16(z, "rot_angle_z");
-			outcount++;
 			frame++;
 		}
 		

--- a/indra/llcommon/llsdserialize.cpp
+++ b/indra/llcommon/llsdserialize.cpp
@@ -2193,9 +2193,9 @@ LLUZipHelper::EZipRresult LLUZipHelper::unzip_llsd(LLSD& data, std::istream& is,
 LLUZipHelper::EZipRresult LLUZipHelper::unzip_llsd(LLSD& data, const U8* in, S32 size)
 {
 	U8* result = NULL;
-	U32 cur_size = 0;
+	llssize cur_size = 0;
 	z_stream strm;
-		
+
 	constexpr U32 CHUNK = 1024 * 512;
 
 	static thread_local std::unique_ptr<U8[]> out;
@@ -2388,7 +2388,7 @@ U8* unzip_llsdNavMesh( bool& valid, size_t& outsize, std::istream& is, S32 size 
 	return result;
 }
 
-char* strip_deprecated_header(char* in, U32& cur_size, U32* header_size)
+char* strip_deprecated_header(char* in, llssize& cur_size, size_t* header_size)
 {
 	const char* deprecated_header = "<? LLSD/Binary ?>";
 	constexpr size_t deprecated_header_size = 17;

--- a/indra/llcommon/llsdserialize.h
+++ b/indra/llcommon/llsdserialize.h
@@ -873,5 +873,5 @@ LL_COMMON_API std::string zip_llsd(LLSD& data);
 LL_COMMON_API U8* unzip_llsdNavMesh( bool& valid, size_t& outsize,std::istream& is, S32 size);
 
 // returns a pointer to the array or past the array if the deprecated header exists
-LL_COMMON_API char* strip_deprecated_header(char* in, U32& cur_size, U32* header_size = nullptr);
+LL_COMMON_API char* strip_deprecated_header(char* in, llssize& cur_size, size_t* header_size = nullptr);
 #endif // LL_LLSDSERIALIZE_H

--- a/indra/llcommon/stdtypes.h
+++ b/indra/llcommon/stdtypes.h
@@ -41,7 +41,7 @@ typedef unsigned int			U32;
 
 // to express an index that might go negative
 // (ssize_t is provided by SOME compilers, don't collide)
-typedef typename std::make_signed<size_t>::type llssize;
+typedef typename std::make_signed<std::size_t>::type llssize;
 
 #if LL_WINDOWS
 // https://docs.microsoft.com/en-us/cpp/build/reference/zc-wchar-t-wchar-t-is-native-type

--- a/indra/llcommon/tests/llleap_test.cpp
+++ b/indra/llcommon/tests/llleap_test.cpp
@@ -109,7 +109,7 @@ namespace tut
                    "import os\n"
                    "import sys\n"
                    "\n"
-                   "from llbase import llsd\n"
+                   "import llsd\n"
                    "\n"
                    "class ProtocolError(Exception):\n"
                    "    def __init__(self, msg, data):\n"

--- a/indra/llcommon/tests/llsdserialize_test.cpp
+++ b/indra/llcommon/tests/llsdserialize_test.cpp
@@ -1706,7 +1706,7 @@ namespace tut
             // scanner.
             import_llsd("import os.path\n"
                         "import sys\n"
-                        "from llbase import llsd\n")
+                        "import llsd\n")
         {}
         ~TestPythonCompatible() {}
 

--- a/indra/llcorehttp/tests/test_llcorehttp_peer.py
+++ b/indra/llcorehttp/tests/test_llcorehttp_peer.py
@@ -38,7 +38,7 @@ from io import StringIO
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
-from llbase import llsd
+import llsd
 
 # we're in llcorehttp/tests ; testrunner.py is found in llmessage/tests
 sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -5482,14 +5482,14 @@ bool LLVolumeFace::cacheOptimize()
 	new_indices.push_back(tri->mVertex[2]->mIdx);
 	tri->complete();
 
-	U32 breaks = 0;
+	//U32 breaks = 0;
 	for (U32 i = 1; i < mNumIndices/3; ++i)
 	{
 		cache.updateScores();
 		tri = cache.mBestTriangle;
 		if (!tri)
 		{
-			breaks++;
+			//breaks++;
 			for (U32 j = 0; j < triangle_data.size(); ++j)
 			{
 				if (triangle_data[j].mActive)

--- a/indra/llmessage/llcircuit.cpp
+++ b/indra/llmessage/llcircuit.cpp
@@ -271,7 +271,6 @@ void LLCircuitData::ackReliablePacket(TPACKETID packet_num)
 
 S32 LLCircuitData::resendUnackedPackets(const F64Seconds now)
 {
-	S32 resent_packets = 0;
 	LLReliablePacket *packetp;
 
 
@@ -375,7 +374,6 @@ S32 LLCircuitData::resendUnackedPackets(const F64Seconds now)
 				// Don't remove it yet, it still gets to try to resend at least once.
 				++iter;
 			}
-			resent_packets++;
 		}
 		else
 		{

--- a/indra/llmessage/tests/test_llsdmessage_peer.py
+++ b/indra/llmessage/tests/test_llsdmessage_peer.py
@@ -33,8 +33,8 @@ import os
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
-from llbase.fastest_elementtree import parse as xml_parse
-from llbase import llsd
+from llsd.fastest_elementtree import parse as xml_parse
+import llsd
 from testrunner import freeport, run, debug, VERBOSE
 import time
 

--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -2329,9 +2329,7 @@ void LLGLSyncFence::wait()
 	if (mSync)
 	{
 		while (glClientWaitSync(mSync, 0, FENCE_WAIT_TIME_NANOSECONDS) == GL_TIMEOUT_EXPIRED)
-		{ //track the number of times we've waited here
-			static S32 waits = 0;
-			waits++;
+		{
 		}
 	}
 #endif

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -942,11 +942,8 @@ void LLButton::draw()
 			break;
 		}
 
-		S32 y_offset = 2 + (getRect().getHeight() - 20)/2;
-	
 		if (pressed && mDisplayPressedState)
 		{
-			y_offset--;
 			x++;
 		}
 

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -487,9 +487,6 @@ void LLMenuItemGL::draw( void )
 	// let disabled items be highlighted, just don't draw them as such
 	if( getEnabled() && getHighlight() && !mBriefItem)
 	{
-		int debug_count = 0;
-		if (dynamic_cast<LLMenuItemCallGL*>(this))
-			debug_count++;
 		gGL.color4fv( mHighlightBackground.get().mV );
 
 		gl_rect_2d( 0, getRect().getHeight(), getRect().getWidth(), 0 );

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -774,7 +774,6 @@ U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, BOOL require
 		return 0;
 	}
 
-	U32		item = 0;
 	U32		validitems = 0;
 	S32 version;
 	
@@ -808,8 +807,6 @@ U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, BOOL require
 		}
 
 		// Got an item.  Load it up.
-		item++;
-
 		// If not declared, assume it's a string
 		if (!declared)
 		{

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -3708,7 +3708,6 @@ void LLAgent::processScriptControlChange(LLMessageSystem *msg, void **)
 			// take controls
 			msg->getU32("Data", "Controls", controls, block_index );
 			msg->getBOOL("Data", "PassToAgent", passon, block_index );
-			U32 total_count = 0;
 			for (i = 0; i < TOTAL_CONTROLS; i++)
 			{
 				if (controls & ( 1 << i))
@@ -3721,7 +3720,6 @@ void LLAgent::processScriptControlChange(LLMessageSystem *msg, void **)
 					{
 						gAgent.mControlsTakenCount[i]++;
 					}
-					total_count++;
 				}
 			}
 		}

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -1861,11 +1861,11 @@ EMeshProcessingResult LLMeshRepoThread::headerReceived(const LLVolumeParams& mes
 {
 	const LLUUID mesh_id = mesh_params.getSculptID();
 	LLSD header;
-	
-	U32 header_size = 0;
+
+	size_t header_size = 0;
 	if (data_size > 0)
 	{
-		U32 dsize = data_size;
+		llssize dsize = data_size;
 		char* result_ptr = strip_deprecated_header((char*)data, dsize, &header_size);
 
 		data_size = dsize;

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -2685,9 +2685,6 @@ void LLModelPreview::clearBuffers()
 
 void LLModelPreview::genBuffers(S32 lod, bool include_skin_weights)
 {
-    U32 mesh_count = 0;
-
-
     LLModelLoader::model_list* model = NULL;
 
     if (lod < 0 || lod > 4)
@@ -2818,8 +2815,6 @@ void LLModelPreview::genBuffers(S32 lod, bool include_skin_weights)
             vb->flush();
 
             mVertexBuffer[lod][mdl].push_back(vb);
-
-            ++mesh_count;
         }
     }
 }

--- a/indra/newview/llpanelnearbymedia.cpp
+++ b/indra/newview/llpanelnearbymedia.cpp
@@ -619,7 +619,6 @@ void LLPanelNearByMedia::refreshList()
 	LLViewerMedia::impl_list impls = media_inst->getPriorityList();
 	LLViewerMedia::impl_list::iterator priority_iter;
 	
-	U32 enabled_count = 0;
 	U32 disabled_count = 0;
 	
 	// iterate over the impl list, creating rows as necessary.
@@ -662,13 +661,10 @@ void LLPanelNearByMedia::refreshList()
 			{
 				disabled_count++;
 			}
-			else {
-				enabled_count++;
 		}
 	}
-	}	
 	mDisableAllCtrl->setEnabled((gSavedSettings.getBOOL("AudioStreamingMusic") || 
-		                         gSavedSettings.getBOOL("AudioStreamingMedia")) &&
+								 gSavedSettings.getBOOL("AudioStreamingMedia")) &&
 								(media_inst->isAnyMediaShowing() || 
 								 media_inst->isParcelMediaPlaying() ||
 								 media_inst->isParcelAudioPlaying()));

--- a/indra/newview/llsceneview.cpp
+++ b/indra/newview/llsceneview.cpp
@@ -100,8 +100,6 @@ void LLSceneView::draw()
 	F32 total_physics[] = { 0.f, 0.f };
 	
 
-	U32 object_count = 0;
-
 	LLViewerRegion* region = gAgent.getRegion();
 	if (region)
 	{
@@ -116,8 +114,7 @@ void LLSceneView::draw()
 				U32 idx = object->isAttachment() ? 1 : 0;
 
 				LLVolume* volume = object->getVolume();
-				object_count++;
-				
+
 				F32 radius = object->getScale().magVec();
 				size[idx].push_back(radius);
 

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -5274,8 +5274,8 @@ void LLSelectMgr::sendListToRegions(LLObjectSelectionHandle selected_handle,
 	LLViewerRegion*	last_region;
 	LLViewerRegion*	current_region;
 
-	S32 objects_sent = 0;
-	S32 packets_sent = 0;
+//	S32 objects_sent = 0;
+//	S32 packets_sent = 0;
 	S32 objects_in_this_packet = 0;
 
 	bool link_operation = message_name == "ObjectLink";
@@ -5407,7 +5407,7 @@ void LLSelectMgr::sendListToRegions(LLObjectSelectionHandle selected_handle,
 			(*pack_body)(node, user_data);
             // do any related logging
             (*log_func)(node, user_data);
-			++objects_sent;
+//			++objects_sent;
 			++objects_in_this_packet;
 
 			// and on to the next object
@@ -5425,7 +5425,7 @@ void LLSelectMgr::sendListToRegions(LLObjectSelectionHandle selected_handle,
 		{
 			// otherwise send current message and start new one
 			gMessageSystem->sendReliable( last_region->getHost());
-			packets_sent++;
+//			packets_sent++;
 			objects_in_this_packet = 0;
 
 			gMessageSystem->newMessage(message_name.c_str());
@@ -5442,7 +5442,7 @@ void LLSelectMgr::sendListToRegions(LLObjectSelectionHandle selected_handle,
 				{
 					// add root instance into new message
 					(*pack_body)(linkset_root, user_data);
-					++objects_sent;
+//					++objects_sent;
 					++objects_in_this_packet;
 				}
 			}
@@ -5456,7 +5456,7 @@ void LLSelectMgr::sendListToRegions(LLObjectSelectionHandle selected_handle,
 	if (gMessageSystem->getCurrentSendTotal() > 0)
 	{
 		gMessageSystem->sendReliable( current_region->getHost());
-		packets_sent++;
+//		packets_sent++;
 	}
 	else
 	{

--- a/indra/newview/llsprite.cpp
+++ b/indra/newview/llsprite.cpp
@@ -79,7 +79,6 @@ void LLSprite::updateFace(LLFace &face)
 
 	// First, figure out how many vertices/indices we need.
 	U32 num_vertices, num_indices;
-	U32 vertex_count = 0;
 	
 	// Get the total number of vertices and indices
 	if (mFollow)
@@ -203,25 +202,21 @@ void LLSprite::updateFace(LLFace &face)
 	*verticesp = mC;
 	tex_coordsp++;
 	verticesp++;
-	vertex_count++;
 
 	*tex_coordsp = LLVector2(0.f, 1.f);
 	*verticesp = mB;
 	tex_coordsp++;
 	verticesp++;
-	vertex_count++;
 
 	*tex_coordsp = LLVector2(1.f, 1.f);
 	*verticesp = mA;
 	tex_coordsp++;
 	verticesp++;
-	vertex_count++;
 
 	*tex_coordsp = LLVector2(1.f, 0.0f);
 	*verticesp = mD;
 	tex_coordsp++;
 	verticesp++;
-	vertex_count++;
 
 	// Generate indices, since they're easy.
 	// Just a series of quads.

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -3260,7 +3260,7 @@ LLSD transform_cert_args(LLPointer<LLCertificate> cert)
 		// are actually arrays, and we want to format them as comma separated          
 		// strings, so special case those.                                             
 		LLSDSerialize::toXML(cert_info[iter->first], std::cout);
-		if((iter->first== std::string(CERT_KEY_USAGE)) |
+		if((iter->first == std::string(CERT_KEY_USAGE)) ||
 		   (iter->first == std::string(CERT_EXTENDED_KEY_USAGE)))
 		{
 			value = "";

--- a/indra/newview/lltextureview.cpp
+++ b/indra/newview/lltextureview.cpp
@@ -845,8 +845,8 @@ void LLTextureView::draw()
 
 			if (imagep->getID() == LLAppViewer::getTextureFetch()->mDebugID)
 			{
-				static S32 debug_count = 0;
-				++debug_count; // for breakpoints
+//				static S32 debug_count = 0;
+//				++debug_count; // for breakpoints
 			}
 			
 			F32 pri;

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -773,7 +773,6 @@ void LLViewerObjectList::dirtyAllObjectInventory()
 void LLViewerObjectList::updateApparentAngles(LLAgent &agent)
 {
 	S32 i;
-	S32 num_objects = 0;
 	LLViewerObject *objectp;
 
 	S32 num_updates, max_value;
@@ -830,8 +829,6 @@ void LLViewerObjectList::updateApparentAngles(LLAgent &agent)
 		objectp = mObjects[i];
 		if (!objectp->isDead())
 		{
-			num_objects++;
-
 			//  Update distance & gpw 
 			objectp->setPixelAreaAndAngle(agent); // Also sets the approx. pixel area
 			objectp->updateTextures();	// Update the image levels of textures for this object.

--- a/indra/newview/llvosurfacepatch.cpp
+++ b/indra/newview/llvosurfacepatch.cpp
@@ -408,7 +408,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 										LLStrider<U16> &indicesp,
 										U32 &index_offset)
 {
-	S32 vertex_count = 0;
 	S32 i, x, y;
 
 	S32 num_vertices;
@@ -443,7 +442,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 		// North patch
@@ -456,7 +454,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 
@@ -493,7 +490,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 		// Iterate through the north patch's points
@@ -507,7 +503,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 
@@ -551,7 +546,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 		// Iterate through the north patch's points
@@ -565,7 +559,6 @@ void LLVOSurfacePatch::updateNorthGeometry(LLFace *facep,
 			normalsp++;
 			texCoords0p++;
 			texCoords1p++;
-			vertex_count++;
 		}
 
 		for (i = 0; i < length; i++)

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -6306,7 +6306,6 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
 	LLSpatialGroup::buffer_map_t buffer_map;
 
 	LLViewerTexture* last_tex = NULL;
-	S32 buffer_index = 0;
 
 	S32 texture_index_channels = 1;
 	
@@ -6319,11 +6318,6 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
 	{
 		texture_index_channels = gDeferredAlphaProgram.mFeatures.mIndexedTextureChannels;
 	}
-    
-    if (distance_sort)
-    {
-        buffer_index = -1;
-    }
 
 	static LLCachedControl<U32> max_texture_index(gSavedSettings, "RenderMaxTextureIndex", 16);
 	texture_index_channels = llmin(texture_index_channels, (S32) max_texture_index);
@@ -6347,14 +6341,9 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
 			tex = NULL;
 		}
 
-		if (last_tex == tex)
-		{
-			buffer_index++;
-		}
-		else
+		if (last_tex != tex)
 		{
 			last_tex = tex;
-			buffer_index = 0;
 		}
 
 		bool bake_sunlight = LLPipeline::sBakeSunlight && facep->getDrawable()->isStatic(); 

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -49,7 +49,7 @@ viewer_dir = os.path.dirname(__file__)
 # indra.util.llmanifest under their system Python!
 sys.path.insert(0, os.path.join(viewer_dir, os.pardir, "lib", "python"))
 from indra.util.llmanifest import LLManifest, main, path_ancestors, CHANNEL_VENDOR_BASE, RELEASE_CHANNEL, ManifestError, MissingError
-from llbase import llsd
+import llsd
 
 class ViewerManifest(LLManifest):
     def is_packaging_viewer(self):

--- a/scripts/metrics/slp_conv.py
+++ b/scripts/metrics/slp_conv.py
@@ -29,7 +29,7 @@ Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
 $/LicenseInfo$
 """
 
-from llbase import llsd
+import llsd
 import argparse
 
 parser = argparse.ArgumentParser(

--- a/scripts/metrics/viewer_asset_logs.py
+++ b/scripts/metrics/viewer_asset_logs.py
@@ -28,7 +28,7 @@ $/LicenseInfo$
 
 import argparse
 from lxml import etree
-from llbase import llsd
+import llsd
 
 def get_metrics_record(infiles):
     for filename in args.infiles:

--- a/scripts/metrics/viewerstats.py
+++ b/scripts/metrics/viewerstats.py
@@ -31,7 +31,7 @@ import numpy as np
 import pandas as pd
 import json
 from collections import Counter, defaultdict
-from llbase import llsd
+import llsd
 import io
 import re
 import os


### PR DESCRIPTION
Also ditch the Python `llbase.llsd` package in favor of standalone `llsd`.