### PR TITLE
BOOL to bool, pt. 1

### DIFF
--- a/indra/llcommon/llapr.cpp
+++ b/indra/llcommon/llapr.cpp
@@ -56,7 +56,7 @@ void ll_init_apr()
 
 	if(!LLAPRFile::sAPRFilePoolp)
 	{
-		LLAPRFile::sAPRFilePoolp = new LLVolatileAPRPool(FALSE) ;
+		LLAPRFile::sAPRFilePoolp = new LLVolatileAPRPool(false) ;
 	}
 
 	gAPRInitialized = true;
@@ -91,7 +91,7 @@ void ll_cleanup_apr()
 //
 //LLAPRPool
 //
-LLAPRPool::LLAPRPool(apr_pool_t *parent, apr_size_t size, BOOL releasePoolFlag) 	
+LLAPRPool::LLAPRPool(apr_pool_t *parent, apr_size_t size, bool releasePoolFlag)
 	: mParent(parent),
 	mReleasePoolFlag(releasePoolFlag),
 	mMaxSize(size),
@@ -145,7 +145,7 @@ apr_pool_t* LLAPRPool::getAPRPool()
 	return mPool ; 
 }
 
-LLVolatileAPRPool::LLVolatileAPRPool(BOOL is_local, apr_pool_t *parent, apr_size_t size, BOOL releasePoolFlag) 
+LLVolatileAPRPool::LLVolatileAPRPool(bool is_local, apr_pool_t *parent, apr_size_t size, bool releasePoolFlag)
 				  : LLAPRPool(parent, size, releasePoolFlag),
 				  mNumActiveRef(0),
 				  mNumTotalRef(0)
@@ -219,7 +219,7 @@ void LLVolatileAPRPool::clearVolatileAPRPool()
 	llassert(mNumTotalRef <= (FULL_VOLATILE_APR_POOL << 2)) ;
 }
 
-BOOL LLVolatileAPRPool::isFull()
+bool LLVolatileAPRPool::isFull()
 {
 	return mNumTotalRef > FULL_VOLATILE_APR_POOL ;
 }
@@ -385,7 +385,7 @@ apr_status_t LLAPRFile::open(const std::string& filename, apr_int32_t flags, LLV
 }
 
 //use gAPRPoolp.
-apr_status_t LLAPRFile::open(const std::string& filename, apr_int32_t flags, BOOL use_global_pool)
+apr_status_t LLAPRFile::open(const std::string& filename, apr_int32_t flags, bool use_global_pool)
 {
 	apr_status_t s;
 

--- a/indra/llcommon/llapr.h
+++ b/indra/llcommon/llapr.h
@@ -78,7 +78,7 @@ bool LL_COMMON_API ll_apr_is_initialized();
 class LL_COMMON_API LLAPRPool
 {
 public:
-	LLAPRPool(apr_pool_t *parent = NULL, apr_size_t size = 0, BOOL releasePoolFlag = TRUE) ;
+	LLAPRPool(apr_pool_t *parent = NULL, apr_size_t size = 0, bool releasePoolFlag = true) ;
 	virtual ~LLAPRPool() ;
 
 	virtual apr_pool_t* getAPRPool() ;
@@ -93,7 +93,7 @@ protected:
 	apr_pool_t*  mParent ;			  //parent pool
 	apr_size_t   mMaxSize ;           //max size of mPool, mPool should return memory to system if allocated memory beyond this limit. However it seems not to work.
 	apr_status_t mStatus ;            //status when creating the pool
-	BOOL         mReleasePoolFlag ;   //if set, mPool is destroyed when LLAPRPool is deleted. default value is true.
+	bool         mReleasePoolFlag ;   //if set, mPool is destroyed when LLAPRPool is deleted. default value is true.
 };
 
 //
@@ -104,14 +104,14 @@ protected:
 class LL_COMMON_API LLVolatileAPRPool : public LLAPRPool
 {
 public:
-	LLVolatileAPRPool(BOOL is_local = TRUE, apr_pool_t *parent = NULL, apr_size_t size = 0, BOOL releasePoolFlag = TRUE);
+	LLVolatileAPRPool(bool is_local = true, apr_pool_t *parent = NULL, apr_size_t size = 0, bool releasePoolFlag = true);
 	virtual ~LLVolatileAPRPool();
 
 	/*virtual*/ apr_pool_t* getAPRPool() ; //define this virtual function to avoid any mistakenly calling LLAPRPool::getAPRPool().
 	apr_pool_t* getVolatileAPRPool() ;	
 	void        clearVolatileAPRPool() ;
 
-	BOOL        isFull() ;
+	bool        isFull() ;
 	
 private:
 	S32 mNumActiveRef ; //number of active pointers pointing to the apr_pool.
@@ -158,7 +158,7 @@ public:
 	~LLAPRFile() ;
 	
 	apr_status_t open(const std::string& filename, apr_int32_t flags, LLVolatileAPRPool* pool = NULL, S32* sizep = NULL);
-	apr_status_t open(const std::string& filename, apr_int32_t flags, BOOL use_global_pool); //use gAPRPoolp.
+	apr_status_t open(const std::string& filename, apr_int32_t flags, bool use_global_pool); //use gAPRPoolp.
 	apr_status_t close() ;
 
 	// Returns actual offset, -1 if seek fails

--- a/indra/llcommon/llassettype.cpp
+++ b/indra/llcommon/llassettype.cpp
@@ -98,7 +98,7 @@ LLAssetDictionary::LLAssetDictionary()
 	addEntry(LLAssetType::AT_SETTINGS,          new AssetEntry("SETTINGS",          "settings", "settings blob",    true,       true,       true));
 	addEntry(LLAssetType::AT_MATERIAL,          new AssetEntry("MATERIAL",          "material", "render material",  true,       true,       true));
 	addEntry(LLAssetType::AT_UNKNOWN,           new AssetEntry("UNKNOWN",           "invalid",  NULL,               false,      false,      false));
-    addEntry(LLAssetType::AT_NONE,              new AssetEntry("NONE",              "-1",		NULL,		  		FALSE,		FALSE,		FALSE));
+    addEntry(LLAssetType::AT_NONE,              new AssetEntry("NONE",              "-1",		NULL,		  		false,		false,		false));
 
 };
 

--- a/indra/llcommon/llcommon.cpp
+++ b/indra/llcommon/llcommon.cpp
@@ -115,7 +115,7 @@ void tracy_aligned_free(void *memblock)
 #endif
 
 //static
-BOOL LLCommon::sAprInitialized = FALSE;
+bool LLCommon::sAprInitialized = false;
 
 static LLTrace::ThreadRecorder* sMasterThreadRecorder = NULL;
 
@@ -125,7 +125,7 @@ void LLCommon::initClass()
 	if (!sAprInitialized)
 	{
 		ll_init_apr();
-		sAprInitialized = TRUE;
+		sAprInitialized = true;
 	}
 	LLTimer::initClass();
 	LLThreadSafeRefCount::initThreadSafeRefCount();
@@ -148,6 +148,6 @@ void LLCommon::cleanupClass()
 	if (sAprInitialized)
 	{
 		ll_cleanup_apr();
-		sAprInitialized = FALSE;
+		sAprInitialized = false;
 	}
 }

