### PR TITLE
Changes from maint W to pull relnotes from PR description

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
       # pass these from build job to release job
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
+      viewer_branch:  ${{ steps.build.outputs.viewer_branch }}
       imagename: ${{ steps.build.outputs.imagename }}
     env:
       AUTOBUILD_ADDRSIZE: 64
@@ -177,9 +178,17 @@ jobs:
           if [[ "$GITHUB_REF_TYPE" == "tag" && "${GITHUB_REF_NAME:0:12}" == "Second_Life_" ]]
           then viewer_channel="${GITHUB_REF_NAME%#*}"
                export viewer_channel="${viewer_channel//_/ }"
+               # Since GITHUB_REF_NAME is a tag rather than a branch, we need
+               # to discover to what branch this tag corresponds. Get the tip
+               # commit (for the tag) and then ask for branches containing it.
+               # Assume GitHub cloned only this tag and its containing branch.
+               viewer_branch="$(git branch --contains "$(git log -n 1 --format=%h)" |
+                                grep -v '(HEAD')"
           else export viewer_channel="Second Life Test"
+               viewer_branch="${GITHUB_REF_NAME}"
           fi
           echo "viewer_channel=$viewer_channel" >> "$GITHUB_OUTPUT"
+          echo "viewer_branch=$viewer_branch" >> "$GITHUB_OUTPUT"
 
           # On windows we need to point the build to the correct python
           # as neither CMake's FindPython nor our custom Python.cmake module
@@ -366,8 +375,10 @@ jobs:
           body: |
             ${{ needs.build.outputs.viewer_channel }}
             ${{ needs.build.outputs.viewer_version }}
+            ${{ needs.build.outputs.viewer_branch }}
           prerelease: true
           generate_release_notes: true
+          append_body: true
           # the only reason we generate a GH release is to post build products
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       # pass these from build job to release job
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
-      viewer_branch:  ${{ steps.build.outputs.viewer_branch }}
+      viewer_branch:  ${{ steps.which-branch.outputs.branch }}
       imagename: ${{ steps.build.outputs.imagename }}
     env:
       AUTOBUILD_ADDRSIZE: 64
@@ -192,10 +192,8 @@ jobs:
                viewer_branch="$(git branch --contains "$(git log -n 1 --format=%h)" |
                                 grep -v '(HEAD')"
           else export viewer_channel="Second Life Test"
-               viewer_branch="${GITHUB_REF_NAME}"
           fi
           echo "viewer_channel=$viewer_channel" >> "$GITHUB_OUTPUT"
-          echo "viewer_branch=$viewer_branch" >> "$GITHUB_OUTPUT"
 
           # On windows we need to point the build to the correct python
           # as neither CMake's FindPython nor our custom Python.cmake module

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -186,12 +186,6 @@ jobs:
           if [[ "$GITHUB_REF_TYPE" == "tag" && "${GITHUB_REF_NAME:0:12}" == "Second_Life_" ]]
           then viewer_channel="${GITHUB_REF_NAME%#*}"
                export viewer_channel="${viewer_channel//_/ }"
-               # Since GITHUB_REF_NAME is a tag rather than a branch, we need
-               # to discover to what branch this tag corresponds. Get the tip
-               # commit (for the tag) and then ask for branches containing it.
-               # Assume GitHub cloned only this tag and its containing branch.
-               viewer_branch="$(git branch --contains "$(git log -n 1 --format=%h)" |
-                                grep -v '(HEAD')"
           else export viewer_channel="Second Life Test"
           fi
           echo "viewer_channel=$viewer_channel" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,10 +98,17 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install nsis-unicode
 
+      - name: Determine source branch
+        id: which-branch
+        uses: secondlife/viewer-build-util/which-branch@v1
+        with:
+          token: ${{ github.token }}
+
       - name: Build
         id: build
         shell: bash
         env:
+          AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch }}
           RUNNER_OS: ${{ runner.os }}
         run: |
           # set up things the viewer's build.sh script expects
@@ -152,7 +159,7 @@ jobs:
           }
           repo_branch()
           {
-            git -C "$1" branch | grep '^* ' | cut -c 3-
+            echo "$AUTOBUILD_VCS_BRANCH"
           }
           record_dependencies_graph()
           {

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -334,7 +334,7 @@ jobs:
           version: ${{ needs.build.outputs.viewer_version }}
 
   release:
-    needs: [sign-and-package-windows, sign-and-package-mac]
+    needs: [build, sign-and-package-windows, sign-and-package-mac]
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'Second_Life_')
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
             configuration: ReleaseOS
     runs-on: ${{ matrix.runner }}
     outputs:
+      # pass these from build job to release job
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
       imagename: ${{ steps.build.outputs.imagename }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
       viewer_branch:  ${{ steps.which-branch.outputs.branch }}
+      relnotes:       ${{ steps.which-branch.outputs.relnotes }}
       imagename: ${{ steps.build.outputs.imagename }}
     env:
       AUTOBUILD_ADDRSIZE: 64
@@ -100,7 +101,7 @@ jobs:
 
       - name: Determine source branch
         id: which-branch
-        uses: secondlife/viewer-build-util/which-branch@v1
+        uses: secondlife/viewer-build-util/which-branch@relnotes
         with:
           token: ${{ github.token }}
 
@@ -381,6 +382,7 @@ jobs:
             ${{ needs.build.outputs.viewer_channel }}
             ${{ needs.build.outputs.viewer_version }}
             ${{ needs.build.outputs.viewer_branch }}
+            ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
           append_body: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -361,6 +361,11 @@ jobs:
           # name the release page for the build number so we can find it
           # easily (analogous to looking up a codeticket build page)
           name: "v${{ github.run_id }}"
+          # SL-20546: want the channel and version to be visible on the
+          # release page
+          body: |
+            ${{ needs.build.outputs.viewer_channel }}
+            ${{ needs.build.outputs.viewer_version }}
           prerelease: true
           generate_release_notes: true
           # the only reason we generate a GH release is to post build products


### PR DESCRIPTION
This branch won't be needed if we ship Maint W before Maint A. But if they ship in the opposite order, these changes should include the Maint A relnotes in the GH generated release notes.