### PR TITLE
SL-20523 Local textures not updating on PBR Materials #5

### DIFF
--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -770,6 +770,15 @@ LLUUID LLGLTFMaterial::getHash() const
     return hash;
 }
 
+void LLGLTFMaterial::addTextureEntry(LLTextureEntry* te)
+{
+    mTextureEntires.insert(te);
+}
+void LLGLTFMaterial::removeTextureEntry(LLTextureEntry* te)
+{
+    mTextureEntires.erase(te);
+}
+
 void LLGLTFMaterial::addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id)
 {
     mLocalTextureTrackingIds.insert(tracking_id);

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -89,6 +89,11 @@ LLGLTFMaterial& LLGLTFMaterial::operator=(const LLGLTFMaterial& rhs)
     mOverrideDoubleSided = rhs.mOverrideDoubleSided;
     mOverrideAlphaMode = rhs.mOverrideAlphaMode;
 
+    mLocalTextureIds = rhs.mLocalTextureIds;
+    mLocalTextureTrackingIds = rhs.mLocalTextureTrackingIds;
+
+    updateTextureTracking();
+
     return *this;
 }
 
@@ -765,3 +770,44 @@ LLUUID LLGLTFMaterial::getHash() const
     return hash;
 }
 
+void LLGLTFMaterial::addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id)
+{
+    mLocalTextureTrackingIds.insert(tracking_id);
+    mLocalTextureIds.insert(tex_id);
+}
+
+void LLGLTFMaterial::removeLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id)
+{
+    mLocalTextureTrackingIds.erase(tracking_id);
+    mLocalTextureIds.erase(tex_id);
+}
+
+bool LLGLTFMaterial::replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id)
+{
+    bool res = false;
+
+    for (int i = 0; i < GLTF_TEXTURE_INFO_COUNT; ++i)
+    {
+        if (mTextureId[i] == old_id)
+        {
+            mTextureId[i] = new_id;
+            res = true;
+        }
+    }
+
+    mLocalTextureIds.erase(old_id);
+    if (res)
+    {
+        mLocalTextureIds.insert(new_id);
+    }
+
+    return res;
+}
+
+void LLGLTFMaterial::updateTextureTracking()
+{
+    if (mLocalTextureTrackingIds.size() > 0)
+    {
+        LL_WARNS() << "copied a material with local textures, but tracking not implemented" << LL_ENDL;
+    }
+}

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -794,6 +794,10 @@ bool LLGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const LLUUID
             mTextureId[i] = new_id;
             res = true;
         }
+        else if (mTextureId[i] == new_id)
+        {
+            res = true;
+        }
     }
 
     if (res)

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -607,6 +607,8 @@ void LLGLTFMaterial::applyOverride(const LLGLTFMaterial& override_mat)
     }
 
     mTrackingIdToLocalTexture.insert(override_mat.mTrackingIdToLocalTexture.begin(), override_mat.mTrackingIdToLocalTexture.begin());
+
+    updateTextureTracking();
 }
 
 void LLGLTFMaterial::getOverrideLLSD(const LLGLTFMaterial& override_mat, LLSD& data)
@@ -771,15 +773,6 @@ LLUUID LLGLTFMaterial::getHash() const
     return hash;
 }
 
-void LLGLTFMaterial::addTextureEntry(LLTextureEntry* te)
-{
-    mTextureEntires.insert(te);
-}
-void LLGLTFMaterial::removeTextureEntry(LLTextureEntry* te)
-{
-    mTextureEntires.erase(te);
-}
-
 void LLGLTFMaterial::addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id)
 {
     mTrackingIdToLocalTexture[tracking_id] = tex_id;
@@ -818,4 +811,5 @@ bool LLGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const LLUUID
 void LLGLTFMaterial::updateTextureTracking()
 {
     // setTEGLTFMaterialOverride is responsible for tracking
+    // for material overrides editor will set it
 }

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -223,8 +223,14 @@ public:
     virtual void removeTextureEntry(LLTextureEntry* te) {};
 
     // For local textures so that editor will know to track changes
-    void setHasLocalTextures(bool val) { mHasLocalTextures = val; }
-    bool hasLocalTextures() { return mHasLocalTextures; }
+    void addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID &tex_id);
+    void removeLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id);
+    bool hasLocalTextures() { return !mLocalTextureIds.empty(); }
+    virtual bool replaceLocalTexture(const LLUUID &old_id, const LLUUID& new_id);
+    virtual void updateTextureTracking();
+
+    uuid_set_t mLocalTextureIds;
+    uuid_set_t mLocalTextureTrackingIds;
 
 protected:
     static LLVector2 vec2FromJson(const std::map<std::string, tinygltf::Value>& object, const char* key, const LLVector2& default_value);
@@ -242,6 +248,4 @@ protected:
     void writeToTexture(tinygltf::Model& model, T& texture_info, TextureInfo texture_info_id, bool force_write = false) const;
     template<typename T>
     static void writeToTexture(tinygltf::Model& model, T& texture_info, const LLUUID& texture_id, const TextureTransform& transform, bool force_write = false);
