### PR TITLE
Fix CMake CMP0148 deprecation warning introduced with CMake 3.27.4

### DIFF
--- a/indra/cmake/Python.cmake
+++ b/indra/cmake/Python.cmake
@@ -40,7 +40,7 @@ elseif (WINDOWS)
     ${regpaths}
     ${pymaybe}
     )
-    include(FindPythonInterp)
+  find_package(Python3 COMPONENTS Interpreter)
 else()
   find_program(python python3)
 


### PR DESCRIPTION
As of CMake 3.27.4, it will issue a CMP0148 deprecation warning about the way Python is located.