### PR TITLE
replaces parts of boost to C++ standard.

### DIFF
--- a/indra/llappearance/llavatarappearance.cpp
+++ b/indra/llappearance/llavatarappearance.cpp
@@ -230,7 +230,7 @@ void LLAvatarAppearance::initInstance()
 		for (U32 lod = 0; lod < mesh_dict->mLOD; lod++)
 		{
 			LLAvatarJointMesh* mesh = createAvatarJointMesh();
-			std::string mesh_name = "m" + mesh_dict->mName + boost::lexical_cast<std::string>(lod);
+			std::string mesh_name = "m" + mesh_dict->mName + std::to_string(lod);
 			// We pre-pended an m - need to capitalize first character for camelCase
 			mesh_name[1] = toupper(mesh_name[1]);
 			mesh->setName(mesh_name);

--- a/indra/llcommon/lldoubledispatch.h
+++ b/indra/llcommon/lldoubledispatch.h
@@ -255,7 +255,7 @@ private:
     };
 
     /// shared_ptr manages Entry lifespan for us
-    typedef boost::shared_ptr<EntryBase> EntryPtr;
+    typedef std::shared_ptr<EntryBase> EntryPtr;
     /// use a @c list to make it easy to insert
     typedef std::list<EntryPtr> DispatchTable;
     DispatchTable mDispatch;

--- a/indra/llcommon/llerror.cpp
+++ b/indra/llcommon/llerror.cpp
@@ -1070,7 +1070,7 @@ namespace LLError
     //
     // NOTE!!! Requires external mutex lock!!!
     template <typename RECORDER>
