### PR TITLE
triage#59 Show 'Friends Only' rendering mode

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -8817,17 +8817,6 @@
         <key>Value</key>
             <integer>1</integer>
         </map>
-  <key>AlwaysRenderFriends</key>
-    <map>
-      <key>Comment</key>
-      <string>Always render friends regardless of max complexity</string>
-      <key>Persist</key>
-      <integer>1</integer>
-      <key>Type</key>
-      <string>Boolean</string>
-      <key>Value</key>
-      <integer>0</integer>
-    </map>
   <key>RenderAvatar</key>
     <map>
       <key>Comment</key>
@@ -10921,16 +10910,16 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-    <key>RenderUseImpostors</key>
+    <key>RenderAvatarComplexityMode</key>
     <map>
-      <key>Comment</key>
-    <string>OBSOLETE and UNUSED. See RenderAvatarMaxNonImpostors and RenderAvatarMaxComplexity.</string>
-      <key>Persist</key>
-    <integer>0</integer>
-      <key>Type</key>
-      <string>Boolean</string>
-      <key>Value</key>
-    <integer>0</integer>
+        <key>Comment</key>
+        <string>0 - complexity limit applies to everyone, 1 - always show friends, 2 - only show friends</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>S32</string>
+        <key>Value</key>
+        <real>0</real>
     </map>
   <key>RenderAvatarMaxNonImpostors</key>
   <map>

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -437,6 +437,12 @@ bool LLFloaterPreference::postBuild()
 
 	gSavedSettings.getControl("PreferredMaturity")->getSignal()->connect(boost::bind(&LLFloaterPreference::onChangeMaturity, this));
 
+    gSavedSettings.getControl("RenderAvatarComplexityMode")->getSignal()->connect(
+        [this](LLControlVariable* control, const LLSD& new_val, const LLSD& old_val)
+        {
+            onChangeComplexityMode(new_val);
+        });
+
 	gSavedPerAccountSettings.getControl("ModelUploadFolder")->getSignal()->connect(boost::bind(&LLFloaterPreference::onChangeModelFolder, this));
     gSavedPerAccountSettings.getControl("PBRUploadFolder")->getSignal()->connect(boost::bind(&LLFloaterPreference::onChangePBRFolder, this));
 	gSavedPerAccountSettings.getControl("TextureUploadFolder")->getSignal()->connect(boost::bind(&LLFloaterPreference::onChangeTextureFolder, this));
@@ -476,6 +482,9 @@ bool LLFloaterPreference::postBuild()
 	LLSliderCtrl* fov_slider = getChild<LLSliderCtrl>("camera_fov");
 	fov_slider->setMinValue(LLViewerCamera::getInstance()->getMinView());
 	fov_slider->setMaxValue(LLViewerCamera::getInstance()->getMaxView());
+
+    bool enable_complexity = gSavedSettings.getS32("RenderAvatarComplexityMode") != LLVOAvatar::AV_RENDER_ONLY_SHOW_FRIENDS;
+    getChild<LLSliderCtrl>("IndirectMaxComplexity")->setEnabled(enable_complexity);
 	
 	// Hook up and init for filtering
 	mFilterEdit = getChild<LLSearchEditor>("search_prefs_edit");
@@ -1627,6 +1636,12 @@ void LLFloaterPreference::onChangeMaturity()
 															|| sim_access == SIM_ACCESS_ADULT);
 
 	getChild<LLIconCtrl>("rating_icon_adult")->setVisible(sim_access == SIM_ACCESS_ADULT);
+}
+
+void LLFloaterPreference::onChangeComplexityMode(const LLSD& newvalue)
+{
+    bool enable_complexity = newvalue.asInteger() != LLVOAvatar::AV_RENDER_ONLY_SHOW_FRIENDS;
+    getChild<LLSliderCtrl>("IndirectMaxComplexity")->setEnabled(enable_complexity);
 }
 
 std::string get_category_path(LLUUID cat_id)

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -164,7 +164,6 @@ public:
 	void onClickLogPath();
 	void changeLogPath(const std::vector<std::string>& filenames, std::string proposed_name);
 	bool moveTranscriptsAndLog();
-	void enableHistory();
 	void setPersonalInfo(const std::string& visibility);
 	void refreshEnabledState();
 	void onCommitWindowedMode();
@@ -174,10 +173,8 @@ public:
 	
 	void refreshUI();
 
-	void onCommitMediaEnabled();
-	void onCommitMusicEnabled();
-	void applyResolution();
 	void onChangeMaturity();
+    void onChangeComplexityMode(const LLSD& newvalue);
 	void onChangeModelFolder();
     void onChangePBRFolder();
 	void onChangeTextureFolder();
@@ -199,7 +196,6 @@ public:
 	void buildPopupLists();
 	static void refreshSkin(void* data);
 	void selectPanel(const LLSD& name);
