### PR TITLE
Update certain autobuild packages per pending PRs

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1185,7 +1185,7 @@
         <key>copyright</key>
         <string>Kakadu software</string>
         <key>version</key>
-        <string>7.10.4.539108</string>
+        <string>7.10.4.4b9ec5f</string>
         <key>name</key>
         <string>kdu</string>
         <key>description</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -408,11 +408,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>f6835c4d7745cd1cadfbce47b40331d08affb532</string>
+              <string>e03eb77224290c875ff84f75b7fe3d0e7c162c94</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-dictionaries/releases/download/v1.0.1-dev2.gf887629-f887629/dictionaries-common-None.tar.zst</string>
+              <string>https://github.com/secondlife/3p-dictionaries/releases/download/v1-a01bb6c/dictionaries-1.a01bb6c-common-a01bb6c.tar.zst</string>
             </map>
             <key>name</key>
             <string>common</string>
@@ -425,7 +425,7 @@
         <key>copyright</key>
         <string>Copyright 2014 Apache OpenOffice software</string>
         <key>version</key>
-        <string>None</string>
+        <string>1.a01bb6c</string>
         <key>name</key>
         <string>dictionaries</string>
         <key>description</key>
@@ -734,11 +734,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>6604c1cca515d287e697997a8d5593d1cae172a9</string>
+              <string>066625e7aa7f697a4b6cd461aad960c57181011f</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-glh_linear/releases/download/v1.0.1-dev2.g3253ed7-3253ed7/glh_linear-common-None.tar.zst</string>
+              <string>https://github.com/secondlife/3p-glh_linear/releases/download/v1.0.1-dev4-984c397/glh_linear-1.0.1-dev4-common-984c397.tar.zst</string>
             </map>
             <key>name</key>
             <string>common</string>
@@ -751,7 +751,7 @@
         <key>copyright</key>
         <string>Copyright (c) 2000 Cass Everitt</string>
         <key>version</key>
-        <string>None</string>
+        <string>1.0.1-dev4</string>
         <key>name</key>
         <string>glh_linear</string>
         <key>description</key>
@@ -882,11 +882,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>a193ff65d6db48626d65d96c6124c6efca85e8ec</string>
+              <string>505379a49dfd189b70025b8406a1a6044b4b7989</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/108912596</string>
+              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136763374</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -910,11 +910,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>ebfb82b6143874e7938b9d1e8a70d0a2e28aa818</string>
+              <string>c4df2599a6ad63c9c883f5b7026ab07086d5c3a2</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/108912599</string>
+              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136763378</string>
             </map>
             <key>name</key>
             <string>windows64</string>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1120,11 +1120,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>bcc7e2c34896fc9cbc41828dee8a4ddf54f10453</string>
+              <string>ad72fa1d103df777906f0d98f3e882b9916aeada</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/108298968</string>
+              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/136774118</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -1136,11 +1136,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>9de772df2ed12e9c742df6c90670c7cbbb9c93a6</string>
+              <string>e46e4ac93a237b5c4a14183766f76ba5d58935a2</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/108298969</string>
+              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/136774125</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -1152,14 +1152,30 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>92533ff0f8c1881ad85e75800f9072c413ccf7b7</string>
+              <string>bb37557f78c72b26580a521f8b8dabfa1b34e6e6</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/108298970</string>
+              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/136774126</string>
             </map>
             <key>name</key>
             <string>windows64</string>
+          </map>
+          <key>linux</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>creds</key>
+              <string>github</string>
+              <key>hash</key>
+              <string>711b82f9f588d3a125af7dcd8c81f93d9c343a7d</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://api.github.com/repos/secondlife/3p-kdu/releases/assets/136774121</string>
+            </map>
+            <key>name</key>
+            <string>linux</string>
           </map>
         </map>
         <key>license</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -882,11 +882,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>505379a49dfd189b70025b8406a1a6044b4b7989</string>
+              <string>ae2c2a215b1bc2e3f37a67e301926dc405902d1a</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136763374</string>
+              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136778143</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -910,11 +910,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>c4df2599a6ad63c9c883f5b7026ab07086d5c3a2</string>
+              <string>0393dd75c58f7046bed47e62a8884a78cb02a5c3</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136763378</string>
+              <string>https://api.github.com/repos/secondlife/3p-havok-source/releases/assets/136778145</string>
             </map>
             <key>name</key>
             <string>windows64</string>


### PR DESCRIPTION
dictionaries, glh_linear, havok-libs, havok-llvm and kdu all have recent builds. havok-source is rebuilt to reference the new builds of havok-libs and havok-llvm.

The dictionaries build was broken. I fixed it on the master branch, but want to vet the fix in a running viewer.

The new [glh_linear](https://github.com/secondlife/3p-glh_linear/pull/3), [havok-libs](https://github.com/secondlife/3p-havok-libs/pull/6), [havok-llvm](https://github.com/secondlife/3p-havok-llvm/pull/4) and [kdu](https://github.com/secondlife/3p-kdu/pull/2) builds are from pull requests (less trivial than the slew of recent dependabot action-autobuild-release version bumps). I don't believe any of them should actually affect viewer functionality, but again, I want them to get a thumbs up in a viewer build.