### PR TITLE
replaces parts of boost to C++ standard.

### DIFF
--- a/indra/llcommon/llcond.h
+++ b/indra/llcommon/llcond.h
@@ -16,7 +16,6 @@
 
 #include "llunits.h"
 #include "llcoros.h"
-#include LLCOROS_MUTEX_HEADER
 #include "mutex.h"
 #include <chrono>
 

--- a/indra/llcommon/llcoros.h
+++ b/indra/llcommon/llcoros.h
@@ -41,10 +41,6 @@
 #include <exception>
 #include <queue>
 
-// e.g. #include LLCOROS_MUTEX_HEADER
-#define LLCOROS_MUTEX_HEADER   <boost/fiber/mutex.hpp>
-#define LLCOROS_CONDVAR_HEADER <boost/fiber/condition_variable.hpp>
-
 namespace boost {
     namespace fibers {
         class mutex;
@@ -289,17 +285,17 @@ public:
      * proxy, so continue using the aliases.
      */
     template <typename T>
-    using Promise = boost::fibers::promise<T>;
+    using Promise = std::promise<T>;
     template <typename T>
-    using Future = boost::fibers::future<T>;
+    using Future = std::future<T>;
     template <typename T>
     static Future<T> getFuture(Promise<T>& promise) { return promise.get_future(); }
 
     // use mutex, lock, condition_variable suitable for coroutines
-    using Mutex = boost::fibers::mutex;
+    using Mutex = std::mutex;
     using LockType = std::unique_lock<Mutex>;
-    using cv_status = boost::fibers::cv_status;
-    using ConditionVariable = boost::fibers::condition_variable;
+    using cv_status = std::cv_status;
+    using ConditionVariable = std::condition_variable;
 
     /// for data local to each running coroutine
     template <typename T>

--- a/indra/llcommon/lleventcoro.cpp
+++ b/indra/llcommon/lleventcoro.cpp
@@ -285,7 +285,7 @@ LLSD llcoro::postAndSuspendWithTimeout(const LLSD& event,
     // declare the future
     LLCoros::Future<LLSD> future = LLCoros::getFuture(promise);
     // wait for specified timeout
-    boost::fibers::future_status status;
+    std::future_status status;
     {
         LLCoros::TempStatus st(STRINGIZE("waiting for " << replyPump.getPump().getName()
                                          << " for " << timeout << "s"));
@@ -296,7 +296,7 @@ LLSD llcoro::postAndSuspendWithTimeout(const LLSD& event,
         status = future.wait_for(std::chrono::milliseconds(long(timeout * 1000)));
     }
     // if the future is NOT yet ready, return timeoutResult instead
-    if (status == boost::fibers::future_status::timeout)
+    if (status == std::future_status::timeout)
     {
         LL_DEBUGS("lleventcoro") << "postAndSuspendWithTimeout(): coroutine " << listenerName
                                  << " timed out after " << timeout << " seconds,"
@@ -305,7 +305,7 @@ LLSD llcoro::postAndSuspendWithTimeout(const LLSD& event,
     }
     else
     {
-        llassert_always(status == boost::fibers::future_status::ready);
+        llassert_always(status == std::future_status::ready);
 
         // future is now ready, no more waiting
         LLSD value(future.get());

--- a/indra/llcommon/llthreadsafequeue.h
+++ b/indra/llcommon/llthreadsafequeue.h
@@ -28,9 +28,6 @@
 #define LL_LLTHREADSAFEQUEUE_H
 
 #include "llcoros.h"
-#include LLCOROS_MUTEX_HEADER
-#include <boost/fiber/timed_mutex.hpp>
-#include LLCOROS_CONDVAR_HEADER
 #include "llexception.h"
 #include "mutex.h"
 #include <chrono>
@@ -182,10 +179,10 @@ protected:
 	size_t mCapacity;
 	bool mClosed;
 
-	boost::fibers::timed_mutex mLock;
+	std::timed_mutex mLock;
 	typedef std::unique_lock<decltype(mLock)> lock_t;
-	boost::fibers::condition_variable_any mCapacityCond;
-	boost::fibers::condition_variable_any mEmptyCond;
+	std::condition_variable_any mCapacityCond;
+	std::condition_variable_any mEmptyCond;
 
 	enum pop_result { EMPTY, DONE, WAITING, POPPED };
 	// implementation logic, suitable for passing to tryLockUntil()

--- a/indra/llcommon/workqueue.cpp
+++ b/indra/llcommon/workqueue.cpp
@@ -18,7 +18,6 @@
 // external library headers
 // other Linden headers
 #include "llcoros.h"
-#include LLCOROS_MUTEX_HEADER
 #include "llerror.h"
 #include "llexception.h"
 #include "stringize.h"

--- a/indra/llmessage/message.h
+++ b/indra/llmessage/message.h
@@ -58,7 +58,6 @@
 #include "boost/function.hpp"
 #include "llpounceable.h"
 #include "llcoros.h"
-#include LLCOROS_MUTEX_HEADER
 
 const U32 MESSAGE_MAX_STRINGS_LENGTH = 64;
 const U32 MESSAGE_NUMBER_OF_HASH_BUCKETS = 8192;


### PR DESCRIPTION
Some of the functions used in boost are provided by the C++ standard.
This PR replaces that functionality.

1. replace boost::fibers::promise to std::promise
2. replace boost::fibers::future to std::future
3. replace boost::fibers::mutex to std::mutex
4. replace boost::fibers::cv_status to std::cv_status
5. replace boost::fibers::condition_variable* to std::condition_variable*
6. replace boost::fibers::future_status to std::future_status
7. replace boost::fibers::timed_mutex to std::timed_mutex