### PR TITLE
Add link to feedback portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,4 @@
+contact_links:
+- name: 💬 Community Feedback (Canny)
+  url: https://feedback.secondlife.com
+  about: Space for discussing and reviewing user-impacting bug reports and feature requests.


### PR DESCRIPTION
Provide a link to feedback.secondlife.com from the issue creation page.