### PR TITLE
Fix for semi-transparent HUDs rendering opaque

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/fullbrightF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/fullbrightF.glsl
@@ -76,9 +76,9 @@ void main()
 
     vec3 pos = vary_position;
 
+    color.a = final_alpha;
 #ifndef IS_HUD
     color.rgb = srgb_to_linear(color.rgb);
-    color.a = final_alpha;
 #ifdef IS_ALPHA
 
     vec3 sunlit;


### PR DESCRIPTION
This commit fixes a bug introduced with commit 6472b75bcd70470fe5775d1cf6eb70a75b3d76e5 where the fullbrightF.glsl shader fails to set color.a to final_alpha for HUDs.