### PR TITLE
SL-18721 Shutdown fixes #2

### DIFF
--- a/indra/llimage/llimageworker.h
+++ b/indra/llimage/llimageworker.h
@@ -39,7 +39,7 @@ public:
 	protected:
 		virtual ~Responder();
 	public:
-		virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux) = 0;
+		virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux, U32 request_id) = 0;
 	};
 
 public:
@@ -53,6 +53,7 @@ public:
 						 const LLPointer<Responder>& responder);
 	size_t getPending();
 	size_t update(F32 max_time_ms);
+    S32 getTotalDecodeCount() { return mDecodeCount; }
 	void shutdown();
 
 private:
@@ -60,6 +61,7 @@ private:
 	// LLQueuedThread - instead this is the API by which we submit work to the
 	// "ImageDecode" ThreadPool.
 	std::unique_ptr<LL::ThreadPool> mThreadPool;
+    LLAtomicU32 mDecodeCount;
 };
 
 #endif


### PR DESCRIPTION
setState(DONE) if decode thread is down instead of waiting for an update.
Decodes can't be canceled, so fix potential situation where we get two responses.