### PR TITLE
SL-19311 Grey textures after teleport

### DIFF
--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -259,6 +259,10 @@ static const S32 HTTP_NONPIPE_REQUESTS_LOW_WATER = 20;
 // request (e.g. 'Range: <start>-') which seems to fix the problem.
 static const S32 HTTP_REQUESTS_RANGE_END_MAX = 20000000;
 
+// stop after 720 seconds, might be overkill, but cap request can keep going forever.
+static const S32 MAX_CAP_MISSING_RETRIES = 720;
+static const S32 CAP_MISSING_EXPIRATION_DELAY = 1; // seconds
+
 //////////////////////////////////////////////////////////////////////////////
 namespace
 {
@@ -554,6 +558,7 @@ private:
 
 	e_state mState;
 	void setState(e_state new_state);
+    LLViewerRegion* getRegion();
 
 	e_write_to_cache_state mWriteToCacheState;
 	LLTextureFetch* mFetcher;
@@ -610,6 +615,10 @@ private:
 	LLCore::HttpStatus mGetStatus;
 	std::string mGetReason;
 	LLAdaptiveRetryPolicy mFetchRetryPolicy;
+    bool mCanUseCapability;
+    LLTimer mRegionRetryTimer;
+    S32 mRegionRetryAttempt;
+    LLUUID mLastRegionId;
 
 	
 	// Work Data
@@ -960,7 +969,9 @@ LLTextureFetchWorker::LLTextureFetchWorker(LLTextureFetch* fetcher,
 	  mCacheReadCount(0U),
 	  mCacheWriteCount(0U),
 	  mResourceWaitCount(0U),
-	  mFetchRetryPolicy(10.0,3600.0,2.0,10)
+      mFetchRetryPolicy(10.0, 3600.0,2.0,10),
+      mCanUseCapability(true),
+      mRegionRetryAttempt(0)
 {
 	calcWorkPriority();
 	mType = host.isOk() ? LLImageBase::TYPE_AVATAR_BAKE : LLImageBase::TYPE_NORMAL;
@@ -1138,6 +1149,19 @@ bool LLTextureFetchWorker::doWork(S32 param)
 			return true; // abort
 		}
 	}
+    if (mState > CACHE_POST && !mCanUseCapability && mCanUseHTTP)
+    {
+        if (mRegionRetryAttempt > MAX_CAP_MISSING_RETRIES)
+        {
+            mCanUseHTTP = false;
+        }
+        else if (!mRegionRetryTimer.hasExpired())
+        {
+            setPriority(LLWorkerThread::PRIORITY_LOW | mWorkPriority);
+            return false;
+        }
+        // else retry
+    }
 	if(mState > CACHE_POST && !mCanUseHTTP)
 	{
 		//nowhere to get data, abort.
@@ -1341,16 +1365,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
 // 		if (mHost.isInvalid()) get_url = false;
 		if ( use_http && mCanUseHTTP && mUrl.empty())//get http url.
 		{
-			LLViewerRegion* region = NULL;
-            if (mHost.isInvalid())
-            {
-                region = gAgent.getRegion();
-            }
-            else if (LLWorld::instanceExists())
-            {
-                region = LLWorld::getInstance()->getRegion(mHost);
-            }
-
+			LLViewerRegion* region = getRegion();
 			if (region)
 			{
 				std::string http_url = region->getViewerAssetUrl();
@@ -1363,19 +1378,29 @@ bool LLTextureFetchWorker::doWork(S32 param)
 					setUrl(http_url + "/?texture_id=" + mID.asString().c_str());
 					LL_DEBUGS(LOG_TXT) << "Texture URL: " << mUrl << LL_ENDL;
 					mWriteToCacheState = CAN_WRITE ; //because this texture has a fixed texture id.
+                    mCanUseCapability = true;
+                    mRegionRetryAttempt = 0;
+                    mLastRegionId = region->getRegionID();
 				}
 				else
 				{
-					mCanUseHTTP = false ;
-					LL_WARNS(LOG_TXT) << "Texture not available via HTTP: empty URL." << LL_ENDL;
+					mCanUseCapability = false;
+                    mRegionRetryAttempt++;
+                    mRegionRetryTimer.setTimerExpirySec(CAP_MISSING_EXPIRATION_DELAY);
+                    setPriority(LLWorkerThread::PRIORITY_LOW | mWorkPriority);
+                    // ex: waiting for caps
+					LL_INFOS_ONCE(LOG_TXT) << "Texture not available via HTTP: empty URL." << LL_ENDL;
 				}
 			}
 			else
 			{
+                mCanUseCapability = false;
+                mRegionRetryAttempt++;
+                mRegionRetryTimer.setTimerExpirySec(CAP_MISSING_EXPIRATION_DELAY);
+                setPriority(LLWorkerThread::PRIORITY_LOW | mWorkPriority);
 				// This will happen if not logged in or if a region deoes not have HTTP Texture enabled
 				//LL_WARNS(LOG_TXT) << "Region not found for host: " << mHost << LL_ENDL;
-                LL_WARNS(LOG_TXT) << "Texture not available via HTTP: no region " << mUrl << LL_ENDL;
-				mCanUseHTTP = false;
+                LL_INFOS_ONCE(LOG_TXT) << "Texture not available via HTTP: no region " << mUrl << LL_ENDL;
 			}
 		}
 		else if (mFTType == FTT_SERVER_BAKE)
@@ -1383,7 +1408,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
 			mWriteToCacheState = CAN_WRITE;
 		}
 
