### PR TITLE
#68175 PR-726 MacOS build fix

### DIFF
--- a/indra/llui/lluictrl.h
+++ b/indra/llui/lluictrl.h
@@ -146,24 +146,24 @@ protected:
     // We shouldn't ever need to set this directly
     //virtual void    setViewModel(const LLViewModelPtr&);
 
-	virtual BOOL	postBuild();
+	/*virtual*/ BOOL	postBuild() override;
 	
 public:
 	// LLView interface
-	/*virtual*/ BOOL	setLabelArg( const std::string& key, const LLStringExplicit& text );
-	/*virtual*/ BOOL	isCtrl() const;
-	/*virtual*/ void	onMouseEnter(S32 x, S32 y, MASK mask);
-	/*virtual*/ void	onMouseLeave(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	canFocusChildren() const;
-	/*virtual*/ BOOL 	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL 	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ BOOL	setLabelArg( const std::string& key, const LLStringExplicit& text ) override;
+	/*virtual*/ BOOL	isCtrl() const override;
+	/*virtual*/ void	onMouseEnter(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ void	onMouseLeave(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ BOOL	canFocusChildren() const override;
+	/*virtual*/ BOOL 	handleMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ BOOL 	handleMouseUp(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask) override;
 
 	// From LLFocusableElement
-	/*virtual*/ void	setFocus( BOOL b );
-	/*virtual*/ BOOL	hasFocus() const;
+	/*virtual*/ void	setFocus( BOOL b ) override;
+	/*virtual*/ BOOL	hasFocus() const override;
 	
 	// New virtuals
 
@@ -318,7 +318,7 @@ protected:
 	static F32 sActiveControlTransparency;
 	static F32 sInactiveControlTransparency;
 	
-	virtual void addInfo(LLSD & info);
+	/*virtual*/ void addInfo(LLSD & info) override;
 	
 private:
 


### PR DESCRIPTION
https://github.com/secondlife/viewer/pull/726 macOS build failed

```
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:154:15: error: 'postBuild' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual BOOL    postBuild();
                        ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:260:15: note: overridden virtual function is here
        virtual BOOL    postBuild() { return TRUE; }
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:158:19: error: 'setLabelArg' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        setLabelArg( const std::string& key, const LLStringExplicit& text );
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:302:15: note: overridden virtual function is here
        virtual BOOL    setLabelArg( const std::string& key, const LLStringExplicit& text );
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:159:19: error: 'isCtrl' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        isCtrl() const;
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:215:15: note: overridden virtual function is here
        virtual BOOL isCtrl() const;
                     ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:160:19: error: 'onMouseEnter' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ void        onMouseEnter(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:445:15: note: overridden virtual function is here
        virtual void    onMouseEnter(S32 x, S32 y, MASK mask);
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:161:19: error: 'onMouseLeave' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ void        onMouseLeave(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:446:15: note: overridden virtual function is here
        virtual void    onMouseLeave(S32 x, S32 y, MASK mask);
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:162:19: error: 'canFocusChildren' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        canFocusChildren() const;
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:273:15: note: overridden virtual function is here
        virtual BOOL canFocusChildren() const;
                     ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:163:20: error: 'handleMouseDown' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        handleMouseDown(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:426:19: note: overridden virtual function is here
        /*virtual*/ BOOL        handleMouseDown(S32 x, S32 y, MASK mask);
                                ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:164:20: error: 'handleMouseUp' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        handleMouseUp(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:425:19: note: overridden virtual function is here
        /*virtual*/ BOOL        handleMouseUp(S32 x, S32 y, MASK mask);
                                ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:165:19: error: 'handleRightMouseDown' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        handleRightMouseDown(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:432:19: note: overridden virtual function is here
        /*virtual*/ BOOL        handleRightMouseDown(S32 x, S32 y, MASK mask);
                                ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:166:19: error: 'handleRightMouseUp' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        handleRightMouseUp(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:433:19: note: overridden virtual function is here
        /*virtual*/ BOOL        handleRightMouseUp(S32 x, S32 y, MASK mask);    
                                ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:167:19: error: 'handleDoubleClick' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        handleDoubleClick(S32 x, S32 y, MASK mask);
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:429:19: note: overridden virtual function is here
        /*virtual*/ BOOL        handleDoubleClick(S32 x, S32 y, MASK mask);
                                ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:172:19: error: 'setFocus' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ void        setFocus( BOOL b );
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
In file included from /Users/runner/work/viewer/viewer/indra/llui/llview.h:49:
/Users/runner/work/viewer/viewer/indra/llui/llfocusmgr.h:48:15: note: overridden virtual function is here
        virtual void    setFocus( BOOL b );
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:173:19: error: 'hasFocus' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        /*virtual*/ BOOL        hasFocus() const;
                                ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
In file included from /Users/runner/work/viewer/viewer/indra/llui/llview.h:49:
/Users/runner/work/viewer/viewer/indra/llui/llfocusmgr.h:49:15: note: overridden virtual function is here
        virtual BOOL    hasFocus() const;
                        ^
/Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:330:15: error: 'addInfo' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual void addInfo(LLSD & info);
                     ^
In file included from /Users/runner/work/viewer/viewer/indra/llui/lluictrl.h:38:
/Users/runner/work/viewer/viewer/indra/llui/llview.h:569:15: note: overridden virtual function is here
        virtual void addInfo(LLSD & info);
                     ^
```
See https://github.com/secondlife/viewer/actions/runs/7781380236/job/21215706278?pr=726