### PR TITLE
SL-19311 Grey textures after teleport

### DIFF
--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -239,6 +239,10 @@ static const S32 HTTP_NONPIPE_REQUESTS_LOW_WATER = 20;
 // request (e.g. 'Range: <start>-') which seems to fix the problem.
 static const S32 HTTP_REQUESTS_RANGE_END_MAX = 20000000;
 
+// stop after 720 seconds, might be overkill, but cap request can keep going forever.
+static const S32 MAX_CAP_MISSING_RETRIES = 720;
+static const S32 CAP_MISSING_EXPIRATION_DELAY = 1; // seconds
+
 //////////////////////////////////////////////////////////////////////////////
 namespace
 {
@@ -526,6 +530,7 @@ private:
 
 	e_state mState;
 	void setState(e_state new_state);
+    LLViewerRegion* getRegion();
 
 	e_write_to_cache_state mWriteToCacheState;
 	LLTextureFetch* mFetcher;
@@ -579,6 +584,10 @@ private:
 	LLCore::HttpStatus mGetStatus;
 	std::string mGetReason;
 	LLAdaptiveRetryPolicy mFetchRetryPolicy;
+    bool mCanUseCapability;
+    LLTimer mRegionRetryTimer;
+    S32 mRegionRetryAttempt;
+    LLUUID mLastRegionId;
 
 	
 	// Work Data
@@ -928,7 +937,9 @@ LLTextureFetchWorker::LLTextureFetchWorker(LLTextureFetch* fetcher,
 	  mCacheReadCount(0U),
 	  mCacheWriteCount(0U),
 	  mResourceWaitCount(0U),
-	  mFetchRetryPolicy(10.f,3600.f,2.f,10)
+      mFetchRetryPolicy(10.f,3600.f,2.f,10),
+      mCanUseCapability(true),
+      mRegionRetryAttempt(0)
 {
 	mType = host.isOk() ? LLImageBase::TYPE_AVATAR_BAKE : LLImageBase::TYPE_NORMAL;
 // 	LL_INFOS(LOG_TXT) << "Create: " << mID << " mHost:" << host << " Discard=" << discard << LL_ENDL;
@@ -1089,6 +1100,18 @@ bool LLTextureFetchWorker::doWork(S32 param)
 			return true; // abort
 		}
 	}
+    if (mState > CACHE_POST && !mCanUseCapability && mCanUseHTTP)
+    {
+        if (mRegionRetryAttempt > MAX_CAP_MISSING_RETRIES)
+        {
+            mCanUseHTTP = false;
+        }
+        else if (!mRegionRetryTimer.hasExpired())
+        {
+            return false;
+        }
+        // else retry
+    }
 	if(mState > CACHE_POST && !mCanUseHTTP)
 	{
         LL_PROFILE_ZONE_NAMED_CATEGORY_THREAD("tfwdw - state > cache_post");
@@ -1290,16 +1313,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
 // 		if (mHost.isInvalid()) get_url = false;
 		if ( use_http && mCanUseHTTP && mUrl.empty())//get http url.
 		{
-			LLViewerRegion* region = NULL;
-            if (mHost.isInvalid())
-            {
-                region = gAgent.getRegion();
-            }
-            else if (LLWorld::instanceExists())
-            {
-                region = LLWorld::getInstance()->getRegion(mHost);
-            }
-
+			LLViewerRegion* region = getRegion();
 			if (region)
 			{
 				std::string http_url = region->getViewerAssetUrl();
@@ -1312,19 +1326,27 @@ bool LLTextureFetchWorker::doWork(S32 param)
 					setUrl(http_url + "/?texture_id=" + mID.asString().c_str());
 					LL_DEBUGS(LOG_TXT) << "Texture URL: " << mUrl << LL_ENDL;
 					mWriteToCacheState = CAN_WRITE ; //because this texture has a fixed texture id.
+                    mCanUseCapability = true;
+                    mRegionRetryAttempt = 0;
+                    mLastRegionId = region->getRegionID();
 				}
 				else
 				{
-					mCanUseHTTP = false ;
-					LL_WARNS(LOG_TXT) << "Texture not available via HTTP: empty URL." << LL_ENDL;
+					mCanUseCapability = false;
+                    mRegionRetryAttempt++;
+                    mRegionRetryTimer.setTimerExpirySec(CAP_MISSING_EXPIRATION_DELAY);
+                    // ex: waiting for caps
+					LL_INFOS_ONCE(LOG_TXT) << "Texture not available via HTTP: empty URL." << LL_ENDL;
 				}
 			}
 			else
 			{
+                mCanUseCapability = false;
+                mRegionRetryAttempt++;
+                mRegionRetryTimer.setTimerExpirySec(CAP_MISSING_EXPIRATION_DELAY);
 				// This will happen if not logged in or if a region deoes not have HTTP Texture enabled
 				//LL_WARNS(LOG_TXT) << "Region not found for host: " << mHost << LL_ENDL;
-                LL_WARNS(LOG_TXT) << "Texture not available via HTTP: no region " << mUrl << LL_ENDL;
-				mCanUseHTTP = false;
+                LL_INFOS_ONCE(LOG_TXT) << "Texture not available via HTTP: no region " << mUrl << LL_ENDL;
 			}
 		}
 		else if (mFTType == FTT_SERVER_BAKE)
@@ -1332,7 +1354,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
 			mWriteToCacheState = CAN_WRITE;
 		}
 
