### PR TITLE
SL-20606 post-merge follow-up

### DIFF
--- a/indra/newview/llfetchedgltfmaterial.h
+++ b/indra/newview/llfetchedgltfmaterial.h
@@ -40,6 +40,8 @@ public:
     virtual ~LLFetchedGLTFMaterial();
 
     LLFetchedGLTFMaterial& operator=(const LLFetchedGLTFMaterial& rhs);
+    // LLGLTFMaterial::operator== is defined, but LLFetchedGLTFMaterial::operator== is not.
+    bool operator==(const LLGLTFMaterial& rhs) const = delete;
 
     // If this material is loaded, fire the given function
     void onMaterialComplete(std::function<void()> material_complete);

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -34,6 +34,7 @@
 #include "llenvironment.h"
 #include "llselectmgr.h"
 #include "llviewercamera.h"
+#include "llviewercontrol.h"
 #include "llviewerobject.h"
 #include "llviewershadermgr.h"
 #include "llviewertexturelist.h"
@@ -419,7 +420,8 @@ BOOL LLGLTFPreviewTexture::render()
     LLVector3 light_dir3(1.0f, 1.0f, 1.0f);
     light_dir3.normalize();
     const LLVector4 light_dir = LLVector4(light_dir3, 0);
-    SetTemporarily<S32> sun_light_only(&LLPipeline::RenderLocalLightCount, 0);
+    const S32 old_local_light_count = gSavedSettings.get<S32>("RenderLocalLightCount");
+    gSavedSettings.set<S32>("RenderLocalLightCount", 0);
 
     gPipeline.mReflectionMapManager.forceDefaultProbeAndUpdateUniforms();
 
@@ -524,6 +526,7 @@ BOOL LLGLTFPreviewTexture::render()
     // Clean up
     gPipeline.setupHWLights();
     gPipeline.mReflectionMapManager.forceDefaultProbeAndUpdateUniforms(false);
