### PR TITLE
Ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ web/locale.*
 web/secondlife.com.*
 
 .env
+.vscode


### PR DESCRIPTION
Minor chore: add the frequently autocreated .vscode directory to .gitignore.