-		if (mCanUseHTTP && !mUrl.empty())
+		if (mCanUseCapability && mCanUseHTTP && !mUrl.empty())
 		{
 			setState(WAIT_HTTP_RESOURCE);
 			if(mWriteToCacheState != NOT_WRITE)
@@ -1534,10 +1556,37 @@ bool LLTextureFetchWorker::doWork(S32 param)
 						}
 						return true; 
 					}
+
+                    if (mCanUseHTTP && !mUrl.empty() && cur_size <= 0)
+                    {
+                        LLViewerRegion* region = getRegion();
+                        if (!region || mLastRegionId != region->getRegionID())
+                        {
+                            // cap failure? try on new region.
+                            mUrl.clear();
+                            ++mRetryAttempt;
+                            mLastRegionId.setNull();
+                            setState(INIT);
+                            return false;
+                        }
+                    }
 				}
 				else if (http_service_unavail == mGetStatus)
 				{
 					LL_INFOS_ONCE(LOG_TXT) << "Texture server busy (503): " << mUrl << LL_ENDL;
+                    if (mCanUseHTTP && !mUrl.empty() && cur_size <= 0)
+                    {
+                        LLViewerRegion* region = getRegion();
+                        if (!region || mLastRegionId != region->getRegionID())
+                        {
+                            // try on new region.
+                            mUrl.clear();
+                            ++mRetryAttempt;
+                            mLastRegionId.setNull();
+                            setState(INIT);
+                            return false;
+                        }
+                    }
 				}
 				else if (http_not_sat == mGetStatus)
 				{
@@ -3052,6 +3101,20 @@ void LLTextureFetchWorker::setState(e_state new_state)
 
 	mStateTimer.reset();
 	mState = new_state;
+}
+
+LLViewerRegion* LLTextureFetchWorker::getRegion()
+{
+    LLViewerRegion* region = NULL;
+    if (mHost.isInvalid())
+    {
+        region = gAgent.getRegion();
+    }
+    else if (LLWorld::instanceExists())
+    {
+        region = LLWorld::getInstance()->getRegion(mHost);
+    }
+    return region;
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There can be no asset capability during teleport and it can take some time to arrive, texture shouldn't just fail to fetch if capability arrives after content.

I don't like how it works, but based on how WAIT_HTTP_RESOURCE2 just returns false without doing anything else, I assume this is the best avaliable way to wait without shutting down fetching and cache.