### PR TITLE
 SL-20709 FIXED Avatar Maximum Complexity changing upon cancelling Advanced Graphics

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -978,7 +978,6 @@ void LLFloaterPreference::onBtnCancel(const LLSD& userdata)
 	if (userdata.asString() == "closeadvanced")
 	{
 		LLFloaterReg::hideInstance("prefs_graphics_advanced");
-		updateMaxComplexity();
 	}
 	else
 	{


### PR DESCRIPTION
We're updating complexity label in different place after Performance floater changes, so it's redundant.