--- a/indra/llcommon/llcommon.h
+++ b/indra/llcommon/llcommon.h
@@ -36,7 +36,7 @@ public:
 	static void initClass();
 	static void cleanupClass();
 private:
-	static BOOL sAprInitialized;
+	static bool sAprInitialized;
 };
 
 #endif

--- a/indra/llcommon/llcrc.cpp
+++ b/indra/llcommon/llcrc.cpp
@@ -200,7 +200,7 @@ void LLCRC::update(const std::string& filename)
 
 
 #ifdef _DEBUG
-BOOL LLCRC::testHarness()
+bool LLCRC::testHarness()
 {
 	const S32 TEST_BUFFER_SIZE = 16;
 	const char TEST_BUFFER[TEST_BUFFER_SIZE] = "hello &#$)$&Nd0";	/* Flawfinder: ignore */

--- a/indra/llcommon/llcrc.h
+++ b/indra/llcommon/llcrc.h
@@ -60,7 +60,7 @@ public:
 #ifdef _DEBUG
 	// This function runs tests to make sure the crc is
 	// working. Returns TRUE if it is.
-	static BOOL testHarness();
+	static bool testHarness();
 #endif
 };
 

--- a/indra/llcommon/lleventemitter.h
+++ b/indra/llcommon/lleventemitter.h
@@ -57,14 +57,14 @@ class eventEmitter
 
 		///////////////////////////////////////////////////////////////////////////////
 		//
-		BOOL addObserver ( T* observerIn )
+		bool addObserver ( T* observerIn )
 		{
 			if ( ! observerIn )
-				return FALSE;
+				return false;
 
 			// check if observer already exists
 			if ( std::find ( observers.begin (), observers.end (), observerIn ) != observers.end () )
-				return FALSE;
+				return false;
 
 			// save it
 			observers.push_back ( observerIn );
@@ -74,14 +74,14 @@ class eventEmitter
 
 		///////////////////////////////////////////////////////////////////////////////
 		//
-		BOOL remObserver ( T* observerIn )
+        bool remObserver ( T* observerIn )
 		{
 			if ( ! observerIn )
-				return FALSE;
+				return false;
 
 			observers.remove ( observerIn );
 
-			return TRUE;
+			return true;
 		};
 
 		///////////////////////////////////////////////////////////////////////////////

--- a/indra/llcommon/llframetimer.cpp
+++ b/indra/llcommon/llframetimer.cpp
@@ -52,12 +52,12 @@ void LLFrameTimer::updateFrameTime()
 void LLFrameTimer::start()
 {
 	reset();
-	mStarted = TRUE;
+	mStarted = true;
 }
 
 void LLFrameTimer::stop()
 {
-	mStarted = FALSE;
+	mStarted = false;
 }
 
 void LLFrameTimer::reset()
@@ -84,14 +84,14 @@ void LLFrameTimer::pause()
 {
 	if (mStarted)
 		mStartTime = sFrameTime - mStartTime; // save dtime
-	mStarted = FALSE;
+	mStarted = false;
 }
 
 void LLFrameTimer::unpause()
 {
 	if (!mStarted)
 		mStartTime = sFrameTime - mStartTime; // restore dtime
-	mStarted = TRUE;
+	mStarted = true;
 }
 
 void LLFrameTimer::setTimerExpirySec(F32 expiration)
@@ -112,7 +112,7 @@ F64 LLFrameTimer::expiresAt() const
 	return expires_at;
 }
 
