### PR TITLE
DRTVWR-594 Mac buildfix (remove unused field)

### DIFF
--- a/indra/newview/lloutfitgallery.h
+++ b/indra/newview/lloutfitgallery.h
@@ -195,16 +195,13 @@ public:
     
     friend class LLOutfitGallery;
     LLOutfitGalleryContextMenu(LLOutfitListBase* outfit_list)
-    : LLOutfitContextMenu(outfit_list),
-    mOutfitList(outfit_list){}
+    : LLOutfitContextMenu(outfit_list){}
 
 protected:
     /* virtual */ LLContextMenu* createMenu();
     bool onEnable(LLSD::String param);
     bool onVisible(LLSD::String param);
     void onCreate(const LLSD& data);
-private:
-    LLOutfitListBase*	mOutfitList;
 };
 
 


### PR DESCRIPTION
`lloutfitgallery.h:207:23: error: private field 'mOutfitList' is not used [-Werror,-Wunused-private-field]`