### PR TITLE
Switch to viewer-build-util@v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -254,7 +254,7 @@ jobs:
     runs-on: windows
     steps:
       - name: Sign and package Windows viewer
-        uses: secondlife/viewer-build-util/sign-pkg-windows@main
+        uses: secondlife/viewer-build-util/sign-pkg-windows@v1
         with:
           vault_uri: "${{ secrets.AZURE_KEY_VAULT_URI }}"
           cert_name: "${{ secrets.AZURE_CERT_NAME }}"
@@ -286,7 +286,7 @@ jobs:
           [[ -n "$USERNAME" && -n "$PASSWORD" && -n "$TEAM_ID" ]]
 
       - name: Sign and package Mac viewer
-        uses: secondlife/viewer-build-util/sign-pkg-mac@main
+        uses: secondlife/viewer-build-util/sign-pkg-mac@v1
         with:
           channel: ${{ needs.build.outputs.viewer_channel }}
           imagename: ${{ needs.build.outputs.imagename }}
@@ -302,7 +302,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post Windows symbols
-        uses: secondlife/viewer-build-util/post-bugsplat-windows@main
+        uses: secondlife/viewer-build-util/post-bugsplat-windows@v1
         with:
           username: ${{ secrets.BUGSPLAT_USER }}
           password: ${{ secrets.BUGSPLAT_PASS }}
@@ -315,7 +315,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post Mac symbols
-        uses: secondlife/viewer-build-util/post-bugsplat-mac@main
+        uses: secondlife/viewer-build-util/post-bugsplat-mac@v1
         with:
           username: ${{ secrets.BUGSPLAT_USER }}
           password: ${{ secrets.BUGSPLAT_PASS }}
@@ -333,7 +333,7 @@ jobs:
           path: artifacts
 
       - name: Reshuffle artifact files
-        uses: secondlife/viewer-build-util/release-artifacts@main
+        uses: secondlife/viewer-build-util/release-artifacts@v1
         with:
           input-path: artifacts
           output-path: assets


### PR DESCRIPTION
Switch the build workflow from targeting the `main` branch of viewer-build-util (which may receive breaking changes) to the stable `v1` major version tag.

It should be noted that we have no intentions of merging breaking changes into viewer-build-util main until this commit is picked up by other branches.