### PR TITLE
build.yaml: Build shared branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: ["*"]
-    tags: ["*"]
+    branches: ["main", "release/*", "project/*"]
+    tags: ["Second_Life_*"]
 
 jobs:
   build:


### PR DESCRIPTION
We're currently building every single commit pushed to Github. This is racking up $20k in build charges a month and is generally excessive.

This changeset alters build triggers so that builds automatically run if they are committed to a **shared branch**:

- `release/*` - A release stabilization branch
- `project/*` - A project viewer branch
- `main/*` - The default/stable branch

These branches are also being set up to require pull requests, which are also automatically built.

...need to build another commit? Developers can trigger one using a manual workflow run.