-		if (mCanUseHTTP && !mUrl.empty())
+		if (mCanUseCapability && mCanUseHTTP && !mUrl.empty())
 		{
 			setState(WAIT_HTTP_RESOURCE);
 			setPriority(LLWorkerThread::PRIORITY_HIGH | mWorkPriority);
@@ -1586,10 +1611,39 @@ bool LLTextureFetchWorker::doWork(S32 param)
 						}
 						return true; 
 					}
+
+                    if (mCanUseHTTP && !mUrl.empty() && cur_size <= 0)
+                    {
+                        LLViewerRegion* region = getRegion();
+                        if (!region || mLastRegionId != region->getRegionID())
+                        {
+                            // cap failure? try on new region.
+                            mUrl.clear();
+                            ++mRetryAttempt;
+                            mLastRegionId.setNull();
+                            setPriority(LLWorkerThread::PRIORITY_HIGH | mWorkPriority);
+                            setState(INIT);
+                            return false;
+                        }
+                    }
 				}
 				else if (http_service_unavail == mGetStatus)
 				{
 					LL_INFOS_ONCE(LOG_TXT) << "Texture server busy (503): " << mUrl << LL_ENDL;
+                    if (mCanUseHTTP && !mUrl.empty() && cur_size <= 0)
+                    {
+                        LLViewerRegion* region = getRegion();
+                        if (!region || mLastRegionId != region->getRegionID())
+                        {
+                            // try on new region.
+                            mUrl.clear();
+                            ++mRetryAttempt;
+                            mLastRegionId.setNull();
+                            setPriority(LLWorkerThread::PRIORITY_HIGH | mWorkPriority);
+                            setState(INIT);
+                            return false;
+                        }
+                    }
 				}
 				else if (http_not_sat == mGetStatus)
 				{
@@ -3123,6 +3177,20 @@ void LLTextureFetchWorker::setState(e_state new_state)
 	
 	mStateTimer.reset();
 	mState = new_state;
+}
+
+LLViewerRegion* LLTextureFetchWorker::getRegion()
+{
+    LLViewerRegion* region = NULL;
+    if (mHost.isInvalid())
+    {
+        region = gAgent.getRegion();
+    }
+    else if (LLWorld::instanceExists())
+    {
+        region = LLWorld::getInstance()->getRegion(mHost);
+    }
+    return region;
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Caps either expire during teleport and textures fail to load as 'missing' or viewer tries to get textures before caps are ready.