### PR TITLE
SL-20750 MacOS Crash processing attributed string

### DIFF
--- a/indra/llwindow/llopenglview-objc.mm
+++ b/indra/llwindow/llopenglview-objc.mm
@@ -736,33 +736,49 @@ attributedStringInfo getSegments(NSAttributedString *str)
 	// SL-19801 Special workaround for system emoji picker
 	if ([aString length] == 2)
 	{
-		uint32_t b0 = [aString characterAtIndex:0];
-		uint32_t b1 = [aString characterAtIndex:1];
-		if (((b0 & 0xF000) == 0xD000) && ((b1 & 0xF000) == 0xD000))
-		{
-			uint32_t b = 0x10000 | ((b0 & 0x3F) << 10) | (b1 & 0x3FF);
-			callUnicodeCallback(b, 0);
-			return;
-		}
+        @try
+        {
+            uint32_t b0 = [aString characterAtIndex:0];
+            uint32_t b1 = [aString characterAtIndex:1];
+            if (((b0 & 0xF000) == 0xD000) && ((b1 & 0xF000) == 0xD000))
+            {
+                uint32_t b = 0x10000 | ((b0 & 0x3F) << 10) | (b1 & 0x3FF);
+                callUnicodeCallback(b, 0);
+                return;
+            }
+        }
+        @catch(NSException * e)
+        {
+            // One of the characters is an attribute string?
+            NSLog(@"Encountered an unsupported attributed character. Exception: %@ String: %@", e.name, aString);
+            return;
+        }
 	}
-
-	if (!mHasMarkedText)
-	{
-		for (NSInteger i = 0; i < [aString length]; i++)
-		{
-			callUnicodeCallback([aString characterAtIndex:i], mModifiers);
-		}
-	} else {
-        resetPreedit();
-		// We may never get this point since unmarkText may be called before insertText ever gets called once we submit our text.
-		// But just in case...
-		
-		for (NSInteger i = 0; i < [aString length]; i++)
-		{
-			handleUnicodeCharacter([aString characterAtIndex:i]);
-		}
-		mHasMarkedText = FALSE;
-	}
+    
+    @try
+    {
+        if (!mHasMarkedText)
+        {
+            for (NSInteger i = 0; i < [aString length]; i++)
+            {
+                callUnicodeCallback([aString characterAtIndex:i], mModifiers);
+            }
+        } else {
+            resetPreedit();
+            // We may never get this point since unmarkText may be called before insertText ever gets called once we submit our text.
+            // But just in case...
+            
+            for (NSInteger i = 0; i < [aString length]; i++)
+            {
+                handleUnicodeCharacter([aString characterAtIndex:i]);
+            }
+            mHasMarkedText = FALSE;
+        }
+    }
+    @catch(NSException * e)
+    {
+        NSLog(@"Failed to process an attributed string. Exception: %@ String: %@", e.name, aString);
+    }
 }
 
 - (void) insertNewline:(id)sender

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -2432,9 +2432,7 @@ void LLInventoryGallery::startDrag()
             ids.push_back(selected_id);
         }
     }
-    // We must have set this for some reason, but it's causing compile errors
-    (void)src;
-    LLToolDragAndDrop::getInstance()->beginMultiDrag(types, ids, LLToolDragAndDrop::SOURCE_AGENT);
+    LLToolDragAndDrop::getInstance()->beginMultiDrag(types, ids, src);
 }
 
 bool LLInventoryGallery::areViewsInitialized()


### PR DESCRIPTION
Might be a better option to strip attributes and show the string, but for now just handling the crash (trying to figure out why bugsplat isn't reporting this).