### PR TITLE
SL-20140 Setting shape hand size to 36 won't save

### DIFF
--- a/indra/newview/character/avatar_lad.xml
+++ b/indra/newview/character/avatar_lad.xml
@@ -1928,8 +1928,8 @@
      edit_group_order="10"
      label_min="Small Hands"
      label_max="Large Hands"
-     value_min="-.3"
-     value_max=".3"
+     value_min="-.5"
+     value_max=".5"
      camera_elevation=".1"
      camera_distance="1.4"
      camera_angle="0">


### PR DESCRIPTION
Stored value is being rounded to 2 decimal digits (format "%.2f")
Value "36%" is being converted to "-0.084" and stored as "-0.08"
But loaded value "-0.08" is being converted to "36.66%" and rounded to "37%"

It is theoretically impossible to store 101 different values from 0 to 100
in 61 sequential values from -0.30 to 0.30, collisions are inevitable

There are 2 ways to fix the problem:
- expand the stored interval at least to 101 values (-0.50 .. 0.50)
- increase the number of decimal digits in the stored values ("%.3f")

The first way looks simpler and safer:
it doesn't affect serialization and server data format