-
-    bool mHasLocalTextures;
 };

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -222,6 +222,10 @@ public:
     virtual void addTextureEntry(LLTextureEntry* te) {};
     virtual void removeTextureEntry(LLTextureEntry* te) {};
 
+    // For local textures so that editor will know to track changes
+    void setHasLocalTextures(bool val) { mHasLocalTextures = val; }
+    bool hasLocalTextures() { return mHasLocalTextures; }
+
 protected:
     static LLVector2 vec2FromJson(const std::map<std::string, tinygltf::Value>& object, const char* key, const LLVector2& default_value);
     static F32 floatFromJson(const std::map<std::string, tinygltf::Value>& object, const char* key, const F32 default_value);
@@ -238,4 +242,6 @@ protected:
     void writeToTexture(tinygltf::Model& model, T& texture_info, TextureInfo texture_info_id, bool force_write = false) const;
     template<typename T>
     static void writeToTexture(tinygltf::Model& model, T& texture_info, const LLUUID& texture_id, const TextureTransform& transform, bool force_write = false);
+
+    bool mHasLocalTextures;
 };

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -219,8 +219,8 @@ public:
 
     // For local materials, they have to keep track of where
     // they are assigned to for full updates
-    virtual void addTextureEntry(LLTextureEntry* te) {};
-    virtual void removeTextureEntry(LLTextureEntry* te) {};
+    virtual void addTextureEntry(LLTextureEntry* te);
+    virtual void removeTextureEntry(LLTextureEntry* te);
 
     // For local textures so that editor will know to track changes
     void addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID &tex_id);
@@ -231,6 +231,7 @@ public:
 
     uuid_set_t mLocalTextureIds;
     uuid_set_t mLocalTextureTrackingIds;
+    std::set<LLTextureEntry*> mTextureEntires;
 
 protected:
     static LLVector2 vec2FromJson(const std::map<std::string, tinygltf::Value>& object, const char* key, const LLVector2& default_value);

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -219,8 +219,8 @@ public:
 
     // For local materials, they have to keep track of where
     // they are assigned to for full updates
-    virtual void addTextureEntry(LLTextureEntry* te);
-    virtual void removeTextureEntry(LLTextureEntry* te);
+    virtual void addTextureEntry(LLTextureEntry* te) {};
+    virtual void removeTextureEntry(LLTextureEntry* te) {};
 
     // For local textures so that editor will know to track changes
     void addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID &tex_id);
@@ -229,9 +229,9 @@ public:
     virtual bool replaceLocalTexture(const LLUUID& tracking_id, const LLUUID &old_id, const LLUUID& new_id);
     virtual void updateTextureTracking();
 
+    // These fields are local to viewer and are a part of local bitmap support
     typedef std::map<LLUUID, LLUUID> local_tex_map_t;
     local_tex_map_t mTrackingIdToLocalTexture;
-    std::set<LLTextureEntry*> mTextureEntires;
 
 protected:
     static LLVector2 vec2FromJson(const std::map<std::string, tinygltf::Value>& object, const char* key, const LLVector2& default_value);

--- a/indra/llprimitive/llgltfmaterial.h
+++ b/indra/llprimitive/llgltfmaterial.h
@@ -196,7 +196,7 @@ public:
     // write to given tinygltf::Model
     void writeToModel(tinygltf::Model& model, S32 mat_index) const;
 
-    void applyOverride(const LLGLTFMaterial& override_mat);
+    virtual void applyOverride(const LLGLTFMaterial& override_mat);
     
     // apply the given LLSD override data
     void applyOverrideLLSD(const LLSD& data);
@@ -224,13 +224,13 @@ public:
 
     // For local textures so that editor will know to track changes
     void addLocalTextureTracking(const LLUUID& tracking_id, const LLUUID &tex_id);
-    void removeLocalTextureTracking(const LLUUID& tracking_id, const LLUUID& tex_id);
-    bool hasLocalTextures() { return !mLocalTextureIds.empty(); }
-    virtual bool replaceLocalTexture(const LLUUID &old_id, const LLUUID& new_id);
+    void removeLocalTextureTracking(const LLUUID& tracking_id);
+    bool hasLocalTextures() { return !mTrackingIdToLocalTexture.empty(); }
+    virtual bool replaceLocalTexture(const LLUUID& tracking_id, const LLUUID &old_id, const LLUUID& new_id);
     virtual void updateTextureTracking();
 
-    uuid_set_t mLocalTextureIds;
-    uuid_set_t mLocalTextureTrackingIds;
+    typedef std::map<LLUUID, LLUUID> local_tex_map_t;
+    local_tex_map_t mTrackingIdToLocalTexture;
     std::set<LLTextureEntry*> mTextureEntires;
 
 protected:

--- a/indra/newview/llfetchedgltfmaterial.cpp
+++ b/indra/newview/llfetchedgltfmaterial.cpp
@@ -144,6 +144,55 @@ void LLFetchedGLTFMaterial::bind(LLViewerTexture* media_tex)
 
 }
 
