### PR TITLE
Replace BOOST_FOREACH with standard C++ range-based for-loops

### DIFF
--- a/indra/llcommon/llprocess.cpp
+++ b/indra/llcommon/llprocess.cpp
@@ -36,7 +36,6 @@
 #include "llevents.h"
 #include "llexception.h"
 
-#include <boost/foreach.hpp>
 #include <boost/bind.hpp>
 #include <boost/asio/streambuf.hpp>
 #include <boost/asio/buffers_iterator.hpp>
@@ -587,7 +586,7 @@ LLProcess::LLProcess(const LLSDOrParams& params):
 	// apr_procattr_child_err_set()), or accepting a filename, opening it and
 	// passing that apr_file_t (simple <, >, 2> redirect emulation).
 	std::vector<apr_int32_t> select;
-	BOOST_FOREACH(const FileParam& fparam, params.files)
+	for (const FileParam& fparam : params.files)
 	{
 		// Every iteration, we're going to append an item to 'select'. At the
 		// top of the loop, its size() is, in effect, an index. Use that to
@@ -684,7 +683,7 @@ LLProcess::LLProcess(const LLSDOrParams& params):
 	argv.push_back(params.executable().c_str());
 
 	// Add arguments. See above remarks about c_str().
-	BOOST_FOREACH(const std::string& arg, params.args)
+	for (const std::string& arg : params.args)
 	{
 		argv.push_back(arg.c_str());
 	}
@@ -961,7 +960,7 @@ void LLProcess::handle_status(int reason, int status)
 		// only be performed if in fact we're going to produce the log message.
 		LL_DEBUGS("LLProcess") << empty;
 		std::string reason_str;
-		BOOST_FOREACH(const ReasonCode& rcp, reasons)
+		for (const ReasonCode& rcp : reasons)
 		{
 			if (reason == rcp.code)
 			{
@@ -1151,7 +1150,7 @@ std::ostream& operator<<(std::ostream& out, const LLProcess::Params& params)
 		out << "cd " << LLStringUtil::quote(params.cwd) << ": ";
 	}
 	out << LLStringUtil::quote(params.executable);
-	BOOST_FOREACH(const std::string& arg, params.args)
+	for (const std::string& arg : params.args)
 	{
 		out << ' ' << LLStringUtil::quote(arg);
 	}

--- a/indra/llcommon/llsdutil.h
+++ b/indra/llcommon/llsdutil.h
@@ -478,9 +478,9 @@ namespace llsd
 {
 
 /*****************************************************************************
-*   BOOST_FOREACH() helpers for LLSD
+*   range-based for-loop helpers for LLSD
 *****************************************************************************/
-/// Usage: BOOST_FOREACH(LLSD item, inArray(someLLSDarray)) { ... }
+/// Usage: for (LLSD item : inArray(someLLSDarray)) { ... }
 class inArray
 {
 public:
@@ -503,7 +503,7 @@ private:
 /// MapEntry is what you get from dereferencing an LLSD::map_[const_]iterator.
 typedef std::map<LLSD::String, LLSD>::value_type MapEntry;
 
-/// Usage: BOOST_FOREACH([const] MapEntry& e, inMap(someLLSDmap)) { ... }
+/// Usage: for([const] MapEntry& e : inMap(someLLSDmap)) { ... }
 class inMap
 {
 public:

--- a/indra/llcommon/llsingleton.cpp
+++ b/indra/llcommon/llsingleton.cpp
@@ -32,7 +32,6 @@
 #include "lldependencies.h"
 #include "llexception.h"
 #include "llcoros.h"
-#include <boost/foreach.hpp>
 #include <algorithm>
 #include <iostream>                 // std::cerr in dire emergency
 #include <sstream>
@@ -411,7 +410,7 @@ void LLSingletonBase::cleanup_()
 void LLSingletonBase::deleteAll()
 {
     // It's essential to traverse these in dependency order.
-    BOOST_FOREACH(LLSingletonBase* sp, dep_sort())
+    for (LLSingletonBase* sp : dep_sort())
     {
         // Capture the class name first: in case of exception, don't count on
         // being able to extract it later.

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -49,7 +49,6 @@
 #include "llsdutil.h"
 #include <boost/bind.hpp>
 #include <boost/circular_buffer.hpp>
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -905,9 +904,9 @@ void LLMemoryInfo::stream(std::ostream& s) const
 
 	// Max key length
 	size_t key_width(0);
-	BOOST_FOREACH(const MapEntry& pair, inMap(mStatsMap))
+	for (const auto& [key, value] : inMap(mStatsMap))
 	{
-		size_t len(pair.first.length());
+		size_t len(key.length());
 		if (len > key_width)
 		{
 			key_width = len;
@@ -915,10 +914,9 @@ void LLMemoryInfo::stream(std::ostream& s) const
 	}
 
 	// Now stream stats
-	BOOST_FOREACH(const MapEntry& pair, inMap(mStatsMap))
+	for (const auto& [key, value] : inMap(mStatsMap))
 	{
-		s << pfx << std::setw(narrow(key_width+1)) << (pair.first + ':') << ' ';
-		LLSD value(pair.second);
+		s << pfx << std::setw(narrow(key_width+1)) << (key + ':') << ' ';
 		if (value.isInteger())
 			s << std::setw(12) << value.asInteger();
 		else if (value.isReal())

--- a/indra/llcommon/tests/llprocess_test.cpp
+++ b/indra/llcommon/tests/llprocess_test.cpp
@@ -21,7 +21,6 @@
 // external library headers
 #include "llapr.h"
 #include "apr_thread_proc.h"
-#include <boost/foreach.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string/find_iterator.hpp>
 #include <boost/algorithm/string/finder.hpp>
@@ -323,7 +322,7 @@ namespace tut
     {
 /*==========================================================================*|
         std::string reason_str;
-        BOOST_FOREACH(const ReasonCode& rcp, reasons)
+        for (const ReasonCode& rcp : reasons)
         {
             if (reason == rcp.code)
             {
@@ -554,7 +553,7 @@ namespace tut
         catch (const failure&)
         {
             std::cout << "History:\n";
-            BOOST_FOREACH(const Item& item, history)
+            for (const Item& item : history)
             {
                 std::string what(item.what);
                 if ((! what.empty()) && what[what.length() - 1] == '\n')

--- a/indra/llcommon/tests/llstreamqueue_test.cpp
+++ b/indra/llcommon/tests/llstreamqueue_test.cpp
@@ -15,9 +15,6 @@
 #include "llstreamqueue.h"
 // STL headers
 #include <vector>
-// std headers
-// external library headers
-#include <boost/foreach.hpp>
 // other Linden headers
 #include "../test/lltut.h"
 #include "stringize.h"
@@ -133,7 +130,7 @@ namespace tut
         std::streamsize leave(5);   // len("craft") above
         std::streamsize skip(total - leave);
         std::streamsize written(0);
-        BOOST_FOREACH(const std::string& block, blocks)
+        for (const std::string& block : blocks)
         {
             written += strq.write(&block[0], block.length());
             ensure_equals("size() after write()", strq.size(), written);
@@ -152,7 +149,7 @@ namespace tut
     {
         set_test_name("concatenate blocks");
         std::string blocks[] = { "abcd", "efghij", "klmnopqrs" };
-        BOOST_FOREACH(const std::string& block, blocks)
+        for (const std::string& block : blocks)
         {
             strq.write(&block[0], block.length());
         }
@@ -170,7 +167,7 @@ namespace tut
     {
         set_test_name("split blocks");
         std::string blocks[] = { "abcdefghijklm", "nopqrstuvwxyz" };
-        BOOST_FOREACH(const std::string& block, blocks)
+        for (const std::string& block : blocks)
         {
             strq.write(&block[0], block.length());
         }

--- a/indra/llcommon/tests/lltreeiterators_test.cpp
+++ b/indra/llcommon/tests/lltreeiterators_test.cpp
@@ -38,7 +38,6 @@
 // external library headers
 #include <boost/bind.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/foreach.hpp>
 
 // associated header
 #include "../lltreeiterators.h"
@@ -402,7 +401,7 @@ private:
  *
  * Example:
  * @code
- * BOOST_FOREACH(TreeNodePtr node, getRootRange<LLTreeIter::UP>(somenode))
+ * for (TreeNodePtr node : getRootRange<LLTreeIter::UP>(somenode))
  * {
  *     std::cout << node->name() << '\n';
  * }
@@ -424,7 +423,7 @@ getRootRange(const TreeNodePtr& node)
  *
  * Example:
  * @code
- * BOOST_FOREACH(TreeNodePtr node, getWalkRange<LLTreeIter::DFS_PRE>(root))
+ * for (TreeNodePtr node : getWalkRange<LLTreeIter::DFS_PRE>(root))
  * {
  *     std::cout << node->name() << '\n';
  * }
@@ -520,7 +519,7 @@ public:
      *
      * Example usage:
      * @code
-     * BOOST_FOREACH(EnhancedTreeNodePtr node, somenode->getRootRange<LLTreeIter::UP>())
+     * for (EnhancedTreeNodePtr node : somenode->getRootRange<LLTreeIter::UP>())
      * {
      *     std::cout << node->name() << '\n';
      * }
@@ -564,7 +563,7 @@ public:
      *
      * Example usage:
      * @code
-     * BOOST_FOREACH(EnhancedTreeNodePtr node, somenode->getWalkRange<LLTreeIter::DFS_PRE>())
+     * for (EnhancedTreeNodePtr node : somenode->getWalkRange<LLTreeIter::DFS_PRE>())
      * {
      *     std::cout << node->name() << '\n';
      * }
@@ -644,7 +643,7 @@ LLLinkedIter<PlainTree> PlainTree_child_end(PlainTree* node)
  *
  * Example:
  * @code
- * BOOST_FOREACH(PlainTree* node, getRootRange<LLTreeIter::UP>(somenode))
+ * for (PlainTree* node : getRootRange<LLTreeIter::UP>(somenode))
  * {
  *     std::cout << node->name() << '\n';
  * }
@@ -668,7 +667,7 @@ getRootRange(PlainTree* node)
  *
  * Example:
  * @code
- * BOOST_FOREACH(PlainTree* node, getWalkRange<LLTreeIter::DFS_PRE>(root))
+ * for (PlainTree* node : getWalkRange<LLTreeIter::DFS_PRE>(root))
  * {
  *     std::cout << node->name() << '\n';
  * }
@@ -1103,18 +1102,18 @@ namespace tut
         // This test function illustrates the looping techniques described in the
         // comments for the getRootRange() free function, the
         // EnhancedTreeNode::root_range template and the
-        // EnhancedTreeNode::getRootRange() method. Obviously the BOOST_FOREACH()
+        // EnhancedTreeNode::getRootRange() method. Obviously the for()
         // forms are more succinct.
         TreeNodePtr tnroot(example_tree<TreeNode>());
         TreeNodePtr tnB2b(get_B2b<TreeNode, TreeNode::child_iterator>
                           (tnroot, boost::bind(&TreeNode::child_begin, _1)));
     
-        std::string desc1("BOOST_FOREACH(TreeNodePr, getRootRange<LLTreeIter::UP>(tnB2b))");
+        std::string desc1("for (TreeNodePr : getRootRange<LLTreeIter::UP>(tnB2b))");
 //      std::cout << desc1 << "\n";
         // Although we've commented out the output statement, ensure that the
         // loop construct is still valid, as promised by the getRootRange()
         // documentation.
-        BOOST_FOREACH(TreeNodePtr node, getRootRange<LLTreeIter::UP>(tnB2b))
+        for (TreeNodePtr node : getRootRange<LLTreeIter::UP>(tnB2b))
         {
 //          std::cout << node->name() << '\n';
         }
@@ -1137,9 +1136,9 @@ namespace tut
 //          std::cout << (*ri)->name() << '\n';
         }
 
-        std::string desc2("BOOST_FOREACH(EnhancedTreeNodePtr node, etnB2b->getRootRange<LLTreeIter::UP>())");
+        std::string desc2("for (EnhancedTreeNodePtr node : etnB2b->getRootRange<LLTreeIter::UP>())");
 //      std::cout << desc2 << '\n';
-        BOOST_FOREACH(EnhancedTreeNodePtr node, etnB2b->getRootRange<LLTreeIter::UP>())
+        for (EnhancedTreeNodePtr node : etnB2b->getRootRange<LLTreeIter::UP>())
         {
 //          std::cout << node->name() << '\n';
         }

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -44,7 +44,6 @@
 #include "stringize.h"
 #include "llstring.h"
 #include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/assign/list_of.hpp>
@@ -691,10 +690,10 @@ void LLDir::walkSearchSkinDirs(const std::string& subdir,
 							   const std::string& filename,
 							   const FUNCTION& function) const
 {
-	BOOST_FOREACH(std::string skindir, mSearchSkinDirs)
+	for (const std::string& skindir : mSearchSkinDirs)
 	{
 		std::string subdir_path(add(skindir, subdir));
-		BOOST_FOREACH(std::string subsubdir, subsubdirs)
+		for (const std::string& subsubdir : subsubdirs)
 		{
 			std::string full_path(add(subdir_path, subsubdir, filename));
 			if (fileExists(full_path))
@@ -843,7 +842,7 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 		// current language, copy them -- in proper order -- into results.
 		// Don't drive this by walking the map itself: it matters that we
 		// generate results in the same order as subsubdirs.
-		BOOST_FOREACH(std::string subsubdir, subsubdirs)
+		for (const std::string& subsubdir : subsubdirs)
 		{
 			StringMap::const_iterator found(path_for.find(subsubdir));
 			if (found != path_for.end())
@@ -855,7 +854,7 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 
 	LL_DEBUGS("LLDir") << empty;
 	const char* comma = "";
-	BOOST_FOREACH(std::string path, results)
+	for (const std::string& path : results)
 	{
 		LL_CONT << comma << "'" << path << "'";
 		comma = ", ";

--- a/indra/llfilesystem/tests/lldir_test.cpp
+++ b/indra/llfilesystem/tests/lldir_test.cpp
@@ -34,7 +34,6 @@
 
 #include "../test/lltut.h"
 #include "stringize.h"
-#include <boost/foreach.hpp>
 #include <boost/assign/list_of.hpp>
 
 using boost::assign::list_of;
@@ -109,7 +108,7 @@ struct LLDir_Dummy: public LLDir
 
             "install/skins/default/future/somefile.txt"
         };
-        BOOST_FOREACH(const char* path, preload)
+        for (const char* path : preload)
         {
             buildFilesystem(path);
         }
@@ -166,7 +165,7 @@ struct LLDir_Dummy: public LLDir
         LLStringUtil::getTokens(path, components, "/");
         // Ensure we have an entry representing every level of this path
         std::string partial;
-        BOOST_FOREACH(std::string component, components)
+        for (std::string component : components)
         {
             append(partial, component);
             mFilesystem.insert(partial);

--- a/indra/llui/llcommandmanager.cpp
+++ b/indra/llui/llcommandmanager.cpp
@@ -34,8 +34,6 @@
 #include "llerror.h"
 #include "llxuiparser.h"
 
-#include <boost/foreach.hpp>
-
 
 //
 // LLCommandId class
@@ -182,7 +180,7 @@ bool LLCommandManager::load()
 		return false;
 	}
 
-	BOOST_FOREACH(LLCommand::Params& commandParams, commandsParams.commands)
+	for (const LLCommand::Params& commandParams : commandsParams.commands)
 	{
 		LLCommand * command = new LLCommand(commandParams);
 

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -59,7 +59,6 @@
 #include "llmultifloater.h"
 #include "llsdutil.h"
 #include "lluiusage.h"
-#include <boost/foreach.hpp>
 
 
 // use this to control "jumping" behavior when Ctrl-Tabbing
@@ -2385,7 +2384,7 @@ void LLFloaterView::reshape(S32 width, S32 height, BOOL called_from_parent)
 			//{
 			//	floaterp->translate(translate_x, translate_y);
 			//}
-			BOOST_FOREACH(LLHandle<LLFloater> dependent_floater, floaterp->mDependents)
+			for (LLHandle<LLFloater> dependent_floater : floaterp->mDependents)
 			{
 				if (dependent_floater.get())
 				{
@@ -2400,10 +2399,9 @@ void LLFloaterView::reshape(S32 width, S32 height, BOOL called_from_parent)
 void LLFloaterView::restoreAll()
 {
 	// make sure all subwindows aren't minimized
-	child_list_t child_list = *(getChildList());
-	for (child_list_const_iter_t child_it = child_list.begin(); child_it != child_list.end(); ++child_it)
+	for (auto child : *getChildList())
 	{
-		LLFloater* floaterp = dynamic_cast<LLFloater*>(*child_it);
+		LLFloater* floaterp = dynamic_cast<LLFloater*>(child);
 		if (floaterp)
 		{
 			floaterp->setMinimized(FALSE);

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -395,8 +395,7 @@ void LLLayoutStack::updateLayout()
 							: getRect().getHeight();
 
 	// first, assign minimum dimensions
-	LLLayoutPanel* panelp = NULL;
-	BOOST_FOREACH(panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (panelp->mAutoResize)
 		{
@@ -409,12 +408,15 @@ void LLLayoutStack::updateLayout()
 	llassert(total_visible_fraction < 1.05f);
 
 	// don't need spacing after last panel
-	space_to_distribute += panelp ? ll_round((F32)mPanelSpacing * panelp->getVisibleAmount()) : 0;
+	{
+		LLLayoutPanel* panelp = mPanels.empty() ? nullptr : mPanels.back();
+		space_to_distribute += panelp ? ll_round((F32)mPanelSpacing * panelp->getVisibleAmount()) : 0;
+	}
 
 	S32 remaining_space = space_to_distribute;
 	if (space_to_distribute > 0 && total_visible_fraction > 0.f)
 	{	// give space proportionally to visible auto resize panels
-		BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+		for (LLLayoutPanel* panelp : mPanels)
 		{
 			if (panelp->mAutoResize)
 			{
@@ -427,7 +429,7 @@ void LLLayoutStack::updateLayout()
 	}
 
 	// distribute any left over pixels to non-collapsed, visible panels
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (remaining_space == 0) break;
 
@@ -443,7 +445,7 @@ void LLLayoutStack::updateLayout()
 
 	F32 cur_pos = (mOrientation == HORIZONTAL) ? 0.f : (F32)getRect().getHeight();
 
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		F32 panel_dim = llmax(panelp->getExpandedMinDim(), panelp->mTargetDim);
 
@@ -538,7 +540,7 @@ LLLayoutPanel* LLLayoutStack::findEmbeddedPanel(LLPanel* panelp) const
 {
 	if (!panelp) return NULL;
 
-	BOOST_FOREACH(LLLayoutPanel* p, mPanels)
+	for (LLLayoutPanel* p : mPanels)
 	{
 		if (p == panelp)
 		{
@@ -552,7 +554,7 @@ LLLayoutPanel* LLLayoutStack::findEmbeddedPanelByName(const std::string& name) c
 {
 	LLLayoutPanel* result = NULL;
 
-	BOOST_FOREACH(LLLayoutPanel* p, mPanels)
+	for (LLLayoutPanel* p : mPanels)
 	{
 		if (p->getName() == name)
 		{
@@ -566,7 +568,7 @@ LLLayoutPanel* LLLayoutStack::findEmbeddedPanelByName(const std::string& name) c
 
 void LLLayoutStack::createResizeBar(LLLayoutPanel* panelp)
 {
-	BOOST_FOREACH(LLLayoutPanel* lp, mPanels)
+	for (LLLayoutPanel* lp : mPanels)
 	{
 		if (lp->mResizeBar == NULL)
 		{
@@ -669,7 +671,7 @@ void LLLayoutStack::updateFractionalSizes()
 {
 	F32 total_resizable_dim = 0.f;
 
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (panelp->mAutoResize)
 		{
@@ -677,7 +679,7 @@ void LLLayoutStack::updateFractionalSizes()
 		}
 	}
 
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (panelp->mAutoResize)
 		{
@@ -698,7 +700,7 @@ void LLLayoutStack::normalizeFractionalSizes()
 	S32 num_auto_resize_panels = 0;
 	F32 total_fractional_size = 0.f;
 	
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (panelp->mAutoResize)
 		{
@@ -709,7 +711,7 @@ void LLLayoutStack::normalizeFractionalSizes()
 
 	if (total_fractional_size == 0.f)
 	{ // equal distribution
-		BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+		for (LLLayoutPanel* panelp : mPanels)
 		{
 			if (panelp->mAutoResize)
 			{
@@ -719,7 +721,7 @@ void LLLayoutStack::normalizeFractionalSizes()
 	}
 	else
 	{ // renormalize
-		BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+		for (LLLayoutPanel* panelp : mPanels)
 		{
 			if (panelp->mAutoResize)
 			{
@@ -736,7 +738,7 @@ bool LLLayoutStack::animatePanels()
 	//
 	// animate visibility
 	//
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (panelp->getVisible())
 		{
@@ -834,7 +836,7 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
 	LLLayoutPanel* other_resize_panel = NULL;
 	LLLayoutPanel* following_panel = NULL;
 
-	BOOST_REVERSE_FOREACH(LLLayoutPanel* panelp, mPanels)
+	BOOST_REVERSE_FOREACH(LLLayoutPanel* panelp, mPanels) // Should replace this when C++20 reverse view adaptor becomes available...
 	{
 		if (panelp->mAutoResize)
 		{
@@ -883,7 +885,7 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
 		AFTER_RESIZED_PANEL
 	} which_panel = BEFORE_RESIZED_PANEL;
 
-	BOOST_FOREACH(LLLayoutPanel* panelp, mPanels)
+	for (LLLayoutPanel* panelp : mPanels)
 	{
 		if (!panelp->getVisible() || panelp->mCollapsed) 
 		{
@@ -974,6 +976,7 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
 												MIN_FRACTIONAL_SIZE,
 												MAX_FRACTIONAL_SIZE);
 			}
+			break;
 		default:
 			break;
 		}
@@ -990,8 +993,8 @@ void LLLayoutStack::reshape(S32 width, S32 height, BOOL called_from_parent)
 
 void LLLayoutStack::updateResizeBarLimits()
 {
-	LLLayoutPanel* previous_visible_panelp = NULL;
-	BOOST_REVERSE_FOREACH(LLLayoutPanel* visible_panelp, mPanels)
+	LLLayoutPanel* previous_visible_panelp{ nullptr };
+	BOOST_REVERSE_FOREACH(LLLayoutPanel* visible_panelp, mPanels) // Should replace this when C++20 reverse view adaptor becomes available...
 	{
 		if (!visible_panelp->getVisible() || visible_panelp->mCollapsed)
 		{

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -408,9 +408,9 @@ void LLLayoutStack::updateLayout()
 	llassert(total_visible_fraction < 1.05f);
 
 	// don't need spacing after last panel
+	if (!mPanels.empty())
 	{
-		LLLayoutPanel* panelp = mPanels.empty() ? nullptr : mPanels.back();
-		space_to_distribute += panelp ? ll_round((F32)mPanelSpacing * panelp->getVisibleAmount()) : 0;
+		space_to_distribute += ll_round(F32(mPanelSpacing) * mPanels.back()->getVisibleAmount());
 	}
 
 	S32 remaining_space = space_to_distribute;

--- a/indra/llui/llloadingindicator.cpp
+++ b/indra/llui/llloadingindicator.cpp
@@ -34,7 +34,6 @@
 // Project includes
 #include "lluictrlfactory.h"
 #include "lluiimage.h"
-#include "boost/foreach.hpp"
 
 // registered in llui.cpp to avoid being left out by MS linker
 //static LLDefaultChildRegistry::Register<LLLoadingIndicator> r("loading_indicator");
@@ -52,7 +51,7 @@ LLLoadingIndicator::LLLoadingIndicator(const Params& p)
 
 void LLLoadingIndicator::initFromParams(const Params& p)
 {
-	BOOST_FOREACH(LLUIImage* image, p.images().image)
+	for (LLUIImage* image : p.images().image)
 	{
 		mImages.push_back(image);
 	}

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -60,7 +60,6 @@
 #include "v2math.h"
 #include <set>
 #include <boost/tokenizer.hpp>
-#include <boost/foreach.hpp>
 
 // static
 LLMenuHolderGL *LLMenuGL::sMenuContainer = NULL;
@@ -2156,7 +2155,7 @@ void LLMenuGL::arrange( void )
 		}
 		else
 		{
-			BOOST_FOREACH(LLMenuItemGL* itemp, mItems)
+			for (LLMenuItemGL* itemp : mItems)
 			{
 				// do first so LLMenuGLItemCall can call on_visible to determine if visible
 				itemp->buildDrawLabel();

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -45,7 +45,6 @@
 
 #include <algorithm>
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 
 
 const std::string NOTIFICATION_PERSIST_VERSION = "0.93";
@@ -444,14 +443,14 @@ LLNotificationTemplate::LLNotificationTemplate(const LLNotificationTemplate::Par
 		mSoundName = p.sound;
 	}
 
-	BOOST_FOREACH(const LLNotificationTemplate::UniquenessContext& context, p.unique.contexts)
+	for (const LLNotificationTemplate::UniquenessContext& context : p.unique.contexts)
 	{
 		mUniqueContext.push_back(context.value);
 	}
 	
 	LL_DEBUGS("Notifications") << "notification \"" << mName << "\": tag count is " << p.tags.size() << LL_ENDL;
 	
-	BOOST_FOREACH(const LLNotificationTemplate::Tag& tag, p.tags)
+	for (const LLNotificationTemplate::Tag& tag : p.tags)
 	{
 		LL_DEBUGS("Notifications") << "    tag \"" << std::string(tag.value) << "\"" << LL_ENDL;
 		mTags.push_back(tag.value);
@@ -1153,7 +1152,7 @@ LLNotificationChannel::LLNotificationChannel(const Params& p)
 	LLInstanceTracker<LLNotificationChannel, std::string>(p.name.isProvided() ? p.name : LLUUID::generateNewID().asString()),
 	mName(p.name.isProvided() ? p.name : LLUUID::generateNewID().asString())
 {
-	BOOST_FOREACH(const std::string& source, p.sources)
+	for (const std::string& source : p.sources)
     {
 		connectToChannel(source);
 	}
@@ -1521,7 +1520,7 @@ void replaceFormText(LLNotificationForm::Params& form, const std::string& patter
 		form.ignore.text = replace;
 	}
 
-	BOOST_FOREACH(LLNotificationForm::FormElement& element, form.form_elements.elements)
+	for (LLNotificationForm::FormElement& element : form.form_elements.elements)
 	{
 		if (element.button.isChosen() && element.button.text() == pattern)
 		{
@@ -1569,19 +1568,19 @@ bool LLNotifications::loadTemplates()
 
 	mTemplates.clear();
 
-	BOOST_FOREACH(LLNotificationTemplate::GlobalString& string, params.strings)
+	for (const LLNotificationTemplate::GlobalString& string : params.strings)
 	{
 		mGlobalStrings[string.name] = string.value;
 	}
 
 	std::map<std::string, LLNotificationForm::Params> form_templates;
 
-	BOOST_FOREACH(LLNotificationTemplate::Template& notification_template, params.templates)
+	for (const LLNotificationTemplate::Template& notification_template : params.templates)
 	{
 		form_templates[notification_template.name] = notification_template.form;
 	}
 
-	BOOST_FOREACH(LLNotificationTemplate::Params& notification, params.notifications)
+	for (LLNotificationTemplate::Params& notification : params.notifications)
 	{
 		if (notification.form_ref.form_template.isChosen())
 		{
@@ -1635,7 +1634,7 @@ bool LLNotifications::loadVisibilityRules()
 
 	mVisibilityRules.clear();
 
-	BOOST_FOREACH(LLNotificationVisibilityRule::Rule& rule, params.rules)
+	for (const LLNotificationVisibilityRule::Rule& rule : params.rules)
 	{
 		mVisibilityRules.push_back(LLNotificationVisibilityRulePtr(new LLNotificationVisibilityRule(rule)));
 	}

--- a/indra/llui/llnotificationslistener.cpp
+++ b/indra/llui/llnotificationslistener.cpp
@@ -32,7 +32,6 @@
 #include "llnotificationtemplate.h"
 #include "llsd.h"
 #include "llui.h"
-#include <boost/foreach.hpp>
 
 LLNotificationsListener::LLNotificationsListener(LLNotifications & notifications) :
     LLEventAPI("LLNotifications",

--- a/indra/llui/lltoolbar.cpp
+++ b/indra/llui/lltoolbar.cpp
@@ -27,7 +27,6 @@
 
 #include "linden_common.h"
 
-#include <boost/foreach.hpp>
 #include "lltoolbar.h"
 
 #include "llcommandmanager.h"
@@ -219,7 +218,7 @@ void LLToolBar::initFromParams(const LLToolBar::Params& p)
 	
 	mCenteringStack->addChild(LLUICtrlFactory::create<LLLayoutPanel>(border_panel_p));
 
-	BOOST_FOREACH(LLCommandId id, p.commands)
+	for (const LLCommandId& id : p.commands)
 	{
 		addCommand(id);
 	}
@@ -417,7 +416,7 @@ BOOL LLToolBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		// Determine which button the mouse was over during the click in case the context menu action
 		// is intended to affect the button.
 		mRightMouseTargetButton = NULL;
-		BOOST_FOREACH(LLToolBarButton* button, mButtons)
+		for (LLToolBarButton* button : mButtons)
 		{
 			LLRect button_rect;
 			button->localRectToOtherView(button->getLocalRect(), &button_rect, this);
@@ -505,7 +504,7 @@ void LLToolBar::setButtonType(LLToolBarEnums::ButtonType button_type)
 void LLToolBar::resizeButtonsInRow(std::vector<LLToolBarButton*>& buttons_in_row, S32 max_row_girth)
 {
 	// make buttons in current row all same girth
-	BOOST_FOREACH(LLToolBarButton* button, buttons_in_row)
+	for (LLToolBarButton* button : buttons_in_row)
 	{
 		if (getOrientation(mSideType) == LLLayoutStack::HORIZONTAL)
 		{
@@ -693,7 +692,7 @@ void LLToolBar::updateLayoutAsNeeded()
 
 	std::vector<LLToolBarButton*> buttons_in_row;
 
-	BOOST_FOREACH(LLToolBarButton* button, mButtons)
+	for (LLToolBarButton* button : mButtons)
 	{
 		button->reshape(button->mWidthRange.getMin(), button->mDesiredHeight);
 		button->autoResize();
@@ -878,7 +877,7 @@ void LLToolBar::createButtons()
 {
 	std::set<LLUUID> set_flashing;
 
-	BOOST_FOREACH(LLToolBarButton* button, mButtons)
+	for (LLToolBarButton* button : mButtons)
 	{
         if (button->getFlashTimer() && button->getFlashTimer()->isFlashingInProgress())
         {
@@ -896,7 +895,7 @@ void LLToolBar::createButtons()
 	mButtonMap.clear();
 	mRightMouseTargetButton = NULL;
 	
-	BOOST_FOREACH(LLCommandId& command_id, mButtonCommands)
+	for (const LLCommandId& command_id : mButtonCommands)
 	{
 		LLToolBarButton* button = createButton(command_id);
 		mButtons.push_back(button);

--- a/indra/llui/lluicolortable.cpp
+++ b/indra/llui/lluicolortable.cpp
@@ -32,7 +32,6 @@
 #include "llui.h"
 #include "lluicolortable.h"
 #include "lluictrlfactory.h"
-#include <boost/foreach.hpp>
 
 LLUIColorTable::ColorParams::ColorParams()
 :	value("value"),
@@ -208,7 +207,7 @@ bool LLUIColorTable::loadFromSettings()
 
 	// pass constraint=LLDir::ALL_SKINS because we want colors.xml from every
 	// skin dir
-	BOOST_FOREACH(std::string colors_path,
+	for (const std::string& colors_path :
 				  gDirUtilp->findSkinnedFilenames(LLDir::SKINBASE, "colors.xml", LLDir::ALL_SKINS))
 	{
 		result |= loadFromFilename(colors_path, mLoadedColors);

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -32,7 +32,6 @@
 
 #include <sstream>
 #include <boost/tokenizer.hpp>
-#include <boost/foreach.hpp>
 #include <boost/bind.hpp>
 
 #include "llrender.h"
@@ -592,7 +591,7 @@ void LLView::deleteAllChildren()
 
 void LLView::setAllChildrenEnabled(BOOL b)
 {
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		viewp->setEnabled(b);
 	}
@@ -621,7 +620,7 @@ void LLView::onVisibilityChange ( BOOL new_visibility )
 {
 	BOOL old_visibility;
 	BOOL log_visibility_change = LLViewerEventRecorder::instance().getLoggingStatus();
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		if (!viewp)
 		{
@@ -725,7 +724,7 @@ LLView* LLView::childrenHandleCharEvent(const std::string& desc, const METHOD& m
 {
 	if ( getVisible() && getEnabled() )
 	{
-		BOOST_FOREACH(LLView* viewp, mChildList)
+		for (LLView* viewp : mChildList)
 		{
 			if ((viewp->*method)(c, mask, TRUE))
 			{
@@ -744,7 +743,7 @@ LLView* LLView::childrenHandleCharEvent(const std::string& desc, const METHOD& m
 template <typename METHOD, typename XDATA>
 LLView* LLView::childrenHandleMouseEvent(const METHOD& method, S32 x, S32 y, XDATA extra, bool allow_mouse_block)
 {
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		S32 local_x = x - viewp->getRect().mLeft;
 		S32 local_y = y - viewp->getRect().mBottom;
@@ -773,7 +772,7 @@ LLView* LLView::childrenHandleMouseEvent(const METHOD& method, S32 x, S32 y, XDA
 
 LLView* LLView::childrenHandleToolTip(S32 x, S32 y, MASK mask)
 {
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		S32 local_x = x - viewp->getRect().mLeft;
 		S32 local_y = y - viewp->getRect().mBottom;
@@ -805,7 +804,7 @@ LLView* LLView::childrenHandleDragAndDrop(S32 x, S32 y, MASK mask,
 	// default to not accepting drag and drop, will be overridden by handler
 	*accept = ACCEPT_NO;
 
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		S32 local_x = x - viewp->getRect().mLeft;
 		S32 local_y = y - viewp->getRect().mBottom;
@@ -831,7 +830,7 @@ LLView* LLView::childrenHandleDragAndDrop(S32 x, S32 y, MASK mask,
 
 LLView* LLView::childrenHandleHover(S32 x, S32 y, MASK mask)
 {
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		S32 local_x = x - viewp->getRect().mLeft;
 		S32 local_y = y - viewp->getRect().mBottom;
@@ -859,7 +858,7 @@ LLView*	LLView::childFromPoint(S32 x, S32 y, bool recur)
 	if (!getVisible())
 		return NULL;
 
-	BOOST_FOREACH(LLView* viewp, mChildList)
+	for (LLView* viewp : mChildList)
 	{
 		S32 local_x = x - viewp->getRect().mLeft;
 		S32 local_y = y - viewp->getRect().mBottom;
@@ -1379,7 +1378,7 @@ void LLView::reshape(S32 width, S32 height, BOOL called_from_parent)
 		mRect.mTop = getRect().mBottom + height;
 
 		// move child views according to reshape flags
-		BOOST_FOREACH(LLView* viewp, mChildList)
+		for (LLView* viewp : mChildList)
 		{
 			if (viewp != NULL)
 			{
@@ -1451,7 +1450,7 @@ LLRect LLView::calcBoundingRect()
 {
 	LLRect local_bounding_rect = LLRect::null;
 
-	BOOST_FOREACH(LLView* childp, mChildList)
+	for (LLView* childp : mChildList)
 	{
 		// ignore invisible and "top" children when calculating bounding rect
 		// such as combobox popups
@@ -1614,7 +1613,7 @@ LLView* LLView::findChildView(const std::string& name, BOOL recurse) const
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 	
     // Look for direct children *first*
-	BOOST_FOREACH(LLView* childp, mChildList)
+	for (LLView* childp : mChildList)
 	{
 		llassert(childp);
 		if (childp->getName() == name)
@@ -1625,7 +1624,7 @@ LLView* LLView::findChildView(const std::string& name, BOOL recurse) const
 	if (recurse)
 	{
 		// Look inside each child as well.
-		BOOST_FOREACH(LLView* childp, mChildList)
+		for (LLView* childp : mChildList)
 		{
 			llassert(childp);
 			LLView* viewp = childp->findChildView(name, recurse);
@@ -2800,7 +2799,7 @@ S32	LLView::notifyParent(const LLSD& info)
 bool	LLView::notifyChildren(const LLSD& info)
 {
 	bool ret = false;
-	BOOST_FOREACH(LLView* childp, mChildList)
+	for (LLView* childp : mChildList)
 	{
 		ret = ret || childp->notifyChildren(info);
 	}

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -95,7 +95,6 @@
 #include "llworld.h"
 #include "llworldmap.h"
 #include "stringize.h"
-#include "boost/foreach.hpp"
 #include "llcorehttputil.h"
 #include "lluiusage.h"
 
@@ -2329,7 +2328,7 @@ void LLAgent::endAnimationUpdateUI()
 			LLFloaterIMContainer* im_box = LLFloaterReg::getTypedInstance<LLFloaterIMContainer>("im_container");
 			LLFloaterIMContainer::floater_list_t conversations;
 			im_box->getDetachedConversationFloaters(conversations);
-			BOOST_FOREACH(LLFloater* conversation, conversations)
+			for (LLFloater* conversation : conversations)
 			{
 				LL_INFOS() << "skip_list.insert(session_floater): " << conversation->getTitle() << LL_ENDL;
 				skip_list.insert(conversation);

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -27,7 +27,6 @@
 #include "llviewerprecompiledheaders.h"
 
 #include <boost/lexical_cast.hpp>
-#include <boost/foreach.hpp>
 #include "llaccordionctrltab.h"
 #include "llagent.h"
 #include "llagentcamera.h"
@@ -1647,7 +1646,7 @@ void LLAppearanceMgr::removeOutfitPhoto(const LLUUID& outfit_id)
         sub_cat_array,
         outfit_item_array,
         LLInventoryModel::EXCLUDE_TRASH);
-    BOOST_FOREACH(LLViewerInventoryItem* outfit_item, outfit_item_array)
+    for (LLViewerInventoryItem* outfit_item : outfit_item_array)
     {
         LLViewerInventoryItem* linked_item = outfit_item->getLinkedItem();
         if (linked_item != NULL)
@@ -3438,7 +3437,7 @@ void update_base_outfit_after_ordering()
 								sub_cat_array,
 								outfit_item_array,
 								LLInventoryModel::EXCLUDE_TRASH);
-	BOOST_FOREACH(LLViewerInventoryItem* outfit_item, outfit_item_array)
+	for (LLViewerInventoryItem* outfit_item : outfit_item_array)
 	{
 		LLViewerInventoryItem* linked_item = outfit_item->getLinkedItem();
 		if (linked_item != NULL)

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -143,7 +143,6 @@
 
 // Third party library includes
 #include <boost/bind.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 #include <boost/throw_exception.hpp>
@@ -1207,7 +1206,7 @@ bool LLAppViewer::init()
             LLSD item(LeapCommand);
             LeapCommand.append(item);
         }
-        BOOST_FOREACH(const std::string& leap, llsd::inArray(LeapCommand))
+        for (const std::string& leap : llsd::inArray(LeapCommand))
         {
             LL_INFOS("InitInfo") << "processing --leap \"" << leap << '"' << LL_ENDL;
             // We don't have any better description of this plugin than the
@@ -2357,7 +2356,7 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
 		LL_ERRS() << "Invalid settings location list" << LL_ENDL;
 	}
 
-	BOOST_FOREACH(const SettingsGroup& group, mSettingsLocationList->groups)
+	for (const SettingsGroup& group : mSettingsLocationList->groups)
 	{
 		// skip settings groups that aren't the one we requested
 		if (group.name() != location_key) continue;
@@ -2369,7 +2368,7 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
 			return false;
 		}
 
-		BOOST_FOREACH(const SettingsFile& file, group.files)
+		for (const SettingsFile& file : group.files)
 		{
 			LL_INFOS("Settings") << "Attempting to load settings for the group " << file.name()
 			    << " - from location " << location_key << LL_ENDL;
@@ -2433,11 +2432,11 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
 std::string LLAppViewer::getSettingsFilename(const std::string& location_key,
 											 const std::string& file)
 {
-	BOOST_FOREACH(const SettingsGroup& group, mSettingsLocationList->groups)
+	for (const SettingsGroup& group : mSettingsLocationList->groups)
 	{
 		if (group.name() == location_key)
 		{
-			BOOST_FOREACH(const SettingsFile& settings_file, group.files)
+			for (const SettingsFile& settings_file : group.files)
 			{
 				if (settings_file.name() == file)
 				{
@@ -3017,7 +3016,7 @@ void LLAppViewer::initStrings()
 	// Now that we've set "[sourceid]", have to go back through
 	// default_trans_args and reinitialize all those other keys because some
 	// of them, in turn, reference "[sourceid]".
-	BOOST_FOREACH(std::string key, default_trans_args)
+	for (const std::string& key : default_trans_args)
 	{
 		std::string brackets(key), nobrackets(key);
 		// Invalid to inspect key[0] if key is empty(). But then, the entire

--- a/indra/newview/llconversationlog.cpp
+++ b/indra/newview/llconversationlog.cpp
@@ -32,7 +32,6 @@
 #include "llnotificationsutil.h"
 #include "lltrans.h"
 
-#include <boost/foreach.hpp>
 #include "boost/lexical_cast.hpp"
 
 const S32Days CONVERSATION_LIFETIME = (S32Days)30; // lifetime of LLConversation is 30 days by spec
@@ -392,7 +391,7 @@ void LLConversationLog::deleteBackupLogs()
 	std::vector<std::string> backup_logs;
 	getListOfBackupLogs(backup_logs);
 
-	BOOST_FOREACH(const std::string& fullpath, backup_logs)
+	for (const std::string& fullpath : backup_logs)
 	{
 		LLFile::remove(fullpath);
 	}

--- a/indra/newview/llconversationmodel.cpp
+++ b/indra/newview/llconversationmodel.cpp
@@ -37,8 +37,6 @@
 #include "llimview.h" //For LLIMModel
 #include "lltrans.h"
 
-#include <boost/foreach.hpp>
-
 //
 // Conversation items : common behaviors
 //
@@ -293,8 +291,7 @@ void LLConversationItemSession::updateName(LLConversationItemParticipant* partic
 		// In the case of a P2P conversation, we need to grab the name of the other participant in the session instance itself
 		// as we do not create participants for such a session.
 
-		LLFolderViewModelItem * itemp;
-		BOOST_FOREACH(itemp, mChildren)
+		for (auto itemp : mChildren)
 		{
 			LLConversationItem* current_participant = dynamic_cast<LLConversationItem*>(itemp);
 			// Add the avatar uuid to the list (except if it's the own agent uuid)

--- a/indra/newview/llexternaleditor.cpp
+++ b/indra/newview/llexternaleditor.cpp
@@ -32,7 +32,6 @@
 #include "llprocess.h"
 #include "llsdutil.h"
 #include "llstring.h"
-#include <boost/foreach.hpp>
 
 // static
 const std::string LLExternalEditor::sFilenameMarker = "%s";
@@ -93,7 +92,7 @@ LLExternalEditor::EErrorCode LLExternalEditor::run(const std::string& file_path)
 	params.executable = mProcessParams.executable;
 
 	// Substitute the filename marker in the command with the actual passed file name.
-	BOOST_FOREACH(const std::string& arg, mProcessParams.args)
+	for (const std::string& arg : mProcessParams.args)
 	{
 		std::string fixed(arg);
 		LLStringUtil::replaceString(fixed, sFilenameMarker, file_path);

--- a/indra/newview/llfloaterimcontainer.cpp
+++ b/indra/newview/llfloaterimcontainer.cpp
@@ -57,7 +57,6 @@
 #include "llsdserialize.h"
 #include "llviewermenu.h" // is_agent_mappable
 #include "llviewerobjectlist.h"
-#include "boost/foreach.hpp"
 
 
 const S32 EVENTS_PER_IDLE_LOOP_CURRENT_SESSION = 80;
@@ -808,9 +807,9 @@ void LLFloaterIMContainer::getDetachedConversationFloaters(floater_list_t& float
 	typedef conversations_widgets_map::value_type conv_pair;
 	LLFloaterIMNearbyChat *nearby_chat = LLFloaterReg::findTypedInstance<LLFloaterIMNearbyChat>("nearby_chat");
 
-	BOOST_FOREACH(conv_pair item, mConversationsWidgets)
+	for (const auto& [key, fvi] : mConversationsWidgets)
 	{
-		LLConversationViewSession* widget = dynamic_cast<LLConversationViewSession*>(item.second);
+		LLConversationViewSession* widget = dynamic_cast<LLConversationViewSession*>(fvi);
 		if (widget)
 		{
 			LLFloater* session_floater = widget->getSessionFloater();

--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -91,8 +91,6 @@
 #include "llvoavatarself.h"
 #include "llwearablelist.h"
 
-#include <boost/foreach.hpp>
-
 BOOL LLInventoryState::sWearNewClothing = FALSE;
 LLUUID LLInventoryState::sWearNewClothingTransactionID;
 std::list<LLUUID> LLInventoryAction::sMarketplaceFolders;

--- a/indra/newview/lllogchat.cpp
+++ b/indra/newview/lllogchat.cpp
@@ -42,7 +42,6 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/regex.hpp>
-#include <boost/foreach.hpp>
 
 #if LL_MSVC
 #pragma warning(push)  
@@ -709,7 +708,7 @@ bool LLLogChat::moveTranscripts(const std::string originDirectory,
 	std::string backupFileName;
 	unsigned backupFileCount;
 
-	BOOST_FOREACH(const std::string& fullpath, listOfFilesToMove)
+	for (const std::string& fullpath : listOfFilesToMove)
 	{
 		backupFileCount = 0;
 		newFullPath = targetDirectory + fullpath.substr(originDirectory.length(), std::string::npos);
@@ -780,7 +779,7 @@ void LLLogChat::deleteTranscripts()
 	getListOfTranscriptFiles(list_of_transcriptions);
 	getListOfTranscriptBackupFiles(list_of_transcriptions);
 
-	BOOST_FOREACH(const std::string& fullpath, list_of_transcriptions)
+	for (const std::string& fullpath : list_of_transcriptions)
 	{
 		S32 retry_count = 0;
 		while (retry_count < 5)

--- a/indra/newview/llmarketplacenotifications.cpp
+++ b/indra/newview/llmarketplacenotifications.cpp
@@ -33,7 +33,6 @@
 
 #include "llerror.h"
 
-#include <boost/foreach.hpp>
 #include <boost/signals2.hpp>
 
 
@@ -54,7 +53,7 @@ namespace LLMarketplaceInventoryNotifications
 			llassert(!no_copy_payloads.empty());
 			llassert(no_copy_cb_action != NULL);
 			
-			BOOST_FOREACH(const LLSD& payload, no_copy_payloads)
+			for (const LLSD& payload : no_copy_payloads)
 			{
 				(*no_copy_cb_action)(payload);
 			}

--- a/indra/newview/llnotificationmanager.cpp
+++ b/indra/newview/llnotificationmanager.cpp
@@ -34,9 +34,6 @@
 #include "llfloaterimnearbychathandler.h"
 #include "llnotifications.h"
 
-#include <boost/bind.hpp>
-#include <boost/foreach.hpp>
-
 using namespace LLNotificationsUI;
 
 //--------------------------------------------------------------------------
@@ -53,15 +50,15 @@ LLNotificationManager::~LLNotificationManager()
 //--------------------------------------------------------------------------
 void LLNotificationManager::init()
 {
-	mChannels.push_back(new LLScriptHandler());
-	mChannels.push_back(new LLTipHandler());
-	mChannels.push_back(new LLGroupHandler());
-	mChannels.push_back(new LLAlertHandler("Alerts", "alert", false));
-	mChannels.push_back(new LLAlertHandler("AlertModal", "alertmodal", true));
-	mChannels.push_back(new LLOfferHandler());
-	mChannels.push_back(new LLHintHandler());
-	mChannels.push_back(new LLBrowserNotification());
-	mChannels.push_back(new LLIMHandler());
+	mChannels.emplace_back(new LLScriptHandler());
+	mChannels.emplace_back(new LLTipHandler());
+	mChannels.emplace_back(new LLGroupHandler());
+	mChannels.emplace_back(new LLAlertHandler("Alerts", "alert", false));
+	mChannels.emplace_back(new LLAlertHandler("AlertModal", "alertmodal", true));
+	mChannels.emplace_back(new LLOfferHandler());
+	mChannels.emplace_back(new LLHintHandler());
+	mChannels.emplace_back(new LLBrowserNotification());
+	mChannels.emplace_back(new LLIMHandler());
   
 	mChatHandler = std::shared_ptr<LLFloaterIMNearbyChatHandler>(new LLFloaterIMNearbyChatHandler());
 }

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -28,8 +28,6 @@
 #include "llviewerprecompiledheaders.h" // must be first include
 #include "lloutfitgallery.h"
 
-#include <boost/foreach.hpp>
-
 // llcommon
 #include "llcommonutils.h"
 #include "llfilesystem.h"
@@ -1253,7 +1251,7 @@ void LLOutfitGallery::refreshOutfit(const LLUUID& category_id)
                 sub_cat_array,
                 outfit_item_array,
                 LLInventoryModel::EXCLUDE_TRASH);
-            BOOST_FOREACH(LLViewerInventoryItem* outfit_item, outfit_item_array)
+            for (LLViewerInventoryItem* outfit_item : outfit_item_array)
             {
                 LLViewerInventoryItem* linked_item = outfit_item->getLinkedItem();
                 LLUUID asset_id, inv_id;

--- a/indra/newview/llpanelexperiencelisteditor.cpp
+++ b/indra/newview/llpanelexperiencelisteditor.cpp
@@ -40,7 +40,6 @@
 #include "lltextbox.h"
 #include "lltrans.h"
 #include "llsdutil.h"
-#include <boost/foreach.hpp>
 
 
 static LLPanelInjector<LLPanelExperienceListEditor> t_panel_experience_list_editor("panel_experience_list_editor");
@@ -96,7 +95,7 @@ void LLPanelExperienceListEditor::addExperienceIds( const uuid_vec_t& experience
 void LLPanelExperienceListEditor::setExperienceIds( const LLSD& experience_ids )
 {
 	mExperienceIds.clear();
-	BOOST_FOREACH(LLSD uuid, llsd::inArray(experience_ids))
+	for (LLSD uuid : llsd::inArray(experience_ids))
 	{
 		// Using insert(range) doesn't work here because the conversion from
 		// LLSD to LLUUID is ambiguous: have to specify asUUID() for each entry.

--- a/indra/newview/llpanelgroupbulkban.cpp
+++ b/indra/newview/llpanelgroupbulkban.cpp
@@ -49,8 +49,6 @@
 #include "lluictrlfactory.h"
 #include "llviewerwindow.h"
 
-#include <boost/foreach.hpp>
-
 LLPanelGroupBulkBan::LLPanelGroupBulkBan(const LLUUID& group_id) : LLPanelGroupBulk(group_id)
 {
 	// Pass on construction of this panel to the control factory.
@@ -163,8 +161,8 @@ void LLPanelGroupBulkBan::submit()
 	// remove already banned users and yourself from request.
 	std::vector<LLAvatarName> banned_avatar_names;
 	std::vector<LLAvatarName> out_of_limit_names;
-	bool banning_self = FALSE;
-	std::vector<LLUUID>::iterator conflict = std::find(banned_agent_list.begin(), banned_agent_list.end(), gAgent.getID());
+	bool banning_self{ false };
+	std::vector<LLUUID>::iterator conflict = std::find(banned_agent_list.begin(), banned_agent_list.end(), gAgentID);
 	if (conflict != banned_agent_list.end())
 	{
 		banned_agent_list.erase(conflict);
@@ -172,18 +170,17 @@ void LLPanelGroupBulkBan::submit()
 	}
 	if (group_datap)
 	{
-		BOOST_FOREACH(const LLGroupMgrGroupData::ban_list_t::value_type& group_ban_pair, group_datap->mBanList)
+		for (const auto& [group_ban_agent_id, group_ban_data] : group_datap->mBanList)
 		{
-			const LLUUID& group_ban_agent_id = group_ban_pair.first;
 			std::vector<LLUUID>::iterator conflict = std::find(banned_agent_list.begin(), banned_agent_list.end(), group_ban_agent_id);
 			if (conflict != banned_agent_list.end())
 			{
 				LLAvatarName av_name;
 				LLAvatarNameCache::get(group_ban_agent_id, &av_name);
-				banned_avatar_names.push_back(av_name);
+				banned_avatar_names.emplace_back(av_name);
 
 				banned_agent_list.erase(conflict);
-				if (banned_agent_list.size() == 0)
+				if (banned_agent_list.empty())
 				{
 					break;
 				}

--- a/indra/newview/lltoolbarview.cpp
+++ b/indra/newview/lltoolbarview.cpp
@@ -46,8 +46,6 @@
 #include "llviewercontrol.h"  // HACK for destinations guide on startup
 #include "llinventorymodel.h" // HACK to disable starter avatars button for NUX
 
-#include <boost/foreach.hpp>
-
 LLToolBarView* gToolBarView = NULL;
 
 static LLDefaultChildRegistry::Register<LLToolBarView> r("toolbar_view");
@@ -282,7 +280,7 @@ bool LLToolBarView::loadToolbars(bool force_default)
 			LLToolBarEnums::ButtonType button_type = toolbar_set.left_toolbar.button_display_mode;
 			mToolbars[LLToolBarEnums::TOOLBAR_LEFT]->setButtonType(button_type);
 		}
-		BOOST_FOREACH(const LLCommandId::Params& command_params, toolbar_set.left_toolbar.commands)
+		for (const LLCommandId::Params& command_params : toolbar_set.left_toolbar.commands)
 		{
 			if (!addCommandInternal(LLCommandId(command_params), mToolbars[LLToolBarEnums::TOOLBAR_LEFT]))
 			{
@@ -297,7 +295,7 @@ bool LLToolBarView::loadToolbars(bool force_default)
 			LLToolBarEnums::ButtonType button_type = toolbar_set.right_toolbar.button_display_mode;
 			mToolbars[LLToolBarEnums::TOOLBAR_RIGHT]->setButtonType(button_type);
 		}
-		BOOST_FOREACH(const LLCommandId::Params& command_params, toolbar_set.right_toolbar.commands)
+		for (const LLCommandId::Params& command_params : toolbar_set.right_toolbar.commands)
 		{
 			if (!addCommandInternal(LLCommandId(command_params), mToolbars[LLToolBarEnums::TOOLBAR_RIGHT]))
 			{
@@ -312,7 +310,7 @@ bool LLToolBarView::loadToolbars(bool force_default)
 			LLToolBarEnums::ButtonType button_type = toolbar_set.bottom_toolbar.button_display_mode;
 			mToolbars[LLToolBarEnums::TOOLBAR_BOTTOM]->setButtonType(button_type);
 		}
-		BOOST_FOREACH(const LLCommandId::Params& command_params, toolbar_set.bottom_toolbar.commands)
+		for (const LLCommandId::Params& command_params : toolbar_set.bottom_toolbar.commands)
 		{
 			if (!addCommandInternal(LLCommandId(command_params), mToolbars[LLToolBarEnums::TOOLBAR_BOTTOM]))
 			{

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -119,8 +119,6 @@
 #include "llviewerregion.h"
 #include "llfloaterregionrestarting.h"
 
-#include <boost/foreach.hpp>
-
 #include "llnotificationmanager.h" //
 #include "llexperiencecache.h"
 
@@ -5620,7 +5618,7 @@ void notify_cautioned_script_question(const LLSD& notification, const LLSD& resp
 		BOOL caution = FALSE;
 		S32 count = 0;
 		std::string perms;
-		BOOST_FOREACH(script_perm_t script_perm, SCRIPT_PERMISSIONS)
+		for (const script_perm_t& script_perm : SCRIPT_PERMISSIONS)
 		{
 			if ((orig_questions & script_perm.permbit)
 				&& script_perm.caution)
@@ -5864,7 +5862,7 @@ void process_script_question(LLMessageSystem *msg, void **user_data)
 		S32 known_questions = 0;
 		bool has_not_only_debit = questions ^ SCRIPT_PERMISSIONS[SCRIPT_PERMISSION_DEBIT].permbit;
 		// check the received permission flags against each permission
-		BOOST_FOREACH(script_perm_t script_perm, SCRIPT_PERMISSIONS)
+		for (const script_perm_t& script_perm : SCRIPT_PERMISSIONS)
 		{
 			if (questions & script_perm.permbit)
 			{


### PR DESCRIPTION
This replaces BOOST_FOREACH with the C++ standard range-based for-loops and eliminates the include of the boost/foreach.hpp header. Unfortunately, there are two occurrances of BOOST_REVERSE_FOREACH in lllayoutstack.cpp. These should be easy to replace once the C++ standard is switched to C++20, which allows the use of std::ranges::view::reverse adaptor.