### PR TITLE
SL-20403 FIXED People floater showing arrows on default size

### DIFF
--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -225,7 +225,8 @@ LLTabContainer::Params::Params()
 	tabs_flashing_color("tabs_flashing_color"),
 	tab_icon_ctrl_pad("tab_icon_ctrl_pad", 0),
 	use_ellipses("use_ellipses"),
-	font_halign("halign")
+	font_halign("halign"),
+    use_tab_offset("use_tab_offset", false)
 {}
 
 LLTabContainer::LLTabContainer(const LLTabContainer::Params& p)
@@ -264,7 +265,8 @@ LLTabContainer::LLTabContainer(const LLTabContainer::Params& p)
 	mTabIconCtrlPad(p.tab_icon_ctrl_pad),
 	mEnableTabsFlashing(p.enable_tabs_flashing),
 	mTabsFlashingColor(p.tabs_flashing_color),
-	mUseTabEllipses(p.use_ellipses)
+	mUseTabEllipses(p.use_ellipses),
+    mUseTabOffset(p.use_tab_offset)
 {
 	static LLUICachedControl<S32> tabcntr_vert_tab_min_width ("UITabCntrVertTabMinWidth", 0);
 
@@ -1023,11 +1025,10 @@ void LLTabContainer::addTabPanel(const TabPanelParams& panel)
 	}
 	else
 	{
-		tab_panel_rect = LLRect(LLPANEL_BORDER_WIDTH * 3,
-								tab_panel_top,
-								getRect().getWidth() - LLPANEL_BORDER_WIDTH * 2,
-								tab_panel_bottom );
-	}
+        S32 left_offset = mUseTabOffset ? LLPANEL_BORDER_WIDTH * 3 : LLPANEL_BORDER_WIDTH;
+        S32 right_offset = mUseTabOffset ? LLPANEL_BORDER_WIDTH * 2 : LLPANEL_BORDER_WIDTH;
+        tab_panel_rect = LLRect(left_offset, tab_panel_top, getRect().getWidth() - right_offset, tab_panel_bottom);
+    }
 	child->setFollowsAll();
 	child->translate( tab_panel_rect.mLeft - child->getRect().mLeft, tab_panel_rect.mBottom - child->getRect().mBottom);
 	child->reshape( tab_panel_rect.getWidth(), tab_panel_rect.getHeight(), TRUE );

--- a/indra/llui/lltabcontainer.h
+++ b/indra/llui/lltabcontainer.h
@@ -121,6 +121,8 @@ public:
 		 */
 		Optional<S32>						tab_icon_ctrl_pad;
 
+        Optional<bool> use_tab_offset;
+
 		Params();
 	};
 
@@ -321,6 +323,8 @@ private:
 	S32								mTabIconCtrlPad;
 	bool							mUseTabEllipses;
     LLFrameTimer					mMouseDownTimer;
+
+    bool mUseTabOffset;
 };
 
 #endif  // LL_TABCONTAINER_H

--- a/indra/newview/skins/default/xui/en/panel_main_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_main_inventory.xml
@@ -217,6 +217,7 @@
        tab_height="30"
        tab_position="top"
        tab_min_width="100"
+       use_tab_offset="true"
        top="0">
         <inventory_panel
          bg_opaque_color="DkGray2"


### PR DESCRIPTION
The issue was caused by https://github.com/secondlife/viewer/commit/2a035c080dec2aa16b9628aac7b120e4f15135c2#diff-018dd621e811a33ee38efeabfc2e0fa246aca4a0bd7b169f84f021efac558865 change. So let's just use the new offset if it's needed.