### PR TITLE
Apparently slvoice is proprietary and thus needs to be handled accordingly. Otherwise *OS builds will fail

### DIFF
--- a/indra/cmake/Copy3rdPartyLibs.cmake
+++ b/indra/cmake/Copy3rdPartyLibs.cmake
@@ -262,21 +262,23 @@ endif(WINDOWS)
 # It's unclear whether this is oversight or intentional, but anyway leave the
 # single copy_if_different command rather than using to_staging_dirs.
 
-if( slvoice_src_dir )
-    copy_if_different(
-            ${slvoice_src_dir}
-            "${SHARED_LIB_STAGING_DIR_RELEASE}"
-            out_targets
-            ${slvoice_files}
-    )
-    list(APPEND third_party_targets ${out_targets})
-endif()
+if( USE_SLVOICE )
+  if( slvoice_src_dir )
+      copy_if_different(
+              ${slvoice_src_dir}
+              "${SHARED_LIB_STAGING_DIR_RELEASE}"
+              out_targets
+              ${slvoice_files}
+      )
+      list(APPEND third_party_targets ${out_targets})
+  endif()
 
-to_staging_dirs(
-    ${vivox_lib_dir}
-    third_party_targets
-    ${vivox_libs}
-    )
+  to_staging_dirs(
+      ${vivox_lib_dir}
+      third_party_targets
+      ${vivox_libs}
+      )
+endif()
 
 to_staging_dirs(
     ${release_src_dir}

--- a/indra/cmake/ViewerMiscLibs.cmake
+++ b/indra/cmake/ViewerMiscLibs.cmake
@@ -16,5 +16,10 @@ if( NOT USE_CONAN )
   use_prebuilt_binary(libhunspell)
 endif()
 
-use_prebuilt_binary(slvoice)
+if (INSTALL_PROPRIETARY)
+  set(USE_SLVOICE ON CACHE BOOL "Using slvoice for voice feature.")
+endif ()
 
+if( USE_SLVOICE )
+  use_prebuilt_binary(slvoice)
+endif()

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -573,11 +573,11 @@ class Windows_x86_64_Manifest(ViewerManifest):
 
             # SLVoice executable
             with self.prefix(src=os.path.join(pkgdir, 'bin', 'release')):
-                self.path("SLVoice.exe")
+                self.path_optional("SLVoice.exe")
 
             # Vivox libraries
-            self.path("vivoxsdk_x64.dll")
-            self.path("ortp_x64.dll")
+            self.path_optional("vivoxsdk_x64.dll")
+            self.path_optional("ortp_x64.dll")
             
             # OpenSSL
             self.path("libcrypto-1_1-x64.dll")
@@ -1372,12 +1372,12 @@ class Linux_i686_Manifest(LinuxManifest):
 
         # Vivox runtimes
         with self.prefix(src=relpkgdir, dst="bin"):
-            self.path("SLVoice")
+            self.path_optional("SLVoice")
         with self.prefix(src=relpkgdir, dst="lib"):
-            self.path("libortp.so")
-            self.path("libsndfile.so.1")
+            self.path_optional("libortp.so")
+            self.path_optional("libsndfile.so.1")
             #self.path("libvivoxoal.so.1") # no - we'll re-use the viewer's own OpenAL lib
-            self.path("libvivoxsdk.so")
+            self.path_optional("libvivoxsdk.so")
 
         self.strip_binaries()
 


### PR DESCRIPTION
- Mac and Windows builds artifacts are not public anymore, rather they are hidden in the private repository https://api.github.com/repos/secondlife/3p-slvoice/
- For some reason the Linux build is still public, but obviously super outdated

-> Guard the slvoice binary behind the USE _PROPRIETARY flag, this is already used for FMOD and KDU and should be a good fit here

