### PR TITLE
Issue #696 RenderResolutionDivisor no longer works

### DIFF
--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -730,8 +730,8 @@ void display(BOOL rebuild, F32 zoom_factor, int subfield, BOOL for_snapshot)
 			LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("display - 2")
 			if (gResizeScreenTexture)
 			{
-				gResizeScreenTexture = FALSE;
 				gPipeline.resizeScreenTexture();
+                gResizeScreenTexture = FALSE;
 			}
 
 			gGL.setColorMask(true, true);


### PR DESCRIPTION
resizeScreenTexture() works if gResizeScreenTexture is true or render target was resized, with gResizeScreenTexture set to false it was doing nothing if RenderResolutionDivisor changed.

I tried to check through history, but code was like this for a while, if it is correct as is, alternative might be to have some kind of gResolutionDivisorChanged.