-    std::pair<boost::shared_ptr<RECORDER>, Recorders::iterator>
+    std::pair<std::shared_ptr<RECORDER>, Recorders::iterator>
     findRecorderPos(SettingsConfigPtr &s)
     {
         // Since we promise to return an iterator, use a classic iterator
@@ -1081,7 +1081,7 @@ namespace LLError
             // *it is a RecorderPtr, a shared_ptr<Recorder>. Use a
             // dynamic_pointer_cast to try to downcast to test if it's also a
             // shared_ptr<RECORDER>.
-            auto ptr = boost::dynamic_pointer_cast<RECORDER>(*it);
+            auto ptr = std::dynamic_pointer_cast<RECORDER>(*it);
             if (ptr)
             {
                 // found the entry we want
@@ -1101,7 +1101,7 @@ namespace LLError
     // shared_ptr might be empty (operator!() returns true) if there was no
     // such RECORDER subclass instance in mRecorders.
     template <typename RECORDER>
-    boost::shared_ptr<RECORDER> findRecorder()
+    std::shared_ptr<RECORDER> findRecorder()
     {
         SettingsConfigPtr s = Globals::getInstance()->getSettingsConfig();
         LLMutexLock lock(&s->mRecorderMutex);
@@ -1134,7 +1134,7 @@ namespace LLError
 
 		if (!file_name.empty())
 		{
-			boost::shared_ptr<RecordToFile> recordToFile(new RecordToFile(file_name));
+			std::shared_ptr<RecordToFile> recordToFile(new RecordToFile(file_name));
 			if (recordToFile->okay())
 			{
 				addRecorder(recordToFile);

--- a/indra/llcommon/llerrorcontrol.h
+++ b/indra/llcommon/llerrorcontrol.h
@@ -174,7 +174,7 @@ namespace LLError
 		bool mWantsMultiline;
 	};
 
-	typedef boost::shared_ptr<Recorder> RecorderPtr;
+	typedef std::shared_ptr<Recorder> RecorderPtr;
 
     /**
      * Instantiate GenericRecorder with a callable(level, message) to get

--- a/indra/llcommon/llinitparam.h
+++ b/indra/llcommon/llinitparam.h
@@ -627,7 +627,7 @@ namespace LLInitParam
 		UserData*			mUserData;
 	};
 
-	typedef boost::shared_ptr<ParamDescriptor> ParamDescriptorPtr;
+	typedef std::shared_ptr<ParamDescriptor> ParamDescriptorPtr;
 
 	// each derived Block class keeps a static data structure maintaining offsets to various params
 	class LL_COMMON_API BlockDescriptor

--- a/indra/llcommon/llleap.cpp
+++ b/indra/llcommon/llleap.cpp
@@ -462,10 +462,10 @@ private:
     LLProcessPtr mChild;
     LLTempBoundListener
         mStdinConnection, mStdoutConnection, mStdoutDataConnection, mStderrConnection;
-    boost::scoped_ptr<LLEventPump::Blocker> mBlocker;
+    std::unique_ptr<LLEventPump::Blocker> mBlocker;
     LLProcess::ReadPipe::size_type mExpect;
     LLError::RecorderPtr mRecorder;
-    boost::scoped_ptr<LLLeapListener> mListener;
+    std::unique_ptr<LLLeapListener> mListener;
 };
 
 // These must follow the declaration of LLLeapImpl, so they may as well be last.

--- a/indra/llcommon/llprocess.h
+++ b/indra/llcommon/llprocess.h
@@ -51,7 +51,7 @@ class LLEventPump;
 class LLProcess;
 /// LLProcess instances are created on the heap by static factory methods and
 /// managed by ref-counted pointers.
-typedef boost::shared_ptr<LLProcess> LLProcessPtr;
+typedef std::shared_ptr<LLProcess> LLProcessPtr;
 
 /**
  * LLProcess handles launching an external process with specified command line

--- a/indra/llcommon/llrun.h
+++ b/indra/llcommon/llrun.h
@@ -48,7 +48,7 @@ public:
 	/**
 	 * @brief The pointer to a runnable.
 	 */
-	typedef boost::shared_ptr<LLRunnable> run_ptr_t;
+	typedef std::shared_ptr<LLRunnable> run_ptr_t;
 
 	/**
 	 * @brief The handle for use in the API.

--- a/indra/llcommon/llstring.h
+++ b/indra/llcommon/llstring.h
@@ -1199,7 +1199,7 @@ void LLStringUtilBase<T>::getTokens(const string_type& string, std::vector<strin
 {
 	// This overload must deal with escapes. Delegate that to InEscString
 	// (unless there ARE no escapes).
-	boost::scoped_ptr< LLStringUtilBaseImpl::InString<T> > instrp;
+	std::unique_ptr< LLStringUtilBaseImpl::InString<T> > instrp;
 	if (escapes.empty())
 		instrp.reset(new LLStringUtilBaseImpl::InString<T>(string.begin(), string.end()));
 	else

--- a/indra/llcommon/tests/llerror_test.cpp
+++ b/indra/llcommon/tests/llerror_test.cpp
@@ -153,27 +153,27 @@ namespace tut
 
 		int countMessages()
 		{
-			return boost::dynamic_pointer_cast<TestRecorder>(mRecorder)->countMessages();
+			return std::dynamic_pointer_cast<TestRecorder>(mRecorder)->countMessages();
 		}
 
 		void clearMessages()
 		{
-			boost::dynamic_pointer_cast<TestRecorder>(mRecorder)->clearMessages();
+			std::dynamic_pointer_cast<TestRecorder>(mRecorder)->clearMessages();
 		}
 
 		void setWantsTime(bool t)
             {
-                boost::dynamic_pointer_cast<TestRecorder>(mRecorder)->showTime(t);
+                std::dynamic_pointer_cast<TestRecorder>(mRecorder)->showTime(t);
             }
 
 		void setWantsMultiline(bool t)
             {
-                boost::dynamic_pointer_cast<TestRecorder>(mRecorder)->showMultiline(t);
+                std::dynamic_pointer_cast<TestRecorder>(mRecorder)->showMultiline(t);
             }
 
 		std::string message(int n)
 		{
-			return boost::dynamic_pointer_cast<TestRecorder>(mRecorder)->message(n);
+			return std::dynamic_pointer_cast<TestRecorder>(mRecorder)->message(n);
 		}
 
 		void ensure_message_count(int expectedCount)
@@ -497,12 +497,12 @@ namespace
 	void testLogName(LLError::RecorderPtr recorder, LogFromFunction f,
 		const std::string& class_name = "")
 	{
-		boost::dynamic_pointer_cast<tut::TestRecorder>(recorder)->clearMessages();
+		std::dynamic_pointer_cast<tut::TestRecorder>(recorder)->clearMessages();
 		std::string name = f(false);
 		f(true);
 
-		std::string messageWithoutName = boost::dynamic_pointer_cast<tut::TestRecorder>(recorder)->message(0);
-		std::string messageWithName = boost::dynamic_pointer_cast<tut::TestRecorder>(recorder)->message(1);
+		std::string messageWithoutName = std::dynamic_pointer_cast<tut::TestRecorder>(recorder)->message(0);
+		std::string messageWithName = std::dynamic_pointer_cast<tut::TestRecorder>(recorder)->message(1);
 
 		ensure_has(name + " logged without name",
 			messageWithoutName, name);
@@ -691,13 +691,13 @@ namespace tut
 		LL_INFOS() << "boo" << LL_ENDL;
 
 		ensure_message_field_equals(0, MSG_FIELD, "boo");
-		ensure_equals("alt recorder count", boost::dynamic_pointer_cast<TestRecorder>(altRecorder)->countMessages(), 1);
-		ensure_contains("alt recorder message 0", boost::dynamic_pointer_cast<TestRecorder>(altRecorder)->message(0), "boo");
+		ensure_equals("alt recorder count", std::dynamic_pointer_cast<TestRecorder>(altRecorder)->countMessages(), 1);
+		ensure_contains("alt recorder message 0", std::dynamic_pointer_cast<TestRecorder>(altRecorder)->message(0), "boo");
 
 		LLError::setTimeFunction(roswell);
 
 		LLError::RecorderPtr anotherRecorder(new TestRecorder());
-		boost::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->showTime(true);
+		std::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->showTime(true);
 		LLError::addRecorder(anotherRecorder);
 
 		LL_INFOS() << "baz" << LL_ENDL;
@@ -705,10 +705,10 @@ namespace tut
 		std::string when = roswell();
 
 		ensure_message_does_not_contain(1, when);
-		ensure_equals("alt recorder count", boost::dynamic_pointer_cast<TestRecorder>(altRecorder)->countMessages(), 2);
-		ensure_does_not_contain("alt recorder message 1", boost::dynamic_pointer_cast<TestRecorder>(altRecorder)->message(1), when);
-		ensure_equals("another recorder count", boost::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->countMessages(), 1);
-		ensure_contains("another recorder message 0", boost::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->message(0), when);
+		ensure_equals("alt recorder count", std::dynamic_pointer_cast<TestRecorder>(altRecorder)->countMessages(), 2);
+		ensure_does_not_contain("alt recorder message 1", std::dynamic_pointer_cast<TestRecorder>(altRecorder)->message(1), when);
+		ensure_equals("another recorder count", std::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->countMessages(), 1);
+		ensure_contains("another recorder message 0", std::dynamic_pointer_cast<TestRecorder>(anotherRecorder)->message(0), when);
 
 		LLError::removeRecorder(altRecorder);
 		LLError::removeRecorder(anotherRecorder);

--- a/indra/llcommon/tests/lleventcoro_test.cpp
+++ b/indra/llcommon/tests/lleventcoro_test.cpp
@@ -101,7 +101,7 @@ namespace tut
         int which;
         LLTestApp testApp;
 
-        void explicit_wait(boost::shared_ptr<LLCoros::Promise<std::string>>& cbp);
+        void explicit_wait(std::shared_ptr<LLCoros::Promise<std::string>>& cbp);
         void waitForEventOn1();
         void coroPump();
         void postAndWait1();
@@ -111,7 +111,7 @@ namespace tut
     typedef coroutine_group::object object;
     coroutine_group coroutinegrp("coroutine");
 
-    void test_data::explicit_wait(boost::shared_ptr<LLCoros::Promise<std::string>>& cbp)
+    void test_data::explicit_wait(std::shared_ptr<LLCoros::Promise<std::string>>& cbp)
     {
         BEGIN
         {
@@ -127,7 +127,7 @@ namespace tut
             // For test purposes, instead of handing 'callback' (or an
             // adapter) off to some I/O subsystem, we'll just pass it back to
             // our caller.
-            cbp = boost::make_shared<LLCoros::Promise<std::string>>();
+            cbp = std::make_shared<LLCoros::Promise<std::string>>();
             LLCoros::Future<std::string> future = LLCoros::getFuture(*cbp);
 
             // calling get() on the future causes us to suspend
@@ -146,7 +146,7 @@ namespace tut
         DEBUG;
 
         // Construct the coroutine instance that will run explicit_wait.
-        boost::shared_ptr<LLCoros::Promise<std::string>> respond;
+        std::shared_ptr<LLCoros::Promise<std::string>> respond;
         LLCoros::instance().launch("test<1>",
                                    [this, &respond](){ explicit_wait(respond); });
         mSync.bump();

--- a/indra/llcommon/tests/llinstancetracker_test.cpp
+++ b/indra/llcommon/tests/llinstancetracker_test.cpp
@@ -94,7 +94,7 @@ namespace tut
             ensure("couldn't find stack Keyed", bool(found));
             ensure_equals("found wrong Keyed instance", found.get(), &one);
             {
-                boost::scoped_ptr<Keyed> two(new Keyed("two"));
+                std::unique_ptr<Keyed> two(new Keyed("two"));
                 ensure_equals(Keyed::instanceCount(), 2);
                 auto found = Keyed::getInstance("two");
                 ensure("couldn't find heap Keyed", bool(found));
@@ -118,7 +118,7 @@ namespace tut
             std::weak_ptr<Unkeyed> found = one.getWeak();
             ensure(! found.expired());
             {
-                boost::scoped_ptr<Unkeyed> two(new Unkeyed);
+                std::unique_ptr<Unkeyed> two(new Unkeyed);
                 ensure_equals(Unkeyed::instanceCount(), 2);
             }
             ensure_equals(Unkeyed::instanceCount(), 1);

--- a/indra/llcommon/tests/wrapllerrs.h
+++ b/indra/llcommon/tests/wrapllerrs.h
@@ -218,12 +218,12 @@ public:
     /// for the sought string.
     std::string messageWith(const std::string& search, bool required=true)
     {
-        return boost::dynamic_pointer_cast<CaptureLogRecorder>(mRecorder)->messageWith(search, required);
+        return std::dynamic_pointer_cast<CaptureLogRecorder>(mRecorder)->messageWith(search, required);
     }
 
     std::ostream& streamto(std::ostream& out) const
     {
-        return boost::dynamic_pointer_cast<CaptureLogRecorder>(mRecorder)->streamto(out);
+        return std::dynamic_pointer_cast<CaptureLogRecorder>(mRecorder)->streamto(out);
     }
 
     friend inline std::ostream& operator<<(std::ostream& out, const CaptureLog& self)

--- a/indra/llcorehttp/_httplibcurl.h
+++ b/indra/llcorehttp/_httplibcurl.h
@@ -65,7 +65,7 @@ private:
 	void operator=(const HttpLibcurl &);		// Not defined
 
 public:
-    typedef boost::shared_ptr<HttpOpRequest> opReqPtr_t;
+    typedef std::shared_ptr<HttpOpRequest> opReqPtr_t;
 
 	/// Give cycles to libcurl to run active requests.  Completed
 	/// operations (successful or failed) will be retried or handed

--- a/indra/llcorehttp/_httpoperation.cpp
+++ b/indra/llcorehttp/_httpoperation.cpp
@@ -58,7 +58,7 @@ HttpOperation::handleMap_t  HttpOperation::mHandleMap;
 LLCoreInt::HttpMutex	    HttpOperation::mOpMutex;
 
 HttpOperation::HttpOperation():
-    boost::enable_shared_from_this<HttpOperation>(),
+    std::enable_shared_from_this<HttpOperation>(),
     mReplyQueue(),
     mUserHandler(),
     mReqPolicy(HttpRequest::DEFAULT_POLICY_ID),

--- a/indra/llcorehttp/_httpoperation.h
+++ b/indra/llcorehttp/_httpoperation.h
@@ -69,12 +69,12 @@ class HttpService;
 /// and those interfaces establish the access rules.
 
 class HttpOperation : private boost::noncopyable,
-    public boost::enable_shared_from_this<HttpOperation>
+    public std::enable_shared_from_this<HttpOperation>
 {
 public:
-    typedef boost::shared_ptr<HttpOperation> ptr_t;
-    typedef boost::weak_ptr<HttpOperation> wptr_t;
-    typedef boost::shared_ptr<HttpReplyQueue> HttpReplyQueuePtr_t;
+    typedef std::shared_ptr<HttpOperation> ptr_t;
+    typedef std::weak_ptr<HttpOperation> wptr_t;
+    typedef std::shared_ptr<HttpReplyQueue> HttpReplyQueuePtr_t;
 
 	/// Threading:  called by consumer thread.
 	HttpOperation();
@@ -157,12 +157,12 @@ public:
     HttpHandle getHandle();
 
     template< class OPT >
-    static boost::shared_ptr< OPT > fromHandle(HttpHandle handle)
+    static std::shared_ptr< OPT > fromHandle(HttpHandle handle)
     {
         ptr_t ptr = findByHandle(handle);
         if (!ptr)
-            return boost::shared_ptr< OPT >();
-        return boost::dynamic_pointer_cast< OPT >(ptr);
+            return std::shared_ptr< OPT >();
+        return std::dynamic_pointer_cast< OPT >(ptr);
     }
 	
 protected:

--- a/indra/llcorehttp/_httpoprequest.cpp
+++ b/indra/llcorehttp/_httpoprequest.cpp
@@ -201,7 +201,7 @@ HttpOpRequest::~HttpOpRequest()
 void HttpOpRequest::stageFromRequest(HttpService * service)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_NETWORK;
-    HttpOpRequest::ptr_t self(boost::dynamic_pointer_cast<HttpOpRequest>(shared_from_this()));
+    HttpOpRequest::ptr_t self(std::dynamic_pointer_cast<HttpOpRequest>(shared_from_this()));
     service->getPolicy().addOp(self);			// transfers refcount
 }
 
@@ -209,7 +209,7 @@ void HttpOpRequest::stageFromRequest(HttpService * service)
 void HttpOpRequest::stageFromReady(HttpService * service)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_NETWORK;
-    HttpOpRequest::ptr_t self(boost::dynamic_pointer_cast<HttpOpRequest>(shared_from_this()));
+    HttpOpRequest::ptr_t self(std::dynamic_pointer_cast<HttpOpRequest>(shared_from_this()));
     service->getTransport().addOp(self);		// transfers refcount
 }
 
@@ -290,7 +290,7 @@ void HttpOpRequest::visitNotifier(HttpRequest * request)
 // HttpOpRequest::ptr_t HttpOpRequest::fromHandle(HttpHandle handle)
 // {
 // 
-//     return boost::dynamic_pointer_cast<HttpOpRequest>((static_cast<HttpOpRequest *>(handle))->shared_from_this());
+//     return std::dynamic_pointer_cast<HttpOpRequest>((static_cast<HttpOpRequest *>(handle))->shared_from_this());
 // }
 
 

--- a/indra/llcorehttp/_httpoprequest.h
+++ b/indra/llcorehttp/_httpoprequest.h
@@ -66,7 +66,7 @@ class BufferArray;
 class HttpOpRequest : public HttpOperation
 {
 public:
-    typedef boost::shared_ptr<HttpOpRequest> ptr_t;
+    typedef std::shared_ptr<HttpOpRequest> ptr_t;
 
 	HttpOpRequest();
 

--- a/indra/llcorehttp/_httpopsetget.h
+++ b/indra/llcorehttp/_httpopsetget.h
@@ -53,7 +53,7 @@ namespace LLCore
 class HttpOpSetGet : public HttpOperation
 {
 public:
-    typedef boost::shared_ptr<HttpOpSetGet> ptr_t;
+    typedef std::shared_ptr<HttpOpSetGet> ptr_t;
 
 	HttpOpSetGet();
 

--- a/indra/llcorehttp/_httppolicy.h
+++ b/indra/llcorehttp/_httppolicy.h
@@ -60,7 +60,7 @@ private:
 	void operator=(const HttpPolicy &);			// Not defined
 
 public:
-    typedef boost::shared_ptr<HttpOpRequest> opReqPtr_t;
+    typedef std::shared_ptr<HttpOpRequest> opReqPtr_t;
 
 	/// Threading:  called by init thread.
 	HttpRequest::policy_t createPolicyClass();

--- a/indra/llcorehttp/_httpreplyqueue.h
+++ b/indra/llcorehttp/_httpreplyqueue.h
@@ -63,8 +63,8 @@ class HttpReplyQueue : private boost::noncopyable
 {
 
 public:
-    typedef boost::shared_ptr<HttpOperation>    opPtr_t;
-    typedef boost::shared_ptr<HttpReplyQueue>   ptr_t;
+    typedef std::shared_ptr<HttpOperation>    opPtr_t;
+    typedef std::shared_ptr<HttpReplyQueue>   ptr_t;
 
 	HttpReplyQueue();
     virtual ~HttpReplyQueue();		

--- a/indra/llcorehttp/_httprequestqueue.h
+++ b/indra/llcorehttp/_httprequestqueue.h
@@ -61,7 +61,7 @@ private:
 	void operator=(const HttpRequestQueue &);			// Not defined
 
 public:
-    typedef boost::shared_ptr<HttpOperation> opPtr_t;
+    typedef std::shared_ptr<HttpOperation> opPtr_t;
 
 	static void init();
 	static void term();

--- a/indra/llcorehttp/httpcommon.h
+++ b/indra/llcorehttp/httpcommon.h
@@ -301,24 +301,24 @@ struct HttpStatus
 	
 	HttpStatus()
 	{
-		mDetails = boost::shared_ptr<Details>(new Details(LLCORE, HE_SUCCESS));
+		mDetails = std::shared_ptr<Details>(new Details(LLCORE, HE_SUCCESS));
     }
 
 	HttpStatus(type_enum_t type, short status)
 	{
-        mDetails = boost::shared_ptr<Details>(new Details(type, status));
+        mDetails = std::shared_ptr<Details>(new Details(type, status));
 	}
 	
 	HttpStatus(int http_status)
 	{
-        mDetails = boost::shared_ptr<Details>(new Details(http_status, 
+        mDetails = std::shared_ptr<Details>(new Details(http_status, 
 			(http_status >= 200 && http_status <= 299) ? HE_SUCCESS : HE_REPLY_ERROR));
 		llassert(http_status >= 100 && http_status <= 999);
 	}
 
 	HttpStatus(int http_status, const std::string &message)
 	{
-        mDetails = boost::shared_ptr<Details>(new Details(http_status,
+        mDetails = std::shared_ptr<Details>(new Details(http_status,
 			(http_status >= 200 && http_status <= 299) ? HE_SUCCESS : HE_REPLY_ERROR));
 		llassert(http_status >= 100 && http_status <= 999);
 		mDetails->mMessage = message;
@@ -341,7 +341,7 @@ struct HttpStatus
 
     HttpStatus & clone(const HttpStatus &rhs)
     {
-        mDetails = boost::shared_ptr<Details>(new Details(*rhs.mDetails));
+        mDetails = std::shared_ptr<Details>(new Details(*rhs.mDetails));
         return *this;
     }
 	
@@ -490,14 +490,14 @@ private:
 		LLSD		mErrorData;
 	};
 
-    boost::shared_ptr<Details> mDetails;
+    std::shared_ptr<Details> mDetails;
 
 }; // end struct HttpStatus
 
 ///  A namespace for several free methods and low level utilities. 
 namespace LLHttp
 {
-    typedef boost::shared_ptr<CURL> CURL_ptr;
+    typedef std::shared_ptr<CURL> CURL_ptr;
 
     void initialize();
     void cleanup();

--- a/indra/llcorehttp/httphandler.h
+++ b/indra/llcorehttp/httphandler.h
@@ -58,8 +58,8 @@ class HttpResponse;
 class HttpHandler 
 {
 public:
-    typedef boost::shared_ptr<HttpHandler>  ptr_t;
-    typedef boost::weak_ptr<HttpHandler>    wptr_t;
+    typedef std::shared_ptr<HttpHandler>  ptr_t;
+    typedef std::weak_ptr<HttpHandler>    wptr_t;
 
 	virtual ~HttpHandler()
 	{ }

--- a/indra/llcorehttp/httpheaders.h
+++ b/indra/llcorehttp/httpheaders.h
@@ -85,7 +85,7 @@ public:
 	typedef container_t::const_reverse_iterator const_reverse_iterator;
 	typedef container_t::value_type value_type;
 	typedef container_t::size_type size_type;
-    typedef boost::shared_ptr<HttpHeaders> ptr_t;
+    typedef std::shared_ptr<HttpHeaders> ptr_t;
 
 public:
 	/// @post In addition to the instance, caller has a refcount

--- a/indra/llcorehttp/httpoptions.h
+++ b/indra/llcorehttp/httpoptions.h
@@ -60,7 +60,7 @@ class HttpOptions : private boost::noncopyable
 public:
 	HttpOptions();
 
-	typedef boost::shared_ptr<HttpOptions> ptr_t;
+	typedef std::shared_ptr<HttpOptions> ptr_t;
 
     virtual ~HttpOptions();						// Use release()
 

--- a/indra/llcorehttp/httprequest.h
+++ b/indra/llcorehttp/httprequest.h
@@ -96,8 +96,8 @@ private:
 public:
 	typedef unsigned int policy_t;
 	
-	typedef boost::shared_ptr<HttpRequest> ptr_t;
-    typedef boost::weak_ptr<HttpRequest>   wptr_t;
+	typedef std::shared_ptr<HttpRequest> ptr_t;
+    typedef std::weak_ptr<HttpRequest>   wptr_t;
 public:
 	/// @name PolicyMethods
 	/// @{
@@ -627,7 +627,7 @@ public:
 protected:
 
 private:
-    typedef boost::shared_ptr<HttpReplyQueue> HttpReplyQueuePtr_t;
+    typedef std::shared_ptr<HttpReplyQueue> HttpReplyQueuePtr_t;
 
 	/// @name InstanceData
 	///

--- a/indra/llcorehttp/httpresponse.h
+++ b/indra/llcorehttp/httpresponse.h
@@ -72,7 +72,7 @@ public:
 	/// Statistics for the HTTP 
 	struct TransferStats
 	{
-		typedef boost::shared_ptr<TransferStats> ptr_t;
+		typedef std::shared_ptr<TransferStats> ptr_t;
 
 		TransferStats() : mSizeDownload(0.0), mTotalTime(0.0), mSpeedDownload(0.0) {}
 		F64 mSizeDownload;

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -48,7 +48,7 @@ std::string LLImageJ2C::getEngineInfo()
 {
 	// All known LLImageJ2CImpl implementation subclasses are cheap to
 	// construct.
-	boost::scoped_ptr<LLImageJ2CImpl> impl(fallbackCreateLLImageJ2CImpl());
+	std::unique_ptr<LLImageJ2CImpl> impl(fallbackCreateLLImageJ2CImpl());
 	return impl->getEngineInfo();
 }
 

--- a/indra/llimage/llimagej2c.h
+++ b/indra/llimage/llimagej2c.h
@@ -95,7 +95,7 @@ protected:
 	S8  mRawDiscardLevel;
 	F32 mRate;
 	bool mReversible;
-	boost::scoped_ptr<LLImageJ2CImpl> mImpl;
+	std::unique_ptr<LLImageJ2CImpl> mImpl;
 	std::string mLastError;
 
     // Image compression/decompression tester

--- a/indra/llkdu/llimagej2ckdu.h
+++ b/indra/llkdu/llimagej2ckdu.h
@@ -113,10 +113,10 @@ private:
 	};
 
 	// Encode variable
-	boost::scoped_ptr<LLKDUMemSource> mInputp;
+	std::unique_ptr<LLKDUMemSource> mInputp;
 	CodeStreamHolder mCodeStreamp;
-	boost::scoped_ptr<kdu_core::kdu_coords> mTPosp; // tile position
-	boost::scoped_ptr<kdu_core::kdu_dims> mTileIndicesp;
+	std::unique_ptr<kdu_core::kdu_coords> mTPosp; // tile position
+	std::unique_ptr<kdu_core::kdu_dims> mTileIndicesp;
 	int mBlocksSize;
 	int mPrecinctsSize;
 	int mLevels;
@@ -125,7 +125,7 @@ private:
 	// We don't own this LLImageRaw. We're simply pointing to an instance
 	// passed into initDecode().
 	LLImageRaw *mRawImagep;
-	boost::scoped_ptr<LLKDUDecodeState> mDecodeState;
+	std::unique_ptr<LLKDUDecodeState> mDecodeState;
 };
 
 #endif

--- a/indra/llmessage/llcoproceduremanager.cpp
+++ b/indra/llmessage/llcoproceduremanager.cpp
@@ -95,7 +95,7 @@ public:
 private:
     struct QueuedCoproc
     {
-        typedef boost::shared_ptr<QueuedCoproc> ptr_t;
+        typedef std::shared_ptr<QueuedCoproc> ptr_t;
 
         QueuedCoproc(const std::string &name, const LLUUID &id, CoProcedure_t proc) :
             mName(name),
@@ -115,7 +115,7 @@ private:
     // Use shared_ptr to control the lifespan of our CoprocQueue_t instance
     // because the consuming coroutine might outlive this LLCoprocedurePool
     // instance.
-    typedef boost::shared_ptr<CoprocQueue_t> CoprocQueuePtr;
+    typedef std::shared_ptr<CoprocQueue_t> CoprocQueuePtr;
 
     std::string     mPoolName;
     size_t          mPoolSize, mActiveCoprocsCount, mPending;
@@ -301,7 +301,7 @@ LLCoprocedurePool::LLCoprocedurePool(const std::string &poolName, size_t size):
     mPoolSize(size),
     mActiveCoprocsCount(0),
     mPending(0),
-    mPendingCoprocs(boost::make_shared<CoprocQueue_t>(LLCoprocedureManager::DEFAULT_QUEUE_SIZE)),
+    mPendingCoprocs(std::make_shared<CoprocQueue_t>(LLCoprocedureManager::DEFAULT_QUEUE_SIZE)),
     mHTTPPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID),
     mCoroMapping()
 {
@@ -384,7 +384,7 @@ LLUUID LLCoprocedurePool::enqueueCoprocedure(const std::string &name, LLCoproced
         LL_INFOS("CoProcMgr") << "Coprocedure(" << name << ") enqueuing with id=" << id.asString() << " in pool \"" << mPoolName << "\" at "
                               << mPending << LL_ENDL;
     }
-    auto pushed = mPendingCoprocs->try_push(boost::make_shared<QueuedCoproc>(name, id, proc));
+    auto pushed = mPendingCoprocs->try_push(std::make_shared<QueuedCoproc>(name, id, proc));
     if (pushed == boost::fibers::channel_op_status::success)
     {
         ++mPending;

--- a/indra/llmessage/llcorehttputil.h
+++ b/indra/llmessage/llcorehttputil.h
@@ -263,8 +263,8 @@ class HttpCoroHandler : public LLCore::HttpHandler
 {
 public:
 
-    typedef boost::shared_ptr<HttpCoroHandler>  ptr_t;
-    typedef boost::weak_ptr<HttpCoroHandler>    wptr_t;
+    typedef std::shared_ptr<HttpCoroHandler>  ptr_t;
+    typedef std::weak_ptr<HttpCoroHandler>    wptr_t;
 
     HttpCoroHandler(LLEventStream &reply);
 
@@ -317,8 +317,8 @@ public:
     static const std::string HTTP_RESULTS_CONTENT;
     static const std::string HTTP_RESULTS_RAW;
 
-    typedef boost::shared_ptr<HttpCoroutineAdapter> ptr_t;
-    typedef boost::weak_ptr<HttpCoroutineAdapter>   wptr_t;
+    typedef std::shared_ptr<HttpCoroutineAdapter> ptr_t;
+    typedef std::weak_ptr<HttpCoroutineAdapter>   wptr_t;
 
     HttpCoroutineAdapter(const std::string &name, LLCore::HttpRequest::policy_t policyId);
     ~HttpCoroutineAdapter();

--- a/indra/llmessage/llexperiencecache.h
+++ b/indra/llmessage/llexperiencecache.h
@@ -112,7 +112,7 @@ private:
 
     // Callback types for get() 
     typedef boost::signals2::signal < void(const LLSD &) > callback_signal_t;
-	typedef boost::shared_ptr<callback_signal_t> signal_ptr;
+	typedef std::shared_ptr<callback_signal_t> signal_ptr;
 	// May have multiple callbacks for a single ID, which are
 	// represented as multiple slots bound to the signal.
 	// Avoid copying signals via pointers.

--- a/indra/llmessage/lliohttpserver.cpp
+++ b/indra/llmessage/lliohttpserver.cpp
@@ -982,7 +982,7 @@ LLHTTPNode& LLIOHTTPServer::create(
     }
 
     LLHTTPResponseFactory* factory = new LLHTTPResponseFactory;
-	boost::shared_ptr<LLChainIOFactory> factory_ptr(factory);
+	std::shared_ptr<LLChainIOFactory> factory_ptr(factory);
 
     LLIOServerSocket* server = new LLIOServerSocket(pool, socket, factory_ptr);
 

--- a/indra/llmessage/lliopipe.h
+++ b/indra/llmessage/lliopipe.h
@@ -89,7 +89,7 @@ public:
 	/** 
 	 * @brief Scattered memory container.
 	 */
-	typedef boost::shared_ptr<LLBufferArray> buffer_ptr_t;
+	typedef std::shared_ptr<LLBufferArray> buffer_ptr_t;
 
 	/** 
 	 * @brief Enumeration for IO return codes

--- a/indra/llmessage/lliosocket.h
+++ b/indra/llmessage/lliosocket.h
@@ -65,7 +65,7 @@ public:
 	/** 
 	 * @brief Reference counted shared pointers to sockets.
 	 */
-	typedef boost::shared_ptr<LLSocket> ptr_t;
+	typedef std::shared_ptr<LLSocket> ptr_t;
 
 	/** 
 	 * @brief Type of socket to create.
@@ -305,7 +305,7 @@ class LLIOServerSocket : public LLIOPipe
 {
 public:
 	typedef LLSocket::ptr_t socket_t;
-	typedef boost::shared_ptr<LLChainIOFactory> factory_t;
+	typedef std::shared_ptr<LLChainIOFactory> factory_t;
 	LLIOServerSocket(apr_pool_t* pool, socket_t listener, factory_t reactor);
 	virtual ~LLIOServerSocket();
 

--- a/indra/llmessage/llservice.h
+++ b/indra/llmessage/llservice.h
@@ -116,7 +116,7 @@ class LLService : public LLIOPipe
 public:
 	//typedef boost::intrusive_ptr<LLServiceCreator> creator_t;
 	//typedef boost::intrusive_ptr<LLService> service_t;
-	typedef boost::shared_ptr<LLChainIOFactory> creator_t;
+	typedef std::shared_ptr<LLChainIOFactory> creator_t;
 
 	/** 
 	 * @brief This method is used to register a protocol name with a

--- a/indra/llmessage/llstoredmessage.h
+++ b/indra/llmessage/llstoredmessage.h
@@ -46,7 +46,7 @@ private:
 	std::string mName;
 };
 
-typedef boost::shared_ptr<LLStoredMessage> LLStoredMessagePtr;
+typedef std::shared_ptr<LLStoredMessage> LLStoredMessagePtr;
 
 
 #endif // LL_STOREDMESSAGE_H

--- a/indra/llmessage/tests/llcurl_stub.cpp
+++ b/indra/llmessage/tests/llcurl_stub.cpp
@@ -49,7 +49,7 @@ void LLCurl::Responder::httpCompleted()
 }
 
 void LLCurl::Responder::completedRaw(LLChannelDescriptors const&,
-									 boost::shared_ptr<LLBufferArray> const&)
+									 std::shared_ptr<LLBufferArray> const&)
 {
 }
 

--- a/indra/llplugin/llpluginclassmedia.h
+++ b/indra/llplugin/llpluginclassmedia.h
@@ -335,7 +335,7 @@ public:
 	// "init_history" message 
 	void initializeUrlHistory(const LLSD& url_history);
 
-	boost::shared_ptr<LLPluginClassMedia> getSharedPtr() { return boost::dynamic_pointer_cast<LLPluginClassMedia>(shared_from_this()); } // due to enable_shared_from_this
+	std::shared_ptr<LLPluginClassMedia> getSharedPtr() { return std::dynamic_pointer_cast<LLPluginClassMedia>(shared_from_this()); } // due to enable_shared_from_this
 
 protected:
 

--- a/indra/llplugin/llpluginprocessparent.h
+++ b/indra/llplugin/llpluginprocessparent.h
@@ -43,7 +43,7 @@
 #include "llsd.h"
 #include "llevents.h"
 
-class LLPluginProcessParentOwner : public boost::enable_shared_from_this < LLPluginProcessParentOwner > 
+class LLPluginProcessParentOwner : public std::enable_shared_from_this < LLPluginProcessParentOwner > 
 {
 public:
 	virtual ~LLPluginProcessParentOwner();
@@ -60,7 +60,7 @@ class LLPluginProcessParent : public LLPluginMessagePipeOwner
 
     LLPluginProcessParent(LLPluginProcessParentOwner *owner);
 public:
-    typedef boost::shared_ptr<LLPluginProcessParent> ptr_t;
+    typedef std::shared_ptr<LLPluginProcessParent> ptr_t;
 
 	~LLPluginProcessParent();
 		

--- a/indra/llprimitive/tests/llmediaentry_test.cpp
+++ b/indra/llprimitive/tests/llmediaentry_test.cpp
@@ -211,7 +211,7 @@ namespace tut
 
     void whitelist_test(int num, bool enable, const char *whitelist, const char *candidate_url, bool expected_pass)
     {
-        std::string message = "Whitelist test " + boost::lexical_cast<std::string>(num);
+        std::string message = "Whitelist test " + std::to_string(num);
         LLMediaEntry entry;
         entry.setWhiteListEnable(enable);
         set_whitelist(entry, whitelist);

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -990,7 +990,7 @@ private:
 
 	bool mIgnoreAllNotifications;
 
-	boost::scoped_ptr<LLNotificationsListener> mListener;
+	std::unique_ptr<LLNotificationsListener> mListener;
 
 	std::vector<LLNotificationChannelPtr> mDefaultChannels;
 };

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -61,7 +61,7 @@ class LLTeleportRequest;
 
 
 
-typedef boost::shared_ptr<LLTeleportRequest> LLTeleportRequestPtr;
+typedef std::shared_ptr<LLTeleportRequest> LLTeleportRequestPtr;
 
 //--------------------------------------------------------------------
 // Types
@@ -131,7 +131,7 @@ public:
 private:
 	bool			mInitialized;
 	bool			mFirstLogin;
-	boost::shared_ptr<LLAgentListener> mListener;
+	std::shared_ptr<LLAgentListener> mListener;
 
 	//--------------------------------------------------------------------
 	// Session

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -3742,7 +3742,7 @@ LLSD LLAppearanceMgr::dumpCOF() const
 			LLUUID linked_asset_id(linked_item->getAssetUUID());
 			md5.update((unsigned char*)linked_asset_id.mData, 16);
 			U32 flags = linked_item->getFlags();
-			md5.update(boost::lexical_cast<std::string>(flags));
+			md5.update(std::to_string(flags));
 		}
 		else if (LLAssetType::AT_LINK_FOLDER != inv_item->getActualType())
 		{

--- a/indra/newview/llchiclet.h
+++ b/indra/newview/llchiclet.h
@@ -552,7 +552,7 @@ protected:
 		LLNotificationChiclet* const mChiclet;
 	};
 				
-	boost::scoped_ptr<ChicletNotificationChannel> mNotificationChannel;
+	std::unique_ptr<ChicletNotificationChannel> mNotificationChannel;
 				
 	LLNotificationChiclet(const Params& p);
 				

--- a/indra/newview/llcompilequeue.cpp
+++ b/indra/newview/llcompilequeue.cpp
@@ -73,7 +73,7 @@ namespace
     class ObjectInventoryFetcher: public LLVOInventoryListener
     {
     public:
-        typedef boost::shared_ptr<ObjectInventoryFetcher> ptr_t;
+        typedef std::shared_ptr<ObjectInventoryFetcher> ptr_t;
 
         ObjectInventoryFetcher(LLEventPump &pump, LLViewerObject* object, void* user_data) :
             mPump(pump),

--- a/indra/newview/llconversationlog.cpp
+++ b/indra/newview/llconversationlog.cpp
@@ -434,7 +434,7 @@ bool LLConversationLog::moveLog(const std::string &originDirectory, const std::s
 			while(LLFile::isfile(backupFileName))
 			{
 				++backupFileCount;
-				backupFileName = targetDirectory + ".backup" + boost::lexical_cast<std::string>(backupFileCount);
+				backupFileName = targetDirectory + ".backup" + std::to_string(backupFileCount);
 			}
 
 			//Rename the file to its backup name so it is not overwritten

--- a/indra/newview/llfloatereditsky.cpp
+++ b/indra/newview/llfloatereditsky.cpp
@@ -84,7 +84,7 @@ BOOL LLFloaterEditSky::postBuild()
 	mSkyPresetCombo = getChild<LLComboBox>("sky_preset_combo");
 	mMakeDefaultCheckBox = getChild<LLCheckBoxCtrl>("make_default_cb");
 	mSaveButton = getChild<LLButton>("save");
-    mSkyAdapter = boost::make_shared<LLSkySettingsAdapter>();
+    mSkyAdapter = std::make_shared<LLSkySettingsAdapter>();
 
     LLEnvironment::instance().setSkyListChange(boost::bind(&LLFloaterEditSky::onSkyPresetListChange, this));
 

--- a/indra/newview/llfloatereditwater.cpp
+++ b/indra/newview/llfloatereditwater.cpp
@@ -71,7 +71,7 @@ BOOL LLFloaterEditWater::postBuild()
 	mMakeDefaultCheckBox = getChild<LLCheckBoxCtrl>("make_default_cb");
 	mSaveButton = getChild<LLButton>("save");
 
-    mWaterAdapter = boost::make_shared<LLWatterSettingsAdapter>();
+    mWaterAdapter = std::make_shared<LLWatterSettingsAdapter>();
 
     LLEnvironment::instance().setWaterListChange(boost::bind(&LLFloaterEditWater::onWaterPresetListChange, this));
 

--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -453,7 +453,7 @@ void LLFloaterIMNearbyChatScreenChannel::arrangeToasts()
 //-----------------------------------------------------------------------------------------------
 //LLFloaterIMNearbyChatHandler
 //-----------------------------------------------------------------------------------------------
-boost::scoped_ptr<LLEventPump> LLFloaterIMNearbyChatHandler::sChatWatcher(new LLEventStream("LLChat"));
+std::unique_ptr<LLEventPump> LLFloaterIMNearbyChatHandler::sChatWatcher(new LLEventStream("LLChat"));
 
 LLFloaterIMNearbyChatHandler::LLFloaterIMNearbyChatHandler()
 {

--- a/indra/newview/llfloaterimnearbychathandler.h
+++ b/indra/newview/llfloaterimnearbychathandler.h
@@ -46,7 +46,7 @@ public:
 protected:
 	virtual void initChannel();
 
-	static boost::scoped_ptr<LLEventPump> sChatWatcher;
+	static std::unique_ptr<LLEventPump> sChatWatcher;
 };
 
 }

--- a/indra/newview/llfloateruipreview.cpp
+++ b/indra/newview/llfloateruipreview.cpp
@@ -158,7 +158,7 @@ public:
 
 	// typedef std::map<std::string,std::pair<std::list<std::string>,std::list<std::string> > > DiffMap; // this version copies the lists etc., and thus is bad memory-wise
 	typedef std::list<std::string> StringList;
-	typedef boost::shared_ptr<StringList> StringListPtr;
+	typedef std::shared_ptr<StringList> StringListPtr;
 	typedef std::map<std::string, std::pair<StringListPtr,StringListPtr> > DiffMap;
 	DiffMap mDiffsMap;							// map, of filename to pair of list of changed element paths and list of errors
 

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -3027,7 +3027,7 @@ BOOL LLFolderBridge::dragCategoryIntoFolder(LLInventoryCategory* inv_cat,
 	return accept;
 }
 
-void warn_move_inventory(LLViewerObject* object, boost::shared_ptr<LLMoveInv> move_inv)
+void warn_move_inventory(LLViewerObject* object, std::shared_ptr<LLMoveInv> move_inv)
 {
 	const char* dialog = NULL;
 	if (object->flagScripted())
@@ -3040,7 +3040,7 @@ void warn_move_inventory(LLViewerObject* object, boost::shared_ptr<LLMoveInv> mo
 	}
 
     static LLNotificationPtr notification_ptr;
-    static boost::shared_ptr<LLMoveInv> inv_ptr;
+    static std::shared_ptr<LLMoveInv> inv_ptr;
 
     // Notification blocks user from interacting with inventories so everything that comes after first message
     // is part of this message - don'r show it again
@@ -3153,7 +3153,7 @@ BOOL move_inv_category_world_to_agent(const LLUUID& object_id,
 	if(drop && accept)
 	{
 		it = inventory_objects.begin();
-        boost::shared_ptr<LLMoveInv> move_inv(new LLMoveInv);
+        std::shared_ptr<LLMoveInv> move_inv(new LLMoveInv);
 		move_inv->mObjectID = object_id;
 		move_inv->mCategoryID = category_id;
 		move_inv->mCallback = callback;
@@ -5012,7 +5012,7 @@ LLFontGL::StyleFlags LLMarketplaceFolderBridge::getLabelStyle() const
 
 
 // helper stuff
-bool move_task_inventory_callback(const LLSD& notification, const LLSD& response, boost::shared_ptr<LLMoveInv> move_inv)
+bool move_task_inventory_callback(const LLSD& notification, const LLSD& response, std::shared_ptr<LLMoveInv> move_inv)
 {
 	LLFloaterOpenObject::LLCatAndWear* cat_and_wear = (LLFloaterOpenObject::LLCatAndWear* )move_inv->mUserData;
 	LLViewerObject* object = gObjectList.findObject(move_inv->mObjectID);
@@ -5486,7 +5486,7 @@ BOOL LLFolderBridge::dragItemIntoFolder(LLInventoryItem* inv_item,
 		if (accept && drop)
 		{
             LLUUID item_id = inv_item->getUUID();
-            boost::shared_ptr<LLMoveInv> move_inv (new LLMoveInv());
+            std::shared_ptr<LLMoveInv> move_inv (new LLMoveInv());
 			move_inv->mObjectID = inv_item->getParentUUID();
 			two_uuids_t item_pair(mUUID, item_id);
 			move_inv->mMoveList.push_back(item_pair);

--- a/indra/newview/llinventorybridge.h
+++ b/indra/newview/llinventorybridge.h
@@ -794,7 +794,7 @@ struct LLMoveInv
     void* mUserData;
 };
 
-void warn_move_inventory(LLViewerObject* object, boost::shared_ptr<LLMoveInv> move_inv);
-bool move_task_inventory_callback(const LLSD& notification, const LLSD& response, boost::shared_ptr<LLMoveInv>);
+void warn_move_inventory(LLViewerObject* object, std::shared_ptr<LLMoveInv> move_inv);
+bool move_task_inventory_callback(const LLSD& notification, const LLSD& response, std::shared_ptr<LLMoveInv>);
 
 #endif // LL_LLINVENTORYBRIDGE_H

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -3323,7 +3323,7 @@ BOOL dragItemIntoFolder(LLUUID folder_id, LLInventoryItem* inv_item, BOOL drop, 
 
         if (accept && drop)
         {
-            boost::shared_ptr<LLMoveInv> move_inv (new LLMoveInv());
+            std::shared_ptr<LLMoveInv> move_inv (new LLMoveInv());
             move_inv->mObjectID = inv_item->getParentUUID();
             std::pair<LLUUID, LLUUID> item_pair(folder_id, inv_item->getUUID());
             move_inv->mMoveList.push_back(item_pair);

--- a/indra/newview/lllogchat.cpp
+++ b/indra/newview/lllogchat.cpp
@@ -723,7 +723,7 @@ bool LLLogChat::moveTranscripts(const std::string originDirectory,
 			while(LLFile::isfile(backupFileName))
 			{
 				++backupFileCount;
-				backupFileName = newFullPath + ".backup" + boost::lexical_cast<std::string>(backupFileCount);
+				backupFileName = newFullPath + ".backup" + std::to_string(backupFileCount);
 			}
 
 			//Rename the file to its backup name so it is not overwritten

--- a/indra/newview/lllogininstance.h
+++ b/indra/newview/lllogininstance.h
@@ -90,7 +90,7 @@ private:
 
 	void attemptComplete() { mAttemptComplete = true; } // In the future an event?
 
-	boost::scoped_ptr<LLLogin> mLoginModule;
+	std::unique_ptr<LLLogin> mLoginModule;
 	LLNotificationsInterface* mNotifications;
 
 	std::string mLoginState;

--- a/indra/newview/llmaterialmgr.cpp
+++ b/indra/newview/llmaterialmgr.cpp
@@ -68,7 +68,7 @@ class LLMaterialHttpHandler : public LLHttpSDHandler
 {
 public: 
 	typedef boost::function<void(bool, const LLSD&)> CallbackFunction;
-	typedef boost::shared_ptr<LLMaterialHttpHandler> ptr_t;
+	typedef std::shared_ptr<LLMaterialHttpHandler> ptr_t;
 
 	LLMaterialHttpHandler(const std::string& method, CallbackFunction cback);
 

--- a/indra/newview/llmediadataclient.h
+++ b/indra/newview/llmediadataclient.h
@@ -116,10 +116,10 @@ protected:
     
 	// Request (pure virtual base class for requests in the queue)
     class Request: 
-        public boost::enable_shared_from_this<Request>
+        public std::enable_shared_from_this<Request>
     {
     public:
-        typedef boost::shared_ptr<Request> ptr_t;
+        typedef std::shared_ptr<Request> ptr_t;
 
         // Subclasses must implement this to build a payload for their request type.
         virtual LLSD getPayload() const = 0;

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -411,7 +411,7 @@ namespace {
 static S32 dump_num = 0;
 std::string make_dump_name(std::string prefix, S32 num)
 {
-	return prefix + boost::lexical_cast<std::string>(num) + std::string(".xml");
+	return prefix + std::to_string(num) + std::string(".xml");
 }
 void dump_llsd_to_file(const LLSD& content, std::string filename);
 LLSD llsd_from_file(std::string filename);
@@ -572,10 +572,10 @@ S32 LLMeshRepoThread::sRequestWaterLevel = 0;
 //   LLMeshUploadThread
 
 class LLMeshHandlerBase : public LLCore::HttpHandler,
-    public boost::enable_shared_from_this<LLMeshHandlerBase>
+    public std::enable_shared_from_this<LLMeshHandlerBase>
 {
 public:
-    typedef boost::shared_ptr<LLMeshHandlerBase> ptr_t;
+    typedef std::shared_ptr<LLMeshHandlerBase> ptr_t;
 
 	LOG_CLASS(LLMeshHandlerBase);
 	LLMeshHandlerBase(U32 offset, U32 requested_bytes)

--- a/indra/newview/llpanellogin.h
+++ b/indra/newview/llpanellogin.h
@@ -112,7 +112,7 @@ private:
 	static void updateServerCombo();
 
 private:
-	boost::scoped_ptr<LLPanelLoginListener> mListener;
+	std::unique_ptr<LLPanelLoginListener> mListener;
 
 	void updateLoginButtons();
 	void populateUserList(LLPointer<LLCredential> credential);

--- a/indra/newview/llpathfindingmanager.cpp
+++ b/indra/newview/llpathfindingmanager.cpp
@@ -114,7 +114,7 @@ public:
 	void handleTerrainLinksetsResult(const LLSD &pContent);
 	void handleTerrainLinksetsError();
 
-    typedef boost::shared_ptr<LinksetsResponder> ptr_t;
+    typedef std::shared_ptr<LinksetsResponder> ptr_t;
 
 protected:
 
@@ -139,7 +139,7 @@ private:
 	LLPathfindingObjectPtr                          mTerrainLinksetPtr;
 };
 
-typedef boost::shared_ptr<LinksetsResponder> LinksetsResponderPtr;
+typedef std::shared_ptr<LinksetsResponder> LinksetsResponderPtr;
 
 //---------------------------------------------------------------------------
 // LLPathfindingManager

--- a/indra/newview/llpathfindingmanager.h
+++ b/indra/newview/llpathfindingmanager.h
@@ -107,8 +107,8 @@ private:
     void navMeshStatusRequestCoro(std::string url, U64 regionHandle, bool isGetStatusOnly);
     void navAgentStateRequestCoro(std::string url);
     void navMeshRebakeCoro(std::string url, rebake_navmesh_callback_t rebakeNavMeshCallback);
-    void linksetObjectsCoro(std::string url, boost::shared_ptr<LinksetsResponder> linksetsResponsderPtr, LLSD putData) const;
-    void linksetTerrainCoro(std::string url, boost::shared_ptr<LinksetsResponder> linksetsResponsderPtr, LLSD putData) const;
+    void linksetObjectsCoro(std::string url, std::shared_ptr<LinksetsResponder> linksetsResponsderPtr, LLSD putData) const;
+    void linksetTerrainCoro(std::string url, std::shared_ptr<LinksetsResponder> linksetsResponsderPtr, LLSD putData) const;
     void charactersCoro(std::string url, request_id_t requestId, object_request_callback_t callback) const;
 
 	//void handleNavMeshStatusRequest(const LLPathfindingNavMeshStatus &pNavMeshStatus, LLViewerRegion *pRegion, bool pIsGetStatusOnly);

--- a/indra/newview/llpathfindingnavmesh.h
+++ b/indra/newview/llpathfindingnavmesh.h
@@ -39,7 +39,7 @@
 class LLPathfindingNavMesh;
 class LLUUID;
 
-typedef boost::shared_ptr<LLPathfindingNavMesh> LLPathfindingNavMeshPtr;
+typedef std::shared_ptr<LLPathfindingNavMesh> LLPathfindingNavMeshPtr;
 
 class LLPathfindingNavMesh
 {

--- a/indra/newview/llpathfindingnavmeshzone.h
+++ b/indra/newview/llpathfindingnavmeshzone.h
@@ -114,7 +114,7 @@ private:
 		LLPathfindingNavMesh::navmesh_slot_t        mNavMeshSlot;
 	};
 
-	typedef boost::shared_ptr<NavMeshLocation> NavMeshLocationPtr;
+	typedef std::shared_ptr<NavMeshLocation> NavMeshLocationPtr;
 	typedef std::vector<NavMeshLocationPtr> NavMeshLocationPtrs;
 
 	void handleNavMeshLocation();

--- a/indra/newview/llpathfindingobject.h
+++ b/indra/newview/llpathfindingobject.h
@@ -41,7 +41,7 @@
 class LLPathfindingObject;
 class LLSD;
 
-typedef boost::shared_ptr<LLPathfindingObject> LLPathfindingObjectPtr;
+typedef std::shared_ptr<LLPathfindingObject> LLPathfindingObjectPtr;
 
 class LLPathfindingObject
 {

--- a/indra/newview/llpathfindingobjectlist.h
+++ b/indra/newview/llpathfindingobjectlist.h
@@ -36,7 +36,7 @@
 
 class LLPathfindingObjectList;
 
-typedef boost::shared_ptr<LLPathfindingObjectList> LLPathfindingObjectListPtr;
+typedef std::shared_ptr<LLPathfindingObjectList> LLPathfindingObjectListPtr;
 typedef std::map<std::string, LLPathfindingObjectPtr> LLPathfindingObjectMap;
 
 class LLPathfindingObjectList

--- a/indra/newview/llpreviewtexture.cpp
+++ b/indra/newview/llpreviewtexture.cpp
@@ -653,7 +653,7 @@ void LLPreviewTexture::adjustAspectRatio()
 			{
 				// No existing ratio found, create an element that will show image at original ratio
 				populateRatioList(); // makes sure previous custom ratio is cleared
-				std::string ratio = boost::lexical_cast<std::string>(num)+":" + boost::lexical_cast<std::string>(denom);
+				std::string ratio = std::to_string(num)+":" + std::to_string(denom);
 				mRatiosList.push_back(ratio);
 				combo->add(ratio);
 				combo->setCurrentByIndex(mRatiosList.size()- 1);

--- a/indra/newview/llsculptidsize.cpp
+++ b/indra/newview/llsculptidsize.cpp
@@ -66,7 +66,7 @@ void LLSculptIDSize::inc(const LLDrawable *pdrawable, int sz)
 	if (itLU.first == itLU.second)
 	{ //register
 		//llassert(mSizeInfo.get<tag_BY_DRAWABLE>().end() == mSizeInfo.get<tag_BY_DRAWABLE>().find(pdrawable));
-		mSizeInfo.get<tag_BY_DRAWABLE>().insert(Info(pdrawable, sz, boost::make_shared<SizeSum>(sz), sculptId));
+		mSizeInfo.get<tag_BY_DRAWABLE>().insert(Info(pdrawable, sz, std::make_shared<SizeSum>(sz), sculptId));
 		total_size = sz;
 	}
 	else

--- a/indra/newview/llsculptidsize.h
+++ b/indra/newview/llsculptidsize.h
@@ -52,7 +52,7 @@ public:
 
 	struct Info
 	{
-		typedef boost::shared_ptr<SizeSum> PtrSizeSum;
+		typedef std::shared_ptr<SizeSum> PtrSizeSum;
 
 		Info(const LLDrawable *drawable, int size, PtrSizeSum sizeInfo, LLUUID sculptId)
 			: mDrawable(drawable)

--- a/indra/newview/llsearchableui.h
+++ b/indra/newview/llsearchableui.h
@@ -93,7 +93,7 @@ namespace ll
 	{
 		struct SearchableItem;
 
-		typedef boost::shared_ptr< SearchableItem > SearchableItemPtr;
+		typedef std::shared_ptr< SearchableItem > SearchableItemPtr;
 
 		typedef std::vector< SearchableItemPtr > tSearchableItemList;
 

--- a/indra/newview/llviewermedia.h
+++ b/indra/newview/llviewermedia.h
@@ -431,7 +431,7 @@ private:
 	
 private:
 	// a single media url with some data and an impl.
-	boost::shared_ptr<LLPluginClassMedia> mMediaSource;
+	std::shared_ptr<LLPluginClassMedia> mMediaSource;
     LLMutex mLock;
 	F64		mZoomFactor;
 	LLUUID mTextureId;

--- a/indra/newview/llviewermenufile.h
+++ b/indra/newview/llviewermenufile.h
@@ -145,7 +145,7 @@ public:
     virtual void notify(const std::vector<std::string>& filenames);
 
 private:
-    boost::shared_ptr<LLPluginClassMedia> mPlugin;
+    std::shared_ptr<LLPluginClassMedia> mPlugin;
 };
 
 

--- a/indra/newview/llviewerparcelaskplay.cpp
+++ b/indra/newview/llviewerparcelaskplay.cpp
@@ -287,7 +287,7 @@ void LLViewerParcelAskPlay::saveSettings()
             if ((iter_parcel->second.mDate.secondsSinceEpoch() + (F64SecondsImplicit)U32Days(30)) > LLTimer::getTotalSeconds())
             {
                 // write unexpired parcels
-                std::string parcel_id = boost::lexical_cast<std::string>(iter_parcel->first);
+                std::string parcel_id = std::to_string(iter_parcel->first);
                 write_llsd[key][parcel_id] = LLSD();
                 write_llsd[key][parcel_id]["mode"] = (LLSD::Integer)iter_parcel->second.mMode;
                 write_llsd[key][parcel_id]["date"] = iter_parcel->second.mDate;

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -616,7 +616,7 @@ std::string LLViewerShaderMgr::loadBasicShaders()
 
 	std::map<std::string, std::string> attribs;
 	attribs["MAX_JOINTS_PER_MESH_OBJECT"] = 
-		boost::lexical_cast<std::string>(LLSkinningUtil::getMaxJointCount());
+		std::to_string(LLSkinningUtil::getMaxJointCount());
 
     BOOL ssr = gSavedSettings.getBOOL("RenderScreenSpaceReflections");
 

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -538,8 +538,8 @@ private:
 	bool			mStatesDirty;
 	U32			mCurrResolutionIndex;
 
-	boost::scoped_ptr<LLWindowListener> mWindowListener;
-	boost::scoped_ptr<LLViewerWindowListener> mViewerWindowListener;
+	std::unique_ptr<LLWindowListener> mWindowListener;
+	std::unique_ptr<LLViewerWindowListener> mViewerWindowListener;
 
 	// Object temporarily hovered over while dragging
 	LLPointer<LLViewerObject>	mDragHoveredObject;

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5952,7 +5952,7 @@ void LLVivoxVoiceClient::filePlaybackSetMode(bool vox, float speed)
 }
 
 //------------------------------------------------------------------------
-std::set<LLVivoxVoiceClient::sessionState::wptr_t> LLVivoxVoiceClient::sessionState::mSession;
+std::set<LLVivoxVoiceClient::sessionState::wptr_t, std::owner_less<LLVivoxVoiceClient::sessionState::wptr_t>> LLVivoxVoiceClient::sessionState::mSession;
 
 
 LLVivoxVoiceClient::sessionState::sessionState() :

--- a/indra/newview/llvoicevivox.h
+++ b/indra/newview/llvoicevivox.h
@@ -294,8 +294,8 @@ protected:
 		bool mAvatarIDValid;
 		bool mIsSelf;
 	};
-    typedef boost::shared_ptr<participantState> participantStatePtr_t;
-    typedef boost::weak_ptr<participantState> participantStateWptr_t;
+    typedef std::shared_ptr<participantState> participantStatePtr_t;
+    typedef std::weak_ptr<participantState> participantStateWptr_t;
 
     typedef std::map<const std::string, participantStatePtr_t> participantMap;
     typedef std::map<const LLUUID, participantStatePtr_t> participantUUIDMap;
@@ -303,10 +303,10 @@ protected:
 	struct sessionState
 	{
     public:
-        typedef boost::shared_ptr<sessionState> ptr_t;
-        typedef boost::weak_ptr<sessionState> wptr_t;
+        typedef std::shared_ptr<sessionState> ptr_t;
+        typedef std::weak_ptr<sessionState> wptr_t;
 
-        typedef boost::function<void(const ptr_t &)> sessionFunc_t;
+        typedef std::function<void(const ptr_t &)> sessionFunc_t;
 
         static ptr_t createSession();
 		~sessionState();
@@ -370,7 +370,7 @@ protected:
     private:
         sessionState();
 
-        static std::set<wptr_t> mSession;   // canonical list of outstanding sessions.
+        static std::set<wptr_t, std::owner_less<wptr_t>> mSession;   // canonical list of outstanding sessions.
         std::set<wptr_t>::iterator  mMyIterator;    // used for delete
 
         static void for_eachPredicate(const wptr_t &a, sessionFunc_t func);
@@ -381,7 +381,7 @@ protected:
         static bool testByCallerId(const LLVivoxVoiceClient::sessionState::wptr_t &a, LLUUID participantId);
 
 	};
-    typedef boost::shared_ptr<sessionState> sessionStatePtr_t;
+    typedef std::shared_ptr<sessionState> sessionStatePtr_t;
 
     typedef std::map<std::string, sessionStatePtr_t> sessionMap;
 	

--- a/indra/newview/llwindowlistener.cpp
+++ b/indra/newview/llwindowlistener.cpp
@@ -388,7 +388,7 @@ static void mouseEvent(const MouseFunc& func, const LLSD& request)
 	LLCoordGL pos(request["x"].asInteger(), request["y"].asInteger());
 	bool has_pos(request.has("x") && request.has("y"));
 
-	boost::scoped_ptr<LLView::TemporaryDrilldownFunc> tempfunc;
+	std::unique_ptr<LLView::TemporaryDrilldownFunc> tempfunc;
 
 	// Documentation for mouseDown(), mouseUp() and mouseMove() claims you
 	// must either specify ["path"], or both of ["x"] and ["y"]. You MAY

--- a/indra/newview/llxmlrpclistener.cpp
+++ b/indra/newview/llxmlrpclistener.cpp
@@ -544,7 +544,7 @@ private:
     const std::string mMethod;
     const std::string mReplyPump;
     LLTempBoundListener mBoundListener;
-    boost::scoped_ptr<LLXMLRPCTransaction> mTransaction;
+    std::unique_ptr<LLXMLRPCTransaction> mTransaction;
 	LLXMLRPCTransaction::EStatus mPreviousStatus; // To detect state changes.
 };
 

--- a/indra/newview/llxmlrpctransaction.cpp
+++ b/indra/newview/llxmlrpctransaction.cpp
@@ -188,7 +188,7 @@ public:
 
 	virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * response);
 
-	typedef boost::shared_ptr<LLXMLRPCTransaction::Handler> ptr_t;
+	typedef std::shared_ptr<LLXMLRPCTransaction::Handler> ptr_t;
 
 private:
 

--- a/indra/newview/tests/llremoteparcelrequest_test.cpp
+++ b/indra/newview/tests/llremoteparcelrequest_test.cpp
@@ -49,7 +49,7 @@ void LLCurl::Responder::failureResult(S32 status, const std::string& reason, con
 void LLCurl::Responder::successResult(const LLSD& content) { }
 void LLCurl::Responder::completeResult(S32 status, const std::string& reason, const LLSD& content) { }
 std::string LLCurl::Responder::dumpResponse() const { return "(failure)"; }
-void LLCurl::Responder::completedRaw(LLChannelDescriptors const &,boost::shared_ptr<LLBufferArray> const &) { }
+void LLCurl::Responder::completedRaw(LLChannelDescriptors const &,std::shared_ptr<LLBufferArray> const &) { }
 void LLMessageSystem::getF32(char const *,char const *,F32 &,S32) { }
 void LLMessageSystem::getU8(char const *,char const *,U8 &,S32) { }
 void LLMessageSystem::getS32(char const *,char const *,S32 &,S32) { }
@@ -110,7 +110,7 @@ namespace tut
 	{
 		set_test_name("observer pointer");
 
-		boost::scoped_ptr<TestObserver> observer(new TestObserver());
+		std::unique_ptr<TestObserver> observer(new TestObserver());
 
 		LLRemoteParcelInfoProcessor & processor = LLRemoteParcelInfoProcessor::instance();
 		processor.addObserver(LLUUID(TEST_PARCEL_ID), observer.get());

--- a/indra/test/io.cpp
+++ b/indra/test/io.cpp
@@ -946,7 +946,7 @@ namespace tut
 		typedef LLCloneIOFactory<LLPipeStringInjector> emitter_t;
 		emitter_t* emitter = new emitter_t(
 			new LLPipeStringInjector("suckers never play me"));
-		boost::shared_ptr<LLChainIOFactory> factory(emitter);
+		std::shared_ptr<LLChainIOFactory> factory(emitter);
 		LLIOServerSocket* server = new LLIOServerSocket(
 			mPool,
 			mSocket,
@@ -993,7 +993,7 @@ namespace tut
 		LLPumpIO::chain_t chain;
 		typedef LLCloneIOFactory<LLIOFuzz> emitter_t;
 		emitter_t* emitter = new emitter_t(new LLIOFuzz(1000000));
-		boost::shared_ptr<LLChainIOFactory> factory(emitter);
+		std::shared_ptr<LLChainIOFactory> factory(emitter);
 		LLIOServerSocket* server = new LLIOServerSocket(
 			mPool,
 			mSocket,
@@ -1036,7 +1036,7 @@ namespace tut
 		LLPumpIO::chain_t chain;
 		typedef LLCloneIOFactory<LLIOFuzz> emitter_t;
 		emitter_t* emitter = new emitter_t(new LLIOFuzz(1000000));
-		boost::shared_ptr<LLChainIOFactory> factory(emitter);
+		std::shared_ptr<LLChainIOFactory> factory(emitter);
 		LLIOServerSocket* server = new LLIOServerSocket(
 			mPool,
 			mSocket,
@@ -1079,7 +1079,7 @@ namespace tut
 		LLPumpIO::chain_t chain;
 		typedef LLCloneIOFactory<LLIOFuzz> emitter_t;
 		emitter_t* emitter = new emitter_t(new LLIOFuzz(1000000));
-		boost::shared_ptr<LLChainIOFactory> factory(emitter);
+		std::shared_ptr<LLChainIOFactory> factory(emitter);
 		LLIOServerSocket* server = new LLIOServerSocket(
 			mPool,
 			mSocket,
@@ -1120,7 +1120,7 @@ namespace tut
 		LLPumpIO::chain_t chain;
 		typedef LLCloneIOFactory<LLIOSleeper> sleeper_t;
 		sleeper_t* sleeper = new sleeper_t(new LLIOSleeper);
-		boost::shared_ptr<LLChainIOFactory> factory(sleeper);
+		std::shared_ptr<LLChainIOFactory> factory(sleeper);
 		LLIOServerSocket* server = new LLIOServerSocket(
 			mPool,
 			mSocket,

--- a/indra/test/llevents_tut.cpp
+++ b/indra/test/llevents_tut.cpp
@@ -368,10 +368,10 @@ void events_object::test<7>()
 	LLEventStream bob("bob"); 		// should work, previous one unregistered
 	LLEventStream bob1("bob", true);// allowed to tweak name
 	ensure_equals("tweaked LLEventStream name", bob1.getName(), "bob1");
-	std::vector<boost::shared_ptr<LLEventStream> > streams;
+	std::vector<std::shared_ptr<LLEventStream> > streams;
 	for (int i = 2; i <= 10; ++i)
 	{
-		streams.push_back(boost::shared_ptr<LLEventStream>(new LLEventStream("bob", true)));
+		streams.push_back(std::shared_ptr<LLEventStream>(new LLEventStream("bob", true)));
 	}
 	ensure_equals("last tweaked LLEventStream name", streams.back()->getName(), "bob10");
 }

--- a/indra/test/test.cpp
+++ b/indra/test/test.cpp
@@ -160,12 +160,12 @@ public:
 
 	virtual void reset()
 	{
-		boost::dynamic_pointer_cast<RecordToTempFile>(mRecorder)->reset();
+		std::dynamic_pointer_cast<RecordToTempFile>(mRecorder)->reset();
 	}
 
 	virtual void replay(std::ostream& out)
 	{
-		boost::dynamic_pointer_cast<RecordToTempFile>(mRecorder)->replay(out);
+		std::dynamic_pointer_cast<RecordToTempFile>(mRecorder)->replay(out);
 	}
 
 private:
@@ -179,7 +179,7 @@ class LLTestCallback : public chained_callback
 
 public:
 	LLTestCallback(bool verbose_mode, std::ostream *stream,
-				   boost::shared_ptr<LLReplayLog> replayer) :
+				   std::shared_ptr<LLReplayLog> replayer) :
 		mVerboseMode(verbose_mode),
 		mTotalTests(0),
 		mPassedTests(0),
@@ -187,7 +187,7 @@ public:
 		mSkippedTests(0),
 		// By default, capture a shared_ptr to std::cout, with a no-op "deleter"
 		// so that destroying the shared_ptr makes no attempt to delete std::cout.
-		mStream(boost::shared_ptr<std::ostream>(&std::cout, [](std::ostream*){})),
+		mStream(std::shared_ptr<std::ostream>(&std::cout, [](std::ostream*){})),
 		mReplayer(replayer)
 	{
 		if (stream)
@@ -201,7 +201,7 @@ public:
 			// Allocate and assign in two separate steps, per Herb Sutter.
 			// (Until we turn on C++11 support, have to wrap *stream with
 			// boost::ref() due to lack of perfect forwarding.)
-			boost::shared_ptr<std::ostream> pstream(new TeeStream(std::cout, boost::ref(*stream)));
+			std::shared_ptr<std::ostream> pstream(new TeeStream(std::cout, boost::ref(*stream)));
 			mStream = pstream;
 		}
 	}
@@ -325,8 +325,8 @@ protected:
 	int mPassedTests;
 	int mFailedTests;
 	int mSkippedTests;
-	boost::shared_ptr<std::ostream> mStream;
-	boost::shared_ptr<LLReplayLog> mReplayer;
+	std::shared_ptr<std::ostream> mStream;
+	std::shared_ptr<LLReplayLog> mReplayer;
 };
 
 // TeamCity specific class which emits service messages
@@ -336,7 +336,7 @@ class LLTCTestCallback : public LLTestCallback
 {
 public:
 	LLTCTestCallback(bool verbose_mode, std::ostream *stream,
-					 boost::shared_ptr<LLReplayLog> replayer) :
+					 std::shared_ptr<LLReplayLog> replayer) :
 		LLTestCallback(verbose_mode, stream, replayer)
 	{
 	}
@@ -549,7 +549,7 @@ int main(int argc, char **argv)
 	apr_status_t apr_err;
 	const char* opt_arg = NULL;
 	int opt_id = 0;
-	boost::scoped_ptr<llofstream> output;
+	std::unique_ptr<llofstream> output;
 	const char *touch = NULL;
 
 	while(true)
@@ -608,7 +608,7 @@ int main(int argc, char **argv)
 
 	// set up logging
 	const char* LOGFAIL = getenv("LOGFAIL");
-	boost::shared_ptr<LLReplayLog> replayer{boost::make_shared<LLReplayLog>()};
+	std::shared_ptr<LLReplayLog> replayer{std::make_shared<LLReplayLog>()};
 
 	// Testing environment variables for both 'set' and 'not empty' allows a
 	// user to suppress a pre-existing environment variable by forcing empty.

--- a/indra/viewer_components/login/lllogin.h
+++ b/indra/viewer_components/login/lllogin.h
@@ -121,7 +121,7 @@ public:
 
 private:
 	class Impl;
-	boost::scoped_ptr<Impl> mImpl;
+	std::unique_ptr<Impl> mImpl;
 };
 
 #endif // LL_LLLOGIN_H


### PR DESCRIPTION
Some of the functions used in boost are provided by the C++ standard.
This PR replaces that functionality.

1. When converting from an integer to a string, use to_string.
2. replace boost::shared_ptr to std::shared_ptr
3. replace boost::scoped_ptr to std::unique_ptr
4. replace boost::dynamic_pointer_cast to std::dynamic_pointer_cast
5. replace boost::make_shared to std::make_shared
6. replace boost::enable_shared_from_this to std::enable_shared_from_this
7. replace boost::weak_ptr to std::weak_ptr