### PR TITLE
Add command-line switches --lua "chunk" and --luafile pathname.

### DIFF
--- a/indra/newview/app_settings/cmd_line.xml
+++ b/indra/newview/app_settings/cmd_line.xml
@@ -195,7 +195,33 @@
       <string>LogPerformance</string>
     </map>
 
-    <key>multiple</key>		  
+    <key>lua</key>
+    <map>
+      <key>desc</key>
+      <string>Run specified Lua chunk</string>
+      <key>count</key>
+      <integer>1</integer>
+      <!-- you can specify multiple such chunks -->
+      <key>compose</key>
+      <boolean>true</boolean>
+      <key>map-to</key>
+      <string>LuaChunk</string>
+    </map>
+
+    <key>luafile</key>
+    <map>
+      <key>desc</key>
+      <string>Run specified Lua script</string>
+      <key>count</key>
+      <integer>1</integer>
+      <!-- you can specify multiple such scripts -->
+      <key>compose</key>
+      <boolean>true</boolean>
+      <key>map-to</key>
+      <string>LuaScript</string>
+    </map>
+
+    <key>multiple</key>
     <map>
       <key>desc</key>
       <string>Allow multiple viewers.</string>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -68,7 +68,7 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-	<key>CrashHostUrl</key>
+    <key>CrashHostUrl</key>
     <map>
       <key>Comment</key>
       <string>A URL pointing to a crash report handler; overrides cluster negotiation to locate crash handler.</string>
@@ -5430,6 +5430,28 @@
       <string>String</string>
       <key>Value</key>
       <string>http://wiki.secondlife.com/wiki/[LSL_STRING]</string>
+    </map>
+    <key>LuaChunk</key>
+    <map>
+      <key>Comment</key>
+      <string>Zero or more Lua chunks to run</string>
+      <key>Persist</key>
+      <integer>0</integer>
+      <key>Type</key>
+      <string>LLSD</string>
+      <key>Value</key>
+      <array />
+    </map>
+    <key>LuaScript</key>
+    <map>
+      <key>Comment</key>
+      <string>Zero or more Lua script files to run</string>
+      <key>Persist</key>
+      <integer>0</integer>
+      <key>Type</key>
+      <string>LLSD</string>
+      <key>Value</key>
+      <array />
     </map>
     <key>GridStatusRSS</key>
     <map>

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -300,8 +300,7 @@ std::pair<int, LLSD> LLLUAmanager::waitScriptFile(LuaState& L, const std::string
 
 void LLLUAmanager::runScriptFile(LuaState& L, const std::string& filename, script_result_fn cb)
 {
-    std::string desc{ stringize("runScriptFile('", filename, "')") };
-    LLCoros::instance().launch(desc, [&L, desc, filename, cb]()
+    LLCoros::instance().launch(filename, [&L, filename, cb]()
     {
         llifstream in_file;
         in_file.open(filename.c_str());
@@ -310,7 +309,7 @@ void LLLUAmanager::runScriptFile(LuaState& L, const std::string& filename, scrip
         {
             std::string text{std::istreambuf_iterator<char>(in_file),
                              std::istreambuf_iterator<char>()};
-            auto [count, result] = L.expr(desc, text);
+            auto [count, result] = L.expr(filename, text);
             if (cb)
             {
                 cb(count, result);


### PR DESCRIPTION
`--lua "chunk"` runs the specified Lua chunk at startup time.

`--luafile pathname` runs the specified Lua script file at startup time.

You may specify more than one `--lua` or `--luafile` switch on the command line.

Fixes secondlife/viewer-issues#6