+LLViewerFetchedTexture* fetch_texture(const LLUUID& id)
+{
+    LLViewerFetchedTexture* img = nullptr;
+    if (id.notNull())
+    {
+        img = LLViewerTextureManager::getFetchedTexture(id, FTT_DEFAULT, TRUE, LLGLTexture::BOOST_NONE, LLViewerTexture::LOD_TEXTURE);
+        img->addTextureStats(64.f * 64.f, TRUE);
+    }
+    return img;
+};
+
+bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id)
+{
+    bool res = false;
+    if (mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] == old_id)
+    {
+        mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] = new_id;
+        mBaseColorTexture = fetch_texture(new_id);
+        res = true;
+    }
+    if (mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL] == old_id)
+    {
+        mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL] = new_id;
+        mNormalTexture = fetch_texture(new_id);
+        res = true;
+    }
+    if (mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_METALLIC_ROUGHNESS] == old_id)
+    {
+        mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_METALLIC_ROUGHNESS] = new_id;
+        mMetallicRoughnessTexture = fetch_texture(new_id);
+        res = true;
+    }
+    if (mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE] == old_id)
+    {
+        mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE] = new_id;
+        mEmissiveTexture = fetch_texture(new_id);
+        res = true;
+    }
+    return res;
+}
+
+void LLFetchedGLTFMaterial::updateTextureTracking()
+{
+    for (const LLUUID& id : mLocalTextureTrackingIds)
+    {
+        LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(id, this);
+    }
+}
+
 void LLFetchedGLTFMaterial::materialBegin()
 {
     llassert(!mFetching);

--- a/indra/newview/llfetchedgltfmaterial.cpp
+++ b/indra/newview/llfetchedgltfmaterial.cpp
@@ -183,6 +183,14 @@ bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const
         res = true;
     }
 
+    for (int i = 0; i < GLTF_TEXTURE_INFO_COUNT; ++i)
+    {
+        if (mTextureId[i] == new_id)
+        {
+            res = true;
+        }
+    }
+
     if (res)
     {
         mTrackingIdToLocalTexture[tracking_id] = new_id;

--- a/indra/newview/llfetchedgltfmaterial.cpp
+++ b/indra/newview/llfetchedgltfmaterial.cpp
@@ -155,13 +155,6 @@ LLViewerFetchedTexture* fetch_texture(const LLUUID& id)
     return img;
 };
 
-void LLFetchedGLTFMaterial::applyOverride(const LLGLTFMaterial& override_mat)
-{
-    LLGLTFMaterial::applyOverride(override_mat);
-
-    updateTextureTracking();
-}
-
 bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const LLUUID& old_id, const LLUUID& new_id)
 {
     bool res = false;
@@ -202,9 +195,19 @@ bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const
     return res;
 }
 
+void LLFetchedGLTFMaterial::addTextureEntry(LLTextureEntry* te)
+{
+    mTextureEntires.insert(te);
+}
+
+void LLFetchedGLTFMaterial::removeTextureEntry(LLTextureEntry* te)
+{
+    mTextureEntires.erase(te);
+}
+
 void LLFetchedGLTFMaterial::updateTextureTracking()
 {
-    for (local_tex_map_t::value_type val : mTrackingIdToLocalTexture)
+    for (local_tex_map_t::value_type &val : mTrackingIdToLocalTexture)
     {
         LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(val.first, this);
     }

--- a/indra/newview/llfetchedgltfmaterial.cpp
+++ b/indra/newview/llfetchedgltfmaterial.cpp
@@ -155,7 +155,14 @@ LLViewerFetchedTexture* fetch_texture(const LLUUID& id)
     return img;
 };
 
-bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id)
+void LLFetchedGLTFMaterial::applyOverride(const LLGLTFMaterial& override_mat)
+{
+    LLGLTFMaterial::applyOverride(override_mat);
+
+    updateTextureTracking();
+}
+
+bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& tracking_id, const LLUUID& old_id, const LLUUID& new_id)
 {
     bool res = false;
     if (mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] == old_id)
@@ -182,14 +189,24 @@ bool LLFetchedGLTFMaterial::replaceLocalTexture(const LLUUID& old_id, const LLUU
         mEmissiveTexture = fetch_texture(new_id);
         res = true;
     }
+
+    if (res)
+    {
+        mTrackingIdToLocalTexture[tracking_id] = new_id;
+    }
+    else
+    {
+        mTrackingIdToLocalTexture.erase(tracking_id);
+    }
+
     return res;
 }
 
 void LLFetchedGLTFMaterial::updateTextureTracking()
 {
-    for (const LLUUID& id : mLocalTextureTrackingIds)
+    for (local_tex_map_t::value_type val : mTrackingIdToLocalTexture)
     {
-        LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(id, this);
+        LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(val.first, this);
     }
 }
 

