### PR TITLE
Fill agent_id fields in LLAvatarData correctly when using capability …

### DIFF
--- a/indra/newview/llavatarpropertiesprocessor.cpp
+++ b/indra/newview/llavatarpropertiesprocessor.cpp
@@ -553,7 +553,7 @@ void LLAvatarPropertiesProcessor::processAvatarPicksReply(LLMessageSystem* msg, 
 		msg->getUUID(_PREHASH_Data, _PREHASH_PickID, pick_id, block);
 		msg->getString(_PREHASH_Data, _PREHASH_PickName, pick_name, block);
 
-		avatar_picks.picks_list.emplace_back(std::make_pair(pick_id,pick_name));
+		avatar_picks.picks_list.emplace_back(pick_id, pick_name);
 	}
 	LLAvatarPropertiesProcessor* self = getInstance();
 	// Request processed, no longer pending

--- a/indra/newview/llavatarpropertiesprocessor.h
+++ b/indra/newview/llavatarpropertiesprocessor.h
@@ -248,7 +248,7 @@ public:
 
 	static bool hasPaymentInfoOnFile(const LLAvatarData* avatar_data);
 
-    static void requestAvatarPropertiesCoro(std::string cap_url, LLUUID agent_id, EAvatarProcessorType type);
+    static void requestAvatarPropertiesCoro(std::string cap_url, LLUUID avatar_id, EAvatarProcessorType type);
 
 	static void processAvatarPropertiesReply(LLMessageSystem* msg, void**);
 


### PR DESCRIPTION
…for avatar properties request

LLAvatarData.agent_id is historically set with the ID of the agent issuing the avatar properties request, which is gAgentID. Legacy code might also be checking if agent_id is the same as gAgentID in the response handler to verify the response is meant for us. Make sure in case of the new cap we set agent_id to the correct ID.