### PR TITLE
Fix failure to save the normalized translation data during collada upload

### DIFF
--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -2584,7 +2584,8 @@ bool LLDAELoader::loadModelsFromDomMesh(domMesh* mesh, std::vector<LLModel*>& mo
 			next->mLabel = model_name + (char)((int)'a' + next->mSubmodelID) + lod_suffix[mLod];
 			next->getVolumeFaces() = remainder;
 			next->mNormalizedScale = ret->mNormalizedScale;
-			
+			next->mNormalizedTranslation = ret->mNormalizedTranslation;
+
 			if ( ret->mMaterialList.size() > LL_SCULPT_MESH_MAX_FACES)
 			{
 				next->mMaterialList.assign(ret->mMaterialList.begin() + LL_SCULPT_MESH_MAX_FACES, ret->mMaterialList.end());

--- a/indra/llprimitive/llmodel.cpp
+++ b/indra/llprimitive/llmodel.cpp
@@ -52,7 +52,8 @@ const int MODEL_NAMES_LENGTH = sizeof(model_names) / sizeof(std::string);
 
 LLModel::LLModel(LLVolumeParams& params, F32 detail)
 	: LLVolume(params, detail), 
-      mNormalizedScale(1,1,1), 
+      mNormalizedScale(1,1,1),
+      mNormalizedTranslation(0, 0, 0),
       mPelvisOffset( 0.0f ), 
       mStatus(NO_ERRORS), 
       mSubmodelID(0)


### PR DESCRIPTION
This fixes a case where translation would no longer be applied during rigged mesh upload resulting in broken mesh preview and the actual upload.

![image](https://github.com/secondlife/viewer/assets/343176/0979c15b-3651-450b-a06a-a99d61ff99ba)
