### PR TITLE
SL-19664 Crash in LLAppViewer::initStrings - make the error message more informative

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2980,7 +2980,10 @@ void LLAppViewer::initStrings()
 	{
 		// initial check to make sure files are there failed
 		gDirUtilp->dumpCurrentDirectories(LLError::LEVEL_WARN);
-		LL_ERRS() << "Viewer failed to find localization and UI files. Please reinstall viewer from  https://secondlife.com/support/downloads/ and contact https://support.secondlife.com if issue persists after reinstall." << LL_ENDL;
+		LL_ERRS() << "Viewer failed to find localization and UI files"
+			<< " (strings_path_full = '" << strings_path_full << "')."
+			<< " Please reinstall viewer from https://secondlife.com/support/downloads"
+			<< " and contact https://support.secondlife.com if issue persists after reinstall." << LL_ENDL;
 	}
 	LLTransUtil::parseStrings(strings_file, default_trans_args);
 	LLTransUtil::parseLanguageStrings("language_settings.xml");


### PR DESCRIPTION
It looks now as follows:
![image](https://github.com/secondlife/viewer/assets/124201357/fde23d1e-4f6a-4d14-b001-920ce8ac93f6)
https://app.bugsplat.com/v2/crash?database=SecondLife_Viewer_2018&id=1300170

The intent is to provide more information for the root cause analysis