### PR TITLE
SL-20214 Crash at LLControlAVBridge::updateSpatialExtents

### DIFF
--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5114,8 +5114,6 @@ void LLControlAVBridge::updateSpatialExtents()
 {
 	LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWABLE
 
-	LLControlAvatar* controlAvatar = getVObj()->getControlAvatar();
-
 	LLSpatialGroup* root = (LLSpatialGroup*)mOctree->getListener(0);
 
 	bool rootWasDirty = root->isDirty();
@@ -5126,7 +5124,11 @@ void LLControlAVBridge::updateSpatialExtents()
 	// disappear when root goes off-screen"
 	//
 	// Expand extents to include Control Avatar placed outside of the bounds
-	if (controlAvatar && (rootWasDirty || controlAvatar->mPlaying))
+    LLControlAvatar* controlAvatar = getVObj() ? getVObj()->getControlAvatar() : NULL;
+    if (controlAvatar
+        && controlAvatar->mDrawable
+        && controlAvatar->mDrawable->getEntry()
+        && (rootWasDirty || controlAvatar->mPlaying))
 	{
 		root->expandExtents(controlAvatar->mDrawable->getSpatialExtents(), *mDrawable->getXform());
 	}


### PR DESCRIPTION
```
LLViewerOctreeEntryData::getSpatialExtents d:/work/viewer/viewer_w64/latest/indra/newview/llvieweroctree.cpp(378)
LLControlAVBridge::updateSpatialExtents d:/work/viewer/viewer_w64/latest/indra/newview/llvovolume.cpp(5131)
LLSpatialGroup::updateInGroup d:/work/viewer/viewer_w64/latest/indra/newview/llspatialpartition.cpp(222)
LLSpatialPartition::move d:/work/viewer/viewer_w64/latest/indra/newview/llspatialpartition.cpp(982)
LLSpatialBridge::updateMove d:/work/viewer/viewer_w64/latest/indra/newview/lldrawable.cpp(1669)
```