### PR TITLE
SL-18366 Crash in LLCullResult::assertDrawMapsEmpty - make the error message more informative

### DIFF
--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -4076,7 +4076,8 @@ void LLCullResult::assertDrawMapsEmpty()
 	{
 		if (mRenderMapSize[i] != 0)
 		{
-			LL_ERRS() << "Stale LLDrawInfo's in LLCullResult!" << LL_ENDL;
+			LL_ERRS() << "Stale LLDrawInfo's in LLCullResult!"
+				<< " (mRenderMapSize[" << i << "] = " << mRenderMapSize[i] << ")" << LL_ENDL;
 		}
 	}
 }


### PR DESCRIPTION
It looks now as follows:
![image](https://github.com/secondlife/viewer/assets/124201357/d00618b1-9dc3-4cec-880b-c2a7e2c924cd)
https://app.bugsplat.com/v2/crash?database=SecondLife_Viewer_2018&id=1113975

The intent is to provide more information for the root cause analysis