-BOOL LLFrameTimer::checkExpirationAndReset(F32 expiration)
+bool LLFrameTimer::checkExpirationAndReset(F32 expiration)
 {
 	//LL_INFOS() << "LLFrameTimer::checkExpirationAndReset()" << LL_ENDL;
 	//LL_INFOS() << "  mStartTime:" << mStartTime << LL_ENDL;
@@ -123,9 +123,9 @@ BOOL LLFrameTimer::checkExpirationAndReset(F32 expiration)
 	{
 		reset();
 		setTimerExpirySec(expiration);
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 // static

--- a/indra/llcommon/llframetimer.h
+++ b/indra/llcommon/llframetimer.h
@@ -39,7 +39,7 @@
 class LL_COMMON_API LLFrameTimer 
 {
 public:
-	LLFrameTimer() : mStartTime( sFrameTime ), mExpiry(0), mStarted(TRUE) {}
+	LLFrameTimer() : mStartTime( sFrameTime ), mExpiry(0), mStarted(true) {}
 
 	// Return the number of seconds since the start of this
 	// application instance.
@@ -84,16 +84,16 @@ public:
 	void unpause();
 	void setTimerExpirySec(F32 expiration);
 	void setExpiryAt(F64 seconds_since_epoch);
-	BOOL checkExpirationAndReset(F32 expiration);
+    bool checkExpirationAndReset(F32 expiration);
 	F32 getElapsedTimeAndResetF32() 				{ F32 t = F32(sFrameTime - mStartTime); reset(); return t; }
 
 	void setAge(const F64 age)						{ mStartTime = sFrameTime - age; }
 
 	// ACCESSORS
-	BOOL hasExpired() const							{ return (sFrameTime >= mExpiry); }
+    bool hasExpired() const							{ return (sFrameTime >= mExpiry); }
 	F32  getTimeToExpireF32() const					{ return (F32)(mExpiry - sFrameTime); }
 	F32  getElapsedTimeF32() const					{ return mStarted ? (F32)(sFrameTime - mStartTime) : (F32)mStartTime; }
-	BOOL getStarted() const							{ return mStarted; }
+    bool getStarted() const							{ return mStarted; }
 
 	// return the seconds since epoch when this timer will expire.
 	F64 expiresAt() const;
@@ -142,7 +142,7 @@ protected:
 
 	// Useful bit of state usually associated with timers, but does
 	// not affect actual functionality
-	BOOL mStarted;
+    bool mStarted;
 };
 
 // Glue code for Havok (or anything else that doesn't want the full .h files)

--- a/indra/llcommon/llkeythrottle.h
+++ b/indra/llcommon/llkeythrottle.h
@@ -93,7 +93,7 @@ class LLKeyThrottle
 public:
 	// @param realtime = FALSE for frame-based throttle, TRUE for usec
 	// real-time throttle
-	LLKeyThrottle(U32 limit, F32 interval, BOOL realtime = TRUE)	
+	LLKeyThrottle(U32 limit, F32 interval, bool realtime = true)
 		: m(* new LLKeyThrottleImpl<T>)
 	{
 		setParameters( limit, interval, realtime );
@@ -287,7 +287,7 @@ public:
 	}
 
 	// Get the throttling parameters
-	void getParameters( U32 & out_limit, F32 & out_interval, BOOL & out_realtime )
+	void getParameters( U32 & out_limit, F32 & out_interval, bool & out_realtime )
 	{
 		out_limit = m.countLimit;
 		out_interval = m.intervalLength;
@@ -295,7 +295,7 @@ public:
 	}
 
 	// Set the throttling behavior
-	void setParameters( U32 limit, F32 interval, BOOL realtime = TRUE )
+	void setParameters( U32 limit, F32 interval, bool realtime = true )
 	{
 		// limit is the maximum number of keys
 		// allowed per interval (in seconds or frames)
@@ -325,7 +325,7 @@ public:
 
 protected:
 	LLKeyThrottleImpl<T>& m;
-	BOOL	mIsRealtime;	// TRUE to be time based (default), FALSE for frame based
+	bool	mIsRealtime;	// TRUE to be time based (default), FALSE for frame based
 };
 
 #endif

--- a/indra/llcommon/llmemory.cpp
+++ b/indra/llcommon/llmemory.cpp
@@ -189,7 +189,7 @@ void* LLMemory::tryToAlloc(void* address, U32 size)
 }
 
 //static 
-void LLMemory::logMemoryInfo(BOOL update)
+void LLMemory::logMemoryInfo(bool update)
 {
 	LL_PROFILE_ZONE_SCOPED
 	if(update)
@@ -343,8 +343,8 @@ void* ll_aligned_malloc_fallback( size_t size, int align )
 		__asm int 3;
 	}
 	DWORD old;
-	BOOL Res = VirtualProtect((void*)((char*)p + for_alloc), sysinfo.dwPageSize, PAGE_NOACCESS, &old);
-	if(FALSE == Res) {
+    bool Res = VirtualProtect((void*)((char*)p + for_alloc), sysinfo.dwPageSize, PAGE_NOACCESS, &old);
+	if(false == Res) {
 		// call debugger
 		__asm int 3;
 	}

--- a/indra/llcommon/llmemory.h
+++ b/indra/llcommon/llmemory.h
@@ -390,7 +390,7 @@ public:
 	static void* tryToAlloc(void* address, U32 size);
 	static void initMaxHeapSizeGB(F32Gigabytes max_heap_size);
 	static void updateMemoryInfo() ;
-	static void logMemoryInfo(BOOL update = FALSE);
+	static void logMemoryInfo(bool update = false);
 
 	static U32Kilobytes getAvailableMemKB() ;
 	static U32Kilobytes getMaxMemKB() ;

--- a/indra/llcommon/llmetricperformancetester.cpp
+++ b/indra/llcommon/llmetricperformancetester.cpp
@@ -50,18 +50,18 @@ void LLMetricPerformanceTesterBasic::cleanupClass()
 }
 
 /*static*/ 
-BOOL LLMetricPerformanceTesterBasic::addTester(LLMetricPerformanceTesterBasic* tester) 
+bool LLMetricPerformanceTesterBasic::addTester(LLMetricPerformanceTesterBasic* tester)
 {
 	llassert_always(tester != NULL);	
 	std::string name = tester->getTesterName() ;
 	if (getTester(name))
 	{
 		LL_ERRS() << "Tester name is already used by some other tester : " << name << LL_ENDL ;
-		return FALSE;
+		return false;
 	}
 
 	sTesterMap.insert(std::make_pair(name, tester));
-	return TRUE;
+	return true;
 }
 
 /*static*/ 
@@ -89,7 +89,7 @@ LLMetricPerformanceTesterBasic* LLMetricPerformanceTesterBasic::getTester(std::s
 
 /*static*/ 
 // Return TRUE if this metric is requested or if the general default "catch all" metric is requested
-BOOL LLMetricPerformanceTesterBasic::isMetricLogRequested(std::string name)
+bool LLMetricPerformanceTesterBasic::isMetricLogRequested(std::string name)
 {
 	return (LLTrace::BlockTimer::sMetricLog && ((LLTrace::BlockTimer::sLogName == name) || (LLTrace::BlockTimer::sLogName == DEFAULT_METRIC_NAME)));
 }
@@ -215,8 +215,8 @@ void LLMetricPerformanceTesterBasic::analyzePerformance(llofstream* os, LLSD* ba
 	resetCurrentCount() ;
 
 	std::string current_label = getCurrentLabelName();
-	BOOL in_base = (*base).has(current_label) ;
-	BOOL in_current = (*current).has(current_label) ;
+	bool in_base = (*base).has(current_label) ;
+	bool in_current = (*current).has(current_label) ;
 
 	while(in_base || in_current)
 	{

--- a/indra/llcommon/llmetricperformancetester.h
+++ b/indra/llcommon/llmetricperformancetester.h
@@ -48,7 +48,7 @@ public:
 	 * Need to be tested after creation of a tester instance so to know if the tester is correctly handled.
 	 * A tester might not be added to the map if another tester with the same name already exists.
 	 */
-	BOOL isValid() const { return mValidInstance; }
+    bool isValid() const { return mValidInstance; }
 
 	/**
 	 * @brief Write a set of test results to the log LLSD.
@@ -122,7 +122,7 @@ private:
 
 	std::string mName ;							// Name of this tester instance
 	S32 mCount ;								// Current record count
-	BOOL mValidInstance;						// TRUE if the instance is managed by the map
+	bool mValidInstance;						// TRUE if the instance is managed by the map
 	std::vector< std::string > mMetricStrings ; // Metrics strings
 
 // Static members managing the collection of testers
@@ -147,12 +147,12 @@ public:
 	 * @return Returns TRUE if that metric *or* the default catch all metric has been requested to be logged
 	 * @param[in] name - Name of the tester queried.
 	 */
-	static BOOL isMetricLogRequested(std::string name);
+	static bool isMetricLogRequested(std::string name);
 	
 	/**
 	 * @return Returns TRUE if there's a tester defined, FALSE otherwise.
 	 */
-	static BOOL hasMetricPerformanceTesters() { return !sTesterMap.empty() ;}
+	static bool hasMetricPerformanceTesters() { return !sTesterMap.empty() ;}
 	/**
 	 * @brief Delete all testers and reset the tester map
 	 */
@@ -160,7 +160,7 @@ public:
 
 private:
 	// Add a tester to the map. Returns false if adding fails.
-	static BOOL addTester(LLMetricPerformanceTesterBasic* tester) ;
+	static bool addTester(LLMetricPerformanceTesterBasic* tester) ;
 };
 
 /**

--- a/indra/llcommon/llmortician.cpp
+++ b/indra/llcommon/llmortician.cpp
@@ -30,7 +30,7 @@
 
 std::list<LLMortician*> LLMortician::sGraveyard;
 
-BOOL LLMortician::sDestroyImmediate = FALSE;
+bool LLMortician::sDestroyImmediate = false;
 
 LLMortician::~LLMortician() 
 {
@@ -88,19 +88,19 @@ void LLMortician::die()
 	if (sDestroyImmediate)
 	{
 		// *NOTE: This is a hack to ensure destruction order on shutdown (relative to non-mortician controlled classes).
-		mIsDead = TRUE;
+		mIsDead = true;
 		delete this;
 		return;
 	}
 	else if (!mIsDead)
 	{
-		mIsDead = TRUE;
+		mIsDead = true;
 		sGraveyard.push_back(this);
 	}
 }
 
 // static
-void LLMortician::setZealous(BOOL b)
+void LLMortician::setZealous(bool b)
 {
 	sDestroyImmediate = b;
 }

--- a/indra/llcommon/llmortician.h
+++ b/indra/llcommon/llmortician.h
@@ -33,21 +33,21 @@
 class LL_COMMON_API LLMortician 
 {
 public:
-	LLMortician() { mIsDead = FALSE; }
+	LLMortician() { mIsDead = false; }
 	static auto graveyardCount() { return sGraveyard.size(); };
 	static size_t logClass(std::stringstream &str);
 	static void updateClass();
 	virtual ~LLMortician();
 	void die();
-	BOOL isDead() { return mIsDead; }
+	bool isDead() { return mIsDead; }
 
 	// sets destroy immediate true
-	static void setZealous(BOOL b);
+	static void setZealous(bool b);
 
 private:
-	static BOOL sDestroyImmediate;
+	static bool sDestroyImmediate;
 
-	BOOL mIsDead;
+	bool mIsDead;
 
 	static std::list<LLMortician*> sGraveyard;
 };

--- a/indra/llcommon/llmutex.cpp
+++ b/indra/llcommon/llmutex.cpp
@@ -56,9 +56,9 @@ void LLMutex::lock()
 #if MUTEX_DEBUG
 	// Have to have the lock before we can access the debug info
 	auto id = LLThread::currentID();
-	if (mIsLocked[id] != FALSE)
+	if (mIsLocked[id] != false)
 		LL_ERRS() << "Already locked in Thread: " << id << LL_ENDL;
-	mIsLocked[id] = TRUE;
+	mIsLocked[id] = true;
 #endif
 
 	mLockingThread = LLThread::currentID();
@@ -76,9 +76,9 @@ void LLMutex::unlock()
 #if MUTEX_DEBUG
 	// Access the debug info while we have the lock
 	auto id = LLThread::currentID();
-	if (mIsLocked[id] != TRUE)
-		LL_ERRS() << "Not locked in Thread: " << id << LL_ENDL;	
-	mIsLocked[id] = FALSE;
+	if (mIsLocked[id] != true)
+		LL_ERRS() << "Not locked in Thread: " << id << LL_ENDL;
+	mIsLocked[id] = false;
 #endif
 
 	mLockingThread = LLThread::id_t();
@@ -126,9 +126,9 @@ bool LLMutex::trylock()
 #if MUTEX_DEBUG
 	// Have to have the lock before we can access the debug info
 	auto id = LLThread::currentID();
-	if (mIsLocked[id] != FALSE)
+	if (mIsLocked[id] != false)
 		LL_ERRS() << "Already locked in Thread: " << id << LL_ENDL;
-	mIsLocked[id] = TRUE;
+	mIsLocked[id] = true;
 #endif
 
 	mLockingThread = LLThread::currentID();

--- a/indra/llcommon/llnametable.h
+++ b/indra/llcommon/llnametable.h
@@ -55,16 +55,16 @@ public:
 		mNameMap[tablename] = data;
 	}
 
-	BOOL checkName(const std::string& name) const
+	bool checkName(const std::string& name) const
 	{
 		return checkName(name.c_str());
 	}
 
 	// "logically const" even though it modifies the global nametable
-	BOOL checkName(const char *name) const
+	bool checkName(const char *name) const
 	{
 		char *tablename = gStringTable.addString(name);
-		return mNameMap.count(tablename) ? TRUE : FALSE;
+		return mNameMap.count(tablename) ? true : false;
 	}
 
 	DATA resolveName(const std::string& name) const

--- a/indra/llcommon/llpriqueuemap.h
+++ b/indra/llcommon/llpriqueuemap.h
@@ -47,17 +47,17 @@ public:
 	{
 		if (mPriority > b.mPriority)
 		{
-			return TRUE;
+			return true;
 		}
 		if (mPriority < b.mPriority)
 		{
-			return FALSE;
+			return false;
 		}
 		if (mData > b.mData)
 		{
-			return TRUE;
+			return true;
 		}
-		return FALSE;
+		return false;
 	}
 
 	F32 mPriority;
@@ -90,18 +90,18 @@ public:
 		mMap.insert(pqm_pair(LLPQMKey<DATA_TYPE>(priority, data), data));
 	}
 
-	BOOL pop(DATA_TYPE *datap)
+	bool pop(DATA_TYPE *datap)
 	{
 		pqm_iter iter;
 		iter = mMap.begin();
 		if (iter == mMap.end())
 		{
-			return FALSE;
+			return false;
 		}
 		*datap = (*(iter)).second;
 		mMap.erase(iter);
 
-		return TRUE;
+		return true;
 	}
 
 	void reprioritize(const F32 new_priority, DATA_TYPE data)

--- a/indra/llcommon/llqueuedthread.cpp
+++ b/indra/llcommon/llqueuedthread.cpp
@@ -37,9 +37,9 @@
 // MAIN THREAD
 LLQueuedThread::LLQueuedThread(const std::string& name, bool threaded, bool should_pause) :
     LLThread(name),
-    mIdleThread(TRUE),
+    mIdleThread(true),
     mNextHandle(0),
-    mStarted(FALSE),
+    mStarted(false),
     mThreaded(threaded),
     mRequestQueue(name, 1024 * 1024)
 {
@@ -131,7 +131,7 @@ size_t LLQueuedThread::update(F32 max_time_ms)
 		if (!mThreaded)
 		{
 			startThread();
-			mStarted = TRUE;
+			mStarted = true;
 		}
 	}
 	return updateQueue(max_time_ms);
@@ -149,9 +149,9 @@ size_t LLQueuedThread::updateQueue(F32 max_time_ms)
             mRequestQueue.post([=]()
                 {
                     LL_PROFILE_ZONE_NAMED_CATEGORY_THREAD("qt - update");
-                    mIdleThread = FALSE;
+                    mIdleThread = false;
                     threadedUpdate();
-                    mIdleThread = TRUE;
+                    mIdleThread = true;
                 }
             );
         }
@@ -392,7 +392,7 @@ void LLQueuedThread::processRequest(LLQueuedThread::QueuedRequest* req)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_THREAD;
 
-    mIdleThread = FALSE;
+    mIdleThread = false;
     //threadedUpdate();
 
 	// Get next request from pool
@@ -494,7 +494,7 @@ void LLQueuedThread::processRequest(LLQueuedThread::QueuedRequest* req)
         }
     }
 
-    mIdleThread = TRUE;
+    mIdleThread = true;
 }
 
 // virtual
@@ -513,7 +513,7 @@ void LLQueuedThread::run()
 	// call checPause() immediately so we don't try to do anything before the class is fully constructed
 	checkPause();
 	startThread();
-	mStarted = TRUE;
+	mStarted = true;
 	
 
 	/*while (1)
@@ -522,7 +522,7 @@ void LLQueuedThread::run()
 		// this will block on the condition until runCondition() returns true, the thread is unpaused, or the thread leaves the RUNNING state.
 		checkPause();
 		
-		mIdleThread = FALSE;
+		mIdleThread = false;
 
 		threadedUpdate();
 		
@@ -531,7 +531,7 @@ void LLQueuedThread::run()
 		if (pending_work == 0)
 		{
             //LL_PROFILE_ZONE_NAMED("LLQueuedThread - sleep");
-			mIdleThread = TRUE;
+			mIdleThread = true;
 			//ms_sleep(1);
 		}
 		//LLThread::yield(); // thread should yield after each request		

--- a/indra/llcommon/llqueuedthread.h
+++ b/indra/llcommon/llqueuedthread.h
@@ -159,8 +159,8 @@ public:
 	bool check();
 	
 protected:
-	BOOL mThreaded;  // if false, run on main thread and do updates during update()
-	BOOL mStarted;  // required when mThreaded is false to call startThread() from update()
+    bool mThreaded;  // if false, run on main thread and do updates during update()
+    bool mStarted;  // required when mThreaded is false to call startThread() from update()
 	LLAtomicBool mIdleThread; // request queue is empty (or we are quitting) and the thread is idle
 	
 	//typedef std::set<QueuedRequest*, queued_request_less> request_queue_t;

--- a/indra/llcommon/llsdutil.cpp
+++ b/indra/llcommon/llsdutil.cpp
@@ -209,7 +209,7 @@ std::string ll_stream_notation_sd(const LLSD& sd)
 //are not of the same type, false is returned or if the LLSDs are not
 //of the same value.  Ordering of arrays matters
 //Otherwise, returns true
-BOOL compare_llsd_with_template(
+bool compare_llsd_with_template(
 	const LLSD& llsd_to_test,
 	const LLSD& template_llsd,
 	LLSD& resultant_llsd)
@@ -221,12 +221,12 @@ BOOL compare_llsd_with_template(
 		template_llsd.isDefined() )
 	{
 		resultant_llsd = template_llsd;
-		return TRUE;
+		return true;
 	}
 	else if ( llsd_to_test.type() != template_llsd.type() )
 	{
 		resultant_llsd = LLSD();
-		return FALSE;
+		return false;
 	}
 
 	if ( llsd_to_test.isArray() )
@@ -255,7 +255,7 @@ BOOL compare_llsd_with_template(
 					 data) )
 			{
 				resultant_llsd = LLSD();
-				return FALSE;
+				return false;
 			}
 			else
 			{
@@ -298,7 +298,7 @@ BOOL compare_llsd_with_template(
 						 value) )
 				{
 					resultant_llsd = LLSD();
-					return FALSE;
+					return false;
 				}
 				else
 				{
@@ -321,7 +321,7 @@ BOOL compare_llsd_with_template(
 	}
 
 
-	return TRUE;
+	return true;
 }
 
 // filter_llsd_with_template() is a direct clone (copy-n-paste) of 

--- a/indra/llcommon/llsdutil.h
+++ b/indra/llcommon/llsdutil.h
@@ -72,7 +72,7 @@ LL_COMMON_API std::string ll_stream_notation_sd(const LLSD& sd);
 //Returns false if the test is of same type but values differ in type
 //Otherwise, returns true
 
-LL_COMMON_API BOOL compare_llsd_with_template(
+LL_COMMON_API bool compare_llsd_with_template(
 	const LLSD& llsd_to_test,
 	const LLSD& template_llsd,
 	LLSD& resultant_llsd);

--- a/indra/llcommon/llstacktrace.cpp
+++ b/indra/llcommon/llstacktrace.cpp
@@ -53,8 +53,8 @@ bool ll_get_stack_trace(std::vector<std::string>& lines)
 	const S32 MAX_STACK_DEPTH = 32;
 	const S32 STRING_NAME_LENGTH = 200;
 	const S32 FRAME_SKIP = 2;
-	static BOOL symbolsLoaded = false;
-	static BOOL firstCall = true;
+	static bool symbolsLoaded = false;
+	static bool firstCall = true;
 
 	HANDLE hProc = GetCurrentProcess();
 
@@ -92,7 +92,7 @@ bool ll_get_stack_trace(std::vector<std::string>& lines)
 		for(S32 i=0; i < depth; i++)
 		{
 			std::stringstream stack_line;
-			BOOL ret;
+            bool ret;
 
 			DWORD64 addr = (DWORD64)frames[i];
 			ret = SymGetSymFromAddr64(hProc, addr, 0, pSym);
@@ -134,7 +134,7 @@ void ll_get_stack_trace_internal(std::vector<std::string>& lines)
 	const S32 STRING_NAME_LENGTH = 256;
 
 	HANDLE process = GetCurrentProcess();
-	SymInitialize( process, NULL, TRUE );
+	SymInitialize( process, NULL, true );
 
 	void *stack[MAX_STACK_DEPTH];
 

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -214,7 +214,7 @@ LLOSInfo::LLOSInfo() :
 		DWORD cbData(sizeof(DWORD));
 		DWORD data(0);
 		HKEY key;
-		BOOL ret_code = RegOpenKeyExW(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &key);
+        LSTATUS ret_code = RegOpenKeyExW(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"), 0, KEY_READ, &key);
 		if (ERROR_SUCCESS == ret_code)
 		{
 			ret_code = RegQueryValueExW(key, L"UBR", 0, NULL, reinterpret_cast<LPBYTE>(&data), &cbData);
@@ -571,7 +571,7 @@ bool LLOSInfo::is64Bit()
     return true;
 #elif defined(_WIN32)
     // 32-bit viewer may be run on both 32-bit and 64-bit Windows, need to elaborate
-    BOOL f64 = FALSE;
+    bool f64 = false;
     return IsWow64Process(GetCurrentProcess(), &f64) && f64;
 #else
     return false;
@@ -1321,11 +1321,11 @@ private:
 // Need an instance of FrameWatcher before it does any good
 static FrameWatcher sFrameWatcher;
 
-BOOL gunzip_file(const std::string& srcfile, const std::string& dstfile)
+bool gunzip_file(const std::string& srcfile, const std::string& dstfile)
 {
 	std::string tmpfile;
 	const S32 UNCOMPRESS_BUFFER_SIZE = 32768;
-	BOOL retval = FALSE;
+	bool retval = false;
 	gzFile src = NULL;
 	U8 buffer[UNCOMPRESS_BUFFER_SIZE];
 	LLFILE *dst = NULL;
@@ -1353,18 +1353,18 @@ BOOL gunzip_file(const std::string& srcfile, const std::string& dstfile)
 	fclose(dst); 
 	dst = NULL;	
 	if (LLFile::rename(tmpfile, dstfile) == -1) goto err;		/* Flawfinder: ignore */
-	retval = TRUE;
+	retval = true;
 err:
 	if (src != NULL) gzclose(src);
 	if (dst != NULL) fclose(dst);
 	return retval;
 }
 
-BOOL gzip_file(const std::string& srcfile, const std::string& dstfile)
+bool gzip_file(const std::string& srcfile, const std::string& dstfile)
 {
 	const S32 COMPRESS_BUFFER_SIZE = 32768;
 	std::string tmpfile;
-	BOOL retval = FALSE;
+	bool retval = false;
 	U8 buffer[COMPRESS_BUFFER_SIZE];
 	gzFile dst = NULL;
 	LLFILE *src = NULL;
@@ -1404,7 +1404,7 @@ BOOL gzip_file(const std::string& srcfile, const std::string& dstfile)
 	LLFile::remove(dstfile);
 #endif
 	if (LLFile::rename(tmpfile, dstfile) == -1) goto err;		/* Flawfinder: ignore */
-	retval = TRUE;
+	retval = true;
  err:
 	if (src != NULL) fclose(src);
 	if (dst != NULL) gzclose(dst);

--- a/indra/llcommon/llsys.h
+++ b/indra/llcommon/llsys.h
@@ -165,9 +165,9 @@ LL_COMMON_API std::ostream& operator<<(std::ostream& s, const LLCPUInfo& info);
 LL_COMMON_API std::ostream& operator<<(std::ostream& s, const LLMemoryInfo& info);
 
 // gunzip srcfile into dstfile.  Returns FALSE on error.
-BOOL LL_COMMON_API gunzip_file(const std::string& srcfile, const std::string& dstfile);
+bool LL_COMMON_API gunzip_file(const std::string& srcfile, const std::string& dstfile);
 // gzip srcfile into dstfile.  Returns FALSE on error.
-BOOL LL_COMMON_API gzip_file(const std::string& srcfile, const std::string& dstfile);
+bool LL_COMMON_API gzip_file(const std::string& srcfile, const std::string& dstfile);
 
 extern LL_COMMON_API LLCPUInfo gSysCPU;
 

--- a/indra/llcommon/llthread.cpp
+++ b/indra/llcommon/llthread.cpp
@@ -188,7 +188,7 @@ void LLThread::threadRun()
 }
 
 LLThread::LLThread(const std::string& name, apr_pool_t *poolp) :
-    mPaused(FALSE),
+    mPaused(false),
     mName(name),
     mThreadp(NULL),
     mStatus(STOPPED),

--- a/indra/llcommon/llthread.h
+++ b/indra/llcommon/llthread.h
@@ -68,7 +68,7 @@ public:
     // Called from MAIN THREAD.
     void pause();
     void unpause();
-    bool isPaused() { return isStopped() || mPaused == TRUE; }
+    bool isPaused() { return isStopped() || mPaused == true; }
     
     // Cause the thread to wake up and check its condition
     void wake();

--- a/indra/llcommon/lltimer.cpp
+++ b/indra/llcommon/lltimer.cpp
@@ -96,7 +96,7 @@ U32 micro_sleep(U64 us, U32 max_yields)
     LARGE_INTEGER ft;
     ft.QuadPart = -static_cast<S64>(us * 10);  // '-' using relative time
 
-    HANDLE timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    HANDLE timer = CreateWaitableTimer(NULL, true, NULL);
     SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
     WaitForSingleObject(timer, INFINITE);
     CloseHandle(timer);
@@ -324,7 +324,7 @@ LLTimer::LLTimer()
 		get_timer_info().update();
 	}
 
-	mStarted = TRUE;
+	mStarted = true;
 	reset();
 }
 