+    gSavedSettings.set<S32>("RenderLocalLightCount", old_local_light_count);
 
     return TRUE;
 }

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -130,6 +130,8 @@ namespace
 
     LLGLTFPreviewTexture::MaterialLoadLevels get_material_load_levels(LLFetchedGLTFMaterial& material)
     {
+        llassert(!material.isFetching());
+
         using MaterialTextures = LLPointer<LLViewerFetchedTexture>*[LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT];
 
         MaterialTextures textures;

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -96,7 +96,7 @@ namespace
 {
     void fetch_texture_for_ui(LLPointer<LLViewerFetchedTexture>& img, const LLUUID& id)
     {
-        if (id.notNull())
+        if (!img && id.notNull())
         {
             if (LLAvatarAppearanceDefines::LLAvatarAppearanceDictionary::isBakedImageId(id))
             {

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -337,7 +337,7 @@ void set_preview_sphere_material(PreviewSphere& preview_sphere, LLPointer<LLFetc
         info->mGLTFMaterial = material;
         LLVertexBuffer* buf = info->mVertexBuffer.get();
         LLStrider<LLColor4U> colors;
-        const S32 count = info->mEnd - info->mStart;
+        const S32 count = info->mEnd - info->mStart + 1;
         buf->getColorStrider(colors, info->mStart, count);
         for (S32 i = 0; i < count; ++i)
         {

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -666,7 +666,7 @@ void LLFloaterTexturePicker::draw()
             {
                 mGLTFMaterial = (LLFetchedGLTFMaterial*) gGLTFMaterialList.getMaterial(mImageAssetID);
                 llassert(mGLTFMaterial == nullptr || dynamic_cast<LLFetchedGLTFMaterial*>(gGLTFMaterialList.getMaterial(mImageAssetID)) != nullptr);
-                if (mGLTFPreview.isNull() || mGLTFMaterial.isNull() || (old_material.notNull() && (*old_material.get() != *mGLTFMaterial.get())))
+                if (mGLTFPreview.isNull() || mGLTFMaterial.isNull() || (old_material.notNull() && (old_material.get() != mGLTFMaterial.get())))
                 {
                     // Only update the preview if needed, since gGLTFMaterialPreviewMgr does not cache the preview.
                     if (mGLTFMaterial.isNull())
@@ -2206,7 +2206,7 @@ void LLTextureCtrl::draw()
             if (mInventoryPickType == PICK_MATERIAL)
             {
                 mGLTFMaterial = gGLTFMaterialList.getMaterial(mImageAssetID);
-                if (mGLTFPreview.isNull() || mGLTFMaterial.isNull() || (old_material.notNull() && (*old_material.get() != *mGLTFMaterial.get())))
+                if (mGLTFPreview.isNull() || mGLTFMaterial.isNull() || (old_material.notNull() && (old_material.get() != mGLTFMaterial.get())))
                 {
                     // Only update the preview if needed, since gGLTFMaterialPreviewMgr does not cache the preview.
                     if (mGLTFMaterial.isNull())

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -163,7 +163,6 @@ F32 LLPipeline::CameraFocusTransitionTime;
 F32 LLPipeline::CameraFNumber;
 F32 LLPipeline::CameraFocalLength;
 F32 LLPipeline::CameraFieldOfView;
-S32 LLPipeline::RenderLocalLightCount;
 F32 LLPipeline::RenderShadowNoise;
 F32 LLPipeline::RenderShadowBlurSize;
 F32 LLPipeline::RenderSSAOScale;
@@ -525,7 +524,6 @@ void LLPipeline::init()
 	connectRefreshCachedSettingsSafe("CameraFNumber");
 	connectRefreshCachedSettingsSafe("CameraFocalLength");
 	connectRefreshCachedSettingsSafe("CameraFieldOfView");
-	connectRefreshCachedSettingsSafe("RenderLocalLightCount");
 	connectRefreshCachedSettingsSafe("RenderShadowNoise");
 	connectRefreshCachedSettingsSafe("RenderShadowBlurSize");
 	connectRefreshCachedSettingsSafe("RenderSSAOScale");
@@ -1025,7 +1023,6 @@ void LLPipeline::refreshCachedSettings()
 	CameraFNumber = gSavedSettings.getF32("CameraFNumber");
 	CameraFocalLength = gSavedSettings.getF32("CameraFocalLength");
 	CameraFieldOfView = gSavedSettings.getF32("CameraFieldOfView");
-	RenderLocalLightCount = gSavedSettings.getS32("RenderLocalLightCount");
 	RenderShadowNoise = gSavedSettings.getF32("RenderShadowNoise");
 	RenderShadowBlurSize = gSavedSettings.getF32("RenderShadowBlurSize");
 	RenderSSAOScale = gSavedSettings.getF32("RenderSSAOScale");
@@ -5262,7 +5259,7 @@ void LLPipeline::calcNearbyLights(LLCamera& camera)
 		return;
 	}
 
-    const S32 local_light_count = LLPipeline::RenderLocalLightCount;
+    static LLCachedControl<S32> local_light_count(gSavedSettings, "RenderLocalLightCount", 256);
 
 	if (local_light_count >= 1)
 	{
@@ -5531,7 +5528,7 @@ void LLPipeline::setupHWLights()
 
 	mLightMovingMask = 0;
 	
-    const S32 local_light_count = LLPipeline::RenderLocalLightCount;
+    static LLCachedControl<S32> local_light_count(gSavedSettings, "RenderLocalLightCount", 256);
 
 	if (local_light_count >= 1)
 	{
@@ -7965,7 +7962,7 @@ void LLPipeline::renderDeferredLighting()
             unbindDeferredShader(gDeferredSoftenProgram);
         }
 
-        const S32 local_light_count = LLPipeline::RenderLocalLightCount;
+        static LLCachedControl<S32> local_light_count(gSavedSettings, "RenderLocalLightCount", 256);
 
         if (local_light_count > 0)
         {

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -1015,7 +1015,6 @@ public:
 	static F32 CameraFNumber;
 	static F32 CameraFocalLength;
 	static F32 CameraFieldOfView;
-	static S32 RenderLocalLightCount;
 	static F32 RenderShadowNoise;
 	static F32 RenderShadowBlurSize;
 	static F32 RenderSSAOScale;


### PR DESCRIPTION
This is a continuation of https://github.com/secondlife/viewer/pull/658 , fixing some issues found during review and incidentally.

<details><summary><strong>Test plan...</strong></summary>

- What was added: The material preview swatch now displays a spherical material preview in the build floater, as well as the floater to select the material for the face from the inventory. See attached screenshot:
    <details><summary><strong>Material picker example...</strong></summary>

    ![material_picker_example](https://github.com/secondlife/viewer/assets/111533034/287d8211-3ba1-4092-903b-987f2718e289)
    </details>
- These are known issues that this ticket does not address:
    - Material swatch preview is a preview of the base material ID only, and ignores other properties on the prim face like material overrides
    - Alpha mask previews as alpha blend
    - Double-sided previews as single-sided
    - Material swatch preview inherits some of its lighting from the current environment
- Check that the material preview swatch looks OK with different materials selected
- Check that the material preview swatch runs reasonably well on different systems, especially when the select material from inventory floater is also open
    - In particular: AMD, MacOS, minimum spec machines
- Watch out for regressions in rendering caused by opening a floater with a material preview swatch
</details>
