### PR TITLE
SL-20361 Avoid of ASSERT (false) in check_rigged_group()

### DIFF
--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -1616,6 +1616,7 @@ void pushVertsColorCoded(LLSpatialGroup* group, U32 mask)
 //  - a linked rigged drawable face has the wrong draw order index
 bool check_rigged_group(LLDrawable* drawable)
 {
+#if 0
     if (drawable->isState(LLDrawable::RIGGED))
     {
         LLSpatialGroup* group = drawable->getSpatialGroup();
@@ -1671,7 +1672,7 @@ bool check_rigged_group(LLDrawable* drawable)
             }
         }
     }
-
+#endif
     return true;
 }
 


### PR DESCRIPTION
This assert is often being raised on developer's builds when menu "Develop | Render Metadata | Octree" is checked
Usually this happens when animated objects or control avatars get into the field of view, and this leads to process exit