@@ -441,31 +441,31 @@ F32SecondsImplicit LLTimer::getRemainingTimeF32() const
 }
 
 
-BOOL  LLTimer::checkExpirationAndReset(F32 expiration)
+bool  LLTimer::checkExpirationAndReset(F32 expiration)
 {
 	U64 cur_ticks = get_clock_count();
 	if (cur_ticks < mExpirationTicks)
 	{
-		return FALSE;
+		return false;
 	}
 
 	mExpirationTicks = cur_ticks
 		+ (U64)((F32)(expiration * get_timer_info().mClockFrequency));
-	return TRUE;
+	return true;
 }
 
 
-BOOL  LLTimer::hasExpired() const
+bool  LLTimer::hasExpired() const
 {
 	return (get_clock_count() >= mExpirationTicks)
-		? TRUE : FALSE;
+		? true : false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-BOOL LLTimer::knownBadTimer()
+bool LLTimer::knownBadTimer()
 {
-	BOOL failed = FALSE;
+	bool failed = false;
 
 #if LL_WINDOWS
 	WCHAR bad_pci_list[][10] = {L"1039:0530",
@@ -507,7 +507,7 @@ BOOL LLTimer::knownBadTimer()
 				if (!wcscmp(pci_id, bad_pci_list[check]))
 				{
 //					LL_WARNS() << "unreliable PCI chipset found!! " << pci_id << endl;
-					failed = TRUE;
+					failed = true;
 					break;
 				}
 			}
@@ -533,7 +533,7 @@ time_t time_corrected()
 
 // Is the current computer (in its current time zone)
 // observing daylight savings time?
-BOOL is_daylight_savings()
+bool is_daylight_savings()
 {
 	time_t now = time(NULL);
 
@@ -547,7 +547,7 @@ BOOL is_daylight_savings()
 }
 
 
-struct tm* utc_to_pacific_time(time_t utc_time, BOOL pacific_daylight_time)
+struct tm* utc_to_pacific_time(time_t utc_time, bool pacific_daylight_time)
 {
 	S32Hours pacific_offset_hours;
 	if (pacific_daylight_time)

--- a/indra/llcommon/lltimer.h
+++ b/indra/llcommon/lltimer.h
@@ -87,19 +87,19 @@ public:
 
 
 	// MANIPULATORS
-	void start() { reset(); mStarted = TRUE; }
-	void stop() { mStarted = FALSE; }
+	void start() { reset(); mStarted = true; }
+	void stop() { mStarted = false; }
 	void reset();								// Resets the timer
 	void setLastClockCount(U64 current_count);		// Sets the timer so that the next elapsed call will be relative to this time
 	void setTimerExpirySec(F32SecondsImplicit expiration);
-	BOOL checkExpirationAndReset(F32 expiration);
-	BOOL hasExpired() const;
+    bool checkExpirationAndReset(F32 expiration);
+    bool hasExpired() const;
 	F32SecondsImplicit getElapsedTimeAndResetF32();	// Returns elapsed time in seconds with reset
 	F64SecondsImplicit getElapsedTimeAndResetF64();
 
 	F32SecondsImplicit getRemainingTimeF32() const;
 
-	static BOOL knownBadTimer();
+	static bool knownBadTimer();
 
 	// ACCESSORS
 	F32SecondsImplicit getElapsedTimeF32() const;			// Returns elapsed time in seconds
@@ -171,14 +171,14 @@ extern LL_COMMON_API S32 gUTCOffset;
 
 // Is the current computer (in its current time zone)
 // observing daylight savings time?
-LL_COMMON_API BOOL is_daylight_savings();
+LL_COMMON_API bool is_daylight_savings();
 
 // Converts internal "struct tm" time buffer to Pacific Standard/Daylight Time
 // Usage:
 // S32 utc_time;
 // utc_time = time_corrected();
 // struct tm* internal_time = utc_to_pacific_time(utc_time, gDaylight);
-LL_COMMON_API struct tm* utc_to_pacific_time(time_t utc_time, BOOL pacific_daylight_time);
+LL_COMMON_API struct tm* utc_to_pacific_time(time_t utc_time, bool pacific_daylight_time);
 
 LL_COMMON_API void microsecondsToTimecodeString(U64MicrosecondsImplicit current_time, std::string& tcstring);
 LL_COMMON_API void secondsToTimecodeString(F32SecondsImplicit current_time, std::string& tcstring);

--- a/indra/llcommon/lluri.cpp
+++ b/indra/llcommon/lluri.cpp
@@ -330,7 +330,7 @@ LLURI::LLURI(const std::string& escaped_str)
 	}
 }
 
-static BOOL isDefault(const std::string& scheme, U16 port)
+static bool isDefault(const std::string& scheme, U16 port)
 {
 	if (scheme == "http")
 		return port == 80;
@@ -339,7 +339,7 @@ static BOOL isDefault(const std::string& scheme, U16 port)
 	if (scheme == "ftp")
 		return port == 21;
 
-	return FALSE;
+	return false;
 }
 
 void LLURI::parseAuthorityAndPathUsingOpaque()
@@ -627,7 +627,7 @@ std::string LLURI::password() const
 	return unescape(pass);
 }
 
