### PR TITLE
Engage new viewer-build-util/which-branch with relnotes output.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
       viewer_branch:  ${{ steps.which-branch.outputs.branch }}
+      relnotes:       ${{ steps.which-branch.outputs.relnotes }}
       imagename: ${{ steps.build.outputs.imagename }}
     env:
       AUTOBUILD_ADDRSIZE: 64
@@ -102,7 +103,7 @@ jobs:
 
       - name: Determine source branch
         id: which-branch
-        uses: secondlife/viewer-build-util/which-branch@v1
+        uses: secondlife/viewer-build-util/which-branch@relnotes
         with:
           token: ${{ github.token }}
 
@@ -377,6 +378,7 @@ jobs:
             ${{ needs.build.outputs.viewer_channel }}
             ${{ needs.build.outputs.viewer_version }}
             ${{ needs.build.outputs.viewer_branch }}
+            ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
           append_body: true


### PR DESCRIPTION
Put whatever release notes we retrieve into the generated release page.

relnotes:
### Sample Release Notes
This text should be prepended to the generated release notes.