### PR TITLE
SL-17076 MacOS crash on clearing ChicletNotificationChannel

### DIFF
--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -994,6 +994,7 @@ LLBoundListener LLNotificationChannelBase::connectChangedImpl(const LLEventListe
 	// all of the notifications that are already in the channel
 	// we use a special signal called "load" in case the channel wants to care
 	// only about new notifications
+    LLMutexLock lock(&mItemsMutex);
 	for (LLNotificationSet::iterator it = mItems.begin(); it != mItems.end(); ++it)
 	{
 		slot(LLSD().with("sigtype", "load").with("id", (*it)->id()));
@@ -1186,17 +1187,7 @@ bool LLNotificationChannel::isEmpty() const
 
 S32 LLNotificationChannel::size() const
 {
-	return mItems.size();
-}
-
-LLNotificationChannel::Iterator LLNotificationChannel::begin()
-{
-	return mItems.begin();
-}
-
-LLNotificationChannel::Iterator LLNotificationChannel::end()
-{
-	return mItems.end();
+    return mItems.size();
 }
 
 size_t LLNotificationChannel::size()
@@ -1204,12 +1195,19 @@ size_t LLNotificationChannel::size()
 	return mItems.size();
 }
 
+void LLNotificationChannel::forEachNotification(NotificationProcess process)
+{
+    LLMutexLock lock(&mItemsMutex);
+    std::for_each(mItems.begin(), mItems.end(), process);
+}
+
 std::string LLNotificationChannel::summarize()
 {
 	std::string s("Channel '");
 	s += mName;
 	s += "'\n  ";
-	for (LLNotificationChannel::Iterator it = begin(); it != end(); ++it)
+    LLMutexLock lock(&mItemsMutex);
+	for (LLNotificationChannel::Iterator it = mItems.begin(); it != mItems.end(); ++it)
 	{
 		s += (*it)->summarize();
 		s += "\n  ";
@@ -1736,6 +1734,7 @@ void LLNotifications::cancel(LLNotificationPtr pNotif)
 
 void LLNotifications::cancelByName(const std::string& name)
 {
+    LLMutexLock lock(&mItemsMutex);
 	std::vector<LLNotificationPtr> notifs_to_cancel;
 	for (LLNotificationSet::iterator it=mItems.begin(), end_it = mItems.end();
 		it != end_it;
@@ -1760,6 +1759,7 @@ void LLNotifications::cancelByName(const std::string& name)
 
 void LLNotifications::cancelByOwner(const LLUUID ownerId)
 {
+    LLMutexLock lock(&mItemsMutex);
 	std::vector<LLNotificationPtr> notifs_to_cancel;
 	for (LLNotificationSet::iterator it = mItems.begin(), end_it = mItems.end();
 		 it != end_it;
@@ -1805,11 +1805,6 @@ LLNotificationPtr LLNotifications::find(LLUUID uuid)
 	{
 		return *it;
 	}
-}
-
-void LLNotifications::forEachNotification(NotificationProcess process)
-{
-	std::for_each(mItems.begin(), mItems.end(), process);
 }
 
 std::string LLNotifications::getGlobalString(const std::string& key) const

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -1171,6 +1171,14 @@ LLNotificationChannel::LLNotificationChannel(const std::string& name,
 	connectToChannel(parent);
 }
 
+LLNotificationChannel::~LLNotificationChannel()
+{
+    for (LLBoundListener &listener : mListeners)
+    {
+        listener.disconnect();
+    }
+}
+
 bool LLNotificationChannel::isEmpty() const
 {
 	return mItems.empty();
@@ -1213,14 +1221,14 @@ void LLNotificationChannel::connectToChannel( const std::string& channel_name )
 {
 	if (channel_name.empty())
 	{
-		LLNotifications::instance().connectChanged(
-			boost::bind(&LLNotificationChannelBase::updateItem, this, _1));
+        mListeners.push_back(LLNotifications::instance().connectChanged(
+			boost::bind(&LLNotificationChannelBase::updateItem, this, _1)));
 	}
 	else
 	{
 		mParents.push_back(channel_name);
 		LLNotificationChannelPtr p = LLNotifications::instance().getChannel(channel_name);
-		p->connectChanged(boost::bind(&LLNotificationChannelBase::updateItem, this, _1));
+        mListeners.push_back(p->connectChanged(boost::bind(&LLNotificationChannelBase::updateItem, this, _1)));
 	}
 }
 

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -835,7 +835,7 @@ public:
 	LLNotificationChannel(const Params& p = Params());
 	LLNotificationChannel(const std::string& name, const std::string& parent, LLNotificationFilter filter);
 
-	virtual ~LLNotificationChannel() {}
+	virtual ~LLNotificationChannel();
 	typedef LLNotificationSet::iterator Iterator;
     
 	std::string getName() const { return mName; }
@@ -844,8 +844,6 @@ public:
 	{
 		return boost::iterator_range<parents_iter>(mParents);
 	}
-    
-	void connectToChannel(const std::string& channel_name);
     
     bool isEmpty() const;
     S32 size() const;
@@ -856,9 +854,13 @@ public:
 	
 	std::string summarize();
 
+protected:
+    void connectToChannel(const std::string& channel_name);
+
 private:
 	std::string mName;
 	std::vector<std::string> mParents;
+    std::vector<LLBoundListener> mListeners;
 };
 
 // An interface class to provide a clean linker seam to the LLNotifications class.

--- a/indra/llui/llnotificationslistener.cpp
+++ b/indra/llui/llnotificationslistener.cpp
@@ -149,11 +149,11 @@ void LLNotificationsListener::listChannelNotifications(const LLSD& params) const
     if (channel)
     {
         LLSD notifications(LLSD::emptyArray());
-        for (LLNotificationChannel::Iterator ni(channel->begin()), nend(channel->end());
-             ni != nend; ++ni)
-        {
-            notifications.append(asLLSD(*ni));
-        }
+        std::function<void(LLNotificationPtr)> func = [notifications](LLNotificationPtr ni) mutable
+            {
+                notifications.append(asLLSD(ni));
+            };
+        channel->forEachNotification(func);
         response["notifications"] = notifications;
     }
     LLEventPumps::instance().obtain(params["reply"]).post(response);

--- a/indra/newview/llchiclet.cpp
+++ b/indra/newview/llchiclet.cpp
@@ -177,6 +177,11 @@ LLNotificationChiclet::LLNotificationChiclet(const Params& p)
 	LLFloaterNotificationsTabbed::getInstance()->setSysWellChiclet(this);
 }
 
+LLNotificationChiclet::~LLNotificationChiclet()
+{
+    mNotificationChannel.reset();
+}
+
 void LLNotificationChiclet::onMenuItemClicked(const LLSD& user_data)
 {
 	std::string action = user_data.asString();

--- a/indra/newview/llchiclet.h
+++ b/indra/newview/llchiclet.h
@@ -531,8 +531,9 @@ public:
 	struct Params : public LLInitParam::Block<Params, LLSysWellChiclet::Params>{};
 		
 protected:
-	struct ChicletNotificationChannel : public LLNotificationChannel
+	class ChicletNotificationChannel : public LLNotificationChannel
 	{
+    public:
 		ChicletNotificationChannel(LLNotificationChiclet* chiclet) 
 			: LLNotificationChannel(LLNotificationChannel::Params().filter(filterNotification).name(chiclet->getSessionId().asString()))
 			, mChiclet(chiclet)
@@ -542,6 +543,7 @@ protected:
 			connectToChannel("Offer");
 			connectToChannel("Notifications");
 		}
+        virtual ~ChicletNotificationChannel() {}
 				
 		static bool filterNotification(LLNotificationPtr notify);
 		// connect counter updaters to the corresponding signals
@@ -553,9 +555,10 @@ protected:
 	};
 				
 	boost::scoped_ptr<ChicletNotificationChannel> mNotificationChannel;
-				
-	LLNotificationChiclet(const Params& p);
-				
+
+    LLNotificationChiclet(const Params& p);
+    ~LLNotificationChiclet();
+
 	/**
 	 * Processes clicks on chiclet menu.
 	 */


### PR DESCRIPTION
Crash appears to happens inside mItems.clear() of the LLNotificationChannelBase, but there is no apparent reson for it and stack jumped some steps, so I'm doing cleanup more explicitly to see if it's indeed there and not a corruption somewhere earlier.

Viewer runs window in a separate thread, it is possible notification was added in a way that corrupted the list, thus adding thread safety as well.