--- a/indra/newview/llfetchedgltfmaterial.h
+++ b/indra/newview/llfetchedgltfmaterial.h
@@ -50,6 +50,9 @@ public:
 
     bool isFetching() const { return mFetching; }
 
+    virtual bool replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id) override;
+    virtual void updateTextureTracking() override;
+
     // Textures used for fetching/rendering
     LLPointer<LLViewerFetchedTexture> mBaseColorTexture;
     LLPointer<LLViewerFetchedTexture> mNormalTexture;

--- a/indra/newview/llfetchedgltfmaterial.h
+++ b/indra/newview/llfetchedgltfmaterial.h
@@ -50,7 +50,8 @@ public:
 
     bool isFetching() const { return mFetching; }
 
-    void applyOverride(const LLGLTFMaterial& override_mat) override;
+    void addTextureEntry(LLTextureEntry* te) override;
+    void removeTextureEntry(LLTextureEntry* te) override;
     virtual bool replaceLocalTexture(const LLUUID& tracking_id, const LLUUID& old_id, const LLUUID& new_id) override;
     virtual void updateTextureTracking() override;
 
@@ -59,6 +60,8 @@ public:
     LLPointer<LLViewerFetchedTexture> mNormalTexture;
     LLPointer<LLViewerFetchedTexture> mMetallicRoughnessTexture;
     LLPointer<LLViewerFetchedTexture> mEmissiveTexture;
+
+    std::set<LLTextureEntry*> mTextureEntires;
 
 protected:
     // Lifetime management

--- a/indra/newview/llfetchedgltfmaterial.h
+++ b/indra/newview/llfetchedgltfmaterial.h
@@ -50,7 +50,8 @@ public:
 
     bool isFetching() const { return mFetching; }
 
-    virtual bool replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id) override;
+    void applyOverride(const LLGLTFMaterial& override_mat) override;
+    virtual bool replaceLocalTexture(const LLUUID& tracking_id, const LLUUID& old_id, const LLUUID& new_id) override;
     virtual void updateTextureTracking() override;
 
     // Textures used for fetching/rendering

--- a/indra/newview/llfloaterchangeitemthumbnail.cpp
+++ b/indra/newview/llfloaterchangeitemthumbnail.cpp
@@ -760,7 +760,7 @@ void LLFloaterChangeItemThumbnail::showTexturePicker(const LLUUID &thumbnail_id)
         {
             //texture_floaterp->setTextureSelectedCallback();
             //texture_floaterp->setOnUpdateImageStatsCallback();
-            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource, const LLUUID&, const LLUUID&)
+            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource, const LLUUID&, const LLUUID&, const LLUUID&)
             {
                 if (op == LLTextureCtrl::TEXTURE_SELECT)
                 {

--- a/indra/newview/lllocalbitmaps.h
+++ b/indra/newview/lllocalbitmaps.h
@@ -44,11 +44,11 @@ class LLLocalBitmap
 		~LLLocalBitmap();
 
 	public: /* accessors */
-		std::string	getFilename();
-		std::string	getShortName();
-		LLUUID		getTrackingID();
-		LLUUID		getWorldID();
-		bool		getValid();
+		std::string	getFilename() const;
+		std::string	getShortName() const;
+		LLUUID		getTrackingID() const;
+		LLUUID		getWorldID() const;
+		bool		getValid() const;
 
 	public: /* self update public section */
 		enum EUpdateType
@@ -59,9 +59,14 @@ class LLLocalBitmap
 
 		bool updateSelf(EUpdateType = UT_REGUPDATE);
 
+        typedef boost::signals2::signal<void(const LLUUID& old_id,
+                                             const LLUUID& new_id)> LLLocalTextureChangedSignal;
+        typedef LLLocalTextureChangedSignal::slot_type LLLocalTextureCallback;
+        boost::signals2::connection setChangedCallback(const LLLocalTextureCallback& cb);
+
 	private: /* self update private section */
 		bool decodeBitmap(LLPointer<LLImageRaw> raw);
-		void replaceIDs(LLUUID old_id, LLUUID new_id);
+        void replaceIDs(const LLUUID &old_id, LLUUID new_id);
 		std::vector<LLViewerObject*> prepUpdateObjects(LLUUID old_id, U32 channel);
 		void updateUserPrims(LLUUID old_id, LLUUID new_id, U32 channel);
 		void updateUserVolumes(LLUUID old_id, LLUUID new_id, U32 channel);
@@ -93,6 +98,7 @@ class LLLocalBitmap
 		EExtension  mExtension;
 		ELinkStatus mLinkStatus;
 		S32         mUpdateRetries;
+        LLLocalTextureChangedSignal	mChangedSignal;
 
 };
 
@@ -120,10 +126,11 @@ public:
 	void         delUnit(LLUUID tracking_id);
 	bool 		checkTextureDimensions(std::string filename);
 
-	LLUUID       getWorldID(LLUUID tracking_id);
-    bool         isLocal(LLUUID world_id);
-	std::string  getFilename(LLUUID tracking_id);
-    
+	LLUUID       getWorldID(const LLUUID &tracking_id) const;
+    bool         isLocal(const LLUUID& world_id) const;
+	std::string  getFilename(const LLUUID &tracking_id) const;
+    boost::signals2::connection setOnChangedCallback(const LLUUID tracking_id, const LLLocalBitmap::LLLocalTextureCallback& cb);
+
 	void         feedScrollList(LLScrollListCtrl* ctrl);
 	void         doUpdates();
 	void         setNeedsRebake();
@@ -134,6 +141,7 @@ private:
 	LLLocalBitmapTimer           mTimer;
 	bool                         mNeedsRebake;
 	typedef std::list<LLLocalBitmap*>::iterator local_list_iter;
+    typedef std::list<LLLocalBitmap*>::const_iterator local_list_citer;
 };
 
 #endif