-BOOL LLURI::defaultPort() const
+bool LLURI::defaultPort() const
 {
 	return isDefault(mScheme, hostPort());
 }

--- a/indra/llcommon/lluri.h
+++ b/indra/llcommon/lluri.h
@@ -99,7 +99,7 @@ public:
   std::string userName() const;
   std::string password() const;
   U16 hostPort() const;			// ex.: 80, will include implicit port
-  BOOL defaultPort() const;		// true if port is default for scheme
+  bool defaultPort() const;		// true if port is default for scheme
   const std::string& escapedPath() const { return mEscapedPath; }
   std::string path() const;		// ex.: "/abc/def", includes leading slash
   LLSD pathArray() const;			// above decoded into an array of strings

--- a/indra/llcommon/lluuid.cpp
+++ b/indra/llcommon/lluuid.cpp
@@ -211,20 +211,20 @@ std::string LLUUID::asString() const
     return str;
 }
 
-BOOL LLUUID::set(const char* in_string, BOOL emit)
+bool LLUUID::set(const char* in_string, bool emit)
 {
     return set(ll_safe_string(in_string), emit);
 }
 
-BOOL LLUUID::set(const std::string& in_string, BOOL emit)
+bool LLUUID::set(const std::string& in_string, bool emit)
 {
-    BOOL broken_format = FALSE;
+    bool broken_format = false;
 
     // empty strings should make NULL uuid
     if (in_string.empty())
     {
         setNull();
-        return TRUE;
+        return true;
     }
 
     if (in_string.length() != (UUID_STR_LENGTH - 1))		/* Flawfinder: ignore */
@@ -237,7 +237,7 @@ BOOL LLUUID::set(const std::string& in_string, BOOL emit)
             {
                 LL_WARNS() << "Warning! Using broken UUID string format" << LL_ENDL;
             }
-            broken_format = TRUE;
+            broken_format = true;
         }
         else
         {
@@ -248,7 +248,7 @@ BOOL LLUUID::set(const std::string& in_string, BOOL emit)
                 LL_WARNS() << "Bad UUID string: " << in_string << LL_ENDL;
             }
             setNull();
