### PR TITLE
BugSplat Crash #1409959 onTopLost

### DIFF
--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -188,6 +188,8 @@ LLComboBox::~LLComboBox()
 	// explicitly disconect this signal, since base class destructor might fire top lost
 	mTopLostSignalConnection.disconnect();
     mImageLoadedConnection.disconnect();
+
+    LLUI::getInstance()->removePopup(this);
 }
 
 

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -256,7 +256,13 @@ LLFolderView::LLFolderView(const Params& p)
 // Destroys the object
 LLFolderView::~LLFolderView( void )
 {
-	closeRenamer();
+    mRenamerTopLostSignalConnection.disconnect();
+    if (mRenamer)
+    {
+        // instead of using closeRenamer remove it directly,
+        // since it might already be hidden
+        LLUI::getInstance()->removePopup(mRenamer);
+    }
 
 	// The release focus call can potentially call the
 	// scrollcontainer, which can potentially be called with a partly
@@ -1072,7 +1078,10 @@ void LLFolderView::startRenamingSelectedItem( void )
 		mRenamer->setVisible( TRUE );
 		// set focus will fail unless item is visible
 		mRenamer->setFocus( TRUE );
-		mRenamer->setTopLostCallback(boost::bind(&LLFolderView::onRenamerLost, this));
+        if (!mRenamerTopLostSignalConnection.connected())
+        {
+            mRenamerTopLostSignalConnection = mRenamer->setTopLostCallback(boost::bind(&LLFolderView::onRenamerLost, this));
+        }
 		LLUI::getInstance()->addPopup(mRenamer);
 	}
 }
@@ -1598,7 +1607,11 @@ BOOL LLFolderView::handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 
 void LLFolderView::deleteAllChildren()
 {
-	closeRenamer();
+    mRenamerTopLostSignalConnection.disconnect();
+    if (mRenamer)
+    {
+        LLUI::getInstance()->removePopup(mRenamer);
+    }
 	if (mPopupMenuHandle.get()) mPopupMenuHandle.get()->die();
 	mPopupMenuHandle.markDead();
 	mScrollContainer = NULL;

--- a/indra/llui/llfolderview.h
+++ b/indra/llui/llfolderview.h
@@ -345,6 +345,8 @@ protected:
 	LLUICtrl::CommitCallbackRegistry::ScopedRegistrar* mCallbackRegistrar;
 	LLUICtrl::EnableCallbackRegistry::ScopedRegistrar* mEnableRegistrar;
 
+    boost::signals2::connection mRenamerTopLostSignalConnection;
+
     bool mForceArrange;
 	
 public:

--- a/indra/llui/llmodaldialog.cpp
+++ b/indra/llui/llmodaldialog.cpp
@@ -67,6 +67,8 @@ LLModalDialog::~LLModalDialog()
 	{
 		LL_ERRS() << "Attempt to delete dialog while still in sModalStack!" << LL_ENDL;
 	}
+
+    LLUI::getInstance()->removePopup(this);
 }
 
 // virtual

--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -106,6 +106,8 @@ LLConversationViewSession::~LLConversationViewSession()
     }
 
 	mFlashTimer->unset();
+    delete mFlashTimer;
+    mFlashStateOn = false;
 }
 
 void LLConversationViewSession::destroyView()

--- a/indra/newview/llexpandabletextbox.cpp
+++ b/indra/newview/llexpandabletextbox.cpp
@@ -243,6 +243,12 @@ LLExpandableTextBox::LLExpandableTextBox(const Params& p)
 	mTextBox->setCommitCallback(boost::bind(&LLExpandableTextBox::onExpandClicked, this));
 }
 
+
+LLExpandableTextBox::~LLExpandableTextBox()
+{
+    gViewerWindow->removePopup(this);
+}
+
 void LLExpandableTextBox::draw()
 {
 	if(mBGVisible && !mExpanded)

--- a/indra/newview/llexpandabletextbox.h
+++ b/indra/newview/llexpandabletextbox.h
@@ -154,6 +154,8 @@ public:
 	 */
 	/*virtual*/ void draw();
 
+    virtual ~LLExpandableTextBox();
+
 protected:
 
 	LLExpandableTextBox(const Params& p);

--- a/indra/newview/llpopupview.cpp
+++ b/indra/newview/llpopupview.cpp
@@ -260,12 +260,12 @@ void LLPopupView::clearPopups()
 		popup_it != mPopups.end();)
 	{
 		LLView* popup = popup_it->get();
+        if (popup)
+        {
+            popup->onTopLost();
+        }
 
-		popup_list_t::iterator cur_popup_it = popup_it;
-		++popup_it;
-
-		mPopups.erase(cur_popup_it);
-		popup->onTopLost();
+		popup_it = mPopups.erase(popup_it);
 	}
 }
 

--- a/indra/newview/llsplitbutton.cpp
+++ b/indra/newview/llsplitbutton.cpp
@@ -243,7 +243,14 @@ LLSplitButton::LLSplitButton(const LLSplitButton::Params& p)
 		item_top -= (rc.getHeight() + BUTTON_PAD);
 	}
 
-	setTopLostCallback(boost::bind(&LLSplitButton::hideButtons, this));
+    mTopLostSignalConnection = setTopLostCallback(boost::bind(&LLSplitButton::hideButtons, this));
+}
+
+LLSplitButton::~LLSplitButton()
+{
+    // explicitly disconect to avoid hideButtons with
+    // dead pointers being called on destruction
+    mTopLostSignalConnection.disconnect();
 }
 
 

--- a/indra/newview/llsplitbutton.h
+++ b/indra/newview/llsplitbutton.h
@@ -67,7 +67,7 @@ public:
 	};
 
 
-	virtual ~LLSplitButton() {};
+	virtual ~LLSplitButton();
 
 	//Overridden
 	virtual void	onFocusLost();
@@ -98,6 +98,8 @@ protected:
 	LLButton* mArrowBtn;
 	LLButton* mShownItem;
 	EArrowPosition mArrowPosition;
+
+    boost::signals2::connection mTopLostSignalConnection;
 
 	commit_callback_t mSelectionCallback;
 };

--- a/indra/newview/lluploaddialog.cpp
+++ b/indra/newview/lluploaddialog.cpp
@@ -149,6 +149,7 @@ void LLUploadDialog::setMessage( const std::string& msg)
 
 LLUploadDialog::~LLUploadDialog()
 {
+    gViewerWindow->removePopup(this);
 	gFocusMgr.releaseFocusIfNeeded( this );
 
 //    LLFilePicker::instance().reset();


### PR DESCRIPTION
onTopLost crashed
1. It contradicts callstack, but clearPopups() definetely has an issue due to not checking the pointer prior to calling onTopLost
2. According to callstack, crash happened around ~LLFolderViewFolder and while it does call removePopup for itself, it isn't a popup, the only one in the list would be the renamer, so made sure to secure it.
3. mFlashTimer was never deleted
4. Some explicit cleanup for TopLost

I might be blowing on cold water with some of this, but with how confusing the crash is, decided that it won't hurt.