### PR TITLE
SL-20099 Thumbnail upload scale textures to be square

### DIFF
--- a/indra/newview/llfloatersimplesnapshot.cpp
+++ b/indra/newview/llfloatersimplesnapshot.cpp
@@ -386,7 +386,7 @@ void LLFloaterSimpleSnapshot::uploadThumbnail(const std::string &file_path, cons
     // generate a temp texture file for coroutine
     std::string temp_file = gDirUtilp->getTempFilename();
     U32 codec = LLImageBase::getCodecFromExtension(gDirUtilp->getExtension(file_path));
-    if (!LLViewerTextureList::createUploadFile(file_path, temp_file, codec, THUMBNAIL_SNAPSHOT_DIM_MAX, THUMBNAIL_SNAPSHOT_DIM_MIN))
+    if (!LLViewerTextureList::createUploadFile(file_path, temp_file, codec, THUMBNAIL_SNAPSHOT_DIM_MAX, THUMBNAIL_SNAPSHOT_DIM_MIN, true))
     {
         LLSD notif_args;
         notif_args["REASON"] = LLImage::getLastError().c_str();

--- a/indra/newview/llviewertexturelist.h
+++ b/indra/newview/llviewertexturelist.h
@@ -96,8 +96,11 @@ public:
                                  const std::string& out_filename,
                                  const U8 codec,
                                  const S32 max_image_dimentions = LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT,
-                                 const S32 min_image_dimentions = 0);
-	static LLPointer<LLImageJ2C> convertToUploadFile(LLPointer<LLImageRaw> raw_image, const S32 max_image_dimentions = LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT);
+                                 const S32 min_image_dimentions = 0,
+                                 bool force_square = false);
+	static LLPointer<LLImageJ2C> convertToUploadFile(LLPointer<LLImageRaw> raw_image,
+                                                     const S32 max_image_dimentions = LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT,
+                                                     bool force_square = false);
 	static void processImageNotInDatabase( LLMessageSystem *msg, void **user_data );
 
 public:


### PR DESCRIPTION
thumbnail copy&paste only allows square textures and wasn't allowing none square ones despite those already being used as thumbnails