--- a/indra/newview/lllocalbitmaps.h
+++ b/indra/newview/lllocalbitmaps.h
@@ -36,6 +36,7 @@
 class LLScrollListCtrl;
 class LLImageRaw;
 class LLViewerObject;
+class LLGLTFMaterial;
 
 class LLLocalBitmap
 {
@@ -59,10 +60,12 @@ class LLLocalBitmap
 
 		bool updateSelf(EUpdateType = UT_REGUPDATE);
 
-        typedef boost::signals2::signal<void(const LLUUID& old_id,
+        typedef boost::signals2::signal<void(const LLUUID& tracking_id,
+                                             const LLUUID& old_id,
                                              const LLUUID& new_id)> LLLocalTextureChangedSignal;
         typedef LLLocalTextureChangedSignal::slot_type LLLocalTextureCallback;
         boost::signals2::connection setChangedCallback(const LLLocalTextureCallback& cb);
+        void addGLTFMaterial(LLGLTFMaterial* mat);
 
 	private: /* self update private section */
 		bool decodeBitmap(LLPointer<LLImageRaw> raw);
@@ -71,6 +74,7 @@ class LLLocalBitmap
 		void updateUserPrims(LLUUID old_id, LLUUID new_id, U32 channel);
 		void updateUserVolumes(LLUUID old_id, LLUUID new_id, U32 channel);
 		void updateUserLayers(LLUUID old_id, LLUUID new_id, LLWearableType::EType type);
+        void updateGLTFMaterials(LLUUID old_id, LLUUID new_id);
 		LLAvatarAppearanceDefines::ETextureIndex getTexIndex(LLWearableType::EType type, LLAvatarAppearanceDefines::EBakedTextureIndex baked_texind);
 
 	private: /* private enums */
@@ -99,6 +103,11 @@ class LLLocalBitmap
 		ELinkStatus mLinkStatus;
 		S32         mUpdateRetries;
         LLLocalTextureChangedSignal	mChangedSignal;
+
+        // Store a list of accosiated materials
+        // Might be a better idea to hold this in LLGLTFMaterialList
+        typedef std::vector<LLPointer<LLGLTFMaterial> > mat_list_t;
+        mat_list_t mGLTFMaterialWithLocalTextures;
 
 };
 
@@ -130,6 +139,7 @@ public:
     bool         isLocal(const LLUUID& world_id) const;
 	std::string  getFilename(const LLUUID &tracking_id) const;
     boost::signals2::connection setOnChangedCallback(const LLUUID tracking_id, const LLLocalBitmap::LLLocalTextureCallback& cb);
+    void associateGLTFMaterial(const LLUUID tracking_id, LLGLTFMaterial* mat);
 
 	void         feedScrollList(LLScrollListCtrl* ctrl);
 	void         doUpdates();

--- a/indra/newview/lllocalgltfmaterials.cpp
+++ b/indra/newview/lllocalgltfmaterials.cpp
@@ -119,15 +119,6 @@ S32 LLLocalGLTFMaterial::getIndexInFile() const
     return mMaterialIndex;
 }
 
-void LLLocalGLTFMaterial::addTextureEntry(LLTextureEntry* te)
-{
-    mTextureEntires.insert(te);
-}
-void LLLocalGLTFMaterial::removeTextureEntry(LLTextureEntry* te)
-{
-    mTextureEntires.erase(te);
-}
-
 /* update functions */
 bool LLLocalGLTFMaterial::updateSelf()
 {

--- a/indra/newview/lllocalgltfmaterials.h
+++ b/indra/newview/lllocalgltfmaterials.h
@@ -49,9 +49,6 @@ public: /* accessors */
     LLUUID		getWorldID() const;
     S32			getIndexInFile() const;
 
-    void addTextureEntry(LLTextureEntry* te) override;
-    void removeTextureEntry(LLTextureEntry* te) override;
-
 public:
     bool updateSelf();
 
@@ -81,7 +78,6 @@ private: /* members */
     ELinkStatus mLinkStatus;
     S32         mUpdateRetries;
     S32         mMaterialIndex; // Single file can have more than one
-    std::set<LLTextureEntry*> mTextureEntires;
 };
 
 class LLLocalGLTFMaterialTimer : public LLEventTimer

