### PR TITLE
SL-20197 Remove 'Edit PBR material' from context menu when editing an attachment

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_attachment_self.xml
+++ b/indra/newview/skins/default/xui/en/menu_attachment_self.xml
@@ -17,7 +17,7 @@
      name="EditGLTFMaterial">
         <menu_item_call.on_click
          function="Object.EditGLTFMaterial" />
-        <menu_item_call.on_enable
+        <menu_item_call.on_visible
          function="Object.EnableEditGLTFMaterial"/>
     </menu_item_call>
     <menu_item_call


### PR DESCRIPTION
As an option, I would propose to rename the handler EnableEditGLTFMaterial to something like IsEditGLTFMaterialVisible