-            return FALSE;
+            return false;
         }
     }
 
@@ -287,7 +287,7 @@ BOOL LLUUID::set(const std::string& in_string, BOOL emit)
                 LL_WARNS() << "Invalid UUID string character" << LL_ENDL;
             }
             setNull();
-            return FALSE;
+            return false;
         }
 
         mData[i] = mData[i] << 4;
@@ -312,27 +312,27 @@ BOOL LLUUID::set(const std::string& in_string, BOOL emit)
                 LL_WARNS() << "Invalid UUID string character" << LL_ENDL;
             }
             setNull();
-            return FALSE;
+            return false;
         }
         cur_pos++;
     }
 
-    return TRUE;
+    return true;
 }
 
-BOOL LLUUID::validate(const std::string& in_string)
+bool LLUUID::validate(const std::string& in_string)
 {
-    BOOL broken_format = FALSE;
+    bool broken_format = false;
     if (in_string.length() != (UUID_STR_LENGTH - 1))		/* Flawfinder: ignore */
     {
         // I'm a moron.  First implementation didn't have the right UUID format.
         if (in_string.length() == (UUID_STR_LENGTH - 2))		/* Flawfinder: ignore */
         {
-            broken_format = TRUE;
+            broken_format = true;
         }
         else
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -360,7 +360,7 @@ BOOL LLUUID::validate(const std::string& in_string)
         }
         else
         {
-            return FALSE;
+            return false;
         }
 
         cur_pos++;
@@ -376,11 +376,11 @@ BOOL LLUUID::validate(const std::string& in_string)
         }
         else
         {
-            return FALSE;
+            return false;
         }
         cur_pos++;
     }
