### PR TITLE
SL-19555 Fix picker failing to highlight default material in inventory

### DIFF
--- a/indra/newview/llfloaterchangeitemthumbnail.cpp
+++ b/indra/newview/llfloaterchangeitemthumbnail.cpp
@@ -751,7 +751,8 @@ void LLFloaterChangeItemThumbnail::showTexturePicker(const LLUUID &thumbnail_id)
             PERM_NONE,
             PERM_NONE,
             FALSE,
-            NULL);
+            NULL,
+            PICK_TEXTURE);
 
         mPickerHandle = floaterp->getHandle();
 

--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -2554,6 +2554,12 @@ bool LLIsOfAssetType::operator()(LLInventoryCategory* cat, LLInventoryItem* item
 	return FALSE;
 }
 
+bool LLAssetIDAndTypeMatches::operator()(LLInventoryCategory* cat, LLInventoryItem* item)
+{
+    if (!item) return false;
+    return (item->getActualType() == mType && item->getAssetUUID() == mAssetID);
+}
+
 bool LLIsValidItemLink::operator()(LLInventoryCategory* cat, LLInventoryItem* item)
 {
 	LLViewerInventoryItem *vitem = dynamic_cast<LLViewerInventoryItem*>(item);

--- a/indra/newview/llinventoryfunctions.h
+++ b/indra/newview/llinventoryfunctions.h
@@ -278,6 +278,28 @@ protected:
 	LLAssetType::EType mType;
 };
 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Class LLAssetIDAndTypeMatches
+//
+// Implementation of a LLInventoryCollectFunctor which returns TRUE if
+// the item matches both asset type and asset id.
+// This is needed in case you are looking for a specific type with default id
+// (since null is default for multiple asset types)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class LLAssetIDAndTypeMatches: public LLInventoryCollectFunctor
+{
+public:
+    LLAssetIDAndTypeMatches(const LLUUID& asset_id, LLAssetType::EType type): mAssetID(asset_id), mType(type) {}
+    virtual ~LLAssetIDAndTypeMatches() {}
+    bool operator()(LLInventoryCategory* cat,
+                    LLInventoryItem* item);
+
+protected:
+    LLUUID mAssetID;
+    LLAssetType::EType mType;
+};
+
 class LLIsValidItemLink : public LLInventoryCollectFunctor
 {
 public:

--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -330,7 +330,7 @@ BOOL	LLPanelFace::postBuild()
         pbr_ctrl->setImmediateFilterPermMask(PERM_NONE);
         pbr_ctrl->setDnDFilterPermMask(PERM_COPY | PERM_TRANSFER);
         pbr_ctrl->setBakeTextureEnabled(false);
-        pbr_ctrl->setInventoryPickType(LLTextureCtrl::PICK_MATERIAL);
+        pbr_ctrl->setInventoryPickType(PICK_MATERIAL);
     }
 
 	mTextureCtrl = getChild<LLTextureCtrl>("texture control");

--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -1969,7 +1969,8 @@ void LLPanelProfileSecondLife::onShowTexturePicker()
                 PERM_NONE,
                 PERM_NONE,
                 FALSE,
-                NULL);
+                NULL,
+                PICK_TEXTURE);
 
             mFloaterTexturePickerHandle = texture_floaterp->getHandle();
 
@@ -2304,7 +2305,8 @@ void LLPanelProfileFirstLife::onChangePhoto()
                 PERM_NONE,
                 PERM_NONE,
                 FALSE,
-                NULL);
+                NULL,
+                PICK_TEXTURE);
 
             mFloaterTexturePickerHandle = texture_floaterp->getHandle();
 

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -151,7 +151,8 @@ LLFloaterTexturePicker::LLFloaterTexturePicker(
 	PermissionMask immediate_filter_perm_mask,
 	PermissionMask dnd_filter_perm_mask,
 	BOOL can_apply_immediately,
-	LLUIImagePtr fallback_image)
+	LLUIImagePtr fallback_image,
+    EPickInventoryType pick_type)
 :	LLFloater(LLSD()),
 	mOwner( owner ),
 	mImageAssetID( image_asset_id ),