--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -3231,6 +3231,10 @@ bool LLMaterialEditor::setFromSelection()
 
         // Ovverdired might have been updated,
         // refresh state of local textures in overrides
+        // 
+        // Todo: this probably shouldn't be here, but in localbitmap,
+        // subscried to all material overrides if we want copied
+        // objects to get properly updated as well
         LLSelectedTEUpdateOverrides local_tex_func(this);
         selected_objects->applyToNodes(&local_tex_func);
     }

--- a/indra/newview/llmaterialeditor.h
+++ b/indra/newview/llmaterialeditor.h
@@ -219,6 +219,7 @@ class LLMaterialEditor : public LLPreview, public LLVOInventoryListener
     void setCanSave(bool value);
     void setEnableEditing(bool can_modify);
 
+    void replaceTexture(const LLUUID& old_id, const LLUUID& new_id); // Local texture support
     void onCommitTexture(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
     void onCancelCtrl(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
     void onSelectCtrl(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
@@ -306,5 +307,6 @@ private:
     static bool mOverrideInProgress;
     static bool mSelectionNeedsUpdate;
     boost::signals2::connection mSelectionUpdateSlot;
+    std::list <boost::signals2::connection> mTextureChangesUpdates;
 };
 

--- a/indra/newview/llmaterialeditor.h
+++ b/indra/newview/llmaterialeditor.h
@@ -87,6 +87,7 @@ protected:
 class LLMaterialEditor : public LLPreview, public LLVOInventoryListener
 { public:
 	LLMaterialEditor(const LLSD& key);
+    ~LLMaterialEditor();
 
     bool setFromGltfModel(const tinygltf::Model& model, S32 index, bool set_textures = false);
 
@@ -219,7 +220,8 @@ class LLMaterialEditor : public LLPreview, public LLVOInventoryListener
     void setCanSave(bool value);
     void setEnableEditing(bool can_modify);
 
-    void replaceTexture(const LLUUID& old_id, const LLUUID& new_id); // Local texture support
+    void subscribeToLocalTexture(S32 dirty_flag, const LLUUID& tracking_id);
+    void replaceLocalTexture(const LLUUID& old_id, const LLUUID& new_id); // Local texture support
     void onCommitTexture(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
     void onCancelCtrl(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
     void onSelectCtrl(LLUICtrl* ctrl, const LLSD& data, S32 dirty_flag);
@@ -307,6 +309,13 @@ private:
     static bool mOverrideInProgress;
     static bool mSelectionNeedsUpdate;
     boost::signals2::connection mSelectionUpdateSlot;
-    std::list <boost::signals2::connection> mTextureChangesUpdates;
+
+    struct LocalTextureConnection
+    {
+        LLUUID mTrackingId;
+        boost::signals2::connection mConnection;
+    };
+    typedef std::map<S32, LocalTextureConnection> mat_connection_map_t;
+    mat_connection_map_t mTextureChangesUpdates;
 };
 

--- a/indra/newview/llmaterialeditor.h
+++ b/indra/newview/llmaterialeditor.h
@@ -231,6 +231,7 @@ class LLMaterialEditor : public LLPreview, public LLVOInventoryListener
 
     U32 getUnsavedChangesFlags() { return mUnsavedChanges; }
     U32 getRevertedChangesFlags() { return mRevertedChanges; }
+    LLUUID getLocalTextureTrackingIdFromFlag(U32 flag);
 
     static bool capabilitiesAvailable();
 

--- a/indra/newview/llmaterialeditor.h
+++ b/indra/newview/llmaterialeditor.h
@@ -232,6 +232,7 @@ class LLMaterialEditor : public LLPreview, public LLVOInventoryListener
     U32 getUnsavedChangesFlags() { return mUnsavedChanges; }
     U32 getRevertedChangesFlags() { return mRevertedChanges; }
     LLUUID getLocalTextureTrackingIdFromFlag(U32 flag);
+    bool updateMaterialLocalSubscription(LLGLTFMaterial* mat);
 
     static bool capabilitiesAvailable();
 

--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -1959,7 +1959,7 @@ void LLPanelProfileSecondLife::onShowTexturePicker()
 
             mFloaterTexturePickerHandle = texture_floaterp->getHandle();
 
-            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID&)
+            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID&, const LLUUID&)
             {
                 if (op == LLTextureCtrl::TEXTURE_SELECT)
                 {
@@ -2285,7 +2285,7 @@ void LLPanelProfileFirstLife::onChangePhoto()
 
             mFloaterTexturePickerHandle = texture_floaterp->getHandle();
 
-            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID&)
+            texture_floaterp->setOnFloaterCommitCallback([this](LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID&, const LLUUID&)
             {
                 if (op == LLTextureCtrl::TEXTURE_SELECT)
                 {

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -846,6 +846,7 @@ void LLFloaterTexturePicker::commitCallback(LLTextureCtrl::ETexturePickOp op)
     }
     LLUUID asset_id = mImageAssetID;
     LLUUID inventory_id;
+    LLUUID tracking_id;
     LLPickerSource mode = (LLPickerSource)mModeSelector->getValue().asInteger();
 
     switch (mode)
@@ -886,16 +887,16 @@ void LLFloaterTexturePicker::commitCallback(LLTextureCtrl::ETexturePickOp op)
                 if (!mLocalScrollCtrl->getAllSelected().empty())
                 {
                     LLSD data = mLocalScrollCtrl->getFirstSelected()->getValue();
-                    LLUUID temp_id = data["id"];
+                    tracking_id = data["id"];
                     S32 asset_type = data["type"].asInteger();
 
                     if (LLAssetType::AT_MATERIAL == asset_type)
                     {
-                        asset_id = LLLocalGLTFMaterialMgr::getInstance()->getWorldID(temp_id);
+                        asset_id = LLLocalGLTFMaterialMgr::getInstance()->getWorldID(tracking_id);
                     }
                     else
                     {
-                        asset_id = LLLocalBitmapMgr::getInstance()->getWorldID(temp_id);
+                        asset_id = LLLocalBitmapMgr::getInstance()->getWorldID(tracking_id);
                     }
                 }
                 else
@@ -912,13 +913,13 @@ void LLFloaterTexturePicker::commitCallback(LLTextureCtrl::ETexturePickOp op)
             break;
     }
 
-    mOnFloaterCommitCallback(op, mode, asset_id, inventory_id);
+    mOnFloaterCommitCallback(op, mode, asset_id, inventory_id, tracking_id);
 }
 void LLFloaterTexturePicker::commitCancel()
 {
 	if (!mNoCopyTextureSelected && mOnFloaterCommitCallback && mCanApply)
 	{
-		mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CANCEL, PICKER_UNKNOWN, mOriginalImageAssetID, LLUUID::null);
+		mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CANCEL, PICKER_UNKNOWN, mOriginalImageAssetID, LLUUID::null, LLUUID::null);
 	}
 }
 
@@ -972,7 +973,7 @@ void LLFloaterTexturePicker::onBtnCancel(void* userdata)
 	self->setImageID( self->mOriginalImageAssetID );
 	if (self->mOnFloaterCommitCallback)
 	{
-		self->mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CANCEL, PICKER_UNKNOWN, self->mOriginalImageAssetID, LLUUID::null);
+		self->mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CANCEL, PICKER_UNKNOWN, self->mOriginalImageAssetID, LLUUID::null, LLUUID::null);
 	}
 	self->mViewModel->resetDirty();
 	self->closeFloater();
