### PR TITLE
SL-20517: When attempting to find orphans, if an object claims to be …

### DIFF
--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -2200,6 +2200,7 @@ void LLViewerObjectList::findOrphans(LLViewerObject* objectp, U32 ip, U32 port)
 			{
 				LL_WARNS() << objectp->mID << " has self as parent, skipping!" 
 					<< LL_ENDL;
+                ++iter;
 				continue;
 			}
 


### PR DESCRIPTION
…its own parent the viewer logs a warning and then continues the loop without incrementing the iterator.  This increments the iterator so that loop processing can continue and the viewer does not get stuck on the bad object.