### PR TITLE
SL-19730 update menu items

### DIFF
--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -5249,9 +5249,19 @@ bool visible_take_object()
 	return !is_selection_buy_not_take() && enable_take();
 }
 
-bool visible_take_objects() 
+bool is_multiple_selection() 
 {
-    return visible_take_object() && (LLSelectMgr::getInstance()->getSelection()->getRootObjectCount() > 1);
+    return (LLSelectMgr::getInstance()->getSelection()->getRootObjectCount() > 1);
+}
+
+bool is_single_selection() 
+{ 
+    return !is_multiple_selection();
+}
+
+bool enable_take_objects() 
+{ 
+    return visible_take_object() && is_multiple_selection(); 
 }
 
 bool tools_visible_buy_object()
@@ -8021,9 +8031,9 @@ bool enable_object_take_copy()
 	return all_valid;
 }
 
-bool visible_take_copy_objects() 
+bool enable_take_copy_objects() 
 { 
-    return enable_object_take_copy() && (LLSelectMgr::getInstance()->getSelection()->getRootObjectCount() > 1);
+    return enable_object_take_copy() && is_multiple_selection();
 }
 
 class LLHasAsset : public LLInventoryCollectFunctor
@@ -9495,7 +9505,7 @@ void initialize_menus()
 	enable.add("Tools.EnableUnlink", boost::bind(&LLSelectMgr::enableUnlinkObjects, LLSelectMgr::getInstance()));
 	view_listener_t::addMenu(new LLToolsEnableBuyOrTake(), "Tools.EnableBuyOrTake");
 	enable.add("Tools.EnableTakeCopy", boost::bind(&enable_object_take_copy));
-    enable.add("Tools.VisibleCopySeparate", boost::bind(&visible_take_copy_objects));
+    enable.add("Tools.EnableCopySeparate", boost::bind(&enable_take_copy_objects));
 	enable.add("Tools.VisibleBuyObject", boost::bind(&tools_visible_buy_object));
 	enable.add("Tools.VisibleTakeObject", boost::bind(&tools_visible_take_object));
 	view_listener_t::addMenu(new LLToolsEnableSaveToObjectInventory(), "Tools.EnableSaveToObjectInventory");
@@ -9756,7 +9766,9 @@ void initialize_menus()
 	view_listener_t::addMenu(new LLObjectMute(), "Object.Mute");
 
 	enable.add("Object.VisibleTake", boost::bind(&visible_take_object));
-    enable.add("Object.VisibleTakeMultiple", boost::bind(&visible_take_objects));
+    enable.add("Object.VisibleTakeMultiple", boost::bind(&is_multiple_selection));
+    enable.add("Object.VisibleTakeSingle", boost::bind(&is_single_selection));
+    enable.add("Object.EnableTakeMultiple", boost::bind(&enable_take_objects));
 	enable.add("Object.VisibleBuy", boost::bind(&visible_buy_object));
 
 	commit.add("Object.Buy", boost::bind(&handle_buy));

--- a/indra/newview/skins/default/xui/en/menu_object.xml
+++ b/indra/newview/skins/default/xui/en/menu_object.xml
@@ -173,6 +173,8 @@
         function="Object.Take"/>
     <menu_item_call.on_enable
         function="Object.VisibleTake"/>
+    <menu_item_call.on_visible
+        function="Object.VisibleTakeSingle"/>
   </menu_item_call>
   <menu_item_call
       enabled="false"
@@ -182,28 +184,52 @@
         function="Tools.TakeCopy" />
     <menu_item_call.on_enable
         function="Tools.EnableTakeCopy" />
+    <menu_item_call.on_visible
+        function="Object.VisibleTakeSingle"/>
   </menu_item_call>
   <menu_item_call
-      label="Take separate"
+      label="Take as combined item"
+      layout="topleft"
+      name="Take combined">
+      <menu_item_call.on_click
+        function="Object.Take"/>
+      <menu_item_call.on_enable
+        function="Object.VisibleTake"/>
+      <menu_item_call.on_visible
+        function="Object.VisibleTakeMultiple"/>
+  </menu_item_call>
+  <menu_item_call
+      enabled="false"
+      label="Take copy as combined item"
+      name="Take Copy combined">
+      <menu_item_call.on_click
+        function="Tools.TakeCopy" />
+      <menu_item_call.on_enable
+        function="Tools.EnableTakeCopy" />
+      <menu_item_call.on_visible
+        function="Object.VisibleTakeMultiple"/>
+  </menu_item_call>
+  <menu_item_call
+      label="Take as separate items"
       layout="topleft"
       name="Take Separate">
       <menu_item_call.on_click
         function="Object.TakeSeparate"/>
       <menu_item_call.on_enable
-        function="Object.VisibleTakeMultiple"/>
+        function="Object.EnableTakeMultiple"/>
       <menu_item_call.on_visible
         function="Object.VisibleTakeMultiple"/>
   </menu_item_call>
   <menu_item_call
-      label="Take copy separate"
+      label="Take copies as separate items"
       layout="topleft"
        name="Take Copy Separate">
        <menu_item_call.on_click
         function="Object.TakeSeparateCopy"/>
        <menu_item_call.on_enable
-        function="Tools.VisibleCopySeparate"/>
+        function="Tools.EnableCopySeparate"/>
        <menu_item_call.on_visible
-        function="Tools.VisibleCopySeparate"/>
+        function="Object.VisibleTakeMultiple"/>
   </menu_item_call>
   <menu_item_call
       enabled="false"


### PR DESCRIPTION
When there are multiple objects selected, 4 labels are:
- Take as combined item
- Take copy as combined item
- Take as separate items
- Take copies as separate items

If there is only one item selected, "Take" and "Take copy" remain as before.