@@ -1177,7 +1178,7 @@ void LLFloaterTexturePicker::onLocalScrollCommit(LLUICtrl* ctrl, void* userdata)
 		{
 			if (self->mOnFloaterCommitCallback)
 			{
-				self->mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CHANGE, PICKER_LOCAL, inworld_id, LLUUID::null);
+				self->mOnFloaterCommitCallback(LLTextureCtrl::TEXTURE_CHANGE, PICKER_LOCAL, inworld_id, LLUUID::null, tracking_id);
 			}
 		}
 	}
@@ -1804,7 +1805,7 @@ void LLTextureCtrl::showPicker(BOOL take_focus)
 		}
 		if (texture_floaterp)
 		{
-			texture_floaterp->setOnFloaterCommitCallback(boost::bind(&LLTextureCtrl::onFloaterCommit, this, _1, _2, _3, _4));
+			texture_floaterp->setOnFloaterCommitCallback(boost::bind(&LLTextureCtrl::onFloaterCommit, this, _1, _2, _3, _4, _5));
 		}
 		if (texture_floaterp)
 		{
@@ -1928,7 +1929,7 @@ void LLTextureCtrl::onFloaterClose()
 	mFloaterHandle.markDead();
 }
 
-void LLTextureCtrl::onFloaterCommit(ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID& inv_id)
+void LLTextureCtrl::onFloaterCommit(ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID& inv_id, const LLUUID& tracking_id)
 {
     LLFloaterTexturePicker* floaterp = (LLFloaterTexturePicker*)mFloaterHandle.get();
 
@@ -1951,16 +1952,23 @@ void LLTextureCtrl::onFloaterCommit(ETexturePickOp op, LLPickerSource source, co
                 case PICKER_INVENTORY:
                     mImageItemID = inv_id;
                     mImageAssetID = asset_id;
+                    mLocalTrackingID.setNull();
                     break;
                 case PICKER_BAKE:
+                    mImageItemID = LLUUID::null;
+                    mImageAssetID = asset_id;
+                    mLocalTrackingID.setNull();
+                    break;
                 case PICKER_LOCAL:
                     mImageItemID = LLUUID::null;
                     mImageAssetID = asset_id;
+                    mLocalTrackingID = tracking_id;
                     break;
                 case PICKER_UNKNOWN:
                 default:
                     mImageItemID = floaterp->findItemID(asset_id, FALSE);
                     mImageAssetID = asset_id;
+                    mLocalTrackingID.setNull();
                     break;
             }
 
@@ -2018,6 +2026,7 @@ void LLTextureCtrl::setImageAssetID( const LLUUID& asset_id )
 	{
 		mImageItemID.setNull();
 		mImageAssetID = asset_id;
+        mLocalTrackingID.setNull();
 		LLFloaterTexturePicker* floaterp = (LLFloaterTexturePicker*)mFloaterHandle.get();
 		if( floaterp && getEnabled() )
 		{

--- a/indra/newview/lltexturectrl.h
+++ b/indra/newview/lltexturectrl.h
@@ -200,7 +200,11 @@ public:
 	void			closeDependentFloater();
 
 	void			onFloaterClose();
-	void			onFloaterCommit(ETexturePickOp op, LLPickerSource source, const LLUUID& local_id, const LLUUID& inv_id);
+    void			onFloaterCommit(ETexturePickOp op,
+                                    LLPickerSource source,
+                                    const LLUUID& local_id,
+                                    const LLUUID& inv_id,
+                                    const LLUUID& tracking_id);
 
 	// This call is returned when a drag is detected. Your callback
 	// should return TRUE if the drag is acceptable.
@@ -230,6 +234,9 @@ public:
     void setInventoryPickType(EPickInventoryType type);
     EPickInventoryType getInventoryPickType() { return mInventoryPickType; };
 
+    bool isImageLocal() { return mLocalTrackingID.notNull(); }
+    LLUUID getLocalTrackingID() { return mLocalTrackingID; }
+
 private:
 	BOOL allowDrop(LLInventoryItem* item, EDragAndDropType cargo_type, std::string& tooltip_msg);
 	BOOL doDrop(LLInventoryItem* item);
@@ -247,6 +254,7 @@ private:
 	LLUUID					 	mImageAssetID;
 	LLUUID					 	mDefaultImageAssetID;
 	LLUUID					 	mBlankImageAssetID;
+    LLUUID						mLocalTrackingID;
 	LLUIImagePtr				mFallbackImage;
 	std::string					mDefaultImageName;
 	LLHandle<LLFloater>			mFloaterHandle;
@@ -272,7 +280,7 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // LLFloaterTexturePicker
-typedef boost::function<void(LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID& inventory_id)> floater_commit_callback;
+typedef boost::function<void(LLTextureCtrl::ETexturePickOp op, LLPickerSource source, const LLUUID& asset_id, const LLUUID& inventory_id, const LLUUID& tracking_id)> floater_commit_callback;
 typedef boost::function<void()> floater_close_callback;
 typedef boost::function<void(const LLUUID& asset_id)> set_image_asset_id_callback;
 typedef boost::function<void(LLPointer<LLViewerTexture> texture)> set_on_update_image_stats_callback;

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -5475,18 +5475,15 @@ S32 LLViewerObject::setTEGLTFMaterialOverride(U8 te, LLGLTFMaterial* override_ma
             tep->setGLTFRenderMaterial(render_mat);
             retval = TEM_CHANGE_TEXTURE;
 
+            for (LLGLTFMaterial::local_tex_map_t::value_type &val : override_mat->mTrackingIdToLocalTexture)
+            {
+                LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(val.first, override_mat);
+            }
+
         }
         else if (tep->setGLTFRenderMaterial(nullptr))
         {
             retval = TEM_CHANGE_TEXTURE;
-        }
-    }
-
-    if (retval == TEM_CHANGE_TEXTURE)
-    {
-        for (LLGLTFMaterial::local_tex_map_t::value_type val : override_mat->mTrackingIdToLocalTexture)
-        {
-            LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(val.first, override_mat);
         }
     }
 

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -5482,6 +5482,14 @@ S32 LLViewerObject::setTEGLTFMaterialOverride(U8 te, LLGLTFMaterial* override_ma
         }
     }
 
+    if (retval == TEM_CHANGE_TEXTURE)
+    {
+        for (LLGLTFMaterial::local_tex_map_t::value_type val : override_mat->mTrackingIdToLocalTexture)
+        {
+            LLLocalBitmapMgr::getInstance()->associateGLTFMaterial(val.first, override_mat);
+        }
+    }
+
     return retval;
 }
 


### PR DESCRIPTION
This ended up fairly convoluted, but I don't think there is a nice way around that sans remaking local textures entirely.

1. Material editor needs update of displayed textures. Simply doing a callback.
2. Base materials are in inventory so if such material gets set it gets force loaded to be properly tracked (can't just edit a material in use so change isn't propagating to server)
3. Overrides are the hardest. Server just sends a material and viewer is forced to check it postfactum. Currently material editor is doing that, but arguably localbitmap should be doing that to support copying objects. But due to how much time it took as is and since localbitmaps don't support everything either, decided that it's fine for now.
4. And finaly render materials are a composition of base and render materials so they also need to be refreshed after base and override are done.