-	void saveCameraPreset(std::string& preset);
 	void saveGraphicsPreset(std::string& preset);
 
     void setRecommendedSettings();

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.h
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.h
@@ -48,6 +48,7 @@ public:
     void updateIndirectMaxNonImpostors(const LLSD& newvalue);
     void setMaxNonImpostorsText(U32 value, LLTextBox* text_box);
     void updateMaxComplexity();
+    void updateComplexityMode(const LLSD& newvalue);
     void updateComplexityText();
     void updateObjectMeshDetailText();
     void refresh();
@@ -61,7 +62,9 @@ protected:
     void		onBtnCancel(const LLSD& userdata);
 
     boost::signals2::connection	mComplexityChangedSignal;
+    boost::signals2::connection	mComplexityModeChangedSignal;
     boost::signals2::connection	mLODFactorChangedSignal;
+    boost::signals2::connection	mNumImpostorsChangedSignal;
 };
 
 #endif //LLFLOATERPREFERENCEGRAPHICSADVANCED_H

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -638,8 +638,13 @@ void handlePerformanceStatsEnabledChanged(const LLSD& newValue)
 }
 void handleUserImpostorByDistEnabledChanged(const LLSD& newValue)
 {
-    const auto newval = gSavedSettings.getBOOL("AutoTuneImpostorByDistEnabled");
-    LLPerfStats::tunables.userImpostorDistanceTuningEnabled = newval;
+    bool auto_tune_newval = false;
+    S32 mode = gSavedSettings.getS32("RenderAvatarComplexityMode");
+    if (mode != LLVOAvatar::AV_RENDER_ONLY_SHOW_FRIENDS)
+    {
+        auto_tune_newval = gSavedSettings.getBOOL("AutoTuneImpostorByDistEnabled");
+    }
+    LLPerfStats::tunables.userImpostorDistanceTuningEnabled = auto_tune_newval;
 }
 void handleUserImpostorDistanceChanged(const LLSD& newValue)
 {
@@ -708,6 +713,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderGlowNoise", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGammaFull", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderVolumeLODFactor", handleVolumeLODChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderAvatarComplexityMode", handleUserImpostorByDistEnabledChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderAvatarLODFactor", handleAvatarLODChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderAvatarPhysicsLODFactor", handleAvatarPhysicsLODChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderTerrainLODFactor", handleTerrainLODChanged);

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -487,7 +487,14 @@ public:
 	U32 		renderImpostor(LLColor4U color = LLColor4U(255,255,255,255), S32 diffuse_channel = 0);
 	bool		isVisuallyMuted();
 	bool 		isInMuteList() const;
-	void		forceUpdateVisualMuteSettings();
+
+    // states for RenderAvatarComplexityMode
+    enum ERenderComplexityMode
+    {
+        AV_RENDER_LIMIT_BY_COMPLEXITY = 0,
+        AV_RENDER_ALWAYS_SHOW_FRIENDS = 1,
+        AV_RENDER_ONLY_SHOW_FRIENDS   = 2
+    };
 
 	// Visual Mute Setting is an input. Does not necessarily determine
 	// what the avatar looks like, because it interacts with other

--- a/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
@@ -139,7 +139,7 @@
       width="128"
       name="AvatarComplexityModeLabel"
       text_readonly_color="LabelDisabledColor">
-        Detail Mode:
+        Avatar display:
     </text>
 
     <combo_box

--- a/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
@@ -128,6 +128,42 @@
      Avatar
   </text>
 
+    <text
+      type="string"
+      length="1"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="30"
+      top_delta="16"
+      width="128"
+      name="AvatarComplexityModeLabel"
+      text_readonly_color="LabelDisabledColor">
+        Detail Mode:
+    </text>
+
+    <combo_box
+     control_name="RenderAvatarComplexityMode"
+     height="18"
+     layout="topleft"
+     left_delta="130"
+     top_delta="0"
+     name="AvatarComplexityMode"
+     width="150">
+        <combo_box.item
+          label="Limit by complexity"
+          name="0"
+          value="0"/>
+        <combo_box.item
+          label="Always show friends"
+          name="1"
+          value="1"/>
+        <combo_box.item
+          label="Only show friends"
+          name="2"
+          value="2"/>
+    </combo_box>
+
   <slider
     control_name="IndirectMaxComplexity"
     tool_tip="Controls at what point a visually complex avatar is drawn as a JellyDoll"

--- a/indra/newview/skins/default/xui/en/panel_performance_nearby.xml
+++ b/indra/newview/skins/default/xui/en/panel_performance_nearby.xml
@@ -135,18 +135,41 @@
     name="exceptions_btn"
     width="100">
   </button>
-  <check_box
-    control_name="AlwaysRenderFriends"
+
+  <text
+    type="string"
+    length="1"
+    follows="left|top"
     height="16"
-    initial_value="true"
-    label="Always display friends in full detail"
-    label_text.text_color="White"
     layout="topleft"
-    name="display_friends"
-    top_pad="3"
     left="18"
-    width="256">
-  </check_box>
+    top_pad="3"
+    name="AvatarComplexityModeLabel"
+    text_readonly_color="LabelDisabledColor"
+    width="128">
+      Detail Mode:
+  </text>
+  <combo_box
+   control_name="RenderAvatarComplexityMode"
+   height="23"
+   layout="topleft"
+   left_delta="130"
+   top_delta="-4"
+   name="AvatarComplexityMode"
+   width="150">
+       <combo_box.item
+        label="Limit by complexity"
+        name="0"
+        value="0"/>
+       <combo_box.item
+        label="Always show friends"
+        name="1"
+        value="1"/>
+       <combo_box.item
+        label="Only show friends"
+        name="2"
+        value="2"/>
+  </combo_box>
   <view_border
     bevel_style="in"
     height="0"

--- a/indra/newview/skins/default/xui/en/panel_performance_nearby.xml
+++ b/indra/newview/skins/default/xui/en/panel_performance_nearby.xml
@@ -147,7 +147,7 @@
     name="AvatarComplexityModeLabel"
     text_readonly_color="LabelDisabledColor"
     width="128">
-      Detail Mode:
+      Avatar display:
   </text>
   <combo_box
    control_name="RenderAvatarComplexityMode"

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -254,7 +254,7 @@
       width="128"
       name="AvatarComplexityModeLabel"
       text_readonly_color="LabelDisabledColor">
-        Avatar Detail Mode:
+        Avatar display:
     </text>
     <combo_box
      control_name="RenderAvatarComplexityMode"
@@ -285,7 +285,7 @@
     height="16"
     initial_value="101"
     increment="1"
-    label="Avatar Maximum Complexity:"
+    label="Avatar maximum complexity:"
     label_width="165"
     layout="topleft"
     left="30"
@@ -312,19 +312,6 @@
     width="65">
        0
   </text>
-<text
-type="string"
-length="1"
-follows="left|top"
-height="16"
-layout="topleft"
-left_delta="68"
-name="IndirectMaxComplexityLink"
-mouse_opaque="false"
-top_delta="0"
-width="120">
-[https://community.secondlife.com/t5/Featured-News/Why-are-all-these-people-made-of-colored-jelly/ba-p/3031255 What's this?]
-</text>
 
   <button
     height="23"

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -242,6 +242,41 @@
     <button.commit_callback
       function="Pref.AutoAdjustments"/>
   </button>
+
+    <text
+      type="string"
+      length="1"
+      follows="left|top"
+      height="16"
+      layout="topleft"
+      left="30"
+      top_delta="42"
+      width="128"
+      name="AvatarComplexityModeLabel"
+      text_readonly_color="LabelDisabledColor">
+        Avatar Detail Mode:
+    </text>
+    <combo_box
+     control_name="RenderAvatarComplexityMode"
+     height="23"
+     layout="topleft"
+     left_delta="130"
+     top_delta="-4"
+     name="AvatarComplexityMode"
+     width="150">
+        <combo_box.item
+         label="Limit by complexity"
+         name="0"
+         value="0"/>
+        <combo_box.item
+         label="Always show friends"
+         name="1"
+         value="1"/>
+        <combo_box.item
+         label="Only show friends"
+         name="2"
+         value="2"/>
+    </combo_box>
   
   <slider
     control_name="IndirectMaxComplexity"
@@ -258,7 +293,7 @@
     max_val="101"
     name="IndirectMaxComplexity"
     show_text="false"
-    top_delta="40"
+    top_delta="28"
     width="300">
     <slider.commit_callback
       function="Pref.UpdateIndirectMaxComplexity"
@@ -291,18 +326,6 @@ width="120">
 [https://community.secondlife.com/t5/Featured-News/Why-are-all-these-people-made-of-colored-jelly/ba-p/3031255 What's this?]
 </text>
 
-
-  <check_box
-    control_name="AlwaysRenderFriends"
-    height="16"
-    initial_value="true"
-    label="Always Render Friends"
-    layout="topleft"
-    left="30"
-    name="AlwaysRenderFriends"
-    top_delta="24"
-    width="256">
-  </check_box>
   <button
     height="23"
     label="Exceptions..."


### PR DESCRIPTION
Always impostor non-friends in 'friends only' mode.

Changes affect 3 floaters dropbox with options: limit by complexity|always show friends|only show friends. In case of graphical settings setting it to 'friends only' disables 'complexity' and 'impostors' sliders.
![image](https://github.com/secondlife/viewer/assets/117672381/a8099143-2b93-457c-acef-5bd7a80741a2)
![image](https://github.com/secondlife/viewer/assets/117672381/36c50449-56e6-499d-942b-7d7215aea514)
![image](https://github.com/secondlife/viewer/assets/117672381/654453b6-d9c1-47b4-86e9-d44c7163f5b6)
