### PR TITLE
Fix for SL-19968 objects missing timing bug due to stall during login

### DIFF
--- a/indra/llcommon/llprofiler.h
+++ b/indra/llcommon/llprofiler.h
@@ -114,6 +114,7 @@ extern thread_local bool gProfilerEnabled;
         #define LL_PROFILER_SET_THREAD_NAME( name )      (void)(name)
         #define LL_RECORD_BLOCK_TIME(name)                                                                  const LLTrace::BlockTimer& LL_GLUE_TOKENS(block_time_recorder, __LINE__)(LLTrace::timeThisBlock(name)); (void)LL_GLUE_TOKENS(block_time_recorder, __LINE__);
         #define LL_PROFILE_ZONE_NAMED(name)             // LL_PROFILE_ZONE_NAMED is a no-op when Tracy is disabled
+        #define LL_PROFILE_ZONE_NAMED_COLOR(name,color) // LL_PROFILE_ZONE_NAMED_COLOR is a no-op when Tracy is disabled
         #define LL_PROFILE_ZONE_SCOPED                  // LL_PROFILE_ZONE_SCOPED is a no-op when Tracy is disabled
         #define LL_PROFILE_ZONE_COLOR(name,color)       // LL_RECORD_BLOCK_TIME(name)
 

--- a/indra/llcommon/llsdserialize.cpp
+++ b/indra/llcommon/llsdserialize.cpp
@@ -475,6 +475,7 @@ LLSDNotationParser::~LLSDNotationParser()
 // virtual
 S32 LLSDNotationParser::doParse(std::istream& istr, LLSD& data, S32 max_depth) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 	// map: { string:object, string:object }
 	// array: [ object, object, object ]
 	// undef: !
@@ -734,6 +735,7 @@ S32 LLSDNotationParser::doParse(std::istream& istr, LLSD& data, S32 max_depth) c
 
 S32 LLSDNotationParser::parseMap(std::istream& istr, LLSD& map, S32 max_depth) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 	// map: { string:object, string:object }
 	map = LLSD::emptyMap();
 	S32 parse_count = 0;
@@ -794,6 +796,7 @@ S32 LLSDNotationParser::parseMap(std::istream& istr, LLSD& map, S32 max_depth) c
 
 S32 LLSDNotationParser::parseArray(std::istream& istr, LLSD& array, S32 max_depth) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 	// array: [ object, object, object ]
 	array = LLSD::emptyArray();
 	S32 parse_count = 0;
@@ -833,6 +836,7 @@ S32 LLSDNotationParser::parseArray(std::istream& istr, LLSD& array, S32 max_dept
 
 bool LLSDNotationParser::parseString(std::istream& istr, LLSD& data) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 	std::string value;
 	auto count = deserialize_string(istr, value, mMaxBytesLeft);
 	if(PARSE_FAILURE == count) return false;
@@ -843,6 +847,7 @@ bool LLSDNotationParser::parseString(std::istream& istr, LLSD& data) const
 
 bool LLSDNotationParser::parseBinary(std::istream& istr, LLSD& data) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 	// binary: b##"ff3120ab1"
 	// or: b(len)"..."
 
@@ -945,6 +950,7 @@ LLSDBinaryParser::~LLSDBinaryParser()
 // virtual
 S32 LLSDBinaryParser::doParse(std::istream& istr, LLSD& data, S32 max_depth) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
 /**
  * Undefined: '!'<br>
  * Boolean: '1' for true '0' for false<br>

--- a/indra/llcommon/llsdserialize_xml.cpp
+++ b/indra/llcommon/llsdserialize_xml.cpp
@@ -923,6 +923,8 @@ void LLSDXMLParser::parsePart(const char *buf, llssize len)
 // virtual
 S32 LLSDXMLParser::doParse(std::istream& input, LLSD& data, S32 max_depth) const
 {
+	LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD
+
 	#ifdef XML_PARSER_PERFORMANCE_TESTS
 	XML_Timer timer( &parseTime );
 	#endif	// XML_PARSER_PERFORMANCE_TESTS

--- a/indra/llinventory/llinventory.cpp
+++ b/indra/llinventory/llinventory.cpp
@@ -1054,6 +1054,8 @@ bool LLInventoryItem::fromLLSD(const LLSD& sd, bool is_new)
 	}
 #else  // if 0 - new implementation follows
 
+    mThumbnailUUID.setNull();
+
     // iterate as map to avoid making unnecessary temp copies of everything
     LLSD::map_const_iterator i, end;
     end = sd.endMap();
@@ -1067,6 +1069,31 @@ bool LLInventoryItem::fromLLSD(const LLSD& sd, bool is_new)
         if (i->first == INV_PARENT_ID_LABEL)
         {
             mParentUUID = i->second;
+        }
+
+        if (i->first == INV_THUMBNAIL_LABEL)
+        {
+            const LLSD &thumbnail_map = i->second;
+            const std::string w = INV_ASSET_ID_LABEL;
+            if (thumbnail_map.has(w))
+            {
+                mThumbnailUUID = thumbnail_map[w];
+            }
+            /* Example:
+                <key> asset_id </key>
+                <uuid> acc0ec86 - 17f2 - 4b92 - ab41 - 6718b1f755f7 </uuid>
+                <key> perms </key>
+                <integer> 8 </integer>
+                <key>service</key>
+                <integer> 3 </integer>
+                <key>version</key>
+                <integer> 1 </key>
+            */
+        }
+
+        if (i->first == INV_THUMBNAIL_ID_LABEL)
+        {
+            mThumbnailUUID = i->second.asUUID();
         }
 
         if (i->first == INV_PERMISSIONS_LABEL)

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -3323,7 +3323,7 @@ bool LLInventoryModel::loadFromFile(const std::string& filename,
 									LLInventoryModel::changed_items_t& cats_to_update,
 									bool &is_cache_obsolete)
 {
-    LL_PROFILE_ZONE_NAMED_COLOR("inventory load from file", 0xFF1111);
+    LL_PROFILE_ZONE_NAMED("inventory load from file");
 
 	if(filename.empty())
 	{

--- a/indra/newview/llstartup.h
+++ b/indra/newview/llstartup.h
@@ -40,6 +40,7 @@ class LLSLURL;
 bool idle_startup();
 void release_start_screen();
 bool login_alert_done(const LLSD& notification, const LLSD& response);
+void pump_idle_startup_network();
 
 // start location constants
 enum EStartLocation
@@ -72,6 +73,8 @@ typedef enum {
 	STATE_AGENT_WAIT,				// Wait for region
 	STATE_INVENTORY_SEND,			// Do inventory transfer
 	STATE_INVENTORY_CALLBACKS,		// Wait for missing system folders and register callbacks
+	STATE_INVENTORY_SKEL,			// Do more inventory skeleton loading
+	STATE_INVENTORY_SEND2,			// Do more inventory init after skeleton is loaded
 	STATE_MISC,						// Do more things (set bandwidth, start audio, save location, etc)
 	STATE_PRECACHE,					// Wait a bit for textures to download
 	STATE_WEARABLES_WAIT,			// Wait for clothing to download


### PR DESCRIPTION
Ensure inventory skeleton loading doesn't block the message system from processing packets.

This addresses the stall during login in 2 ways: some minor optimizations in LLSD inventory skeleton loading to avoid a lot of unnecessary temporary copy allocations, and periodically calling back to `pump_idle_startup_network()` to ensure that UDP messages can still be processed as we are going.