### PR TITLE
[viewer#811] Do not crash on 'Default configuration file settings_files.xml not found'

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2497,11 +2497,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>eb1316584188dafb591f80b46b357c737f90d1a7</string>
+              <string>2dc2c02a4a7f46d4b20d6dd921af97c31fafc349</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-08bf5ee/viewer_manager-3.0-08bf5ee-darwin64-08bf5ee.tar.zst</string>
+              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-2c4be99/viewer_manager-3.0-2c4be99-darwin64-2c4be99.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2511,11 +2511,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>f4677b0ebd9880f29c118af51ada50883dd0a1e4</string>
+              <string>42a5050b890c503ae4d0b3442ba67f8d2b88feff</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-08bf5ee/viewer_manager-3.0-08bf5ee-linux64-08bf5ee.tar.zst</string>
+              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-2c4be99/viewer_manager-3.0-2c4be99-linux64-2c4be99.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2525,11 +2525,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>7426c5a1d7eb231b476625637a1f2daba0a6bc55</string>
+              <string>ac592053df08e8651797a492630ba5660910f793</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-08bf5ee/viewer_manager-3.0-08bf5ee-windows64-08bf5ee.tar.zst</string>
+              <string>https://github.com/secondlife/viewer-manager/releases/download/v3.0-2c4be99/viewer_manager-3.0-2c4be99-windows64-2c4be99.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -71,6 +71,7 @@ LLDir *gDirUtilp = (LLDir *)&gDirUtil;
 /// Values for findSkinnedFilenames(subdir) parameter
 const char
 	*LLDir::XUI      = "xui",
+	*LLDir::HTML     = "html",
 	*LLDir::TEXTURES = "textures",
 	*LLDir::SKINBASE = "";
 
@@ -761,14 +762,13 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 		else
 		{
 			// We do not recognize this subdir. Investigate.
-			std::string subdir_path(add(getDefaultSkinDir(), subdir));
-			if (fileExists(add(subdir_path, "en")))
+			if (skinExists(subdir, "en"))
 			{
 				// defaultSkinDir/subdir contains subdir "en". That's our
 				// default language; this subdir is localized.
 				found = sLocalized.insert(StringMap::value_type(subdir, "en")).first;
 			}
-			else if (fileExists(add(subdir_path, "en-us")))
+			else if (skinExists(subdir, "en-us"))
 			{
 				// defaultSkinDir/subdir contains subdir "en-us" but not "en".
 				// Set as default language; this subdir is localized.
@@ -863,6 +863,13 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 	LL_CONT << LL_ENDL;
 
 	return results;
+}
+
+// virtual
+bool LLDir::skinExists(const std::string& subdir, const std::string& skin) const
+{
+    std::string skin_path(add(getDefaultSkinDir(), subdir, skin));
+    return fileExists(skin_path);
 }
 
 std::string LLDir::getTempFilename() const

--- a/indra/llfilesystem/lldir.h
+++ b/indra/llfilesystem/lldir.h
@@ -72,6 +72,7 @@ class LLDir
 // pure virtual functions
 	virtual std::string getCurPath() = 0;
 	virtual bool fileExists(const std::string &filename) const = 0;
+	virtual bool skinExists(const std::string& subdir, const std::string &skin) const;
 
 	const std::string findFile(const std::string& filename, const std::vector<std::string> filenames) const; 
 	const std::string findFile(const std::string& filename, const std::string& searchPath1 = "", const std::string& searchPath2 = "", const std::string& searchPath3 = "") const;
@@ -150,7 +151,7 @@ class LLDir
 												  const std::string& filename,
 												  ESkinConstraint constraint=CURRENT_SKIN) const;
 	/// Values for findSkinnedFilenames(subdir) parameter
-	static const char *XUI, *TEXTURES, *SKINBASE;
+	static const char *XUI, *HTML, *TEXTURES, *SKINBASE;
 	/**
 	 * Return the base-language pathname from findSkinnedFilenames(), or
 	 * the empty string if no such file exists. Parameters are identical to

--- a/indra/llfilesystem/lldir_win32.cpp
+++ b/indra/llfilesystem/lldir_win32.cpp
@@ -390,6 +390,15 @@ bool LLDir_Win32::fileExists(const std::string &filename) const
 	}
 }
 
+// virtual
+bool LLDir_Win32::skinExists(const std::string& subdir, const std::string &skin) const
+{
+    if (subdir == LLDir::XUI && skin == "en")
+        return true;
+
+    return LLDir::skinExists(subdir, skin);
+}
+
 
 /*virtual*/ std::string LLDir_Win32::getLLPluginLauncher()
 {

--- a/indra/llfilesystem/lldir_win32.h
+++ b/indra/llfilesystem/lldir_win32.h
@@ -45,6 +45,7 @@ public:
 	/*virtual*/ std::string getCurPath();
 	/*virtual*/ U32 countFilesInDir(const std::string &dirname, const std::string &mask);
 	/*virtual*/ bool fileExists(const std::string &filename) const;
+	/*virtual*/ bool skinExists(const std::string& subdir, const std::string &skin) const;
 
 	/*virtual*/ std::string getLLPluginLauncher();
 	/*virtual*/ std::string getLLPluginFilename(std::string base_name);

--- a/indra/llui/llxuiparser.cpp
+++ b/indra/llui/llxuiparser.cpp
@@ -1397,36 +1397,17 @@ bool LLSimpleXUIParser::readXUI(const std::string& filename, LLInitParam::BaseBl
 	mCurReadDepth = 0;
 	setParseSilently(silent);
 
-	ScopedFile file(filename, "rb");
-	if( !file.isOpen() )
+	std::string xml = LLXMLNode::getXML(filename);
+	if (xml.empty())
 	{
 		LL_WARNS("ReadXUI") << "Unable to open file " << filename << LL_ENDL;
 		XML_ParserFree( mParser );
 		return false;
 	}
 
-	S32 bytes_read = 0;
-	
-	S32 buffer_size = file.getRemainingBytes();
-	void* buffer = XML_GetBuffer(mParser, buffer_size);
-	if( !buffer ) 
-	{
-		LL_WARNS("ReadXUI") << "Unable to allocate XML buffer while reading file " << filename << LL_ENDL;
-		XML_ParserFree( mParser );
-		return false;
-	}
-
-	bytes_read = (S32)fread(buffer, 1, buffer_size, file.mFile);
-	if( bytes_read <= 0 )
-	{
-		LL_WARNS("ReadXUI") << "Error while reading file  " << filename << LL_ENDL;
-		XML_ParserFree( mParser );
-		return false;
-	}
-	
 	mEmptyLeafNode.push_back(false);
 
-	if( !XML_ParseBuffer(mParser, bytes_read, true ) )
+	if (!XML_Parse(mParser, xml.data(), (int)xml.size(), true))
 	{
 		LL_WARNS("ReadXUI") << "Error while parsing file  " << filename << LL_ENDL;
 		XML_ParserFree( mParser );

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -42,6 +42,7 @@
 #include "v3color.h"
 #include "llquaternion.h"
 #include "llrect.h"
+#include "llxmlnode.h"
 #include "llxmltree.h"
 #include "llsdserialize.h"
 #include "llfile.h"
@@ -753,13 +754,13 @@ void LLControlGroup::setUntypedValue(std::string_view name, const LLSD& val)
 //---------------------------------------------------------------
 
 // Returns number of controls loaded, so 0 if failure
-U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, bool require_declaration, eControlType declare_as)
+U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, const std::string& xml, bool require_declaration, eControlType declare_as)
 {
 	std::string name;
 
 	LLXmlTree xml_controls;
 
-	if (!xml_controls.parseFile(filename))
+	if (!xml_controls.parseString(xml))
 	{
 		LL_WARNS("Settings") << "Unable to open control file " << filename << LL_ENDL;
 		return 0;
@@ -772,7 +773,7 @@ U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, bool require
 		return 0;
 	}
 
-	U32		validitems = 0;
+	U32 validitems = 0;
 	S32 version;
 	
 	rootp->getAttributeS32("version", version);
@@ -990,24 +991,24 @@ U32 LLControlGroup::saveToFile(const std::string& filename, bool nondefault_only
 U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_values, bool save_values)
 {
 	LLSD settings;
-	llifstream infile;
-	infile.open(filename.c_str());
-	if(!infile.is_open())
+
+	std::string xml = LLXMLNode::getXML(filename);
+	if (xml.empty())
 	{
 		LL_WARNS("Settings") << "Cannot find file " << filename << " to load." << LL_ENDL;
 		return 0;
 	}
 
-	if (LLSDParser::PARSE_FAILURE == LLSDSerialize::fromXML(settings, infile))
+	std::stringstream stream(xml);
+	if (LLSDParser::PARSE_FAILURE == LLSDSerialize::fromXML(settings, stream))
 	{
-		infile.close();
 		LL_WARNS("Settings") << "Unable to parse LLSD control file " << filename << ". Trying Legacy Method." << LL_ENDL;
-		return loadFromFileLegacy(filename, TRUE, TYPE_STRING);
+		return loadFromFileLegacy(filename, xml, TRUE, TYPE_STRING);
 	}
 
 	U32	validitems = 0;
 	bool hidefromsettingseditor = false;
-	
+
 	for(LLSD::map_const_iterator itr = settings.beginMap(); itr != settings.endMap(); ++itr)
 	{
 		LLControlVariable::ePersist persist = LLControlVariable::PERSIST_NONDFT;
@@ -1019,7 +1020,7 @@ U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_v
 			persist = control_map["Persist"].asInteger()?
 					  LLControlVariable::PERSIST_NONDFT : LLControlVariable::PERSIST_NO;
 		}
-		
+
 		// Sometimes we want to use the settings system to provide cheap persistence, but we
 		// don't want the settings themselves to be easily manipulated in the UI because 
 		// doing so can cause support problems. So we have this option:
@@ -1031,7 +1032,7 @@ U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_v
 		{
 			hidefromsettingseditor = false;
 		}
-		
+
 		// If the control exists just set the value from the input file.
 		LLControlVariable* existing_control = getControl(name);
 		if(existing_control)

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -300,7 +300,7 @@ public:
 	// Returns number of controls loaded, 0 if failed
 	// If require_declaration is false, will auto-declare controls it finds
 	// as the given type.
-	U32	loadFromFileLegacy(const std::string& filename, bool require_declaration = true, eControlType declare_as = TYPE_STRING);
+	U32	loadFromFileLegacy(const std::string& filename, const std::string& xml, bool require_declaration = true, eControlType declare_as = TYPE_STRING);
  	U32 saveToFile(const std::string& filename, bool nondefault_only);
  	U32	loadFromFile(const std::string& filename, bool default_values = false, bool save_values = true);
 	void	resetToDefaults();

--- a/indra/llxml/llxmlnode.h
+++ b/indra/llxml/llxmlnode.h
@@ -126,34 +126,35 @@ public:
 	bool isNull();
 
 	bool deleteChild(LLXMLNode* child);
-    void addChild(LLXMLNodePtr& new_child); 
+    void addChild(LLXMLNodePtr& new_child);
     void setParent(LLXMLNodePtr& new_parent); // reparent if necessary
 
-    // Serialization
+    static std::string getXML(const std::string& filename);
+
+    // Deserialization
 	static bool parseFile(
 		const std::string& filename,
-		LLXMLNodePtr& node, 
+		LLXMLNodePtr& node,
 		LLXMLNode* defaults_tree);
 	static bool parseBuffer(
-		U8* buffer,
+		const char* buffer,
 		U32 length,
-		LLXMLNodePtr& node, 
+		LLXMLNodePtr& node,
 		LLXMLNode* defaults);
 	static bool parseStream(
 		std::istream& str,
-		LLXMLNodePtr& node, 
+		LLXMLNodePtr& node,
 		LLXMLNode* defaults);
 	static bool updateNode(
 		LLXMLNodePtr& node,
 		LLXMLNodePtr& update_node);
-	
+
 	static bool getLayeredXMLNode(LLXMLNodePtr& root, const std::vector<std::string>& paths);
-	
-	
+
 	// Write standard XML file header:
 	// <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 	static void writeHeaderToFile(LLFILE *out_file);
-	
+
 	// Write XML to file with one attribute per line.
 	// XML escapes values as they are written.
     void writeToFile(LLFILE *out_file, const std::string& indent = std::string(), bool use_type_decorations=true);
@@ -237,7 +238,7 @@ public:
 	// Setters
 
 	bool setAttributeString(const char* attr, const std::string& value);
-	
+
 	void setBoolValue(const bool value)	{ setBoolValue(1, &value); }
 	void setByteValue(const U8 value, Encoding encoding = ENCODING_DEFAULT) { setByteValue(1, &value, encoding); }
 	void setIntValue(const S32 value, Encoding encoding = ENCODING_DEFAULT) { setIntValue(1, &value, encoding); }

--- a/indra/llxml/llxmltree.h
+++ b/indra/llxml/llxmltree.h
@@ -56,6 +56,7 @@ public:
 	void cleanup();
 
 	virtual bool	parseFile(const std::string &path, bool keep_contents = true);
+	virtual bool	parseString(const std::string &xml, bool keep_contents = true);
 
 	LLXmlTreeNode*	getRoot() { return mRoot; }
 
@@ -199,7 +200,8 @@ public:
 	LLXmlTreeParser(LLXmlTree* tree);
 	virtual ~LLXmlTreeParser();
 
-	bool parseFile(const std::string &path, LLXmlTreeNode** root, bool keep_contents );
+	bool parseFile(const std::string &path, LLXmlTreeNode** root, bool keep_contents);
+	bool parseString(const std::string &xml, LLXmlTreeNode** root, bool keep_contents);
 
 protected:
 	const std::string& tabs();

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1530,6 +1530,56 @@ if (WINDOWS)
     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/res/viewerRes.rc
                     ${CMAKE_CURRENT_BINARY_DIR}/viewerRes.rc
                     )
+
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/viewerRes.rc
+         "\n"
+         "/////////////////////////////////////////////////////////////////////////////\n"
+         "//\n"
+         "// Embed XML files into the resource\n"
+         "//\n"
+         "\n"
+         )
+
+    file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/res/listXML.rc)
+
+    # Collect relative names of all XML files
+    # to a semicolon-separated list XML_FILES
+    file(GLOB_RECURSE XML_FILES
+         RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+         ${CMAKE_CURRENT_SOURCE_DIR}/*.xml
+         )
+
+    # Process each XML file name in a loop
+    foreach(XML_FILE IN LISTS XML_FILES)
+
+        # Make resource id from XML file name
+        string(TOUPPER ${XML_FILE} RESOURCE_ID)
+        string(REPLACE "/" "_" RESOURCE_ID ${RESOURCE_ID})
+        string(REPLACE "%" "_" RESOURCE_ID ${RESOURCE_ID})
+        string(REPLACE "." "_" RESOURCE_ID ${RESOURCE_ID})
+
+        # Write resource id, resource type and file name
+        # to the output resource file viewerRes.rc
+        # to embed XML into the executable binary
+        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/viewerRes.rc
+             "IDR_${RESOURCE_ID}\tXML\t\"../${XML_FILE}\"\n"
+             )
+
+        # Write resource id and file name to the list
+        file(APPEND ${CMAKE_CURRENT_SOURCE_DIR}/res/listXML.rc
+             "IDR_${RESOURCE_ID}\t${XML_FILE}\n"
+             )
+
+    endforeach()
+
+    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/viewerRes.rc
+         "\n"
+         "IDR_LIST_XML\tTEXT\t\"listXML.rc\"\n"
+         "\n"
+         "/////////////////////////////////////////////////////////////////////////////\n"
+         "\n"
+         )
+
     set(viewer_RESOURCE_FILES
         ${CMAKE_CURRENT_BINARY_DIR}/viewerRes.rc
         ${viewer_RESOURCE_FILES}

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -633,7 +633,7 @@ void LLMediaCtrl::navigateTo( std::string url_in, std::string mime_type, bool cl
 void LLMediaCtrl::navigateToLocalPage( const std::string& subdir, const std::string& filename_in )
 {
 	std::string filename(gDirUtilp->add(subdir, filename_in));
-	std::string expanded_filename = gDirUtilp->findSkinnedFilename("html", filename);
+	std::string expanded_filename = gDirUtilp->findSkinnedFilename(LLDir::HTML, filename);
 
 	if (expanded_filename.empty())
 	{

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -407,7 +407,7 @@ LLViewerFetchedTexture* LLViewerTextureList::getImageFromFile(const std::string&
 		return NULL ;
 	}
 
-	std::string full_path = gDirUtilp->findSkinnedFilename("textures", filename);
+	std::string full_path = gDirUtilp->findSkinnedFilename(LLDir::TEXTURES, filename);
 	if (full_path.empty())
 	{
 		LL_WARNS() << "Failed to find local image file: " << filename << LL_ENDL;

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -59,6 +59,10 @@ class ViewerManifest(LLManifest):
         # files during the build (see copy_w_viewer_manifest
         # and copy_l_viewer_manifest targets)
         return 'package' in self.args['actions']
+
+    # This differs for Windows, it delivers XML files as resources
+    def is_packaging_xml_files(self):
+        return True;
     
     def construct(self):
         super(ViewerManifest, self).construct()
@@ -67,10 +71,12 @@ class ViewerManifest(LLManifest):
 
         if self.is_packaging_viewer():
             with self.prefix(src_dst="app_settings"):
-                self.exclude("logcontrol.xml")
-                self.exclude("logcontrol-dev.xml")
+                # XML files are delivered as resources on Windows
+                if self.is_packaging_xml_files():
+                    self.exclude("logcontrol.xml")
+                    self.exclude("logcontrol-dev.xml")
+                    self.path("*.xml")
                 self.path("*.ini")
-                self.path("*.xml")
 
                 # include the entire shaders directory recursively
                 self.path("shaders")
@@ -136,8 +142,10 @@ class ViewerManifest(LLManifest):
 
 
             with self.prefix(src_dst="character"):
+                # XML files are delivered as resources on Windows
+                if self.is_packaging_xml_files():
+                    self.path("*.xml")
                 self.path("*.llm")
-                self.path("*.xml")
                 self.path("*.tga")
 
             # Include our fonts
@@ -155,9 +163,12 @@ class ViewerManifest(LLManifest):
                             self.path("*.j2c")
                             self.path("*.png")
                             self.path("textures.xml")
-                    self.path("*/xui/*/*.xml")
-                    self.path("*/xui/*/widgets/*.xml")
-                    self.path("*/*.xml")
+
+                    # XML files are delivered as resources on Windows
+                    if self.is_packaging_xml_files():
+                        self.path("*/xui/*/*.xml")
+                        self.path("*/xui/*/widgets/*.xml")
+                        self.path("*/*.xml")
 
                     # Update: 2017-11-01 CP Now we store app code in the html folder
                     #         Initially the HTML/JS code to render equirectangular
@@ -492,6 +503,10 @@ class Windows_x86_64_Manifest(ViewerManifest):
         else:
             print("Doesn't exist:", src)
         
+    # This differs for Windows, it delivers XML files as resources
+    def is_packaging_xml_files(self):
+        return False;
+
     def construct(self):
         super().construct()
 


### PR DESCRIPTION
In the context of https://github.com/secondlife/viewer/issues/811

For Windows we can pack XML files into the binary and read them from there on run-time instead of reading the file
