### PR TITLE
SL-19299 Viewer crashes after change 'Pick a physics model:' dropdown

### DIFF
--- a/indra/llcommon/llpointer.h
+++ b/indra/llcommon/llpointer.h
@@ -129,16 +129,6 @@ protected:
 	void ref();                             
 	void unref();
 #else
-
-	void assign(const LLPointer<Type>& ptr)
-	{
-		if( mPointer != ptr.mPointer )
-		{
-			unref(); 
-			mPointer = ptr.mPointer;
-			ref();
-		}
-	}
 	void ref()                             
 	{ 
 		if (mPointer)
@@ -161,7 +151,18 @@ protected:
 			}
 		}
 	}
-#endif
+#endif // LL_LIBRARY_INCLUDE
+
+	void assign(const LLPointer<Type>& ptr)
+	{
+		if (mPointer != ptr.mPointer)
+		{
+			unref();
+			mPointer = ptr.mPointer;
+			ref();
+		}
+	}
+
 protected:
 	Type*	mPointer;
 };
@@ -264,7 +265,7 @@ protected:
 #ifdef LL_LIBRARY_INCLUDE
 	void ref();                             
 	void unref();
-#else
+#else // LL_LIBRARY_INCLUDE
 	void ref()                             
 	{ 
 		if (mPointer)
@@ -277,9 +278,9 @@ protected:
 	{
 		if (mPointer)
 		{
-			const Type *tempp = mPointer;
+			const Type *temp = mPointer;
 			mPointer = NULL;
-			tempp->unref();
+			temp->unref();
 			if (mPointer != NULL)
 			{
 				LL_WARNS() << "Unreference did assignment to non-NULL because of destructor" << LL_ENDL;
@@ -287,7 +288,7 @@ protected:
 			}
 		}
 	}
-#endif
+#endif // LL_LIBRARY_INCLUDE
 protected:
 	const Type*	mPointer;
 };

--- a/indra/llcommon/llrefcount.cpp
+++ b/indra/llcommon/llrefcount.cpp
@@ -30,7 +30,7 @@
 #include "llerror.h"
 
 // maximum reference count before sounding memory leak alarm
-const S32 gMaxRefCount = S32_MAX;
+const S32 gMaxRefCount = LL_REFCOUNT_FREE;
 
 LLRefCount::LLRefCount(const LLRefCount& other)
 :	mRef(0)

--- a/indra/llcommon/llrefcount.h
+++ b/indra/llcommon/llrefcount.h
@@ -51,21 +51,17 @@ protected:
 public:
 	LLRefCount();
 
-    inline void validateRefCount() const
-    {
-        llassert(mRef > 0); // ref count below 0, likely corrupted
-        llassert(mRef < gMaxRefCount); // ref count excessive, likely memory leak
-    }
-
 	inline void ref() const
 	{ 
+		llassert(mRef != LL_REFCOUNT_FREE); // object is deleted
 		mRef++; 
-        validateRefCount();
+		llassert(mRef < gMaxRefCount); // ref count excessive, likely memory leak
 	} 
 
 	inline S32 unref() const
 	{
-        validateRefCount();
+		llassert(mRef != LL_REFCOUNT_FREE); // object is deleted
+		llassert(mRef > 0); // ref count below 1, likely corrupted
 		if (0 == --mRef)
 		{
             mRef = LL_REFCOUNT_FREE; // set to nonsense yet recognizable value to aid in debugging

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -270,6 +270,7 @@ void LLModelPreview::rebuildUploadData()
 {
     assert_main_thread();
 
+    mDefaultPhysicsShapeP = NULL;
     mUploadData.clear();
     mTextureSet.clear();
 


### PR DESCRIPTION
The key changes:
1. File **llmodelpreview.cpp** - Zero pointer `mDefaultPhysicsShapeP` before deleting the correspondent object
2. File **llrefcount.cpp** - Initialize `const S32 gMaxRefCount = LL_REFCOUNT_FREE;`
3. File **llrefcount.h** - Add `assert` for `(mRef != LL_REFCOUNT_FREE) // object is deleted`
4. File **llpointer.h** - Move method `assign()` out of the `ifdef LL_LIBRARY_INCLUDE` block
