### PR TITLE
SL-18721 Shutdown fixes #4

### DIFF
--- a/indra/llcommon/threadpool.h
+++ b/indra/llcommon/threadpool.h
@@ -87,6 +87,7 @@ namespace LL
 
     protected:
         std::unique_ptr<WorkQueueBase> mQueue;
+        std::vector<std::pair<std::string, std::thread>> mThreads;
         bool mAutomaticShutdown;
 
     private:
@@ -94,7 +95,6 @@ namespace LL
 
         std::string mName;
         size_t mThreadCount;
-        std::vector<std::pair<std::string, std::thread>> mThreads;
     };
 
     /**


### PR DESCRIPTION
Missed that 'kickWindowThread' requires handle to still be alive, also it should happen after closing queue