### PR TITLE
SL-20748 Fix library materials not being previewable on an object

### DIFF
--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -5176,8 +5176,9 @@ void LLPanelFace::onPbrSelectionChanged(LLInventoryItem* itemp)
         bool can_modify = itemp->getPermissions().allowOperationBy(PERM_MODIFY, gAgentID); // do we have perm to transfer this material?
         bool is_object_owner = gAgentID == obj_owner_id; // does object for which we are going to apply material belong to the agent?
         bool not_for_sale = !sale_info.isForSale(); // is object for which we are going to apply material not for sale?
+        bool from_library = ALEXANDRIA_LINDEN_ID == itemp->getPermissions().getOwner();
 
-        if (can_copy && can_transfer && can_modify)
+        if ((can_copy && can_transfer && can_modify) || from_library)
         {
             pbr_ctrl->setCanApply(true, true);
             return;

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -1959,26 +1959,30 @@ bool LLSelectMgr::selectionSetGLTFMaterial(const LLUUID& mat_id)
             {
                 return false;
             }
-            if (mItem && objectp->isAttachment())
-            {
-                const LLPermissions& perm = mItem->getPermissions();
-                BOOL unrestricted = ((perm.getMaskBase() & PERM_ITEM_UNRESTRICTED) == PERM_ITEM_UNRESTRICTED) ? TRUE : FALSE;
-                if (!unrestricted)
-                {
-                    // Attachments are in world and in inventory simultaneously,
-                    // at the moment server doesn't support such a situation.
-                    return false;
-                }
-            }
             LLUUID asset_id = mMatId;
             if (mItem)
             {
-                // If success, the material may be copied into the object's inventory
-                BOOL success = LLToolDragAndDrop::handleDropMaterialProtections(objectp, mItem, LLToolDragAndDrop::SOURCE_AGENT, LLUUID::null);
-                if (!success)
+                const LLPermissions& perm = mItem->getPermissions();
+                bool from_library = perm.getOwner() == ALEXANDRIA_LINDEN_ID;
+                if (objectp->isAttachment())
+                {
+                    bool unrestricted = (perm.getMaskBase() & PERM_ITEM_UNRESTRICTED) == PERM_ITEM_UNRESTRICTED;
+
+                    if (!unrestricted && !from_library)
+                    {
+                        // Attachments are in world and in inventory simultaneously,
+                        // at the moment server doesn't support such a situation.
+                        return false;
+                    }
+                }
+
+                if (!from_library
+                    // Check if item may be copied into the object's inventory
+                    && !LLToolDragAndDrop::handleDropMaterialProtections(objectp, mItem, LLToolDragAndDrop::SOURCE_AGENT, LLUUID::null))
                 {
                     return false;
                 }
+
                 asset_id = mItem->getAssetUUID();
                 if (asset_id.isNull())
                 {
@@ -1994,11 +1998,13 @@ bool LLSelectMgr::selectionSetGLTFMaterial(const LLUUID& mat_id)
     };
 
     bool success = true;
-    if (item &&
-            (!item->getPermissions().allowOperationBy(PERM_COPY, gAgent.getID()) ||
+    if (item
+        &&  (!item->getPermissions().allowOperationBy(PERM_COPY, gAgent.getID()) ||
              !item->getPermissions().allowOperationBy(PERM_TRANSFER, gAgent.getID()) ||
              !item->getPermissions().allowOperationBy(PERM_MODIFY, gAgent.getID())
-            ))
+            )
+        && item->getPermissions().getOwner() != ALEXANDRIA_LINDEN_ID
+        )
     {
         success = success && getSelection()->applyRestrictedPbrMaterialToTEs(item);
     }


### PR DESCRIPTION
Textures didn't care about modifications, but materials do and library items do not pass can_modify check.