-    return TRUE;
+    return true;
 }
 
 const LLUUID& LLUUID::operator^=(const LLUUID& rhs)
@@ -736,12 +736,12 @@ void LLUUID::getCurrentTime(uuid_time_t* timestamp)
 
     static uuid_time_t time_last;
     static U32    uuids_this_tick;
-    static BOOL     init = FALSE;
+    static bool     init = false;
 
     if (!init) {
         getSystemTime(&time_last);
         uuids_this_tick = uuids_per_tick;
-        init = TRUE;
+        init = true;
         mMutex = new LLMutex();
     }
 
@@ -889,11 +889,11 @@ U32 LLUUID::getRandomSeed()
    return U32(seed64) ^ U32(seed64 >> 32);
 }
 
-BOOL LLUUID::parseUUID(const std::string& buf, LLUUID* value)
+bool LLUUID::parseUUID(const std::string& buf, LLUUID* value)
 {
     if (buf.empty() || value == NULL)
     {
-        return FALSE;
+        return false;
     }
 
     std::string temp(buf);
@@ -901,9 +901,9 @@ BOOL LLUUID::parseUUID(const std::string& buf, LLUUID* value)
     if (LLUUID::validate(temp))
     {
         value->set(temp);
-        return TRUE;
+        return true;
     }
-    return FALSE;
+    return false;
 }
 
 //static
