### PR TITLE
SL-20356 Allow menu navigation by tabbing around emoji menu

### DIFF
--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -514,7 +514,7 @@ BOOL LLView::focusNext(LLView::child_list_t & result)
 		{
 			next = result.rbegin();
 		}
-		if((*next)->isCtrl())
+		if ((*next)->isCtrl() && ((LLUICtrl*)*next)->hasTabStop())
 		{
 			LLUICtrl * ctrl = static_cast<LLUICtrl*>(*next);
 			ctrl->setFocus(TRUE);

--- a/indra/newview/skins/default/xui/en/floater_emoji_picker.xml
+++ b/indra/newview/skins/default/xui/en/floater_emoji_picker.xml
@@ -54,6 +54,7 @@
       background_visible="true"
       background_opaque="true"
       bg_opaque_color="FrogGreen"
+      tab_stop="false"
       bottom="0"
       height="2"
       width="20"


### PR DESCRIPTION
Skip focusing the "Badge" panel during Tab navigation
The "Badge" panel is just a container for category buttons
These buttons stay in the tab order list even after this change,
they allow to choose any other category using a keyboard only