### PR TITLE
Fix BUG-225288: Detaching stops unrelated animations

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4152,6 +4152,12 @@ void process_avatar_animation(LLMessageSystem *mesgsys, void **user_data)
 					LLVOAvatar::AnimSourceIterator anim_it = avatarp->mAnimationSources.find(object_id);
 					for (;anim_it != avatarp->mAnimationSources.end(); ++anim_it)
 					{
+						if (anim_it->first != object_id)
+						{
+							// elements with the same key are always contiguous, bail if we went past the
+							// end of this object's animations
+							break;
+						}
 						if (anim_it->second == animation_id)
 						{
 							anim_found = TRUE;

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -834,7 +834,11 @@ void LLVOAvatarSelf::stopMotionFromSource(const LLUUID& source_id)
 	for (AnimSourceIterator motion_it = mAnimationSources.find(source_id); motion_it != mAnimationSources.end(); )
 	{
 		gAgent.sendAnimationRequest(motion_it->second, ANIM_REQUEST_STOP);
-		mAnimationSources.erase(motion_it++);
+		mAnimationSources.erase(motion_it);
+		// Must find() after each erase() to deal with potential iterator invalidation
+		// This also ensures that we don't go past the end of this source's animations
+		// into those of another source.
+		motion_it = mAnimationSources.find(source_id);
 	}
 
 


### PR DESCRIPTION
See https://jira.secondlife.com/browse/BUG-225288.

This is to do with a misunderstanding about how `.find()` works with multimaps. [`.find()` will, in fact, return an iterator to the first item it finds](https://cplusplus.com/reference/map/multimap/find/), and will iterate through all elements in the multimap when incremented, not just items with the same key.

Change code working with animation sources to be aware of this fact, so unrelated animation sources do not have their animations stopped.

## Debugging

It might be helpful to know how I narrowed this down for future reference.

I first suspected it was some iterator shenanigans due to residents mentioning things to do with this only happening when keys are "larger" than the object whose animation was actually supposed to be stopped. Iteration over `std::map` always happens in sort order, and I suspected that an `std::map` related to animations was being misused.

To narrow it down to server vs viewer, I used [Hippolyzer](https://github.com/SaladDais/Hippolyzer) and filtered on (viewer-initiated) `AgentAnimation` and (server-initiated) `AvatarAnimation` messages. I wasn't seeing any messages from the server that was asking the viewer to stop the animations of unrelated objects, but the viewer was sending a ton of its own spurious `AgentAnimations` with `StartAnim=false` after detaching objects. This made me believe that the issue was likely in the viewer.

I looked through the animation code for `std::map`s that stored `LLUUID`s, and `LLVOAvatar::mAnimationSources` stuck out. To verify that it was actually related, I set breakpoints on any methods that sent `AgentAnimation` messages, so I could look at the backtraces. Sure enough, `LLAgent::sendAnimationRequest()` was called by `LLVOAvatarSelf::stopMotionFromSource()`, which had a loop over `mAnimationSources`:

```
Thread 1 "do-not-directly" hit Breakpoint 2.1, LLAgent::sendAnimationRequest (this=0x5555598489c0 <gAgent>, 
    anim_id=..., request=ANIM_REQUEST_STOP)
    at /source/firestorm/indra/newview/llagent.cpp:3951
3951		if (gAgentID.isNull() || anim_id.isNull() || !mRegionp)
(gdb) bt
#0  LLAgent::sendAnimationRequest(LLUUID const&, EAnimRequest)
    (this=0x5555598489c0 <gAgent>, anim_id=..., request=ANIM_REQUEST_STOP)
    at /source/firestorm/indra/newview/llagent.cpp:3951
#1  0x00005555571795e4 in LLVOAvatarSelf::stopMotionFromSource(LLUUID const&) (this=0x7fffadb14800, source_id=...)
    at /source/firestorm/indra/newview/llvoavatarself.cpp:1197
#2  0x000055555700d71b in LLViewerObject::markDead() (this=0x7fffb4c2db00)
    at /source/firestorm/indra/newview/llviewerobject.cpp:525
#3  LLViewerObject::markDead() (this=0x7fffb4c2db00)
    at /source/firestorm/indra/newview/llviewerobject.cpp:431
#4  0x0000555557021815 in LLViewerObjectList::killObject(LLViewerObject*)
    (this=this@entry=0x5555599f8fc0 <gObjectList>, objectp=objectp@entry=0x7fffb4c2db00)
    at /source/firestorm/indra/newview/llviewerobjectlist.cpp:1565
#5  0x0000555556fea7f1 in process_kill_object(LLMessageSystem*, void**)
    (mesgsys=0x7fffb3dfe9c0, user_data=<optimized out>)
    at /source/firestorm/indra/newview/llviewermessage.cpp:4754
#6  0x00005555575c12de in LLMessageTemplate::callHandlerFunc(LLMessageSystem*) const
    (this=<optimized out>, msgsystem=<optimized out>)
    at /source/firestorm/indra/llmessage/llmessagetemplate.h:377
#7  LLTemplateMessageReader::decodeData(unsigned char const*, LLHost const&)
    (this=<optimized out>, buffer=<optimized out>, sender=<optimized out>)
    at /source/firestorm/indra/llmessage/lltemplatemessagereader.cpp:714
#8  0x00005555575c1b55 in LLTemplateMessageReader::readMessage(unsigned char const*, LLHost const&)
    (this=<optimized out>, buffer=<optimized out>, sender=<optimized out>)
    at /source/firestorm/indra/llmessage/lltemplatemessagereader.cpp:794
#9  0x0000555557585a6e in LLMessageSystem::checkMessages(LockMessageChecker&, long long)
    (this=0x7fffb3dfe9c0, frame_count=frame_count@entry=28055)
    at /source/firestorm/indra/llmessage/message.cpp:691
```

`sendAnimationRequest()` was being called multiple times by `stopMotionFromSource()` even when the source only had a single animation.

Changing the iterator increment (which might be invalid anyway after the `.erase()`) to a second `mAnimationSources.find()` call appears to have fixed it. Just incrementing the iterator until it hit `mAnimationSources.end()` was killing all animations that appeared after the object in the multimap, not just ones that had the same key.