@@ -989,7 +989,7 @@ bool LLUUID::operator!=(const LLUUID& rhs) const
 }
 */
 
-BOOL LLUUID::notNull() const
+bool LLUUID::notNull() const
 {
     U32* word = (U32*)mData;
     return (word[0] | word[1] | word[2] | word[3]) > 0;
@@ -997,7 +997,7 @@ BOOL LLUUID::notNull() const
 
 // Faster than == LLUUID::null because doesn't require
 // as much memory access.
-BOOL LLUUID::isNull() const
+bool LLUUID::isNull() const
 {
     U32* word = (U32*)mData;
     // If all bits are zero, return !0 == TRUE

--- a/indra/llcommon/lluuid.h
+++ b/indra/llcommon/lluuid.h
@@ -65,8 +65,8 @@ public:
 
 	static LLUUID generateNewID(std::string stream = "");	//static version of above for use in initializer expressions such as constructor params, etc. 
 
-	BOOL	set(const char *in_string, BOOL emit = TRUE);	// Convert from string, if emit is FALSE, do not emit warnings
-	BOOL	set(const std::string& in_string, BOOL emit = TRUE);	// Convert from string, if emit is FALSE, do not emit warnings
+	bool	set(const char *in_string, bool emit = true);	// Convert from string, if emit is FALSE, do not emit warnings
+	bool	set(const std::string& in_string, bool emit = true);	// Convert from string, if emit is FALSE, do not emit warnings
 	void	setNull();					// Faster than setting to LLUUID::null.
 
     S32     cmpTime(uuid_time_t *t1, uuid_time_t *t2);
@@ -76,8 +76,8 @@ public:
 	//
 	// ACCESSORS
 	//
-	BOOL	isNull() const;			// Faster than comparing to LLUUID::null.
-	BOOL	notNull() const;		// Faster than comparing to LLUUID::null.
+	bool	isNull() const;			// Faster than comparing to LLUUID::null.
+	bool	notNull() const;		// Faster than comparing to LLUUID::null.
 	// JC: This is dangerous.  It allows UUIDs to be cast automatically
 	// to integers, among other things.  Use isNull() or notNull().
 	//		operator bool() const;
@@ -124,7 +124,7 @@ public:
 		return tmp[0] ^ tmp[1];
 	}
 
-	static BOOL validate(const std::string& in_string); // Validate that the UUID string is legal.
+	static bool validate(const std::string& in_string); // Validate that the UUID string is legal.
 
 	static const LLUUID null;
 	static LLMutex * mMutex;
@@ -132,7 +132,7 @@ public:
 	static U32 getRandomSeed();
 	static S32 getNodeID(unsigned char * node_id);
 
-	static BOOL parseUUID(const std::string& buf, LLUUID* value);
+	static bool parseUUID(const std::string& buf, LLUUID* value);
 
 	U8 mData[UUID_BYTES];
 };

--- a/indra/llcrashlogger/llcrashlogger.cpp
+++ b/indra/llcrashlogger/llcrashlogger.cpp
@@ -50,8 +50,8 @@
 #include <curl/curl.h>
 #include <openssl/crypto.h>
 
-BOOL gBreak = false;
-BOOL gSent = false;
+bool gBreak = false;
+bool gSent = false;
 
 int LLCrashLogger::ssl_mutex_count = 0;
 LLCoreInt::HttpMutex ** LLCrashLogger::ssl_mutex_list = NULL;

--- a/indra/llcrashlogger/llcrashlogger.h
+++ b/indra/llcrashlogger/llcrashlogger.h
@@ -77,7 +77,7 @@ protected:
     static void ssl_locking_callback(int mode, int type, const char * file, int line);
 
 	S32 mCrashBehavior;
-	BOOL mCrashInPreviousExec;
+	bool mCrashInPreviousExec;
 	std::map<std::string, std::string> mFileMap;
 	std::string mGridName;
 	LLControlGroup mCrashSettings;


### PR DESCRIPTION
The first in (hopefully) a long series of PRs seeing `BOOL/TRUE/FALSE` (int) replaced by `bool/true/false` to make it easier for the compiler to optimize code. This should impact performance and memory use somewhat. Some 3rd party viewers have already done this replacement.

In addition to this, in the long run it will make it easier to improve the macOS Objective-C ([which defines BOOL also](https://developer.apple.com/documentation/objectivec/bool)) bridging code.

143 occurrences of `BOOL` and their `FALSE` and `TRUE` companions were converted in `llcommon`. This leaves 13729(!) to fix, though this number includes comments.

If it gets accepted, I will make a much larger next PR. But of course this needs to be done in parts.

Note: I have only been able to test on macOS and x86, so I have not been able to test #ifdef'd Windows code.