@@ -181,7 +182,7 @@ LLFloaterTexturePicker::LLFloaterTexturePicker(
 	mSetImageAssetIDCallback(NULL),
 	mOnUpdateImageStatsCallback(NULL),
 	mBakeTextureEnabled(FALSE),
-    mInventoryPickType(LLTextureCtrl::PICK_TEXTURE)
+    mInventoryPickType(pick_type)
 {
 	mCanApplyImmediately = can_apply_immediately;
 	buildFromFile("floater_texture_ctrl.xml");
@@ -225,7 +226,7 @@ void LLFloaterTexturePicker::setImageID(const LLUUID& image_id, bool set_selecti
 
                 LLInventoryItem* itemp = gInventory.getItem(inv_view->getUUID());
 
-                if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL
+                if (mInventoryPickType == PICK_MATERIAL
                     && mImageAssetID == LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID
                     && itemp && itemp->getAssetUUID().isNull())
                 {
@@ -266,7 +267,7 @@ void LLFloaterTexturePicker::setImageID(const LLUUID& image_id, bool set_selecti
 void LLFloaterTexturePicker::setImageIDFromItem(const LLInventoryItem* itemp, bool set_selection)
 {
     LLUUID asset_id = itemp->getAssetUUID();
-    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL && asset_id.isNull())
+    if (mInventoryPickType == PICK_MATERIAL && asset_id.isNull())
     {
         // If an inventory item has a null asset, consider it a valid blank material(gltf)
         asset_id = LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID;
@@ -425,11 +426,11 @@ BOOL LLFloaterTexturePicker::handleDragAndDrop(
     bool is_material = cargo_type == DAD_MATERIAL;
 
     bool allow_dnd = false;
-    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    if (mInventoryPickType == PICK_MATERIAL)
     {
         allow_dnd = is_material;
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+    else if (mInventoryPickType == PICK_TEXTURE)
     {
         allow_dnd = is_texture || is_mesh;
     }
@@ -602,9 +603,7 @@ BOOL LLFloaterTexturePicker::postBuild()
 		// don't put keyboard focus on selected item, because the selection callback
 		// will assume that this was user input
 
-		
-
-		if(!mImageAssetID.isNull())
+		if(!mImageAssetID.isNull() || mInventoryPickType == PICK_MATERIAL)
 		{
 			mInventoryPanel->setSelection(findItemID(mImageAssetID, FALSE), TAKE_FOCUS_NO);
 		}
@@ -661,7 +660,7 @@ void LLFloaterTexturePicker::draw()
         mGLTFMaterial = NULL;
         if (mImageAssetID.notNull())
         {
-            if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+            if (mInventoryPickType == PICK_MATERIAL)
             {
                 mGLTFMaterial = (LLFetchedGLTFMaterial*) gGLTFMaterialList.getMaterial(mImageAssetID);
                 llassert(mGLTFMaterial == nullptr || dynamic_cast<LLFetchedGLTFMaterial*>(gGLTFMaterialList.getMaterial(mImageAssetID)) != nullptr);
@@ -786,27 +785,43 @@ void LLFloaterTexturePicker::draw()
 
 const LLUUID& LLFloaterTexturePicker::findItemID(const LLUUID& asset_id, BOOL copyable_only, BOOL ignore_library)
 {
-    LLUUID loockup_id = asset_id;
-	if (loockup_id.isNull())
+	if (asset_id.isNull())
 	{
-        if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
-        {
-            loockup_id = LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID;
-        }
-        else
-        {
-            return LLUUID::null;
-        }
+        // null asset id means, no material or texture assigned
+        return LLUUID::null;
 	}
+
+    LLUUID loockup_id = asset_id;
+    if (mInventoryPickType == PICK_MATERIAL && loockup_id == LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID)
+    {
+        // default asset id means we are looking for an inventory item with a default asset UUID (null)
+        loockup_id = LLUUID::null;
+    }
 
 	LLViewerInventoryCategory::cat_array_t cats;
 	LLViewerInventoryItem::item_array_t items;
-	LLAssetIDMatches asset_id_matches(loockup_id);
-	gInventory.collectDescendentsIf(LLUUID::null,
-							cats,
-							items,
-							LLInventoryModel::INCLUDE_TRASH,
-							asset_id_matches);
+
+    if (loockup_id.isNull())
+    {
+        // looking for a material with a null id, null id is shared by a lot
+        // of objects as a default value, so have to filter by type as well
+        LLAssetIDAndTypeMatches matches(loockup_id, LLAssetType::AT_MATERIAL);
+        gInventory.collectDescendentsIf(LLUUID::null,
+                                        cats,
+                                        items,
+                                        LLInventoryModel::INCLUDE_TRASH,
+                                        matches);
+    }
+    else
+    {
+        LLAssetIDMatches asset_id_matches(loockup_id);
+        gInventory.collectDescendentsIf(LLUUID::null,
+                                        cats,
+                                        items,
+                                        LLInventoryModel::INCLUDE_TRASH,
+                                        asset_id_matches);
+    }
+
 
 	if (items.size())
 	{
@@ -871,7 +886,7 @@ void LLFloaterTexturePicker::commitCallback(LLTextureCtrl::ETexturePickOp op)
 
                     LLInventoryItem* itemp = gInventory.getItem(inv_view->getUUID());
 
-                    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL
+                    if (mInventoryPickType == PICK_MATERIAL
                         && mImageAssetID == LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID
                         && itemp && itemp->getAssetUUID().isNull())
                     {
@@ -1064,15 +1079,15 @@ void LLFloaterTexturePicker::onBtnAdd(void* userdata)
 {
     LLFloaterTexturePicker* self = (LLFloaterTexturePicker*)userdata;
 
-    if (self->mInventoryPickType == LLTextureCtrl::PICK_TEXTURE_MATERIAL)
+    if (self->mInventoryPickType == PICK_TEXTURE_MATERIAL)
     {
         LLFilePickerReplyThread::startPicker(boost::bind(&onPickerCallback, _1, self->getHandle()), LLFilePicker::FFLOAD_MATERIAL_TEXTURE, true);
     }
-    else if (self->mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+    else if (self->mInventoryPickType == PICK_TEXTURE)
     {
         LLFilePickerReplyThread::startPicker(boost::bind(&onPickerCallback, _1, self->getHandle()), LLFilePicker::FFLOAD_IMAGE, true);
     }
-    else if (self->mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    else if (self->mInventoryPickType == PICK_MATERIAL)
     {
         LLFilePickerReplyThread::startPicker(boost::bind(&onPickerCallback, _1, self->getHandle()), LLFilePicker::FFLOAD_MATERIAL, true);
     }
@@ -1351,7 +1366,7 @@ void LLFloaterTexturePicker::changeMode()
     getChild<LLCheckBoxCtrl>("hide_base_mesh_region")->setVisible(FALSE);// index == 2 ? TRUE : FALSE);
 
     bool pipette_visible = (index == PICKER_INVENTORY)
-        && (mInventoryPickType != LLTextureCtrl::PICK_MATERIAL);
+        && (mInventoryPickType != PICK_MATERIAL);
     mPipetteBtn->setVisible(pipette_visible);
 
     if (index == PICKER_BAKE)
@@ -1414,16 +1429,16 @@ void LLFloaterTexturePicker::refreshLocalList()
 {
     mLocalScrollCtrl->clearRows();
 
-    if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE_MATERIAL)
+    if (mInventoryPickType == PICK_TEXTURE_MATERIAL)
     {
         LLLocalBitmapMgr::getInstance()->feedScrollList(mLocalScrollCtrl);
         LLLocalGLTFMaterialMgr::getInstance()->feedScrollList(mLocalScrollCtrl);
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+    else if (mInventoryPickType == PICK_TEXTURE)
     {
         LLLocalBitmapMgr::getInstance()->feedScrollList(mLocalScrollCtrl);
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    else if (mInventoryPickType == PICK_MATERIAL)
     {
         LLLocalGLTFMaterialMgr::getInstance()->feedScrollList(mLocalScrollCtrl);
     }
@@ -1433,18 +1448,18 @@ void LLFloaterTexturePicker::refreshInventoryFilter()
 {
     U32 filter_types = 0x0;
 
-    if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE_MATERIAL)
+    if (mInventoryPickType == PICK_TEXTURE_MATERIAL)
     {
         filter_types |= 0x1 << LLInventoryType::IT_TEXTURE;
         filter_types |= 0x1 << LLInventoryType::IT_SNAPSHOT;
         filter_types |= 0x1 << LLInventoryType::IT_MATERIAL;
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+    else if (mInventoryPickType == PICK_TEXTURE)
     {
         filter_types |= 0x1 << LLInventoryType::IT_TEXTURE;
         filter_types |= 0x1 << LLInventoryType::IT_SNAPSHOT;
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    else if (mInventoryPickType == PICK_MATERIAL)
     {
         filter_types |= 0x1 << LLInventoryType::IT_MATERIAL;
     }
@@ -1479,13 +1494,13 @@ void LLFloaterTexturePicker::setBakeTextureEnabled(BOOL enabled)
 	onModeSelect(0, this);
 }
 
-void LLFloaterTexturePicker::setInventoryPickType(LLTextureCtrl::EPickInventoryType type)
+void LLFloaterTexturePicker::setInventoryPickType(EPickInventoryType type)
 {
     mInventoryPickType = type;
     refreshLocalList();
     refreshInventoryFilter();
 
-    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    if (mInventoryPickType == PICK_MATERIAL)
     {
         getChild<LLButton>("Pipette")->setVisible(false);
     }
@@ -1501,13 +1516,19 @@ void LLFloaterTexturePicker::setInventoryPickType(LLTextureCtrl::EPickInventoryT
 
         setTitle(pick + mLabel);
     }
-    else if(mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    else if(mInventoryPickType == PICK_MATERIAL)
     {
         setTitle(getString("pick_material"));
     }
     else
     {
         setTitle(getString("pick_texture"));
+    }
+
+    // refresh selection
+    if (!mImageAssetID.isNull() || mInventoryPickType == PICK_MATERIAL)
+    {
+        mInventoryPanel->setSelection(findItemID(mImageAssetID, FALSE), TAKE_FOCUS_NO);
     }
 }
 
@@ -1543,16 +1564,16 @@ void LLFloaterTexturePicker::onPickerCallback(const std::vector<std::string>& fi
         LLFloaterTexturePicker* self = (LLFloaterTexturePicker*)handle.get();
         self->mLocalScrollCtrl->clearRows();
 
-        if (self->mInventoryPickType == LLTextureCtrl::PICK_TEXTURE_MATERIAL)
+        if (self->mInventoryPickType == PICK_TEXTURE_MATERIAL)
         {
             LLLocalBitmapMgr::getInstance()->feedScrollList(self->mLocalScrollCtrl);
             LLLocalGLTFMaterialMgr::getInstance()->feedScrollList(self->mLocalScrollCtrl);
         }
-        else if (self->mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+        else if (self->mInventoryPickType == PICK_TEXTURE)
         {
             LLLocalBitmapMgr::getInstance()->feedScrollList(self->mLocalScrollCtrl);
         }
-        else if (self->mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+        else if (self->mInventoryPickType == PICK_MATERIAL)
         {
             LLLocalGLTFMaterialMgr::getInstance()->feedScrollList(self->mLocalScrollCtrl);
         }
@@ -1565,7 +1586,7 @@ void LLFloaterTexturePicker::onTextureSelect( const LLTextureEntry& te )
 	if (inventory_item_id.notNull())
 	{
 		LLToolPipette::getInstance()->setResult(TRUE, "");
-        if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+        if (mInventoryPickType == PICK_MATERIAL)
         {
             // tes have no data about material ids
             // Plus gltf materials are layered with overrides,
@@ -1807,7 +1828,8 @@ void LLTextureCtrl::showPicker(BOOL take_focus)
 			mImmediateFilterPermMask,
 			mDnDFilterPermMask,
 			mCanApplyImmediately,
-			mFallbackImage);
+			mFallbackImage,
+			mInventoryPickType);
 		mFloaterHandle = floaterp->getHandle();
 
 		LLFloaterTexturePicker* texture_floaterp = dynamic_cast<LLFloaterTexturePicker*>(floaterp);
@@ -1828,7 +1850,6 @@ void LLTextureCtrl::showPicker(BOOL take_focus)
 			texture_floaterp->setSetImageAssetIDCallback(boost::bind(&LLTextureCtrl::setImageAssetID, this, _1));
 
 			texture_floaterp->setBakeTextureEnabled(mBakeTextureEnabled);
-            texture_floaterp->setInventoryPickType(mInventoryPickType);
 		}
 
 		LLFloater* root_floater = gFloaterView->getParentFloater(this);
@@ -1891,7 +1912,7 @@ BOOL LLTextureCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 		if (!mOpenTexPreview)
 		{
 			showPicker(FALSE);
-            if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+            if (mInventoryPickType == PICK_MATERIAL)
             {
                 //grab materials first...
                 LLInventoryModelBackgroundFetch::instance().start(gInventory.findCategoryUUIDForType(LLFolderType::FT_MATERIAL));
@@ -2089,11 +2110,11 @@ BOOL LLTextureCtrl::handleDragAndDrop(S32 x, S32 y, MASK mask,
     bool is_material = cargo_type == DAD_MATERIAL;
 
     bool allow_dnd = false;
-    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+    if (mInventoryPickType == PICK_MATERIAL)
     {
         allow_dnd = is_material;
     }
-    else if (mInventoryPickType == LLTextureCtrl::PICK_TEXTURE)
+    else if (mInventoryPickType == PICK_TEXTURE)
     {
         allow_dnd = is_texture || is_mesh;
     }
@@ -2156,7 +2177,7 @@ void LLTextureCtrl::draw()
 
 		if (texture.isNull())
 		{
-            if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL)
+            if (mInventoryPickType == PICK_MATERIAL)
             {
                 LLPointer<LLFetchedGLTFMaterial> material = gGLTFMaterialList.getMaterial(mImageAssetID);
                 if (material)
@@ -2313,7 +2334,7 @@ BOOL LLTextureCtrl::doDrop(LLInventoryItem* item)
     // no callback installed, so just set the image ids and carry on.
     LLUUID asset_id = item->getAssetUUID();
 
-    if (mInventoryPickType == LLTextureCtrl::PICK_MATERIAL && asset_id.isNull())
+    if (mInventoryPickType == PICK_MATERIAL && asset_id.isNull())
     {
         // If an inventory material has a null asset, consider it a valid blank material(gltf)
         asset_id = LLGLTFMaterialList::BLANK_MATERIAL_ASSET_ID;

--- a/indra/newview/lltexturectrl.h
+++ b/indra/newview/lltexturectrl.h
@@ -72,6 +72,13 @@ enum LLPickerSource
     PICKER_UNKNOWN, // on cancel, default ids
 };
 
+typedef enum e_pick_inventory_type
+{
+    PICK_TEXTURE_MATERIAL = 0,
+    PICK_TEXTURE = 1,
+    PICK_MATERIAL = 2,
+} EPickInventoryType;
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // LLTextureCtrl
 
@@ -86,13 +93,6 @@ public:
 		TEXTURE_SELECT,
 		TEXTURE_CANCEL
 	} ETexturePickOp;
-
-    typedef enum e_pick_inventory_type
-    {
-        PICK_TEXTURE_MATERIAL = 0,
-        PICK_TEXTURE = 1,
-        PICK_MATERIAL = 2,
-    } EPickInventoryType;
 
 public:
 	struct Params : public LLInitParam::Block<Params, LLUICtrl::Params>
@@ -276,7 +276,7 @@ private:
 	S32						 	mLabelWidth;
 	bool						mOpenTexPreview;
 	bool						mBakeTextureEnabled;
-    LLTextureCtrl::EPickInventoryType mInventoryPickType;
+    EPickInventoryType mInventoryPickType;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -300,8 +300,8 @@ public:
 		PermissionMask immediate_filter_perm_mask,
 		PermissionMask dnd_filter_perm_mask,
 		BOOL can_apply_immediately,
-		LLUIImagePtr fallback_image_name
-		);
+		LLUIImagePtr fallback_image_name,
+		EPickInventoryType pick_type);
 
 	virtual ~LLFloaterTexturePicker();
 
@@ -369,7 +369,7 @@ public:
 	void 			setLocalTextureEnabled(BOOL enabled);
 	void 			setBakeTextureEnabled(BOOL enabled);
 
-    void setInventoryPickType(LLTextureCtrl::EPickInventoryType type);
+    void setInventoryPickType(EPickInventoryType type);
     void setImmediateFilterPermMask(PermissionMask mask);
 
     static void		onPickerCallback(const std::vector<std::string>& filenames, LLHandle<LLFloater> handle);
@@ -428,7 +428,7 @@ private:
     bool mLimitsSet;
     S32 mMaxDim;
     S32 mMinDim;
-    LLTextureCtrl::EPickInventoryType mInventoryPickType;
+    EPickInventoryType mInventoryPickType;
 
 
 	texture_selected_callback mTextureSelectedCallback;


### PR DESCRIPTION
1. Fixed inventory search to look for a correct item
2. Updated constuctor to include inventory pick type from the start (needed for initial search to pick it up) 