### PR TITLE
SL-20563 Add 'No Post' option to Snapshot floater

### DIFF
--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -461,13 +461,24 @@ void LLFloaterSnapshotBase::ImplBase::onClickAutoSnap(LLUICtrl *ctrl, void* data
 {
 	LLCheckBoxCtrl *check = (LLCheckBoxCtrl *)ctrl;
 	gSavedSettings.setBOOL( "AutoSnapshot", check->get() );
-	
-	LLFloaterSnapshotBase *view = (LLFloaterSnapshotBase *)data;		
+
+	LLFloaterSnapshotBase *view = (LLFloaterSnapshotBase *)data;
 	if (view)
 	{
 		view->impl->checkAutoSnapshot(view->getPreviewView());
 		view->impl->updateControls(view);
 	}
+}
+
+// static
+void LLFloaterSnapshotBase::ImplBase::onClickNoPost(LLUICtrl *ctrl, void* data)
+{
+    BOOL no_post = ((LLCheckBoxCtrl*)ctrl)->get();
+    gSavedSettings.setBOOL("RenderDisablePostProcessing", no_post);
+
+    LLFloaterSnapshotBase* view = (LLFloaterSnapshotBase*)data;
+    view->getPreviewView()->updateSnapshot(TRUE, TRUE);
+    view->impl->updateControls(view);
 }
 
 // static
@@ -996,6 +1007,9 @@ BOOL LLFloaterSnapshot::postBuild()
 
 	getChild<LLUICtrl>("auto_snapshot_check")->setValue(gSavedSettings.getBOOL("AutoSnapshot"));
 	childSetCommitCallback("auto_snapshot_check", ImplBase::onClickAutoSnap, this);
+
+    getChild<LLUICtrl>("no_post_check")->setValue(gSavedSettings.getBOOL("RenderDisablePostProcessing"));
+    childSetCommitCallback("no_post_check", ImplBase::onClickNoPost, this);
 
     getChild<LLButton>("retract_btn")->setCommitCallback(boost::bind(&LLFloaterSnapshot::onExtendFloater, this));
     getChild<LLButton>("extend_btn")->setCommitCallback(boost::bind(&LLFloaterSnapshot::onExtendFloater, this));

--- a/indra/newview/llfloatersnapshot.h
+++ b/indra/newview/llfloatersnapshot.h
@@ -100,6 +100,7 @@ public:
 
 	static void onClickNewSnapshot(void* data);
 	static void onClickAutoSnap(LLUICtrl *ctrl, void* data);
+	static void onClickNoPost(LLUICtrl *ctrl, void* data);
 	static void onClickFilter(LLUICtrl *ctrl, void* data);
 	static void onClickUICheck(LLUICtrl *ctrl, void* data);
 	static void onClickHUDCheck(LLUICtrl *ctrl, void* data);

--- a/indra/newview/skins/default/xui/en/floater_snapshot.xml
+++ b/indra/newview/skins/default/xui/en/floater_snapshot.xml
@@ -115,7 +115,7 @@
 	   top_delta="0"
        width="31" />
 	<panel
-     height="159"
+     height="179"
      layout="topleft"
 	 follows="top|left"
      left="0"
@@ -193,6 +193,14 @@
          top_pad="1"
          width="180"
          name="auto_snapshot_check" />
+        <check_box
+         label="No post-processing"
+         layout="topleft"
+         height="16"
+         left="10"
+         top_pad="1"
+         width="180"
+         name="no_post_check" />
         <text
          type="string"
          length="1"
@@ -233,7 +241,7 @@
     </panel>
 	<panel_container
      follows="left|top"
-     height="230"
+     height="210"
      layout="topleft"
      left="0"
      name="panel_container"

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -1545,7 +1545,7 @@ function="World.EnvPreset"
         <menu_item_separator/>
           
           <menu_item_check
-            label="No Post"
+            label="No Post-processing"
             name="No Post">
             <menu_item_check.on_check
              control="RenderDisablePostProcessing" />


### PR DESCRIPTION
The "No post-processing" check-box is added and synchronized with the "Build | Options | No Post" menu item
The "Build | Options | No Post" menu item label is changed to "No Post-processing"
![image](https://github.com/secondlife/viewer/assets/124201357/5064ef73-34e8-41de-b00e-4c8222724a30)


