### PR TITLE
SL-20341 Item Properties floater closes on changes for task inventory item

### DIFF
--- a/indra/newview/llsidepaneliteminfo.cpp
+++ b/indra/newview/llsidepaneliteminfo.cpp
@@ -257,6 +257,17 @@ void LLSidepanelItemInfo::refresh()
         }
 		return;
 	}
+
+    if (mObjectID.notNull())
+    {
+        LLViewerObject* object = gObjectList.findObject(mObjectID);
+        if (object)
+        {
+            // Object exists, but object's content is not nessesary
+            // loaded, so assume item exists as well
+            return;
+        }
+    }
     
     if (mParentFloater)
     {

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -6034,7 +6034,7 @@ LLViewerObject::ExtraParameter* LLViewerObject::createNewParameterEntry(U16 para
       }
 	  default:
 	  {
-		  LL_INFOS() << "Unknown param type." << LL_ENDL;
+		  LL_INFOS_ONCE() << "Unknown param type: " << param_type << LL_ENDL;
 		  break;
 	  }
 	};


### PR DESCRIPTION
Ideally need to subscribe to object's inventory updates, but it's not nessesary open or loading and release viewer doesn't so for now just doing a 'return'.