### PR TITLE
Replace BOOL with bool in llwindow and dependent classes

### DIFF
--- a/indra/llui/llaccordionctrl.cpp
+++ b/indra/llui/llaccordionctrl.cpp
@@ -199,7 +199,7 @@ void LLAccordionCtrl::reshape(S32 width, S32 height, BOOL called_from_parent)
 }
 
 //---------------------------------------------------------------------------------
-BOOL LLAccordionCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLAccordionCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	return LLPanel::handleRightMouseDown(x, y, mask);
 }
@@ -552,13 +552,13 @@ void LLAccordionCtrl::arrange()
 
 //---------------------------------------------------------------------------------
 
-BOOL LLAccordionCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLAccordionCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (LLPanel::handleScrollWheel(x, y, clicks))
-		return TRUE;
+		return true;
 	if (mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, clicks))
-		return TRUE;
-	return FALSE;
+		return true;
+	return false;
 }
 
 BOOL LLAccordionCtrl::handleKeyHere(KEY key, MASK mask)

--- a/indra/llui/llaccordionctrl.h
+++ b/indra/llui/llaccordionctrl.h
@@ -90,8 +90,8 @@ public:
 
 	virtual BOOL postBuild();
 	
-	virtual BOOL handleRightMouseDown	( S32 x, S32 y, MASK mask); 
-	virtual BOOL handleScrollWheel		( S32 x, S32 y, S32 clicks );
+	virtual bool handleRightMouseDown	( S32 x, S32 y, MASK mask);
+	virtual bool handleScrollWheel		( S32 x, S32 y, S32 clicks );
 	virtual BOOL handleKeyHere			(KEY key, MASK mask);
 	virtual BOOL handleDragAndDrop		(S32 x, S32 y, MASK mask, BOOL drop,
 										 EDragAndDropType cargo_type,

--- a/indra/llui/llaccordionctrltab.cpp
+++ b/indra/llui/llaccordionctrltab.cpp
@@ -482,7 +482,7 @@ void LLAccordionCtrlTab::onUpdateScrollToChild(const LLUICtrl *cntrl)
     LLUICtrl::onUpdateScrollToChild(cntrl);
 }
 
-BOOL LLAccordionCtrlTab::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLAccordionCtrlTab::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mCollapsible && mHeaderVisible && mCanOpenClose)
 	{
@@ -493,13 +493,13 @@ BOOL LLAccordionCtrlTab::handleMouseDown(S32 x, S32 y, MASK mask)
 
 			// Reset stored state
 			mWasStateStored = false;
-			return TRUE;
+			return true;
 		}
 	}
 	return LLUICtrl::handleMouseDown(x,y,mask);
 }
 
-BOOL LLAccordionCtrlTab::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLAccordionCtrlTab::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	return LLUICtrl::handleMouseUp(x,y,mask);
 }
@@ -820,7 +820,7 @@ BOOL LLAccordionCtrlTab::handleKey(KEY key, MASK mask, BOOL called_from_parent)
 	if ((key == KEY_RETURN) && mask == MASK_NONE)
 	{
 		changeOpenClose(getDisplayChildren());
-		return TRUE;
+		return true;
 	}
 
 	if ((key == KEY_ADD || key == KEY_RIGHT) && mask == MASK_NONE)
@@ -828,7 +828,7 @@ BOOL LLAccordionCtrlTab::handleKey(KEY key, MASK mask, BOOL called_from_parent)
 		if (!getDisplayChildren())
 		{
 			changeOpenClose(getDisplayChildren());
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -837,7 +837,7 @@ BOOL LLAccordionCtrlTab::handleKey(KEY key, MASK mask, BOOL called_from_parent)
 		if (getDisplayChildren())
 		{
 			changeOpenClose(getDisplayChildren());
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -853,7 +853,7 @@ BOOL LLAccordionCtrlTab::handleKey(KEY key, MASK mask, BOOL called_from_parent)
 		{
 			getAccordionView()->notify(LLSD().with("action", "select_first"));
 		}
-		return TRUE;
+		return true;
 	}
 
 	if (key == KEY_UP && mask == MASK_NONE)
@@ -862,7 +862,7 @@ BOOL LLAccordionCtrlTab::handleKey(KEY key, MASK mask, BOOL called_from_parent)
 
 		// we're processing notifyParent so let call parent directly
 		getParent()->notifyParent(LLSD().with("action", "select_prev"));
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleKey(key, mask, called_from_parent);
@@ -1097,7 +1097,7 @@ void LLAccordionCtrlTab::ctrlSetLeftTopAndSize(LLView* panel, S32 left, S32 top,
 	panel->setRect(panel_rect);
 }
 
-BOOL LLAccordionCtrlTab::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLAccordionCtrlTab::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	//header may be not the first child but we need to process it first
 	if (y >= (getRect().getHeight() - HEADER_HEIGHT - HEADER_HEIGHT / 2))
@@ -1105,22 +1105,22 @@ BOOL LLAccordionCtrlTab::handleToolTip(S32 x, S32 y, MASK mask)
 		//inside tab header
 		//fix for EXT-6619
 		mHeader->handleToolTip(x, y, mask);
-		return TRUE;
+		return true;
 	}
 	return LLUICtrl::handleToolTip(x, y, mask);
 }
 
-BOOL LLAccordionCtrlTab::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLAccordionCtrlTab::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (LLUICtrl::handleScrollWheel(x, y, clicks))
 	{
-		return TRUE;
+		return true;
 	}
 
 	if (mScrollbar && mScrollbar->getVisible() && mScrollbar->handleScrollWheel(0, 0, clicks))
 	{
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }

--- a/indra/llui/llaccordionctrltab.h
+++ b/indra/llui/llaccordionctrltab.h
@@ -162,13 +162,13 @@ public:
 	virtual void onUpdateScrollToChild(const LLUICtrl * cntrl);
 
 	// Changes expand/collapse state and triggers expand/collapse callbacks
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
 	virtual BOOL handleKey(KEY key, MASK mask, BOOL called_from_parent);
 
-	virtual BOOL handleToolTip(S32 x, S32 y, MASK mask);
-	virtual BOOL handleScrollWheel( S32 x, S32 y, S32 clicks );
+	virtual bool handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
 
 
 	virtual bool addChild(LLView* child, S32 tab_group = 0 );

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -393,9 +393,9 @@ BOOL LLButton::postBuild()
 	return LLUICtrl::postBuild();
 }
 
-BOOL LLButton::handleUnicodeCharHere(llwchar uni_char)
+bool LLButton::handleUnicodeCharHere(llwchar uni_char)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if(' ' == uni_char 
 		&& !gKeyboard->getKeyRepeated(' '))
 	{
@@ -406,9 +406,9 @@ BOOL LLButton::handleUnicodeCharHere(llwchar uni_char)
 
 		LLUICtrl::onCommit();
 		
-		handled = TRUE;		
+		handled = true;
 	}
-	return handled;	
+	return handled;
 }
 
 BOOL LLButton::handleKeyHere(KEY key, MASK mask )
@@ -429,7 +429,7 @@ BOOL LLButton::handleKeyHere(KEY key, MASK mask )
 }
 
 
-BOOL LLButton::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLButton::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (!childrenHandleMouseDown(x, y, mask))
 	{
@@ -438,7 +438,7 @@ BOOL LLButton::handleMouseDown(S32 x, S32 y, MASK mask)
 
 		if (hasTabStop() && !getIsChrome())
 		{
-			setFocus(TRUE);
+			setFocus(true);
 		}
 
 		if (!mFunctionName.empty())
@@ -469,11 +469,11 @@ BOOL LLButton::handleMouseDown(S32 x, S32 y, MASK mask)
 			make_ui_sound("UISndClick");
 		}
 	}
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLButton::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLButton::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// We only handle the click if the click both started and ended within us
 	if( hasMouseCapture() )
@@ -518,10 +518,10 @@ BOOL LLButton::handleMouseUp(S32 x, S32 y, MASK mask)
 		childrenHandleMouseUp(x, y, mask);
 	}
 
-	return TRUE;
+	return true;
 }
 
-BOOL	LLButton::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool	LLButton::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mHandleRightMouse && !childrenHandleRightMouseDown(x, y, mask))
 	{
@@ -530,7 +530,7 @@ BOOL	LLButton::handleRightMouseDown(S32 x, S32 y, MASK mask)
 
 		if (hasTabStop() && !getIsChrome())
 		{
-			setFocus(TRUE);
+			setFocus(true);
 		}
 
 //		if (pointInView(x, y))
@@ -543,10 +543,10 @@ BOOL	LLButton::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		// if they are not mouse opaque.
 	}
 
-	return TRUE;
+	return true;
 }
 
-BOOL	LLButton::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool	LLButton::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (mHandleRightMouse)
 	{
@@ -572,7 +572,7 @@ BOOL	LLButton::handleRightMouseUp(S32 x, S32 y, MASK mask)
 		// but this might change the mouse handling of existing buttons in a bad way.
 		// if they are not mouse opaque.
 	}
-	return TRUE;
+	return true;
 }
 
 void LLButton::onMouseLeave(S32 x, S32 y, MASK mask)
@@ -587,11 +587,11 @@ void LLButton::setHighlight(bool b)
 	mNeedsHighlight = b;
 }
 
-BOOL LLButton::handleHover(S32 x, S32 y, MASK mask)
+bool LLButton::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (isInEnabledChain() 
 		&& (!gFocusMgr.getMouseCapture() || gFocusMgr.getMouseCapture() == this))
-		mNeedsHighlight = TRUE;
+		mNeedsHighlight = true;
 
 	if (!childrenHandleHover(x, y, mask))
 	{
@@ -610,7 +610,7 @@ BOOL LLButton::handleHover(S32 x, S32 y, MASK mask)
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << LL_ENDL;
 	}
-	return TRUE;
+	return true;
 }
 
 void LLButton::getOverlayImageSize(S32& overlay_width, S32& overlay_height)
@@ -1308,7 +1308,7 @@ void LLButton::resetMouseDownTimer()
 	mMouseDownTimer.reset();
 }
 
-BOOL LLButton::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLButton::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	// just treat a double click as a second click
 	return handleMouseDown(x, y, mask);

--- a/indra/llui/llbutton.h
+++ b/indra/llui/llbutton.h
@@ -155,14 +155,14 @@ public:
 
 	void			addImageAttributeToXML(LLXMLNodePtr node, const std::string& imageName,
 										const LLUUID&	imageID,const std::string&	xmlTagName) const;
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask);	
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
 	virtual void	draw();
 	/*virtual*/ BOOL postBuild();
 

--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -782,13 +782,13 @@ void LLComboBox::onItemSelected(const LLSD& data)
 	onCommit();
 }
 
-BOOL LLComboBox::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLComboBox::handleToolTip(S32 x, S32 y, MASK mask)
 {
     std::string tool_tip;
 
 	if(LLUICtrl::handleToolTip(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 	
 	tool_tip = getToolTip();
@@ -803,7 +803,7 @@ BOOL LLComboBox::handleToolTip(S32 x, S32 y, MASK mask)
 			.message(tool_tip)
 			.sticky_rect(calcScreenRect()));
 	}
-	return TRUE;
+	return true;
 }
 
 BOOL LLComboBox::handleKeyHere(KEY key, MASK mask)
@@ -852,9 +852,9 @@ BOOL LLComboBox::handleKeyHere(KEY key, MASK mask)
 	return result;
 }
 
-BOOL LLComboBox::handleUnicodeCharHere(llwchar uni_char)
+bool LLComboBox::handleUnicodeCharHere(llwchar uni_char)
 {
-	BOOL result = FALSE;
+	bool result = false;
 	if (gFocusMgr.childHasKeyboardFocus(this))
 	{
 		// space bar just shows the list

--- a/indra/llui/llcombobox.h
+++ b/indra/llui/llcombobox.h
@@ -111,9 +111,9 @@ public:
 	// LLView interface
 	virtual void	onFocusLost();
 
-	virtual BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool	handleToolTip(S32 x, S32 y, MASK mask);
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
 
 	// LLUICtrl interface
 	virtual void	clear();					// select nothing

--- a/indra/llui/llcontainerview.cpp
+++ b/indra/llui/llcontainerview.cpp
@@ -74,14 +74,14 @@ bool LLContainerView::addChild(LLView* child, S32 tab_group)
 	return res;
 }
 
-BOOL LLContainerView::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLContainerView::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	return handleMouseDown(x, y, mask);
 }
 
-BOOL LLContainerView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLContainerView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if (mDisplayChildren)
 	{
 		handled = (LLView::childrenHandleMouseDown(x, y, mask) != NULL);
@@ -92,15 +92,15 @@ BOOL LLContainerView::handleMouseDown(S32 x, S32 y, MASK mask)
 		{
 			setDisplayChildren(!mDisplayChildren);
 			reshape(getRect().getWidth(), getRect().getHeight(), FALSE);
-			handled = TRUE;
+			handled = true;
 		}
 	}
 	return handled;
 }
 
-BOOL LLContainerView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLContainerView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if (mDisplayChildren)
 	{
 		handled = (LLView::childrenHandleMouseUp(x, y, mask) != NULL);

--- a/indra/llui/llcontainerview.h
+++ b/indra/llui/llcontainerview.h
@@ -68,9 +68,9 @@ public:
 	/*virtual*/ BOOL postBuild();
 	/*virtual*/ bool addChild(LLView* view, S32 tab_group = 0);
 	
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ void draw();
 	/*virtual*/ void reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);

--- a/indra/llui/lldraghandle.cpp
+++ b/indra/llui/lldraghandle.cpp
@@ -271,7 +271,7 @@ void LLDragHandleLeft::reshape(S32 width, S32 height, BOOL called_from_parent)
 // UI event handling
 //-------------------------------------------------------------
 
-BOOL LLDragHandle::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLDragHandle::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Route future Mouse messages here preemptively.  (Release on mouse up.)
 	// No handler needed for focus lost since this clas has no state that depends on it.
@@ -282,11 +282,11 @@ BOOL LLDragHandle::handleMouseDown(S32 x, S32 y, MASK mask)
 	mLastMouseScreenY = mDragLastScreenY;
 
 	// Note: don't pass on to children
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLDragHandle::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLDragHandle::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if( hasMouseCapture() )
 	{
@@ -295,13 +295,13 @@ BOOL LLDragHandle::handleMouseUp(S32 x, S32 y, MASK mask)
 	}
 
 	// Note: don't pass on to children
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLDragHandle::handleHover(S32 x, S32 y, MASK mask)
+bool LLDragHandle::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// We only handle the click if the click both started and ended within us
 	if( hasMouseCapture() )
@@ -324,11 +324,11 @@ BOOL LLDragHandle::handleHover(S32 x, S32 y, MASK mask)
 				delta_y >= SLOP)
 			{
 				parent->setDocked(false, false);
-				return TRUE;
+				return true;
 			}
 			else
 			{
-				return FALSE;
+				return false;
 			}
 		}
 
@@ -367,13 +367,13 @@ BOOL LLDragHandle::handleHover(S32 x, S32 y, MASK mask)
 
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (active)" <<LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (inactive)" << LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 
 	// Note: don't pass on to children

--- a/indra/llui/lldraghandle.h
+++ b/indra/llui/lldraghandle.h
@@ -72,9 +72,9 @@ public:
 	virtual void	setTitle( const std::string& title ) = 0;
 	virtual std::string	getTitle() const = 0;
 
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
 
 protected:
 	LLDragHandle(const Params&);

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -1561,17 +1561,17 @@ BOOL LLFloater::offerClickToButton(S32 x, S32 y, MASK mask, EFloaterButton index
 	return FALSE;
 }
 
-BOOL LLFloater::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloater::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	LLPanel::handleScrollWheel(x,y,clicks);
-	return TRUE;//always
+	return true;//always
 }
 
 // virtual
-BOOL LLFloater::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLFloater::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LL_DEBUGS() << "LLFloater::handleMouseUp calling LLPanel (really LLView)'s handleMouseUp (first initialized xui to: " << getPathname() << " )" << LL_ENDL;
-	BOOL handled = LLPanel::handleMouseUp(x,y,mask); // Not implemented in LLPanel so this actually calls LLView
+	bool handled = LLPanel::handleMouseUp(x,y,mask); // Not implemented in LLPanel so this actually calls LLView
 	if (handled) {
 		LLViewerEventRecorder::instance().updateMouseEventInfo(x,y,-55,-55,getPathname());
 	}
@@ -1579,7 +1579,7 @@ BOOL LLFloater::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLFloater::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloater::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if( mMinimized )
 	{
@@ -1587,19 +1587,19 @@ BOOL LLFloater::handleMouseDown(S32 x, S32 y, MASK mask)
 		// Note: this block and the offerClickToButton helper method can be removed
 		// because the parent container will handle it for us but we'll keep it here
 		// for safety until after reworking the panel code to manage hidden children.
-		if(offerClickToButton(x, y, mask, BUTTON_CLOSE)) return TRUE;
-		if(offerClickToButton(x, y, mask, BUTTON_RESTORE)) return TRUE;
-		if(offerClickToButton(x, y, mask, BUTTON_TEAR_OFF)) return TRUE;
-		if(offerClickToButton(x, y, mask, BUTTON_DOCK)) return TRUE;
+		if(offerClickToButton(x, y, mask, BUTTON_CLOSE)) return true;
+		if(offerClickToButton(x, y, mask, BUTTON_RESTORE)) return true;
+		if(offerClickToButton(x, y, mask, BUTTON_TEAR_OFF)) return true;
+		if(offerClickToButton(x, y, mask, BUTTON_DOCK)) return true;
 
-		setFrontmost(TRUE, FALSE);
+		setFrontmost(true, false);
 		// Otherwise pass to drag handle for movement
 		return mDragHandle->handleMouseDown(x, y, mask);
 	}
 	else
 	{
 		bringToFront( x, y );
-		BOOL handled = LLPanel::handleMouseDown( x, y, mask ); 
+		bool handled = LLPanel::handleMouseDown( x, y, mask );
 		if (handled) {
 			LLViewerEventRecorder::instance().updateMouseEventInfo(x,y,-55,-55,getPathname()); 
 		}
@@ -1608,14 +1608,14 @@ BOOL LLFloater::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLFloater::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloater::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL was_minimized = mMinimized;
+	bool was_minimized = mMinimized;
 	bringToFront( x, y );
 	return was_minimized || LLPanel::handleRightMouseDown( x, y, mask );
 }
 
-BOOL LLFloater::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloater::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
 	bringToFront( x, y );
 	return LLPanel::handleMiddleMouseDown( x, y, mask );
@@ -1623,10 +1623,10 @@ BOOL LLFloater::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 
 
 // virtual
-BOOL LLFloater::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLFloater::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL was_minimized = mMinimized;
-	setMinimized(FALSE);
+	bool was_minimized = mMinimized;
+	setMinimized(false);
 	return was_minimized || LLPanel::handleDoubleClick(x, y, mask);
 }
 

--- a/indra/llui/llfloater.h
+++ b/indra/llui/llfloater.h
@@ -293,13 +293,13 @@ public:
 	S32				getMinHeight() const{ return mMinHeight; }
 	S32				getHeaderHeight() const { return mHeaderHeight; }
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
 	
-	virtual BOOL	handleScrollWheel(S32 x, S32 y, S32 mask);
+	virtual bool	handleScrollWheel(S32 x, S32 y, S32 mask);
 	
 	virtual void	draw();
 	virtual void	drawShadow(LLPanel* panel);

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -1310,20 +1310,20 @@ BOOL LLFolderView::handleKeyHere( KEY key, MASK mask )
 }
 
 
-BOOL LLFolderView::handleUnicodeCharHere(llwchar uni_char)
+bool LLFolderView::handleUnicodeCharHere(llwchar uni_char)
 {
 	if ((uni_char < 0x20) || (uni_char == 0x7F)) // Control character or DEL
 	{
-		return FALSE;
+		return false;
 	}
 
 	if (uni_char > 0x7f)
 	{
 		LL_WARNS() << "LLFolderView::handleUnicodeCharHere - Don't handle non-ascii yet, aborting" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
-	BOOL handled = FALSE;
+	bool handled = false;
 	if (mParentPanel.get()->hasFocus())
 	{
 		// SL-51858: Key presses are not being passed to the Popup menu.
@@ -1344,21 +1344,21 @@ BOOL LLFolderView::handleUnicodeCharHere(llwchar uni_char)
 		{
 			mSearchString += uni_char;
 		}
-		search(getCurSelectedItem(), mSearchString, FALSE);
+		search(getCurSelectedItem(), mSearchString, false);
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLFolderView::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderView::handleMouseDown( S32 x, S32 y, MASK mask )
 {
-	mKeyboardSelection = FALSE;
+	mKeyboardSelection = false;
 	mSearchString.clear();
 
-	mParentPanel.get()->setFocus(TRUE);
+	mParentPanel.get()->setFocus(true);
 
 	LLEditMenuHandler::gEditMenuHandler = this;
 
@@ -1432,19 +1432,19 @@ BOOL LLFolderView::search(LLFolderViewItem* first_item, const std::string &searc
 	return found;
 }
 
-BOOL LLFolderView::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLFolderView::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
 	// skip LLFolderViewFolder::handleDoubleClick()
 	return LLView::handleDoubleClick( x, y, mask );
 }
 
-BOOL LLFolderView::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderView::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
 	// all user operations move keyboard focus to inventory
 	// this way, we know when to stop auto-updating a search
-	mParentPanel.get()->setFocus(TRUE);
+	mParentPanel.get()->setFocus(true);
 
-	BOOL handled = childrenHandleRightMouseDown(x, y, mask) != NULL;
+	bool handled = childrenHandleRightMouseDown(x, y, mask) != NULL;
 	S32 count = mSelectedItems.size();
 
 	LLMenuGL* menu = static_cast<LLMenuGL*>(mPopupMenuHandle.get());
@@ -1516,9 +1516,9 @@ BOOL LLFolderView::handleRightMouseDown( S32 x, S32 y, MASK mask )
 	{
 		if (menu && menu->getVisible())
 		{
-			menu->setVisible(FALSE);
+			menu->setVisible(false);
 		}
-		setSelection(NULL, FALSE, TRUE);
+		setSelection(NULL, false, true);
 	}
 	return handled;
 }
@@ -1554,7 +1554,7 @@ BOOL LLFolderView::addNoOptions(LLMenuGL* menu) const
 	return FALSE;
 }
 
-BOOL LLFolderView::handleHover( S32 x, S32 y, MASK mask )
+bool LLFolderView::handleHover( S32 x, S32 y, MASK mask )
 {
 	return LLView::handleHover( x, y, mask );
 }

--- a/indra/llui/llfolderview.h
+++ b/indra/llui/llfolderview.h
@@ -202,11 +202,11 @@ public:
 	// LLView functionality
 	///*virtual*/ BOOL handleKey( KEY key, MASK mask, BOOL called_from_parent );
 	/*virtual*/ BOOL handleKeyHere( KEY key, MASK mask );
-	/*virtual*/ BOOL handleUnicodeCharHere(llwchar uni_char);
-	/*virtual*/ BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleDoubleClick( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleHover( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleUnicodeCharHere(llwchar uni_char);
+	/*virtual*/ bool handleMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleDoubleClick( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleRightMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleHover( S32 x, S32 y, MASK mask );
 	/*virtual*/ BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 								   EDragAndDropType cargo_type,
 								   void* cargo_data,

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -550,21 +550,21 @@ const std::string& LLFolderViewItem::getName( void ) const
 }
 
 // LLView functionality
-BOOL LLFolderViewItem::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderViewItem::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
 	if(!mIsSelected)
 	{
-		getRoot()->setSelection(this, FALSE);
+		getRoot()->setSelection(this, false);
 	}
 	make_ui_sound("UISndClick");
-	return TRUE;
+	return true;
 }
 
-BOOL LLFolderViewItem::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderViewItem::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	if (LLView::childrenHandleMouseDown(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 	
 	// No handler needed for focus lost since this class has no
@@ -583,7 +583,7 @@ BOOL LLFolderViewItem::handleMouseDown( S32 x, S32 y, MASK mask )
 		}
 		else
 		{
-			getRoot()->setSelection(this, FALSE);
+			getRoot()->setSelection(this, false);
 		}
 		make_ui_sound("UISndClick");
 	}
@@ -591,15 +591,15 @@ BOOL LLFolderViewItem::handleMouseDown( S32 x, S32 y, MASK mask )
 	{
 		// If selected, we reserve the decision of deselecting/reselecting to the mouse up moment.
 		// This is necessary so we maintain selection consistent when starting a drag.
-		mSelectPending = TRUE;
+		mSelectPending = true;
 	}
 
 	mDragStartX = x;
 	mDragStartY = y;
-	return TRUE;
+	return true;
 }
 
-BOOL LLFolderViewItem::handleHover( S32 x, S32 y, MASK mask )
+bool LLFolderViewItem::handleHover( S32 x, S32 y, MASK mask )
 {
 	static LLCachedControl<S32> drag_and_drop_threshold(*LLUI::getInstance()->mSettingGroups["config"],"DragAndDropDistanceThreshold", 3);
 
@@ -616,7 +616,7 @@ BOOL LLFolderViewItem::handleHover( S32 x, S32 y, MASK mask )
 		{
 					// RN: when starting drag and drop, clear out last auto-open
 					root->autoOpenTest(NULL);
-					root->setShowSelectionContext(TRUE);
+					root->setShowSelectionContext(true);
 
 					// Release keyboard focus, so that if stuff is dropped into the
 					// world, pressing the delete key won't blow away the inventory
@@ -631,31 +631,31 @@ BOOL LLFolderViewItem::handleHover( S32 x, S32 y, MASK mask )
 		}
 
 		root->clearHoveredItem();
-		return TRUE;
+		return true;
 	}
 	else
 	{
 		LLFolderView* pRoot = getRoot();
 		pRoot->setHoveredItem(this);
-		pRoot->setShowSelectionContext(FALSE);
+		pRoot->setShowSelectionContext(false);
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		// let parent handle this then...
-		return FALSE;
+		return false;
 	}
 }
 
 
-BOOL LLFolderViewItem::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLFolderViewItem::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
 	openItem();
-	return TRUE;
+	return true;
 }
 
-BOOL LLFolderViewItem::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLFolderViewItem::handleMouseUp( S32 x, S32 y, MASK mask )
 {
 	if (LLView::childrenHandleMouseUp(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 	
 	// if mouse hasn't moved since mouse down...
@@ -672,21 +672,21 @@ BOOL LLFolderViewItem::handleMouseUp( S32 x, S32 y, MASK mask )
 		}
 		else
 		{
-			getRoot()->setSelection(this, FALSE);
+			getRoot()->setSelection(this, false);
 		}
 	}
 
-	mSelectPending = FALSE;
+	mSelectPending = false;
 
 	if( hasMouseCapture() )
 	{
 		if (getRoot())
 		{
-		getRoot()->setShowSelectionContext(FALSE);
+		getRoot()->setShowSelectionContext(false);
 		}
 		gFocusMgr.setMouseCapture( NULL );
 	}
-	return TRUE;
+	return true;
 }
 
 void LLFolderViewItem::onMouseLeave(S32 x, S32 y, MASK mask)
@@ -2019,9 +2019,9 @@ BOOL LLFolderViewFolder::handleDragAndDropToThisFolder(MASK mask,
 }
 
 
-BOOL LLFolderViewFolder::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderViewFolder::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if( isOpen() )
 	{
@@ -2035,11 +2035,11 @@ BOOL LLFolderViewFolder::handleRightMouseDown( S32 x, S32 y, MASK mask )
 }
 
 
-BOOL LLFolderViewFolder::handleHover(S32 x, S32 y, MASK mask)
+bool LLFolderViewFolder::handleHover(S32 x, S32 y, MASK mask)
 {
 	mIsMouseOverTitle = (y > (getRect().getHeight() - mItemHeight));
 
-	BOOL handled = LLView::handleHover(x, y, mask);
+	bool handled = LLView::handleHover(x, y, mask);
 
 	if (!handled)
 	{
@@ -2050,9 +2050,9 @@ BOOL LLFolderViewFolder::handleHover(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if( isOpen() )
 	{
 		handled = childrenHandleMouseDown(x,y,mask) != NULL;
@@ -2063,7 +2063,7 @@ BOOL LLFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
            && !mSingleFolderMode)
 		{
 			toggleOpen();
-			handled = TRUE;
+			handled = true;
 		}
 		else
 		{
@@ -2075,9 +2075,9 @@ BOOL LLFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
 	return handled;
 }
 
-BOOL LLFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
+	bool handled = false;
     if(mSingleFolderMode)
     {
         static LLUICachedControl<bool> double_click_new_window("SingleModeDoubleClickOpenWindow", false);
@@ -2094,7 +2094,7 @@ BOOL LLFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
                                 getViewModelItem()->navigateToFolder(false);
                             });
         }
-        return TRUE;
+        return true;
     }
 
 	if( isOpen() )
@@ -2109,12 +2109,12 @@ BOOL LLFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
             if (double_click_action == 1)
             {
                 getViewModelItem()->navigateToFolder(true);
-                return TRUE;
+                return true;
             }
             if (double_click_action == 2)
             {
                 getViewModelItem()->navigateToFolder(false, true);
-                return TRUE;
+                return true;
             }
         }
 		if(mIndentation < x && x < mIndentation + (isCollapsed() ? 0 : mArrowSize) + mTextPad)
@@ -2125,10 +2125,10 @@ BOOL LLFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
 		}
 		else
 		{
-			getRoot()->setSelection(this, FALSE);
+			getRoot()->setSelection(this, false);
 			toggleOpen();
 		}
-		handled = TRUE;
+		handled = true;
 	}
 	return handled;
 }

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -284,11 +284,11 @@ public:
     bool isSingleFolderMode() { return mSingleFolderMode; }
 
 	// LLView functionality
-	virtual BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleHover( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseUp( S32 x, S32 y, MASK mask );
-	virtual BOOL handleDoubleClick( S32 x, S32 y, MASK mask );
+	virtual bool handleRightMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleHover( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
+	virtual bool handleDoubleClick( S32 x, S32 y, MASK mask );
 
 	virtual void onMouseLeave(S32 x, S32 y, MASK mask);
 
@@ -447,10 +447,10 @@ public:
 	virtual void openItem( void );
 
 	// LLView functionality
-	virtual BOOL handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleDoubleClick( S32 x, S32 y, MASK mask );
+	virtual bool handleHover(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleDoubleClick( S32 x, S32 y, MASK mask );
 	virtual BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, 
 									BOOL drop,
 									EDragAndDropType cargo_type,

--- a/indra/llui/lliconctrl.cpp
+++ b/indra/llui/lliconctrl.cpp
@@ -86,12 +86,12 @@ void LLIconCtrl::draw()
 	LLUICtrl::draw();
 }
 
-BOOL LLIconCtrl::handleHover(S32 x, S32 y, MASK mask)
+bool LLIconCtrl::handleHover(S32 x, S32 y, MASK mask)
 {
     if (mInteractable && getEnabled())
     {
         getWindow()->setCursor(UI_CURSOR_HAND);
-        return TRUE;
+        return true;
     }
     return LLUICtrl::handleHover(x, y, mask);
 }

--- a/indra/llui/lliconctrl.h
+++ b/indra/llui/lliconctrl.h
@@ -71,7 +71,7 @@ public:
 	virtual void	draw();
 
     // llview overrides
-    virtual BOOL handleHover(S32 x, S32 y, MASK mask);
+    virtual bool handleHover(S32 x, S32 y, MASK mask);
 
 	// lluictrl overrides
 	void onVisibilityChange(BOOL new_visibility);

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -660,9 +660,9 @@ void LLLineEditor::onSpellCheckSettingsChange()
 	mSpellCheckStart = mSpellCheckEnd = -1;
 }
 
-BOOL LLLineEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	setFocus( TRUE );
+	setFocus( true );
 	mTripleClickTimer.setTimerExpirySec(TRIPLE_CLICK_INTERVAL);
 
 	if (mSelectionEnd == 0 && mSelectionStart == mText.length())
@@ -674,7 +674,7 @@ BOOL LLLineEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 	{
 		const LLWString& wtext = mText.getWString();
 
-		BOOL doSelectAll = TRUE;
+		bool doSelectAll = true;
 
 		// Select the word we're on
 		if( LLWStringUtil::isPartOfWord( wtext[mCursorPos] ) )
@@ -709,7 +709,7 @@ BOOL LLLineEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 	// We don't want handleMouseUp() to "finish" the selection (and thereby
 	// set mSelectionEnd to where the mouse is), so we finish the selection 
 	// here.
-	mIsSelecting = FALSE;  
+	mIsSelecting = false;
 
 	// delay cursor flashing
 	mKeystrokeTimer.reset();
@@ -717,15 +717,15 @@ BOOL LLLineEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 	// take selection to 'primary' clipboard
 	updatePrimary();
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Check first whether the "clear search" button wants to deal with this.
 	if(childrenHandleMouseDown(x, y, mask) != NULL) 
 	{
-		return TRUE;
+		return true;
 	}
 	
 	if (!mSelectAllonFocusReceived
@@ -737,7 +737,7 @@ BOOL LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 		if (mask & MASK_SHIFT)
 		{
 			// assume we're starting a drag select
-			mIsSelecting = TRUE;
+			mIsSelecting = true;
 
 			// Handle selection extension
 			S32 old_cursor_pos = getCursor();
@@ -793,14 +793,14 @@ BOOL LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 				// We don't want handleMouseUp() to "finish" the selection (and thereby
 				// set mSelectionEnd to where the mouse is), so we finish the selection 
 				// here.
-				mIsSelecting = FALSE;
+				mIsSelecting = false;
 			}
 		}
 
 		gFocusMgr.setMouseCapture( this );
 	}
 
-	setFocus(TRUE);
+	setFocus(true);
 
 	// delay cursor flashing
 	mKeystrokeTimer.reset();
@@ -808,40 +808,40 @@ BOOL LLLineEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 	if (mMouseDownSignal)
 		(*mMouseDownSignal)(this,x,y,mask);
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLLineEditor::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
         // LL_INFOS() << "MiddleMouseDown" << LL_ENDL;
-	setFocus( TRUE );
+	setFocus( true );
 	if( canPastePrimary() )
 	{
 		setCursorAtLocalPos(x);
 		pastePrimary();
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLLineEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	setFocus(TRUE);
+	setFocus(true);
     if (!LLUICtrl::handleRightMouseDown(x, y, mask) && getShowContextMenu())
 	{
 		showContextMenu(x, y);
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLLineEditor::handleHover(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	// Check first whether the "clear search" button wants to deal with this.
 	if(!hasMouseCapture())
 	{
 		if(childrenHandleHover(x, y, mask) != NULL) 
 		{
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -884,34 +884,34 @@ BOOL LLLineEditor::handleHover(S32 x, S32 y, MASK mask)
 
 		getWindow()->setCursor(UI_CURSOR_IBEAM);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (active)" << LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 
 	if( !handled  )
 	{
 		getWindow()->setCursor(UI_CURSOR_IBEAM);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (inactive)" << LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLLineEditor::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLLineEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if( hasMouseCapture() )
 	{
 		gFocusMgr.setMouseCapture( NULL );
-		handled = TRUE;
+		handled = true;
 	}
 
 	// Check first whether the "clear search" button wants to deal with this.
 	if(!handled && childrenHandleMouseUp(x, y, mask) != NULL) 
 	{
-		return TRUE;
+		return true;
 	}
 
 	if( mIsSelecting )
@@ -919,7 +919,7 @@ BOOL LLLineEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 		setCursorAtLocalPos( x );
 		mSelectionEnd = getCursor();
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	if( handled )
@@ -1597,18 +1597,18 @@ BOOL LLLineEditor::handleKeyHere(KEY key, MASK mask )
 }
 
 
-BOOL LLLineEditor::handleUnicodeCharHere(llwchar uni_char)
+bool LLLineEditor::handleUnicodeCharHere(llwchar uni_char)
 {
 	if ((uni_char < 0x20) || (uni_char == 0x7F)) // Control character or DEL
 	{
-		return FALSE;
+		return false;
 	}
 
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if ( (gFocusMgr.getKeyboardFocus() == this) && getVisible() && !mReadOnly)
 	{
-		handled = TRUE;
+		handled = true;
 
 		LLLineEditorRollback rollback( this );
 
@@ -2489,7 +2489,7 @@ void LLLineEditor::updatePreedit(const LLWString &preedit_string,
 	mSpellCheckTimer.setTimerExpirySec(SPELLCHECK_DELAY);
 }
 
-BOOL LLLineEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const
+bool LLLineEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const
 {
 	if (control)
 	{
@@ -2511,13 +2511,13 @@ BOOL LLLineEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect
 	if (preedit_right_column < mScrollHPos)
 	{
 		// This should not occure...
-		return FALSE;
+		return false;
 	}
 
 	const S32 query = (query_offset >= 0 ? preedit_left_column + query_offset : getCursor());
 	if (query < mScrollHPos || query < preedit_left_column || query > preedit_right_column)
 	{
-		return FALSE;
+		return false;
 	}
 
 	if (coord)
@@ -2544,7 +2544,7 @@ BOOL LLLineEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect
 		LLUI::getInstance()->screenRectToGL(preedit_rect_screen, bounds);
 	}
 
-	return TRUE;
+	return true;
 }
 
 void LLLineEditor::getPreeditRange(S32 *position, S32 *length) const

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -122,14 +122,14 @@ public:
 	virtual ~LLLineEditor();
 
 	// mousehandler overrides
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x,S32 y,MASK mask);
-	/*virtual*/ BOOL	handleMiddleMouseDown(S32 x,S32 y,MASK mask);
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleDoubleClick(S32 x,S32 y,MASK mask);
+	/*virtual*/ bool	handleMiddleMouseDown(S32 x,S32 y,MASK mask);
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL	handleKeyHere(KEY key, MASK mask );
-	/*virtual*/ BOOL	handleUnicodeCharHere(llwchar uni_char);
+	/*virtual*/ bool	handleUnicodeCharHere(llwchar uni_char);
 	/*virtual*/ void	onMouseCaptureLost();
 
 	// LLEditMenuHandler overrides
@@ -319,7 +319,7 @@ public:
 						const segment_lengths_t &preedit_segment_lengths, const standouts_t &preedit_standouts, S32 caret_position);
 	virtual void	markAsPreedit(S32 position, S32 length);
 	virtual void	getPreeditRange(S32 *position, S32 *length) const;
-	virtual BOOL	getPreeditLocation(S32 query_position, LLCoordGL *coord, LLRect *bounds, LLRect *control) const;
+	virtual bool	getPreeditLocation(S32 query_position, LLCoordGL *coord, LLRect *bounds, LLRect *control) const;
 	virtual S32		getPreeditFontSize() const;
 	virtual LLWString getPreeditString() const { return getWText(); }
 

--- a/indra/llui/llmenubutton.cpp
+++ b/indra/llui/llmenubutton.cpp
@@ -142,13 +142,13 @@ BOOL LLMenuButton::handleKeyHere(KEY key, MASK mask )
 	return FALSE;
 }
 
-BOOL LLMenuButton::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLMenuButton::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLButton::handleMouseDown(x, y, mask);
 
 	toggleMenu();
 	
-	return TRUE;
+	return true;
 }
 
 void LLMenuButton::toggleMenu()

--- a/indra/llui/llmenubutton.h
+++ b/indra/llui/llmenubutton.h
@@ -65,7 +65,7 @@ public:
 	
 	boost::signals2::connection setMouseDownCallback( const mouse_signal_t::slot_type& cb );
 
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL handleKeyHere(KEY key, MASK mask );
 
 	void hideMenu();

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -229,14 +229,14 @@ BOOL LLMenuItemGL::handleAcceleratorKey(KEY key, MASK mask)
 	return FALSE;
 }
 
-BOOL LLMenuItemGL::handleHover(S32 x, S32 y, MASK mask)
+bool LLMenuItemGL::handleHover(S32 x, S32 y, MASK mask)
 {
 	getWindow()->setCursor(UI_CURSOR_ARROW);
-	return TRUE;
+	return true;
 }
 
 //virtual
-BOOL LLMenuItemGL::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLMenuItemGL::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	return LLUICtrl::handleRightMouseDown(x,y,mask);
 }
@@ -254,14 +254,14 @@ void LLMenuItemGL::onMouseLeave(S32 x, S32 y, MASK mask)
 }
 
 //virtual
-BOOL LLMenuItemGL::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLMenuItemGL::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	// If this event came from a right-click context menu spawn,
 	// process as a left-click to allow menu items to be hit
 	if (LLMenuHolderGL::sContextMenuSpawnPos.mX != S32_MAX
 		|| LLMenuHolderGL::sContextMenuSpawnPos.mY != S32_MAX)
 	{
-		BOOL handled = handleMouseUp(x, y, mask);
+		bool handled = handleMouseUp(x, y, mask);
 		return handled;
 	}
 	return LLUICtrl::handleRightMouseUp(x,y,mask);
@@ -453,26 +453,26 @@ BOOL LLMenuItemGL::handleKeyHere( KEY key, MASK mask )
 	return FALSE;
 }
 
-BOOL LLMenuItemGL::handleMouseUp( S32 x, S32 y, MASK mask)
+bool LLMenuItemGL::handleMouseUp( S32 x, S32 y, MASK mask)
 {
 	// switch to mouse navigation mode
-	LLMenuGL::setKeyboardMode(FALSE);
+	LLMenuGL::setKeyboardMode(false);
 
 	onCommit();
 	make_ui_sound("UISndClickRelease");
 	return LLView::handleMouseUp(x, y, mask);
 }
 
-BOOL LLMenuItemGL::handleMouseDown( S32 x, S32 y, MASK mask)
+bool LLMenuItemGL::handleMouseDown( S32 x, S32 y, MASK mask)
 {
 	// switch to mouse navigation mode
-	LLMenuGL::setKeyboardMode(FALSE);
+	LLMenuGL::setKeyboardMode(false);
 
-	setHighlight(TRUE);
+	setHighlight(true);
 	return LLView::handleMouseDown(x, y, mask);
 }
 
-BOOL LLMenuItemGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMenuItemGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
 {
 	// If the menu is scrollable let it handle the wheel event.
 	return !getMenu()->isScrollable();
@@ -605,49 +605,49 @@ void LLMenuItemSeparatorGL::buildDrawLabel( void )
     }
 }
 
-BOOL LLMenuItemSeparatorGL::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLMenuItemSeparatorGL::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLMenuGL* parent_menu = getMenu();
 	if (y > getRect().getHeight() / 2)
 	{
 		// the menu items are in the child list in bottom up order
 		LLView* prev_menu_item = parent_menu->findNextSibling(this);
-		return (prev_menu_item && prev_menu_item->getVisible() && prev_menu_item->getEnabled()) ? prev_menu_item->handleMouseDown(x, prev_menu_item->getRect().getHeight(), mask) : FALSE;
+		return (prev_menu_item && prev_menu_item->getVisible() && prev_menu_item->getEnabled()) ? prev_menu_item->handleMouseDown(x, prev_menu_item->getRect().getHeight(), mask) : false;
 	}
 	else
 	{
 		LLView* next_menu_item = parent_menu->findPrevSibling(this);
-		return (next_menu_item && next_menu_item->getVisible() && next_menu_item->getEnabled()) ? next_menu_item->handleMouseDown(x, 0, mask) : FALSE;
+		return (next_menu_item && next_menu_item->getVisible() && next_menu_item->getEnabled()) ? next_menu_item->handleMouseDown(x, 0, mask) : false;
 	}
 }
 
-BOOL LLMenuItemSeparatorGL::handleMouseUp(S32 x, S32 y, MASK mask) 
+bool LLMenuItemSeparatorGL::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLMenuGL* parent_menu = getMenu();
 	if (y > getRect().getHeight() / 2)
 	{
 		LLView* prev_menu_item = parent_menu->findNextSibling(this);
-		return (prev_menu_item && prev_menu_item->getVisible() && prev_menu_item->getEnabled()) ? prev_menu_item->handleMouseUp(x, prev_menu_item->getRect().getHeight(), mask) : FALSE;
+		return (prev_menu_item && prev_menu_item->getVisible() && prev_menu_item->getEnabled()) ? prev_menu_item->handleMouseUp(x, prev_menu_item->getRect().getHeight(), mask) : false;
 	}
 	else
 	{
 		LLView* next_menu_item = parent_menu->findPrevSibling(this);
-		return (next_menu_item && next_menu_item->getVisible() && next_menu_item->getEnabled()) ? next_menu_item->handleMouseUp(x, 0, mask) : FALSE;
+		return (next_menu_item && next_menu_item->getVisible() && next_menu_item->getEnabled()) ? next_menu_item->handleMouseUp(x, 0, mask) : false;
 	}
 }
 
-BOOL LLMenuItemSeparatorGL::handleHover(S32 x, S32 y, MASK mask) 
+bool LLMenuItemSeparatorGL::handleHover(S32 x, S32 y, MASK mask)
 {
 	LLMenuGL* parent_menu = getMenu();
 	if (y > getRect().getHeight() / 2)
 	{
-		parent_menu->highlightPrevItem(this, FALSE);
-		return FALSE;
+		parent_menu->highlightPrevItem(this, false);
+		return false;
 	}
 	else
 	{
-		parent_menu->highlightNextItem(this, FALSE);
-		return FALSE;
+		parent_menu->highlightNextItem(this, false);
+		return false;
 	}
 }
 
@@ -663,7 +663,7 @@ class LLMenuItemVerticalSeparatorGL
 public:
 	LLMenuItemVerticalSeparatorGL( void );
 
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask) { return FALSE; }
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask) { return false; }
 };
 
 LLMenuItemVerticalSeparatorGL::LLMenuItemVerticalSeparatorGL( void )
@@ -1019,14 +1019,14 @@ LLView* LLMenuItemBranchGL::findChildView(const std::string& name, BOOL recurse)
 }
 
 // virtual
-BOOL LLMenuItemBranchGL::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLMenuItemBranchGL::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// switch to mouse navigation mode
 	LLMenuGL::setKeyboardMode(FALSE);
 
 	onCommit();
 	make_ui_sound("UISndClickRelease");
-	return TRUE;
+	return true;
 }
 
 bool LLMenuItemBranchGL::hasAccelerator(const KEY &key, const MASK &mask) const
@@ -1363,8 +1363,8 @@ public:
 	virtual BOOL isActive( void ) const;
 
 	// LLView functionality
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseUp( S32 x, S32 y, MASK mask ); 
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
 	virtual void draw( void );
 	virtual BOOL handleKeyHere(KEY key, MASK mask);
 	
@@ -1490,10 +1490,10 @@ BOOL LLMenuItemBranchDownGL::isActive() const
 	return isOpen();
 }
 
-BOOL LLMenuItemBranchDownGL::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLMenuItemBranchDownGL::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	// switch to mouse control mode
-	LLMenuGL::setKeyboardMode(FALSE);
+	LLMenuGL::setKeyboardMode(false);
 
 	if (getVisible() && isOpen())
 	{
@@ -1505,12 +1505,12 @@ BOOL LLMenuItemBranchDownGL::handleMouseDown( S32 x, S32 y, MASK mask )
 	}
 
 	make_ui_sound("UISndClick");
-	return TRUE;
+	return true;
 }
 
-BOOL LLMenuItemBranchDownGL::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLMenuItemBranchDownGL::handleMouseUp( S32 x, S32 y, MASK mask )
 {
-	return TRUE;
+	return true;
 }
 
 
@@ -3118,19 +3118,19 @@ BOOL LLMenuGL::handleAcceleratorKey(KEY key, MASK mask)
 	return FALSE;
 }
 
-BOOL LLMenuGL::handleUnicodeCharHere( llwchar uni_char )
+bool LLMenuGL::handleUnicodeCharHere( llwchar uni_char )
 {
 	if (jumpKeysActive())
 	{
 		return handleJumpKey((KEY)uni_char);
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
+bool LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
 {
 	// leave submenu in place if slope of mouse < MAX_MOUSE_SLOPE_SUB_MENU
-	BOOL no_mouse_data = mLastMouseX == 0 && mLastMouseY == 0;
+	bool no_mouse_data = mLastMouseX == 0 && mLastMouseY == 0;
 	S32 mouse_delta_x = no_mouse_data ? 0 : x - mLastMouseX;
 	S32 mouse_delta_y = no_mouse_data ? 0 : y - mLastMouseY;
 	LLVector2 mouse_dir((F32)mouse_delta_x, (F32)mouse_delta_y);
@@ -3161,7 +3161,7 @@ BOOL LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
 				// moving mouse always highlights new item
 				if (mouse_delta_x != 0 || mouse_delta_y != 0)
 				{
-					((LLMenuItemGL*)viewp)->setHighlight(FALSE);
+					((LLMenuItemGL*)viewp)->setHighlight(false);
 				}
 			}
 		}
@@ -3183,8 +3183,8 @@ BOOL LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
 				// moving mouse always highlights new item
 				if (mouse_delta_x != 0 || mouse_delta_y != 0)
 				{
-					((LLMenuItemGL*)viewp)->setHighlight(TRUE);
-					LLMenuGL::setKeyboardMode(FALSE);
+					((LLMenuItemGL*)viewp)->setHighlight(true);
+					LLMenuGL::setKeyboardMode(false);
 				}
 				mHasSelection = true;
 			}
@@ -3197,10 +3197,10 @@ BOOL LLMenuGL::handleHover( S32 x, S32 y, MASK mask )
 	// drop-down menu is shown. Otherwise any other view won't be able to handle mouse events
 	// until the user chooses one of the drop-down menu items.
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLMenuGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMenuGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
 {
 	if (!mScrollable)
 		return blockMouseEvent(x, y);
@@ -3216,7 +3216,7 @@ BOOL LLMenuGL::handleScrollWheel( S32 x, S32 y, S32 clicks )
 			scrollItems(SD_UP);
 	}
 
-	return TRUE;
+	return true;
 }
 
 
@@ -3503,7 +3503,7 @@ BOOL LLMenuBarGL::handleJumpKey(KEY key)
 	return TRUE;
 }
 
-BOOL LLMenuBarGL::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLMenuBarGL::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// clicks on menu bar closes existing menus from other contexts but leave
 	// own menu open so that we get toggle behavior
@@ -3515,7 +3515,7 @@ BOOL LLMenuBarGL::handleMouseDown(S32 x, S32 y, MASK mask)
 	return LLMenuGL::handleMouseDown(x, y, mask);
 }
 
-BOOL LLMenuBarGL::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLMenuBarGL::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	return LLMenuGL::handleMouseDown(x, y, mask);
 }
@@ -3652,9 +3652,9 @@ BOOL LLMenuBarGL::appendMenu( LLMenuGL* menu )
 	return success;
 }
 
-BOOL LLMenuBarGL::handleHover( S32 x, S32 y, MASK mask )
+bool LLMenuBarGL::handleHover( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	LLView* active_menu = NULL;
 
 	BOOL no_mouse_data = mLastMouseX == 0 && mLastMouseY == 0;
@@ -3690,14 +3690,14 @@ BOOL LLMenuBarGL::handleHover( S32 x, S32 y, MASK mask )
 				viewp->pointInView(local_x, local_y) && 
 				viewp->handleHover(local_x, local_y, mask))
 			{
-				((LLMenuItemGL*)viewp)->setHighlight(TRUE);
+				((LLMenuItemGL*)viewp)->setHighlight(true);
 				handled = TRUE;
 				if (active_menu && active_menu != viewp)
 				{
 					((LLMenuItemGL*)viewp)->onCommit();
-					LLMenuGL::setKeyboardMode(FALSE);
+					LLMenuGL::setKeyboardMode(false);
 				}
-				LLMenuGL::setKeyboardMode(FALSE);
+				LLMenuGL::setKeyboardMode(false);
 			}
 		}
 
@@ -3711,7 +3711,7 @@ BOOL LLMenuBarGL::handleHover( S32 x, S32 y, MASK mask )
 				S32 local_y = y - viewp->getRect().mBottom;
 				if (!viewp->pointInView(local_x, local_y) && ((LLMenuItemGL*)viewp)->getHighlight())
 				{
-					((LLMenuItemGL*)viewp)->setHighlight(FALSE);
+					((LLMenuItemGL*)viewp)->setHighlight(false);
 				}
 			}
 		}
@@ -3719,7 +3719,7 @@ BOOL LLMenuBarGL::handleHover( S32 x, S32 y, MASK mask )
 
 	getWindow()->setCursor(UI_CURSOR_ARROW);
 	
-	return TRUE;
+	return true;
 }
 
 ///============================================================================
@@ -3759,9 +3759,9 @@ void LLMenuHolderGL::draw()
 	}
 }
 
-BOOL LLMenuHolderGL::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLMenuHolderGL::handleMouseDown( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = LLView::childrenHandleMouseDown(x, y, mask) != NULL;
+	bool handled = LLView::childrenHandleMouseDown(x, y, mask) != NULL;
 	if (!handled)
 	{
 		LLMenuGL* visible_menu = (LLMenuGL*)getVisibleMenu();
@@ -3786,9 +3786,9 @@ BOOL LLMenuHolderGL::handleMouseDown( S32 x, S32 y, MASK mask )
 	return handled;
 }
 
-BOOL LLMenuHolderGL::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLMenuHolderGL::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = LLView::childrenHandleRightMouseDown(x, y, mask) != NULL;
+	bool handled = LLView::childrenHandleRightMouseDown(x, y, mask) != NULL;
 	if (!handled)
 	{
 		// clicked off of menu, hide them all
@@ -3799,7 +3799,7 @@ BOOL LLMenuHolderGL::handleRightMouseDown( S32 x, S32 y, MASK mask )
 
 // This occurs when you mouse-down to spawn a context menu, hold the button 
 // down, move off the menu, then mouse-up.  We want this to close the menu.
-BOOL LLMenuHolderGL::handleRightMouseUp( S32 x, S32 y, MASK mask )
+bool LLMenuHolderGL::handleRightMouseUp( S32 x, S32 y, MASK mask )
 {
 	const S32 SLOP = 2;
 	S32 spawn_dx = (x - sContextMenuSpawnPos.mX);
@@ -3811,10 +3811,10 @@ BOOL LLMenuHolderGL::handleRightMouseUp( S32 x, S32 y, MASK mask )
 		// so interpret the mouse-up as a single-click to show and leave on
 		// screen
 		sContextMenuSpawnPos.set(S32_MAX, S32_MAX);
-		return TRUE;
+		return true;
 	}
 
-	BOOL handled = LLView::childrenHandleRightMouseUp(x, y, mask) != NULL;
+	bool handled = LLView::childrenHandleRightMouseUp(x, y, mask) != NULL;
 	if (!handled)
 	{
 		// clicked off of menu, hide them all
@@ -4296,36 +4296,36 @@ void LLContextMenu::hide()
 }
 
 
-BOOL LLContextMenu::handleHover( S32 x, S32 y, MASK mask )
+bool LLContextMenu::handleHover( S32 x, S32 y, MASK mask )
 {
 	LLMenuGL::handleHover(x,y,mask);
 
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	LLMenuItemGL *item = getHighlightedItem();
 
 	if (item && item->getEnabled())
 	{
 		getWindow()->setCursor(UI_CURSOR_ARROW);
-		handled = TRUE;
+		handled = true;
 
 		if (item != mHoverItem)
 		{
 			if (mHoverItem)
 			{
-				mHoverItem->setHighlight( FALSE );
+				mHoverItem->setHighlight( false );
 			}
 			mHoverItem = item;
-			mHoverItem->setHighlight( TRUE );
+			mHoverItem->setHighlight( true );
 		}
-		mHoveredAnyItem = TRUE;
+		mHoveredAnyItem = true;
 	}
 	else
 	{
 		// clear out our selection
 		if (mHoverItem)
 		{
-			mHoverItem->setHighlight(FALSE);
+			mHoverItem->setHighlight(false);
 			mHoverItem = NULL;
 		}
 	}
@@ -4333,7 +4333,7 @@ BOOL LLContextMenu::handleHover( S32 x, S32 y, MASK mask )
 	if( !handled && pointInView( x, y ) )
 	{
 		getWindow()->setCursor(UI_CURSOR_ARROW);
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
@@ -4342,9 +4342,9 @@ BOOL LLContextMenu::handleHover( S32 x, S32 y, MASK mask )
 // handleMouseDown and handleMouseUp are handled by LLMenuGL
 
 
-BOOL LLContextMenu::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLContextMenu::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	// The click was somewhere within our rectangle
 	LLMenuItemGL *item = getHighlightedItem();
@@ -4352,13 +4352,13 @@ BOOL LLContextMenu::handleRightMouseDown(S32 x, S32 y, MASK mask)
 	S32 local_x = x - getRect().mLeft;
 	S32 local_y = y - getRect().mBottom;
 
-	BOOL clicked_in_menu = pointInView(local_x, local_y) ;
+	bool clicked_in_menu = pointInView(local_x, local_y) ;
 
 	// grab mouse if right clicking anywhere within pie (even deadzone in middle), to detect drag outside of pie
 	if (clicked_in_menu)
 	{
 		// capture mouse cursor as if on initial menu show
-		handled = TRUE;
+		handled = true;
 	}
 	
 	if (item)
@@ -4367,14 +4367,14 @@ BOOL LLContextMenu::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		// to make sure it's within the item's rectangle
 		if (item->handleMouseDown( 0, 0, mask ))
 		{
-			handled = TRUE;
+			handled = true;
 		}
 	}
 
 	return handled;
 }
 
-BOOL LLContextMenu::handleRightMouseUp( S32 x, S32 y, MASK mask )
+bool LLContextMenu::handleRightMouseUp( S32 x, S32 y, MASK mask )
 {
 	S32 local_x = x - getRect().mLeft;
 	S32 local_y = y - getRect().mBottom;
@@ -4382,12 +4382,12 @@ BOOL LLContextMenu::handleRightMouseUp( S32 x, S32 y, MASK mask )
 	if (!mHoveredAnyItem && !pointInView(local_x, local_y))
 	{
 		sMenuContainer->hideMenus();
-		return TRUE;
+		return true;
 	}
 
 
 	BOOL result = handleMouseUp( x, y, mask );
-	mHoveredAnyItem = FALSE;
+	mHoveredAnyItem = false;
 	
 	return result;
 }

--- a/indra/llui/llmenugl.h
+++ b/indra/llui/llmenugl.h
@@ -90,9 +90,9 @@ protected:
 public:
 	// LLView overrides
 	/*virtual*/ void onVisibilityChange(BOOL new_visibility);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleRightMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseUp(S32 x, S32 y, MASK mask);
 
 	// LLUICtrl overrides
 	/*virtual*/ void setValue(const LLSD& value);
@@ -163,9 +163,9 @@ public:
 
 	// LLView Functionality
 	virtual BOOL handleKeyHere( KEY key, MASK mask );
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseUp( S32 x, S32 y, MASK mask );
-	virtual BOOL handleScrollWheel( S32 x, S32 y, S32 clicks );
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
+	virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
 
 	virtual void	onMouseEnter(S32 x, S32 y, MASK mask);
 	virtual void	onMouseLeave(S32 x, S32 y, MASK mask);
@@ -241,9 +241,9 @@ public:
 	LLMenuItemSeparatorGL(const LLMenuItemSeparatorGL::Params& p = LLMenuItemSeparatorGL::Params());
 
 	/*virtual*/ void draw( void );
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 
     virtual void buildDrawLabel();
 
@@ -442,9 +442,9 @@ public:
 	void parseChildXML(LLXMLNodePtr child, LLView* parent);
 
 	// LLView Functionality
-	/*virtual*/ BOOL handleUnicodeCharHere( llwchar uni_char );
-	/*virtual*/ BOOL handleHover( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleScrollWheel( S32 x, S32 y, S32 clicks );
+	/*virtual*/ bool handleUnicodeCharHere( llwchar uni_char );
+	/*virtual*/ bool handleHover( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleScrollWheel( S32 x, S32 y, S32 clicks );
 	/*virtual*/ void draw( void );
 	/*virtual*/ void drawBackground(LLMenuItemGL* itemp, F32 alpha);
 	/*virtual*/ void setVisible(BOOL visible);
@@ -643,7 +643,7 @@ protected:
 public:
 	virtual ~LLMenuItemBranchGL();
 	
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
 
 	virtual bool hasAccelerator(const KEY &key, const MASK &mask) const;
 	virtual BOOL handleAcceleratorKey(KEY key, MASK mask);
@@ -721,9 +721,9 @@ public:
 	virtual void	show				(S32 x, S32 y, LLView* spawning_view = NULL);
 	virtual void	hide				();
 
-	virtual BOOL	handleHover			( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleRightMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleRightMouseUp	( S32 x, S32 y, MASK mask );
+	virtual bool	handleHover			( S32 x, S32 y, MASK mask );
+	virtual bool	handleRightMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool	handleRightMouseUp	( S32 x, S32 y, MASK mask );
 
 	virtual bool	addChild			(LLView* view, S32 tab_group = 0);
 
@@ -788,8 +788,8 @@ public:
 	/*virtual*/ BOOL handleAcceleratorKey(KEY key, MASK mask);
 	/*virtual*/ BOOL handleKeyHere(KEY key, MASK mask);
 	/*virtual*/ BOOL handleJumpKey(KEY key);
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ void draw();
 	/*virtual*/ BOOL jumpKeysActive();
@@ -798,7 +798,7 @@ public:
 	virtual BOOL addSeparator();
 
 	// LLView Functionality
-	virtual BOOL handleHover( S32 x, S32 y, MASK mask );
+	virtual bool handleHover( S32 x, S32 y, MASK mask );
 
 	// Returns x position of rightmost child, usually Help menu
 	S32 getRightmostMenuEdge();
@@ -837,11 +837,11 @@ public:
 
 	// LLView functionality
 	virtual void draw();
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleRightMouseDown( S32 x, S32 y, MASK mask );
 
 	// Close context menus on right mouse up not handled by menus.
-	/*virtual*/ BOOL handleRightMouseUp( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleRightMouseUp( S32 x, S32 y, MASK mask );
 
 	virtual BOOL handleKey(KEY key, MASK mask, BOOL called_from_parent);
 	virtual const LLRect getMenuRect() const { return getLocalRect(); }

--- a/indra/llui/llmodaldialog.cpp
+++ b/indra/llui/llmodaldialog.cpp
@@ -169,7 +169,7 @@ void LLModalDialog::setVisible( BOOL visible )
 	LLFloater::setVisible( visible );
 }
 
-BOOL LLModalDialog::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLModalDialog::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLView* popup_menu = LLMenuGL::sMenuContainer->getVisibleMenu();
 	if (popup_menu != NULL)
@@ -197,10 +197,10 @@ BOOL LLModalDialog::handleMouseDown(S32 x, S32 y, MASK mask)
 	}
 
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLModalDialog::handleHover(S32 x, S32 y, MASK mask)		
+bool LLModalDialog::handleHover(S32 x, S32 y, MASK mask)
 { 
 	if( childrenHandleHover(x, y, mask) == NULL )
 	{
@@ -223,36 +223,36 @@ BOOL LLModalDialog::handleHover(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLModalDialog::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLModalDialog::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	childrenHandleMouseUp(x, y, mask);
-	return TRUE;
+	return true;
 }
 
-BOOL LLModalDialog::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLModalDialog::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	childrenHandleScrollWheel(x, y, clicks);
-	return TRUE;
+	return true;
 }
 
-BOOL LLModalDialog::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLModalDialog::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (!LLFloater::handleDoubleClick(x, y, mask))
 	{
 		// Click outside the panel
 		make_ui_sound("UISndInvalidOp");
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLModalDialog::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLModalDialog::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLMenuGL::sMenuContainer->hideMenus();
 	childrenHandleRightMouseDown(x, y, mask);
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/llui/llmodaldialog.h
+++ b/indra/llui/llmodaldialog.h
@@ -49,12 +49,12 @@ public:
 	
 	/*virtual*/ void 	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 	
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL	handleKeyHere(KEY key, MASK mask );
 
 	/*virtual*/ void	setVisible(BOOL visible);

--- a/indra/llui/llmultislider.cpp
+++ b/indra/llui/llmultislider.cpp
@@ -498,7 +498,7 @@ void LLMultiSlider::clear()
 	LLF32UICtrl::clear();
 }
 
-BOOL LLMultiSlider::handleHover(S32 x, S32 y, MASK mask)
+bool LLMultiSlider::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( gFocusMgr.getMouseCapture() == this )
 	{
@@ -531,12 +531,12 @@ BOOL LLMultiSlider::handleHover(S32 x, S32 y, MASK mask)
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (inactive)" << LL_ENDL;		
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLMultiSlider::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLMultiSlider::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if( gFocusMgr.getMouseCapture() == this )
 	{
@@ -545,23 +545,23 @@ BOOL LLMultiSlider::handleMouseUp(S32 x, S32 y, MASK mask)
 		if (mMouseUpSignal)
 			(*mMouseUpSignal)( this, LLSD() );
 
-		handled = TRUE;
+		handled = true;
 		make_ui_sound("UISndClickRelease");
 	}
 	else
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
-BOOL LLMultiSlider::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLMultiSlider::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// only do sticky-focus on non-chrome widgets
 	if (!getIsChrome())
 	{
-		setFocus(TRUE);
+		setFocus(true);
 	}
 	if (mMouseDownSignal)
 		(*mMouseDownSignal)( this, LLSD() );
@@ -611,7 +611,7 @@ BOOL LLMultiSlider::handleMouseDown(S32 x, S32 y, MASK mask)
 	}
 	make_ui_sound("UISndClick");
 
-	return TRUE;
+	return true;
 }
 
 BOOL	LLMultiSlider::handleKeyHere(KEY key, MASK mask)

--- a/indra/llui/llmultislider.h
+++ b/indra/llui/llmultislider.h
@@ -110,9 +110,9 @@ public:
 	void				deleteCurSlider()			{ deleteSlider(mCurSlider); }
 	/*virtual*/ void	clear() override;
 
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask) override;
 	/*virtual*/ BOOL	handleKeyHere(KEY key, MASK mask) override;
 	/*virtual*/ void	onMouseLeave(S32 x, S32 y, MASK mask) override;
 	/*virtual*/ void	draw() override;

--- a/indra/llui/llradiogroup.cpp
+++ b/indra/llui/llradiogroup.cpp
@@ -54,7 +54,7 @@ public:
 	/*virtual*/ void setValue(const LLSD& value);
 
 	/*virtual*/ BOOL postBuild();
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
 
 	LLSD getPayload() { return mPayload; }
 
@@ -470,12 +470,12 @@ BOOL LLRadioCtrl::postBuild()
 	return TRUE;
 }
 
-BOOL LLRadioCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLRadioCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     // Grab focus preemptively, before button takes mousecapture
     if (hasTabStop() && getEnabled())
     {
-        focusFirstItem(FALSE, FALSE);
+        focusFirstItem(false, false);
     }
     else
     {

--- a/indra/llui/llresizebar.cpp
+++ b/indra/llui/llresizebar.cpp
@@ -89,9 +89,9 @@ LLResizeBar::LLResizeBar(const LLResizeBar::Params& p)
 	}
 }
 
-BOOL LLResizeBar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLResizeBar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	if (!canResize()) return FALSE;
+	if (!canResize()) return false;
 
 	// Route future Mouse messages here preemptively.  (Release on mouse up.)
 	// No handler needed for focus lost since this clas has no state that depends on it.
@@ -101,31 +101,31 @@ BOOL LLResizeBar::handleMouseDown(S32 x, S32 y, MASK mask)
 	mLastMouseScreenX = mDragLastScreenX;
 	mLastMouseScreenY = mDragLastScreenY;
 
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLResizeBar::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLResizeBar::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if( hasMouseCapture() )
 	{
 		// Release the mouse
 		gFocusMgr.setMouseCapture( NULL );
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
-		handled = TRUE;
+		handled = true;
 	}
 	return handled;
 }
 
 
-BOOL LLResizeBar::handleHover(S32 x, S32 y, MASK mask)
+bool LLResizeBar::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// We only handle the click if the click both started and ended within us
 	if( hasMouseCapture() )
@@ -289,11 +289,11 @@ BOOL LLResizeBar::handleHover(S32 x, S32 y, MASK mask)
 			}
 		}
 
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	if( handled && canResize() )
@@ -320,7 +320,7 @@ BOOL LLResizeBar::handleHover(S32 x, S32 y, MASK mask)
 	return handled;
 } // end LLResizeBar::handleHover
 
-BOOL LLResizeBar::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLResizeBar::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	LLRect orig_rect = mResizingView->getRect();
 	LLRect scaled_rect = orig_rect;
@@ -350,7 +350,7 @@ BOOL LLResizeBar::handleDoubleClick(S32 x, S32 y, MASK mask)
 		mResizingView->setShape(scaled_rect, true);
 	}
 
-	return TRUE;
+	return true;
 }
 
 void LLResizeBar::setImagePanel(LLPanel * panelp)

--- a/indra/llui/llresizebar.h
+++ b/indra/llui/llresizebar.h
@@ -53,10 +53,10 @@ protected:
 
 public:
 
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
 
 	void			setResizeLimits( S32 min_size, S32 max_size ) { mMinSize = min_size; mMaxSize = max_size; }
 	void			setEnableSnapping(BOOL enable) { mSnappingEnabled = enable; }

--- a/indra/llui/llresizehandle.cpp
+++ b/indra/llui/llresizehandle.cpp
@@ -76,12 +76,12 @@ LLResizeHandle::~LLResizeHandle()
 }
 
 
-BOOL LLResizeHandle::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLResizeHandle::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if( pointInHandle(x, y) )
 	{
-		handled = TRUE;
+		handled = true;
 		// Route future Mouse messages here preemptively.  (Release on mouse up.)
 		// No handler needed for focus lost since this clas has no state that depends on it.
 		gFocusMgr.setMouseCapture( this );
@@ -95,28 +95,28 @@ BOOL LLResizeHandle::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLResizeHandle::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLResizeHandle::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if( hasMouseCapture() )
 	{
 		// Release the mouse
 		gFocusMgr.setMouseCapture( NULL );
-		handled = TRUE;
+		handled = true;
 	}
 	else if( pointInHandle(x, y) )
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLResizeHandle::handleHover(S32 x, S32 y, MASK mask)
+bool LLResizeHandle::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// We only handle the click if the click both started and ended within us
 	if( hasMouseCapture() )
@@ -327,13 +327,13 @@ BOOL LLResizeHandle::handleHover(S32 x, S32 y, MASK mask)
 			}
 		}
 
-		handled = TRUE;
+		handled = true;
 	}
 	else // don't have mouse capture
 	{
 		if( pointInHandle( x, y ) )
 		{
-			handled = TRUE;
+			handled = true;
 		}
 	}
 

--- a/indra/llui/llresizehandle.h
+++ b/indra/llui/llresizehandle.h
@@ -51,9 +51,9 @@ protected:
 	friend class LLUICtrlFactory;
 public:
 	virtual void	draw();
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
 
 	void			setResizeLimits( S32 min_width, S32 min_height ) { mMinWidth = min_width; mMinHeight = min_height; }
 	

--- a/indra/llui/llscrollbar.cpp
+++ b/indra/llui/llscrollbar.cpp
@@ -238,10 +238,10 @@ void LLScrollbar::updateThumbRect()
 	}
 }
 
-BOOL LLScrollbar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLScrollbar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Check children first
-	BOOL handled_by_child = LLView::childrenHandleMouseDown(x, y, mask) != NULL;
+	bool handled_by_child = LLView::childrenHandleMouseDown(x, y, mask) != NULL;
 	if( !handled_by_child )
 	{
 		if( mThumbRect.pointInRect(x,y) )
@@ -279,16 +279,16 @@ BOOL LLScrollbar::handleMouseDown(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
+bool LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
 {
 	// Note: we don't bother sending the event to the children (the arrow buttons)
 	// because they'll capture the mouse whenever they need hover events.
 	
-	BOOL handled = FALSE;
+	bool handled = false;
 	if( hasMouseCapture() )
 	{
 		S32 height = getRect().getHeight();
@@ -382,7 +382,7 @@ BOOL LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
 
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (active)" << LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
@@ -394,26 +394,26 @@ BOOL LLScrollbar::handleHover(S32 x, S32 y, MASK mask)
 	{
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (inactive)"  << LL_ENDL;		
-		handled = TRUE;
+		handled = true;
 	}
 
-	mDocChanged = FALSE;
+	mDocChanged = false;
 	return handled;
 } // end handleHover
 
 
-BOOL LLScrollbar::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollbar::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
-	BOOL handled = changeLine( clicks * mStepSize, TRUE );
+	bool handled = changeLine( clicks * mStepSize, true );
 	return handled;
 }
 
-BOOL LLScrollbar::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollbar::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
-	BOOL handled = FALSE;
+	bool handled = FALSE;
 	if (LLScrollbar::HORIZONTAL == mOrientation)
 	{
-		handled = changeLine(clicks * mStepSize, TRUE);
+		handled = changeLine(clicks * mStepSize, true);
 	}
 	return handled;
 }
@@ -440,13 +440,13 @@ BOOL LLScrollbar::handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 	return FALSE;
 }
 
-BOOL LLScrollbar::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLScrollbar::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if( hasMouseCapture() )
 	{
 		gFocusMgr.setMouseCapture( NULL );
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
@@ -457,7 +457,7 @@ BOOL LLScrollbar::handleMouseUp(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLScrollbar::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLScrollbar::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	// just treat a double click as a second click
 	return handleMouseDown(x, y, mask);

--- a/indra/llui/llscrollbar.h
+++ b/indra/llui/llscrollbar.h
@@ -83,12 +83,12 @@ public:
 
 	// Overrides from LLView
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool	handleScrollHWheel(S32 x, S32 y, S32 clicks);
 	virtual BOOL	handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop, 
 		EDragAndDropType cargo_type, void *cargo_data, EAcceptance *accept, std::string &tooltip_msg);
 

--- a/indra/llui/llscrollcontainer.cpp
+++ b/indra/llui/llscrollcontainer.cpp
@@ -227,21 +227,21 @@ BOOL LLScrollContainer::handleKeyHere(KEY key, MASK mask)
 	return FALSE;
 }
 
-BOOL LLScrollContainer::handleUnicodeCharHere(llwchar uni_char)
+bool LLScrollContainer::handleUnicodeCharHere(llwchar uni_char)
 {
 	if (mScrolledView && mScrolledView->handleUnicodeCharHere(uni_char))
 	{
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
 {
 	// Give event to my child views - they may have scroll bars
 	// (Bad UI design, but technically possible.)
 	if (LLUICtrl::handleScrollWheel(x,y,clicks))
-		return TRUE;
+		return true;
 
 	// When the vertical scrollbar is visible, scroll wheel
 	// only affects vertical scrolling.  It's confusing to have
@@ -257,7 +257,7 @@ BOOL LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
 			updateScroll();
 		}
 		// Always eat the event
-		return TRUE;
+		return true;
 	}
 
 	LLScrollbar* horizontal = mScrollbar[HORIZONTAL];
@@ -268,16 +268,16 @@ BOOL LLScrollContainer::handleScrollWheel( S32 x, S32 y, S32 clicks )
 		&& horizontal->handleScrollWheel( 0, 0, clicks ) )
 	{
 		updateScroll();
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLScrollContainer::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollContainer::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
 	if (LLUICtrl::handleScrollHWheel(x,y,clicks))
 	{
-		return TRUE;
+		return true;
 	}
 
 	LLScrollbar* horizontal = mScrollbar[HORIZONTAL];
@@ -286,10 +286,10 @@ BOOL LLScrollContainer::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 		&& horizontal->handleScrollHWheel( 0, 0, clicks ) )
 	{
 		updateScroll();
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 BOOL LLScrollContainer::handleDragAndDrop(S32 x, S32 y, MASK mask,

--- a/indra/llui/llscrollcontainer.h
+++ b/indra/llui/llscrollcontainer.h
@@ -107,9 +107,9 @@ public:
 	// LLView functionality
 	virtual void	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
-	virtual BOOL	handleScrollWheel( S32 x, S32 y, S32 clicks );
-	virtual BOOL	handleScrollHWheel( S32 x, S32 y, S32 clicks );
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleScrollWheel( S32 x, S32 y, S32 clicks );
+	virtual bool	handleScrollHWheel( S32 x, S32 y, S32 clicks );
 	virtual BOOL	handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 								   EDragAndDropType cargo_type,
 								   void* cargo_data,

--- a/indra/llui/llscrolllistcolumn.cpp
+++ b/indra/llui/llscrolllistcolumn.cpp
@@ -93,7 +93,7 @@ void LLScrollColumnHeader::draw()
 	LLButton::draw();
 }
 
-BOOL LLScrollColumnHeader::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLScrollColumnHeader::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (canResize() && mResizeBar->getRect().pointInRect(x, y))
 	{
@@ -107,7 +107,7 @@ BOOL LLScrollColumnHeader::handleDoubleClick(S32 x, S32 y, MASK mask)
 	{
 		onClick(LLSD());
 	}
-	return TRUE;
+	return true;
 }
 
 void LLScrollColumnHeader::onClick(const LLSD& data)

--- a/indra/llui/llscrolllistcolumn.h
+++ b/indra/llui/llscrolllistcolumn.h
@@ -50,7 +50,7 @@ public:
 	~LLScrollColumnHeader();
 
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ LLView*	findSnapEdge(S32& new_edge_val, const LLCoordGL& mouse_dir, ESnapEdge snap_edge, ESnapType snap_type, S32 threshold, S32 padding);
 	/*virtual*/ void handleReshape(const LLRect& new_rect, bool by_user = false);

--- a/indra/llui/llscrolllistctrl.cpp
+++ b/indra/llui/llscrolllistctrl.cpp
@@ -1743,29 +1743,29 @@ void LLScrollListCtrl::setEnabled(BOOL enabled)
 	mScrollbar->setTabStop(!enabled && mScrollbar->getPageSize() < mScrollbar->getDocSize());
 }
 
-BOOL LLScrollListCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollListCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	// Pretend the mouse is over the scrollbar
 	handled = mScrollbar->handleScrollWheel( 0, 0, clicks );
 
 	if (mMouseWheelOpaque)
 	{
-		return TRUE;
+		return true;
 	}
 
 	return handled;
 }
 
-BOOL LLScrollListCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLScrollListCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	// Pretend the mouse is over the scrollbar
 	handled = mScrollbar->handleScrollHWheel( 0, 0, clicks );
 
 	if (mMouseWheelOpaque)
 	{
-		return TRUE;
+		return true;
 	}
 
 	return handled;
@@ -1783,20 +1783,20 @@ LLRect LLScrollListCtrl::getCellRect(S32 row_index, S32 column_index)
 	return cell_rect;
 }
 
-BOOL LLScrollListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLScrollListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	S32 column_index = getColumnIndexFromOffset(x);
 	LLScrollListColumn* columnp = getColumn(column_index);
 
-	if (columnp == NULL) return FALSE;
+	if (columnp == NULL) return false;
 
-	BOOL handled = FALSE;
+	bool handled = false;
 	// show tooltip for full name of hovered item if it has been truncated
 	LLScrollListItem* hit_item = hitItem(x, y);
 	if (hit_item)
 	{
 		LLScrollListCell* hit_cell = hit_item->getColumn(column_index);
-		if (!hit_cell) return FALSE;
+		if (!hit_cell) return false;
 		if (hit_cell 
 			&& hit_cell->isText()
 			&& hit_cell->needsToolTip())
@@ -1815,7 +1815,7 @@ BOOL LLScrollListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 										.delay_time(0.2f)
 										.sticky_rect(sticky_rect));		
 		}
-		handled = TRUE;
+		handled = true;
 	}
 
 	// otherwise, look for a tooltip associated with this column
@@ -1934,14 +1934,14 @@ BOOL LLScrollListCtrl::selectItemAt(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLScrollListCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLScrollListCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = childrenHandleMouseDown(x, y, mask) != NULL;
+	bool handled = childrenHandleMouseDown(x, y, mask) != NULL;
 
 	if( !handled )
 	{
 		// set keyboard focus first, in case click action wants to move focus elsewhere
-		setFocus(TRUE);
+		setFocus(true);
 
 		// clear selection changed flag because user is starting a selection operation
 		mSelectionChanged = false;
@@ -1952,7 +1952,7 @@ BOOL LLScrollListCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 	return TRUE;
 }
 
-BOOL LLScrollListCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLScrollListCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 {	
 	if (hasMouseCapture())
 	{
@@ -1978,7 +1978,7 @@ BOOL LLScrollListCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLScrollListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLScrollListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLScrollListItem *item = hitItem(x, y);
 	if (item)
@@ -2035,7 +2035,7 @@ BOOL LLScrollListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		}
 		return LLUICtrl::handleRightMouseDown(x, y, mask);
 	}
-	return FALSE;
+	return false;
 }
 
 void LLScrollListCtrl::showProfile(std::string id, bool is_group)
@@ -2108,10 +2108,10 @@ void LLScrollListCtrl::copySLURLToClipboard(std::string id, bool is_group)
 	LLUrlAction::copyURLToClipboard(slurl);
 }
 
-BOOL LLScrollListCtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLScrollListCtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	//BOOL handled = FALSE;
-	BOOL handled = handleClick(x, y, mask);
+	bool handled = handleClick(x, y, mask);
 
 	if (!handled)
 	{
@@ -2127,7 +2127,7 @@ BOOL LLScrollListCtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 BOOL LLScrollListCtrl::handleClick(S32 x, S32 y, MASK mask)
@@ -2279,9 +2279,9 @@ S32 LLScrollListCtrl::getRowOffsetFromIndex(S32 index)
 }
 
 
-BOOL LLScrollListCtrl::handleHover(S32 x,S32 y,MASK mask)
+bool LLScrollListCtrl::handleHover(S32 x,S32 y,MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if (hasMouseCapture())
 	{
@@ -2521,11 +2521,11 @@ BOOL LLScrollListCtrl::handleKeyHere(KEY key,MASK mask )
 	return handled;
 }
 
-BOOL LLScrollListCtrl::handleUnicodeCharHere(llwchar uni_char)
+bool LLScrollListCtrl::handleUnicodeCharHere(llwchar uni_char)
 {
 	if ((uni_char < 0x20) || (uni_char == 0x7F)) // Control character or DEL
 	{
-		return FALSE;
+		return false;
 	}
 
 	// perform incremental search based on keyboard input
@@ -2538,7 +2538,7 @@ BOOL LLScrollListCtrl::handleUnicodeCharHere(llwchar uni_char)
 	// type ahead search is case insensitive
 	uni_char = LLStringOps::toLower((llwchar)uni_char);
 
-	if (selectItemByPrefix(wstring_to_utf8str(mSearchString + (llwchar)uni_char), FALSE))
+	if (selectItemByPrefix(wstring_to_utf8str(mSearchString + (llwchar)uni_char), false))
 	{
 		// update search string only on successful match
 		mNeedsScroll = true;
@@ -2609,7 +2609,7 @@ BOOL LLScrollListCtrl::handleUnicodeCharHere(llwchar uni_char)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/llui/llscrolllistctrl.h
+++ b/indra/llui/llscrolllistctrl.h
@@ -337,16 +337,16 @@ public:
 
 	// Overridden from LLView
 	/*virtual*/ void    draw();
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL	handleKeyHere(KEY key, MASK mask);
-	/*virtual*/ BOOL	handleUnicodeCharHere(llwchar uni_char);
-	/*virtual*/ BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleUnicodeCharHere(llwchar uni_char);
+	/*virtual*/ bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ void	setEnabled(BOOL enabled);
 	/*virtual*/ void	setFocus( BOOL b );
 	/*virtual*/ void	onFocusReceived();

--- a/indra/llui/llslider.cpp
+++ b/indra/llui/llslider.cpp
@@ -157,7 +157,7 @@ void LLSlider::setValueAndCommit(F32 value)
 }
 
 
-BOOL LLSlider::handleHover(S32 x, S32 y, MASK mask)
+bool LLSlider::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( hasMouseCapture() )
 	{
@@ -193,12 +193,12 @@ BOOL LLSlider::handleHover(S32 x, S32 y, MASK mask)
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (inactive)" << LL_ENDL;		
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLSlider::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLSlider::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if( hasMouseCapture() )
 	{
@@ -207,23 +207,23 @@ BOOL LLSlider::handleMouseUp(S32 x, S32 y, MASK mask)
 		if (mMouseUpSignal)
 			(*mMouseUpSignal)( this, getValueF32() );
 
-		handled = TRUE;
+		handled = true;
 		make_ui_sound("UISndClickRelease");
 	}
 	else
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
-BOOL LLSlider::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLSlider::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// only do sticky-focus on non-chrome widgets
 	if (!getIsChrome())
 	{
-		setFocus(TRUE);
+		setFocus(true);
 	}
 	if (mMouseDownSignal)
 		(*mMouseDownSignal)( this, getValueF32() );
@@ -253,7 +253,7 @@ BOOL LLSlider::handleMouseDown(S32 x, S32 y, MASK mask)
 	}
 	make_ui_sound("UISndClick");
 
-	return TRUE;
+	return true;
 }
 
 BOOL LLSlider::handleKeyHere(KEY key, MASK mask)
@@ -277,13 +277,13 @@ BOOL LLSlider::handleKeyHere(KEY key, MASK mask)
 	return handled;
 }
 
-BOOL LLSlider::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLSlider::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if ( mOrientation == VERTICAL )
 	{
 		F32 new_val = getValueF32() - clicks * getIncrement();
 		setValueAndCommit(new_val);
-		return TRUE;
+		return true;
 	}
 	return LLF32UICtrl::handleScrollWheel(x,y,clicks);
 }

--- a/indra/llui/llslider.h
+++ b/indra/llui/llslider.h
@@ -72,11 +72,11 @@ public:
 	boost::signals2::connection setMouseDownCallback( const commit_signal_t::slot_type& cb );
 	boost::signals2::connection setMouseUpCallback(	const commit_signal_t::slot_type& cb );
 
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
-	virtual BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
 	virtual void	draw();
 
 private:

--- a/indra/llui/llspinctrl.cpp
+++ b/indra/llui/llspinctrl.cpp
@@ -457,7 +457,7 @@ void LLSpinCtrl::reportInvalidData()
 	make_ui_sound("UISndBadKeystroke");
 }
 
-BOOL LLSpinCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLSpinCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if( clicks > 0 )
 	{
@@ -472,7 +472,7 @@ BOOL LLSpinCtrl::handleScrollWheel(S32 x, S32 y, S32 clicks)
 		onUpBtn(getValue());
 	}
 
-	return TRUE;
+	return true;
 }
 
 BOOL LLSpinCtrl::handleKeyHere(KEY key, MASK mask)

--- a/indra/llui/llspinctrl.h
+++ b/indra/llui/llspinctrl.h
@@ -88,7 +88,7 @@ public:
 
 	void 			forceEditorCommit();			// for commit on external button
 
-	virtual BOOL	handleScrollWheel(S32 x,S32 y,S32 clicks);
+	virtual bool	handleScrollWheel(S32 x,S32 y,S32 clicks);
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
 
 	void			onEditorCommit(const LLSD& data);

--- a/indra/llui/llstatbar.cpp
+++ b/indra/llui/llstatbar.cpp
@@ -209,7 +209,7 @@ LLStatBar::LLStatBar(const Params& p)
 	setStat(p.stat);
 }
 
-BOOL LLStatBar::handleHover(S32 x, S32 y, MASK mask)
+bool LLStatBar::handleHover(S32 x, S32 y, MASK mask)
 {
 	switch(mStatType)
 	{
@@ -228,38 +228,38 @@ BOOL LLStatBar::handleHover(S32 x, S32 y, MASK mask)
 	default:
 		break;
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLStatBar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLStatBar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLView::handleMouseDown(x, y, mask);
+	bool handled = LLView::handleMouseDown(x, y, mask);
 	if (!handled)
 	{
 		if (mDisplayBar)
 		{
 			if (mDisplayHistory || mOrientation == HORIZONTAL)
 			{
-				mDisplayBar = FALSE;
-				mDisplayHistory = FALSE;
+				mDisplayBar = false;
+				mDisplayHistory = false;
 			}
 			else
 			{
-				mDisplayHistory = TRUE;
+				mDisplayHistory = true;
 			}
 		}
 		else
 		{
-			mDisplayBar = TRUE;
+			mDisplayBar = true;
 			if (mOrientation == HORIZONTAL)
 			{
-				mDisplayHistory = TRUE;
+				mDisplayHistory = true;
 			}
 		}
 		LLView* parent = getParent();
-		parent->reshape(parent->getRect().getWidth(), parent->getRect().getHeight(), FALSE);
+		parent->reshape(parent->getRect().getWidth(), parent->getRect().getHeight(), false);
 	}
-	return TRUE;
+	return true;
 }
 
 template<typename T>

--- a/indra/llui/llstatbar.h
+++ b/indra/llui/llstatbar.h
@@ -61,8 +61,8 @@ public:
 	LLStatBar(const Params&);
 
 	virtual void draw();
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleHover(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleHover(S32 x, S32 y, MASK mask);
 
 	void setStat(const std::string& stat_name);
 

--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -541,11 +541,11 @@ void LLTabContainer::draw()
 
 
 // virtual
-BOOL LLTabContainer::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLTabContainer::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	static LLUICachedControl<S32> tabcntrv_pad ("UITabCntrvPad", 0);
-	BOOL handled = FALSE;
-	BOOL has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0) && !getTabsHidden();
+	bool handled = false;
+	bool has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0) && !getTabsHidden();
 
 	if (has_scroll_arrows)
 	{
@@ -617,10 +617,10 @@ BOOL LLTabContainer::handleMouseDown( S32 x, S32 y, MASK mask )
 }
 
 // virtual
-BOOL LLTabContainer::handleHover( S32 x, S32 y, MASK mask )
+bool LLTabContainer::handleHover( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
-	BOOL has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0) && !getTabsHidden();
+	bool handled = false;
+	bool has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0) && !getTabsHidden();
 
 	if (has_scroll_arrows)
 	{
@@ -663,10 +663,10 @@ BOOL LLTabContainer::handleHover( S32 x, S32 y, MASK mask )
 }
 
 // virtual
-BOOL LLTabContainer::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLTabContainer::handleMouseUp( S32 x, S32 y, MASK mask )
 {
-	BOOL handled = FALSE;
-	BOOL has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0)  && !getTabsHidden();
+	bool handled = false;
+	bool has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0)  && !getTabsHidden();
 
 	S32 local_x = x - getRect().mLeft;
 	S32 local_y = y - getRect().mBottom;
@@ -710,11 +710,11 @@ BOOL LLTabContainer::handleMouseUp( S32 x, S32 y, MASK mask )
 	{
 		if (cur_panel)
 		{
-			if (!cur_panel->focusFirstItem(FALSE))
+			if (!cur_panel->focusFirstItem(false))
 			{
 				// if nothing in the panel gets focus, make sure the new tab does
 				// otherwise the last tab might keep focus
-				getTab(getCurrentPanelIndex())->mButton->setFocus(TRUE);
+				getTab(getCurrentPanelIndex())->mButton->setFocus(true);
 			}
 		}
 		gFocusMgr.setMouseCapture(NULL);
@@ -727,15 +727,15 @@ BOOL LLTabContainer::handleMouseUp( S32 x, S32 y, MASK mask )
 }
 
 // virtual
-BOOL LLTabContainer::handleToolTip( S32 x, S32 y, MASK mask)
+bool LLTabContainer::handleToolTip( S32 x, S32 y, MASK mask)
 {
 	static LLUICachedControl<S32> tabcntrv_pad ("UITabCntrvPad", 0);
-	BOOL handled = LLPanel::handleToolTip( x, y, mask);
+	bool handled = LLPanel::handleToolTip( x, y, mask);
 	if (!handled && getTabCount() > 0 && !getTabsHidden()) 
 	{
 		LLTabTuple* firsttuple = getTab(0);
 
-		BOOL has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0);
+		bool has_scroll_arrows = !mHideScrollArrows && (getMaxScrollPos() > 0);
 		LLRect clip;
 		if (mIsVertical)
 		{

--- a/indra/llui/lltabcontainer.h
+++ b/indra/llui/lltabcontainer.h
@@ -139,10 +139,10 @@ public:
 
 	/*virtual*/ void reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleHover( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleMouseUp( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleHover( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleMouseUp( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL handleKeyHere(KEY key, MASK mask);
 	/*virtual*/ BOOL handleDragAndDrop(S32 x, S32 y, MASK mask,	BOOL drop,
 									   EDragAndDropType type, void* cargo_data,

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1079,14 +1079,14 @@ void LLTextBase::insertSegment(LLTextSegmentPtr segment_to_insert)
 	needsReflow(reflow_start_index);
 }
 
-BOOL LLTextBase::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// handle triple click
 	if (!mTripleClickTimer.hasExpired())
 	{
 		if (mSkipTripleClick)
 		{
-			return TRUE;
+			return true;
 		}
 		
 		S32 real_line = getLineNumFromDocIndex(mCursorPos, false);
@@ -1114,26 +1114,26 @@ BOOL LLTextBase::handleMouseDown(S32 x, S32 y, MASK mask)
 
 		if (line_start == -1)
 		{
-			return TRUE;
+			return true;
 		}
 
 		mSelectionEnd = line_start;
 		mSelectionStart = line_end;
 		setCursorPos(line_start);
 
-		return TRUE;
+		return true;
 	}
 
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleMouseDown(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleMouseDown(x, y, mask);
 }
 
-BOOL LLTextBase::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (hasMouseCapture() && cur_segment && cur_segment->handleMouseUp(x, y, mask))
@@ -1146,57 +1146,57 @@ BOOL LLTextBase::handleMouseUp(S32 x, S32 y, MASK mask)
 			// *TODO: send URL here?
 			(*mURLClickSignal)(this, LLSD() );
 		}
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleMouseUp(x, y, mask);
 }
 
-BOOL LLTextBase::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleMiddleMouseDown(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleMiddleMouseDown(x, y, mask);
 }
 
-BOOL LLTextBase::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleMiddleMouseUp(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleMiddleMouseUp(x, y, mask);
 }
 
-BOOL LLTextBase::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleRightMouseDown(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleRightMouseDown(x, y, mask);
 }
 
-BOOL LLTextBase::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleRightMouseUp(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleRightMouseUp(x, y, mask);
 }
 
-BOOL LLTextBase::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	//Don't start triple click timer if user have clicked on scrollbar
 	mVisibleTextRect = mScroller ? mScroller->getContentWindowRect() : getLocalRect();
@@ -1209,40 +1209,40 @@ BOOL LLTextBase::handleDoubleClick(S32 x, S32 y, MASK mask)
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleDoubleClick(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleDoubleClick(x, y, mask);
 }
 
-BOOL LLTextBase::handleHover(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleHover(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleHover(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleHover(x, y, mask);
 }
 
-BOOL LLTextBase::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLTextBase::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleScrollWheel(x, y, clicks))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleScrollWheel(x, y, clicks);
 }
 
-BOOL LLTextBase::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLTextBase::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	LLTextSegmentPtr cur_segment = getSegmentAtLocalPos(x, y);
 	if (cur_segment && cur_segment->handleToolTip(x, y, mask))
 	{
-		return TRUE;
+		return true;
 	}
 
 	return LLUICtrl::handleToolTip(x, y, mask);
@@ -3228,17 +3228,17 @@ void LLTextSegment::setToken( LLKeywordToken* token ) {}
 LLKeywordToken*	LLTextSegment::getToken() const { return NULL; }
 void LLTextSegment::setToolTip( const std::string &msg ) {}
 void LLTextSegment::dump() const {}
-BOOL LLTextSegment::handleMouseDown(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleMouseUp(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleMiddleMouseDown(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleMiddleMouseUp(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleRightMouseUp(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleDoubleClick(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleHover(S32 x, S32 y, MASK mask) { return FALSE; }
-BOOL LLTextSegment::handleScrollWheel(S32 x, S32 y, S32 clicks) { return FALSE; }
-BOOL LLTextSegment::handleScrollHWheel(S32 x, S32 y, S32 clicks) { return FALSE; }
-BOOL LLTextSegment::handleToolTip(S32 x, S32 y, MASK mask) { return FALSE; }
+bool LLTextSegment::handleMouseDown(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleMouseUp(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleMiddleMouseDown(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleMiddleMouseUp(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleRightMouseUp(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleDoubleClick(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleHover(S32 x, S32 y, MASK mask) { return false; }
+bool LLTextSegment::handleScrollWheel(S32 x, S32 y, S32 clicks) { return false; }
+bool LLTextSegment::handleScrollHWheel(S32 x, S32 y, S32 clicks) { return false; }
+bool LLTextSegment::handleToolTip(S32 x, S32 y, MASK mask) { return false; }
 const std::string&	LLTextSegment::getName() const 
 {
 	return LLStringUtil::null;
@@ -3246,7 +3246,7 @@ const std::string&	LLTextSegment::getName() const
 void LLTextSegment::onMouseCaptureLost() {}
 void LLTextSegment::screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const {}
 void LLTextSegment::localPointToScreen(S32 local_x, S32 local_y, S32* screen_x, S32* screen_y) const {}
-BOOL LLTextSegment::hasMouseCapture() { return FALSE; }
+bool LLTextSegment::hasMouseCapture() { return false; }
 
 //
 // LLNormalTextSegment
@@ -3364,7 +3364,7 @@ F32 LLNormalTextSegment::drawClippedSegment(S32 seg_start, S32 seg_end, S32 sele
     return right_x;
 }
 
-BOOL LLNormalTextSegment::handleHover(S32 x, S32 y, MASK mask)
+bool LLNormalTextSegment::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (getStyle() && getStyle()->isLink())
 	{
@@ -3372,13 +3372,13 @@ BOOL LLNormalTextSegment::handleHover(S32 x, S32 y, MASK mask)
 		if(mEditor.getSegmentAtLocalPos(x, y, false) == this)
 		{
 			LLUI::getInstance()->getWindow()->setCursor(UI_CURSOR_HAND);
-			return TRUE;
+			return true;
 		}
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLNormalTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLNormalTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (getStyle() && getStyle()->isLink())
 	{
@@ -3386,13 +3386,13 @@ BOOL LLNormalTextSegment::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		if(mEditor.getSegmentAtLocalPos(x, y, false) == this)
 		{
 			mEditor.createUrlContextMenu(x, y, getStyle()->getLinkHREF());
-			return TRUE;
+			return true;
 		}
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLNormalTextSegment::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLNormalTextSegment::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (getStyle() && getStyle()->isLink())
 	{
@@ -3400,14 +3400,14 @@ BOOL LLNormalTextSegment::handleMouseDown(S32 x, S32 y, MASK mask)
 		if(mEditor.getSegmentAtLocalPos(x, y, false) == this)
 		{
 			// eat mouse down event on hyperlinks, so we get the mouse up
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLNormalTextSegment::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLNormalTextSegment::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (getStyle() && getStyle()->isLink())
 	{
@@ -3423,14 +3423,14 @@ BOOL LLNormalTextSegment::handleMouseUp(S32 x, S32 y, MASK mask)
             {
                 LLUrlAction::openURLExternal(url);
             }
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLNormalTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLNormalTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	std::string msg;
 	// do we have a tooltip for a loaded keyword (for script editor)?
@@ -3438,16 +3438,16 @@ BOOL LLNormalTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
 	{
 		const LLWString& wmsg = mToken->getToolTip();
 		LLToolTipMgr::instance().show(wstring_to_utf8str(wmsg));
-		return TRUE;
+		return true;
 	}
 	// or do we have an explicitly set tooltip (e.g., for Urls)
 	if (!mTooltip.empty())
 	{
 		LLToolTipMgr::instance().show(mTooltip);
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 void LLNormalTextSegment::setToolTip(const std::string& tooltip)
@@ -3611,7 +3611,7 @@ F32 LLOnHoverChangeableTextSegment::draw(S32 start, S32 end, S32 selection_start
 }
 
 /*virtual*/
-BOOL LLOnHoverChangeableTextSegment::handleHover(S32 x, S32 y, MASK mask)
+bool LLOnHoverChangeableTextSegment::handleHover(S32 x, S32 y, MASK mask)
 {
 	mStyle = mEditor.getSkipLinkUnderline() ? mNormalStyle : mHoveredStyle;
 	return LLNormalTextSegment::handleHover(x, y, mask);
@@ -3786,15 +3786,15 @@ S32	 LLImageTextSegment::getNumChars(S32 num_pixels, S32 segment_offset, S32 lin
 	return 0;
 }
 
-BOOL LLImageTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLImageTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if (!mTooltip.empty())
 	{
 		LLToolTipMgr::instance().show(mTooltip);
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 void LLImageTextSegment::setToolTip(const std::string& tooltip)

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -94,22 +94,22 @@ public:
 	virtual void				dump() const;
 
 	// LLMouseHandler interface
-	/*virtual*/ BOOL			handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleMiddleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleRightMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL			handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL			handleScrollHWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL			handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleMiddleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleRightMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool			handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool			handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool			handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ const std::string&	getName() const;
 	/*virtual*/ void			onMouseCaptureLost();
 	/*virtual*/ void			screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const;
 	/*virtual*/ void			localPointToScreen(S32 local_x, S32 local_y, S32* screen_x, S32* screen_y) const;
-	/*virtual*/ BOOL			hasMouseCapture();
+	/*virtual*/ bool			hasMouseCapture();
 
 	S32						getStart() const 					{ return mStart; }
 	void					setStart(S32 start)					{ mStart = start; }
@@ -142,11 +142,11 @@ public:
 	/*virtual*/ void				setToolTip(const std::string& tooltip);
 	/*virtual*/ void				dump() const;
 
-	/*virtual*/ BOOL				handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL				handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL				handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL				handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL				handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool				handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool				handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool				handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool				handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool				handleToolTip(S32 x, S32 y, MASK mask);
 
 protected:
 	F32					drawClippedSegment(S32 seg_start, S32 seg_end, S32 selection_start, S32 selection_end, LLRectf rect);
@@ -184,7 +184,7 @@ class LLOnHoverChangeableTextSegment : public LLNormalTextSegment
 public:
 	LLOnHoverChangeableTextSegment( LLStyleConstSP style, LLStyleConstSP normal_style, S32 start, S32 end, LLTextBase& editor );
 	/*virtual*/ F32 draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 protected:
 	// Style used for text when mouse pointer is over segment
 	LLStyleConstSP		mHoveredStyle;
@@ -255,7 +255,7 @@ public:
 	S32			getNumChars(S32 num_pixels, S32 segment_offset, S32 char_offset, S32 max_chars, S32 line_ind) const;
 	F32			draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
 
-	/*virtual*/ BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ void	setToolTip(const std::string& tooltip);
 
 private:
@@ -339,16 +339,16 @@ public:
 	};
 
 	// LLMouseHandler interface
-	/*virtual*/ BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleMiddleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleRightMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL		handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMiddleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleRightMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool		handleToolTip(S32 x, S32 y, MASK mask);
 
 	// LLView interface
 	/*virtual*/ void		reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);

--- a/indra/llui/lltextbox.cpp
+++ b/indra/llui/lltextbox.cpp
@@ -52,9 +52,9 @@ LLTextBox::LLTextBox(const LLTextBox::Params& p)
 LLTextBox::~LLTextBox()
 {}
 
-BOOL LLTextBox::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextBox::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = LLTextBase::handleMouseDown(x, y, mask);
+	bool	handled = LLTextBase::handleMouseDown(x, y, mask);
 
 	if (getSoundFlags() & MOUSE_DOWN)
 	{
@@ -63,7 +63,7 @@ BOOL LLTextBox::handleMouseDown(S32 x, S32 y, MASK mask)
 
 	if (!handled && mClickedCallback)
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	if (handled)
@@ -75,9 +75,9 @@ BOOL LLTextBox::handleMouseDown(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLTextBox::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextBox::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = LLTextBase::handleMouseUp(x, y, mask);
+	bool	handled = LLTextBase::handleMouseUp(x, y, mask);
 
 	if (getSoundFlags() & MOUSE_UP)
 	{
@@ -96,21 +96,21 @@ BOOL LLTextBox::handleMouseUp(S32 x, S32 y, MASK mask)
 		if (mClickedCallback && !handled)
 		{
 			mClickedCallback();
-			handled = TRUE;
+			handled = true;
 		}
 	}
 
 	return handled;
 }
 
-BOOL LLTextBox::handleHover(S32 x, S32 y, MASK mask)
+bool LLTextBox::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLTextBase::handleHover(x, y, mask);
+	bool handled = LLTextBase::handleHover(x, y, mask);
 	if (!handled && mClickedCallback && mShowCursorHand)
 	{
 		// Clickable text boxes change the cursor to a hand
 		LLUI::getInstance()->getWindow()->setCursor(UI_CURSOR_HAND);
-		return TRUE;
+		return true;
 	}
 	return handled;
 }

--- a/indra/llui/lltextbox.h
+++ b/indra/llui/lltextbox.h
@@ -48,9 +48,9 @@ protected:
 public:
 	virtual ~LLTextBox();
 
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ void setEnabled(BOOL enabled);
 

--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -668,15 +668,15 @@ void LLTextEditor::selectByCursorPosition(S32 prev_cursor_pos, S32 next_cursor_p
 	endSelection();
 }
 
-BOOL LLTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// set focus first, in case click callbacks want to change it
 	// RN: do we really need to have a tab stop?
 	if (hasTabStop())
 	{
-		setFocus( TRUE );
+		setFocus( true );
 	}
 
 	// Let scrollbar have first dibs
@@ -689,7 +689,7 @@ BOOL LLTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 			deselect();
 		}
 
-		BOOL start_select = TRUE;
+		bool start_select = true;
 		if( start_select )
 		{
 			// If we're not scrolling (handled by child), then we're selecting
@@ -717,7 +717,7 @@ BOOL LLTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 			}
 		}
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	// Delay cursor flashing
@@ -730,11 +730,11 @@ BOOL LLTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLTextEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (hasTabStop())
 	{
-		setFocus(TRUE);
+		setFocus(true);
 	}
 
 	bool show_menu = false;
@@ -742,7 +742,7 @@ BOOL LLTextEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
 	// Prefer editor menu if it has selection. See EXT-6806.
 	if (hasSelection())
 	{
-		S32 click_pos = getDocIndexFromLocalCoord(x, y, FALSE);
+		S32 click_pos = getDocIndexFromLocalCoord(x, y, false);
 		if (click_pos > mSelectionStart && click_pos < mSelectionEnd)
 		{
 			show_menu = true;
@@ -760,16 +760,16 @@ BOOL LLTextEditor::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		showContextMenu(x, y);
 	}
 
-	return TRUE;
+	return true;
 }
 
 
 
-BOOL LLTextEditor::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (hasTabStop())
 	{
-		setFocus(TRUE);
+		setFocus(true);
 	}
 
 	if (!LLTextBase::handleMouseDown(x, y, mask))
@@ -781,13 +781,13 @@ BOOL LLTextEditor::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 			pastePrimary();
 		}
 	}
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLTextEditor::handleHover(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if(hasMouseCapture() )
 	{
@@ -804,7 +804,7 @@ BOOL LLTextEditor::handleHover(S32 x, S32 y, MASK mask)
 		}
 		LL_DEBUGS("UserInput") << "hover handled by " << getName() << " (active)" << LL_ENDL;		
 		getWindow()->setCursor(UI_CURSOR_IBEAM);
-		handled = TRUE;
+		handled = true;
 	}
 
 	if( !handled )
@@ -822,16 +822,16 @@ BOOL LLTextEditor::handleHover(S32 x, S32 y, MASK mask)
 	if( !handled )
 	{
 		getWindow()->setCursor(UI_CURSOR_IBEAM);
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// if I'm not currently selecting text
 	if (!(mIsSelecting && hasMouseCapture()))
@@ -857,7 +857,7 @@ BOOL LLTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 		// take selection to 'primary' clipboard
 		updatePrimary();
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	// Delay cursor flashing
@@ -867,16 +867,16 @@ BOOL LLTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 	{
 		gFocusMgr.setMouseCapture( NULL );
 		
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// let scrollbar and text segments have first dibs
 	handled = LLTextBase::handleDoubleClick(x, y, mask);
@@ -914,7 +914,7 @@ BOOL LLTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 
 		// We don't want handleMouseUp() to "finish" the selection (and thereby
 		// set mSelectionEnd to where the mouse is), so we finish the selection here.
-		mIsSelecting = FALSE;  
+		mIsSelecting = false;  
 
 		// delay cursor flashing
 		resetCursorBlink();
@@ -922,7 +922,7 @@ BOOL LLTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 		// take selection to 'primary' clipboard
 		updatePrimary();
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
@@ -1825,14 +1825,14 @@ BOOL LLTextEditor::handleKeyHere(KEY key, MASK mask )
 }
 
 
-BOOL LLTextEditor::handleUnicodeCharHere(llwchar uni_char)
+bool LLTextEditor::handleUnicodeCharHere(llwchar uni_char)
 {
 	if ((uni_char < 0x20) || (uni_char == 0x7F)) // Control character or DEL
 	{
-		return FALSE;
+		return false;
 	}
 
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// Handle most keys only if the text editor is writeable.
 	if( !mReadOnly )
@@ -1848,7 +1848,7 @@ BOOL LLTextEditor::handleUnicodeCharHere(llwchar uni_char)
 		// Keys that add characters temporarily hide the cursor
 		getWindow()->hideCursorUntilMouseMove();
 
-		handled = TRUE;
+		handled = true;
 	}
 
 	if( handled )
@@ -2755,7 +2755,7 @@ void LLTextEditor::updatePreedit(const LLWString &preedit_string,
 	onKeyStroke();
 }
 
-BOOL LLTextEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const
+bool LLTextEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const
 {
 	if (control)
 	{
@@ -2778,13 +2778,13 @@ BOOL LLTextEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect
 	const S32 query = (query_offset >= 0 ? preedit_left_position + query_offset : mCursorPos);
 	if (query < preedit_left_position || query > preedit_right_position)
 	{
-		return FALSE;
+		return false;
 	}
 
 	const S32 first_visible_line = getFirstVisibleLine();
 	if (query < getLineStart(first_visible_line))
 	{
-		return FALSE;
+		return false;
 	}
 
 	S32 current_line = first_visible_line;
@@ -2845,7 +2845,7 @@ BOOL LLTextEditor::getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect
 		LLUI::getInstance()->screenRectToGL(preedit_rect_screen, bounds);
 	}
 
-	return TRUE;
+	return true;
 }
 
 void LLTextEditor::getSelectionRange(S32 *position, S32 *length) const
@@ -2891,7 +2891,7 @@ void LLTextEditor::markAsPreedit(S32 position, S32 length)
 		mPreeditPositions[0] = position;
 		mPreeditPositions[1] = position + length;
 		mPreeditStandouts.resize(1);
-		mPreeditStandouts[0] = FALSE;
+		mPreeditStandouts[0] = false;
 	}
 	else
 	{

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -92,15 +92,15 @@ public:
 	static S32		spacesPerTab();
 
 	// mousehandler overrides
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask );
-	virtual BOOL	handleMiddleMouseDown(S32 x,S32 y,MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask );
+	virtual bool	handleMiddleMouseDown(S32 x,S32 y,MASK mask);
 
 	virtual BOOL	handleKeyHere(KEY key, MASK mask );
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
 
 	virtual void	onMouseCaptureLost();
 
@@ -259,7 +259,7 @@ protected:
 	virtual void	markAsPreedit(S32 position, S32 length);
 	virtual void	getPreeditRange(S32 *position, S32 *length) const;
 	virtual void	getSelectionRange(S32 *position, S32 *length) const;
-	virtual BOOL	getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const;
+	virtual bool	getPreeditLocation(S32 query_offset, LLCoordGL *coord, LLRect *bounds, LLRect *control) const;
 	virtual S32		getPreeditFontSize() const;
 	virtual LLWString getPreeditString() const { return getWText(); }
 	//
@@ -276,7 +276,7 @@ protected:
 	LLWString			mPreeditWString;
 	LLWString			mPreeditOverwrittenWString;
 	std::vector<S32> 	mPreeditPositions;
-	std::vector<BOOL> 	mPreeditStandouts;
+	std::vector<bool> 	mPreeditStandouts;
 
 protected:
 	LLUIColor			mDefaultColor;

--- a/indra/llui/lltoolbar.cpp
+++ b/indra/llui/lltoolbar.cpp
@@ -406,11 +406,11 @@ bool LLToolBar::flashCommand(const LLCommandId& commandId, bool flash, bool forc
 	return (command_button != NULL);
 }
 
-BOOL LLToolBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLRect button_panel_rect;
 	mButtonPanel->localRectToOtherView(mButtonPanel->getLocalRect(), &button_panel_rect, this);
-	BOOL handle_it_here = !mReadOnly && button_panel_rect.pointInRect(x, y);
+	bool handle_it_here = !mReadOnly && button_panel_rect.pointInRect(x, y);
 
 	if (handle_it_here)
 	{
@@ -1122,16 +1122,16 @@ LLToolBarButton::~LLToolBarButton()
 	delete mIsStartingSignal;
 }
 
-BOOL LLToolBarButton::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolBarButton::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mMouseDownX = x;
 	mMouseDownY = y;
 	return LLButton::handleMouseDown(x, y, mask);
 }
 
-BOOL LLToolBarButton::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolBarButton::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 		
 	S32 mouse_distance_squared = (x - mMouseDownX) * (x - mMouseDownX) + (y - mMouseDownY) * (y - mMouseDownY);
 	static LLCachedControl<S32> drag_threshold(*LLUI::getInstance()->mSettingGroups["config"], "DragAndDropDistanceThreshold", 3);
@@ -1143,7 +1143,7 @@ BOOL LLToolBarButton::handleHover(S32 x, S32 y, MASK mask)
 		{
 			mStartDragItemCallback(x, y, this);
 			mIsDragged = true;
-			handled = TRUE;
+			handled = true;
 		}
 		else 
 		{

--- a/indra/llui/lltoolbar.h
+++ b/indra/llui/lltoolbar.h
@@ -62,8 +62,8 @@ public:
 	LLToolBarButton(const Params& p);
 	~LLToolBarButton();
 
-	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleHover(S32 x, S32 y, MASK mask);
+	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	bool handleHover(S32 x, S32 y, MASK mask);
 
 	void reshape(S32 width, S32 height, BOOL called_from_parent = true);
 	void setEnabled(BOOL enabled);
@@ -215,7 +215,7 @@ public:
 	// virtuals
 	void draw();
 	void reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
-	BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 	virtual BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 								   EDragAndDropType cargo_type,
 								   void* cargo_data,

--- a/indra/llui/lltooltip.cpp
+++ b/indra/llui/lltooltip.cpp
@@ -71,7 +71,7 @@ void LLToolTipView::draw()
 	LLView::draw();
 }
 
-BOOL LLToolTipView::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolTipView::handleHover(S32 x, S32 y, MASK mask)
 {
 	static S32 last_x = x;
 	static S32 last_y = y;
@@ -89,7 +89,7 @@ BOOL LLToolTipView::handleHover(S32 x, S32 y, MASK mask)
 	return LLView::handleHover(x, y, mask);
 }
 
-BOOL LLToolTipView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolTipView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLToolTipMgr::instance().blockToolTips();
 
@@ -98,29 +98,29 @@ BOOL LLToolTipView::handleMouseDown(S32 x, S32 y, MASK mask)
 		// If we are handling the mouse event menu holder 
 		// won't get a chance to close menus so do this here 
 		LLMenuGL::sMenuContainer->hideMenus();
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLToolTipView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolTipView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLToolTipMgr::instance().blockToolTips();
 	return LLView::handleMiddleMouseDown(x, y, mask);
 }
 
-BOOL LLToolTipView::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolTipView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLToolTipMgr::instance().blockToolTips();
 	return LLView::handleRightMouseDown(x, y, mask);
 }
 
 
-BOOL LLToolTipView::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLToolTipView::handleScrollWheel( S32 x, S32 y, S32 clicks )
 {
 	LLToolTipMgr::instance().blockToolTips();
-	return FALSE;
+	return false;
 }
 
 void LLToolTipView::drawStickyRect()
@@ -341,7 +341,7 @@ void LLToolTip::setVisible(BOOL visible)
 	}
 }
 
-BOOL LLToolTip::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolTip::handleHover(S32 x, S32 y, MASK mask)
 {
 	//mInfoButton->setFlashing(true);
 	if(mInfoButton)
@@ -352,7 +352,7 @@ BOOL LLToolTip::handleHover(S32 x, S32 y, MASK mask)
 	{
 		getWindow()->setCursor(UI_CURSOR_HAND);
 	}
-	return TRUE;
+	return true;
 }
 
 void LLToolTip::onMouseLeave(S32 x, S32 y, MASK mask)

--- a/indra/llui/lltooltip.h
+++ b/indra/llui/lltooltip.h
@@ -44,11 +44,11 @@ public:
 		Params();
 	};
 	LLToolTipView(const LLToolTipView::Params&);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleScrollWheel( S32 x, S32 y, S32 clicks );
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleScrollWheel( S32 x, S32 y, S32 clicks );
 
 	void drawStickyRect();
 
@@ -97,7 +97,7 @@ public:
 		Params();
 	};
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 	/*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
 	/*virtual*/ void setVisible(BOOL visible);
 

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -342,12 +342,12 @@ void LLUICtrl::onMouseLeave(S32 x, S32 y, MASK mask)
 }
 
 //virtual 
-BOOL LLUICtrl::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLUICtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 
 	LL_DEBUGS() << "LLUICtrl::handleMouseDown calling	LLView)'s handleMouseUp (first initialized xui to: " << getPathname() << " )" << LL_ENDL;
   
-	BOOL handled  = LLView::handleMouseDown(x,y,mask);
+	bool handled  = LLView::handleMouseDown(x,y,mask);
 	
 	if (mMouseDownSignal)
 	{
@@ -362,12 +362,12 @@ BOOL LLUICtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 //virtual
-BOOL LLUICtrl::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLUICtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 
 	LL_DEBUGS() << "LLUICtrl::handleMouseUp calling LLView)'s handleMouseUp (first initialized xui to: " << getPathname() << " )" << LL_ENDL;
 
-	BOOL handled  = LLView::handleMouseUp(x,y,mask);
+	bool handled  = LLView::handleMouseUp(x,y,mask);
 	if (handled) {
 		LLViewerEventRecorder::instance().updateMouseEventInfo(x,y,-56,-56,getPathname()); 
 	}
@@ -382,9 +382,9 @@ BOOL LLUICtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 //virtual
-BOOL LLUICtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLUICtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled  = LLView::handleRightMouseDown(x,y,mask);
+	bool handled  = LLView::handleRightMouseDown(x,y,mask);
 	if (mRightMouseDownSignal)
 	{
 		(*mRightMouseDownSignal)(this,x,y,mask);
@@ -393,9 +393,9 @@ BOOL LLUICtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 }
 
 //virtual
-BOOL LLUICtrl::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLUICtrl::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled  = LLView::handleRightMouseUp(x,y,mask);
+	bool handled  = LLView::handleRightMouseUp(x,y,mask);
 	if(mRightMouseUpSignal)
 	{
 		(*mRightMouseUpSignal)(this,x,y,mask);
@@ -403,9 +403,9 @@ BOOL LLUICtrl::handleRightMouseUp(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLUICtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLUICtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLView::handleDoubleClick(x, y, mask);
+	bool handled = LLView::handleDoubleClick(x, y, mask);
 	if (mDoubleClickSignal)
 	{
 		(*mDoubleClickSignal)(this, x, y, mask);

--- a/indra/llui/lluictrl.h
+++ b/indra/llui/lluictrl.h
@@ -155,11 +155,11 @@ public:
 	/*virtual*/ void	onMouseEnter(S32 x, S32 y, MASK mask) override;
 	/*virtual*/ void	onMouseLeave(S32 x, S32 y, MASK mask) override;
 	/*virtual*/ BOOL	canFocusChildren() const override;
-	/*virtual*/ BOOL 	handleMouseDown(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL 	handleMouseUp(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool 	handleMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool 	handleMouseUp(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleRightMouseUp(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask) override;
 
 	// From LLFocusableElement
 	/*virtual*/ void	setFocus( BOOL b ) override;

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -683,7 +683,7 @@ void LLView::setSnappedTo(const LLView* snap_view)
 {
 }
 
-BOOL LLView::handleHover(S32 x, S32 y, MASK mask)
+bool LLView::handleHover(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleHover( x, y, mask ) != NULL;
 }
@@ -897,9 +897,9 @@ F32 LLView::getTooltipTimeout()
     : tooltip_delay);
 }
 
-BOOL LLView::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLView::handleToolTip(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	// parents provide tooltips first, which are optionally
 	// overridden by children, in case child is mouse_opaque
@@ -916,14 +916,14 @@ BOOL LLView::handleToolTip(S32 x, S32 y, MASK mask)
 			                              .sticky_rect(calcScreenRect())
 			                              .delay_time(getTooltipTimeout()));
 		}
-		handled = TRUE;
+		handled = true;
 	}
 
 	// child tooltips will override our own
 	LLView* child_handler = childrenHandleToolTip(x, y, mask);
 	if (child_handler)
 	{
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
@@ -1044,9 +1044,9 @@ BOOL LLView::handleUnicodeChar(llwchar uni_char, BOOL called_from_parent)
 }
 
 
-BOOL LLView::handleUnicodeCharHere(llwchar uni_char )
+bool LLView::handleUnicodeCharHere(llwchar uni_char )
 {
-	return FALSE;
+	return false;
 }
 
 
@@ -1062,56 +1062,56 @@ void LLView::onMouseCaptureLost()
 {
 }
 
-BOOL LLView::hasMouseCapture()
+bool LLView::hasMouseCapture()
 { 
 	return gFocusMgr.getMouseCapture() == this; 
 }
 
-BOOL LLView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLView* r = childrenHandleMouseUp( x, y, mask );
 
 	return (r!=NULL);
 }
 
-BOOL LLView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLView* r= childrenHandleMouseDown(x, y, mask );
 
 	return (r!=NULL);
 }
 
-BOOL LLView::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLView::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleDoubleClick( x, y, mask ) != NULL;
 }
 
-BOOL LLView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLView::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	return childrenHandleScrollWheel( x, y, clicks ) != NULL;
 }
 
-BOOL LLView::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLView::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
 	return childrenHandleScrollHWheel( x, y, clicks ) != NULL;
 }
 
-BOOL LLView::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleRightMouseDown( x, y, mask ) != NULL;
 }
 
-BOOL LLView::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLView::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleRightMouseUp( x, y, mask ) != NULL;
 }
  
-BOOL LLView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleMiddleMouseDown( x, y, mask ) != NULL;
 }
 
-BOOL LLView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
+bool LLView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
 {
 	return childrenHandleMiddleMouseUp( x, y, mask ) != NULL;
 }

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -421,21 +421,21 @@ public:
 
 	// LLMouseHandler functions
 	//  Default behavior is to pass events to children
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMiddleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask);	
-	/*virtual*/ BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMiddleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleRightMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleToolTip(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ const std::string& getName() const;
 	/*virtual*/ void	onMouseCaptureLost();
-	/*virtual*/ BOOL	hasMouseCapture();
+	/*virtual*/ bool	hasMouseCapture();
 	/*virtual*/ void	screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const;
 	/*virtual*/ void	localPointToScreen(S32 local_x, S32 local_y, S32* screen_x, S32* screen_y) const;
 
@@ -514,7 +514,7 @@ public:
 	//virtual BOOL	addChildFromParam(const LLInitParam::BaseBlock& params) { return TRUE; }
 	virtual BOOL	handleKeyHere(KEY key, MASK mask);
 	virtual BOOL	handleKeyUpHere(KEY key, MASK mask);
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
 
 	virtual void	handleReshape(const LLRect& rect, bool by_user);
 	virtual void	dirtyRect();

--- a/indra/llui/llvirtualtrackball.cpp
+++ b/indra/llui/llvirtualtrackball.cpp
@@ -384,7 +384,7 @@ void LLVirtualTrackball::getAzimuthAndElevationDeg(const LLQuaternion &quat, F32
     elevation *= RAD_TO_DEG;
 }
 
-BOOL LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
+bool LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
 {
     if (hasMouseCapture())
     {
@@ -413,7 +413,7 @@ BOOL LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
         { // set on click mode
             if (!pointInTouchCircle(x, y))
             {
-                return TRUE; // don't drag outside the circle
+                return true; // don't drag outside the circle
             }
 
             F32 radius = mTouchArea->getRect().getWidth() / 2;
@@ -453,10 +453,10 @@ BOOL LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
         mPrevY = y;
         onCommit();
     }
-    return TRUE;
+    return true;
 }
 
-BOOL LLVirtualTrackball::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLVirtualTrackball::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if (hasMouseCapture())
     {
@@ -468,7 +468,7 @@ BOOL LLVirtualTrackball::handleMouseUp(S32 x, S32 y, MASK mask)
     return LLView::handleMouseUp(x, y, mask);
 }
 
-BOOL LLVirtualTrackball::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLVirtualTrackball::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     if (pointInTouchCircle(x, y))
     {
@@ -481,7 +481,7 @@ BOOL LLVirtualTrackball::handleMouseDown(S32 x, S32 y, MASK mask)
     return LLView::handleMouseDown(x, y, mask);
 }
 
-BOOL LLVirtualTrackball::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLVirtualTrackball::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     if (pointInTouchCircle(x, y))
     {

--- a/indra/llui/llvirtualtrackball.h
+++ b/indra/llui/llvirtualtrackball.h
@@ -81,10 +81,10 @@ public:
     virtual ~LLVirtualTrackball();
     /*virtual*/ BOOL postBuild();
 
-    virtual BOOL    handleHover(S32 x, S32 y, MASK mask);
-    virtual BOOL    handleMouseUp(S32 x, S32 y, MASK mask);
-    virtual BOOL    handleMouseDown(S32 x, S32 y, MASK mask);
-    virtual BOOL    handleRightMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool    handleHover(S32 x, S32 y, MASK mask);
+    virtual bool    handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool    handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool    handleRightMouseDown(S32 x, S32 y, MASK mask);
     virtual BOOL    handleKeyHere(KEY key, MASK mask);
 
     virtual void    draw();

--- a/indra/llui/llxyvector.cpp
+++ b/indra/llui/llxyvector.cpp
@@ -275,7 +275,7 @@ void LLXYVector::update()
     mYEntry->setValue(mValueY);
 }
 
-BOOL LLXYVector::handleHover(S32 x, S32 y, MASK mask)
+bool LLXYVector::handleHover(S32 x, S32 y, MASK mask)
 {
     if (hasMouseCapture())
     {
@@ -298,10 +298,10 @@ BOOL LLXYVector::handleHover(S32 x, S32 y, MASK mask)
         }
     }
 
-    return TRUE;
+    return true;
 }
 
-BOOL LLXYVector::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLXYVector::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if (hasMouseCapture())
     {
@@ -311,7 +311,7 @@ BOOL LLXYVector::handleMouseUp(S32 x, S32 y, MASK mask)
 
     if (mTouchArea->getRect().pointInRect(x, y))
     {
-        return TRUE;
+        return true;
     }
     else
     {
@@ -319,7 +319,7 @@ BOOL LLXYVector::handleMouseUp(S32 x, S32 y, MASK mask)
     }
 }
 
-BOOL LLXYVector::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLXYVector::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 
     if (mTouchArea->getRect().pointInRect(x, y))
@@ -327,7 +327,7 @@ BOOL LLXYVector::handleMouseDown(S32 x, S32 y, MASK mask)
         gFocusMgr.setMouseCapture(this);
         make_ui_sound("UISndClick");
 
-        return TRUE;
+        return true;
     }
     else
     {

--- a/indra/llui/llxyvector.h
+++ b/indra/llui/llxyvector.h
@@ -68,9 +68,9 @@ public:
     virtual ~LLXYVector();
     /*virtual*/ BOOL postBuild();
 
-    virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-    virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-    virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool	handleHover(S32 x, S32 y, MASK mask);
+    virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
 
     virtual void	draw();
 

--- a/indra/llwindow/lldragdropwin32.cpp
+++ b/indra/llwindow/lldragdropwin32.cpp
@@ -124,7 +124,7 @@ class LLDragDropWin32Target:
 						ScreenToClient( mAppWindowHandle, &pt2 );
 
 						LLCoordWindow cursor_coord_window( pt2.x, pt2.y );
-						MASK mask = gKeyboard->currentMask(TRUE);
+						MASK mask = gKeyboard->currentMask(true);
 
 						LLWindowCallbacks::DragNDropResult result = window_imp->completeDragNDropRequest( cursor_coord_window.convert(), mask, 
 							LLWindowCallbacks::DNDA_START_TRACKING, mDropUrl );
@@ -179,7 +179,7 @@ class LLDragDropWin32Target:
 					ScreenToClient( mAppWindowHandle, &pt2 );
 
 					LLCoordWindow cursor_coord_window( pt2.x, pt2.y );
-					MASK mask = gKeyboard->currentMask(TRUE);
+					MASK mask = gKeyboard->currentMask(true);
 
 					LLWindowCallbacks::DragNDropResult result = window_imp->completeDragNDropRequest( cursor_coord_window.convert(), mask, 
 						LLWindowCallbacks::DNDA_TRACK, mDropUrl );
@@ -219,7 +219,7 @@ class LLDragDropWin32Target:
 			if (NULL != window_imp)
 			{
 				LLCoordGL gl_coord( 0, 0 );
-				MASK mask = gKeyboard->currentMask(TRUE);
+				MASK mask = gKeyboard->currentMask(true);
 				window_imp->completeDragNDropRequest( gl_coord, mask, LLWindowCallbacks::DNDA_STOP_TRACKING, mDropUrl );
 			};
 			return S_OK;
@@ -249,7 +249,7 @@ class LLDragDropWin32Target:
 					LL_INFOS() << LL_ENDL;
 
 					// no keyboard modifier option yet but we could one day
-					MASK mask = gKeyboard->currentMask( TRUE );
+					MASK mask = gKeyboard->currentMask( true );
 
 					// actually do the drop
 					LLWindowCallbacks::DragNDropResult result = window_imp->completeDragNDropRequest( gl_coord, mask, 
@@ -312,7 +312,7 @@ LLDragDropWin32::~LLDragDropWin32()
 bool LLDragDropWin32::init( HWND hWnd )
 {
 	if ( NOERROR != OleInitialize( NULL ) )
-		return FALSE; 
+		return false; 
 
 	mDropTarget = new LLDragDropWin32Target( hWnd );
 	if ( mDropTarget )

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -486,7 +486,7 @@ std::string get_string(IDxDiagContainer *containerp, WCHAR *wszPropName)
 
 LLVersion::LLVersion()
 {
-	mValid = FALSE;
+	mValid = false;
 	S32 i;
 	for (i = 0; i < 4; i++)
 	{
@@ -494,7 +494,7 @@ LLVersion::LLVersion()
 	}
 }
 
-BOOL LLVersion::set(const std::string &version_string)
+bool LLVersion::set(const std::string &version_string)
 {
 	S32 i;
 	for (i = 0; i < 4; i++)
@@ -521,11 +521,11 @@ BOOL LLVersion::set(const std::string &version_string)
 		{
 			mFields[i] = 0;
 		}
-		mValid = FALSE;
+		mValid = false;
 	}
 	else
 	{
-		mValid = TRUE;
+		mValid = true;
 	}
 	return mValid;
 }
@@ -681,10 +681,10 @@ LLDXDevice *LLDXHardware::findDevice(const std::string &vendor, const std::strin
 }
 */
 
-BOOL LLDXHardware::getInfo(BOOL vram_only)
+bool LLDXHardware::getInfo(bool vram_only)
 {
 	LLTimer hw_timer;
-	BOOL ok = FALSE;
+	bool ok = false;
     HRESULT       hr;
 
     CoInitialize(NULL);
@@ -811,7 +811,7 @@ BOOL LLDXHardware::getInfo(BOOL vram_only)
 
 		if (vram_only)
 		{
-			ok = TRUE;
+			ok = true;
 			goto LCleanup;
 		}
 
@@ -871,7 +871,7 @@ BOOL LLDXHardware::getInfo(BOOL vram_only)
 
 			tokenizer::iterator iter = tokens.begin();
 			S32 count = 0;
-			BOOL valid = TRUE;
+			bool valid = true;
 			for (;(iter != tokens.end()) && (count < 3);++iter)
 			{
 				switch (count)
@@ -879,7 +879,7 @@ BOOL LLDXHardware::getInfo(BOOL vram_only)
 				case 0:
 					if (strcmp(iter->c_str(), "PCI"))
 					{
-						valid = FALSE;
+						valid = false;
 					}
 					break;
 				case 1:
@@ -950,7 +950,7 @@ BOOL LLDXHardware::getInfo(BOOL vram_only)
     }
 
     // dumpDevices();
-    ok = TRUE;
+    ok = true;
 	
 LCleanup:
 	if (!ok)

--- a/indra/llwindow/lldxhardware.h
+++ b/indra/llwindow/lldxhardware.h
@@ -37,12 +37,12 @@ class LLVersion
 {
 public:
 	LLVersion();
-	BOOL set(const std::string &version_string);
+	bool set(const std::string &version_string);
 	S32 getField(const S32 field_num);
 protected:
 	std::string mVersionString;
 	S32 mFields[4];
-	BOOL mValid;
+	bool mValid;
 };
 
 class LLDXDriverFile
@@ -84,9 +84,9 @@ public:
 	void setWriteDebugFunc(void (*func)(const char*));
 	void cleanup();
 
-	// Returns TRUE on success.
-	// vram_only TRUE does a "light" probe.
-	BOOL getInfo(BOOL vram_only);
+	// Returns true on success.
+	// vram_only true does a "light" probe.
+	bool getInfo(bool vram_only);
 
     // WMI can return multiple GPU drivers
     // specify which one to output

--- a/indra/llwindow/llkeyboard.cpp
+++ b/indra/llwindow/llkeyboard.cpp
@@ -55,10 +55,10 @@ LLKeyboard::LLKeyboard() : mCallbacks(NULL)
 	for (i = 0; i < KEY_COUNT; i++)
 	{
 		mKeyLevelFrameCount[i] = 0;
-		mKeyLevel[i] = FALSE;
-		mKeyUp[i]    = FALSE;
-		mKeyDown[i]  = FALSE;
-		mKeyRepeated[i] = FALSE;
+		mKeyLevel[i] = false;
+		mKeyUp[i]    = false;
+		mKeyDown[i]  = false;
+		mKeyRepeated[i] = false;
 	}
 
 	mInsertMode = LL_KIM_INSERT;
@@ -150,14 +150,14 @@ void LLKeyboard::addKeyName(KEY key, const std::string& name)
 
 void LLKeyboard::resetKeyDownAndHandle()
 {
-    MASK mask = currentMask(FALSE);
+    MASK mask = currentMask(false);
     for (S32 i = 0; i < KEY_COUNT; i++)
     {
         if (mKeyLevel[i])
         {
-            mKeyDown[i] = FALSE;
-            mKeyLevel[i] = FALSE;
-            mKeyUp[i] = TRUE;
+            mKeyDown[i] = false;
+            mKeyLevel[i] = false;
+            mKeyUp[i] = true;
             mCurTranslatedKey = (KEY)i;
             mCallbacks->handleTranslatedKeyUp(i, mask);
         }
@@ -174,28 +174,28 @@ void LLKeyboard::resetKeys()
 	{
 		if( mKeyLevel[i] )
 		{
-			mKeyLevel[i] = FALSE;
+			mKeyLevel[i] = false;
 		}
 	}
 
 	for (i = 0; i < KEY_COUNT; i++)
 	{
-		mKeyUp[i] = FALSE;
+		mKeyUp[i] = false;
 	}
 
 	for (i = 0; i < KEY_COUNT; i++)
 	{
-		mKeyDown[i] = FALSE;
+		mKeyDown[i] = false;
 	}
 
 	for (i = 0; i < KEY_COUNT; i++)
 	{
-		mKeyRepeated[i] = FALSE;
+		mKeyRepeated[i] = false;
 	}
 }
 
 
-BOOL LLKeyboard::translateKey(const U16 os_key, KEY *out_key)
+bool LLKeyboard::translateKey(const U16 os_key, KEY *out_key)
 {
 	std::map<U16, KEY>::iterator iter;
 
@@ -205,12 +205,12 @@ BOOL LLKeyboard::translateKey(const U16 os_key, KEY *out_key)
 	{
 		//LL_WARNS() << "Unknown virtual key " << os_key << LL_ENDL;
 		*out_key = 0;
-		return FALSE;
+		return false;
 	}
 	else
 	{
 		*out_key = iter->second;
-		return TRUE;
+		return true;
 	}
 }
 
@@ -230,47 +230,47 @@ U16 LLKeyboard::inverseTranslateKey(const KEY translated_key)
 }
 
 
-BOOL LLKeyboard::handleTranslatedKeyDown(KEY translated_key, U32 translated_mask)
+bool LLKeyboard::handleTranslatedKeyDown(KEY translated_key, U32 translated_mask)
 {
-	BOOL handled = FALSE;
-	BOOL repeated = FALSE;
+	bool handled = false;
+	bool repeated = false;
 
 	// is this the first time the key went down?
 	// if so, generate "character" message
 	if( !mKeyLevel[translated_key] )
 	{
-		mKeyLevel[translated_key] = TRUE;
+		mKeyLevel[translated_key] = true;
 		mKeyLevelTimer[translated_key].reset();
 		mKeyLevelFrameCount[translated_key] = 0;
-		mKeyRepeated[translated_key] = FALSE;
+		mKeyRepeated[translated_key] = false;
 	}
 	else
 	{
 		// Level is already down, assume it's repeated.
-		repeated = TRUE;
-		mKeyRepeated[translated_key] = TRUE;
+		repeated = true;
+		mKeyRepeated[translated_key] = true;
 	}
 	
-	mKeyDown[translated_key] = TRUE;
+	mKeyDown[translated_key] = true;
 	mCurTranslatedKey = (KEY)translated_key;
 	handled = mCallbacks->handleTranslatedKeyDown(translated_key, translated_mask, repeated);
 	return handled;
 }
 
 
-BOOL LLKeyboard::handleTranslatedKeyUp(KEY translated_key, U32 translated_mask)
+bool LLKeyboard::handleTranslatedKeyUp(KEY translated_key, U32 translated_mask)
 {	
-	BOOL handled = FALSE;
+	bool handled = false;
 	if( mKeyLevel[translated_key] )
 	{
-		mKeyLevel[translated_key] = FALSE;
+		mKeyLevel[translated_key] = false;
 		
 		// Only generate key up events if the key is thought to
 		// be down.  This allows you to call resetKeys() in the
 		// middle of a frame and ignore subsequent KEY_UP
 		// messages in the same frame.  This was causing the
 		// sequence W<return> in chat to move agents forward. JC
-		mKeyUp[translated_key] = TRUE;
+		mKeyUp[translated_key] = true;
 		handled = mCallbacks->handleTranslatedKeyUp(translated_key, translated_mask);
 	}
 	
@@ -306,14 +306,14 @@ S32 LLKeyboard::getKeyElapsedFrameCount(KEY key)
 }
 
 // static
-BOOL LLKeyboard::keyFromString(const std::string& str, KEY *key)
+bool LLKeyboard::keyFromString(const std::string& str, KEY *key)
 {
 	std::string instring(str);
 	size_t length = instring.size();
 
 	if (length < 1)
 	{
-		return FALSE;
+		return false;
 	}
 	if (length == 1)
 	{
@@ -326,7 +326,7 @@ BOOL LLKeyboard::keyFromString(const std::string& str, KEY *key)
 			('{' <= ch && ch <= '~'))   // {|}~
 		{
 			*key = ch;
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -335,10 +335,10 @@ BOOL LLKeyboard::keyFromString(const std::string& str, KEY *key)
 	if (res != 0)
 	{
 		*key = res;
-		return TRUE;
+		return true;
 	}
 	LL_WARNS() << "keyFromString failed: " << str << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
 
@@ -486,52 +486,52 @@ std::string LLKeyboard::stringFromAccelerator(MASK accel_mask, EMouseClickType c
 }
 
 //static
-BOOL LLKeyboard::maskFromString(const std::string& str, MASK *mask)
+bool LLKeyboard::maskFromString(const std::string& str, MASK *mask)
 {
 	std::string instring(str);
 	if (instring == "NONE")
 	{
 		*mask = MASK_NONE;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "SHIFT")
 	{
 		*mask = MASK_SHIFT;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "CTL")
 	{
 		*mask = MASK_CONTROL;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "ALT")
 	{
 		*mask = MASK_ALT;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "CTL_SHIFT")
 	{
 		*mask = MASK_CONTROL | MASK_SHIFT;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "ALT_SHIFT")
 	{
 		*mask = MASK_ALT | MASK_SHIFT;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "CTL_ALT")
 	{
 		*mask = MASK_CONTROL | MASK_ALT;
-		return TRUE;
+		return true;
 	}
 	else if (instring == "CTL_ALT_SHIFT")
 	{
 		*mask = MASK_CONTROL | MASK_ALT | MASK_SHIFT;
-		return TRUE;
+		return true;
 	}
 	else 
 	{
-		return FALSE;
+		return false;
 	}
 }
 

--- a/indra/llwindow/llkeyboard.h
+++ b/indra/llwindow/llkeyboard.h
@@ -64,17 +64,17 @@ public:
 
 	F32				getCurKeyElapsedTime()	{ return getKeyDown(mCurScanKey) ? getKeyElapsedTime( mCurScanKey ) : 0.f; }
 	F32				getCurKeyElapsedFrameCount()	{ return getKeyDown(mCurScanKey) ? (F32)getKeyElapsedFrameCount( mCurScanKey ) : 0.f; }
-	BOOL			getKeyDown(const KEY key) { return mKeyLevel[key]; }
-	BOOL			getKeyRepeated(const KEY key) { return mKeyRepeated[key]; }
+	bool			getKeyDown(const KEY key) { return mKeyLevel[key]; }
+	bool			getKeyRepeated(const KEY key) { return mKeyRepeated[key]; }
 
-	BOOL			translateKey(const U16 os_key, KEY *translated_key);
+	bool			translateKey(const U16 os_key, KEY *translated_key);
 	U16				inverseTranslateKey(const KEY translated_key);
-	BOOL			handleTranslatedKeyUp(KEY translated_key, U32 translated_mask);		// Translated into "Linden" keycodes
-	BOOL			handleTranslatedKeyDown(KEY translated_key, U32 translated_mask);	// Translated into "Linden" keycodes
+	bool			handleTranslatedKeyUp(KEY translated_key, U32 translated_mask);		// Translated into "Linden" keycodes
+	bool			handleTranslatedKeyDown(KEY translated_key, U32 translated_mask);	// Translated into "Linden" keycodes
 
 
-	virtual BOOL	handleKeyUp(const U16 key, MASK mask) = 0;
-	virtual BOOL	handleKeyDown(const U16 key, MASK mask) = 0;
+	virtual bool	handleKeyUp(const U16 key, MASK mask) = 0;
+	virtual bool	handleKeyDown(const U16 key, MASK mask) = 0;
 	
 #ifdef LL_DARWIN
 	// We only actually use this for macOS.
@@ -87,14 +87,14 @@ public:
 	virtual void	scanKeyboard() = 0;															// scans keyboard, calls functions as necessary
 	// Mac must differentiate between Command = Control for keyboard events
 	// and Command != Control for mouse events.
-	virtual MASK	currentMask(BOOL for_mouse_event) = 0;
+	virtual MASK	currentMask(bool for_mouse_event) = 0;
 	virtual KEY		currentKey() { return mCurTranslatedKey; }
 
 	EKeyboardInsertMode getInsertMode()	{ return mInsertMode; }
 	void toggleInsertMode();
 
-	static BOOL		maskFromString(const std::string& str, MASK *mask);		// False on failure
-	static BOOL		keyFromString(const std::string& str, KEY *key);			// False on failure
+	static bool		maskFromString(const std::string& str, MASK *mask);		// False on failure
+	static bool		keyFromString(const std::string& str, KEY *key);			// False on failure
 	static std::string stringFromKey(KEY key, bool translate = true);
     static std::string stringFromMouse(EMouseClickType click, bool translate = true);
 	static std::string stringFromAccelerator( MASK accel_mask ); // separated for convinience, returns with "+": "Shift+" or "Shift+Alt+"...
@@ -117,10 +117,10 @@ protected:
 
 	LLTimer			mKeyLevelTimer[KEY_COUNT];	// Time since level was set
 	S32				mKeyLevelFrameCount[KEY_COUNT];	// Frames since level was set
-	BOOL			mKeyLevel[KEY_COUNT];		// Levels
-	BOOL			mKeyRepeated[KEY_COUNT];	// Key was repeated
-	BOOL			mKeyUp[KEY_COUNT];			// Up edge
-	BOOL			mKeyDown[KEY_COUNT];		// Down edge
+	bool			mKeyLevel[KEY_COUNT];		// Levels
+	bool			mKeyRepeated[KEY_COUNT];	// Key was repeated
+	bool			mKeyUp[KEY_COUNT];			// Up edge
+	bool			mKeyDown[KEY_COUNT];		// Down edge
 	KEY				mCurTranslatedKey;
 	KEY				mCurScanKey;		// Used during the scanKeyboard()
 

--- a/indra/llwindow/llkeyboardheadless.cpp
+++ b/indra/llwindow/llkeyboardheadless.cpp
@@ -35,14 +35,14 @@ void LLKeyboardHeadless::resetMaskKeys()
 { }
 
 
-BOOL LLKeyboardHeadless::handleKeyDown(const U16 key, const U32 mask)
-{ return FALSE; }
+bool LLKeyboardHeadless::handleKeyDown(const U16 key, const U32 mask)
+{ return false; }
 
 
-BOOL LLKeyboardHeadless::handleKeyUp(const U16 key, const U32 mask)
-{ return FALSE; }
+bool LLKeyboardHeadless::handleKeyUp(const U16 key, const U32 mask)
+{ return false; }
 
-MASK LLKeyboardHeadless::currentMask(BOOL for_mouse_event)
+MASK LLKeyboardHeadless::currentMask(bool for_mouse_event)
 { return MASK_NONE; }
 
 #ifdef LL_DARWIN
@@ -69,8 +69,8 @@ void LLKeyboardHeadless::scanKeyboard()
 	// Reset edges for next frame
 	for (S32 key = 0; key < KEY_COUNT; key++)
 	{
-		mKeyUp[key] = FALSE;
-		mKeyDown[key] = FALSE;
+		mKeyUp[key] = false;
+		mKeyDown[key] = false;
 		if (mKeyLevel[key])
 		{
 			mKeyLevelFrameCount[key]++;

--- a/indra/llwindow/llkeyboardheadless.h
+++ b/indra/llwindow/llkeyboardheadless.h
@@ -35,10 +35,10 @@ public:
 	LLKeyboardHeadless();
 	/*virtual*/ ~LLKeyboardHeadless() {};
 
-	/*virtual*/ BOOL	handleKeyUp(const U16 key, MASK mask);
-	/*virtual*/ BOOL	handleKeyDown(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyUp(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyDown(const U16 key, MASK mask);
 	/*virtual*/ void	resetMaskKeys();
-	/*virtual*/ MASK	currentMask(BOOL for_mouse_event);
+	/*virtual*/ MASK	currentMask(bool for_mouse_event);
 	/*virtual*/ void	scanKeyboard();
 #ifdef LL_DARWIN
 	/*virtual*/ void	handleModifier(MASK mask);

--- a/indra/llwindow/llkeyboardmacosx.cpp
+++ b/indra/llwindow/llkeyboardmacosx.cpp
@@ -172,22 +172,22 @@ void LLKeyboardMacOSX::resetMaskKeys()
 
 	if(mask & MAC_SHIFT_KEY)
 	{
-		mKeyLevel[KEY_SHIFT] = TRUE;
+		mKeyLevel[KEY_SHIFT] = true;
 	}
 
 	if(mask & MAC_CTRL_KEY)
 	{
-		mKeyLevel[KEY_CONTROL] = TRUE;
+		mKeyLevel[KEY_CONTROL] = true;
 	}
 
 	if(mask & MAC_ALT_KEY)
 	{
-		mKeyLevel[KEY_ALT] = TRUE;
+		mKeyLevel[KEY_ALT] = true;
 	}
 }
 
 /*
-static BOOL translateKeyMac(const U16 key, const U32 mask, KEY &outKey, U32 &outMask)
+static bool translateKeyMac(const U16 key, const U32 mask, KEY &outKey, U32 &outMask)
 {
 	// Translate the virtual keycode into the keycodes the keyboard system expects.
 	U16 virtualKey = (mask >> 24) & 0x0000007F;
@@ -226,11 +226,11 @@ MASK LLKeyboardMacOSX::updateModifiers(const U32 mask)
 	return out_mask;
 }
 
-BOOL LLKeyboardMacOSX::handleKeyDown(const U16 key, const U32 mask)
+bool LLKeyboardMacOSX::handleKeyDown(const U16 key, const U32 mask)
 {
 	KEY		translated_key = 0;
 	U32		translated_mask = 0;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	translated_mask = updateModifiers(mask);
 
@@ -243,11 +243,11 @@ BOOL LLKeyboardMacOSX::handleKeyDown(const U16 key, const U32 mask)
 }
 
 
-BOOL LLKeyboardMacOSX::handleKeyUp(const U16 key, const U32 mask)
+bool LLKeyboardMacOSX::handleKeyUp(const U16 key, const U32 mask)
 {
 	KEY		translated_key = 0;
 	U32		translated_mask = 0;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	translated_mask = updateModifiers(mask);
 
@@ -259,7 +259,7 @@ BOOL LLKeyboardMacOSX::handleKeyUp(const U16 key, const U32 mask)
 	return handled;
 }
 
-MASK LLKeyboardMacOSX::currentMask(BOOL for_mouse_event)
+MASK LLKeyboardMacOSX::currentMask(bool for_mouse_event)
 {
 	MASK result = MASK_NONE;
 	U32 mask = getModifiers();
@@ -295,8 +295,8 @@ void LLKeyboardMacOSX::scanKeyboard()
 	// Reset edges for next frame
 	for (key = 0; key < KEY_COUNT; key++)
 	{
-		mKeyUp[key] = FALSE;
-		mKeyDown[key] = FALSE;
+		mKeyUp[key] = false;
+		mKeyDown[key] = false;
 		if (mKeyLevel[key])
 		{
 			mKeyLevelFrameCount[key]++;
@@ -304,7 +304,7 @@ void LLKeyboardMacOSX::scanKeyboard()
 	}
 }
 
-BOOL LLKeyboardMacOSX::translateNumpadKey( const U16 os_key, KEY *translated_key )
+bool LLKeyboardMacOSX::translateNumpadKey( const U16 os_key, KEY *translated_key )
 {
 	return translateKey(os_key, translated_key);
 }

--- a/indra/llwindow/llkeyboardmacosx.h
+++ b/indra/llwindow/llkeyboardmacosx.h
@@ -44,17 +44,17 @@ public:
 	LLKeyboardMacOSX();
 	/*virtual*/ ~LLKeyboardMacOSX() {};
 	
-	/*virtual*/ BOOL	handleKeyUp(const U16 key, MASK mask);
-	/*virtual*/ BOOL	handleKeyDown(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyUp(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyDown(const U16 key, MASK mask);
 	/*virtual*/ void	resetMaskKeys();
-	/*virtual*/ MASK	currentMask(BOOL for_mouse_event);
+	/*virtual*/ MASK	currentMask(bool for_mouse_event);
 	/*virtual*/ void	scanKeyboard();
 	/*virtual*/ void	handleModifier(MASK mask);
 	
 protected:
 	MASK	updateModifiers(const U32 mask);
-	void	setModifierKeyLevel( KEY key, BOOL new_state );
-	BOOL	translateNumpadKey( const U16 os_key, KEY *translated_key );
+	void	setModifierKeyLevel( KEY key, bool new_state );
+	bool	translateNumpadKey( const U16 os_key, KEY *translated_key );
 	U16		inverseTranslateNumpadKey(const KEY translated_key);
 private:
 	std::map<U16, KEY> mTranslateNumpadMap;  // special map for translating OS keys to numpad keys

--- a/indra/llwindow/llkeyboardsdl.cpp
+++ b/indra/llwindow/llkeyboardsdl.cpp
@@ -162,17 +162,17 @@ void LLKeyboardSDL::resetMaskKeys()
 
 	if(mask & KMOD_SHIFT)
 	{
-		mKeyLevel[KEY_SHIFT] = TRUE;
+		mKeyLevel[KEY_SHIFT] = true;
 	}
 
 	if(mask & KMOD_CTRL)
 	{
-		mKeyLevel[KEY_CONTROL] = TRUE;
+		mKeyLevel[KEY_CONTROL] = true;
 	}
 
 	if(mask & KMOD_ALT)
 	{
-		mKeyLevel[KEY_ALT] = TRUE;
+		mKeyLevel[KEY_ALT] = true;
 	}
 }
 
@@ -226,12 +226,12 @@ static U16 adjustNativekeyFromUnhandledMask(const U16 key, const U32 mask)
 }
 
 
-BOOL LLKeyboardSDL::handleKeyDown(const U16 key, const U32 mask)
+bool LLKeyboardSDL::handleKeyDown(const U16 key, const U32 mask)
 {
 	U16     adjusted_nativekey;
 	KEY	translated_key = 0;
 	U32	translated_mask = MASK_NONE;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
 
@@ -246,12 +246,12 @@ BOOL LLKeyboardSDL::handleKeyDown(const U16 key, const U32 mask)
 }
 
 
-BOOL LLKeyboardSDL::handleKeyUp(const U16 key, const U32 mask)
+bool LLKeyboardSDL::handleKeyUp(const U16 key, const U32 mask)
 {
 	U16     adjusted_nativekey;
 	KEY	translated_key = 0;
 	U32	translated_mask = MASK_NONE;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	adjusted_nativekey = adjustNativekeyFromUnhandledMask(key, mask);
 
@@ -265,7 +265,7 @@ BOOL LLKeyboardSDL::handleKeyUp(const U16 key, const U32 mask)
 	return handled;
 }
 
-MASK LLKeyboardSDL::currentMask(BOOL for_mouse_event)
+MASK LLKeyboardSDL::currentMask(bool for_mouse_event)
 {
 	MASK result = MASK_NONE;
 	SDLMod mask = SDL_GetModState();
@@ -300,8 +300,8 @@ void LLKeyboardSDL::scanKeyboard()
 	// Reset edges for next frame
 	for (S32 key = 0; key < KEY_COUNT; key++)
 	{
-		mKeyUp[key] = FALSE;
-		mKeyDown[key] = FALSE;
+		mKeyUp[key] = false;
+		mKeyDown[key] = false;
 		if (mKeyLevel[key])
 		{
 			mKeyLevelFrameCount[key]++;
@@ -310,7 +310,7 @@ void LLKeyboardSDL::scanKeyboard()
 }
 
  
-BOOL LLKeyboardSDL::translateNumpadKey( const U16 os_key, KEY *translated_key)
+bool LLKeyboardSDL::translateNumpadKey( const U16 os_key, KEY *translated_key)
 {
 	return translateKey(os_key, translated_key);	
 }

--- a/indra/llwindow/llkeyboardsdl.h
+++ b/indra/llwindow/llkeyboardsdl.h
@@ -36,16 +36,16 @@ public:
 	LLKeyboardSDL();
 	/*virtual*/ ~LLKeyboardSDL() {};
 
-	/*virtual*/ BOOL	handleKeyUp(const U16 key, MASK mask);
-	/*virtual*/ BOOL	handleKeyDown(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyUp(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyDown(const U16 key, MASK mask);
 	/*virtual*/ void	resetMaskKeys();
-	/*virtual*/ MASK	currentMask(BOOL for_mouse_event);
+	/*virtual*/ MASK	currentMask(bool for_mouse_event);
 	/*virtual*/ void	scanKeyboard();
 
 protected:
 	MASK	updateModifiers(const U32 mask);
-	void	setModifierKeyLevel( KEY key, BOOL new_state );
-	BOOL	translateNumpadKey( const U16 os_key, KEY *translated_key );
+	void	setModifierKeyLevel( KEY key, bool new_state );
+	bool	translateNumpadKey( const U16 os_key, KEY *translated_key );
 	U16	inverseTranslateNumpadKey(const KEY translated_key);
 private:
 	std::map<U16, KEY> mTranslateNumpadMap;  // special map for translating OS keys to numpad keys

--- a/indra/llwindow/llkeyboardwin32.cpp
+++ b/indra/llwindow/llkeyboardwin32.cpp
@@ -152,22 +152,22 @@ void LLKeyboardWin32::resetMaskKeys()
 	// bit to indicate that the key is down.
 	if (GetAsyncKeyState(VK_SHIFT) & 0x8000)
 	{
-		mKeyLevel[KEY_SHIFT] = TRUE;
+		mKeyLevel[KEY_SHIFT] = true;
 	}
 
 	if (GetAsyncKeyState(VK_CONTROL) & 0x8000)
 	{
-		mKeyLevel[KEY_CONTROL] = TRUE;
+		mKeyLevel[KEY_CONTROL] = true;
 	}
 
 	if (GetAsyncKeyState(VK_MENU) & 0x8000)
 	{
-		mKeyLevel[KEY_ALT] = TRUE;
+		mKeyLevel[KEY_ALT] = true;
 	}
 }
 
 
-//void LLKeyboardWin32::setModifierKeyLevel( KEY key, BOOL new_state )
+//void LLKeyboardWin32::setModifierKeyLevel( KEY key, bool new_state )
 //{
 //	if( mKeyLevel[key] != new_state )
 //	{
@@ -191,17 +191,17 @@ MASK LLKeyboardWin32::updateModifiers()
 	// (keydown encoded in high order bit of short)
 	mKeyLevel[KEY_CAPSLOCK] = (GetKeyState(VK_CAPITAL) & 0x0001) != 0; // Low order bit carries the toggle state.
 	// Get mask for keyboard events
-	MASK mask = currentMask(FALSE);
+	MASK mask = currentMask(false);
 	return mask;
 }
 
 
 // mask is ignored, except for extended flag -- we poll the modifier keys for the other flags
-BOOL LLKeyboardWin32::handleKeyDown(const U16 key, MASK mask)
+bool LLKeyboardWin32::handleKeyDown(const U16 key, MASK mask)
 {
 	KEY		translated_key;
 	U32		translated_mask;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	translated_mask = updateModifiers();
 
@@ -214,11 +214,11 @@ BOOL LLKeyboardWin32::handleKeyDown(const U16 key, MASK mask)
 }
 
 // mask is ignored, except for extended flag -- we poll the modifier keys for the other flags
-BOOL LLKeyboardWin32::handleKeyUp(const U16 key, MASK mask)
+bool LLKeyboardWin32::handleKeyUp(const U16 key, MASK mask)
 {
 	KEY		translated_key;
 	U32		translated_mask;
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	translated_mask = updateModifiers();
 
@@ -231,7 +231,7 @@ BOOL LLKeyboardWin32::handleKeyUp(const U16 key, MASK mask)
 }
 
 
-MASK LLKeyboardWin32::currentMask(BOOL)
+MASK LLKeyboardWin32::currentMask(bool)
 {
 	MASK mask = MASK_NONE;
 
@@ -263,8 +263,8 @@ void LLKeyboardWin32::scanKeyboard()
 	// Reset edges for next frame
 	for (key = 0; key < KEY_COUNT; key++)
 	{
-		mKeyUp[key] = FALSE;
-		mKeyDown[key] = FALSE;
+		mKeyUp[key] = false;
+		mKeyDown[key] = false;
 		if (mKeyLevel[key])
 		{
 			mKeyLevelFrameCount[key]++;
@@ -272,7 +272,7 @@ void LLKeyboardWin32::scanKeyboard()
 	}
 }
 
-BOOL LLKeyboardWin32::translateExtendedKey(const U16 os_key, const MASK mask, KEY *translated_key)
+bool LLKeyboardWin32::translateExtendedKey(const U16 os_key, const MASK mask, KEY *translated_key)
 {
 	return translateKey(os_key, translated_key);
 }

--- a/indra/llwindow/llkeyboardwin32.h
+++ b/indra/llwindow/llkeyboardwin32.h
@@ -39,17 +39,17 @@ public:
 	LLKeyboardWin32();
 	/*virtual*/ ~LLKeyboardWin32() {};
 
-	/*virtual*/ BOOL	handleKeyUp(const U16 key, MASK mask);
-	/*virtual*/ BOOL	handleKeyDown(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyUp(const U16 key, MASK mask);
+	/*virtual*/ bool	handleKeyDown(const U16 key, MASK mask);
 	/*virtual*/ void	resetMaskKeys();
-	/*virtual*/ MASK	currentMask(BOOL for_mouse_event);
+	/*virtual*/ MASK	currentMask(bool for_mouse_event);
 	/*virtual*/ void	scanKeyboard();
-	BOOL				translateExtendedKey(const U16 os_key, const MASK mask, KEY *translated_key);
+	bool				translateExtendedKey(const U16 os_key, const MASK mask, KEY *translated_key);
 	U16					inverseTranslateExtendedKey(const KEY translated_key);
 
 protected:
 	MASK	updateModifiers();
-	//void	setModifierKeyLevel( KEY key, BOOL new_state );
+	//void	setModifierKeyLevel( KEY key, bool new_state );
 private:
 	std::map<U16, KEY> mTranslateNumpadMap;
 	std::map<KEY, U16> mInvTranslateNumpadMap;

--- a/indra/llwindow/llmousehandler.cpp
+++ b/indra/llwindow/llmousehandler.cpp
@@ -27,9 +27,9 @@
 #include "llmousehandler.h"
 
 //virtual
-BOOL LLMouseHandler::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down)
+bool LLMouseHandler::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	if (down)
 	{
 		switch (clicktype)

--- a/indra/llwindow/llmousehandler.h
+++ b/indra/llwindow/llmousehandler.h
@@ -47,19 +47,19 @@ public:
 		SHOW_ALWAYS,
 	} EShowToolTip;
 
-	virtual BOOL	handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleMiddleMouseDown(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleMiddleMouseUp(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleMiddleMouseDown(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleMiddleMouseUp(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleRightMouseDown(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleRightMouseUp(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask) = 0;
 
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask) = 0;
-	virtual BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks) = 0;
-	virtual BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks) = 0;
-	virtual BOOL	handleToolTip(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleHover(S32 x, S32 y, MASK mask) = 0;
+	virtual bool	handleScrollWheel(S32 x, S32 y, S32 clicks) = 0;
+	virtual bool	handleScrollHWheel(S32 x, S32 y, S32 clicks) = 0;
+	virtual bool	handleToolTip(S32 x, S32 y, MASK mask) = 0;
 	virtual const std::string& getName() const = 0;
 
 	virtual void	onMouseCaptureLost() = 0;
@@ -67,7 +67,7 @@ public:
 	virtual void	screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const = 0;
 	virtual void	localPointToScreen(S32 local_x, S32 local_y, S32* screen_x, S32* screen_y) const = 0;
 
-	virtual BOOL hasMouseCapture() = 0;
+	virtual bool hasMouseCapture() = 0;
 };
 
 #endif

--- a/indra/llwindow/llpreeditor.h
+++ b/indra/llwindow/llpreeditor.h
@@ -34,7 +34,7 @@ class LLPreeditor
 public:
 
 	typedef std::vector<S32> segment_lengths_t;
-	typedef std::vector<BOOL> standouts_t;
+	typedef std::vector<bool> standouts_t;
 	
 	// We don't delete against LLPreeditor, but compilers complain without this...
 	
@@ -79,7 +79,7 @@ public:
 	// Locations are relative to the app window and measured in GL coordinate space (before scaling.)
 	// query_position is IN argument, and other three are OUT.
 
-	virtual BOOL getPreeditLocation(S32 query_position, LLCoordGL *coord, LLRect *bounds, LLRect *control) const = 0;
+	virtual bool getPreeditLocation(S32 query_position, LLCoordGL *coord, LLRect *bounds, LLRect *control) const = 0;
 
 	// Get the size (height) of the current font used in this preeditor.
 
@@ -93,9 +93,9 @@ public:
 	// Handle a UTF-32 char on this preeditor, i.e., add the character
 	// to the contents.
 	// This is a back door of the method of same name of LLWindowCallback.
-	// called_from_parent should be set to FALSE if calling through LLPreeditor.
+	// called_from_parent should be set to false if calling through LLPreeditor.
 
-	virtual BOOL handleUnicodeCharHere(llwchar uni_char) = 0;
+	virtual bool handleUnicodeCharHere(llwchar uni_char) = 0;
 };
 
 #endif

--- a/indra/llwindow/llwindow.cpp
+++ b/indra/llwindow/llwindow.cpp
@@ -46,8 +46,8 @@
 // Globals
 //
 LLSplashScreen *gSplashScreenp = NULL;
-BOOL gDebugClicks = FALSE;
-BOOL gDebugWindowProc = FALSE;
+bool gDebugClicks = false;
+bool gDebugWindowProc = false;
 
 const S32 gURLProtocolWhitelistCount = 5;
 const std::string gURLProtocolWhitelist[] = { "secondlife:", "http:", "https:", "data:", "mailto:" };
@@ -63,10 +63,10 @@ const std::string gURLProtocolWhitelist[] = { "secondlife:", "http:", "https:", 
 S32 OSMessageBox(const std::string& text, const std::string& caption, U32 type)
 {
 	// Properly hide the splash screen when displaying the message box
-	BOOL was_visible = FALSE;
+	bool was_visible = false;
 	if (LLSplashScreen::isVisible())
 	{
-		was_visible = TRUE;
+		was_visible = true;
 		LLSplashScreen::hide();
 	}
 
@@ -97,9 +97,9 @@ S32 OSMessageBox(const std::string& text, const std::string& caption, U32 type)
 // LLWindow
 //
 
-LLWindow::LLWindow(LLWindowCallbacks* callbacks, BOOL fullscreen, U32 flags)
+LLWindow::LLWindow(LLWindowCallbacks* callbacks, bool fullscreen, U32 flags)
 	: mCallbacks(callbacks),
-	  mPostQuit(TRUE),
+	  mPostQuit(true),
 	  mFullscreen(fullscreen),
 	  mFullscreenWidth(0),
 	  mFullscreenHeight(0),
@@ -109,13 +109,13 @@ LLWindow::LLWindow(LLWindowCallbacks* callbacks, BOOL fullscreen, U32 flags)
 	  mNumSupportedResolutions(0),
 	  mCurrentCursor(UI_CURSOR_ARROW),
 	  mNextCursor(UI_CURSOR_ARROW),
-	  mCursorHidden(FALSE),
+	  mCursorHidden(false),
 	  mBusyCount(0),
-	  mIsMouseClipping(FALSE),
+	  mIsMouseClipping(false),
 	  mMinWindowWidth(0),
 	  mMinWindowHeight(0),
 	  mSwapMethod(SWAP_METHOD_UNDEFINED),
-	  mHideCursorPermanent(FALSE),
+	  mHideCursorPermanent(false),
 	  mFlags(flags),
 	  mHighSurrogate(0),
 	  mRefreshRate(0)
@@ -127,15 +127,15 @@ LLWindow::~LLWindow()
 }
 
 //virtual
-BOOL LLWindow::isValid()
+bool LLWindow::isValid()
 {
-	return TRUE;
+	return true;
 }
 
 //virtual
-BOOL LLWindow::canDelete()
+bool LLWindow::canDelete()
 {
-	return TRUE;
+	return true;
 }
 
 //virtual
@@ -178,9 +178,9 @@ ECursorType LLWindow::getCursor() const
 }
 
 //virtual
-BOOL LLWindow::dialogColorPicker(F32 *r, F32 *g, F32 *b)
+bool LLWindow::dialogColorPicker(F32 *r, F32 *g, F32 *b)
 {
-	return FALSE;
+	return false;
 }
 
 void *LLWindow::getMediaWindow()
@@ -189,7 +189,7 @@ void *LLWindow::getMediaWindow()
 	return getPlatformWindow();
 }
 
-BOOL LLWindow::setSize(LLCoordScreen size)
+bool LLWindow::setSize(LLCoordScreen size)
 {
 	if (!getMaximized())
 	{
@@ -199,7 +199,7 @@ BOOL LLWindow::setSize(LLCoordScreen size)
 	return setSizeImpl(size);
 }
 
-BOOL LLWindow::setSize(LLCoordWindow size)
+bool LLWindow::setSize(LLCoordWindow size)
 {
 	//HACK: we are inconsistently using minimum window dimensions
 	// in this case, we are constraining the inner "client" rect and other times
@@ -241,19 +241,19 @@ void LLWindow::processMiscNativeEvents()
 }
 
 //virtual
-BOOL LLWindow::isPrimaryTextAvailable()
+bool LLWindow::isPrimaryTextAvailable()
 {
-	return FALSE; // no
+	return false; // no
 }
 //virtual
-BOOL LLWindow::pasteTextFromPrimary(LLWString &dst)
+bool LLWindow::pasteTextFromPrimary(LLWString &dst)
 {
-	return FALSE; // fail
+	return false; // fail
 }
 // virtual
-BOOL LLWindow::copyTextToPrimary(const LLWString &src)
+bool LLWindow::copyTextToPrimary(const LLWString &src)
 {
-	return FALSE; // fail
+	return false; // fail
 }
 
 // static
@@ -402,11 +402,11 @@ static std::set<LLWindow*> sWindowList;
 LLWindow* LLWindowManager::createWindow(
 	LLWindowCallbacks* callbacks,
 	const std::string& title, const std::string& name, S32 x, S32 y, S32 width, S32 height, U32 flags,
-	BOOL fullscreen, 
-	BOOL clearBg,
-	BOOL enable_vsync,
-	BOOL use_gl,
-	BOOL ignore_pixel_depth,
+	bool fullscreen, 
+	bool clearBg,
+	bool enable_vsync,
+	bool use_gl,
+	bool ignore_pixel_depth,
 	U32 fsaa_samples,
     U32 max_cores,
     U32 max_vram,
@@ -441,7 +441,7 @@ LLWindow* LLWindowManager::createWindow(
 			fullscreen, clearBg, enable_vsync, use_gl, ignore_pixel_depth);
 	}
 
-	if (FALSE == new_window->isValid())
+	if (false == new_window->isValid())
 	{
 		delete new_window;
 		LL_WARNS() << "LLWindowManager::create() : Error creating window." << LL_ENDL;
@@ -451,13 +451,13 @@ LLWindow* LLWindowManager::createWindow(
 	return new_window;
 }
 
-BOOL LLWindowManager::destroyWindow(LLWindow* window)
+bool LLWindowManager::destroyWindow(LLWindow* window)
 {
 	if (sWindowList.find(window) == sWindowList.end())
 	{
 		LL_ERRS() << "LLWindowManager::destroyWindow() : Window pointer not valid, this window doesn't exist!" 
 			<< LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
 	window->close();
@@ -466,10 +466,10 @@ BOOL LLWindowManager::destroyWindow(LLWindow* window)
 
 	delete window;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowManager::isWindowValid(LLWindow *window)
+bool LLWindowManager::isWindowValid(LLWindow *window)
 {
 	return sWindowList.find(window) != sWindowList.end();
 }

--- a/indra/llwindow/llwindow.h
+++ b/indra/llwindow/llwindow.h
@@ -63,21 +63,21 @@ public:
 	virtual void show() = 0;
 	virtual void hide() = 0;
 	virtual void close() = 0;
-	virtual BOOL getVisible() = 0;
-	virtual BOOL getMinimized() = 0;
-	virtual BOOL getMaximized() = 0;
-	virtual BOOL maximize() = 0;
+	virtual bool getVisible() = 0;
+	virtual bool getMinimized() = 0;
+	virtual bool getMaximized() = 0;
+	virtual bool maximize() = 0;
 	virtual void minimize() = 0;
 	virtual void restore() = 0;
-	BOOL getFullscreen()	{ return mFullscreen; };
-	virtual BOOL getPosition(LLCoordScreen *position) = 0;
-	virtual BOOL getSize(LLCoordScreen *size) = 0;
-	virtual BOOL getSize(LLCoordWindow *size) = 0;
-	virtual BOOL setPosition(LLCoordScreen position) = 0;
-	BOOL setSize(LLCoordScreen size);
-	BOOL setSize(LLCoordWindow size);
+	bool getFullscreen()	{ return mFullscreen; };
+	virtual bool getPosition(LLCoordScreen *position) = 0;
+	virtual bool getSize(LLCoordScreen *size) = 0;
+	virtual bool getSize(LLCoordWindow *size) = 0;
+	virtual bool setPosition(LLCoordScreen position) = 0;
+	bool setSize(LLCoordScreen size);
+	bool setSize(LLCoordWindow size);
 	virtual void setMinSize(U32 min_width, U32 min_height, bool enforce_immediately = true);
-	virtual BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL enable_vsync, const LLCoordScreen * const posp = NULL) = 0;
+	virtual bool switchContext(bool fullscreen, const LLCoordScreen &size, bool enable_vsync, const LLCoordScreen * const posp = NULL) = 0;
 
     //create a new GL context that shares a namespace with this Window's main GL context and make it current on the current thread
     // returns a pointer to be handed back to destroySharedConext/makeContextCurrent
@@ -90,14 +90,14 @@ public:
 
     virtual void toggleVSync(bool enable_vsync) = 0;
 
-    virtual BOOL setCursorPosition(LLCoordWindow position) = 0;
-	virtual BOOL getCursorPosition(LLCoordWindow *position) = 0;
+    virtual bool setCursorPosition(LLCoordWindow position) = 0;
+	virtual bool getCursorPosition(LLCoordWindow *position) = 0;
 #if LL_WINDOWS
-    virtual BOOL getCursorDelta(LLCoordCommon* delta) = 0;
+    virtual bool getCursorDelta(LLCoordCommon* delta) = 0;
 #endif
 	virtual void showCursor() = 0;
 	virtual void hideCursor() = 0;
-	virtual BOOL isCursorHidden() = 0;
+	virtual bool isCursorHidden() = 0;
 	virtual void showCursorFromMouseMove() = 0;
 	virtual void hideCursorUntilMouseMove() = 0;
 
@@ -124,22 +124,22 @@ public:
 
 	virtual void captureMouse() = 0;
 	virtual void releaseMouse() = 0;
-	virtual void setMouseClipping( BOOL b ) = 0;
+	virtual void setMouseClipping( bool b ) = 0;
 
-	virtual BOOL isClipboardTextAvailable() = 0;
-	virtual BOOL pasteTextFromClipboard(LLWString &dst) = 0;
-	virtual BOOL copyTextToClipboard(const LLWString &src) = 0;
+	virtual bool isClipboardTextAvailable() = 0;
+	virtual bool pasteTextFromClipboard(LLWString &dst) = 0;
+	virtual bool copyTextToClipboard(const LLWString &src) = 0;
 
-	virtual BOOL isPrimaryTextAvailable();
-	virtual BOOL pasteTextFromPrimary(LLWString &dst);
-	virtual BOOL copyTextToPrimary(const LLWString &src);
+	virtual bool isPrimaryTextAvailable();
+	virtual bool pasteTextFromPrimary(LLWString &dst);
+	virtual bool copyTextToPrimary(const LLWString &src);
  
 	virtual void flashIcon(F32 seconds) = 0;
 	virtual F32 getGamma() = 0;
-	virtual BOOL setGamma(const F32 gamma) = 0; // Set the gamma
+	virtual bool setGamma(const F32 gamma) = 0; // Set the gamma
 	virtual void setFSAASamples(const U32 fsaa_samples) = 0; //set number of FSAA samples
 	virtual U32	 getFSAASamples() = 0;
-	virtual BOOL restoreGamma() = 0;			// Restore original gamma table (before updating gamma)
+	virtual bool restoreGamma() = 0;			// Restore original gamma table (before updating gamma)
 	virtual ESwapMethod getSwapMethod() { return mSwapMethod; }
 	virtual void processMiscNativeEvents();
 	virtual void gatherInput() = 0;
@@ -151,12 +151,12 @@ public:
 	// handy coordinate space conversion routines
 	// NB: screen to window and vice verse won't work on width/height coordinate pairs,
 	// as the conversion must take into account left AND right border widths, etc.
-	virtual BOOL convertCoords( LLCoordScreen from, LLCoordWindow *to) = 0;
-	virtual BOOL convertCoords( LLCoordWindow from, LLCoordScreen *to) = 0;
-	virtual BOOL convertCoords( LLCoordWindow from, LLCoordGL *to) = 0;
-	virtual BOOL convertCoords( LLCoordGL from, LLCoordWindow *to) = 0;
-	virtual BOOL convertCoords( LLCoordScreen from, LLCoordGL *to) = 0;
-	virtual BOOL convertCoords( LLCoordGL from, LLCoordScreen *to) = 0;
+	virtual bool convertCoords( LLCoordScreen from, LLCoordWindow *to) = 0;
+	virtual bool convertCoords( LLCoordWindow from, LLCoordScreen *to) = 0;
+	virtual bool convertCoords( LLCoordWindow from, LLCoordGL *to) = 0;
+	virtual bool convertCoords( LLCoordGL from, LLCoordWindow *to) = 0;
+	virtual bool convertCoords( LLCoordScreen from, LLCoordGL *to) = 0;
+	virtual bool convertCoords( LLCoordGL from, LLCoordScreen *to) = 0;
 
 	// query supported resolutions
 	virtual LLWindowResolution* getSupportedResolutions(S32 &num_resolutions) = 0;
@@ -172,8 +172,8 @@ public:
 	virtual void afterDialog() {};	// undo whatever was done in beforeDialog()
 
 	// opens system default color picker, modally
-	// Returns TRUE if valid color selected
-	virtual BOOL dialogColorPicker(F32 *r, F32 *g, F32 *b);
+	// Returns true if valid color selected
+	virtual bool dialogColorPicker(F32 *r, F32 *g, F32 *b);
 
 // return a platform-specific window reference (HWND on Windows, WindowRef on the Mac, Gtk window on Linux)
 	virtual void *getPlatformWindow() = 0;
@@ -182,7 +182,7 @@ public:
 	virtual void *getMediaWindow();
 	
 	// control platform's Language Text Input mechanisms.
-	virtual void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b) {}
+	virtual void allowLanguageTextInput(LLPreeditor *preeditor, bool b) {}
 	virtual void setLanguageTextInput( const LLCoordGL & pos ) {};
 	virtual void updateLanguageTextInputArea() {}
 	virtual void interruptLanguageTextInput() {}
@@ -204,21 +204,21 @@ public:
 
     virtual S32 getRefreshRate() { return mRefreshRate; }
 protected:
-	LLWindow(LLWindowCallbacks* callbacks, BOOL fullscreen, U32 flags);
+	LLWindow(LLWindowCallbacks* callbacks, bool fullscreen, U32 flags);
 	virtual ~LLWindow();
 	// Defaults to true
-	virtual BOOL isValid();
+	virtual bool isValid();
 	// Defaults to true
-	virtual BOOL canDelete();
+	virtual bool canDelete();
 
-	virtual BOOL setSizeImpl(LLCoordScreen size) = 0;
-	virtual BOOL setSizeImpl(LLCoordWindow size) = 0;
+	virtual bool setSizeImpl(LLCoordScreen size) = 0;
+	virtual bool setSizeImpl(LLCoordWindow size) = 0;
 
 protected:
 	LLWindowCallbacks*	mCallbacks;
 
-	BOOL		mPostQuit;		// should this window post a quit message when destroyed?
-	BOOL		mFullscreen;
+	bool		mPostQuit;		// should this window post a quit message when destroyed?
+	bool		mFullscreen;
 	S32			mFullscreenWidth;
 	S32			mFullscreenHeight;
 	S32			mFullscreenBits;
@@ -227,11 +227,11 @@ protected:
 	S32			mNumSupportedResolutions;
 	ECursorType	mCurrentCursor;
 	ECursorType	mNextCursor;
-	BOOL		mCursorHidden;
+	bool		mCursorHidden;
 	S32			mBusyCount;	// how deep is the "cursor busy" stack?
-	BOOL		mIsMouseClipping;  // Is this window currently clipping the mouse
+	bool		mIsMouseClipping;  // Is this window currently clipping the mouse
 	ESwapMethod mSwapMethod;
-	BOOL		mHideCursorPermanent;
+	bool		mHideCursorPermanent;
 	U32			mFlags;
 	U16			mHighSurrogate;
 	S32			mMinWindowWidth;
@@ -276,7 +276,7 @@ protected:
 	virtual void updateImpl(const std::string& string) = 0;
 	virtual void hideImpl() = 0;
 
-	static BOOL sVisible;
+	static bool sVisible;
 
 };
 
@@ -302,23 +302,23 @@ public:
 		LLWindowCallbacks* callbacks,
 		const std::string& title, const std::string& name, S32 x, S32 y, S32 width, S32 height,
 		U32 flags = 0,
-		BOOL fullscreen = FALSE,
-		BOOL clearBg = FALSE,
-		BOOL enable_vsync = FALSE,
-		BOOL use_gl = TRUE,
-		BOOL ignore_pixel_depth = FALSE,
+		bool fullscreen = false,
+		bool clearBg = false,
+		bool enable_vsync = false,
+		bool use_gl = true,
+		bool ignore_pixel_depth = false,
 		U32 fsaa_samples = 0,
         U32 max_cores = 0,
         U32 max_vram = 0,
         F32 max_gl_version = 4.6f);
-	static BOOL destroyWindow(LLWindow* window);
-	static BOOL isWindowValid(LLWindow *window);
+	static bool destroyWindow(LLWindow* window);
+	static bool isWindowValid(LLWindow *window);
 };
 
 //
 // helper funcs
 //
-extern BOOL gDebugWindowProc;
+extern bool gDebugWindowProc;
 
 // Protocols, like "http" and "https" we support in URLs
 extern const S32 gURLProtocolWhitelistCount;

--- a/indra/llwindow/llwindowcallbacks.cpp
+++ b/indra/llwindow/llwindowcallbacks.cpp
@@ -32,35 +32,35 @@
 // LLWindowCallbacks
 //
 
-BOOL LLWindowCallbacks::handleTranslatedKeyDown(const KEY key, const MASK mask, BOOL repeated)
+bool LLWindowCallbacks::handleTranslatedKeyDown(const KEY key, const MASK mask, bool repeated)
 {
-	return FALSE;
+	return false;
 }
 
 
-BOOL LLWindowCallbacks::handleTranslatedKeyUp(const KEY key, const MASK mask)
+bool LLWindowCallbacks::handleTranslatedKeyUp(const KEY key, const MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-void LLWindowCallbacks::handleScanKey(KEY key, BOOL key_down, BOOL key_up, BOOL key_level)
+void LLWindowCallbacks::handleScanKey(KEY key, bool key_down, bool key_up, bool key_level)
 {
 }
 
-BOOL LLWindowCallbacks::handleUnicodeChar(llwchar uni_char, MASK mask)
+bool LLWindowCallbacks::handleUnicodeChar(llwchar uni_char, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 
-BOOL LLWindowCallbacks::handleMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 void LLWindowCallbacks::handleMouseLeave(LLWindow *window)
@@ -68,54 +68,54 @@ void LLWindowCallbacks::handleMouseLeave(LLWindow *window)
 	return;
 }
 
-BOOL LLWindowCallbacks::handleCloseRequest(LLWindow *window)
+bool LLWindowCallbacks::handleCloseRequest(LLWindow *window)
 {
 	//allow the window to close
-	return TRUE;
+	return true;
 }
 
 void LLWindowCallbacks::handleQuit(LLWindow *window)
 {
 }
 
-BOOL LLWindowCallbacks::handleRightMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleRightMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleRightMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleRightMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleMiddleMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleMiddleMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleMiddleMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleMiddleMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleOtherMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask, S32 button)
+bool LLWindowCallbacks::handleOtherMouseDown(LLWindow *window, const LLCoordGL pos, MASK mask, S32 button)
 {
-    return FALSE;
+    return false;
 }
 
-BOOL LLWindowCallbacks::handleOtherMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask, S32 button)
+bool LLWindowCallbacks::handleOtherMouseUp(LLWindow *window, const LLCoordGL pos, MASK mask, S32 button)
 {
-    return FALSE;
+    return false;
 }
 
-BOOL LLWindowCallbacks::handleActivate(LLWindow *window, BOOL activated)
+bool LLWindowCallbacks::handleActivate(LLWindow *window, bool activated)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleActivateApp(LLWindow *window, BOOL activating)
+bool LLWindowCallbacks::handleActivateApp(LLWindow *window, bool activating)
 {
-	return FALSE;
+	return false;
 }
 
 void LLWindowCallbacks::handleMouseMove(LLWindow *window, const LLCoordGL pos, MASK mask)
@@ -151,15 +151,15 @@ void LLWindowCallbacks::handleMenuSelect(LLWindow *window, const S32 menu_item)
 {
 }
 
-BOOL LLWindowCallbacks::handlePaint(LLWindow *window, const S32 x, const S32 y, 
+bool LLWindowCallbacks::handlePaint(LLWindow *window, const S32 x, const S32 y, 
 									const S32 width, const S32 height)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleDoubleClick(LLWindow *window, const LLCoordGL pos, MASK mask)
+bool LLWindowCallbacks::handleDoubleClick(LLWindow *window, const LLCoordGL pos, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 void LLWindowCallbacks::handleWindowBlock(LLWindow *window)
@@ -179,24 +179,24 @@ LLWindowCallbacks::DragNDropResult LLWindowCallbacks::handleDragNDrop(LLWindow *
 	return LLWindowCallbacks::DND_NONE;
 }
 
-BOOL LLWindowCallbacks::handleTimerEvent(LLWindow *window)
+bool LLWindowCallbacks::handleTimerEvent(LLWindow *window)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleDeviceChange(LLWindow *window)
+bool LLWindowCallbacks::handleDeviceChange(LLWindow *window)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height)
+bool LLWindowCallbacks::handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height)
 {
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowCallbacks::handleWindowDidChangeScreen(LLWindow *window)
+bool LLWindowCallbacks::handleWindowDidChangeScreen(LLWindow *window)
 {
-	return FALSE;
+	return false;
 }
 
 void LLWindowCallbacks::handlePingWatchdog(LLWindow *window, const char * msg)

--- a/indra/llwindow/llwindowcallbacks.h
+++ b/indra/llwindow/llwindowcallbacks.h
@@ -33,26 +33,26 @@ class LLWindowCallbacks
 {
 public:
 	virtual ~LLWindowCallbacks() {}
-	virtual BOOL handleTranslatedKeyDown(KEY key,  MASK mask, BOOL repeated);
-	virtual BOOL handleTranslatedKeyUp(KEY key,  MASK mask);
-	virtual void handleScanKey(KEY key, BOOL key_down, BOOL key_up, BOOL key_level);
-	virtual BOOL handleUnicodeChar(llwchar uni_char, MASK mask);
+	virtual bool handleTranslatedKeyDown(KEY key,  MASK mask, bool repeated);
+	virtual bool handleTranslatedKeyUp(KEY key,  MASK mask);
+	virtual void handleScanKey(KEY key, bool key_down, bool key_up, bool key_level);
+	virtual bool handleUnicodeChar(llwchar uni_char, MASK mask);
 
-	virtual BOOL handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	virtual BOOL handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
 	virtual void handleMouseLeave(LLWindow *window);
-	// return TRUE to allow window to close, which will then cause handleQuit to be called
-	virtual BOOL handleCloseRequest(LLWindow *window);
+	// return true to allow window to close, which will then cause handleQuit to be called
+	virtual bool handleCloseRequest(LLWindow *window);
 	// window is about to be destroyed, clean up your business
 	virtual void handleQuit(LLWindow *window);
-	virtual BOOL handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	virtual BOOL handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
-	virtual BOOL handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	virtual BOOL handleMiddleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
-	virtual BOOL handleOtherMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask, S32 button);
-	virtual BOOL handleOtherMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask, S32 button);
-	virtual BOOL handleActivate(LLWindow *window, BOOL activated);
-	virtual BOOL handleActivateApp(LLWindow *window, BOOL activating);
+	virtual bool handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleMiddleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+	virtual bool handleOtherMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask, S32 button);
+	virtual bool handleOtherMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask, S32 button);
+	virtual bool handleActivate(LLWindow *window, bool activated);
+	virtual bool handleActivateApp(LLWindow *window, bool activating);
 	virtual void handleMouseMove(LLWindow *window,  LLCoordGL pos, MASK mask);
     virtual void handleMouseDragged(LLWindow *window,  LLCoordGL pos, MASK mask);
 	virtual void handleScrollWheel(LLWindow *window,  S32 clicks);
@@ -61,15 +61,15 @@ public:
 	virtual void handleFocus(LLWindow *window);
 	virtual void handleFocusLost(LLWindow *window);
 	virtual void handleMenuSelect(LLWindow *window,  S32 menu_item);
-	virtual BOOL handlePaint(LLWindow *window,  S32 x,  S32 y,  S32 width,  S32 height);
-	virtual BOOL handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask);			// double-click of left mouse button
+	virtual bool handlePaint(LLWindow *window,  S32 x,  S32 y,  S32 width,  S32 height);
+	virtual bool handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask);			// double-click of left mouse button
 	virtual void handleWindowBlock(LLWindow *window);							// window is taking over CPU for a while
 	virtual void handleWindowUnblock(LLWindow *window);							// window coming back after taking over CPU for a while
 	virtual void handleDataCopy(LLWindow *window, S32 data_type, void *data);
-	virtual BOOL handleTimerEvent(LLWindow *window);
-	virtual BOOL handleDeviceChange(LLWindow *window);
-	virtual BOOL handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
-	virtual BOOL handleWindowDidChangeScreen(LLWindow *window);
+	virtual bool handleTimerEvent(LLWindow *window);
+	virtual bool handleDeviceChange(LLWindow *window);
+	virtual bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
+	virtual bool handleWindowDidChangeScreen(LLWindow *window);
 
 	enum DragNDropAction {
 		DNDA_START_TRACKING = 0,// Start tracking an incoming drag

--- a/indra/llwindow/llwindowheadless.cpp
+++ b/indra/llwindow/llwindowheadless.cpp
@@ -34,8 +34,8 @@
 // LLWindowHeadless
 //
 LLWindowHeadless::LLWindowHeadless(LLWindowCallbacks* callbacks, const std::string& title, const std::string& name, S32 x, S32 y, S32 width, S32 height,
-							 U32 flags,  BOOL fullscreen, BOOL clear_background,
-							 BOOL enable_vsync, BOOL use_gl, BOOL ignore_pixel_depth)
+							 U32 flags,  bool fullscreen, bool clear_background,
+							 bool enable_vsync, bool use_gl, bool ignore_pixel_depth)
 	: LLWindow(callbacks, fullscreen, flags)
 {
 	// Initialize a headless keyboard.

--- a/indra/llwindow/llwindowheadless.h
+++ b/indra/llwindow/llwindowheadless.h
@@ -35,10 +35,10 @@ public:
 	/*virtual*/ void show() override {}
 	/*virtual*/ void hide() override {}
 	/*virtual*/ void close() override {}
-	/*virtual*/ BOOL getVisible() override {return FALSE;}
-	/*virtual*/ BOOL getMinimized() override {return FALSE;}
-	/*virtual*/ BOOL getMaximized() override {return FALSE;}
-	/*virtual*/ BOOL maximize() override {return FALSE;}
+	/*virtual*/ bool getVisible() override {return false;}
+	/*virtual*/ bool getMinimized() override {return false;}
+	/*virtual*/ bool getMaximized() override {return false;}
+	/*virtual*/ bool maximize() override {return false;}
 	/*virtual*/ void minimize() override {}
 	/*virtual*/ void restore() override {}
 	// TODO: LLWindow::getFullscreen() is (intentionally?) NOT virtual.
@@ -46,42 +46,42 @@ public:
 	// mistake to shadow the base-class method with an LLWindowHeadless
 	// override when called on the subclass, yet call the base-class method
 	// when indirecting through a polymorphic pointer or reference?
-	BOOL getFullscreen() {return FALSE;}
-	/*virtual*/ BOOL getPosition(LLCoordScreen *position) override {return FALSE;}
-	/*virtual*/ BOOL getSize(LLCoordScreen *size) override {return FALSE;}
-	/*virtual*/ BOOL getSize(LLCoordWindow *size) override {return FALSE;}
-	/*virtual*/ BOOL setPosition(LLCoordScreen position) override {return FALSE;}
-	/*virtual*/ BOOL setSizeImpl(LLCoordScreen size) override {return FALSE;}
-	/*virtual*/ BOOL setSizeImpl(LLCoordWindow size) override {return FALSE;}
-	/*virtual*/ BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL enable_vsync, const LLCoordScreen * const posp = NULL) override {return FALSE;}
+	bool getFullscreen() {return false;}
+	/*virtual*/ bool getPosition(LLCoordScreen *position) override {return false;}
+	/*virtual*/ bool getSize(LLCoordScreen *size) override {return false;}
+	/*virtual*/ bool getSize(LLCoordWindow *size) override {return false;}
+	/*virtual*/ bool setPosition(LLCoordScreen position) override {return false;}
+	/*virtual*/ bool setSizeImpl(LLCoordScreen size) override {return false;}
+	/*virtual*/ bool setSizeImpl(LLCoordWindow size) override {return false;}
+	/*virtual*/ bool switchContext(bool fullscreen, const LLCoordScreen &size, bool enable_vsync, const LLCoordScreen * const posp = NULL) override {return false;}
     void* createSharedContext() override  { return nullptr; }
     void makeContextCurrent(void*) override  {}
     void destroySharedContext(void*) override  {}
     /*virtual*/ void toggleVSync(bool enable_vsync) override { }
-    /*virtual*/ BOOL setCursorPosition(LLCoordWindow position) override {return FALSE;}
-    /*virtual*/ BOOL getCursorPosition(LLCoordWindow *position) override {return FALSE;}
+    /*virtual*/ bool setCursorPosition(LLCoordWindow position) override {return false;}
+    /*virtual*/ bool getCursorPosition(LLCoordWindow *position) override {return false;}
 #if LL_WINDOWS
-    /*virtual*/ BOOL getCursorDelta(LLCoordCommon* delta) override { return FALSE; }
+    /*virtual*/ bool getCursorDelta(LLCoordCommon* delta) override { return false; }
 #endif
 	/*virtual*/ void showCursor() override {}
 	/*virtual*/ void hideCursor() override {}
 	/*virtual*/ void showCursorFromMouseMove() override {}
 	/*virtual*/ void hideCursorUntilMouseMove() override {}
-	/*virtual*/ BOOL isCursorHidden() override {return FALSE;}
+	/*virtual*/ bool isCursorHidden() override {return false;}
 	/*virtual*/ void updateCursor() override {}
 	//virtual ECursorType getCursor() override { return mCurrentCursor; }
 	/*virtual*/ void captureMouse() override {}
 	/*virtual*/ void releaseMouse() override {}
-	/*virtual*/ void setMouseClipping( BOOL b ) override {}
-	/*virtual*/ BOOL isClipboardTextAvailable() override {return FALSE; }
-	/*virtual*/ BOOL pasteTextFromClipboard(LLWString &dst) override {return FALSE; }
-	/*virtual*/ BOOL copyTextToClipboard(const LLWString &src) override {return FALSE; }
+	/*virtual*/ void setMouseClipping( bool b ) override {}
+	/*virtual*/ bool isClipboardTextAvailable() override {return false; }
+	/*virtual*/ bool pasteTextFromClipboard(LLWString &dst) override {return false; }
+	/*virtual*/ bool copyTextToClipboard(const LLWString &src) override {return false; }
 	/*virtual*/ void flashIcon(F32 seconds) override {}
 	/*virtual*/ F32 getGamma() override {return 1.0f; }
-	/*virtual*/ BOOL setGamma(const F32 gamma) override {return FALSE; } // Set the gamma
+	/*virtual*/ bool setGamma(const F32 gamma) override {return false; } // Set the gamma
 	/*virtual*/ void setFSAASamples(const U32 fsaa_samples) override { }
 	/*virtual*/ U32 getFSAASamples() override { return 0; }
-	/*virtual*/ BOOL restoreGamma() override {return FALSE; }	// Restore original gamma table (before updating gamma)
+	/*virtual*/ bool restoreGamma() override {return false; }	// Restore original gamma table (before updating gamma)
 	//virtual ESwapMethod getSwapMethod() override { return mSwapMethod; }
 	/*virtual*/ void gatherInput() override {}
 	/*virtual*/ void delayInputProcessing() override {}
@@ -89,12 +89,12 @@ public:
 
 	
     // handy coordinate space conversion routines
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordWindow *to) override { return FALSE; }
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordScreen *to) override { return FALSE; }
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordGL *to) override { return FALSE; }
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordWindow *to) override { return FALSE; }
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordGL *to) override { return FALSE; }
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordScreen *to) override { return FALSE; }
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordWindow *to) override { return false; }
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordScreen *to) override { return false; }
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordGL *to) override { return false; }
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordWindow *to) override { return false; }
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordGL *to) override { return false; }
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordScreen *to) override { return false; }
 
 	/*virtual*/ LLWindowResolution* getSupportedResolutions(S32 &num_resolutions) override { return NULL; }
 	/*virtual*/ F32	getNativeAspectRatio() override { return 1.0f; }
@@ -111,8 +111,8 @@ public:
 		const std::string& title, const std::string& name,
 		S32 x, S32 y, 
 		S32 width, S32 height,
-		U32 flags,  BOOL fullscreen, BOOL clear_background,
-		BOOL enable_vsync, BOOL use_gl, BOOL ignore_pixel_depth);
+		U32 flags,  bool fullscreen, bool clear_background,
+		bool enable_vsync, bool use_gl, bool ignore_pixel_depth);
 	virtual ~LLWindowHeadless();
 
 private:

--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -43,8 +43,8 @@
 #include <CoreServices/CoreServices.h>
 #include <CoreGraphics/CGDisplayConfiguration.h>
 
-extern BOOL gDebugWindowProc;
-BOOL gHiDPISupport = TRUE;
+extern bool gDebugWindowProc;
+bool gHiDPISupport = true;
 
 const S32	BITS_PER_PIXEL = 32;
 const S32	MAX_NUM_RESOLUTIONS = 32;
@@ -59,11 +59,11 @@ namespace
 // LLWindowMacOSX
 //
 
-BOOL LLWindowMacOSX::sUseMultGL = FALSE;
+bool LLWindowMacOSX::sUseMultGL = false;
 
 // Cross-platform bits:
 
-BOOL check_for_card(const char* RENDERER, const char* bad_card)
+bool check_for_card(const char* RENDERER, const char* bad_card)
 {
 	if (!strnicmp(RENDERER, bad_card, strlen(bad_card)))
 	{
@@ -84,15 +84,15 @@ BOOL check_for_card(const char* RENDERER, const char* bad_card)
 		S32 button = OSMessageBox(buffer.c_str(), "Unsupported video card", OSMB_YESNO);
 		if (OSBTN_YES == button)
 		{
-			return FALSE;
+			return false;
 		}
 		else
 		{
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
 // Switch to determine whether we capture all displays, or just the main one.
@@ -112,9 +112,9 @@ static LLWindowMacOSX *gWindowImplementation = NULL;
 LLWindowMacOSX::LLWindowMacOSX(LLWindowCallbacks* callbacks,
 							   const std::string& title, const std::string& name, S32 x, S32 y, S32 width,
 							   S32 height, U32 flags,
-							   BOOL fullscreen, BOOL clearBg,
-							   BOOL enable_vsync, BOOL use_gl,
-							   BOOL ignore_pixel_depth,
+							   bool fullscreen, bool clearBg,
+							   bool enable_vsync, bool use_gl,
+							   bool ignore_pixel_depth,
 							   U32 fsaa_samples,
                                U32 max_vram)
 	: LLWindow(NULL, fullscreen, flags)
@@ -138,21 +138,21 @@ LLWindowMacOSX::LLWindowMacOSX(LLWindowCallbacks* callbacks,
 	mContext = NULL;
 	mPixelFormat = NULL;
 	mDisplay = CGMainDisplayID();
-	mSimulatedRightClick = FALSE;
+	mSimulatedRightClick = false;
 	mLastModifiers = 0;
-	mHandsOffEvents = FALSE;
-	mCursorDecoupled = FALSE;
+	mHandsOffEvents = false;
+	mCursorDecoupled = false;
 	mCursorLastEventDeltaX = 0;
 	mCursorLastEventDeltaY = 0;
-	mCursorIgnoreNextDelta = FALSE;
-	mNeedsResize = FALSE;
+	mCursorIgnoreNextDelta = false;
+	mNeedsResize = false;
 	mOverrideAspectRatio = 0.f;
-	mMaximized = FALSE;
-	mMinimized = FALSE;
-	mLanguageTextInputAllowed = FALSE;
+	mMaximized = false;
+	mMinimized = false;
+	mLanguageTextInputAllowed = false;
 	mPreeditor = NULL;
 	mFSAASamples = fsaa_samples;
-	mForceRebuild = FALSE;
+	mForceRebuild = false;
 
 	// Get the original aspect ratio of the main device.
 	mOriginalAspectRatio = (double)CGDisplayPixelsWide(mDisplay) / (double)CGDisplayPixelsHigh(mDisplay);
@@ -192,7 +192,7 @@ LLWindowMacOSX::LLWindowMacOSX(LLWindowCallbacks* callbacks,
 		initCursors();
 		setCursor( UI_CURSOR_ARROW );
 		
-		allowLanguageTextInput(NULL, FALSE);
+		allowLanguageTextInput(NULL, false);
 	}
 
 	mCallbacks = callbacks;
@@ -281,7 +281,7 @@ void callRightMouseDown(float *pos, MASK mask)
 	LLCoordGL		outCoords;
 	outCoords.mX = ll_round(pos[0]);
 	outCoords.mY = ll_round(pos[1]);
-	gWindowImplementation->getCallbacks()->handleRightMouseDown(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleRightMouseDown(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 }
 
 void callRightMouseUp(float *pos, MASK mask)
@@ -294,7 +294,7 @@ void callRightMouseUp(float *pos, MASK mask)
 	LLCoordGL		outCoords;
 	outCoords.mX = ll_round(pos[0]);
 	outCoords.mY = ll_round(pos[1]);
-	gWindowImplementation->getCallbacks()->handleRightMouseUp(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleRightMouseUp(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 }
 
 void callLeftMouseDown(float *pos, MASK mask)
@@ -307,7 +307,7 @@ void callLeftMouseDown(float *pos, MASK mask)
 	LLCoordGL		outCoords;
 	outCoords.mX = ll_round(pos[0]);
 	outCoords.mY = ll_round(pos[1]);
-	gWindowImplementation->getCallbacks()->handleMouseDown(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleMouseDown(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 }
 
 void callLeftMouseUp(float *pos, MASK mask)
@@ -320,7 +320,7 @@ void callLeftMouseUp(float *pos, MASK mask)
 	LLCoordGL		outCoords;
 	outCoords.mX = ll_round(pos[0]);
 	outCoords.mY = ll_round(pos[1]);
-	gWindowImplementation->getCallbacks()->handleMouseUp(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleMouseUp(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 	
 }
 
@@ -334,7 +334,7 @@ void callDoubleClick(float *pos, MASK mask)
 	LLCoordGL	outCoords;
 	outCoords.mX = ll_round(pos[0]);
 	outCoords.mY = ll_round(pos[1]);
-	gWindowImplementation->getCallbacks()->handleDoubleClick(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleDoubleClick(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 }
 
 void callResize(unsigned int width, unsigned int height)
@@ -354,7 +354,7 @@ void callMouseMoved(float *pos, MASK mask)
 	gWindowImplementation->getMouseDeltas(deltas);
 	outCoords.mX += deltas[0];
 	outCoords.mY += deltas[1];
-	gWindowImplementation->getCallbacks()->handleMouseMove(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+	gWindowImplementation->getCallbacks()->handleMouseMove(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 	//gWindowImplementation->getCallbacks()->handleScrollWheel(gWindowImplementation, 0);
 }
 
@@ -367,7 +367,7 @@ void callMouseDragged(float *pos, MASK mask)
     gWindowImplementation->getMouseDeltas(deltas);
     outCoords.mX += deltas[0];
     outCoords.mY += deltas[1];
-    gWindowImplementation->getCallbacks()->handleMouseDragged(gWindowImplementation, outCoords, gKeyboard->currentMask(TRUE));
+    gWindowImplementation->getCallbacks()->handleMouseDragged(gWindowImplementation, outCoords, gKeyboard->currentMask(true));
 }
 
 void callScrollMoved(float deltaX, float deltaY)
@@ -609,7 +609,7 @@ void LLWindowMacOSX::updateMouseDeltas(float* deltas)
 		{
 			mCursorLastEventDeltaX = 0;
 			mCursorLastEventDeltaY = 0;
-			mCursorIgnoreNextDelta = FALSE;
+			mCursorIgnoreNextDelta = false;
 		}
 	} else {
 		mCursorLastEventDeltaX = 0;
@@ -623,7 +623,7 @@ void LLWindowMacOSX::getMouseDeltas(float* delta)
 	delta[1] = mCursorLastEventDeltaY;
 }
 
-BOOL LLWindowMacOSX::createContext(int x, int y, int width, int height, int bits, BOOL fullscreen, BOOL enable_vsync)
+bool LLWindowMacOSX::createContext(int x, int y, int width, int height, int bits, bool fullscreen, bool enable_vsync)
 {
 	mFullscreen = fullscreen;
 	
@@ -682,7 +682,7 @@ BOOL LLWindowMacOSX::createContext(int x, int y, int width, int height, int bits
 		if (err != kCGLNoError)
 		{
 			setupFailure("Can't activate GL rendering context", "Error", OSMB_OK);
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -715,15 +715,15 @@ BOOL LLWindowMacOSX::createContext(int x, int y, int width, int height, int bits
 	}
 	makeFirstResponder(mWindow, mGLView);
     
-	return TRUE;
+	return true;
 }
 
 
 // We only support OS X 10.7's fullscreen app mode which is literally a full screen window that fills a virtual desktop.
 // This makes this method obsolete.
-BOOL LLWindowMacOSX::switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL enable_vsync, const LLCoordScreen * const posp)
+bool LLWindowMacOSX::switchContext(bool fullscreen, const LLCoordScreen &size, bool enable_vsync, const LLCoordScreen * const posp)
 {
-	return FALSE;
+	return false;
 }
 
 void LLWindowMacOSX::destroyContext()
@@ -793,13 +793,13 @@ void LLWindowMacOSX::show()
 
 void LLWindowMacOSX::hide()
 {
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 }
 
 //virtual
 void LLWindowMacOSX::minimize()
 {
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	showCursor();
 }
 
@@ -821,48 +821,48 @@ void LLWindowMacOSX::close()
 	//	}
 
 	// Make sure cursor is visible and we haven't mangled the clipping state.
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	showCursor();
 
 	destroyContext();
 }
 
-BOOL LLWindowMacOSX::isValid()
+bool LLWindowMacOSX::isValid()
 {
 	if(mFullscreen)
 	{
-		return(TRUE);
+		return(true);
 	}
 
 	return (mWindow != NULL);
 }
 
-BOOL LLWindowMacOSX::getVisible()
+bool LLWindowMacOSX::getVisible()
 {
-	BOOL result = FALSE;
+	bool result = false;
 
 	if(mFullscreen)
 	{
-		result = TRUE;
+		result = true;
 	}if (mWindow)
 	{
-			result = TRUE;
+			result = true;
 	}
 
 	return(result);
 }
 
-BOOL LLWindowMacOSX::getMinimized()
+bool LLWindowMacOSX::getMinimized()
 {
 	return mMinimized;
 }
 
-BOOL LLWindowMacOSX::getMaximized()
+bool LLWindowMacOSX::getMaximized()
 {
 	return mMaximized;
 }
 
-BOOL LLWindowMacOSX::maximize()
+bool LLWindowMacOSX::maximize()
 {
 	if (mWindow && !mMaximized)
 	{
@@ -871,7 +871,7 @@ BOOL LLWindowMacOSX::maximize()
 	return mMaximized;
 }
 
-BOOL LLWindowMacOSX::getFullscreen()
+bool LLWindowMacOSX::getFullscreen()
 {
 	return mFullscreen;
 }
@@ -881,7 +881,7 @@ void LLWindowMacOSX::gatherInput()
 	updateCursor();
 }
 
-BOOL LLWindowMacOSX::getPosition(LLCoordScreen *position)
+bool LLWindowMacOSX::getPosition(LLCoordScreen *position)
 {
 	S32 err = -1;
 
@@ -908,7 +908,7 @@ BOOL LLWindowMacOSX::getPosition(LLCoordScreen *position)
 	return (err == noErr);
 }
 
-BOOL LLWindowMacOSX::getSize(LLCoordScreen *size)
+bool LLWindowMacOSX::getSize(LLCoordScreen *size)
 {
 	S32 err = -1;
 
@@ -934,7 +934,7 @@ BOOL LLWindowMacOSX::getSize(LLCoordScreen *size)
 	return (err == noErr);
 }
 
-BOOL LLWindowMacOSX::getSize(LLCoordWindow *size)
+bool LLWindowMacOSX::getSize(LLCoordWindow *size)
 {
 	S32 err = -1;
 	
@@ -962,7 +962,7 @@ BOOL LLWindowMacOSX::getSize(LLCoordWindow *size)
 	return (err == noErr);
 }
 
-BOOL LLWindowMacOSX::setPosition(const LLCoordScreen position)
+bool LLWindowMacOSX::setPosition(const LLCoordScreen position)
 {
 	if(mWindow)
 	{
@@ -970,32 +970,32 @@ BOOL LLWindowMacOSX::setPosition(const LLCoordScreen position)
 		setWindowPos(mWindow, pos);
 	}
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowMacOSX::setSizeImpl(const LLCoordScreen size)
+bool LLWindowMacOSX::setSizeImpl(const LLCoordScreen size)
 {
 	if(mWindow)
 	{
         LLCoordWindow to;
         convertCoords(size, &to);
 		setWindowSize(mWindow, to.mX, to.mY);
-        return TRUE;
+        return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowMacOSX::setSizeImpl(const LLCoordWindow size)
+bool LLWindowMacOSX::setSizeImpl(const LLCoordWindow size)
 {
 	if (mWindow)
 	{
         const int titlePadding = 22;
         setWindowSize(mWindow, size.mX, size.mY + titlePadding);
-        return TRUE;
+        return true;
 	}
     
-	return FALSE;
+	return false;
 }
 
 void LLWindowMacOSX::swapBuffers()
@@ -1050,16 +1050,16 @@ U32 LLWindowMacOSX::getFSAASamples()
 void LLWindowMacOSX::setFSAASamples(const U32 samples)
 {
 	mFSAASamples = samples;
-	mForceRebuild = TRUE;
+	mForceRebuild = true;
 }
 
-BOOL LLWindowMacOSX::restoreGamma()
+bool LLWindowMacOSX::restoreGamma()
 {
 	CGDisplayRestoreColorSyncSettings();
 	return true;
 }
 
-BOOL LLWindowMacOSX::setGamma(const F32 gamma)
+bool LLWindowMacOSX::setGamma(const F32 gamma)
 {
 	CGGammaValue redMin;
 	CGGammaValue redMax;
@@ -1107,7 +1107,7 @@ BOOL LLWindowMacOSX::setGamma(const F32 gamma)
 	return true;
 }
 
-BOOL LLWindowMacOSX::isCursorHidden()
+bool LLWindowMacOSX::isCursorHidden()
 {
 	return mCursorHidden;
 }
@@ -1115,31 +1115,31 @@ BOOL LLWindowMacOSX::isCursorHidden()
 
 
 // Constrains the mouse to the window.
-void LLWindowMacOSX::setMouseClipping( BOOL b )
+void LLWindowMacOSX::setMouseClipping( bool b )
 {
 	// Just stash the requested state.  We'll simulate this when the cursor is hidden by decoupling.
 	mIsMouseClipping = b;
 
 	if(b)
 	{
-		//		LL_INFOS() << "setMouseClipping(TRUE)" << LL_ENDL;
+		//		LL_INFOS() << "setMouseClipping(true)" << LL_ENDL;
 	}
 	else
 	{
-		//		LL_INFOS() << "setMouseClipping(FALSE)" << LL_ENDL;
+		//		LL_INFOS() << "setMouseClipping(false)" << LL_ENDL;
 	}
 
 	adjustCursorDecouple();
 }
 
-BOOL LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
+bool LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
 {
-	BOOL result = FALSE;
+	bool result = false;
 	LLCoordScreen screen_pos;
 
 	if (!convertCoords(position, &screen_pos))
 	{
-		return FALSE;
+		return false;
 	}
 
 	CGPoint newPosition;
@@ -1152,7 +1152,7 @@ BOOL LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
 	CGSetLocalEventsSuppressionInterval(0.0);
 	if(CGWarpMouseCursorPosition(newPosition) == noErr)
 	{
-		result = TRUE;
+		result = true;
 	}
 
 	// Under certain circumstances, this will trigger us to decouple the cursor.
@@ -1169,13 +1169,13 @@ BOOL LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
 	return result;
 }
 
-BOOL LLWindowMacOSX::getCursorPosition(LLCoordWindow *position)
+bool LLWindowMacOSX::getCursorPosition(LLCoordWindow *position)
 {
 	float cursor_point[2];
 	LLCoordScreen screen_pos;
 
 	if(mWindow == NULL)
-		return FALSE;
+		return false;
 	
 	getCursorPos(mWindow, cursor_point);
 
@@ -1198,7 +1198,7 @@ BOOL LLWindowMacOSX::getCursorPosition(LLCoordWindow *position)
 	position->mX = cursor_point[0] * scale;
 	position->mY = cursor_point[1] * scale;
 
-	return TRUE;
+	return true;
 }
 
 void LLWindowMacOSX::adjustCursorDecouple(bool warpingMouse)
@@ -1213,7 +1213,7 @@ void LLWindowMacOSX::adjustCursorDecouple(bool warpingMouse)
 				//			LL_INFOS() << "adjustCursorDecouple: decoupling cursor" << LL_ENDL;
 				CGAssociateMouseAndMouseCursorPosition(false);
 				mCursorDecoupled = true;
-				mCursorIgnoreNextDelta = TRUE;
+				mCursorIgnoreNextDelta = true;
 			}
 		}
 	}
@@ -1293,12 +1293,12 @@ void LLWindowMacOSX::flashIcon(F32 seconds)
 	requestUserAttention();
 }
 
-BOOL LLWindowMacOSX::isClipboardTextAvailable()
+bool LLWindowMacOSX::isClipboardTextAvailable()
 {
 	return pasteBoardAvailable();
 }
 
-BOOL LLWindowMacOSX::pasteTextFromClipboard(LLWString &dst)
+bool LLWindowMacOSX::pasteTextFromClipboard(LLWString &dst)
 {
     unsigned short* pboard_data = copyFromPBoard(); // must free returned data
 	llutf16string str(pboard_data);
@@ -1313,9 +1313,9 @@ BOOL LLWindowMacOSX::pasteTextFromClipboard(LLWString &dst)
 	}
 }
 
-BOOL LLWindowMacOSX::copyTextToClipboard(const LLWString &s)
+bool LLWindowMacOSX::copyTextToClipboard(const LLWString &s)
 {
-	BOOL result = false;
+	bool result = false;
 	llutf16string utf16str = wstring_to_utf16str(s);
 	
 	result = copyToPBoard(utf16str.data(), utf16str.length());
@@ -1325,7 +1325,7 @@ BOOL LLWindowMacOSX::copyTextToClipboard(const LLWString &s)
 
 
 // protected
-BOOL LLWindowMacOSX::resetDisplayResolution()
+bool LLWindowMacOSX::resetDisplayResolution()
 {
 	// This is only called from elsewhere in this class, and it's not used by the Mac implementation.
 	return true;
@@ -1358,13 +1358,13 @@ LLWindow::LLWindowResolution* LLWindowMacOSX::getSupportedResolutions(S32 &num_r
 
 				if(bits == BITS_PER_PIXEL && width >= 800 && height >= 600)
 				{
-					BOOL resolution_exists = FALSE;
+					bool resolution_exists = false;
 					for(S32 i = 0; i < mNumSupportedResolutions; i++)
 					{
 						if (mSupportedResolutions[i].mWidth == width &&
 							mSupportedResolutions[i].mHeight == height)
 						{
-							resolution_exists = TRUE;
+							resolution_exists = true;
 						}
 					}
 					if (!resolution_exists)
@@ -1383,21 +1383,21 @@ LLWindow::LLWindowResolution* LLWindowMacOSX::getSupportedResolutions(S32 &num_r
 	return mSupportedResolutions;
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordGL from, LLCoordWindow *to)
+bool LLWindowMacOSX::convertCoords(LLCoordGL from, LLCoordWindow *to)
 {
 	to->mX = from.mX;
 	to->mY = from.mY;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordWindow from, LLCoordGL* to)
+bool LLWindowMacOSX::convertCoords(LLCoordWindow from, LLCoordGL* to)
 {
 	to->mX = from.mX;
 	to->mY = from.mY;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordScreen from, LLCoordWindow* to)
+bool LLWindowMacOSX::convertCoords(LLCoordScreen from, LLCoordWindow* to)
 {
 	if(mWindow)
 	{
@@ -1411,12 +1411,12 @@ BOOL LLWindowMacOSX::convertCoords(LLCoordScreen from, LLCoordWindow* to)
 		to->mX = mouse_point[0];
 		to->mY = mouse_point[1];
 
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordWindow from, LLCoordScreen *to)
+bool LLWindowMacOSX::convertCoords(LLCoordWindow from, LLCoordScreen *to)
 {
 	if(mWindow)
 	{
@@ -1430,19 +1430,19 @@ BOOL LLWindowMacOSX::convertCoords(LLCoordWindow from, LLCoordScreen *to)
 		to->mX = mouse_point[0];
 		to->mY = mouse_point[1];
 
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordScreen from, LLCoordGL *to)
+bool LLWindowMacOSX::convertCoords(LLCoordScreen from, LLCoordGL *to)
 {
 	LLCoordWindow window_coord;
 
 	return(convertCoords(from, &window_coord) && convertCoords(window_coord, to));
 }
 
-BOOL LLWindowMacOSX::convertCoords(LLCoordGL from, LLCoordScreen *to)
+bool LLWindowMacOSX::convertCoords(LLCoordGL from, LLCoordScreen *to)
 {
 	LLCoordWindow window_coord;
 
@@ -1704,8 +1704,8 @@ void LLWindowMacOSX::hideCursor()
 	if(!mCursorHidden)
 	{
 		//		LL_INFOS() << "hideCursor: hiding" << LL_ENDL;
-		mCursorHidden = TRUE;
-		mHideCursorPermanent = TRUE;
+		mCursorHidden = true;
+		mHideCursorPermanent = true;
 		hideNSCursor();
 	}
 	else
@@ -1721,8 +1721,8 @@ void LLWindowMacOSX::showCursor()
 	if(mCursorHidden || !isCGCursorVisible())
 	{
 		//		LL_INFOS() << "showCursor: showing" << LL_ENDL;
-		mCursorHidden = FALSE;
-		mHideCursorPermanent = FALSE;
+		mCursorHidden = false;
+		mHideCursorPermanent = false;
 		showNSCursor();
 	}
 	else
@@ -1746,7 +1746,7 @@ void LLWindowMacOSX::hideCursorUntilMouseMove()
 	if (!mHideCursorPermanent)
 	{
 		hideCursor();
-		mHideCursorPermanent = FALSE;
+		mHideCursorPermanent = false;
 	}
 }
 
@@ -1867,9 +1867,9 @@ LLSD LLWindowMacOSX::getNativeKeyData()
 	return result;
 }
 
-BOOL LLWindowMacOSX::dialogColorPicker( F32 *r, F32 *g, F32 *b)
+bool LLWindowMacOSX::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 {
-	BOOL	retval = FALSE;
+	bool	retval = false;
 	OSErr	error = noErr;
 	NColorPickerInfo	info;
 	
@@ -1926,12 +1926,12 @@ static long getDictLong (CFDictionaryRef refDict, CFStringRef key)
 	return int_value; // otherwise return the long value
 }
 
-void LLWindowMacOSX::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
+void LLWindowMacOSX::allowLanguageTextInput(LLPreeditor *preeditor, bool b)
 {
 	if (preeditor != mPreeditor && !b)
 	{
 		// This condition may occur by a call to
-		// setEnabled(BOOL) against LLTextEditor or LLLineEditor
+		// setEnabled(bool) against LLTextEditor or LLLineEditor
 		// when the control is not focused.
 		// We need to silently ignore the case so that
 		// the language input status of the focused control

--- a/indra/llwindow/llwindowmacosx.h
+++ b/indra/llwindow/llwindowmacosx.h
@@ -47,53 +47,53 @@ public:
 	void show() override;
 	void hide() override;
 	void close() override;
-	BOOL getVisible() override;
-	BOOL getMinimized() override;
-	BOOL getMaximized() override;
-	BOOL maximize() override;
+	bool getVisible() override;
+	bool getMinimized() override;
+	bool getMaximized() override;
+	bool maximize() override;
 	void minimize() override;
 	void restore() override;
-	BOOL getFullscreen();
-	BOOL getPosition(LLCoordScreen *position) override;
-	BOOL getSize(LLCoordScreen *size) override;
-	BOOL getSize(LLCoordWindow *size) override;
-	BOOL setPosition(LLCoordScreen position) override;
-	BOOL setSizeImpl(LLCoordScreen size) override;
-	BOOL setSizeImpl(LLCoordWindow size) override;
-	BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL enable_vsync, const LLCoordScreen * const posp = NULL) override;
-	BOOL setCursorPosition(LLCoordWindow position) override;
-	BOOL getCursorPosition(LLCoordWindow *position) override;
+	bool getFullscreen();
+	bool getPosition(LLCoordScreen *position) override;
+	bool getSize(LLCoordScreen *size) override;
+	bool getSize(LLCoordWindow *size) override;
+	bool setPosition(LLCoordScreen position) override;
+	bool setSizeImpl(LLCoordScreen size) override;
+	bool setSizeImpl(LLCoordWindow size) override;
+	bool switchContext(bool fullscreen, const LLCoordScreen &size, bool enable_vsync, const LLCoordScreen * const posp = NULL) override;
+	bool setCursorPosition(LLCoordWindow position) override;
+	bool getCursorPosition(LLCoordWindow *position) override;
 	void showCursor() override;
 	void hideCursor() override;
 	void showCursorFromMouseMove() override;
 	void hideCursorUntilMouseMove() override;
-	BOOL isCursorHidden() override;
+	bool isCursorHidden() override;
 	void updateCursor() override;
 	ECursorType getCursor() const override;
 	void captureMouse() override;
 	void releaseMouse() override;
-	void setMouseClipping( BOOL b ) override;
-	BOOL isClipboardTextAvailable() override;
-	BOOL pasteTextFromClipboard(LLWString &dst) override;
-	BOOL copyTextToClipboard(const LLWString & src) override;
+	void setMouseClipping( bool b ) override;
+	bool isClipboardTextAvailable() override;
+	bool pasteTextFromClipboard(LLWString &dst) override;
+	bool copyTextToClipboard(const LLWString & src) override;
 	void flashIcon(F32 seconds) override;
 	F32 getGamma() override;
-	BOOL setGamma(const F32 gamma) override; // Set the gamma
+	bool setGamma(const F32 gamma) override; // Set the gamma
 	U32 getFSAASamples() override;
 	void setFSAASamples(const U32 fsaa_samples) override;
-	BOOL restoreGamma() override;			// Restore original gamma table (before updating gamma)
+	bool restoreGamma() override;			// Restore original gamma table (before updating gamma)
 	ESwapMethod getSwapMethod() override { return mSwapMethod; }
 	void gatherInput() override;
 	void delayInputProcessing() override {};
 	void swapBuffers() override;
 	
 	// handy coordinate space conversion routines
-	BOOL convertCoords(LLCoordScreen from, LLCoordWindow *to) override;
-	BOOL convertCoords(LLCoordWindow from, LLCoordScreen *to) override;
-	BOOL convertCoords(LLCoordWindow from, LLCoordGL *to) override;
-	BOOL convertCoords(LLCoordGL from, LLCoordWindow *to) override;
-	BOOL convertCoords(LLCoordScreen from, LLCoordGL *to) override;
-	BOOL convertCoords(LLCoordGL from, LLCoordScreen *to) override;
+	bool convertCoords(LLCoordScreen from, LLCoordWindow *to) override;
+	bool convertCoords(LLCoordWindow from, LLCoordScreen *to) override;
+	bool convertCoords(LLCoordWindow from, LLCoordGL *to) override;
+	bool convertCoords(LLCoordGL from, LLCoordWindow *to) override;
+	bool convertCoords(LLCoordScreen from, LLCoordGL *to) override;
+	bool convertCoords(LLCoordGL from, LLCoordScreen *to) override;
 
 	LLWindowResolution* getSupportedResolutions(S32 &num_resolutions) override;
 	F32	getNativeAspectRatio() override;
@@ -107,12 +107,12 @@ public:
 	void beforeDialog() override;
 	void afterDialog() override;
 
-	BOOL dialogColorPicker(F32 *r, F32 *g, F32 *b) override;
+	bool dialogColorPicker(F32 *r, F32 *g, F32 *b) override;
 
 	void *getPlatformWindow() override;
 	void bringToFront() override {};
 	
-	void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b) override;
+	void allowLanguageTextInput(LLPreeditor *preeditor, bool b) override;
 	void interruptLanguageTextInput() override;
 	void spawnWebBrowser(const std::string& escaped_url, bool async) override;
 	F32 getSystemUISize() override;
@@ -149,27 +149,27 @@ public:
 protected:
 	LLWindowMacOSX(LLWindowCallbacks* callbacks,
 		const std::string& title, const std::string& name, int x, int y, int width, int height, U32 flags,
-		BOOL fullscreen, BOOL clearBg, BOOL enable_vsync, BOOL use_gl,
-		BOOL ignore_pixel_depth,
+		bool fullscreen, bool clearBg, bool enable_vsync, bool use_gl,
+		bool ignore_pixel_depth,
 		U32 fsaa_samples,
         U32 max_vram);
 		~LLWindowMacOSX();
 
 	void	initCursors();
-	BOOL	isValid() override;
+	bool	isValid() override;
 	void	moveWindow(const LLCoordScreen& position,const LLCoordScreen& size);
 
 
 	// Changes display resolution. Returns true if successful
-	BOOL	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
+	bool	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
 
 	// Go back to last fullscreen display resolution.
-	BOOL	setFullscreenResolution();
+	bool	setFullscreenResolution();
 
 	// Restore the display resolution to its value before we ran the app.
-	BOOL	resetDisplayResolution();
+	bool	resetDisplayResolution();
 
-	BOOL	shouldPostQuit() { return mPostQuit; }
+	bool	shouldPostQuit() { return mPostQuit; }
     
     //Satisfy MAINT-3135 and MAINT-3288 with a flag.
     /*virtual */ void setOldResize(bool oldresize) override {setResizeMode(oldresize, mGLView); }
@@ -183,7 +183,7 @@ protected:
 	//
 
 	// create or re-create the GL context/window.  Called from the constructor and switchContext().
-	BOOL createContext(int x, int y, int width, int height, int bits, BOOL fullscreen, BOOL enable_vsync);
+	bool createContext(int x, int y, int width, int height, int bits, bool fullscreen, bool enable_vsync);
 	void destroyContext();
 	void setupFailure(const std::string& text, const std::string& caption, U32 type);
 	void adjustCursorDecouple(bool warpingMouse = false);
@@ -211,31 +211,31 @@ protected:
 	LLRect		mOldMouseClip;  // Screen rect to which the mouse cursor was globally constrained before we changed it in clipMouse()
 	std::string mWindowTitle;
 	double		mOriginalAspectRatio;
-	BOOL		mSimulatedRightClick;
+	bool		mSimulatedRightClick;
 	U32			mLastModifiers;
-	BOOL		mHandsOffEvents;	// When true, temporarially disable CarbonEvent processing.
+	bool		mHandsOffEvents;	// When true, temporarially disable CarbonEvent processing.
 	// Used to allow event processing when putting up dialogs in fullscreen mode.
-	BOOL		mCursorDecoupled;
+	bool		mCursorDecoupled;
 	S32			mCursorLastEventDeltaX;
 	S32			mCursorLastEventDeltaY;
-	BOOL		mCursorIgnoreNextDelta;
-	BOOL		mNeedsResize;		// Constructor figured out the window is too big, it needs a resize.
+	bool		mCursorIgnoreNextDelta;
+	bool		mNeedsResize;		// Constructor figured out the window is too big, it needs a resize.
 	LLCoordScreen   mNeedsResizeSize;
 	F32			mOverrideAspectRatio;
-	BOOL		mMaximized;
-	BOOL		mMinimized;
+	bool		mMaximized;
+	bool		mMinimized;
 	U32			mFSAASamples;
-	BOOL		mForceRebuild;
+	bool		mForceRebuild;
     U32			mMaxVRAM;
 	
 	S32	mDragOverrideCursor;
 
 	// Input method management through Text Service Manager.
-	BOOL		mLanguageTextInputAllowed;
+	bool		mLanguageTextInputAllowed;
 	LLPreeditor*	mPreeditor;
 	
 public:
-	static BOOL	sUseMultGL;
+	static bool	sUseMultGL;
 
 	friend class LLWindowManager;
 	

--- a/indra/llwindow/llwindowmesaheadless.cpp
+++ b/indra/llwindow/llwindowmesaheadless.cpp
@@ -40,8 +40,8 @@ U16 *gMesaBuffer = NULL;
 //
 LLWindowMesaHeadless::LLWindowMesaHeadless(LLWindowCallbacks* callbacks,
                                            const std::string& title, const std::string& name, S32 x, S32 y, S32 width, S32 height,
-							 U32 flags,  BOOL fullscreen, BOOL clearBg,
-							 BOOL disable_vsync, BOOL use_gl, BOOL ignore_pixel_depth)
+							 U32 flags,  bool fullscreen, bool clearBg,
+							 bool disable_vsync, bool use_gl, bool ignore_pixel_depth)
 	: LLWindow(callbacks, fullscreen, flags)
 {
 	if (use_gl)

--- a/indra/llwindow/llwindowmesaheadless.h
+++ b/indra/llwindow/llwindowmesaheadless.h
@@ -39,38 +39,38 @@ public:
 	/*virtual*/ void show() {};
 	/*virtual*/ void hide() {};
 	/*virtual*/ void close() {};
-	/*virtual*/ BOOL getVisible() {return FALSE;};
-	/*virtual*/ BOOL getMinimized() {return FALSE;};
-	/*virtual*/ BOOL getMaximized() {return FALSE;};
-	/*virtual*/ BOOL maximize() {return FALSE;};
+	/*virtual*/ bool getVisible() {return false;};
+	/*virtual*/ bool getMinimized() {return false;};
+	/*virtual*/ bool getMaximized() {return false;};
+	/*virtual*/ bool maximize() {return false;};
 	/*virtual*/ void minimize() {};
 	/*virtual*/ void restore() {};
-	/*virtual*/ BOOL getFullscreen() {return FALSE;};
-	/*virtual*/ BOOL getPosition(LLCoordScreen *position) {return FALSE;};
-	/*virtual*/ BOOL getSize(LLCoordScreen *size) {return FALSE;};
-	/*virtual*/ BOOL getSize(LLCoordWindow *size) {return FALSE;};
-	/*virtual*/ BOOL setPosition(LLCoordScreen position) {return FALSE;};
-	/*virtual*/ BOOL setSizeImpl(LLCoordScreen size) {return FALSE;};
-	/*virtual*/ BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL disable_vsync, const LLCoordScreen * const posp = NULL) {return FALSE;};
-	/*virtual*/ BOOL setCursorPosition(LLCoordWindow position) {return FALSE;};
-	/*virtual*/ BOOL getCursorPosition(LLCoordWindow *position) {return FALSE;};
+	/*virtual*/ bool getFullscreen() {return false;};
+	/*virtual*/ bool getPosition(LLCoordScreen *position) {return false;};
+	/*virtual*/ bool getSize(LLCoordScreen *size) {return false;};
+	/*virtual*/ bool getSize(LLCoordWindow *size) {return false;};
+	/*virtual*/ bool setPosition(LLCoordScreen position) {return false;};
+	/*virtual*/ bool setSizeImpl(LLCoordScreen size) {return false;};
+	/*virtual*/ bool switchContext(bool fullscreen, const LLCoordScreen &size, bool disable_vsync, const LLCoordScreen * const posp = NULL) {return false;};
+	/*virtual*/ bool setCursorPosition(LLCoordWindow position) {return false;};
+	/*virtual*/ bool getCursorPosition(LLCoordWindow *position) {return false;};
 	/*virtual*/ void showCursor() {};
 	/*virtual*/ void hideCursor() {};
 	/*virtual*/ void showCursorFromMouseMove() {};
 	/*virtual*/ void hideCursorUntilMouseMove() {};
-	/*virtual*/ BOOL isCursorHidden() {return FALSE;};
+	/*virtual*/ bool isCursorHidden() {return false;};
 	/*virtual*/ void updateCursor() {};
 	//virtual ECursorType getCursor() { return mCurrentCursor; };
 	/*virtual*/ void captureMouse() {};
 	/*virtual*/ void releaseMouse() {};
-	/*virtual*/ void setMouseClipping( BOOL b ) {};
-	/*virtual*/ BOOL isClipboardTextAvailable() {return FALSE; };
-	/*virtual*/ BOOL pasteTextFromClipboard(LLWString &dst) {return FALSE; };
-	/*virtual*/ BOOL copyTextToClipboard(const LLWString &src) {return FALSE; };
+	/*virtual*/ void setMouseClipping( bool b ) {};
+	/*virtual*/ bool isClipboardTextAvailable() {return false; };
+	/*virtual*/ bool pasteTextFromClipboard(LLWString &dst) {return false; };
+	/*virtual*/ bool copyTextToClipboard(const LLWString &src) {return false; };
 	/*virtual*/ void flashIcon(F32 seconds) {};
 	/*virtual*/ F32 getGamma() {return 1.0f; };
-	/*virtual*/ BOOL setGamma(const F32 gamma) {return FALSE; }; // Set the gamma
-	/*virtual*/ BOOL restoreGamma() {return FALSE; };	// Restore original gamma table (before updating gamma)
+	/*virtual*/ bool setGamma(const F32 gamma) {return false; }; // Set the gamma
+	/*virtual*/ bool restoreGamma() {return false; };	// Restore original gamma table (before updating gamma)
 	/*virtual*/ void setFSAASamples(const U32 fsaa_samples) { /* FSAA not supported yet on Mesa headless.*/ }
 	/*virtual*/ U32	 getFSAASamples() { return 0; }
 	//virtual ESwapMethod getSwapMethod() { return mSwapMethod; }
@@ -80,12 +80,12 @@ public:
 	/*virtual*/ void restoreGLContext() {};
 
 	// handy coordinate space conversion routines
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordWindow *to) { return FALSE; };
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordScreen *to) { return FALSE; };
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordGL *to) { return FALSE; };
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordWindow *to) { return FALSE; };
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordGL *to) { return FALSE; };
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordScreen *to) { return FALSE; };
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordWindow *to) { return false; };
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordScreen *to) { return false; };
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordGL *to) { return false; };
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordWindow *to) { return false; };
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordGL *to) { return false; };
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordScreen *to) { return false; };
 
 	/*virtual*/ LLWindowResolution* getSupportedResolutions(S32 &num_resolutions) { return NULL; };
 	/*virtual*/ F32	getNativeAspectRatio() { return 1.0f; };
@@ -97,8 +97,8 @@ public:
 	
 	LLWindowMesaHeadless(LLWindowCallbacks* callbacks,
                          const std::string& title, const std::string& name, S32 x, S32 y, S32 width, S32 height,
-				  U32 flags,  BOOL fullscreen, BOOL clearBg,
-				  BOOL disable_vsync, BOOL use_gl, BOOL ignore_pixel_depth);
+				  U32 flags,  bool fullscreen, bool clearBg,
+				  bool disable_vsync, bool use_gl, bool ignore_pixel_depth);
 	~LLWindowMesaHeadless();
 
 private:

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -59,7 +59,7 @@ extern "C" {
 # include <sys/wait.h>
 #endif // LL_LINUX
 
-extern BOOL gDebugWindowProc;
+extern bool gDebugWindowProc;
 
 const S32 MAX_NUM_RESOLUTIONS = 200;
 
@@ -102,10 +102,10 @@ void maybe_unlock_display(void)
 // static
 bool LLWindowSDL::ll_try_gtk_init(void)
 {
-	static BOOL done_gtk_diag = FALSE;
-	static BOOL gtk_is_good = FALSE;
-	static BOOL done_setlocale = FALSE;
-	static BOOL tried_gtk_init = FALSE;
+	static bool done_gtk_diag = false;
+	static bool gtk_is_good = false;
+	static bool done_setlocale = false;
+	static bool tried_gtk_init = false;
 
 	if (!done_setlocale)
 	{
@@ -113,12 +113,12 @@ bool LLWindowSDL::ll_try_gtk_init(void)
 		maybe_lock_display();
 		gtk_disable_setlocale();
 		maybe_unlock_display();
-		done_setlocale = TRUE;
+		done_setlocale = true;
 	}
 	
 	if (!tried_gtk_init)
 	{
-		tried_gtk_init = TRUE;
+		tried_gtk_init = true;
 		if (!g_thread_supported ()) g_thread_init (NULL);
 		maybe_lock_display();
 		gtk_is_good = gtk_init_check(NULL, NULL);
@@ -148,12 +148,12 @@ bool LLWindowSDL::ll_try_gtk_init(void)
 		{
 			LL_WARNS() << "- GTK COMPATIBILITY WARNING: " <<
 				gtk_warning << LL_ENDL;
-			gtk_is_good = FALSE;
+			gtk_is_good = false;
 		} else {
 			LL_INFOS() << "- GTK version is good." << LL_ENDL;
 		}
 
-		done_gtk_diag = TRUE;
+		done_gtk_diag = true;
 	}
 
 	return gtk_is_good;
@@ -185,9 +185,9 @@ Display* LLWindowSDL::get_SDL_Display(void)
 LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
 			 const std::string& title, S32 x, S32 y, S32 width,
 			 S32 height, U32 flags,
-			 BOOL fullscreen, BOOL clearBg,
-			 BOOL disable_vsync, BOOL use_gl,
-			 BOOL ignore_pixel_depth, U32 fsaa_samples)
+			 bool fullscreen, bool clearBg,
+			 bool disable_vsync, bool use_gl,
+			 bool ignore_pixel_depth, U32 fsaa_samples)
 	: LLWindow(callbacks, fullscreen, flags),
 	  Lock_Display(NULL),
 	  Unlock_Display(NULL), mGamma(1.0f)
@@ -199,7 +199,7 @@ LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
 
 	// Ignore use_gl for now, only used for drones on PC
 	mWindow = NULL;
-	mNeedsResize = FALSE;
+	mNeedsResize = false;
 	mOverrideAspectRatio = 0.f;
 	mGrabbyKeyFlags = 0;
 	mReallyCapturedCount = 0;
@@ -243,7 +243,7 @@ LLWindowSDL::LLWindowSDL(LLWindowCallbacks* callbacks,
 	gWindowImplementation = this;
 
 #if LL_X11
-	mFlashing = FALSE;
+	mFlashing = false;
 #endif // LL_X11
 
 	mKeyScanCode = 0;
@@ -406,7 +406,7 @@ static int x11_detect_VRAM_kb()
 }
 #endif // LL_X11
 
-BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, BOOL fullscreen, BOOL disable_vsync)
+bool LLWindowSDL::createContext(int x, int y, int width, int height, int bits, bool fullscreen, bool disable_vsync)
 {
 	//bool			glneedsinit = false;
 
@@ -442,7 +442,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 	{
 		LL_INFOS() << "SDL_GetVideoInfo() failed! " << SDL_GetError() << LL_ENDL;
 		setupFailure("SDL_GetVideoInfo() failed, Window creation error", "Error", OSMB_OK);
-		return FALSE;
+		return false;
 	}
 
 	if (video_info->current_h > 0)
@@ -560,7 +560,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 
 		if (mWindow)
 		{
-			mFullscreen = TRUE;
+			mFullscreen = true;
 			mFullscreenWidth   = mWindow->w;
 			mFullscreenHeight  = mWindow->h;
 			mFullscreenBits    = mWindow->format->BitsPerPixel;
@@ -576,7 +576,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 		{
 			LL_WARNS() << "createContext: fullscreen creation failure. SDL: " << SDL_GetError() << LL_ENDL;
 			// No fullscreen support
-			mFullscreen = FALSE;
+			mFullscreen = false;
 			mFullscreenWidth   = -1;
 			mFullscreenHeight  = -1;
 			mFullscreenBits    = -1;
@@ -606,7 +606,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 		{
 			LL_WARNS() << "createContext: window creation failure. SDL: " << SDL_GetError() << LL_ENDL;
 			setupFailure("Window creation error", "Error", OSMB_OK);
-			return FALSE;
+			return false;
 		}
 	} else if (!mFullscreen && (mWindow != NULL))
 	{
@@ -669,7 +669,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 			"will automatically adjust the screen each time it runs.",
 			"Error",
 			OSMB_OK);
-		return FALSE;
+		return false;
 	}
 
 #if 0  // *FIX: we're going to brave it for now...
@@ -685,7 +685,7 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 			"If you continue to receive this message, contact customer service.",
 			"Error",
 			OSMB_OK);
-		return FALSE;
+		return false;
 	}
 #endif
 
@@ -726,15 +726,15 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
 	    LL_WARNS() << "Couldn't enable key-repeat: " << SDL_GetError() <<LL_ENDL;
 
 	// Don't need to get the current gamma, since there's a call that restores it to the system defaults.
-	return TRUE;
+	return true;
 }
 
 
 // changing fullscreen resolution, or switching between windowed and fullscreen mode.
-BOOL LLWindowSDL::switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL disable_vsync, const LLCoordScreen * const posp)
+bool LLWindowSDL::switchContext(bool fullscreen, const LLCoordScreen &size, bool disable_vsync, const LLCoordScreen * const posp)
 {
-	const BOOL needsRebuild = TRUE;  // Just nuke the context and start over.
-	BOOL result = true;
+	const bool needsRebuild = true;  // Just nuke the context and start over.
+	bool result = true;
 
 	LL_INFOS() << "switchContext, fullscreen=" << fullscreen << LL_ENDL;
 	stop_glerror();
@@ -825,45 +825,45 @@ void LLWindowSDL::close()
 	//	}
 
 	// Make sure cursor is visible and we haven't mangled the clipping state.
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	showCursor();
 
 	destroyContext();
 }
 
-BOOL LLWindowSDL::isValid()
+bool LLWindowSDL::isValid()
 {
 	return (mWindow != NULL);
 }
 
-BOOL LLWindowSDL::getVisible()
+bool LLWindowSDL::getVisible()
 {
-	BOOL result = FALSE;
+	bool result = false;
 
     // *FIX: This isn't really right...
 	// Then what is?
 	if (mWindow)
 	{
-		result = TRUE;
+		result = true;
 	}
 
 	return(result);
 }
 
-BOOL LLWindowSDL::getMinimized()
+bool LLWindowSDL::getMinimized()
 {
-	BOOL result = FALSE;
+	bool result = false;
 
 	if (mWindow && (1 == mIsMinimized))
 	{
-		result = TRUE;
+		result = true;
 	}
 	return(result);
 }
 
-BOOL LLWindowSDL::getMaximized()
+bool LLWindowSDL::getMaximized()
 {
-	BOOL result = FALSE;
+	bool result = false;
 
 	if (mWindow)
 	{
@@ -873,50 +873,50 @@ BOOL LLWindowSDL::getMaximized()
 	return(result);
 }
 
-BOOL LLWindowSDL::maximize()
+bool LLWindowSDL::maximize()
 {
 	// TODO
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowSDL::getFullscreen()
+bool LLWindowSDL::getFullscreen()
 {
 	return mFullscreen;
 }
 
-BOOL LLWindowSDL::getPosition(LLCoordScreen *position)
+bool LLWindowSDL::getPosition(LLCoordScreen *position)
 {
     // *FIX: can anything be done with this?
 	position->mX = 0;
 	position->mY = 0;
-    return TRUE;
+    return true;
 }
 
-BOOL LLWindowSDL::getSize(LLCoordScreen *size)
+bool LLWindowSDL::getSize(LLCoordScreen *size)
 {
     if (mWindow)
     {
         size->mX = mWindow->w;
         size->mY = mWindow->h;
-	return (TRUE);
+	return (true);
     }
 
-    return (FALSE);
+    return (false);
 }
 
-BOOL LLWindowSDL::getSize(LLCoordWindow *size)
+bool LLWindowSDL::getSize(LLCoordWindow *size)
 {
     if (mWindow)
     {
         size->mX = mWindow->w;
         size->mY = mWindow->h;
-	return (TRUE);
+	return (true);
     }
 
-    return (FALSE);
+    return (false);
 }
 
-BOOL LLWindowSDL::setPosition(const LLCoordScreen position)
+bool LLWindowSDL::setPosition(const LLCoordScreen position)
 {
 	if(mWindow)
 	{
@@ -924,10 +924,10 @@ BOOL LLWindowSDL::setPosition(const LLCoordScreen position)
 		//MacMoveWindow(mWindow, position.mX, position.mY, false);
 	}
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowSDL::setSizeImpl(const LLCoordScreen size)
+bool LLWindowSDL::setSizeImpl(const LLCoordScreen size)
 {
 	if(mWindow)
 	{
@@ -939,13 +939,13 @@ BOOL LLWindowSDL::setSizeImpl(const LLCoordScreen size)
 		event.resize.h = size.mY;
 		SDL_PushEvent(&event); // copied into queue
 
-		return TRUE;
+		return true;
 	}
 		
-	return FALSE;
+	return false;
 }
 
-BOOL LLWindowSDL::setSizeImpl(const LLCoordWindow size)
+bool LLWindowSDL::setSizeImpl(const LLCoordWindow size)
 {
 	if(mWindow)
 	{
@@ -957,10 +957,10 @@ BOOL LLWindowSDL::setSizeImpl(const LLCoordWindow size)
 		event.resize.h = size.mY;
 		SDL_PushEvent(&event); // copied into queue
 
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 
@@ -987,14 +987,14 @@ F32 LLWindowSDL::getGamma()
 	return 1/mGamma;
 }
 
-BOOL LLWindowSDL::restoreGamma()
+bool LLWindowSDL::restoreGamma()
 {
 	//CGDisplayRestoreColorSyncSettings();
     SDL_SetGamma(1.0f, 1.0f, 1.0f);
 	return true;
 }
 
-BOOL LLWindowSDL::setGamma(const F32 gamma)
+bool LLWindowSDL::setGamma(const F32 gamma)
 {
 	mGamma = gamma;
 	if (mGamma == 0) mGamma = 0.1f;
@@ -1003,7 +1003,7 @@ BOOL LLWindowSDL::setGamma(const F32 gamma)
 	return true;
 }
 
-BOOL LLWindowSDL::isCursorHidden()
+bool LLWindowSDL::isCursorHidden()
 {
 	return mCursorHidden;
 }
@@ -1011,7 +1011,7 @@ BOOL LLWindowSDL::isCursorHidden()
 
 
 // Constrains the mouse to the window.
-void LLWindowSDL::setMouseClipping( BOOL b )
+void LLWindowSDL::setMouseClipping( bool b )
 {
     //SDL_WM_GrabInput(b ? SDL_GRAB_ON : SDL_GRAB_OFF);
 }
@@ -1035,14 +1035,14 @@ void LLWindowSDL::setMinSize(U32 min_width, U32 min_height, bool enforce_immedia
 #endif
 }
 
-BOOL LLWindowSDL::setCursorPosition(const LLCoordWindow position)
+bool LLWindowSDL::setCursorPosition(const LLCoordWindow position)
 {
-	BOOL result = TRUE;
+	bool result = true;
 	LLCoordScreen screen_pos;
 
 	if (!convertCoords(position, &screen_pos))
 	{
-		return FALSE;
+		return false;
 	}
 
 	//LL_INFOS() << "setCursorPosition(" << screen_pos.mX << ", " << screen_pos.mY << ")" << LL_ENDL;
@@ -1055,7 +1055,7 @@ BOOL LLWindowSDL::setCursorPosition(const LLCoordWindow position)
 	return result;
 }
 
-BOOL LLWindowSDL::getCursorPosition(LLCoordWindow *position)
+bool LLWindowSDL::getCursorPosition(LLCoordWindow *position)
 {
 	//Point cursor_point;
 	LLCoordScreen screen_pos;
@@ -1137,7 +1137,7 @@ void LLWindowSDL::beforeDialog()
 
 	LL_INFOS() << "LLWindowSDL::beforeDialog()" << LL_ENDL;
 
-	if (SDLReallyCaptureInput(FALSE)) // must ungrab input so popup works!
+	if (SDLReallyCaptureInput(false)) // must ungrab input so popup works!
 	{
 		if (mFullscreen)
 		{
@@ -1196,7 +1196,7 @@ void LLWindowSDL::afterDialog()
 
 #if LL_X11
 // set/reset the XWMHints flag for 'urgency' that usually makes the icon flash
-void LLWindowSDL::x11_set_urgent(BOOL urgent)
+void LLWindowSDL::x11_set_urgent(bool urgent)
 {
 	if (mSDL_Display && !mFullscreen)
 	{
@@ -1235,26 +1235,26 @@ void LLWindowSDL::flashIcon(F32 seconds)
 	mFlashTimer.reset();
 	mFlashTimer.setTimerExpirySec(remaining_time);
 
-	x11_set_urgent(TRUE);
-	mFlashing = TRUE;
+	x11_set_urgent(true);
+	mFlashing = true;
 #endif // LL_X11
 }
 
 
 #if LL_GTK
-BOOL LLWindowSDL::isClipboardTextAvailable()
+bool LLWindowSDL::isClipboardTextAvailable()
 {
 	if (ll_try_gtk_init())
 	{
 		GtkClipboard * const clipboard =
 			gtk_clipboard_get(GDK_NONE);
 		return gtk_clipboard_wait_is_text_available(clipboard) ?
-			TRUE : FALSE;
+			true : false;
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
-BOOL LLWindowSDL::pasteTextFromClipboard(LLWString &text)
+bool LLWindowSDL::pasteTextFromClipboard(LLWString &text)
 {
 	if (ll_try_gtk_init())
 	{
@@ -1265,13 +1265,13 @@ BOOL LLWindowSDL::pasteTextFromClipboard(LLWString &text)
 		{
 			text = LLWString(utf8str_to_wstring(data));
 			g_free(data);
-			return TRUE;
+			return true;
 		}
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
-BOOL LLWindowSDL::copyTextToClipboard(const LLWString &text)
+bool LLWindowSDL::copyTextToClipboard(const LLWString &text)
 {
 	if (ll_try_gtk_init())
 	{
@@ -1279,25 +1279,25 @@ BOOL LLWindowSDL::copyTextToClipboard(const LLWString &text)
 		GtkClipboard * const clipboard =
 			gtk_clipboard_get(GDK_NONE);
 		gtk_clipboard_set_text(clipboard, utf8.c_str(), utf8.length());
-		return TRUE;
+		return true;
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
 
-BOOL LLWindowSDL::isPrimaryTextAvailable()
+bool LLWindowSDL::isPrimaryTextAvailable()
 {
 	if (ll_try_gtk_init())
 	{
 		GtkClipboard * const clipboard =
 			gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 		return gtk_clipboard_wait_is_text_available(clipboard) ?
-			TRUE : FALSE;
+			true : false;
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
-BOOL LLWindowSDL::pasteTextFromPrimary(LLWString &text)
+bool LLWindowSDL::pasteTextFromPrimary(LLWString &text)
 {
 	if (ll_try_gtk_init())
 	{
@@ -1308,13 +1308,13 @@ BOOL LLWindowSDL::pasteTextFromPrimary(LLWString &text)
 		{
 			text = LLWString(utf8str_to_wstring(data));
 			g_free(data);
-			return TRUE;
+			return true;
 		}
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
-BOOL LLWindowSDL::copyTextToPrimary(const LLWString &text)
+bool LLWindowSDL::copyTextToPrimary(const LLWString &text)
 {
 	if (ll_try_gtk_init())
 	{
@@ -1322,41 +1322,41 @@ BOOL LLWindowSDL::copyTextToPrimary(const LLWString &text)
 		GtkClipboard * const clipboard =
 			gtk_clipboard_get(GDK_SELECTION_PRIMARY);
 		gtk_clipboard_set_text(clipboard, utf8.c_str(), utf8.length());
-		return TRUE;
+		return true;
 	}
-	return FALSE; // failure
+	return false; // failure
 }
 
 #else
 
-BOOL LLWindowSDL::isClipboardTextAvailable()
+bool LLWindowSDL::isClipboardTextAvailable()
 {
-	return FALSE; // unsupported
+	return false; // unsupported
 }
 
-BOOL LLWindowSDL::pasteTextFromClipboard(LLWString &dst)
+bool LLWindowSDL::pasteTextFromClipboard(LLWString &dst)
 {
-	return FALSE; // unsupported
+	return false; // unsupported
 }
 
-BOOL LLWindowSDL::copyTextToClipboard(const LLWString &s)
+bool LLWindowSDL::copyTextToClipboard(const LLWString &s)
 {
-	return FALSE;  // unsupported
+	return false;  // unsupported
 }
 
-BOOL LLWindowSDL::isPrimaryTextAvailable()
+bool LLWindowSDL::isPrimaryTextAvailable()
 {
-	return FALSE; // unsupported
+	return false; // unsupported
 }
 
-BOOL LLWindowSDL::pasteTextFromPrimary(LLWString &dst)
+bool LLWindowSDL::pasteTextFromPrimary(LLWString &dst)
 {
-	return FALSE; // unsupported
+	return false; // unsupported
 }
 
-BOOL LLWindowSDL::copyTextToPrimary(const LLWString &s)
+bool LLWindowSDL::copyTextToPrimary(const LLWString &s)
 {
-	return FALSE;  // unsupported
+	return false;  // unsupported
 }
 
 #endif // LL_GTK
@@ -1404,58 +1404,58 @@ LLWindow::LLWindowResolution* LLWindowSDL::getSupportedResolutions(S32 &num_reso
 	return mSupportedResolutions;
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordGL from, LLCoordWindow *to)
+bool LLWindowSDL::convertCoords(LLCoordGL from, LLCoordWindow *to)
 {
     if (!to)
-        return FALSE;
+        return false;
 
 	to->mX = from.mX;
 	to->mY = mWindow->h - from.mY - 1;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordWindow from, LLCoordGL* to)
+bool LLWindowSDL::convertCoords(LLCoordWindow from, LLCoordGL* to)
 {
     if (!to)
-        return FALSE;
+        return false;
 
 	to->mX = from.mX;
 	to->mY = mWindow->h - from.mY - 1;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordScreen from, LLCoordWindow* to)
+bool LLWindowSDL::convertCoords(LLCoordScreen from, LLCoordWindow* to)
 {
     if (!to)
-		return FALSE;
+		return false;
 
 	// In the fullscreen case, window and screen coordinates are the same.
 	to->mX = from.mX;
 	to->mY = from.mY;
-    return (TRUE);
+    return (true);
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordWindow from, LLCoordScreen *to)
+bool LLWindowSDL::convertCoords(LLCoordWindow from, LLCoordScreen *to)
 {
     if (!to)
-		return FALSE;
+		return false;
 
 	// In the fullscreen case, window and screen coordinates are the same.
 	to->mX = from.mX;
 	to->mY = from.mY;
-    return (TRUE);
+    return (true);
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordScreen from, LLCoordGL *to)
+bool LLWindowSDL::convertCoords(LLCoordScreen from, LLCoordGL *to)
 {
 	LLCoordWindow window_coord;
 
 	return(convertCoords(from, &window_coord) && convertCoords(window_coord, to));
 }
 
-BOOL LLWindowSDL::convertCoords(LLCoordGL from, LLCoordScreen *to)
+bool LLWindowSDL::convertCoords(LLCoordGL from, LLCoordScreen *to)
 {
 	LLCoordWindow window_coord;
 
@@ -1472,7 +1472,7 @@ void LLWindowSDL::setupFailure(const std::string& text, const std::string& capti
 	OSMessageBox(text, caption, type);
 }
 
-BOOL LLWindowSDL::SDLReallyCaptureInput(BOOL capture)
+bool LLWindowSDL::SDLReallyCaptureInput(bool capture)
 {
 	// note: this used to be safe to call nestedly, but in the
 	// end that's not really a wise usage pattern, so don't.
@@ -1554,7 +1554,7 @@ BOOL LLWindowSDL::SDLReallyCaptureInput(BOOL capture)
 		(!capture && SDL_GRAB_OFF==newmode);
 }
 
-U32 LLWindowSDL::SDLCheckGrabbyKeys(SDLKey keysym, BOOL gain)
+U32 LLWindowSDL::SDLCheckGrabbyKeys(SDLKey keysym, bool gain)
 {
 	/* part of the fix for SL-13243: Some popular window managers like
 	   to totally eat alt-drag for the purposes of moving windows.  We
@@ -1714,7 +1714,7 @@ void LLWindowSDL::processMiscNativeEvents()
 	    pump_timer.setTimerExpirySec(1.0f / 15.0f);
 	    do {
 		     // Always do at least one non-blocking pump
-		    gtk_main_iteration_do(FALSE);
+		    gtk_main_iteration_do(false);
 	    } while (gtk_events_pending() &&
 		     !pump_timer.hasExpired());
 
@@ -1748,7 +1748,7 @@ void LLWindowSDL::gatherInput()
                 LLCoordWindow winCoord(event.button.x, event.button.y);
                 LLCoordGL openGlCoord;
                 convertCoords(winCoord, &openGlCoord);
-				MASK mask = gKeyboard->currentMask(TRUE);
+				MASK mask = gKeyboard->currentMask(true);
 				mCallbacks->handleMouseMove(this, openGlCoord, mask);
                 break;
             }
@@ -1760,13 +1760,13 @@ void LLWindowSDL::gatherInput()
 
 		    gKeyboard->handleKeyDown(event.key.keysym.sym, event.key.keysym.mod);
 		    // part of the fix for SL-13243
-		    if (SDLCheckGrabbyKeys(event.key.keysym.sym, TRUE) != 0)
-			    SDLReallyCaptureInput(TRUE);
+		    if (SDLCheckGrabbyKeys(event.key.keysym.sym, true) != 0)
+			    SDLReallyCaptureInput(true);
 
 		    if (event.key.keysym.unicode)
 		    {
 			    handleUnicodeUTF16(event.key.keysym.unicode,
-					       gKeyboard->currentMask(FALSE));
+					       gKeyboard->currentMask(false));
 		    }
                 break;
 
@@ -1775,8 +1775,8 @@ void LLWindowSDL::gatherInput()
 		    mKeyVirtualKey = event.key.keysym.unicode;
 		    mKeyModifiers = event.key.keysym.mod;
 
-		    if (SDLCheckGrabbyKeys(event.key.keysym.sym, FALSE) == 0)
-			    SDLReallyCaptureInput(FALSE); // part of the fix for SL-13243
+		    if (SDLCheckGrabbyKeys(event.key.keysym.sym, false) == 0)
+			    SDLReallyCaptureInput(false); // part of the fix for SL-13243
 
 		    gKeyboard->handleKeyUp(event.key.keysym.sym, event.key.keysym.mod);
 		    break;
@@ -1787,7 +1787,7 @@ void LLWindowSDL::gatherInput()
                 LLCoordWindow winCoord(event.button.x, event.button.y);
                 LLCoordGL openGlCoord;
                 convertCoords(winCoord, &openGlCoord);
-		MASK mask = gKeyboard->currentMask(TRUE);
+		MASK mask = gKeyboard->currentMask(true);
 
                 if (event.button.button == SDL_BUTTON_LEFT)   // SDL doesn't manage double clicking...
                 {
@@ -1850,7 +1850,7 @@ void LLWindowSDL::gatherInput()
                 LLCoordWindow winCoord(event.button.x, event.button.y);
                 LLCoordGL openGlCoord;
                 convertCoords(winCoord, &openGlCoord);
-		MASK mask = gKeyboard->currentMask(TRUE);
+		MASK mask = gKeyboard->currentMask(true);
 
                 if (event.button.button == SDL_BUTTON_LEFT)  // left
 			mCallbacks->handleMouseUp(this, openGlCoord, mask);
@@ -1921,11 +1921,11 @@ void LLWindowSDL::gatherInput()
 				mIsMinimized = (!event.active.gain);
 
 				mCallbacks->handleActivate(this, !mIsMinimized);
-				LL_INFOS() << "SDL deiconification state switched to " << BOOL(event.active.gain) << LL_ENDL;
+				LL_INFOS() << "SDL deiconification state switched to " << bool(event.active.gain) << LL_ENDL;
 			}
 			else
 			{
-				LL_INFOS() << "Ignored bogus redundant SDL deiconification state switch to " << BOOL(event.active.gain) << LL_ENDL;
+				LL_INFOS() << "Ignored bogus redundant SDL deiconification state switch to " << bool(event.active.gain) << LL_ENDL;
 			}
                 }
                 break;
@@ -1951,8 +1951,8 @@ void LLWindowSDL::gatherInput()
     // expired.
     if (mFlashing && mFlashTimer.hasExpired())
     {
-	    x11_set_urgent(FALSE);
-	    mFlashing = FALSE;
+	    x11_set_urgent(false);
+	    mFlashing = false;
     }
 #endif // LL_X11
 }
@@ -2003,10 +2003,10 @@ static SDL_Cursor *makeSDLCursorFromBMP(const char *filename, int hotx, int hoty
 					U8 srcred = pixelp[0];
 					U8 srcgreen = pixelp[1];
 					U8 srcblue = pixelp[2];
-					BOOL mask_bit = (srcred != 200)
+					bool mask_bit = (srcred != 200)
 						|| (srcgreen != 200)
 						|| (srcblue != 200);
-					BOOL data_bit = mask_bit && (srcgreen <= 80);//not 0x80
+					bool data_bit = mask_bit && (srcgreen <= 80);//not 0x80
 					unsigned char bit_offset = (cursurface->w/8) * i
 						+ j/8;
 					cursor_data[bit_offset]	|= (data_bit) << (7 - (j&7));
@@ -2165,8 +2165,8 @@ void LLWindowSDL::hideCursor()
 	if(!mCursorHidden)
 	{
 		// LL_INFOS() << "hideCursor: hiding" << LL_ENDL;
-		mCursorHidden = TRUE;
-		mHideCursorPermanent = TRUE;
+		mCursorHidden = true;
+		mHideCursorPermanent = true;
 		SDL_ShowCursor(0);
 	}
 	else
@@ -2180,8 +2180,8 @@ void LLWindowSDL::showCursor()
 	if(mCursorHidden)
 	{
 		// LL_INFOS() << "showCursor: showing" << LL_ENDL;
-		mCursorHidden = FALSE;
-		mHideCursorPermanent = FALSE;
+		mCursorHidden = false;
+		mHideCursorPermanent = false;
 		SDL_ShowCursor(1);
 	}
 	else
@@ -2203,7 +2203,7 @@ void LLWindowSDL::hideCursorUntilMouseMove()
 	if (!mHideCursorPermanent)
 	{
 		hideCursor();
-		mHideCursorPermanent = FALSE;
+		mHideCursorPermanent = false;
 	}
 }
 
@@ -2385,9 +2385,9 @@ LLSD LLWindowSDL::getNativeKeyData()
 }
 
 
-BOOL LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
+bool LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 {
-	BOOL rtn = FALSE;
+	bool rtn = false;
 
 	beforeDialog();
 
@@ -2421,8 +2421,8 @@ BOOL LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 
 		gtk_color_selection_set_previous_color (colorsel, &color);
 		gtk_color_selection_set_current_color (colorsel, &color);
-		gtk_color_selection_set_has_palette (colorsel, TRUE);
-		gtk_color_selection_set_has_opacity_control(colorsel, FALSE);
+		gtk_color_selection_set_has_palette (colorsel, true);
+		gtk_color_selection_set_has_opacity_control(colorsel, false);
 
 		gint response = GTK_RESPONSE_NONE;
 		g_signal_connect (win,
@@ -2434,7 +2434,7 @@ BOOL LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 				  G_CALLBACK (color_changed_callback),
 				  &color);
 
-		gtk_window_set_modal(GTK_WINDOW(win), TRUE);
+		gtk_window_set_modal(GTK_WINDOW(win), true);
 		gtk_widget_show_all(win);
 		// hide the help button - we don't service it.
 		gtk_widget_hide(GTK_COLOR_SELECTION_DIALOG(win)->help_button);
@@ -2448,7 +2448,7 @@ BOOL LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 			*r = color.red / 65535.0f;
 			*g = color.green / 65535.0f;
 			*b = color.blue / 65535.0f;
-			rtn = TRUE;
+			rtn = true;
 		}
 	}
 
@@ -2463,9 +2463,9 @@ S32 OSMessageBoxSDL(const std::string& text, const std::string& caption, U32 typ
 	return 0;
 }
 
-BOOL LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
+bool LLWindowSDL::dialogColorPicker( F32 *r, F32 *g, F32 *b)
 {
-	return (FALSE);
+	return (false);
 }
 #endif // LL_GTK
 

--- a/indra/llwindow/llwindowsdl.h
+++ b/indra/llwindow/llwindowsdl.h
@@ -52,47 +52,47 @@ public:
 	/*virtual*/ void show();
 	/*virtual*/ void hide();
 	/*virtual*/ void close();
-	/*virtual*/ BOOL getVisible();
-	/*virtual*/ BOOL getMinimized();
-	/*virtual*/ BOOL getMaximized();
-	/*virtual*/ BOOL maximize();
+	/*virtual*/ bool getVisible();
+	/*virtual*/ bool getMinimized();
+	/*virtual*/ bool getMaximized();
+	/*virtual*/ bool maximize();
 	/*virtual*/ void minimize();
 	/*virtual*/ void restore();
-	/*virtual*/ BOOL getFullscreen();
-	/*virtual*/ BOOL getPosition(LLCoordScreen *position);
-	/*virtual*/ BOOL getSize(LLCoordScreen *size);
-	/*virtual*/ BOOL getSize(LLCoordWindow *size);
-	/*virtual*/ BOOL setPosition(LLCoordScreen position);
-	/*virtual*/ BOOL setSizeImpl(LLCoordScreen size);
-	/*virtual*/ BOOL setSizeImpl(LLCoordWindow size);
-	/*virtual*/ BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL disable_vsync, const LLCoordScreen * const posp = NULL);
-	/*virtual*/ BOOL setCursorPosition(LLCoordWindow position);
-	/*virtual*/ BOOL getCursorPosition(LLCoordWindow *position);
+	/*virtual*/ bool getFullscreen();
+	/*virtual*/ bool getPosition(LLCoordScreen *position);
+	/*virtual*/ bool getSize(LLCoordScreen *size);
+	/*virtual*/ bool getSize(LLCoordWindow *size);
+	/*virtual*/ bool setPosition(LLCoordScreen position);
+	/*virtual*/ bool setSizeImpl(LLCoordScreen size);
+	/*virtual*/ bool setSizeImpl(LLCoordWindow size);
+	/*virtual*/ bool switchContext(bool fullscreen, const LLCoordScreen &size, bool disable_vsync, const LLCoordScreen * const posp = NULL);
+	/*virtual*/ bool setCursorPosition(LLCoordWindow position);
+	/*virtual*/ bool getCursorPosition(LLCoordWindow *position);
 	/*virtual*/ void showCursor();
 	/*virtual*/ void hideCursor();
 	/*virtual*/ void showCursorFromMouseMove();
 	/*virtual*/ void hideCursorUntilMouseMove();
-	/*virtual*/ BOOL isCursorHidden();
+	/*virtual*/ bool isCursorHidden();
 	/*virtual*/ void updateCursor();
 	/*virtual*/ void captureMouse();
 	/*virtual*/ void releaseMouse();
-	/*virtual*/ void setMouseClipping( BOOL b );
+	/*virtual*/ void setMouseClipping( bool b );
 	/*virtual*/	void setMinSize(U32 min_width, U32 min_height, bool enforce_immediately = true);
 
-	/*virtual*/ BOOL isClipboardTextAvailable();
-	/*virtual*/ BOOL pasteTextFromClipboard(LLWString &dst);
-	/*virtual*/ BOOL copyTextToClipboard(const LLWString & src);
+	/*virtual*/ bool isClipboardTextAvailable();
+	/*virtual*/ bool pasteTextFromClipboard(LLWString &dst);
+	/*virtual*/ bool copyTextToClipboard(const LLWString & src);
 
-	/*virtual*/ BOOL isPrimaryTextAvailable();
-	/*virtual*/ BOOL pasteTextFromPrimary(LLWString &dst);
-	/*virtual*/ BOOL copyTextToPrimary(const LLWString & src);
+	/*virtual*/ bool isPrimaryTextAvailable();
+	/*virtual*/ bool pasteTextFromPrimary(LLWString &dst);
+	/*virtual*/ bool copyTextToPrimary(const LLWString & src);
  
 	/*virtual*/ void flashIcon(F32 seconds);
 	/*virtual*/ F32 getGamma();
-	/*virtual*/ BOOL setGamma(const F32 gamma); // Set the gamma
+	/*virtual*/ bool setGamma(const F32 gamma); // Set the gamma
 	/*virtual*/ U32 getFSAASamples();
 	/*virtual*/ void setFSAASamples(const U32 samples);
-	/*virtual*/ BOOL restoreGamma();			// Restore original gamma table (before updating gamma)
+	/*virtual*/ bool restoreGamma();			// Restore original gamma table (before updating gamma)
 	/*virtual*/ ESwapMethod getSwapMethod() { return mSwapMethod; }
 	/*virtual*/ void processMiscNativeEvents();
 	/*virtual*/ void gatherInput();
@@ -102,12 +102,12 @@ public:
 	/*virtual*/ void delayInputProcessing() { };
 
 	// handy coordinate space conversion routines
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordWindow *to);
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordScreen *to);
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordGL *to);
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordWindow *to);
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordGL *to);
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordScreen *to);
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordWindow *to);
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordScreen *to);
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordGL *to);
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordWindow *to);
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordGL *to);
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordScreen *to);
 
 	/*virtual*/ LLWindowResolution* getSupportedResolutions(S32 &num_resolutions);
 	/*virtual*/ F32	getNativeAspectRatio();
@@ -117,7 +117,7 @@ public:
 	/*virtual*/ void beforeDialog();
 	/*virtual*/ void afterDialog();
 
-	/*virtual*/ BOOL dialogColorPicker(F32 *r, F32 *g, F32 *b);
+	/*virtual*/ bool dialogColorPicker(F32 *r, F32 *g, F32 *b);
 
 	/*virtual*/ void *getPlatformWindow();
 	/*virtual*/ void bringToFront();
@@ -148,11 +148,11 @@ public:
 protected:
 	LLWindowSDL(LLWindowCallbacks* callbacks,
 		const std::string& title, int x, int y, int width, int height, U32 flags,
-		BOOL fullscreen, BOOL clearBg, BOOL disable_vsync, BOOL use_gl,
-		BOOL ignore_pixel_depth, U32 fsaa_samples);
+		bool fullscreen, bool clearBg, bool disable_vsync, bool use_gl,
+		bool ignore_pixel_depth, U32 fsaa_samples);
 	~LLWindowSDL();
 
-	/*virtual*/ BOOL	isValid();
+	/*virtual*/ bool	isValid();
 	/*virtual*/ LLSD    getNativeKeyData();
 
 	void	initCursors();
@@ -160,12 +160,12 @@ protected:
 	void	moveWindow(const LLCoordScreen& position,const LLCoordScreen& size);
 
 	// Changes display resolution. Returns true if successful
-	BOOL	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
+	bool	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
 
 	// Go back to last fullscreen display resolution.
-	BOOL	setFullscreenResolution();
+	bool	setFullscreenResolution();
 
-	BOOL	shouldPostQuit() { return mPostQuit; }
+	bool	shouldPostQuit() { return mPostQuit; }
 
 protected:
 	//
@@ -173,12 +173,12 @@ protected:
 	//
 
 	// create or re-create the GL context/window.  Called from the constructor and switchContext().
-	BOOL createContext(int x, int y, int width, int height, int bits, BOOL fullscreen, BOOL disable_vsync);
+	bool createContext(int x, int y, int width, int height, int bits, bool fullscreen, bool disable_vsync);
 	void destroyContext();
 	void setupFailure(const std::string& text, const std::string& caption, U32 type);
 	void fixWindowSize(void);
-	U32 SDLCheckGrabbyKeys(SDLKey keysym, BOOL gain);
-	BOOL SDLReallyCaptureInput(BOOL capture);
+	U32 SDLCheckGrabbyKeys(SDLKey keysym, bool gain);
+	bool SDLReallyCaptureInput(bool capture);
 
 	//
 	// Platform specific variables
@@ -188,7 +188,7 @@ protected:
 	SDL_Surface *	mWindow;
 	std::string mWindowTitle;
 	double		mOriginalAspectRatio;
-	BOOL		mNeedsResize;		// Constructor figured out the window is too big, it needs a resize.
+	bool		mNeedsResize;		// Constructor figured out the window is too big, it needs a resize.
 	LLCoordScreen   mNeedsResizeSize;
 	F32			mOverrideAspectRatio;
 	F32		mGamma;
@@ -204,8 +204,8 @@ protected:
 
 private:
 #if LL_X11
-	void x11_set_urgent(BOOL urgent);
-	BOOL mFlashing;
+	void x11_set_urgent(bool urgent);
+	bool mFlashing;
 	LLTimer mFlashTimer;
 #endif //LL_X11
 	

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -92,7 +92,7 @@ const F32	ICON_FLASH_TIME = 0.5f;
 const UINT WM_DUMMY_(WM_USER + 0x0017);
 const UINT WM_POST_FUNCTION_(WM_USER + 0x0018);
 
-extern BOOL gDebugWindowProc;
+extern bool gDebugWindowProc;
 
 static std::thread::id sWindowThreadId;
 static std::thread::id sMainThreadId;
@@ -178,10 +178,10 @@ GLuint SafeChoosePixelFormat(HDC &hdc, const PIXELFORMATDESCRIPTOR *ppfd)
 }
 
 //static
-BOOL LLWindowWin32::sIsClassRegistered = FALSE;
+bool LLWindowWin32::sIsClassRegistered = false;
 
-BOOL	LLWindowWin32::sLanguageTextInputAllowed = TRUE;
-BOOL	LLWindowWin32::sWinIMEOpened = FALSE;
+bool	LLWindowWin32::sLanguageTextInputAllowed = true;
+bool	LLWindowWin32::sWinIMEOpened = false;
 HKL		LLWindowWin32::sWinInputLocale = 0;
 DWORD	LLWindowWin32::sWinIMEConversionMode = IME_CMODE_NATIVE;
 DWORD	LLWindowWin32::sWinIMESentenceMode = IME_SMODE_AUTOMATIC;
@@ -200,24 +200,24 @@ public:
 
 public:
 	// Wrappers for IMM API.
-	static BOOL		isIME(HKL hkl);															
+	static bool		isIME(HKL hkl);															
 	static HIMC		getContext(HWND hwnd);													
-	static BOOL		releaseContext(HWND hwnd, HIMC himc);
-	static BOOL		getOpenStatus(HIMC himc);												
-	static BOOL		setOpenStatus(HIMC himc, BOOL status);									
-	static BOOL		getConversionStatus(HIMC himc, LPDWORD conversion, LPDWORD sentence);	
-	static BOOL		setConversionStatus(HIMC himc, DWORD conversion, DWORD sentence);		
-	static BOOL		getCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form);					
-	static BOOL		setCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form);					
+	static bool		releaseContext(HWND hwnd, HIMC himc);
+	static bool		getOpenStatus(HIMC himc);												
+	static bool		setOpenStatus(HIMC himc, bool status);									
+	static bool		getConversionStatus(HIMC himc, LPDWORD conversion, LPDWORD sentence);	
+	static bool		setConversionStatus(HIMC himc, DWORD conversion, DWORD sentence);		
+	static bool		getCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form);					
+	static bool		setCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form);					
 	static LONG		getCompositionString(HIMC himc, DWORD index, LPVOID data, DWORD length);
-	static BOOL		setCompositionString(HIMC himc, DWORD index, LPVOID pComp, DWORD compLength, LPVOID pRead, DWORD readLength);
-	static BOOL		setCompositionFont(HIMC himc, LPLOGFONTW logfont);
-	static BOOL		setCandidateWindow(HIMC himc, LPCANDIDATEFORM candidate_form);
-	static BOOL		notifyIME(HIMC himc, DWORD action, DWORD index, DWORD value);
+	static bool		setCompositionString(HIMC himc, DWORD index, LPVOID pComp, DWORD compLength, LPVOID pRead, DWORD readLength);
+	static bool		setCompositionFont(HIMC himc, LPLOGFONTW logfont);
+	static bool		setCandidateWindow(HIMC himc, LPCANDIDATEFORM candidate_form);
+	static bool		notifyIME(HIMC himc, DWORD action, DWORD index, DWORD value);
 };
 
 // static 
-BOOL	LLWinImm::isIME(HKL hkl)
+bool	LLWinImm::isIME(HKL hkl)
 { 
 	return ImmIsIME(hkl);
 }
@@ -229,43 +229,43 @@ HIMC		LLWinImm::getContext(HWND hwnd)
 }
 
 //static 
-BOOL		LLWinImm::releaseContext(HWND hwnd, HIMC himc)
+bool		LLWinImm::releaseContext(HWND hwnd, HIMC himc)
 { 
 	return ImmReleaseContext(hwnd, himc);
 }
 
 // static 
-BOOL		LLWinImm::getOpenStatus(HIMC himc)
+bool		LLWinImm::getOpenStatus(HIMC himc)
 { 
 	return ImmGetOpenStatus(himc);
 }
 
 // static 
-BOOL		LLWinImm::setOpenStatus(HIMC himc, BOOL status)
+bool		LLWinImm::setOpenStatus(HIMC himc, bool status)
 { 
 	return ImmSetOpenStatus(himc, status);
 }
 
 // static 
-BOOL		LLWinImm::getConversionStatus(HIMC himc, LPDWORD conversion, LPDWORD sentence)	
+bool		LLWinImm::getConversionStatus(HIMC himc, LPDWORD conversion, LPDWORD sentence)	
 { 
 	return ImmGetConversionStatus(himc, conversion, sentence);
 }
 
 // static 
-BOOL		LLWinImm::setConversionStatus(HIMC himc, DWORD conversion, DWORD sentence)		
+bool		LLWinImm::setConversionStatus(HIMC himc, DWORD conversion, DWORD sentence)		
 { 
 	return ImmSetConversionStatus(himc, conversion, sentence);
 }
 
 // static 
-BOOL		LLWinImm::getCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form)					
+bool		LLWinImm::getCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form)					
 { 
 	return ImmGetCompositionWindow(himc, form);
 }
 
 // static 
-BOOL		LLWinImm::setCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form)					
+bool		LLWinImm::setCompositionWindow(HIMC himc, LPCOMPOSITIONFORM form)					
 { 
 	return ImmSetCompositionWindow(himc, form);
 }
@@ -279,25 +279,25 @@ LONG		LLWinImm::getCompositionString(HIMC himc, DWORD index, LPVOID data, DWORD 
 
 
 // static 
-BOOL		LLWinImm::setCompositionString(HIMC himc, DWORD index, LPVOID pComp, DWORD compLength, LPVOID pRead, DWORD readLength)					
+bool		LLWinImm::setCompositionString(HIMC himc, DWORD index, LPVOID pComp, DWORD compLength, LPVOID pRead, DWORD readLength)					
 { 
 	return ImmSetCompositionString(himc, index, pComp, compLength, pRead, readLength);
 }
 
 // static 
-BOOL		LLWinImm::setCompositionFont(HIMC himc, LPLOGFONTW pFont)					
+bool		LLWinImm::setCompositionFont(HIMC himc, LPLOGFONTW pFont)					
 { 
 	return ImmSetCompositionFont(himc, pFont);
 }
 
 // static 
-BOOL		LLWinImm::setCandidateWindow(HIMC himc, LPCANDIDATEFORM form)					
+bool		LLWinImm::setCandidateWindow(HIMC himc, LPCANDIDATEFORM form)					
 { 
 	return ImmSetCandidateWindow(himc, form);
 }
 
 // static 
-BOOL		LLWinImm::notifyIME(HIMC himc, DWORD action, DWORD index, DWORD value)					
+bool		LLWinImm::notifyIME(HIMC himc, DWORD action, DWORD index, DWORD value)					
 { 
 	return ImmNotifyIME(himc, action, index, value);
 }
@@ -432,9 +432,9 @@ struct LLWindowWin32::LLWindowWin32Thread : public LL::ThreadPool
 LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 							 const std::string& title, const std::string& name, S32 x, S32 y, S32 width,
 							 S32 height, U32 flags, 
-							 BOOL fullscreen, BOOL clearBg,
-							 BOOL enable_vsync, BOOL use_gl,
-							 BOOL ignore_pixel_depth,
+							 bool fullscreen, bool clearBg,
+							 bool enable_vsync, bool use_gl,
+							 bool ignore_pixel_depth,
 							 U32 fsaa_samples,
                              U32 max_cores,
                              U32 max_vram,
@@ -527,7 +527,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 	mIconResource = gIconResource;
 	mOverrideAspectRatio = 0.f;
 	mNativeAspectRatio = 0.f;
-	mInputProcessingPaused = FALSE;
+	mInputProcessingPaused = false;
 	mPreeditor = NULL;
 	mKeyCharCode = 0;
 	mKeyScanCode = 0;
@@ -536,7 +536,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 	mhRC = NULL;
 	memset(mCurrentGammaRamp, 0, sizeof(mCurrentGammaRamp));
 	memset(mPrevGammaRamp, 0, sizeof(mPrevGammaRamp));
-	mCustomGammaSet = FALSE;
+	mCustomGammaSet = false;
 	mWindowHandle = NULL;
 
     mRect = {0, 0, 0, 0};
@@ -544,7 +544,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 	
 	if (!SystemParametersInfo(SPI_GETMOUSEVANISH, 0, &mMouseVanish, 0))
 	{
-		mMouseVanish = TRUE;
+		mMouseVanish = true;
 	}
 
 	// Initialize the keyboard
@@ -556,7 +556,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 
 	// Initialize (boot strap) the Language text input management,
 	// based on the system's (user's) default settings.
-	allowLanguageTextInput(mPreeditor, FALSE);
+	allowLanguageTextInput(mPreeditor, false);
 
 	WNDCLASS		wc;
 	RECT			window_rect;
@@ -674,7 +674,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 				mCallbacks->translateString("MBError"), OSMB_OK);
 			return;
 		}
-		sIsClassRegistered = TRUE;
+		sIsClassRegistered = true;
 	}
 
 	//-----------------------------------------------------------------------
@@ -702,7 +702,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 	//-----------------------------------------------------------------------
 	if (mFullscreen)
 	{
-		BOOL success = FALSE;
+		bool success = false;
 		DWORD closest_refresh = 0;
 
 		for (S32 mode_num = 0;; mode_num++)
@@ -716,7 +716,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 				dev_mode.dmPelsHeight == height &&
 				dev_mode.dmBitsPerPel == BITS_PER_PIXEL)
 			{
-				success = TRUE;
+				success = true;
 				if ((dev_mode.dmDisplayFrequency - current_refresh)
 					< (closest_refresh - current_refresh))
 				{
@@ -728,11 +728,11 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 		if (closest_refresh == 0)
 		{
 			LL_WARNS("Window") << "Couldn't find display mode " << width << " by " << height << " at " << BITS_PER_PIXEL << " bits per pixel" << LL_ENDL;
-			//success = FALSE;
+			//success = false;
 
 			if (!EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dev_mode))
 			{
-				success = FALSE;
+				success = false;
 			}
 			else
 			{
@@ -741,12 +741,12 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 					LL_WARNS("Window") << "Current BBP is OK falling back to that" << LL_ENDL;
 					window_rect.right=width=dev_mode.dmPelsWidth;
 					window_rect.bottom=height=dev_mode.dmPelsHeight;
-					success = TRUE;
+					success = true;
 				}
 				else
 				{
 					LL_WARNS("Window") << "Current BBP is BAD" << LL_ENDL;
-					success = FALSE;
+					success = false;
 				}
 			}
 		}
@@ -764,7 +764,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 		// If it failed, we don't want to run fullscreen
 		if (success)
 		{
-			mFullscreen = TRUE;
+			mFullscreen = true;
 			mFullscreenWidth   = dev_mode.dmPelsWidth;
 			mFullscreenHeight  = dev_mode.dmPelsHeight;
 			mFullscreenBits    = dev_mode.dmBitsPerPel;
@@ -778,7 +778,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 		}
 		else
 		{
-			mFullscreen = FALSE;
+			mFullscreen = false;
 			mFullscreenWidth   = -1;
 			mFullscreenHeight  = -1;
 			mFullscreenBits    = -1;
@@ -859,7 +859,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
 
 	// Initialize (boot strap) the Language text input management,
 	// based on the system's (or user's) default settings.
-	allowLanguageTextInput(NULL, FALSE);
+	allowLanguageTextInput(NULL, false);
 }
 
 
@@ -889,14 +889,14 @@ void LLWindowWin32::show()
 
 void LLWindowWin32::hide()
 {
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	ShowWindow(mWindowHandle, SW_HIDE);
 }
 
 //virtual
 void LLWindowWin32::minimize()
 {
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	showCursor();
 	ShowWindow(mWindowHandle, SW_MINIMIZE);
 }
@@ -953,7 +953,7 @@ void LLWindowWin32::close()
 
 	// Make sure cursor is visible and we haven't mangled the clipping state.
 	showCursor();
-	setMouseClipping(FALSE);
+	setMouseClipping(false);
 	if (gKeyboard)
 	{
 		gKeyboard->resetKeys();
@@ -1029,29 +1029,29 @@ void LLWindowWin32::close()
     mWindowThread->close();
 }
 
-BOOL LLWindowWin32::isValid()
+bool LLWindowWin32::isValid()
 {
 	return (mWindowHandle != NULL);
 }
 
-BOOL LLWindowWin32::getVisible()
+bool LLWindowWin32::getVisible()
 {
 	return (mWindowHandle && IsWindowVisible(mWindowHandle));
 }
 
-BOOL LLWindowWin32::getMinimized()
+bool LLWindowWin32::getMinimized()
 {
 	return (mWindowHandle && IsIconic(mWindowHandle));
 }
 
-BOOL LLWindowWin32::getMaximized()
+bool LLWindowWin32::getMaximized()
 {
 	return (mWindowHandle && IsZoomed(mWindowHandle));
 }
 
-BOOL LLWindowWin32::maximize()
+bool LLWindowWin32::maximize()
 {
-	BOOL success = FALSE;
+	bool success = false;
 	if (!mWindowHandle) return success;
 
     mWindowThread->post([=]
@@ -1066,56 +1066,56 @@ BOOL LLWindowWin32::maximize()
             }
         });
 
-    return TRUE;
+    return true;
 }
 
-BOOL LLWindowWin32::getFullscreen()
+bool LLWindowWin32::getFullscreen()
 {
 	return mFullscreen;
 }
 
-BOOL LLWindowWin32::getPosition(LLCoordScreen *position)
+bool LLWindowWin32::getPosition(LLCoordScreen *position)
 {
     position->mX = mRect.left;
 	position->mY = mRect.top;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::getSize(LLCoordScreen *size)
+bool LLWindowWin32::getSize(LLCoordScreen *size)
 {
 	size->mX = mRect.right - mRect.left;
 	size->mY = mRect.bottom - mRect.top;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::getSize(LLCoordWindow *size)
+bool LLWindowWin32::getSize(LLCoordWindow *size)
 {
 	size->mX = mClientRect.right - mClientRect.left;
 	size->mY = mClientRect.bottom - mClientRect.top;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::setPosition(const LLCoordScreen position)
+bool LLWindowWin32::setPosition(const LLCoordScreen position)
 {
 	LLCoordScreen size;
 
 	if (!mWindowHandle)
 	{
-		return FALSE;
+		return false;
 	}
 	getSize(&size);
 	moveWindow(position, size);
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::setSizeImpl(const LLCoordScreen size)
+bool LLWindowWin32::setSizeImpl(const LLCoordScreen size)
 {
 	LLCoordScreen position;
 
 	getPosition(&position);
 	if (!mWindowHandle)
 	{
-		return FALSE;
+		return false;
 	}
 
     mWindowThread->post([=]()
@@ -1131,10 +1131,10 @@ BOOL LLWindowWin32::setSizeImpl(const LLCoordScreen size)
         });
 
 	moveWindow(position, size);
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::setSizeImpl(const LLCoordWindow size)
+bool LLWindowWin32::setSizeImpl(const LLCoordWindow size)
 {
 	RECT window_rect = {0, 0, size.mX, size.mY };
 	DWORD dw_ex_style = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;
@@ -1146,7 +1146,7 @@ BOOL LLWindowWin32::setSizeImpl(const LLCoordWindow size)
 }
 
 // changing fullscreen resolution
-BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BOOL enable_vsync, const LLCoordScreen* const posp)
+bool LLWindowWin32::switchContext(bool fullscreen, const LLCoordScreen& size, bool enable_vsync, const LLCoordScreen* const posp)
 {
     //called from main thread
     GLuint	pixel_format;
@@ -1159,11 +1159,11 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
     RECT	window_rect = { 0, 0, 0, 0 };
     S32 width = size.mX;
     S32 height = size.mY;
-    BOOL auto_show = FALSE;
+    bool auto_show = false;
 
     if (mhRC)
     {
-        auto_show = TRUE;
+        auto_show = true;
         resetDisplayResolution();
     }
 
@@ -1196,8 +1196,8 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 
     if (fullscreen)
     {
-        mFullscreen = TRUE;
-        BOOL success = FALSE;
+        mFullscreen = true;
+        bool success = false;
         DWORD closest_refresh = 0;
 
         for (S32 mode_num = 0;; mode_num++)
@@ -1211,7 +1211,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
                 dev_mode.dmPelsHeight == height &&
                 dev_mode.dmBitsPerPel == BITS_PER_PIXEL)
             {
-                success = TRUE;
+                success = true;
                 if ((dev_mode.dmDisplayFrequency - current_refresh)
                     < (closest_refresh - current_refresh))
                 {
@@ -1223,7 +1223,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
         if (closest_refresh == 0)
         {
             LL_WARNS("Window") << "Couldn't find display mode " << width << " by " << height << " at " << BITS_PER_PIXEL << " bits per pixel" << LL_ENDL;
-            return FALSE;
+            return false;
         }
 
         // If we found a good resolution, use it.
@@ -1238,7 +1238,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 
         if (success)
         {
-            mFullscreen = TRUE;
+            mFullscreen = true;
             mFullscreenWidth = dev_mode.dmPelsWidth;
             mFullscreenHeight = dev_mode.dmPelsHeight;
             mFullscreenBits = dev_mode.dmBitsPerPel;
@@ -1264,19 +1264,19 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
         // If it failed, we don't want to run fullscreen
         else
         {
-            mFullscreen = FALSE;
+            mFullscreen = false;
             mFullscreenWidth = -1;
             mFullscreenHeight = -1;
             mFullscreenBits = -1;
             mFullscreenRefresh = -1;
 
             LL_INFOS("Window") << "Unable to run fullscreen at " << width << "x" << height << LL_ENDL;
-            return FALSE;
+            return false;
         }
     }
     else
     {
-        mFullscreen = FALSE;
+        mFullscreen = false;
         window_rect.left = (long)(posp ? posp->mX : 0);
         window_rect.right = (long)width + window_rect.left;			// Windows GDI rects don't include rightmost pixel
         window_rect.top = (long)(posp ? posp->mY : 0);
@@ -1288,7 +1288,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 
 
     // don't post quit messages when destroying old windows
-    mPostQuit = FALSE;
+    mPostQuit = false;
 
 
     // create window
@@ -1338,7 +1338,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		close();
 		OSMessageBox(mCallbacks->translateString("MBDevContextErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
-		return FALSE;
+		return false;
 	}
 
 	LL_INFOS("Window") << "Device context retrieved." << LL_ENDL ;
@@ -1352,7 +1352,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
             OSMessageBox(mCallbacks->translateString("MBPixelFmtErr"),
                 mCallbacks->translateString("MBError"), OSMB_OK);
 		close();
-            return FALSE;
+            return false;
         }
     }
     catch (...)
@@ -1361,7 +1361,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		OSMessageBox(mCallbacks->translateString("MBPixelFmtErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 
 	LL_INFOS("Window") << "Pixel format chosen." << LL_ENDL ;
@@ -1373,7 +1373,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		OSMessageBox(mCallbacks->translateString("MBPixelFmtDescErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 
 	// (EXP-1765) dump pixel data to see if there is a pattern that leads to unreproducible crash
@@ -1412,7 +1412,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		OSMessageBox(mCallbacks->translateString("MBPixelFmtSetErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 
 
@@ -1421,7 +1421,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		OSMessageBox(mCallbacks->translateString("MBGLContextErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 		
 	if (!wglMakeCurrent(mhDC, mhRC))
@@ -1429,7 +1429,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 		OSMessageBox(mCallbacks->translateString("MBGLContextActErr"),
 			mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 
 	LL_INFOS("Window") << "Drawing context is created." << LL_ENDL ;
@@ -1521,7 +1521,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 
 			close();
 			show_window_creation_error("Error after wglChoosePixelFormatARB 32-bit");
-			return FALSE;
+			return false;
 		}
 
 		if (!num_formats)
@@ -1536,7 +1536,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 				{
 					close();
 					show_window_creation_error("Error after wglChoosePixelFormatARB 32-bit no AA");
-					return FALSE;
+					return false;
 				}
 			}
 
@@ -1550,7 +1550,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 				{
 					close();
 					show_window_creation_error("Error after wglChoosePixelFormatARB 24-bit");
-					return FALSE;
+					return false;
 				}
 
 				if (!num_formats)
@@ -1562,7 +1562,7 @@ BOOL LLWindowWin32::switchContext(BOOL fullscreen, const LLCoordScreen& size, BO
 					{
 						close();
 						show_window_creation_error("Error after wglChoosePixelFormatARB 16-bit");
-						return FALSE;
+						return false;
 					}
 				}
 			}
@@ -1635,7 +1635,7 @@ const	S32   max_format  = (S32)num_formats - 1;
 		{
 			OSMessageBox(mCallbacks->translateString("MBDevContextErr"), mCallbacks->translateString("MBError"), OSMB_OK);
 			close();
-			return FALSE;
+			return false;
 		}
 
 		if (!SetPixelFormat(mhDC, pixel_format, &pfd))
@@ -1643,7 +1643,7 @@ const	S32   max_format  = (S32)num_formats - 1;
 			OSMessageBox(mCallbacks->translateString("MBPixelFmtSetErr"),
 				mCallbacks->translateString("MBError"), OSMB_OK);
 			close();
-			return FALSE;
+			return false;
 		}
 
 		if (wglGetPixelFormatAttribivARB(mhDC, pixel_format, 0, 1, &swap_query, &swap_method))
@@ -1680,7 +1680,7 @@ const	S32   max_format  = (S32)num_formats - 1;
 	{
 		OSMessageBox(mCallbacks->translateString("MBPixelFmtDescErr"), mCallbacks->translateString("MBError"), OSMB_OK);
 		close();
-		return FALSE;
+		return false;
 	}
 
 	LL_INFOS("Window") << "GL buffer: Color Bits " << S32(pfd.cColorBits) 
@@ -1694,7 +1694,7 @@ const	S32   max_format  = (S32)num_formats - 1;
         mhRC = (HGLRC) createSharedContext();
         if (!mhRC)
         {
-            return FALSE;
+            return false;
         }
 	}
 
@@ -1702,14 +1702,14 @@ const	S32   max_format  = (S32)num_formats - 1;
 	{
 		OSMessageBox(mCallbacks->translateString("MBGLContextActErr"), mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 
 	if (!gGLManager.initGL())
 	{
 		OSMessageBox(mCallbacks->translateString("MBVideoDrvErr"), mCallbacks->translateString("MBError"), OSMB_OK);
         close();
-		return FALSE;
+		return false;
 	}
 	
 	// Disable vertical sync for swap
@@ -1726,7 +1726,7 @@ const	S32   max_format  = (S32)num_formats - 1;
 	SetTimer( mWindowHandle, 0, 1000 / 30, NULL ); // 30 fps timer
 
 	// ok to post quit messages now
-	mPostQuit = TRUE;
+	mPostQuit = true;
 
     // *HACK: Attempt to prevent startup crashes by deferring memory accounting
     // until after some graphics setup. See SL-20177. -Cosmic,2023-09-18
@@ -1745,7 +1745,7 @@ const	S32   max_format  = (S32)num_formats - 1;
 
     LL_PROFILER_GPU_CONTEXT;
 
-	return TRUE;
+	return true;
 }
 
 void LLWindowWin32::recreateWindow(RECT window_rect, DWORD dw_ex_style, DWORD dw_style)
@@ -1970,13 +1970,13 @@ void LLWindowWin32::setTitle(const std::string title)
         });
 }
 
-BOOL LLWindowWin32::setCursorPosition(const LLCoordWindow position)
+bool LLWindowWin32::setCursorPosition(const LLCoordWindow position)
 {
     ASSERT_MAIN_THREAD();
 
     if (!mWindowHandle)
     {
-        return FALSE;
+        return false;
     }
 
     LLCoordScreen screen_pos(position.convert());
@@ -1996,31 +1996,31 @@ BOOL LLWindowWin32::setCursorPosition(const LLCoordWindow position)
             SetCursorPos(screen_pos.mX, screen_pos.mY);
         });
 
-    return TRUE;
+    return true;
 }
 
-BOOL LLWindowWin32::getCursorPosition(LLCoordWindow *position)
+bool LLWindowWin32::getCursorPosition(LLCoordWindow *position)
 {
     ASSERT_MAIN_THREAD();
     if (!position)
     {
-        return FALSE;
+        return false;
     }
 
     *position = mCursorPosition;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::getCursorDelta(LLCoordCommon* delta)
+bool LLWindowWin32::getCursorDelta(LLCoordCommon* delta)
 {
     if (delta == nullptr)
     {
-        return FALSE;
+        return false;
     }
 
     *delta = mMouseFrameDelta;
 
-    return TRUE;
+    return true;
 }
 
 void LLWindowWin32::hideCursor()
@@ -2035,8 +2035,8 @@ void LLWindowWin32::hideCursor()
             }
         });
 
-	mCursorHidden = TRUE;
-	mHideCursorPermanent = TRUE;
+	mCursorHidden = true;
+	mHideCursorPermanent = true;
 }
 
 void LLWindowWin32::showCursor()
@@ -2054,8 +2054,8 @@ void LLWindowWin32::showCursor()
             }
         });
 
-	mCursorHidden = FALSE;
-	mHideCursorPermanent = FALSE;
+	mCursorHidden = false;
+	mHideCursorPermanent = false;
 }
 
 void LLWindowWin32::showCursorFromMouseMove()
@@ -2071,11 +2071,11 @@ void LLWindowWin32::hideCursorUntilMouseMove()
 	if (!mHideCursorPermanent && mMouseVanish)
 	{
 		hideCursor();
-		mHideCursorPermanent = FALSE;
+		mHideCursorPermanent = false;
 	}
 }
 
-BOOL LLWindowWin32::isCursorHidden()
+bool LLWindowWin32::isCursorHidden()
 {
 	return mCursorHidden;
 }
@@ -2195,7 +2195,7 @@ void LLWindowWin32::releaseMouse()
 
 void LLWindowWin32::delayInputProcessing()
 {
-	mInputProcessingPaused = TRUE;
+	mInputProcessingPaused = true;
 }
 
 
@@ -2276,7 +2276,7 @@ void LLWindowWin32::gatherInput()
         }
     }
 
-	mInputProcessingPaused = FALSE;
+	mInputProcessingPaused = false;
 
 	updateCursor();
 }
@@ -2321,7 +2321,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
 
         // pass along extended flag in mask
         MASK mask = (l_param >> 16 & KF_EXTENDED) ? MASK_EXTENDED : 0x0;
-        BOOL eat_keystroke = TRUE;
+        bool eat_keystroke = true;
 
         switch (u_msg)
         {
@@ -2343,7 +2343,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             {
                 WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp));
                 
-                return TRUE;
+                return true;
             }
             break;
         }
@@ -2500,7 +2500,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_SYSKEYDOWN");
             // allow system keys, such as ALT-F4 to be processed by Windows
-            eat_keystroke = FALSE;
+            eat_keystroke = false;
             // intentional fall-through here
         }
         case WM_KEYDOWN:
@@ -2521,7 +2521,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             break;
         }
         case WM_SYSKEYUP:
-            eat_keystroke = FALSE;
+            eat_keystroke = false;
             // intentional fall-through here
         case WM_KEYUP:
         {
@@ -2613,9 +2613,9 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     // characters.  We just need to take care of surrogate pairs sent as two WM_CHAR's
                     // by ourselves.  It is not that tough.  -- Alissa Sabre @ SL
                     
-                    // Even if LLWindowCallbacks::handleUnicodeChar(llwchar, BOOL) returned FALSE,
+                    // Even if LLWindowCallbacks::handleUnicodeChar(llwchar, bool) returned false,
                     // we *did* processed the event, so I believe we should not pass it to DefWindowProc...
-                    window_imp->handleUnicodeUTF16((U16)w_param, gKeyboard->currentMask(FALSE));
+                    window_imp->handleUnicodeUTF16((U16)w_param, gKeyboard->currentMask(false));
                 });
             return 0;
         }
@@ -2646,7 +2646,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                             window_imp->interruptLanguageTextInput();
                         }
                         
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         auto gl_coord = window_imp->mCursorPosition.convert();
                         window_imp->mCallbacks->handleMouseMove(window_imp, gl_coord, mask);
                         window_imp->mCallbacks->handleMouseDown(window_imp, gl_coord, mask);
@@ -2669,7 +2669,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                         sHandleDoubleClick = true;
                         return;
                     }
-                    MASK mask = gKeyboard->currentMask(TRUE);
+                    MASK mask = gKeyboard->currentMask(true);
 
                     // generate move event to update mouse coordinates
                     window_imp->mCursorPosition = window_coord;
@@ -2693,7 +2693,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                         sHandleDoubleClick = true;
 
                         
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         // generate move event to update mouse coordinates
                         window_imp->mCursorPosition = window_coord;
                         window_imp->mCallbacks->handleMouseUp(window_imp, window_imp->mCursorPosition.convert(), mask);
@@ -2714,7 +2714,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                             WINDOW_IMP_POST(window_imp->interruptLanguageTextInput());
                         }
 
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         // generate move event to update mouse coordinates
                         auto gl_coord = window_imp->mCursorPosition.convert();
                         window_imp->mCallbacks->handleMouseMove(window_imp, gl_coord, mask);
@@ -2732,7 +2732,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 LL_RECORD_BLOCK_TIME(FTM_MOUSEHANDLER);
                 window_imp->postMouseButtonEvent([=]()
                     {
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         window_imp->mCallbacks->handleRightMouseUp(window_imp, window_imp->mCursorPosition.convert(), mask);
                     });
             }
@@ -2752,7 +2752,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                             window_imp->interruptLanguageTextInput();
                         }
 
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         window_imp->mCallbacks->handleMiddleMouseDown(window_imp, window_imp->mCursorPosition.convert(), mask);
                     });
             }
@@ -2766,7 +2766,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 LL_RECORD_BLOCK_TIME(FTM_MOUSEHANDLER);
                 window_imp->postMouseButtonEvent([=]()
                     {
-                        MASK mask = gKeyboard->currentMask(TRUE);
+                        MASK mask = gKeyboard->currentMask(true);
                         window_imp->mCallbacks->handleMiddleMouseUp(window_imp, window_imp->mCursorPosition.convert(), mask);
                     });
             }
@@ -2784,7 +2784,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                         window_imp->interruptLanguageTextInput();
                     }
 
-                    MASK mask = gKeyboard->currentMask(TRUE);
+                    MASK mask = gKeyboard->currentMask(true);
                     // Windows uses numbers 1 and 2 for buttons, remap to 4, 5
                     window_imp->mCallbacks->handleOtherMouseDown(window_imp, window_imp->mCursorPosition.convert(), mask, button + 3);
                 });
@@ -2801,7 +2801,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     LL_RECORD_BLOCK_TIME(FTM_MOUSEHANDLER);
 
                     S32 button = GET_XBUTTON_WPARAM(w_param);
-                    MASK mask = gKeyboard->currentMask(TRUE);
+                    MASK mask = gKeyboard->currentMask(true);
                     // Windows uses numbers 1 and 2 for buttons, remap to 4, 5
                     window_imp->mCallbacks->handleOtherMouseUp(window_imp, window_imp->mCursorPosition.convert(), mask, button + 3);
                 });
@@ -2911,7 +2911,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 {
                     LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_MOUSEMOVE lambda");
 
-                    MASK mask = gKeyboard->currentMask(TRUE);
+                    MASK mask = gKeyboard->currentMask(true);
                     window_imp->mMouseMask = mask;
                     window_imp->mCursorPosition = window_coord;
                 });
@@ -2948,19 +2948,19 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             // means that the window was un-minimized.
             if (w_param == SIZE_RESTORED && window_imp->mLastSizeWParam != SIZE_RESTORED)
             {
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, TRUE));
+                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, true));
             }
 
             // handle case of window being maximized from fully minimized state
             if (w_param == SIZE_MAXIMIZED && window_imp->mLastSizeWParam != SIZE_MAXIMIZED)
             {
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, TRUE));
+                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, true));
             }
 
             // Also handle the minimization case
             if (w_param == SIZE_MINIMIZED && window_imp->mLastSizeWParam != SIZE_MINIMIZED)
             {
-                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, FALSE));
+                WINDOW_IMP_POST(window_imp->mCallbacks->handleActivate(window_imp, false));
             }
 
             // Actually resize all of our views
@@ -3039,7 +3039,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             {
                 if (!SystemParametersInfo(SPI_GETMOUSEVANISH, 0, &window_imp->mMouseVanish, 0))
                 {
-                    WINDOW_IMP_POST(window_imp->mMouseVanish = TRUE);
+                    WINDOW_IMP_POST(window_imp->mMouseVanish = true);
                 }
             }
         }
@@ -3148,7 +3148,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
     return ret;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordGL from, LLCoordWindow *to)
+bool LLWindowWin32::convertCoords(LLCoordGL from, LLCoordWindow *to)
 {
 	S32		client_height;
 	RECT	client_rect;
@@ -3158,17 +3158,17 @@ BOOL LLWindowWin32::convertCoords(LLCoordGL from, LLCoordWindow *to)
 		!GetClientRect(mWindowHandle, &client_rect) ||
 		NULL == to)
 	{
-		return FALSE;
+		return false;
 	}
 
 	to->mX = from.mX;
 	client_height = client_rect.bottom - client_rect.top;
 	to->mY = client_height - from.mY - 1;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordGL* to)
+bool LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordGL* to)
 {
 	S32		client_height;
 	RECT	client_rect;
@@ -3177,23 +3177,23 @@ BOOL LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordGL* to)
 		!GetClientRect(mWindowHandle, &client_rect) ||
 		NULL == to)
 	{
-		return FALSE;
+		return false;
 	}
 
 	to->mX = from.mX;
 	client_height = client_rect.bottom - client_rect.top;
 	to->mY = client_height - from.mY - 1;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordScreen from, LLCoordWindow* to)
+bool LLWindowWin32::convertCoords(LLCoordScreen from, LLCoordWindow* to)
 {	
 	POINT mouse_point;
 
 	mouse_point.x = from.mX;
 	mouse_point.y = from.mY;
-	BOOL result = ScreenToClient(mWindowHandle, &mouse_point);
+	bool result = ScreenToClient(mWindowHandle, &mouse_point);
 
 	if (result)
 	{
@@ -3204,13 +3204,13 @@ BOOL LLWindowWin32::convertCoords(LLCoordScreen from, LLCoordWindow* to)
 	return result;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordScreen *to)
+bool LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordScreen *to)
 {
 	POINT mouse_point;
 
 	mouse_point.x = from.mX;
 	mouse_point.y = from.mY;
-	BOOL result = ClientToScreen(mWindowHandle, &mouse_point);
+	bool result = ClientToScreen(mWindowHandle, &mouse_point);
 
 	if (result)
 	{
@@ -3221,44 +3221,44 @@ BOOL LLWindowWin32::convertCoords(LLCoordWindow from, LLCoordScreen *to)
 	return result;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordScreen from, LLCoordGL *to)
+bool LLWindowWin32::convertCoords(LLCoordScreen from, LLCoordGL *to)
 {
 	LLCoordWindow window_coord;
 
 	if (!mWindowHandle || (NULL == to))
 	{
-		return FALSE;
+		return false;
 	}
 
 	convertCoords(from, &window_coord);
 	convertCoords(window_coord, to);
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::convertCoords(LLCoordGL from, LLCoordScreen *to)
+bool LLWindowWin32::convertCoords(LLCoordGL from, LLCoordScreen *to)
 {
 	LLCoordWindow window_coord;
 
 	if (!mWindowHandle || (NULL == to))
 	{
-		return FALSE;
+		return false;
 	}
 
 	convertCoords(from, &window_coord);
 	convertCoords(window_coord, to);
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLWindowWin32::isClipboardTextAvailable()
+bool LLWindowWin32::isClipboardTextAvailable()
 {
 	return IsClipboardFormatAvailable(CF_UNICODETEXT);
 }
 
 
-BOOL LLWindowWin32::pasteTextFromClipboard(LLWString &dst)
+bool LLWindowWin32::pasteTextFromClipboard(LLWString &dst)
 {
-	BOOL success = FALSE;
+	bool success = false;
 
 	if (IsClipboardFormatAvailable(CF_UNICODETEXT))
 	{
@@ -3273,7 +3273,7 @@ BOOL LLWindowWin32::pasteTextFromClipboard(LLWString &dst)
 					dst = utf16str_to_wstring(utf16str);
 					LLWStringUtil::removeWindowsCR(dst);
 					GlobalUnlock(h_data);
-					success = TRUE;
+					success = true;
 				}
 			}
 			CloseClipboard();
@@ -3284,9 +3284,9 @@ BOOL LLWindowWin32::pasteTextFromClipboard(LLWString &dst)
 }
 
 
-BOOL LLWindowWin32::copyTextToClipboard(const LLWString& wstr)
+bool LLWindowWin32::copyTextToClipboard(const LLWString& wstr)
 {
-	BOOL success = FALSE;
+	bool success = false;
 
 	if (OpenClipboard(mWindowHandle))
 	{
@@ -3310,7 +3310,7 @@ BOOL LLWindowWin32::copyTextToClipboard(const LLWString& wstr)
 
 				if (SetClipboardData(CF_UNICODETEXT, hglobal_copy_utf16))
 				{
-					success = TRUE;
+					success = true;
 				}
 			}
 		}
@@ -3322,13 +3322,13 @@ BOOL LLWindowWin32::copyTextToClipboard(const LLWString& wstr)
 }
 
 // Constrains the mouse to the window.
-void LLWindowWin32::setMouseClipping( BOOL b )
+void LLWindowWin32::setMouseClipping( bool b )
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_WIN32;
     ASSERT_MAIN_THREAD();
 	if( b != mIsMouseClipping )
 	{
-		BOOL success = FALSE;
+		bool success = false;
 
 		if( b )
 		{
@@ -3354,9 +3354,9 @@ void LLWindowWin32::setMouseClipping( BOOL b )
 	}
 }
 
-BOOL LLWindowWin32::getClientRectInScreenSpace( RECT* rectp )
+bool LLWindowWin32::getClientRectInScreenSpace( RECT* rectp )
 {
-    BOOL success = FALSE;
+    bool success = false;
 
     RECT client_rect;
     if (mWindowHandle && GetClientRect(mWindowHandle, &client_rect))
@@ -3377,7 +3377,7 @@ BOOL LLWindowWin32::getClientRectInScreenSpace( RECT* rectp )
             bottom_right.x,
             bottom_right.y);
 
-        success = TRUE;
+        success = true;
     }
 
     return success;
@@ -3403,25 +3403,25 @@ F32 LLWindowWin32::getGamma()
 	return mCurrentGamma;
 }
 
-BOOL LLWindowWin32::restoreGamma()
+bool LLWindowWin32::restoreGamma()
 {
     ASSERT_MAIN_THREAD();
-	if (mCustomGammaSet != FALSE)
+	if (mCustomGammaSet != false)
 	{
         LL_DEBUGS("Window") << "Restoring gamma" << LL_ENDL;
-		mCustomGammaSet = FALSE;
+		mCustomGammaSet = false;
 		return SetDeviceGammaRamp(mhDC, mPrevGammaRamp);
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLWindowWin32::setGamma(const F32 gamma)
+bool LLWindowWin32::setGamma(const F32 gamma)
 {
     ASSERT_MAIN_THREAD();
 	mCurrentGamma = gamma;
 
 	//Get the previous gamma ramp to restore later.
-	if (mCustomGammaSet == FALSE)
+	if (mCustomGammaSet == false)
 	{
         if (!gGLManager.mIsIntel) // skip for Intel GPUs (see SL-11341)
         {
@@ -3429,10 +3429,10 @@ BOOL LLWindowWin32::setGamma(const F32 gamma)
             if(GetDeviceGammaRamp(mhDC, mPrevGammaRamp) == FALSE)
             {
                 LL_WARNS("Window") << "Failed to get the previous gamma ramp" << LL_ENDL;
-                return FALSE;
+                return false;
             }
         }
-		mCustomGammaSet = TRUE;
+		mCustomGammaSet = true;
 	}
 
 	LL_DEBUGS("Window") << "Setting gamma to " << gamma << LL_ENDL;
@@ -3487,13 +3487,13 @@ LLWindow::LLWindowResolution* LLWindowWin32::getSupportedResolutions(S32 &num_re
 				dev_mode.dmPelsWidth >= 800 &&
 				dev_mode.dmPelsHeight >= 600)
 			{
-				BOOL resolution_exists = FALSE;
+				bool resolution_exists = false;
 				for(S32 i = 0; i < mNumSupportedResolutions; i++)
 				{
 					if (mSupportedResolutions[i].mWidth == dev_mode.dmPelsWidth &&
 						mSupportedResolutions[i].mHeight == dev_mode.dmPelsHeight)
 					{
-						resolution_exists = TRUE;
+						resolution_exists = true;
 					}
 				}
 				if (!resolution_exists)
@@ -3546,12 +3546,12 @@ F32 LLWindowWin32::getPixelAspectRatio()
 
 // Change display resolution.  Returns true if successful.
 // protected
-BOOL LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh)
+bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh)
 {
 	DEVMODE dev_mode;
 	::ZeroMemory(&dev_mode, sizeof(DEVMODE));
 	dev_mode.dmSize = sizeof(DEVMODE);
-	BOOL success = FALSE;
+	bool success = false;
 
 	// Don't change anything if we don't have to
 	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &dev_mode))
@@ -3562,7 +3562,7 @@ BOOL LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 re
 			dev_mode.dmDisplayFrequency == refresh )
 		{
 			// ...display mode identical, do nothing
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -3589,7 +3589,7 @@ BOOL LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 re
 }
 
 // protected
-BOOL LLWindowWin32::setFullscreenResolution()
+bool LLWindowWin32::setFullscreenResolution()
 {
 	if (mFullscreen)
 	{
@@ -3597,18 +3597,18 @@ BOOL LLWindowWin32::setFullscreenResolution()
 	}
 	else
 	{
-		return FALSE;
+		return false;
 	}
 }
 
 // protected
-BOOL LLWindowWin32::resetDisplayResolution()
+bool LLWindowWin32::resetDisplayResolution()
 {
 	LL_DEBUGS("Window") << "resetDisplayResolution START" << LL_ENDL;
 
 	LONG cds_result = ChangeDisplaySettings(NULL, 0);
 
-	BOOL success = (DISP_CHANGE_SUCCESSFUL == cds_result);
+	bool success = (DISP_CHANGE_SUCCESSFUL == cds_result);
 
 	if (!success)
 	{
@@ -3815,9 +3815,9 @@ LLSD LLWindowWin32::getNativeKeyData()
 	return result;
 }
 
-BOOL LLWindowWin32::dialogColorPicker( F32 *r, F32 *g, F32 *b )
+bool LLWindowWin32::dialogColorPicker( F32 *r, F32 *g, F32 *b )
 {
-	BOOL retval = FALSE;
+	bool retval = false;
 
 	static CHOOSECOLOR cc;
 	static COLORREF crCustColors[16];
@@ -3870,7 +3870,7 @@ void LLWindowWin32::focusClient()
         });
 }
 
-void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
+void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, bool b)
 {
 	if (b == sLanguageTextInputAllowed || !LLWinImm::isAvailable())
 	{
@@ -3880,7 +3880,7 @@ void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
 	if (preeditor != mPreeditor && !b)
 	{
 		// This condition may occur with a call to
-		// setEnabled(BOOL) from LLTextEditor or LLLineEditor
+		// setEnabled(bool) from LLTextEditor or LLLineEditor
 		// when the control is not focused.
 		// We need to silently ignore the case so that
 		// the language input status of the focused control
@@ -3910,7 +3910,7 @@ void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
             if (sWinIMEOpened && GetKeyboardLayout(0) == sWinInputLocale)
             {
                 HIMC himc = LLWinImm::getContext(mWindowHandle);
-                LLWinImm::setOpenStatus(himc, TRUE);
+                LLWinImm::setOpenStatus(himc, true);
                 LLWinImm::setConversionStatus(himc, sWinIMEConversionMode, sWinIMESentenceMode);
                 LLWinImm::releaseContext(mWindowHandle, himc);
             }
@@ -3936,7 +3936,7 @@ void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, BOOL b)
                     // We need both ImmSetConversionStatus and ImmSetOpenStatus here to surely disable IME's 
                     // keyboard hooking, because Some IME reacts only on the former and some other on the latter...
                     LLWinImm::setConversionStatus(himc, IME_CMODE_NOCONVERSION, sWinIMESentenceMode);
-                    LLWinImm::setOpenStatus(himc, FALSE);
+                    LLWinImm::setOpenStatus(himc, false);
                 }
                 LLWinImm::releaseContext(mWindowHandle, himc);
             }
@@ -4142,7 +4142,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
     {
         return;
     }
-	BOOL needs_update = FALSE;
+	bool needs_update = false;
 	LLWString result_string;
 	LLWString preedit_string;
 	S32 preedit_string_utf16_length = 0;
@@ -4165,7 +4165,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
 				result_string = utf16str_to_wstring(llutf16string(data, size / sizeof(WCHAR)));
 			}
 			delete[] data;
-			needs_update = TRUE;
+			needs_update = true;
 		}
 	}
 	
@@ -4182,7 +4182,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
 				preedit_string = utf16str_to_wstring(llutf16string(data, size / sizeof(WCHAR)));
 			}
 			delete[] data;
-			needs_update = TRUE;
+			needs_update = true;
 		}
 	}
 
@@ -4218,13 +4218,13 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
 			size = LLWinImm::getCompositionString(himc, GCS_COMPATTR, data, size);
 			if (size == preedit_string_utf16_length)
 			{
-				preedit_standouts.assign(preedit_segment_lengths.size(), FALSE);
+				preedit_standouts.assign(preedit_segment_lengths.size(), false);
 				S32 offset = 0;
 				for (U32 i = 0; i < preedit_segment_lengths.size(); i++)
 				{
 					if (ATTR_TARGET_CONVERTED == data[offset] || ATTR_TARGET_NOTCONVERTED == data[offset])
 					{
-						preedit_standouts[i] = TRUE;
+						preedit_standouts[i] = true;
 					}
 					offset += wstring_utf16_length(preedit_string, offset, preedit_segment_lengths[i]);
 				}
@@ -4248,7 +4248,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
 		// I'm not sure this condition really happens, but
 		// Windows SDK document says it is an indication
 		// of "reset everything."
-		needs_update = TRUE;
+		needs_update = true;
 	}
 
 	LLWinImm::releaseContext(mWindowHandle, himc);
@@ -4283,7 +4283,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
 			}
 			if (preedit_standouts.size() == 0)
 			{
-				preedit_standouts.assign(preedit_segment_lengths.size(), FALSE);
+				preedit_standouts.assign(preedit_segment_lengths.size(), false);
 			}
 		}
 		mPreeditor->updatePreedit(preedit_string, preedit_segment_lengths, preedit_standouts, caret_position);
@@ -4330,11 +4330,11 @@ LLWindowCallbacks::DragNDropResult LLWindowWin32::completeDragNDropRequest( cons
 }
 
 // Handle WM_IME_REQUEST message.
-// If it handled the message, returns TRUE.  Otherwise, FALSE.
+// If it handled the message, returns true.  Otherwise, false.
 // When it handled the message, the value to be returned from
 // the Window Procedure is set to *result.
 
-BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *result)
+bool LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *result)
 {
 	if ( mPreeditor )
 	{
@@ -4352,7 +4352,7 @@ BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *res
 				form->dwIndex = dwIndex;
 
 				*result = 1;
-				return TRUE;
+				return true;
 			}
 			case IMR_QUERYCHARPOSITION:
 			{
@@ -4372,20 +4372,20 @@ BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *res
 				if (!mPreeditor->getPreeditLocation(position, &caret_coord, &preedit_bounds, &text_control))
 				{
 					LL_WARNS("Window") << "*** IMR_QUERYCHARPOSITON called but getPreeditLocation failed." << LL_ENDL;
-					return FALSE;
+					return false;
 				}
 
 				fillCharPosition(caret_coord, preedit_bounds, text_control, char_position);
 
 				*result = 1;
-				return TRUE;
+				return true;
 			}
 			case IMR_COMPOSITIONFONT:
 			{
 				fillCompositionLogfont((LOGFONT *)param);
 
 				*result = 1;
-				return TRUE;
+				return true;
 			}
 			case IMR_RECONVERTSTRING:
 			{
@@ -4406,7 +4406,7 @@ BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *res
 						// Let the IME to decide the reconversion range, and
 						// adjust the reconvert_string structure accordingly.
 						HIMC himc = LLWinImm::getContext(mWindowHandle);
-						const BOOL adjusted = LLWinImm::setCompositionString(himc,
+						const bool adjusted = LLWinImm::setCompositionString(himc,
 									SCS_QUERYRECONVERTSTRING, reconvert_string, size, NULL, 0);
 						LLWinImm::releaseContext(mWindowHandle, himc);
 						if (adjusted)
@@ -4423,12 +4423,12 @@ BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *res
 				}
 
 				*result = size;
-				return TRUE;
+				return true;
 			}
 			case IMR_CONFIRMRECONVERTSTRING:
 			{
-				*result = FALSE;
-				return TRUE;
+				*result = 0;
+				return true;
 			}
 			case IMR_DOCUMENTFEED:
 			{
@@ -4450,14 +4450,14 @@ BOOL LLWindowWin32::handleImeRequests(WPARAM request, LPARAM param, LRESULT *res
 				
 				RECONVERTSTRING *reconvert_string = (RECONVERTSTRING *)param;
 				*result = fillReconvertString(context, preedit, 0, reconvert_string);
-				return TRUE;
+				return true;
 			}
 			default:
-				return FALSE;
+				return false;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
 //static

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2343,7 +2343,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             {
                 WINDOW_IMP_POST(window_imp->mCallbacks->handleDeviceChange(window_imp));
                 
-                return true;
+                return 1;
             }
             break;
         }
@@ -2502,6 +2502,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             // allow system keys, such as ALT-F4 to be processed by Windows
             eat_keystroke = false;
             // intentional fall-through here
+            [[fallthrough]];
         }
         case WM_KEYDOWN:
         {
@@ -2523,6 +2524,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
         case WM_SYSKEYUP:
             eat_keystroke = false;
             // intentional fall-through here
+            [[fallthrough]];
         case WM_KEYUP:
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_KEYUP");
@@ -3029,8 +3031,6 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     });
             };
             return 0;
-
-            break;
         }
         case WM_SETTINGCHANGE:
         {
@@ -3115,6 +3115,7 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                 }
             }
         }
+        break;
 
         //list of messages we get often that we don't care to log about
         case WM_NCHITTEST:

--- a/indra/llwindow/llwindowwin32.h
+++ b/indra/llwindow/llwindowwin32.h
@@ -48,47 +48,47 @@ public:
 	/*virtual*/ void show();
 	/*virtual*/ void hide();
 	/*virtual*/ void close();
-	/*virtual*/ BOOL getVisible();
-	/*virtual*/ BOOL getMinimized();
-	/*virtual*/ BOOL getMaximized();
-	/*virtual*/ BOOL maximize();
+	/*virtual*/ bool getVisible();
+	/*virtual*/ bool getMinimized();
+	/*virtual*/ bool getMaximized();
+	/*virtual*/ bool maximize();
 	/*virtual*/ void minimize();
 	/*virtual*/ void restore();
-	/*virtual*/ BOOL getFullscreen();
-	/*virtual*/ BOOL getPosition(LLCoordScreen *position);
-	/*virtual*/ BOOL getSize(LLCoordScreen *size);
-	/*virtual*/ BOOL getSize(LLCoordWindow *size);
-	/*virtual*/ BOOL setPosition(LLCoordScreen position);
-	/*virtual*/ BOOL setSizeImpl(LLCoordScreen size);
-	/*virtual*/ BOOL setSizeImpl(LLCoordWindow size);
-	/*virtual*/ BOOL switchContext(BOOL fullscreen, const LLCoordScreen &size, BOOL enable_vsync, const LLCoordScreen * const posp = NULL);
+	/*virtual*/ bool getFullscreen();
+	/*virtual*/ bool getPosition(LLCoordScreen *position);
+	/*virtual*/ bool getSize(LLCoordScreen *size);
+	/*virtual*/ bool getSize(LLCoordWindow *size);
+	/*virtual*/ bool setPosition(LLCoordScreen position);
+	/*virtual*/ bool setSizeImpl(LLCoordScreen size);
+	/*virtual*/ bool setSizeImpl(LLCoordWindow size);
+	/*virtual*/ bool switchContext(bool fullscreen, const LLCoordScreen &size, bool enable_vsync, const LLCoordScreen * const posp = NULL);
     /*virtual*/ void setTitle(const std::string title);
     void* createSharedContext() override;
     void makeContextCurrent(void* context) override;
     void destroySharedContext(void* context) override;
     /*virtual*/ void toggleVSync(bool enable_vsync);
-	/*virtual*/ BOOL setCursorPosition(LLCoordWindow position);
-	/*virtual*/ BOOL getCursorPosition(LLCoordWindow *position);
-    /*virtual*/ BOOL getCursorDelta(LLCoordCommon* delta);
+	/*virtual*/ bool setCursorPosition(LLCoordWindow position);
+	/*virtual*/ bool getCursorPosition(LLCoordWindow *position);
+    /*virtual*/ bool getCursorDelta(LLCoordCommon* delta);
 	/*virtual*/ void showCursor();
 	/*virtual*/ void hideCursor();
 	/*virtual*/ void showCursorFromMouseMove();
 	/*virtual*/ void hideCursorUntilMouseMove();
-	/*virtual*/ BOOL isCursorHidden();
+	/*virtual*/ bool isCursorHidden();
 	/*virtual*/ void updateCursor();
 	/*virtual*/ ECursorType getCursor() const;
 	/*virtual*/ void captureMouse();
 	/*virtual*/ void releaseMouse();
-	/*virtual*/ void setMouseClipping( BOOL b );
-	/*virtual*/ BOOL isClipboardTextAvailable();
-	/*virtual*/ BOOL pasteTextFromClipboard(LLWString &dst);
-	/*virtual*/ BOOL copyTextToClipboard(const LLWString &src);
+	/*virtual*/ void setMouseClipping( bool b );
+	/*virtual*/ bool isClipboardTextAvailable();
+	/*virtual*/ bool pasteTextFromClipboard(LLWString &dst);
+	/*virtual*/ bool copyTextToClipboard(const LLWString &src);
 	/*virtual*/ void flashIcon(F32 seconds);
 	/*virtual*/ F32 getGamma();
-	/*virtual*/ BOOL setGamma(const F32 gamma); // Set the gamma
+	/*virtual*/ bool setGamma(const F32 gamma); // Set the gamma
 	/*virtual*/ void setFSAASamples(const U32 fsaa_samples);
 	/*virtual*/ U32 getFSAASamples();
-	/*virtual*/ BOOL restoreGamma();			// Restore original gamma table (before updating gamma)
+	/*virtual*/ bool restoreGamma();			// Restore original gamma table (before updating gamma)
 	/*virtual*/ ESwapMethod getSwapMethod() { return mSwapMethod; }
 	/*virtual*/ void gatherInput();
 	/*virtual*/ void delayInputProcessing();
@@ -96,12 +96,12 @@ public:
 	/*virtual*/ void restoreGLContext() {};
 
 	// handy coordinate space conversion routines
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordWindow *to);
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordScreen *to);
-	/*virtual*/ BOOL convertCoords(LLCoordWindow from, LLCoordGL *to);
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordWindow *to);
-	/*virtual*/ BOOL convertCoords(LLCoordScreen from, LLCoordGL *to);
-	/*virtual*/ BOOL convertCoords(LLCoordGL from, LLCoordScreen *to);
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordWindow *to);
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordScreen *to);
+	/*virtual*/ bool convertCoords(LLCoordWindow from, LLCoordGL *to);
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordWindow *to);
+	/*virtual*/ bool convertCoords(LLCoordScreen from, LLCoordGL *to);
+	/*virtual*/ bool convertCoords(LLCoordGL from, LLCoordScreen *to);
 
 	/*virtual*/ LLWindowResolution* getSupportedResolutions(S32 &num_resolutions);
 	/*virtual*/ F32	getNativeAspectRatio();
@@ -111,13 +111,13 @@ public:
     U32 getAvailableVRAMMegabytes() override;
     /*virtual*/ void setMaxVRAMMegabytes(U32 max_vram) override;
 	
-    /*virtual*/	BOOL dialogColorPicker(F32 *r, F32 *g, F32 *b );
+    /*virtual*/	bool dialogColorPicker(F32 *r, F32 *g, F32 *b );
 
 	/*virtual*/ void *getPlatformWindow();
 	/*virtual*/ void bringToFront();
 	/*virtual*/ void focusClient();
 
-	/*virtual*/ void allowLanguageTextInput(LLPreeditor *preeditor, BOOL b);
+	/*virtual*/ void allowLanguageTextInput(LLPreeditor *preeditor, bool b);
 	/*virtual*/ void setLanguageTextInput( const LLCoordGL & pos );
 	/*virtual*/ void updateLanguageTextInputArea();
 	/*virtual*/ void interruptLanguageTextInput();
@@ -139,27 +139,27 @@ public:
 protected:
 	LLWindowWin32(LLWindowCallbacks* callbacks,
 		const std::string& title, const std::string& name, int x, int y, int width, int height, U32 flags, 
-		BOOL fullscreen, BOOL clearBg, BOOL enable_vsync, BOOL use_gl,
-		BOOL ignore_pixel_depth, U32 fsaa_samples, U32 max_cores, U32 max_vram, F32 max_gl_version);
+		bool fullscreen, bool clearBg, bool enable_vsync, bool use_gl,
+		bool ignore_pixel_depth, U32 fsaa_samples, U32 max_cores, U32 max_vram, F32 max_gl_version);
 	~LLWindowWin32();
 
 	void	initCursors();
 	void	initInputDevices();
 	HCURSOR loadColorCursor(LPCTSTR name);
-	BOOL	isValid();
+	bool	isValid();
 	void	moveWindow(const LLCoordScreen& position,const LLCoordScreen& size);
 	virtual LLSD	getNativeKeyData();
 
 	// Changes display resolution. Returns true if successful
-	BOOL	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
+	bool	setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
 
 	// Go back to last fullscreen display resolution.
-	BOOL	setFullscreenResolution();
+	bool	setFullscreenResolution();
 
 	// Restore the display resolution to its value before we ran the app.
-	BOOL	resetDisplayResolution();
+	bool	resetDisplayResolution();
 
-	BOOL	shouldPostQuit() { return mPostQuit; }
+	bool	shouldPostQuit() { return mPostQuit; }
 
 	void	fillCompositionForm(const LLRect& bounds, COMPOSITIONFORM *form);
 	void	fillCandidateForm(const LLCoordGL& caret, const LLRect& bounds, CANDIDATEFORM *form);
@@ -168,18 +168,18 @@ protected:
 	U32		fillReconvertString(const LLWString &text, S32 focus, S32 focus_length, RECONVERTSTRING *reconvert_string);
 	void	handleStartCompositionMessage();
 	void	handleCompositionMessage(U32 indexes);
-	BOOL	handleImeRequests(WPARAM request, LPARAM param, LRESULT *result);
+	bool	handleImeRequests(WPARAM request, LPARAM param, LRESULT *result);
 
 protected:
 	//
 	// Platform specific methods
 	//
 
-	BOOL	getClientRectInScreenSpace(RECT* rectp);
+	bool	getClientRectInScreenSpace(RECT* rectp);
 	void 	updateJoystick( );
 
 	static LRESULT CALLBACK mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_param, LPARAM l_param);
-	static BOOL CALLBACK enumChildWindows(HWND h_wnd, LPARAM l_param);
+	static bool CALLBACK enumChildWindows(HWND h_wnd, LPARAM l_param);
 
 
 	//
@@ -207,7 +207,7 @@ protected:
 
     MASK        mMouseMask;
 
-	static BOOL sIsClassRegistered; // has the window class been registered?
+	static bool sIsClassRegistered; // has the window class been registered?
 
 	F32			mCurrentGamma;
 	U32			mFSAASamples;
@@ -215,16 +215,16 @@ protected:
     F32         mMaxGLVersion; // maximum OpenGL version to attempt to use (clamps to 3.2 - 4.6)
 	WORD		mPrevGammaRamp[3][256];
 	WORD		mCurrentGammaRamp[3][256];
-	BOOL		mCustomGammaSet;
+	bool		mCustomGammaSet;
 
 	LPWSTR		mIconResource;
-	BOOL		mInputProcessingPaused;
+	bool		mInputProcessingPaused;
 
 	// The following variables are for Language Text Input control.
 	// They are all static, since one context is shared by all LLWindowWin32
 	// instances.
-	static BOOL		sLanguageTextInputAllowed;
-	static BOOL		sWinIMEOpened;
+	static bool		sLanguageTextInputAllowed;
+	static bool		sWinIMEOpened;
 	static HKL		sWinInputLocale;
 	static DWORD	sWinIMEConversionMode;
 	static DWORD	sWinIMESentenceMode;
@@ -243,7 +243,7 @@ protected:
 	U32				mRawWParam;
 	U32				mRawLParam;
 
-	BOOL			mMouseVanish;
+	bool			mMouseVanish;
 
     // Cached values of GetWindowRect and GetClientRect to be used by app thread
     void updateWindowRect();

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -289,7 +289,7 @@ extern BOOL gPeriodicSlowFrame;
 extern BOOL gDebugGL;
 
 #if LL_DARWIN
-extern BOOL gHiDPISupport;
+extern bool gHiDPISupport;
 #endif
 
 ////////////////////////////////////////////////////////////

--- a/indra/newview/llavatarlist.cpp
+++ b/indra/newview/llavatarlist.cpp
@@ -437,9 +437,9 @@ void LLAvatarList::addNewItem(const LLUUID& id, const std::string& name, BOOL is
 }
 
 // virtual
-BOOL LLAvatarList::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLAvatarList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLUICtrl::handleRightMouseDown(x, y, mask);
+	bool handled = LLUICtrl::handleRightMouseDown(x, y, mask);
 	if ( mContextMenu)
 	{
 		uuid_vec_t selected_uuids;
@@ -449,7 +449,7 @@ BOOL LLAvatarList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLAvatarList::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLAvatarList::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	gFocusMgr.setMouseCapture(this);
 
@@ -461,7 +461,7 @@ BOOL LLAvatarList::handleMouseDown(S32 x, S32 y, MASK mask)
 	return LLFlatListViewEx::handleMouseDown(x, y, mask);
 }
 
-BOOL LLAvatarList::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLAvatarList::handleMouseUp( S32 x, S32 y, MASK mask )
 {
 	if(hasMouseCapture())
 	{
@@ -471,7 +471,7 @@ BOOL LLAvatarList::handleMouseUp( S32 x, S32 y, MASK mask )
 	return LLFlatListViewEx::handleMouseUp(x, y, mask);
 }
 
-BOOL LLAvatarList::handleHover(S32 x, S32 y, MASK mask)
+bool LLAvatarList::handleHover(S32 x, S32 y, MASK mask)
 {
 	bool handled = hasMouseCapture();
 	if(handled)

--- a/indra/newview/llavatarlist.h
+++ b/indra/newview/llavatarlist.h
@@ -84,10 +84,10 @@ public:
 	bool getIconsVisible() const { return mShowIcons; }
 	const std::string getIconParamName() const{return mIconParamName;}
 	std::string getAvatarName(LLAvatarName av_name);
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 
 	// Return true if filter has at least one match.
 	bool filterHasMatches();

--- a/indra/newview/llavatarlistitem.cpp
+++ b/indra/newview/llavatarlistitem.cpp
@@ -356,17 +356,17 @@ void LLAvatarListItem::onProfileBtnClick()
 	LLAvatarActions::showProfile(mAvatarId);
 }
 
-BOOL LLAvatarListItem::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLAvatarListItem::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if(mInfoBtn->getRect().pointInRect(x, y))
 	{
 		onInfoBtnClick();
-		return TRUE;
+		return true;
 	}
 	if(mProfileBtn->getRect().pointInRect(x, y))
 	{
 		onProfileBtnClick();
-		return TRUE;
+		return true;
 	}
 	return LLPanel::handleDoubleClick(x, y, mask);
 }

--- a/indra/newview/llavatarlistitem.h
+++ b/indra/newview/llavatarlistitem.h
@@ -115,7 +115,7 @@ public:
 	void onInfoBtnClick();
 	void onProfileBtnClick();
 
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
 
 protected:
 	/**

--- a/indra/newview/llblocklist.cpp
+++ b/indra/newview/llblocklist.cpp
@@ -113,9 +113,9 @@ void LLBlockList::onChangeDetailed(const LLMute &mute)
 	refresh();
 }
 
-BOOL LLBlockList::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLBlockList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLUICtrl::handleRightMouseDown(x, y, mask);
+	bool handled = LLUICtrl::handleRightMouseDown(x, y, mask);
 
 	LLToggleableMenu* context_menu = mContextMenu.get();
 	if (context_menu && size())

--- a/indra/newview/llblocklist.h
+++ b/indra/newview/llblocklist.h
@@ -54,7 +54,7 @@ public:
 	LLBlockList(const Params& p);
 	virtual ~LLBlockList();
 
-	virtual BOOL 		handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool 		handleRightMouseDown(S32 x, S32 y, MASK mask);
 	LLToggleableMenu*	getContextMenu() const { return mContextMenu.get(); }
 	LLBlockedListItem*	getBlockedItem() const;
 

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -155,7 +155,7 @@ public:
 		}
 	}
 
-	BOOL handleMouseUp(S32 x, S32 y, MASK mask)
+	bool handleMouseUp(S32 x, S32 y, MASK mask)
 	{
 		return LLPanel::handleMouseUp(x,y,mask);
 	}
@@ -619,12 +619,12 @@ public:
 		return 	child->pointInView(local_x, local_y);
 	}
 
-	BOOL handleRightMouseDown(S32 x, S32 y, MASK mask)
+	bool handleRightMouseDown(S32 x, S32 y, MASK mask)
 	{
 		if(pointInChild("avatar_icon",x,y) || pointInChild("user_name",x,y))
 		{
 			showContextMenu(x,y);
-			return TRUE;
+			return true;
 		}
 
 		return LLPanel::handleRightMouseDown(x,y,mask);

--- a/indra/newview/llchatitemscontainerctrl.cpp
+++ b/indra/newview/llchatitemscontainerctrl.cpp
@@ -326,12 +326,12 @@ void LLFloaterIMNearbyChatToastPanel::onMouseEnter				(S32 x, S32 y, MASK mask)
 		return;
 }
 
-BOOL	LLFloaterIMNearbyChatToastPanel::handleMouseDown	(S32 x, S32 y, MASK mask)
+bool	LLFloaterIMNearbyChatToastPanel::handleMouseDown	(S32 x, S32 y, MASK mask)
 {
 	return LLPanel::handleMouseDown(x,y,mask);
 }
 
-BOOL	LLFloaterIMNearbyChatToastPanel::handleMouseUp	(S32 x, S32 y, MASK mask)
+bool	LLFloaterIMNearbyChatToastPanel::handleMouseUp	(S32 x, S32 y, MASK mask)
 {
 	/*
 	fix for request  EXT-4780
@@ -347,11 +347,11 @@ BOOL	LLFloaterIMNearbyChatToastPanel::handleMouseUp	(S32 x, S32 y, MASK mask)
 	if (mMsgText->pointInView(local_x, local_y) )
 	{
 		if (mMsgText->handleMouseUp(local_x,local_y,mask) == TRUE)
-			return TRUE;
+			return true;
 		else
 		{
 			LLFloaterReg::getTypedInstance<LLFloaterIMNearbyChat>("nearby_chat")->showHistory();
-			return FALSE;
+			return false;
 		}
 	}
 	LLFloaterReg::getTypedInstance<LLFloaterIMNearbyChat>("nearby_chat")->showHistory();
@@ -374,7 +374,7 @@ bool	LLFloaterIMNearbyChatToastPanel::canAddText	()
 	return msg_text->getLineCount()<10;
 }
 
-BOOL	LLFloaterIMNearbyChatToastPanel::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool	LLFloaterIMNearbyChatToastPanel::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLUICtrl* avatar_icon = getChild<LLUICtrl>("avatar_icon", false);
 
@@ -383,7 +383,7 @@ BOOL	LLFloaterIMNearbyChatToastPanel::handleRightMouseDown(S32 x, S32 y, MASK ma
 
 	//eat message for avatar icon if msg was from object
 	if(avatar_icon->pointInView(local_x, local_y) && mSourceType != CHAT_SOURCE_AGENT)
-		return TRUE;
+		return true;
 	return LLPanel::handleRightMouseDown(x,y,mask);
 }
 void LLFloaterIMNearbyChatToastPanel::draw()

--- a/indra/newview/llchatitemscontainerctrl.h
+++ b/indra/newview/llchatitemscontainerctrl.h
@@ -66,15 +66,15 @@ public:
 
 	void	onMouseLeave	(S32 x, S32 y, MASK mask);
 	void	onMouseEnter	(S32 x, S32 y, MASK mask);
-	BOOL	handleMouseDown	(S32 x, S32 y, MASK mask);
-	BOOL	handleMouseUp	(S32 x, S32 y, MASK mask);
+	bool	handleMouseDown	(S32 x, S32 y, MASK mask);
+	bool	handleMouseUp	(S32 x, S32 y, MASK mask);
 
 	virtual BOOL postBuild();
 
 	void	reshape		(S32 width, S32 height, BOOL called_from_parent = TRUE);
 
 	void	setHeaderVisibility(EShowItemHeader e);
-	BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	virtual void init(LLSD& data);
 	virtual void addMessage(LLSD& data);

--- a/indra/newview/llchiclet.cpp
+++ b/indra/newview/llchiclet.cpp
@@ -148,7 +148,7 @@ void LLSysWellChiclet::updateWidget(bool is_window_empty)
 	}
 }
 // virtual
-BOOL LLSysWellChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLSysWellChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLContextMenu* menu_avatar = mContextMenuHandle.get();
 	if(!menu_avatar)
@@ -161,7 +161,7 @@ BOOL LLSysWellChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		menu_avatar->show(x, y);
 		LLMenuGL::showPopup(this, menu_avatar, x, y);
 	}
-	return TRUE;
+	return true;
 }
 
 /************************************************************************/
@@ -279,11 +279,11 @@ boost::signals2::connection LLChiclet::setLeftButtonClickCallback(
 	return setCommitCallback(cb);
 }
 
-BOOL LLChiclet::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLChiclet::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	onCommit();
 	childrenHandleMouseDown(x,y,mask);
-	return TRUE;
+	return true;
 }
 
 boost::signals2::connection LLChiclet::setChicletSizeChangedCallback(
@@ -382,7 +382,7 @@ void LLIMChiclet::setToggleState(bool toggle)
 	mChicletButton->setToggleState(toggle);
 }
 
-BOOL LLIMChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLIMChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	auto menu = static_cast<LLMenuGL*>(mPopupMenuHandle.get());
 	if(!menu)
@@ -398,7 +398,7 @@ BOOL LLIMChiclet::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		LLMenuGL::showPopup(this, menu, x, y);
 	}
 
-	return TRUE;
+	return true;
 }
 
 void LLIMChiclet::hidePopupMenu()
@@ -994,7 +994,7 @@ boost::signals2::connection LLChicletPanel::setChicletClickedCallback(
 	return setCommitCallback(cb);
 }
 
-BOOL LLChicletPanel::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLChicletPanel::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if(clicks > 0)
 	{
@@ -1004,7 +1004,7 @@ BOOL LLChicletPanel::handleScrollWheel(S32 x, S32 y, S32 clicks)
 	{
 		scrollLeft();
 	}
-	return TRUE;
+	return true;
 }
 
 bool LLChicletPanel::isAnyIMFloaterDoked()

--- a/indra/newview/llchiclet.h
+++ b/indra/newview/llchiclet.h
@@ -214,7 +214,7 @@ protected:
 	/**
 	 * Notifies subscribers about click on chiclet.
 	 */
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
 
 	/**
 	 * Notifies subscribers about chiclet size changed event.
@@ -303,7 +303,7 @@ public:
 	/**
 	 * Displays popup menu.
 	 */
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	void hidePopupMenu();
 
@@ -507,7 +507,7 @@ protected:
 	/**
 	 * Displays menu.
 	 */
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	virtual void createMenu() = 0;
 
@@ -775,7 +775,7 @@ protected:
 	/**
 	 * Callback for mouse wheel scrolled, calls scrollRight() or scrollLeft()
 	 */
-	BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
+	bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 
 	/**
 	 * Notifies subscribers about click on chiclet.

--- a/indra/newview/llcolorswatch.cpp
+++ b/indra/newview/llcolorswatch.cpp
@@ -108,18 +108,18 @@ LLColorSwatchCtrl::~LLColorSwatchCtrl ()
 	}
 }
 
-BOOL LLColorSwatchCtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLColorSwatchCtrl::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	return handleMouseDown(x, y, mask);
 }
 
-BOOL LLColorSwatchCtrl::handleHover(S32 x, S32 y, MASK mask)
+bool LLColorSwatchCtrl::handleHover(S32 x, S32 y, MASK mask)
 {
 	getWindow()->setCursor(UI_CURSOR_HAND);
-	return TRUE;
+	return true;
 }
 
-BOOL LLColorSwatchCtrl::handleUnicodeCharHere(llwchar uni_char)
+bool LLColorSwatchCtrl::handleUnicodeCharHere(llwchar uni_char)
 {
 	if( ' ' == uni_char )
 	{
@@ -158,17 +158,17 @@ void LLColorSwatchCtrl::setLabel(const std::string& label)
 	mCaption->setText(label);
 }
 
-BOOL LLColorSwatchCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLColorSwatchCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Route future Mouse messages here preemptively.  (Release on mouse up.)
 	// No handler is needed for capture lost since this object has no state that depends on it.
 	gFocusMgr.setMouseCapture( this );
 
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLColorSwatchCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLColorSwatchCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// We only handle the click if the click both started and ended within us
 	if( hasMouseCapture() )
@@ -190,7 +190,7 @@ BOOL LLColorSwatchCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 // assumes GL state is set for 2D

--- a/indra/newview/llcolorswatch.h
+++ b/indra/newview/llcolorswatch.h
@@ -89,11 +89,11 @@ public:
 
 	void			showPicker(BOOL take_focus);
 
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x,S32 y,MASK mask);
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleUnicodeCharHere(llwchar uni_char);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleDoubleClick(S32 x,S32 y,MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleUnicodeCharHere(llwchar uni_char);
 	/*virtual*/ void	draw();
 	/*virtual*/ void	setEnabled( BOOL enabled );
 

--- a/indra/newview/llconversationloglist.cpp
+++ b/indra/newview/llconversationloglist.cpp
@@ -86,9 +86,9 @@ void LLConversationLogList::draw()
 	LLFlatListViewEx::draw();
 }
 
-BOOL LLConversationLogList::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLConversationLogList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLUICtrl::handleRightMouseDown(x, y, mask);
+	bool handled = LLUICtrl::handleRightMouseDown(x, y, mask);
 
 	LLToggleableMenu* context_menu = mContextMenu.get();
     if (context_menu && size())

--- a/indra/newview/llconversationloglist.h
+++ b/indra/newview/llconversationloglist.h
@@ -59,7 +59,7 @@ public:
 
 	virtual void draw();
 
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	LLToggleableMenu*	getContextMenu() const { return mContextMenu.get(); }
 

--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -320,10 +320,10 @@ void LLConversationViewSession::draw()
 	LLView::draw();
 }
 
-BOOL LLConversationViewSession::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLConversationViewSession::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	//Will try to select a child node and then itself (if a child was not selected)
-    BOOL result = LLFolderViewFolder::handleMouseDown(x, y, mask);
+    bool result = LLFolderViewFolder::handleMouseDown(x, y, mask);
 
     //This node (conversation) was selected and a child (participant) was not
     if(result && getRoot())
@@ -349,9 +349,9 @@ BOOL LLConversationViewSession::handleMouseDown( S32 x, S32 y, MASK mask )
 	return result;
 }
 
-BOOL LLConversationViewSession::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLConversationViewSession::handleMouseUp( S32 x, S32 y, MASK mask )
 {
-	BOOL result = LLFolderViewFolder::handleMouseUp(x, y, mask);
+	bool result = LLFolderViewFolder::handleMouseUp(x, y, mask);
 
 	LLFloater* volume_floater = LLFloaterReg::findInstance("floater_voice_volume");
 	LLFloater* chat_volume_floater = LLFloaterReg::findInstance("chat_voice");
@@ -372,9 +372,9 @@ BOOL LLConversationViewSession::handleMouseUp( S32 x, S32 y, MASK mask )
 	return result;
 }
 
-BOOL LLConversationViewSession::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLConversationViewSession::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
-    BOOL result = LLFolderViewFolder::handleRightMouseDown(x, y, mask);
+    bool result = LLFolderViewFolder::handleRightMouseDown(x, y, mask);
 
     if(result)
     {
@@ -763,9 +763,9 @@ void LLConversationViewParticipant::onInfoBtnClick()
 	LLFloaterReg::showInstance("inspect_avatar", LLSD().with("avatar_id", mUUID));
 }
 
-BOOL LLConversationViewParticipant::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLConversationViewParticipant::handleMouseDown( S32 x, S32 y, MASK mask )
 {
-	BOOL result = LLFolderViewItem::handleMouseDown(x, y, mask);
+	bool result = LLFolderViewItem::handleMouseDown(x, y, mask);
 
     if(result && getRoot())
     {

--- a/indra/newview/llconversationview.h
+++ b/indra/newview/llconversationview.h
@@ -71,9 +71,9 @@ public:
 
 	/*virtual*/ BOOL postBuild();
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL handleMouseUp( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleRightMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleMouseUp( S32 x, S32 y, MASK mask );
 
 	/*virtual*/ S32 arrange(S32* width, S32* height);
 
@@ -151,7 +151,7 @@ public:
     void onMouseLeave(S32 x, S32 y, MASK mask);
 
     /*virtual*/ S32 getLabelXPos();
-    /*virtual*/ BOOL handleMouseDown( S32 x, S32 y, MASK mask );
+    /*virtual*/ bool handleMouseDown( S32 x, S32 y, MASK mask );
 	void allowSpeakingIndicator(bool val);
 
 protected:

--- a/indra/newview/llexpandabletextbox.cpp
+++ b/indra/newview/llexpandabletextbox.cpp
@@ -93,12 +93,12 @@ public:
 	}
 	/*virtual*/ bool	canEdit() const { return false; }
 	// eat handleMouseDown event so we get the mouseup event
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask) { return TRUE; }
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask) { mEditor.onCommit(); return TRUE; }
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask) 
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask) { return true; }
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask) { mEditor.onCommit(); return true; }
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask)
 	{
 		LLUI::getInstance()->getWindow()->setCursor(UI_CURSOR_HAND);
-		return TRUE; 
+		return true; 
 	}
 private:
 	LLTextBase& mEditor;

--- a/indra/newview/llfasttimerview.cpp
+++ b/indra/newview/llfasttimerview.cpp
@@ -135,7 +135,7 @@ BOOL LLFastTimerView::postBuild()
 	return TRUE;
 }
 
-BOOL LLFastTimerView::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mHoverTimer )
 	{
@@ -148,14 +148,14 @@ BOOL LLFastTimerView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 		{
 			mHoverTimer->getParent()->getTreeNode().mCollapsed = true;
 		}
-		return TRUE;
+		return true;
 	}
 	else if (mBarRect.pointInRect(x, y))
 	{
 		S32 bar_idx = MAX_VISIBLE_HISTORY - ((y - mBarRect.mBottom) * (MAX_VISIBLE_HISTORY + 2) / mBarRect.getHeight());
 		bar_idx = llclamp(bar_idx, 0, MAX_VISIBLE_HISTORY);
 		mStatsIndex = mScrollIndex + bar_idx;
-		return TRUE;
+		return true;
 	}
 	return LLFloater::handleRightMouseDown(x, y, mask);
 }
@@ -172,7 +172,7 @@ BlockTimerStatHandle* LLFastTimerView::getLegendID(S32 y)
 	return NULL;
 }
 
-BOOL LLFastTimerView::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	for(LLTrace::block_timer_tree_df_iterator_t it = LLTrace::begin_block_timer_tree_df(FTM_FRAME);
 		it != LLTrace::end_block_timer_tree_df();
@@ -180,10 +180,10 @@ BOOL LLFastTimerView::handleDoubleClick(S32 x, S32 y, MASK mask)
 	{
 		(*it)->getTreeNode().mCollapsed = false;
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLFastTimerView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (x < mScrollBar->getRect().mLeft)
 	{
@@ -201,13 +201,13 @@ BOOL LLFastTimerView::handleMouseDown(S32 x, S32 y, MASK mask)
 	else if (mGraphRect.pointInRect(x, y))
 	{
 		gFocusMgr.setMouseCapture(this);
-		return TRUE;
+		return true;
 	}
 
 	return LLFloater::handleMouseDown(x, y, mask);
 }
 
-BOOL LLFastTimerView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (hasMouseCapture())
 	{
@@ -216,14 +216,14 @@ BOOL LLFastTimerView::handleMouseUp(S32 x, S32 y, MASK mask)
 	return LLFloater::handleMouseUp(x, y, mask);;
 }
 
-BOOL LLFastTimerView::handleHover(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (hasMouseCapture())
 	{
 		F32 lerp = llclamp(1.f - (F32) (x - mGraphRect.mLeft) / (F32) mGraphRect.getWidth(), 0.f, 1.f);
 		mScrollIndex = ll_round( lerp * (F32)(mRecording.getNumRecordedPeriods() - MAX_VISIBLE_HISTORY));
 		mScrollIndex = llclamp(	mScrollIndex, 0, (S32)mRecording.getNumRecordedPeriods());
-		return TRUE;
+		return true;
 	}
 	mHoverTimer = NULL;
 	mHoverID = NULL;
@@ -314,7 +314,7 @@ static std::string get_tooltip(BlockTimerStatHandle& timer, S32 history_index, P
 	return tooltip;
 }
 
-BOOL LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if(mPauseHistory && mBarRect.pointInRect(x, y))
 	{
@@ -331,7 +331,7 @@ BOOL LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
 				.sticky_rect(screen_rect)
 				.delay_time(0.f));
 
-			return TRUE;
+			return true;
 		}
 	}
 	else
@@ -344,7 +344,7 @@ BOOL LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
 			{
 				LLToolTipMgr::instance().show(get_tooltip(*idp, 0, mRecording));
 
-				return TRUE;
+				return true;
 			}
 		}
 	}
@@ -352,7 +352,7 @@ BOOL LLFastTimerView::handleToolTip(S32 x, S32 y, MASK mask)
 	return LLFloater::handleToolTip(x, y, mask);
 }
 
-BOOL LLFastTimerView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFastTimerView::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     if (x < mBarRect.mLeft)
     {
@@ -366,7 +366,7 @@ BOOL LLFastTimerView::handleScrollWheel(S32 x, S32 y, S32 clicks)
 							0,
 							llmin((S32)mRecording.getNumRecordedPeriods(), (S32)mRecording.getNumRecordedPeriods() - MAX_VISIBLE_HISTORY));
     }
-	return TRUE;
+	return true;
 }
 
 static BlockTimerStatHandle FTM_RENDER_TIMER("Timers");

--- a/indra/newview/llfasttimerview.h
+++ b/indra/newview/llfasttimerview.h
@@ -55,13 +55,13 @@ private:
 
 public:
 
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL handleToolTip(S32 x, S32 y, MASK mask);
-	virtual BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleHover(S32 x, S32 y, MASK mask);
+	virtual bool handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 	virtual void draw();
 	virtual void onOpen(const LLSD& key);
 	virtual void onClose(bool app_quitting);

--- a/indra/newview/llfavoritesbar.cpp
+++ b/indra/newview/llfavoritesbar.cpp
@@ -160,7 +160,7 @@ class LLFavoriteLandmarkButton : public LLButton
 {
 public:
 
-	BOOL handleToolTip(S32 x, S32 y, MASK mask)
+	bool handleToolTip(S32 x, S32 y, MASK mask)
 	{
 		std::string region_name = mLandmarkInfoGetter.getName();
 		
@@ -176,10 +176,10 @@ public:
 
 			LLToolTipMgr::instance().show(params);
 		}
-		return TRUE;
+		return true;
 	}
 
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask)
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask)
 	{
 		LLFavoritesBarCtrl* fb = dynamic_cast<LLFavoritesBarCtrl*>(getParent());
 
@@ -224,7 +224,7 @@ private:
 class LLFavoriteLandmarkMenuItem : public LLMenuItemCallGL
 {
 public:
-	BOOL handleToolTip(S32 x, S32 y, MASK mask)
+	bool handleToolTip(S32 x, S32 y, MASK mask)
 	{
 		std::string region_name = mLandmarkInfoGetter.getName();
 		if (!region_name.empty())
@@ -234,34 +234,34 @@ public:
 			params.sticky_rect = calcScreenRect();
 			LLToolTipMgr::instance().show(params);
 		}
-		return TRUE;
+		return true;
 	}
 	
 	const LLUUID& getLandmarkID() const { return mLandmarkInfoGetter.getLandmarkID(); }
 	void setLandmarkID(const LLUUID& id) { mLandmarkInfoGetter.setLandmarkID(id); }
 
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask)
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask)
 	{
 		if (mMouseDownSignal)
 			(*mMouseDownSignal)(this, x, y, mask);
 		return LLMenuItemCallGL::handleMouseDown(x, y, mask);
 	}
 
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask)
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask)
 	{
 		if (mMouseUpSignal)
 			(*mMouseUpSignal)(this, x, y, mask);
 		return LLMenuItemCallGL::handleMouseUp(x, y, mask);
 	}
 
-	virtual BOOL handleHover(S32 x, S32 y, MASK mask)
+	virtual bool handleHover(S32 x, S32 y, MASK mask)
 	{
 		if (fb)
 		{
 			fb->handleHover(x, y, mask);
 		}
 
-		return TRUE;
+		return true;
 	}
 
 	void initFavoritesBarPointer(LLFavoritesBarCtrl* fb) { this->fb = fb; }
@@ -295,12 +295,12 @@ public:
     }
 
     // virtual
-    BOOL handleHover(S32 x, S32 y, MASK mask) override
+    bool handleHover(S32 x, S32 y, MASK mask) override
     {
         mIsHovering = true;
         LLToggleableMenu::handleHover(x, y, mask);
         mIsHovering = false;
-        return TRUE;
+        return true;
     }
 
     // virtual
@@ -1335,9 +1335,9 @@ void LLFavoritesBarCtrl::onButtonRightClick( LLUUID item_id,LLView* fav_button,S
 	LLMenuGL::showPopup(fav_button, menu, x, y);
 }
 
-BOOL LLFavoritesBarCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLFavoritesBarCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = childrenHandleRightMouseDown( x, y, mask) != NULL;
+	bool handled = childrenHandleRightMouseDown( x, y, mask) != NULL;
 	if(!handled && !gMenuHolder->hasVisibleMenu())
 	{
 		show_navbar_context_menu(this,x,y);
@@ -1580,7 +1580,7 @@ void LLFavoritesBarCtrl::onEndDrag()
 	LLView::getWindow()->setCursor(UI_CURSOR_ARROW);
 }
 
-BOOL LLFavoritesBarCtrl::handleHover(S32 x, S32 y, MASK mask)
+bool LLFavoritesBarCtrl::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (mDragItemId != LLUUID::null && mStartDrag)
 	{
@@ -1599,7 +1599,7 @@ BOOL LLFavoritesBarCtrl::handleHover(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 LLUICtrl* LLFavoritesBarCtrl::findChildByLocalCoords(S32 x, S32 y)

--- a/indra/newview/llfavoritesbar.h
+++ b/indra/newview/llfavoritesbar.h
@@ -63,8 +63,8 @@ public:
 	bool handleDragAndDropToMenu(S32 x, S32 y, MASK mask, BOOL drop,
 		EDragAndDropType cargo_type, void* cargo_data, EAcceptance* accept, std::string& tooltip_msg);
 
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask) override;
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask) override;
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask) override;
 	// LLInventoryObserver observer trigger
     /*virtual*/ void changed(U32 mask) override;
     /*virtual*/ void reshape(S32 width, S32 height, BOOL called_from_parent = TRUE) override;

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -471,7 +471,7 @@ void LLFloaterBvhPreview::resetMotion()
 //-----------------------------------------------------------------------------
 // handleMouseDown()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterBvhPreview::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloaterBvhPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mPreviewRect.pointInRect(x, y))
 	{
@@ -480,7 +480,7 @@ BOOL LLFloaterBvhPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 		gViewerWindow->hideCursor();
 		mLastMouseX = x;
 		mLastMouseY = y;
-		return TRUE;
+		return true;
 	}
 
 	return LLFloater::handleMouseDown(x, y, mask);
@@ -489,7 +489,7 @@ BOOL LLFloaterBvhPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleMouseUp()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterBvhPreview::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLFloaterBvhPreview::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	gFocusMgr.setMouseCapture(FALSE);
 	gViewerWindow->showCursor();
@@ -499,7 +499,7 @@ BOOL LLFloaterBvhPreview::handleMouseUp(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleHover()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterBvhPreview::handleHover(S32 x, S32 y, MASK mask)
+bool LLFloaterBvhPreview::handleHover(S32 x, S32 y, MASK mask)
 {
 	MASK local_mask = mask & ~MASK_ALT;
 
@@ -548,13 +548,13 @@ BOOL LLFloaterBvhPreview::handleHover(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_TOOLZOOMIN);
 	}
 
-	return TRUE;
+	return true;
 }
 
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (!mAnimPreview)
 		return false;
@@ -562,7 +562,7 @@ BOOL LLFloaterBvhPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
 	mAnimPreview->zoom((F32)clicks * -0.2f);
 	mAnimPreview->requestUpdate();
 
-	return TRUE;
+	return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llfloaterbvhpreview.h
+++ b/indra/newview/llfloaterbvhpreview.h
@@ -75,10 +75,10 @@ public:
 	
 	BOOL postBuild();
 
-	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	BOOL handleHover(S32 x, S32 y, MASK mask);
-	BOOL handleScrollWheel(S32 x, S32 y, S32 clicks); 
+	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	bool handleMouseUp(S32 x, S32 y, MASK mask);
+	bool handleHover(S32 x, S32 y, MASK mask);
+	bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 	void onMouseCaptureLost();
 
 	void refresh();

--- a/indra/newview/llfloatercolorpicker.cpp
+++ b/indra/newview/llfloatercolorpicker.cpp
@@ -782,7 +782,7 @@ BOOL LLFloaterColorPicker::updateRgbHslFromPoint ( S32 xPosIn, S32 yPosIn )
 
 //////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
+bool LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 {
 	// make it the frontmost
 	gFloaterView->bringToFront(this);
@@ -803,7 +803,7 @@ BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 		updateRgbHslFromPoint ( x, y );
 
 		// required by base class
-		return TRUE;
+		return true;
 	}
 
 	// rect containing RGB area
@@ -819,7 +819,7 @@ BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 		setMouseDownInLumRegion ( TRUE );
 
 		// required by base class
-		return TRUE;
+		return true;
 	}
 
 	// rect containing swatch area
@@ -834,7 +834,7 @@ BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 		setMouseDownInSwatch( TRUE );
 
 		// required - dont drag windows here.
-		return TRUE;
+		return true;
 	}
 
 	// rect containing palette area
@@ -871,7 +871,7 @@ BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 			updateTextEntry ();
 		}
 
-		return TRUE;
+		return true;
 	}
 
 	// dispatch to base class for the rest of things
@@ -881,7 +881,7 @@ BOOL LLFloaterColorPicker::handleMouseDown ( S32 x, S32 y, MASK mask )
 
 //////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLFloaterColorPicker::handleHover ( S32 x, S32 y, MASK mask )
+bool LLFloaterColorPicker::handleHover ( S32 x, S32 y, MASK mask )
 {
 	// if we're the front most window
 	if ( isFrontmost () )
@@ -939,7 +939,7 @@ BOOL LLFloaterColorPicker::handleHover ( S32 x, S32 y, MASK mask )
 				highlightEntry = xOffset + yOffset * numPaletteColumns;
 			}
 
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -949,7 +949,7 @@ BOOL LLFloaterColorPicker::handleHover ( S32 x, S32 y, MASK mask )
 
 //////////////////////////////////////////////////////////////////////////////
 // reverts state once mouse button is released
-BOOL LLFloaterColorPicker::handleMouseUp ( S32 x, S32 y, MASK mask )
+bool LLFloaterColorPicker::handleMouseUp ( S32 x, S32 y, MASK mask )
 {
 	getWindow()->setCursor ( UI_CURSOR_ARROW );
 

--- a/indra/newview/llfloatercolorpicker.h
+++ b/indra/newview/llfloatercolorpicker.h
@@ -50,9 +50,9 @@ class LLFloaterColorPicker
 		// overrides
 		virtual BOOL postBuild ();
 		virtual void draw ();
-		virtual BOOL handleMouseDown ( S32 x, S32 y, MASK mask );
-		virtual BOOL handleMouseUp ( S32 x, S32 y, MASK mask );
-		virtual BOOL handleHover ( S32 x, S32 y, MASK mask );
+		virtual bool handleMouseDown ( S32 x, S32 y, MASK mask );
+		virtual bool handleMouseUp ( S32 x, S32 y, MASK mask );
+		virtual bool handleHover ( S32 x, S32 y, MASK mask );
 		virtual void onMouseCaptureLost();
 		virtual F32  getSwatchTransparency();
 

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -387,7 +387,7 @@ bool LLFloaterImagePreview::loadImage(const std::string& src_filename)
 //-----------------------------------------------------------------------------
 // handleMouseDown()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterImagePreview::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloaterImagePreview::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mPreviewRect.pointInRect(x, y))
 	{
@@ -396,7 +396,7 @@ BOOL LLFloaterImagePreview::handleMouseDown(S32 x, S32 y, MASK mask)
 		gViewerWindow->hideCursor();
 		mLastMouseX = x;
 		mLastMouseY = y;
-		return TRUE;
+		return true;
 	}
 
 	return LLFloater::handleMouseDown(x, y, mask);
@@ -405,7 +405,7 @@ BOOL LLFloaterImagePreview::handleMouseDown(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleMouseUp()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterImagePreview::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLFloaterImagePreview::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	gFocusMgr.setMouseCapture(FALSE);
 	gViewerWindow->showCursor();
@@ -415,7 +415,7 @@ BOOL LLFloaterImagePreview::handleMouseUp(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleHover()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterImagePreview::handleHover(S32 x, S32 y, MASK mask)
+bool LLFloaterImagePreview::handleHover(S32 x, S32 y, MASK mask)
 {
 	MASK local_mask = mask & ~MASK_ALT;
 
@@ -529,13 +529,13 @@ BOOL LLFloaterImagePreview::handleHover(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_TOOLZOOMIN);
 	}
 
-	return TRUE;
+	return true;
 }
 
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (mPreviewRect.pointInRect(x, y) && mAvatarPreview)
 	{
@@ -546,7 +546,7 @@ BOOL LLFloaterImagePreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
 		mSculptedPreview->refresh();
 	}
 
-	return TRUE;
+	return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llfloaterimagepreview.h
+++ b/indra/newview/llfloaterimagepreview.h
@@ -115,10 +115,10 @@ public:
 
 	virtual BOOL postBuild();
 	
-	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	BOOL handleHover(S32 x, S32 y, MASK mask);
-	BOOL handleScrollWheel(S32 x, S32 y, S32 clicks); 
+	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	bool handleMouseUp(S32 x, S32 y, MASK mask);
+	bool handleHover(S32 x, S32 y, MASK mask);
+	bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 
 	static void onMouseCaptureLostImagePreview(LLMouseHandler*);
 

--- a/indra/newview/llfloatermap.cpp
+++ b/indra/newview/llfloatermap.cpp
@@ -117,13 +117,13 @@ BOOL LLFloaterMap::postBuild()
     return true;
 }
 
-BOOL LLFloaterMap::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLFloaterMap::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	// If floater is minimized, minimap should be shown on doubleclick (STORM-299)
 	if (isMinimized())
 	{
 		setMinimized(FALSE);
-		return TRUE;
+		return true;
 	}
 
 	LLVector3d pos_global = mMap->viewPosToGlobal(x, y);
@@ -144,7 +144,7 @@ BOOL LLFloaterMap::handleDoubleClick(S32 x, S32 y, MASK mask)
 	{
 		LLFloaterReg::showInstance("world_map");
 	}
-	return TRUE;
+	return true;
 }
 
 void LLFloaterMap::setDirectionPos(LLTextBox *text_box, F32 rotation)

--- a/indra/newview/llfloatermap.h
+++ b/indra/newview/llfloatermap.h
@@ -43,7 +43,7 @@ public:
 	virtual ~LLFloaterMap();
 	
 	/*virtual*/ BOOL 	postBuild();
-	/*virtual*/ BOOL	handleDoubleClick( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool	handleDoubleClick( S32 x, S32 y, MASK mask );
 	/*virtual*/ void	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 	/*virtual*/ void	draw();
 

--- a/indra/newview/llfloatermarketplacelistings.cpp
+++ b/indra/newview/llfloatermarketplacelistings.cpp
@@ -728,7 +728,7 @@ BOOL LLFloaterMarketplaceListings::handleDragAndDrop(S32 x, S32 y, MASK mask, BO
 	return handled;
 }
 
-BOOL LLFloaterMarketplaceListings::handleHover(S32 x, S32 y, MASK mask)
+bool LLFloaterMarketplaceListings::handleHover(S32 x, S32 y, MASK mask)
 {
 	return LLFloater::handleHover(x, y, mask);
 }

--- a/indra/newview/llfloatermarketplacelistings.h
+++ b/indra/newview/llfloatermarketplacelistings.h
@@ -108,7 +108,7 @@ public:
 	
 	void showNotification(const LLNotificationPtr& notification);
     
-	BOOL handleHover(S32 x, S32 y, MASK mask);
+	bool handleHover(S32 x, S32 y, MASK mask);
 	void onMouseLeave(S32 x, S32 y, MASK mask);
     
 protected:

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -849,7 +849,7 @@ void LLFloaterModelPreview::draw()
 //-----------------------------------------------------------------------------
 // handleMouseDown()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterModelPreview::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLFloaterModelPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (mPreviewRect.pointInRect(x, y))
 	{
@@ -858,7 +858,7 @@ BOOL LLFloaterModelPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 		gViewerWindow->hideCursor();
 		mLastMouseX = x;
 		mLastMouseY = y;
-		return TRUE;
+		return true;
 	}
 
 	return LLFloater::handleMouseDown(x, y, mask);
@@ -867,7 +867,7 @@ BOOL LLFloaterModelPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleMouseUp()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterModelPreview::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLFloaterModelPreview::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	gFocusMgr.setMouseCapture(FALSE);
 	gViewerWindow->showCursor();
@@ -877,7 +877,7 @@ BOOL LLFloaterModelPreview::handleMouseUp(S32 x, S32 y, MASK mask)
 //-----------------------------------------------------------------------------
 // handleHover()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterModelPreview::handleHover	(S32 x, S32 y, MASK mask)
+bool LLFloaterModelPreview::handleHover	(S32 x, S32 y, MASK mask)
 {
 	MASK local_mask = mask & ~MASK_ALT;
 
@@ -928,13 +928,13 @@ BOOL LLFloaterModelPreview::handleHover	(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_TOOLZOOMIN);
 	}
 
-	return TRUE;
+	return true;
 }
 
 //-----------------------------------------------------------------------------
 // handleScrollWheel()
 //-----------------------------------------------------------------------------
-BOOL LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (mPreviewRect.pointInRect(x, y) && mModelPreview)
 	{
@@ -945,7 +945,7 @@ BOOL LLFloaterModelPreview::handleScrollWheel(S32 x, S32 y, S32 clicks)
     {
         LLFloaterModelUploadBase::handleScrollWheel(x, y, clicks);
     }
-	return TRUE;
+	return true;
 }
 
 /*virtual*/

--- a/indra/newview/llfloatermodelpreview.h
+++ b/indra/newview/llfloatermodelpreview.h
@@ -75,10 +75,10 @@ public:
 	void initModelPreview();
 	static bool showModelPreview();
 
-	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	BOOL handleHover(S32 x, S32 y, MASK mask);
-	BOOL handleScrollWheel(S32 x, S32 y, S32 clicks); 
+	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	bool handleMouseUp(S32 x, S32 y, MASK mask);
+	bool handleHover(S32 x, S32 y, MASK mask);
+	bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 	
 	/*virtual*/ void onOpen(const LLSD& key);
 	/*virtual*/ void onClose(bool app_quitting);

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -1446,7 +1446,7 @@ BOOL LLSnapshotFloaterView::handleKey(KEY key, MASK mask, BOOL called_from_paren
 }
 
 // virtual
-BOOL LLSnapshotFloaterView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLSnapshotFloaterView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// use default handler when not in freeze-frame mode
 	if(!gSavedSettings.getBOOL("FreezeTime"))
@@ -1458,11 +1458,11 @@ BOOL LLSnapshotFloaterView::handleMouseDown(S32 x, S32 y, MASK mask)
 	{
 		LLToolMgr::getInstance()->getCurrentTool()->handleMouseDown( x, y, mask );
 	}
-	return TRUE;
+	return true;
 }
 
 // virtual
-BOOL LLSnapshotFloaterView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLSnapshotFloaterView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// use default handler when not in freeze-frame mode
 	if(!gSavedSettings.getBOOL("FreezeTime"))
@@ -1474,11 +1474,11 @@ BOOL LLSnapshotFloaterView::handleMouseUp(S32 x, S32 y, MASK mask)
 	{
 		LLToolMgr::getInstance()->getCurrentTool()->handleMouseUp( x, y, mask );
 	}
-	return TRUE;
+	return true;
 }
 
 // virtual
-BOOL LLSnapshotFloaterView::handleHover(S32 x, S32 y, MASK mask)
+bool LLSnapshotFloaterView::handleHover(S32 x, S32 y, MASK mask)
 {
 	// use default handler when not in freeze-frame mode
 	if(!gSavedSettings.getBOOL("FreezeTime"))
@@ -1490,5 +1490,5 @@ BOOL LLSnapshotFloaterView::handleHover(S32 x, S32 y, MASK mask)
 	{
 		LLToolMgr::getInstance()->getCurrentTool()->handleHover( x, y, mask );
 	}
-	return TRUE;
+	return true;
 }

--- a/indra/newview/llfloatersnapshot.h
+++ b/indra/newview/llfloatersnapshot.h
@@ -233,9 +233,9 @@ public:
 	virtual ~LLSnapshotFloaterView();
 
 	/*virtual*/	BOOL handleKey(KEY key, MASK mask, BOOL called_from_parent);
-	/*virtual*/	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/	BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/	BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/	bool handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/	bool handleHover(S32 x, S32 y, MASK mask);
 };
 
 extern LLSnapshotFloaterView* gSnapshotFloaterView;

--- a/indra/newview/llfloateruipreview.cpp
+++ b/indra/newview/llfloateruipreview.cpp
@@ -273,8 +273,8 @@ public:
 	}
 
 	virtual void draw();
-	BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	bool handleToolTip(S32 x, S32 y, MASK mask);
 	BOOL selectElement(LLView* parent, int x, int y, int depth);	// select element to display its overlappers
 
 	LLFloaterUIPreview* mFloaterUIPreview;
@@ -1369,7 +1369,7 @@ void append_view_tooltip(LLView* tooltip_view, std::string *tooltip_msg)
 	tooltip_msg->append( msg );
 }
 
-BOOL LLPreviewedFloater::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLPreviewedFloater::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if (!sShowRectangles)
 	{
@@ -1413,13 +1413,13 @@ BOOL LLPreviewedFloater::handleToolTip(S32 x, S32 y, MASK mask)
 	LLToolTipMgr::instance().show(LLToolTip::Params()
 		.message(tooltip_msg)
 		.max_width(400));
-	return TRUE;
+	return true;
 }
 
-BOOL LLPreviewedFloater::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPreviewedFloater::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	selectElement(this,x,y,0);
-	return TRUE;
+	return true;
 }
 
 // *NOTE: In order to hide all of the overlapping elements of the selected element so as to see it in context, here is what you would need to do:

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -448,14 +448,14 @@ void LLFloaterWorldMap::reloadIcons(void*)
 }
 
 // virtual
-BOOL LLFloaterWorldMap::handleHover(S32 x, S32 y, MASK mask)
+bool LLFloaterWorldMap::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled;
+	bool handled;
 	handled = LLFloater::handleHover(x, y, mask);
 	return handled;
 }
 
-BOOL LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLFloaterWorldMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     if (!isMinimized() && isFrontmost())
     {

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -64,8 +64,8 @@ public:
 	static void reloadIcons(void*);
 
 	/*virtual*/ void reshape( S32 width, S32 height, BOOL called_from_parent = TRUE );
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleScrollWheel(S32 x, S32 y, S32 clicks);
 	/*virtual*/ void draw();
 
 	/*virtual*/ void onFocusLost();

--- a/indra/newview/llgrouplist.cpp
+++ b/indra/newview/llgrouplist.cpp
@@ -163,9 +163,9 @@ void LLGroupList::draw()
 }
 
 // virtual
-BOOL LLGroupList::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLGroupList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLUICtrl::handleRightMouseDown(x, y, mask);
+	bool handled = LLUICtrl::handleRightMouseDown(x, y, mask);
 
     if (mForAgent)
     {
@@ -182,9 +182,9 @@ BOOL LLGroupList::handleRightMouseDown(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLGroupList::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLGroupList::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLView::handleDoubleClick(x, y, mask);
+	bool handled = LLView::handleDoubleClick(x, y, mask);
 	// Handle double click only for the selected item in the list, skip clicks on empty space.
 	if (handled)
 	{

--- a/indra/newview/llgrouplist.h
+++ b/indra/newview/llgrouplist.h
@@ -60,8 +60,8 @@ public:
     void enableForAgent(bool show_icons);
 
 	virtual void draw(); // from LLView
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask); // from LLView
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask); // from LLView
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask); // from LLView
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask); // from LLView
 
 	void setNameFilter(const std::string& filter);
 	void toggleIcons();

--- a/indra/newview/llhudview.cpp
+++ b/indra/newview/llhudview.cpp
@@ -62,11 +62,11 @@ void LLHUDView::draw()
 }
 
 /*virtual*/
-BOOL LLHUDView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLHUDView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (LLTracker::handleMouseDown(x, y))
 	{
-		return TRUE;
+		return true;
 	}
 	return LLView::handleMouseDown(x, y, mask);
 }

--- a/indra/newview/llhudview.h
+++ b/indra/newview/llhudview.h
@@ -42,7 +42,7 @@ public:
 	virtual void draw();
 
 protected:
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
 };
 
 extern LLHUDView *gHUDView;

--- a/indra/newview/llinspect.cpp
+++ b/indra/newview/llinspect.cpp
@@ -93,15 +93,15 @@ void LLInspect::onFocusLost()
 }
 
 // virtual
-BOOL LLInspect::handleHover(S32 x, S32 y, MASK mask)
+bool LLInspect::handleHover(S32 x, S32 y, MASK mask)
 {
 	mOpenTimer.pause();
 	return LLView::handleHover(x, y, mask);
 }
 
-BOOL LLInspect::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLInspect::handleToolTip(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 
 	//delegate handling of tooltip to the hovered child
@@ -115,7 +115,7 @@ BOOL LLInspect::handleToolTip(S32 x, S32 y, MASK mask)
 		//set up delay if there is no visible tooltip at this moment
 		params.delay_time =  LLToolTipMgr::instance().toolTipVisible() ? 0.f : LLUI::getInstance()->mSettingGroups["config"]->getF32( "ToolTipDelay" );
 		LLToolTipMgr::instance().show(params);
-		handled = TRUE;
+		handled = true;
 	}
 	return handled;
 }

--- a/indra/newview/llinspect.h
+++ b/indra/newview/llinspect.h
@@ -40,8 +40,8 @@ public:
 	/// Inspectors have a custom fade-in/fade-out animation
 	/*virtual*/ void draw();
 	
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
 	
 	/// Start open animation

--- a/indra/newview/llinspecttoast.cpp
+++ b/indra/newview/llinspecttoast.cpp
@@ -46,7 +46,7 @@ public:
 	virtual ~LLInspectToast();
 
 	/*virtual*/ void onOpen(const LLSD& notification_id);
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
     /*virtual*/ void deleteAllChildren();
 	/*virtual*/ void removeChild(LLView* child);
 private:
@@ -115,7 +115,7 @@ void LLInspectToast::onOpen(const LLSD& notification_id)
 }
 
 // virtual
-BOOL LLInspectToast::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLInspectToast::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	// We don't like the way LLInspect handles tooltips
 	// (black tooltips look weird),

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -1020,7 +1020,7 @@ void LLInventoryGallery::updateItemThumbnail(LLUUID item_id)
     }
 }
 
-BOOL LLInventoryGallery::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLInventoryGallery::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     if (mSelectedItemIDs.size() > 0)
     {
@@ -1029,7 +1029,7 @@ BOOL LLInventoryGallery::handleRightMouseDown(S32 x, S32 y, MASK mask)
     mLastInteractedUUID = LLUUID::null;
 
     // Scroll is going to always return true
-    BOOL res = LLPanel::handleRightMouseDown(x, y, mask);
+    bool res = LLPanel::handleRightMouseDown(x, y, mask);
 
     if (mLastInteractedUUID.isNull()) // no child were hit
     {
@@ -1039,7 +1039,7 @@ BOOL LLInventoryGallery::handleRightMouseDown(S32 x, S32 y, MASK mask)
             uuid_vec_t selected_uuids;
             selected_uuids.push_back(mFolderID);
             mRootGalleryMenu->show(this, selected_uuids, x, y);
-            return TRUE;
+            return true;
         }
     }
     return res;
@@ -2733,7 +2733,7 @@ void LLInventoryGalleryItem::setSelected(bool value)
     }
 }
 
-BOOL LLInventoryGalleryItem::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLInventoryGalleryItem::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     // call changeItemSelection directly, before setFocus
     // to avoid autoscroll from LLInventoryGallery::onFocusReceived()
@@ -2757,10 +2757,10 @@ BOOL LLInventoryGalleryItem::handleMouseDown(S32 x, S32 y, MASK mask)
     S32 screen_y;
     localPointToScreen(x, y, &screen_x, &screen_y );
     LLToolDragAndDrop::getInstance()->setDragStart(screen_x, screen_y);
-    return TRUE;
+    return true;
 }
 
-BOOL LLInventoryGalleryItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLInventoryGalleryItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     if (!isSelected())
     {
@@ -2776,20 +2776,20 @@ BOOL LLInventoryGalleryItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
     mGallery->showContextMenu(this, x, y, mUUID);
 
     LLUICtrl::handleRightMouseDown(x, y, mask);
-    return TRUE;
+    return true;
 }
 
-BOOL LLInventoryGalleryItem::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLInventoryGalleryItem::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if(hasMouseCapture())
     {
         gFocusMgr.setMouseCapture(NULL);
-        return TRUE;
+        return true;
     }
     return LLPanel::handleMouseUp(x, y, mask);
 }
 
-BOOL LLInventoryGalleryItem::handleHover(S32 x, S32 y, MASK mask)
+bool LLInventoryGalleryItem::handleHover(S32 x, S32 y, MASK mask)
 {
     if(hasMouseCapture())
     {
@@ -2806,7 +2806,7 @@ BOOL LLInventoryGalleryItem::handleHover(S32 x, S32 y, MASK mask)
     return LLUICtrl::handleHover(x,y,mask);
 }
 
-BOOL LLInventoryGalleryItem::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLInventoryGalleryItem::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
     if (mIsFolder && mGallery)
     {
@@ -2829,7 +2829,7 @@ BOOL LLInventoryGalleryItem::handleDoubleClick(S32 x, S32 y, MASK mask)
         LLInvFVBridgeAction::doAction(mUUID, &gInventory);
     }
 
-    return TRUE;
+    return true;
 }
 
 BOOL LLInventoryGalleryItem::handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,

--- a/indra/newview/llinventorygallery.h
+++ b/indra/newview/llinventorygallery.h
@@ -82,7 +82,7 @@ public:
     BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop, EDragAndDropType cargo_type,
                            void* cargo_data, EAcceptance* accept, std::string& tooltip_msg) override;
     void startDrag();
-    BOOL handleRightMouseDown(S32 x, S32 y, MASK mask) override;
+    bool handleRightMouseDown(S32 x, S32 y, MASK mask) override;
     BOOL handleKeyHere(KEY key, MASK mask) override;
     void moveUp(MASK mask);
     void moveDown(MASK mask);
@@ -301,11 +301,11 @@ public:
 
     BOOL postBuild();
     void draw();
-    BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-    BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-    BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
-    BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-    BOOL handleHover(S32 x, S32 y, MASK mask);
+    bool handleMouseDown(S32 x, S32 y, MASK mask);
+    bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+    bool handleDoubleClick(S32 x, S32 y, MASK mask);
+    bool handleMouseUp(S32 x, S32 y, MASK mask);
+    bool handleHover(S32 x, S32 y, MASK mask);
     BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
                                    EDragAndDropType cargo_type,
                                    void* cargo_data,

--- a/indra/newview/llinventorylistitem.cpp
+++ b/indra/newview/llinventorylistitem.cpp
@@ -182,7 +182,7 @@ void LLPanelInventoryListItemBase::setValue(const LLSD& value)
 	mSelected = value["selected"];
 }
 
-BOOL LLPanelInventoryListItemBase::handleHover(S32 x, S32 y, MASK mask)
+bool LLPanelInventoryListItemBase::handleHover(S32 x, S32 y, MASK mask)
 {
 	mHovered = true;
 	return LLPanel::handleHover(x, y, mask);
@@ -399,13 +399,13 @@ void LLPanelInventoryListItemBase::setTitle(const std::string& title,
 		highlit_text);
 }
 
-BOOL LLPanelInventoryListItemBase::handleToolTip( S32 x, S32 y, MASK mask)
+bool LLPanelInventoryListItemBase::handleToolTip( S32 x, S32 y, MASK mask)
 {
 	LLRect text_box_rect = mTitleCtrl->getRect();
 	if (text_box_rect.pointInRect(x, y) &&
 		mTitleCtrl->getTextPixelWidth() <= text_box_rect.getWidth())
 	{
-		return FALSE;
+		return false;
 	}
 	return LLPanel::handleToolTip(x, y, mask);
 }

--- a/indra/newview/llinventorylistitem.h
+++ b/indra/newview/llinventorylistitem.h
@@ -130,7 +130,7 @@ public:
 	/*virtual*/ S32  notify(const LLSD& info);
 
 	/* Highlights item */
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 	/* Removes item highlight */
 	/*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
 
@@ -194,7 +194,7 @@ protected:
 	/**
 	 * Show tool tip if item name text size > panel size
 	 */
-	virtual BOOL handleToolTip( S32 x, S32 y, MASK mask);
+	virtual bool handleToolTip( S32 x, S32 y, MASK mask);
 
 	const LLUUID mInventoryItemUUID;
     bool mHovered;

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -1352,9 +1352,9 @@ void LLInventoryPanel::unSelectAll()
 }
 
 
-BOOL LLInventoryPanel::handleHover(S32 x, S32 y, MASK mask)
+bool LLInventoryPanel::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLView::handleHover(x, y, mask);
+	bool handled = LLView::handleHover(x, y, mask);
 	if(handled)
     {
         // getCursor gets current cursor, setCursor sets next cursor
@@ -1370,10 +1370,10 @@ BOOL LLInventoryPanel::handleHover(S32 x, S32 y, MASK mask)
 	{
 		getWindow()->setCursor(UI_CURSOR_ARROW);
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLInventoryPanel::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLInventoryPanel::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if (const LLFolderViewItem* hover_item_p = (!mFolderRoot.isDead()) ? mFolderRoot.get()->getHoveredItem() : nullptr)
 	{
@@ -1398,7 +1398,7 @@ BOOL LLInventoryPanel::handleToolTip(S32 x, S32 y, MASK mask)
 					.delay_time(LLView::getTooltipTimeout())
 					.create_callback(boost::bind(&LLInspectTextureUtil::createInventoryToolTip, _1))
 					.create_params(params));
-			return TRUE;
+			return true;
 		}
 	}
 	return LLPanel::handleToolTip(x, y, mask);

--- a/indra/newview/llinventorypanel.h
+++ b/indra/newview/llinventorypanel.h
@@ -164,13 +164,13 @@ public:
 	/*virtual*/ void onVisibilityChange(BOOL new_visibility) override;
 	void draw() override;
 	/*virtual*/ BOOL handleKeyHere( KEY key, MASK mask ) override;
-	BOOL handleHover(S32 x, S32 y, MASK mask) override;
+	bool handleHover(S32 x, S32 y, MASK mask) override;
 	/*virtual*/ BOOL handleDragAndDrop(S32 x, S32 y, MASK mask, BOOL drop,
 								   EDragAndDropType cargo_type,
 								   void* cargo_data,
 								   EAcceptance* accept,
 								   std::string& tooltip_msg) override;
-	            BOOL handleToolTip(S32 x, S32 y, MASK mask) override;
+	            bool handleToolTip(S32 x, S32 y, MASK mask) override;
 	// LLUICtrl methods
 	 /*virtual*/ void onFocusLost() override;
 	 /*virtual*/ void onFocusReceived() override;

--- a/indra/newview/lljoystickbutton.cpp
+++ b/indra/newview/lljoystickbutton.cpp
@@ -160,7 +160,7 @@ bool LLJoystick::pointInCenterDot(S32 x, S32 y, S32 radius) const
 	return in_center_circle;
 }
 
-BOOL LLJoystick::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLJoystick::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	//LL_INFOS() << "joystick mouse down " << x << ", " << y << LL_ENDL;
 	bool handles = false;
@@ -177,14 +177,14 @@ BOOL LLJoystick::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLJoystick::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLJoystick::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// LL_INFOS() << "joystick mouse up " << x << ", " << y << LL_ENDL;
 
 	if( hasMouseCapture() )
 	{
 		mLastMouse.set(x, y);
-		mHeldDown = FALSE;
+		mHeldDown = false;
 		onMouseUp();
 	}
 
@@ -192,7 +192,7 @@ BOOL LLJoystick::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLJoystick::handleHover(S32 x, S32 y, MASK mask)
+bool LLJoystick::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( hasMouseCapture() )
 	{
@@ -444,7 +444,7 @@ void LLJoystickCameraRotate::updateSlop()
 }
 
 
-BOOL LLJoystickCameraRotate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLJoystickCameraRotate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	gAgent.setMovementLocked(TRUE);
 	updateSlop();
@@ -497,14 +497,14 @@ BOOL LLJoystickCameraRotate::handleMouseDown(S32 x, S32 y, MASK mask)
 	return LLJoystick::handleMouseDown(x, y, mask);
 }
 
-BOOL LLJoystickCameraRotate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLJoystickCameraRotate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	gAgent.setMovementLocked(FALSE);
 	mInCenter = FALSE;
 	return LLJoystick::handleMouseUp(x, y, mask);
 }
 
-BOOL LLJoystickCameraRotate::handleHover(S32 x, S32 y, MASK mask)
+bool LLJoystickCameraRotate::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (!pointInCenterDot(x, y, CENTER_DOT_RADIUS))
 	{
@@ -745,7 +745,7 @@ void LLJoystickQuaternion::setToggleState(BOOL left, BOOL top, BOOL right, BOOL 
     mInBottom = bottom;
 }
 
-BOOL LLJoystickQuaternion::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLJoystickQuaternion::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     updateSlop();
 
@@ -788,7 +788,7 @@ BOOL LLJoystickQuaternion::handleMouseDown(S32 x, S32 y, MASK mask)
     return LLJoystick::handleMouseDown(x, y, mask);
 }
 
-BOOL LLJoystickQuaternion::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLJoystickQuaternion::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     return LLJoystick::handleMouseUp(x, y, mask);
 }

--- a/indra/newview/lljoystickbutton.h
+++ b/indra/newview/lljoystickbutton.h
@@ -63,9 +63,9 @@ public:
 	};
 	LLJoystick(const Params&);
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 
 	virtual void	onMouseUp() {}
 	virtual void	onHeldDown() = 0;
@@ -147,9 +147,9 @@ public:
 
 	virtual void	setToggleState( BOOL left, BOOL top, BOOL right, BOOL bottom );
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual void	onHeldDown();
 	virtual void	resetJoystickCamera();
 	virtual void	draw();
@@ -201,8 +201,8 @@ public:
 
     virtual void	setToggleState(BOOL left, BOOL top, BOOL right, BOOL bottom);
 
-    virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-    virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
     virtual void	onHeldDown();
     virtual void	draw();
 

--- a/indra/newview/lllocationinputctrl.cpp
+++ b/indra/newview/lllocationinputctrl.cpp
@@ -468,7 +468,7 @@ void LLLocationInputCtrl::hideList()
 		focusTextEntry();
 }
 
-BOOL LLLocationInputCtrl::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLLocationInputCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 {
 
 	if(mAddLandmarkBtn->parentPointInView(x,y))
@@ -496,10 +496,10 @@ BOOL LLLocationInputCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 			}
 		}
 
-		return TRUE;
+		return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 BOOL LLLocationInputCtrl::handleKeyHere(KEY key, MASK mask)

--- a/indra/newview/lllocationinputctrl.h
+++ b/indra/newview/lllocationinputctrl.h
@@ -89,7 +89,7 @@ public:
 
 	// LLView interface
 	/*virtual*/ void		setEnabled(BOOL enabled);
-	/*virtual*/ BOOL		handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleToolTip(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL		handleKeyHere(KEY key, MASK mask);
 	/*virtual*/ void		onFocusReceived();
 	/*virtual*/ void		onFocusLost();

--- a/indra/newview/llmanip.cpp
+++ b/indra/newview/llmanip.cpp
@@ -215,7 +215,7 @@ LLObjectSelectionHandle LLManip::getSelection()
 	return mObjectSelection;
 }
 
-BOOL LLManip::handleHover(S32 x, S32 y, MASK mask)
+bool LLManip::handleHover(S32 x, S32 y, MASK mask)
 {
 	// We only handle the event if mousedown started with us
 	if( hasMouseCapture() )
@@ -234,16 +234,16 @@ BOOL LLManip::handleHover(S32 x, S32 y, MASK mask)
 		LL_DEBUGS("UserInput") << "hover handled by LLManip (inactive)" << LL_ENDL;
 	}
 	gViewerWindow->setCursor(UI_CURSOR_ARROW);
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLManip::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLManip::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 	if( hasMouseCapture() )
 	{
-		handled = TRUE;
+		handled = true;
 		setMouseCapture( FALSE );
 	}
 	return handled;

--- a/indra/newview/llmanip.h
+++ b/indra/newview/llmanip.h
@@ -121,8 +121,8 @@ public:
 	void				renderGuidelines(BOOL draw_x = TRUE, BOOL draw_y = TRUE, BOOL draw_z = TRUE);
 	static void			renderXYZ(const LLVector3 &vec);
 
-    /*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual void		highlightManipulators(S32 x, S32 y) = 0;
 	virtual void		handleSelect();
 	virtual void		handleDeselect();

--- a/indra/newview/llmaniprotate.cpp
+++ b/indra/newview/llmaniprotate.cpp
@@ -362,9 +362,9 @@ void LLManipRotate::render()
 	renderXYZ(euler_angles);
 }
 
-BOOL LLManipRotate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLManipRotate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	LLViewerObject* first_object = mObjectSelection->getFirstMoveableObject(TRUE);
 	if( first_object )
@@ -459,7 +459,7 @@ LLVector3 LLManipRotate::findNearestPointOnRing( S32 x, S32 y, const LLVector3& 
 	return center + proj_onto_ring * mRadiusMeters;
 }
 
-BOOL LLManipRotate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLManipRotate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// first, perform normal processing in case this was a quick-click
 	handleHover(x, y, mask);
@@ -497,7 +497,7 @@ BOOL LLManipRotate::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLManipRotate::handleHover(S32 x, S32 y, MASK mask)
+bool LLManipRotate::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( hasMouseCapture() )
 	{
@@ -520,7 +520,7 @@ BOOL LLManipRotate::handleHover(S32 x, S32 y, MASK mask)
 	}
 
 	gViewerWindow->setCursor(UI_CURSOR_TOOLROTATE);
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/newview/llmaniprotate.h
+++ b/indra/newview/llmaniprotate.h
@@ -53,9 +53,9 @@ public:
 	
 	LLManipRotate( LLToolComposite* composite );
 
-	virtual BOOL	handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleMouseUp( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleHover( S32 x, S32 y, MASK mask );
+	virtual bool	handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool	handleMouseUp( S32 x, S32 y, MASK mask );
+	virtual bool	handleHover( S32 x, S32 y, MASK mask );
 	virtual void	render();
 
 	virtual void	handleSelect();

--- a/indra/newview/llmanipscale.cpp
+++ b/indra/newview/llmanipscale.cpp
@@ -319,9 +319,9 @@ void LLManipScale::render()
 	}
 }
 
-BOOL LLManipScale::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLManipScale::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	if(mHighlightedPart != LL_NO_PART)
 	{
@@ -373,7 +373,7 @@ BOOL LLManipScale::handleMouseDownOnPart( S32 x, S32 y, MASK mask )
 }
 
 
-BOOL LLManipScale::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLManipScale::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// first, perform normal processing in case this was a quick-click
 	handleHover(x, y, mask);
@@ -408,7 +408,7 @@ BOOL LLManipScale::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLManipScale::handleHover(S32 x, S32 y, MASK mask)
+bool LLManipScale::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( hasMouseCapture() )
 	{
@@ -442,7 +442,7 @@ BOOL LLManipScale::handleHover(S32 x, S32 y, MASK mask)
 	LLSelectMgr::getInstance()->adjustTexturesByScale(FALSE, getStretchTextures());
 
 	gViewerWindow->setCursor(UI_CURSOR_TOOLSCALE);
-	return TRUE;
+	return true;
 }
 
 void LLManipScale::highlightManipulators(S32 x, S32 y)

--- a/indra/newview/llmanipscale.h
+++ b/indra/newview/llmanipscale.h
@@ -76,9 +76,9 @@ public:
 	LLManipScale( LLToolComposite* composite );
 	~LLManipScale();
 
-	virtual BOOL	handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleMouseUp( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleHover( S32 x, S32 y, MASK mask );
+	virtual bool	handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool	handleMouseUp( S32 x, S32 y, MASK mask );
+	virtual bool	handleHover( S32 x, S32 y, MASK mask );
 	virtual void	render();
 	virtual void	handleSelect();
 

--- a/indra/newview/llmaniptranslate.cpp
+++ b/indra/newview/llmaniptranslate.cpp
@@ -290,9 +290,9 @@ void LLManipTranslate::handleSelect()
 	LLManip::handleSelect();
 }
 
-BOOL LLManipTranslate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLManipTranslate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// didn't click in any UI object, so must have clicked in the world
 	if( (mHighlightedPart == LL_X_ARROW ||
@@ -403,7 +403,7 @@ BOOL LLManipTranslate::handleMouseDownOnPart( S32 x, S32 y, MASK mask )
 	return TRUE;
 }
 
-BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
+bool LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 {
 	// Translation tool only works if mouse button is down.
 	// Bail out if mouse not down.
@@ -415,7 +415,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
 
 		highlightManipulators(x, y);
-		return TRUE;
+		return true;
 	}
 	
 	// Handle auto-rotation if necessary.
@@ -447,7 +447,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 	{
 		LL_DEBUGS("UserInput") << "hover handled by LLManipTranslate (mouse unmoved)" << LL_ENDL;
 		gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
-		return TRUE;
+		return true;
 	}
 	mLastHoverMouseX = x;
 	mLastHoverMouseY = y;
@@ -460,7 +460,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 		{
 			LL_DEBUGS("UserInput") << "hover handled by LLManipTranslate (mouse inside slop)" << LL_ENDL;
 			gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
-			return TRUE;
+			return true;
 		}
 		else
 		{
@@ -494,7 +494,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 		// somehow we lost the object!
 		LL_WARNS() << "Translate manip lost the object, no selectNode" << LL_ENDL;
 		gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
-		return TRUE;
+		return true;
 	}
 
 	LLViewerObject* object = selectNode->getObject();
@@ -503,7 +503,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 		// somehow we lost the object!
 		LL_WARNS() << "Translate manip lost the object, no object in selectNode" << LL_ENDL;
 		gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
-		return TRUE;
+		return true;
 	}
 
 	// Compute unit vectors for arrow hit and a plane through that vector
@@ -530,7 +530,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 		{
 			LL_DEBUGS("UserInput") << "hover handled by LLManipTranslate (too far)" << LL_ENDL;
 			gViewerWindow->setCursor(UI_CURSOR_NOLOCKED);
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -770,7 +770,7 @@ BOOL LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
 
 	LL_DEBUGS("UserInput") << "hover handled by LLManipTranslate (active)" << LL_ENDL;
 	gViewerWindow->setCursor(UI_CURSOR_TOOLTRANSLATE);
-	return TRUE;
+	return true;
 }
 
 void LLManipTranslate::highlightManipulators(S32 x, S32 y)
@@ -1022,7 +1022,7 @@ F32 LLManipTranslate::getMinGridScale()
 }
 
 
-BOOL LLManipTranslate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLManipTranslate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// first, perform normal processing in case this was a quick-click
 	handleHover(x, y, mask);

--- a/indra/newview/llmaniptranslate.h
+++ b/indra/newview/llmaniptranslate.h
@@ -53,9 +53,9 @@ public:
 	static  U32     getGridTexName() ;
 	static  void    destroyGL();
 	static	void	restoreGL();
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual void	render();
 	virtual void	handleSelect();
 

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -183,9 +183,9 @@ void LLMediaCtrl::setTakeFocusOnClick( bool take_focus )
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleHover( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleHover( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleHover(x, y, mask)) return TRUE;
+	if (LLPanel::handleHover(x, y, mask)) return true;
 	convertInputCoords(x, y);
 
 	if (mMediaSource)
@@ -201,40 +201,40 @@ BOOL LLMediaCtrl::handleHover( S32 x, S32 y, MASK mask )
 		handleToolTip(x, y, mask);
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleScrollWheel( S32 x, S32 y, S32 clicks )
+bool LLMediaCtrl::handleScrollWheel( S32 x, S32 y, S32 clicks )
 {
-	if (LLPanel::handleScrollWheel(x, y, clicks)) return TRUE;
+	if (LLPanel::handleScrollWheel(x, y, clicks)) return true;
 	if (mMediaSource && mMediaSource->hasMedia())
 	{
 		convertInputCoords(x, y);
-		mMediaSource->scrollWheel(x, y, 0, clicks, gKeyboard->currentMask(TRUE));
+		mMediaSource->scrollWheel(x, y, 0, clicks, gKeyboard->currentMask(true));
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLMediaCtrl::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
-    if (LLPanel::handleScrollHWheel(x, y, clicks)) return TRUE;
+    if (LLPanel::handleScrollHWheel(x, y, clicks)) return true;
     if (mMediaSource && mMediaSource->hasMedia())
     {
         convertInputCoords(x, y);
-        mMediaSource->scrollWheel(x, y, clicks, 0, gKeyboard->currentMask(TRUE));
+        mMediaSource->scrollWheel(x, y, clicks, 0, gKeyboard->currentMask(true));
     }
 
-    return TRUE;
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //	virtual 
-BOOL LLMediaCtrl::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLMediaCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	std::string hover_text;
 	
@@ -243,7 +243,7 @@ BOOL LLMediaCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 	
 	if(hover_text.empty())
 	{
-		return FALSE;
+		return false;
 	}
 	else
 	{
@@ -258,14 +258,14 @@ BOOL LLMediaCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 			.sticky_rect(sticky_rect_screen));		
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleMouseUp( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleMouseUp(x, y, mask)) return TRUE;
+	if (LLPanel::handleMouseUp(x, y, mask)) return true;
 	convertInputCoords(x, y);
 
 	if (mMediaSource)
@@ -275,14 +275,14 @@ BOOL LLMediaCtrl::handleMouseUp( S32 x, S32 y, MASK mask )
 	
 	gFocusMgr.setMouseCapture( NULL );
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleMouseDown( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleMouseDown(x, y, mask)) return TRUE;
+	if (LLPanel::handleMouseDown(x, y, mask)) return true;
 	convertInputCoords(x, y);
 
 	if (mMediaSource)
@@ -292,17 +292,17 @@ BOOL LLMediaCtrl::handleMouseDown( S32 x, S32 y, MASK mask )
 
 	if (mTakeFocusOnClick)
 	{
-		setFocus( TRUE );
+		setFocus( true );
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleRightMouseUp( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleRightMouseUp( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleRightMouseUp(x, y, mask)) return TRUE;
+	if (LLPanel::handleRightMouseUp(x, y, mask)) return true;
 	convertInputCoords(x, y);
 
 	if (mMediaSource)
@@ -320,14 +320,14 @@ BOOL LLMediaCtrl::handleRightMouseUp( S32 x, S32 y, MASK mask )
 	
 	gFocusMgr.setMouseCapture( NULL );
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleRightMouseDown( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleRightMouseDown( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleRightMouseDown(x, y, mask)) return TRUE;
+	if (LLPanel::handleRightMouseDown(x, y, mask)) return true;
 
 	S32 media_x = x, media_y = y;
 	convertInputCoords(media_x, media_y);
@@ -339,7 +339,7 @@ BOOL LLMediaCtrl::handleRightMouseDown( S32 x, S32 y, MASK mask )
 
 	if (mTakeFocusOnClick)
 	{
-		setFocus( TRUE );
+		setFocus( true );
 	}
 
 	auto menu = mContextMenuHandle.get();
@@ -371,14 +371,14 @@ BOOL LLMediaCtrl::handleRightMouseDown( S32 x, S32 y, MASK mask )
 		LLMenuGL::showPopup(this, menu, x, y);
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLMediaCtrl::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
-	if (LLPanel::handleDoubleClick(x, y, mask)) return TRUE;
+	if (LLPanel::handleDoubleClick(x, y, mask)) return true;
 	convertInputCoords(x, y);
 
 	if (mMediaSource)
@@ -388,10 +388,10 @@ BOOL LLMediaCtrl::handleDoubleClick( S32 x, S32 y, MASK mask )
 
 	if (mTakeFocusOnClick)
 	{
-		setFocus( TRUE );
+		setFocus( true );
 	}
 
-	return TRUE;
+	return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -491,9 +491,9 @@ void LLMediaCtrl::onVisibilityChange ( BOOL new_visibility )
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-BOOL LLMediaCtrl::handleUnicodeCharHere(llwchar uni_char)
+bool LLMediaCtrl::handleUnicodeCharHere(llwchar uni_char)
 {
-	BOOL result = FALSE;
+	bool result = false;
 	
 	if (mMediaSource)
 	{

--- a/indra/newview/llmediactrl.h
+++ b/indra/newview/llmediactrl.h
@@ -86,15 +86,15 @@ public:
 		void setTakeFocusOnClick( bool take_focus );
 
 		// handle mouse related methods
-		virtual BOOL handleHover( S32 x, S32 y, MASK mask );
-		virtual BOOL handleMouseUp( S32 x, S32 y, MASK mask );
-		virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-		virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-		virtual BOOL handleRightMouseUp(S32 x, S32 y, MASK mask);
-		virtual BOOL handleDoubleClick( S32 x, S32 y, MASK mask );
-		virtual BOOL handleScrollWheel( S32 x, S32 y, S32 clicks );
-		virtual BOOL handleScrollHWheel( S32 x, S32 y, S32 clicks );
-		virtual BOOL handleToolTip(S32 x, S32 y, MASK mask);
+		virtual bool handleHover( S32 x, S32 y, MASK mask );
+		virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
+		virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+		virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+		virtual bool handleRightMouseUp(S32 x, S32 y, MASK mask);
+		virtual bool handleDoubleClick( S32 x, S32 y, MASK mask );
+		virtual bool handleScrollWheel( S32 x, S32 y, S32 clicks );
+		virtual bool handleScrollHWheel( S32 x, S32 y, S32 clicks );
+		virtual bool handleToolTip(S32 x, S32 y, MASK mask);
 
 		// navigation
 		void navigateTo( std::string url_in, std::string mime_type = "", bool clean_browser = false);
@@ -157,7 +157,7 @@ public:
 		virtual BOOL handleKeyHere( KEY key, MASK mask);
 		virtual BOOL handleKeyUpHere(KEY key, MASK mask);
 		virtual void onVisibilityChange ( BOOL new_visibility );
-		virtual BOOL handleUnicodeCharHere(llwchar uni_char);
+		virtual bool handleUnicodeCharHere(llwchar uni_char);
 		virtual void reshape( S32 width, S32 height, BOOL called_from_parent = TRUE);
 		virtual void draw();
 		virtual BOOL postBuild();

--- a/indra/newview/llmoveview.cpp
+++ b/indra/newview/llmoveview.cpp
@@ -603,7 +603,7 @@ void LLPanelStandStopFlying::setVisible(BOOL visible)
 	LLPanel::setVisible(visible);
 }
 
-BOOL LLPanelStandStopFlying::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLPanelStandStopFlying::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	LLToolTipMgr::instance().unblockToolTips();
 

--- a/indra/newview/llmoveview.h
+++ b/indra/newview/llmoveview.h
@@ -147,7 +147,7 @@ public:
 	// *HACK: due to hard enough to have this control aligned with "Move" button while resizing
 	// let update its position in each frame
 	/*virtual*/ void draw(){updatePosition(); LLPanel::draw();}
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 
 
 protected:

--- a/indra/newview/llnamelistctrl.cpp
+++ b/indra/newview/llnamelistctrl.cpp
@@ -216,9 +216,9 @@ void	LLNameListCtrl::mouseOverHighlightNthItem( S32 target_index )
 }
 
 //virtual
-BOOL LLNameListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLNameListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	S32 column_index = getColumnIndexFromOffset(x);
 	LLNameListItem* hit_item = dynamic_cast<LLNameListItem*>(hitItem(x, y));
 	LLFloater* floater = gFloaterView->getParentFloater(this);
@@ -268,7 +268,7 @@ BOOL LLNameListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 					params.sticky_rect(sticky_rect);
 
 					LLToolTipMgr::getInstance()->show(params);
-					handled = TRUE;
+					handled = true;
 				}
 			}
 		}
@@ -281,7 +281,7 @@ BOOL LLNameListCtrl::handleToolTip(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLNameListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLNameListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     LLNameListItem* hit_item = dynamic_cast<LLNameListItem*>(hitItem(x, y));
     LLFloater* floater = gFloaterView->getParentFloater(this);
@@ -291,7 +291,7 @@ BOOL LLNameListCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
         {
             ContextMenuType prev_menu = getContextMenuType();
             setContextMenu(MENU_GROUP);
-            BOOL handled = LLScrollListCtrl::handleRightMouseDown(x, y, mask);
+            bool handled = LLScrollListCtrl::handleRightMouseDown(x, y, mask);
             setContextMenu(prev_menu);
             return handled;
         }

--- a/indra/newview/llnamelistctrl.h
+++ b/indra/newview/llnamelistctrl.h
@@ -170,7 +170,7 @@ public:
 									  BOOL drop, EDragAndDropType cargo_type, void *cargo_data,
 									  EAcceptance *accept,
 									  std::string& tooltip_msg);
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 
 	void setAllowCallingCardDrop(BOOL b) { mAllowCallingCardDrop = b; }
 
@@ -180,7 +180,7 @@ public:
 
 	/*virtual*/ void mouseOverHighlightNthItem( S32 index );
 
-    /*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
     bool isSpecialType() { return (mNameListType == SPECIAL); }
 

--- a/indra/newview/llnavigationbar.cpp
+++ b/indra/newview/llnavigationbar.cpp
@@ -213,9 +213,9 @@ void LLPullButton::onMouseLeave(S32 x, S32 y, MASK mask)
 }
 
 /*virtual*/
-BOOL LLPullButton::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPullButton::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLButton::handleMouseDown(x, y, mask);
+	bool handled = LLButton::handleMouseDown(x, y, mask);
 	if (handled)
 	{
 		//if mouse down was handled by button, 
@@ -226,7 +226,7 @@ BOOL LLPullButton::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 /*virtual*/
-BOOL LLPullButton::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLPullButton::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// reset data to get ready for next circle 
 	mLastMouseDown.clear();
@@ -361,9 +361,9 @@ void LLNavigationBar::draw()
 	LLPanel::draw();
 }
 
-BOOL LLNavigationBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLNavigationBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = childrenHandleRightMouseDown( x, y, mask) != NULL;
+	bool handled = childrenHandleRightMouseDown( x, y, mask) != NULL;
 	if(!handled && !gMenuHolder->hasVisibleMenu())
 	{
 		show_navbar_context_menu(this,x,y);

--- a/indra/newview/llnavigationbar.h
+++ b/indra/newview/llnavigationbar.h
@@ -60,9 +60,9 @@ public:
 		}
 	};
 	
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
 
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
 
 	/*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
 
@@ -93,7 +93,7 @@ class LLNavigationBar
 public:
 	
 	/*virtual*/ void	draw();
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL	postBuild();
 	/*virtual*/ void	setVisible(BOOL visible);
 

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -688,7 +688,7 @@ LLVector3d LLNetMap::viewPosToGlobal( S32 x, S32 y )
 	return pos_global;
 }
 
-BOOL LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     // note that clicks are reversed from what you'd think: i.e. > 0  means zoom out, < 0 means zoom in
     F32 new_scale = mScale * pow(MAP_SCALE_ZOOM_FACTOR, -clicks);
@@ -709,7 +709,7 @@ BOOL LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
     return true;
 }
 
-BOOL LLNetMap::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLNetMap::handleToolTip(S32 x, S32 y, MASK mask)
 {
     if (gDisconnected)
     {
@@ -1009,7 +1009,7 @@ void LLNetMap::createObjectImage()
 	mUpdateNow = true;
 }
 
-BOOL LLNetMap::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLNetMap::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     // Start panning
     gFocusMgr.setMouseCapture(this);
@@ -1020,7 +1020,7 @@ BOOL LLNetMap::handleMouseDown(S32 x, S32 y, MASK mask)
     return true;
 }
 
-BOOL LLNetMap::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLNetMap::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if (abs(mMouseDown.mX - x) < 3 && abs(mMouseDown.mY - y) < 3)
     {
@@ -1053,7 +1053,7 @@ BOOL LLNetMap::handleMouseUp(S32 x, S32 y, MASK mask)
     return false;
 }
 
-BOOL LLNetMap::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLNetMap::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     auto menu = static_cast<LLMenuGL*>(mPopupMenuHandle.get());
     if (menu)
@@ -1064,7 +1064,7 @@ BOOL LLNetMap::handleRightMouseDown(S32 x, S32 y, MASK mask)
         menu->setItemEnabled("Stop Tracking", LLTracker::isTracking(0));
 		LLMenuGL::showPopup(this, menu, x, y);
 	}
-	return TRUE;
+	return true;
 }
 
 BOOL LLNetMap::handleClick(S32 x, S32 y, MASK mask)
@@ -1077,7 +1077,7 @@ BOOL LLNetMap::handleClick(S32 x, S32 y, MASK mask)
 	return TRUE;
 }
 
-BOOL LLNetMap::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLNetMap::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	LLVector3d pos_global = viewPosToGlobal(x, y);
 
@@ -1106,7 +1106,7 @@ BOOL LLNetMap::handleDoubleClick(S32 x, S32 y, MASK mask)
 	{
 		LLFloaterReg::showInstance("world_map");
 	}
-	return TRUE;
+	return true;
 }
 
 F32 LLNetMap::getScaleForName(std::string scale_name)
@@ -1139,7 +1139,7 @@ bool LLNetMap::outsideSlop( S32 x, S32 y, S32 start_x, S32 start_y, S32 slop )
 	return (dx <= -slop || slop <= dx || dy <= -slop || slop <= dy);
 }
 
-BOOL LLNetMap::handleHover( S32 x, S32 y, MASK mask )
+bool LLNetMap::handleHover( S32 x, S32 y, MASK mask )
 {
 	if (hasMouseCapture())
 	{
@@ -1173,7 +1173,7 @@ BOOL LLNetMap::handleHover( S32 x, S32 y, MASK mask )
         gViewerWindow->setCursor( UI_CURSOR_CROSS );
     }
 
-	return TRUE;
+	return true;
 }
 
 bool LLNetMap::isZoomChecked(const LLSD &userdata)

--- a/indra/newview/llnetmap.h
+++ b/indra/newview/llnetmap.h
@@ -70,17 +70,17 @@ public:
     static const F32 MAP_SCALE_MAX;
 
 	/*virtual*/ void	draw();
-	/*virtual*/ BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleHover( S32 x, S32 y, MASK mask );
-	/*virtual*/ BOOL	handleToolTip( S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool	handleToolTip( S32 x, S32 y, MASK mask);
 	/*virtual*/ void	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 
 	/*virtual*/ BOOL 	postBuild();
-	/*virtual*/ BOOL	handleRightMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool	handleRightMouseDown( S32 x, S32 y, MASK mask );
 	/*virtual*/ BOOL	handleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool	handleDoubleClick( S32 x, S32 y, MASK mask );
 
     void            setScale(F32 scale);
 

--- a/indra/newview/llnotificationlistitem.cpp
+++ b/indra/newview/llnotificationlistitem.cpp
@@ -151,9 +151,9 @@ void LLNotificationListItem::onClickCloseBtn()
     close();
 }
 
-BOOL LLNotificationListItem::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLNotificationListItem::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-    BOOL res = LLPanel::handleMouseUp(x, y, mask);
+    bool res = LLPanel::handleMouseUp(x, y, mask);
     mOnItemClick(this);
     return res;
 }

--- a/indra/newview/llnotificationlistitem.h
+++ b/indra/newview/llnotificationlistitem.h
@@ -79,7 +79,7 @@ public:
     std::string& getNotificationName() { return mNotificationName; }
 
     // handlers
-    virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
 	virtual void onMouseEnter(S32 x, S32 y, MASK mask);
 	virtual void onMouseLeave(S32 x, S32 y, MASK mask);
 

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -1019,19 +1019,19 @@ void LLOutfitGalleryItem::setSelected(bool value)
     setOutfitWorn(mWorn);
 }
 
-BOOL LLOutfitGalleryItem::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLOutfitGalleryItem::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     setFocus(TRUE);
     return LLUICtrl::handleMouseDown(x, y, mask);
 }
 
-BOOL LLOutfitGalleryItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLOutfitGalleryItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     setFocus(TRUE);
     return LLUICtrl::handleRightMouseDown(x, y, mask);
 }
 
-BOOL LLOutfitGalleryItem::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLOutfitGalleryItem::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
     return openOutfitsContent() || LLPanel::handleDoubleClick(x, y, mask);
 }

--- a/indra/newview/lloutfitgallery.h
+++ b/indra/newview/lloutfitgallery.h
@@ -234,9 +234,9 @@ public:
 
     /*virtual*/ BOOL postBuild();
     /*virtual*/ void draw();
-    /*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
     /*virtual*/ BOOL handleKeyHere(KEY key, MASK mask);
     /*virtual*/ void onFocusLost();
     /*virtual*/ void onFocusReceived();

--- a/indra/newview/lloutputmonitorctrl.cpp
+++ b/indra/newview/lloutputmonitorctrl.cpp
@@ -243,7 +243,7 @@ void LLOutputMonitorCtrl::draw()
 }
 
 // virtual
-BOOL LLOutputMonitorCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLOutputMonitorCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (mSpeakerId != gAgentID)
 	{
@@ -254,7 +254,7 @@ BOOL LLOutputMonitorCtrl::handleMouseUp(S32 x, S32 y, MASK mask)
 		LLFloaterReg::showInstance("chat_voice", LLSD());
 	}
 
-	return TRUE;
+	return true;
 }
 
 void LLOutputMonitorCtrl::setIsActiveChannel(bool val)

--- a/indra/newview/lloutputmonitorctrl.h
+++ b/indra/newview/lloutputmonitorctrl.h
@@ -68,7 +68,7 @@ public:
 
 	// llview overrides
 	virtual void	draw();
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
 
 	void			setPower(F32 val);
 	F32				getPower(F32 val) const { return mPower; }

--- a/indra/newview/llpanelavatartag.cpp
+++ b/indra/newview/llpanelavatartag.cpp
@@ -89,10 +89,10 @@ boost::signals2::connection LLPanelAvatarTag::setLeftButtonClickCallback(
 	return setCommitCallback(cb);
 }
 
-BOOL LLPanelAvatarTag::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelAvatarTag::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	onCommit();
-	return TRUE;
+	return true;
 }
 
 void LLPanelAvatarTag::onClick()

--- a/indra/newview/llpanelavatartag.h
+++ b/indra/newview/llpanelavatartag.h
@@ -62,7 +62,7 @@ public:
 	
 	virtual boost::signals2::connection setLeftButtonClickCallback(
 																   const commit_callback_t& cb);
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 
 	void onClick();
 private:

--- a/indra/newview/llpanelmarketplaceinboxinventory.cpp
+++ b/indra/newview/llpanelmarketplaceinboxinventory.cpp
@@ -176,13 +176,13 @@ void LLInboxFolderViewFolder::draw()
 
 }
 
-BOOL LLInboxFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLInboxFolderViewFolder::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	deFreshify();
 	return LLFolderViewFolder::handleMouseDown(x, y, mask);
 }
 
-BOOL LLInboxFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLInboxFolderViewFolder::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
 	deFreshify();
 	return LLFolderViewFolder::handleDoubleClick(x, y, mask);
@@ -252,7 +252,7 @@ void LLInboxFolderViewItem::addToFolder(LLFolderViewFolder* folder)
 	}
 }
 
-BOOL LLInboxFolderViewItem::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLInboxFolderViewItem::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	deFreshify();
 	

--- a/indra/newview/llpanelmarketplaceinboxinventory.h
+++ b/indra/newview/llpanelmarketplaceinboxinventory.h
@@ -71,8 +71,8 @@ public:
     void addItem(LLFolderViewItem* item);
 	void draw();
 	
-	BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	bool handleMouseDown(S32 x, S32 y, MASK mask);
+	bool handleDoubleClick(S32 x, S32 y, MASK mask);
 	void selectItem();
 
 	void computeFreshness();
@@ -101,7 +101,7 @@ public:
 	LLInboxFolderViewItem(const Params& p);
 
 	void addToFolder(LLFolderViewFolder* folder);
-	BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	bool handleDoubleClick(S32 x, S32 y, MASK mask);
 
 	void draw();
 

--- a/indra/newview/llpanelnearbymedia.cpp
+++ b/indra/newview/llpanelnearbymedia.cpp
@@ -241,7 +241,7 @@ void LLPanelNearByMedia::draw()
 }
 
 /*virtual*/
-BOOL LLPanelNearByMedia::handleHover(S32 x, S32 y, MASK mask)
+bool LLPanelNearByMedia::handleHover(S32 x, S32 y, MASK mask)
 {
 	LLPanelPulldown::handleHover(x, y, mask);
 	
@@ -255,7 +255,7 @@ BOOL LLPanelNearByMedia::handleHover(S32 x, S32 y, MASK mask)
 	return true;
 }
 
-BOOL LLPanelNearByMedia::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelNearByMedia::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     S32 x_list, y_list;
     localPointToOtherView(x, y, &x_list, &y_list, mMediaList);
@@ -268,7 +268,7 @@ BOOL LLPanelNearByMedia::handleRightMouseDown(S32 x, S32 y, MASK mask)
             mContextMenu->buildDrawLabels();
             mContextMenu->updateParent(LLMenuGL::sMenuContainer);
             LLMenuGL::showPopup(this, mContextMenu, x, y);
-            return TRUE;
+            return true;
         }
     }
 

--- a/indra/newview/llpanelnearbymedia.h
+++ b/indra/newview/llpanelnearbymedia.h
@@ -47,8 +47,8 @@ public:
 	BOOL postBuild() override;
 	void draw() override;
 	void reshape(S32 width, S32 height, BOOL called_from_parent) override;
-	BOOL handleHover(S32 x, S32 y, MASK mask) override;
-    BOOL handleRightMouseDown(S32 x, S32 y, MASK mask) override;
+	bool handleHover(S32 x, S32 y, MASK mask) override;
+	bool handleRightMouseDown(S32 x, S32 y, MASK mask) override;
     void onVisibilityChange(BOOL new_visibility) override;
 
 	// this is part of the nearby media *dialog* so we can track whether

--- a/indra/newview/llpanelprimmediacontrols.cpp
+++ b/indra/newview/llpanelprimmediacontrols.cpp
@@ -834,10 +834,10 @@ void LLPanelPrimMediaControls::draw()
 	}
 }
 
-BOOL LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     mInactivityTimer.start();
-    BOOL res = FALSE;
+    bool res = false;
 
     // Unlike other mouse events, we need to handle scroll here otherwise
     // it will be intercepted by camera and won't reach toolpie
@@ -850,10 +850,10 @@ BOOL LLPanelPrimMediaControls::handleScrollWheel(S32 x, S32 y, S32 clicks)
     return res;
 }
 
-BOOL LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
     mInactivityTimer.start();
-    BOOL res = FALSE;
+    bool res = false;
 
     if (LLViewerMediaFocus::getInstance()->isHoveringOverFocused())
     {
@@ -864,13 +864,13 @@ BOOL LLPanelPrimMediaControls::handleScrollHWheel(S32 x, S32 y, S32 clicks)
     return res;
 }
 
-BOOL LLPanelPrimMediaControls::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelPrimMediaControls::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mInactivityTimer.start();
 	return LLPanel::handleMouseDown(x, y, mask);
 }
 
-BOOL LLPanelPrimMediaControls::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLPanelPrimMediaControls::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mInactivityTimer.start();
 	return LLPanel::handleMouseUp(x, y, mask);

--- a/indra/newview/llpanelprimmediacontrols.h
+++ b/indra/newview/llpanelprimmediacontrols.h
@@ -48,11 +48,11 @@ public:
 	virtual ~LLPanelPrimMediaControls();
 	/*virtual*/ BOOL postBuild();
 	virtual void draw();
-	virtual BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	virtual bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool handleScrollHWheel(S32 x, S32 y, S32 clicks);
 
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
 	virtual BOOL handleKeyHere(KEY key, MASK mask);
 	
 	void updateShape();

--- a/indra/newview/llpanelpulldown.cpp
+++ b/indra/newview/llpanelpulldown.cpp
@@ -56,30 +56,30 @@ void LLPanelPulldown::onTopLost()
 }
 
 /*virtual*/
-BOOL LLPanelPulldown::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelPulldown::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     LLPanel::handleMouseDown(x, y, mask);
-    return TRUE;
+    return true;
 }
 
 /*virtual*/
-BOOL LLPanelPulldown::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelPulldown::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     LLPanel::handleRightMouseDown(x, y, mask);
-    return TRUE;
+    return true;
 }
 
 /*virtual*/
-BOOL LLPanelPulldown::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLPanelPulldown::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
     LLPanel::handleDoubleClick(x, y, mask);
-    return TRUE;
+    return true;
 }
 
-BOOL LLPanelPulldown::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPanelPulldown::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     LLPanel::handleScrollWheel(x, y, clicks);
-    return TRUE; //If we got here, then we are in Pulldown's rect, consume the event.
+    return true; //If we got here, then we are in Pulldown's rect, consume the event.
 }
 
 /*virtual*/

--- a/indra/newview/llpanelpulldown.h
+++ b/indra/newview/llpanelpulldown.h
@@ -39,10 +39,10 @@ public:
     LLPanelPulldown();
     /*virtual*/ void onMouseEnter(S32 x, S32 y, MASK mask);
     /*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
-    /*virtual*/ BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
+    /*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
+    /*virtual*/ bool handleScrollWheel(S32 x, S32 y, S32 clicks);
     /*virtual*/ void onTopLost();
     /*virtual*/ void onVisibilityChange(BOOL new_visibility);
 

--- a/indra/newview/llpanelteleporthistory.cpp
+++ b/indra/newview/llpanelteleporthistory.cpp
@@ -78,7 +78,7 @@ public:
 
 	void onMouseEnter(S32 x, S32 y, MASK mask);
 	void onMouseLeave(S32 x, S32 y, MASK mask);
-	virtual BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	static void showPlaceInfoPanel(S32 index);
 
@@ -265,11 +265,11 @@ void LLTeleportHistoryFlatItem::onMouseLeave(S32 x, S32 y, MASK mask)
 }
 
 // virtual
-BOOL LLTeleportHistoryFlatItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLTeleportHistoryFlatItem::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     LLPanel::handleRightMouseDown(x, y, mask);
 	showMenu(x, y);
-    return TRUE;
+    return true;
 }
 
 void LLTeleportHistoryFlatItem::showPlaceInfoPanel(S32 index)

--- a/indra/newview/llpaneltopinfobar.cpp
+++ b/indra/newview/llpaneltopinfobar.cpp
@@ -128,7 +128,7 @@ void LLPanelTopInfoBar::handleLoginComplete()
 	update();
 }
 
-BOOL LLPanelTopInfoBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPanelTopInfoBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	if(!LLUICtrl::CommitCallbackRegistry::getValue("TopInfoBar.Action"))
 	{
@@ -136,7 +136,7 @@ BOOL LLPanelTopInfoBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 				.add("TopInfoBar.Action", boost::bind(&LLPanelTopInfoBar::onContextMenuItemClicked, this, _2));
 	}
 	show_topinfobar_context_menu(this, x, y);
-	return TRUE;
+	return true;
 }
 
 BOOL LLPanelTopInfoBar::postBuild()

--- a/indra/newview/llpaneltopinfobar.h
+++ b/indra/newview/llpaneltopinfobar.h
@@ -83,7 +83,7 @@ private:
 	 */
 	void initParcelIcons();
 
-	BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	/**
 	 * Handles clicks on the parcel icons.

--- a/indra/newview/llpathfindingpathtool.cpp
+++ b/indra/newview/llpathfindingpathtool.cpp
@@ -63,9 +63,9 @@ LLPathfindingPathTool::~LLPathfindingPathTool()
 {
 }
 
-BOOL LLPathfindingPathTool::handleMouseDown(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleMouseDown(S32 pX, S32 pY, MASK pMask)
 {
-	BOOL returnVal = FALSE;
+	bool returnVal = false;
 
 	if (!mIsLeftMouseButtonHeld && !mIsMiddleMouseButtonHeld && !mIsRightMouseButtonHeld)
 	{
@@ -77,14 +77,14 @@ BOOL LLPathfindingPathTool::handleMouseDown(S32 pX, S32 pY, MASK pMask)
 			computeFinalPoints(pX, pY, pMask);
 			mIsLeftMouseButtonHeld = true;
 			setMouseCapture(TRUE);
-			returnVal = TRUE;
+			returnVal = true;
 		}
 		else if (!isCameraModKeys(pMask))
 		{
 			gViewerWindow->setCursor(UI_CURSOR_TOOLNO);
 			mIsLeftMouseButtonHeld = true;
 			setMouseCapture(TRUE);
-			returnVal = TRUE;
+			returnVal = true;
 		}
 	}
 	mIsLeftMouseButtonHeld = true;
@@ -92,31 +92,31 @@ BOOL LLPathfindingPathTool::handleMouseDown(S32 pX, S32 pY, MASK pMask)
 	return returnVal;
 }
 
-BOOL LLPathfindingPathTool::handleMouseUp(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleMouseUp(S32 pX, S32 pY, MASK pMask)
 {
-	BOOL returnVal = FALSE;
+	bool returnVal = false;
 
 	if (mIsLeftMouseButtonHeld && !mIsMiddleMouseButtonHeld && !mIsRightMouseButtonHeld)
 	{
 		computeFinalPoints(pX, pY, pMask);
 		setMouseCapture(FALSE);
-		returnVal = TRUE;
+		returnVal = true;
 	}
 	mIsLeftMouseButtonHeld = false;
 
 	return returnVal;
 }
 
-BOOL LLPathfindingPathTool::handleMiddleMouseDown(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleMiddleMouseDown(S32 pX, S32 pY, MASK pMask)
 {
 	setMouseCapture(TRUE);
 	mIsMiddleMouseButtonHeld = true;
 	gViewerWindow->setCursor(UI_CURSOR_TOOLNO);
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLPathfindingPathTool::handleMiddleMouseUp(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleMiddleMouseUp(S32 pX, S32 pY, MASK pMask)
 {
 	if (!mIsLeftMouseButtonHeld && mIsMiddleMouseButtonHeld && !mIsRightMouseButtonHeld)
 	{
@@ -124,19 +124,19 @@ BOOL LLPathfindingPathTool::handleMiddleMouseUp(S32 pX, S32 pY, MASK pMask)
 	}
 	mIsMiddleMouseButtonHeld = false;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLPathfindingPathTool::handleRightMouseDown(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleRightMouseDown(S32 pX, S32 pY, MASK pMask)
 {
 	setMouseCapture(TRUE);
 	mIsRightMouseButtonHeld = true;
 	gViewerWindow->setCursor(UI_CURSOR_TOOLNO);
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLPathfindingPathTool::handleRightMouseUp(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleRightMouseUp(S32 pX, S32 pY, MASK pMask)
 {
 	if (!mIsLeftMouseButtonHeld && !mIsMiddleMouseButtonHeld && mIsRightMouseButtonHeld)
 	{
@@ -144,17 +144,17 @@ BOOL LLPathfindingPathTool::handleRightMouseUp(S32 pX, S32 pY, MASK pMask)
 	}
 	mIsRightMouseButtonHeld = false;
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLPathfindingPathTool::handleDoubleClick(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleDoubleClick(S32 pX, S32 pY, MASK pMask)
 {
-	return TRUE;
+	return true;
 }
 
-BOOL LLPathfindingPathTool::handleHover(S32 pX, S32 pY, MASK pMask)
+bool LLPathfindingPathTool::handleHover(S32 pX, S32 pY, MASK pMask)
 {
-	BOOL returnVal = FALSE;
+	bool returnVal = false;
 
 	if (!mIsLeftMouseButtonHeld && !mIsMiddleMouseButtonHeld && !mIsRightMouseButtonHeld && !isAnyPathToolModKeys(pMask))
 	{
@@ -167,7 +167,7 @@ BOOL LLPathfindingPathTool::handleHover(S32 pX, S32 pY, MASK pMask)
 			? (mIsLeftMouseButtonHeld ? UI_CURSOR_TOOLPATHFINDING_PATH_START_ADD : UI_CURSOR_TOOLPATHFINDING_PATH_START)
 			: (mIsLeftMouseButtonHeld ? UI_CURSOR_TOOLPATHFINDING_PATH_END_ADD : UI_CURSOR_TOOLPATHFINDING_PATH_END));
 		computeTempPoints(pX, pY, pMask);
-		returnVal = TRUE;
+		returnVal = true;
 	}
 	else
 	{

--- a/indra/newview/llpathfindingpathtool.h
+++ b/indra/newview/llpathfindingpathtool.h
@@ -66,15 +66,15 @@ public:
 	typedef boost::signals2::signal<void (void)> path_event_signal_t;
 	typedef boost::signals2::connection          path_event_slot_t;
 
-	virtual BOOL      handleMouseDown(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleMouseUp(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleMiddleMouseDown(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleMiddleMouseUp(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleRightMouseDown(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleRightMouseUp(S32 pX, S32 pY, MASK pMask);
-	virtual BOOL      handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool      handleMouseDown(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleMouseUp(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleMiddleMouseDown(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleMiddleMouseUp(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleRightMouseDown(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleRightMouseUp(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleDoubleClick(S32 x, S32 y, MASK mask);
 
-	virtual BOOL      handleHover(S32 pX, S32 pY, MASK pMask);
+	virtual bool      handleHover(S32 pX, S32 pY, MASK pMask);
 
 	virtual BOOL      handleKey(KEY pKey, MASK pMask);
 

--- a/indra/newview/llplacesfolderview.cpp
+++ b/indra/newview/llplacesfolderview.cpp
@@ -42,7 +42,7 @@ LLPlacesFolderView::LLPlacesFolderView(const LLFolderView::Params& p)
     mAutoSelectOverride = TRUE;
 }
 
-BOOL LLPlacesFolderView::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPlacesFolderView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     // let children to change selection first
     childrenHandleRightMouseDown(x, y, mask);

--- a/indra/newview/llplacesfolderview.h
+++ b/indra/newview/llplacesfolderview.h
@@ -49,7 +49,7 @@ public:
 	 * Contains workaround for EXT-2786: sets current selected list for landmark
 	 * panel using @c mParentLandmarksPanel which is set in @c LLLandmarksPanel::initLandmarksPanel
 	 */
-	/*virtual*/ BOOL handleRightMouseDown( S32 x, S32 y, MASK mask );
+	/*virtual*/ bool handleRightMouseDown( S32 x, S32 y, MASK mask );
 
 	/*virtual*/ void updateMenu();
 

--- a/indra/newview/llpopupview.cpp
+++ b/indra/newview/llpopupview.cpp
@@ -136,9 +136,9 @@ BOOL LLPopupView::handleMouseEvent(boost::function<BOOL(LLView*, S32, S32)> func
 }
 
 
-BOOL LLPopupView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
 	if (!handled)
 	{
 		handled = LLPanel::handleMouseDown(x, y, mask);
@@ -146,9 +146,9 @@ BOOL LLPopupView::handleMouseDown(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLPopupView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleMouseUp(x, y, mask);
@@ -156,9 +156,9 @@ BOOL LLPopupView::handleMouseUp(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLPopupView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMiddleMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMiddleMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
 	if (!handled)
 	{
 		handled = LLPanel::handleMiddleMouseDown(x, y, mask);
@@ -166,9 +166,9 @@ BOOL LLPopupView::handleMiddleMouseDown(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMiddleMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleMiddleMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleMiddleMouseUp(x, y, mask);
@@ -176,9 +176,9 @@ BOOL LLPopupView::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleRightMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleRightMouseDown, _1, _2, _3, mask), view_visible_and_enabled, x, y, true);
 	if (!handled)
 	{
 		handled = LLPanel::handleRightMouseDown(x, y, mask);
@@ -186,9 +186,9 @@ BOOL LLPopupView::handleRightMouseDown(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleRightMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleRightMouseUp, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleRightMouseUp(x, y, mask);
@@ -196,9 +196,9 @@ BOOL LLPopupView::handleRightMouseUp(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleDoubleClick, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleDoubleClick, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleDoubleClick(x, y, mask);
@@ -206,9 +206,9 @@ BOOL LLPopupView::handleDoubleClick(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleHover(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleHover, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleHover, _1, _2, _3, mask), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleHover(x, y, mask);
@@ -216,9 +216,9 @@ BOOL LLPopupView::handleHover(S32 x, S32 y, MASK mask)
 	return handled;	
 }
 
-BOOL LLPopupView::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLPopupView::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleScrollWheel, _1, _2, _3, clicks), view_visible_and_enabled, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleScrollWheel, _1, _2, _3, clicks), view_visible_and_enabled, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleScrollWheel(x, y, clicks);
@@ -226,9 +226,9 @@ BOOL LLPopupView::handleScrollWheel(S32 x, S32 y, S32 clicks)
 	return handled;	
 }
 
-BOOL LLPopupView::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLPopupView::handleToolTip(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleToolTip, _1, _2, _3, mask), view_visible, x, y, false);
+	bool handled = handleMouseEvent(boost::bind(&LLMouseHandler::handleToolTip, _1, _2, _3, mask), view_visible, x, y, false);
 	if (!handled)
 	{
 		handled = LLPanel::handleToolTip(x, y, mask);

--- a/indra/newview/llpopupview.h
+++ b/indra/newview/llpopupview.h
@@ -36,16 +36,16 @@ public:
 	~LLPopupView();
 
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMiddleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleRightMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleScrollWheel(S32 x, S32 y, S32 clicks);
-	/*virtual*/ BOOL handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMiddleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleScrollWheel(S32 x, S32 y, S32 clicks);
+	/*virtual*/ bool handleToolTip(S32 x, S32 y, MASK mask);
 
 	void addPopup(LLView* popup);
 	void removePopup(LLView* popup);

--- a/indra/newview/llpreview.cpp
+++ b/indra/newview/llpreview.cpp
@@ -306,7 +306,7 @@ void LLPreview::dirty(const LLUUID& item_uuid)
 	}
 }
 
-BOOL LLPreview::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if(mClientRect.pointInRect(x, y))
 	{
@@ -318,22 +318,22 @@ BOOL LLPreview::handleMouseDown(S32 x, S32 y, MASK mask)
 		S32 screen_y;
 		localPointToScreen(x, y, &screen_x, &screen_y );
 		LLToolDragAndDrop::getInstance()->setDragStart(screen_x, screen_y);
-		return TRUE;
+		return true;
 	}
 	return LLFloater::handleMouseDown(x, y, mask);
 }
 
-BOOL LLPreview::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLPreview::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if(hasMouseCapture())
 	{
 		gFocusMgr.setMouseCapture(NULL);
-		return TRUE;
+		return true;
 	}
 	return LLFloater::handleMouseUp(x, y, mask);
 }
 
-BOOL LLPreview::handleHover(S32 x, S32 y, MASK mask)
+bool LLPreview::handleHover(S32 x, S32 y, MASK mask)
 {
 	if(hasMouseCapture())
 	{

--- a/indra/newview/llpreview.h
+++ b/indra/newview/llpreview.h
@@ -79,9 +79,9 @@ public:
 	static void hide(const LLUUID& item_uuid, BOOL no_saving = FALSE );
 	static void	dirty(const LLUUID& item_uuid);
 	
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL handleHover(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleHover(S32 x, S32 y, MASK mask);
 	virtual void onOpen(const LLSD& key);
 	
 	virtual void setAuxItem( const LLInventoryItem* item );

--- a/indra/newview/llprogressview.cpp
+++ b/indra/newview/llprogressview.cpp
@@ -115,13 +115,13 @@ LLProgressView::~LLProgressView()
 	sInstance = NULL;
 }
 
-BOOL LLProgressView::handleHover(S32 x, S32 y, MASK mask)
+bool LLProgressView::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( childrenHandleHover( x, y, mask ) == NULL )
 	{
 		gViewerWindow->setCursor(UI_CURSOR_WAIT);
 	}
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/newview/llprogressview.h
+++ b/indra/newview/llprogressview.h
@@ -54,7 +54,7 @@ public:
 	void drawStartTexture(F32 alpha);
 	void drawLogos(F32 alpha);
 
-	/*virtual*/ BOOL handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL handleKeyHere(KEY key, MASK mask);
 	/*virtual*/ void setVisible(BOOL visible);
 

--- a/indra/newview/llsetkeybinddialog.cpp
+++ b/indra/newview/llsetkeybinddialog.cpp
@@ -272,14 +272,14 @@ bool LLSetKeyBindDialog::recordAndHandleKey(KEY key, MASK mask, BOOL down)
     return true;
 }
 
-BOOL LLSetKeyBindDialog::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down)
+bool LLSetKeyBindDialog::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down)
 {
-    BOOL result = FALSE;
+    bool result = false;
     if (!pParent)
     {
         // we already processed 'down' event, this is 'up', consume
         closeFloater();
-        result = TRUE;
+        result = true;
     }
     if (!result && clicktype == CLICK_LEFT)
     {
@@ -305,7 +305,7 @@ BOOL LLSetKeyBindDialog::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClic
             {
                 // Note: default doubleclick time is 500ms, but can stretch up to 5s
                 pUpdater = new Updater(boost::bind(&onClickTimeout, this, _1), 0.7f, mask);
-                result = TRUE;
+                result = true;
             }
         }
     }

--- a/indra/newview/llsetkeybinddialog.h
+++ b/indra/newview/llsetkeybinddialog.h
@@ -70,7 +70,7 @@ public:
     // It does not record, it handles, but handleKey function is already in use
     static bool recordKey(KEY key, MASK mask, BOOL down);
 
-    BOOL handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down);
+    bool handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down);
     static void onCancel(void* user_data);
     static void onBlank(void* user_data);
     static void onDefault(void* user_data);

--- a/indra/newview/llsettingspicker.cpp
+++ b/indra/newview/llsettingspicker.cpp
@@ -359,9 +359,9 @@ void LLFloaterSettingsPicker::onButtonSelect()
     closeFloater();
 }
 
-BOOL LLFloaterSettingsPicker::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLFloaterSettingsPicker::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-    BOOL result = FALSE;
+    bool result = false;
     if (mSettingItemID.notNull()
         && mInventoryPanel)
     {
@@ -387,7 +387,7 @@ BOOL LLFloaterSettingsPicker::handleDoubleClick(S32 x, S32 y, MASK mask)
                     }
                     closeFloater();
                     // hit inside panel on selected item, double click should do nothing
-                    result = TRUE;
+                    result = true;
                 }
             }
         }

--- a/indra/newview/llsettingspicker.h
+++ b/indra/newview/llsettingspicker.h
@@ -107,7 +107,7 @@ private:
     void                    onAssetLoaded(LLUUID asset_id, LLSettingsBase::ptr_t settings);
     void                    onButtonCancel();
     void                    onButtonSelect();
-    virtual BOOL            handleDoubleClick(S32 x, S32 y, MASK mask) override;
+    virtual bool            handleDoubleClick(S32 x, S32 y, MASK mask) override;
     BOOL                    handleKeyHere(KEY key, MASK mask) override;
     void                    onFocusLost() override;
 

--- a/indra/newview/llsplitbutton.cpp
+++ b/indra/newview/llsplitbutton.cpp
@@ -126,14 +126,14 @@ void LLSplitButton::onItemSelected(LLUICtrl* ctrl)
 	gFocusMgr.setKeyboardFocus(NULL);
 }
 
-BOOL LLSplitButton::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLSplitButton::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	gFocusMgr.setMouseCapture(NULL);
 
 	if (mShownItem->parentPointInView(x, y))
 	{
 		onItemSelected(mShownItem);
-		return TRUE;
+		return true;
 	}
 
 	for (std::list<LLButton*>::const_iterator it = mHidenItems.begin(); it != mHidenItems.end(); ++it)
@@ -147,10 +147,10 @@ BOOL LLSplitButton::handleMouseUp(S32 x, S32 y, MASK mask)
 		if (item->parentPointInView(panel_x, panel_y))
 		{
 			onItemSelected(item);
-			return TRUE;
+			return true;
 		}
 	}
-	return TRUE;
+	return true;
 }
 
 void LLSplitButton::showButtons()

--- a/indra/newview/llsplitbutton.h
+++ b/indra/newview/llsplitbutton.h
@@ -80,7 +80,7 @@ public:
 	void	onItemSelected(LLUICtrl* ctrl);
 	void	setSelectionCallback(commit_callback_t cb) { mSelectionCallback = cb; }
 
-	virtual BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseUp(S32 x, S32 y, MASK mask);
 
 	virtual void	showButtons();
 	virtual void	hideButtons();

--- a/indra/newview/llstatusbar.cpp
+++ b/indra/newview/llstatusbar.cpp
@@ -153,10 +153,10 @@ void LLStatusBar::draw()
 	LLPanel::draw();
 }
 
-BOOL LLStatusBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLStatusBar::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	show_navbar_context_menu(this,x,y);
-	return TRUE;
+	return true;
 }
 
 BOOL LLStatusBar::postBuild()

--- a/indra/newview/llstatusbar.h
+++ b/indra/newview/llstatusbar.h
@@ -64,7 +64,7 @@ public:
 	
 	/*virtual*/ void draw();
 
-	/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL postBuild();
 
 	// MANIPULATORS

--- a/indra/newview/llsyswellitem.cpp
+++ b/indra/newview/llsyswellitem.cpp
@@ -68,9 +68,9 @@ void LLSysWellItem::onClickCloseBtn()
 }
 
 //---------------------------------------------------------------------------------
-BOOL LLSysWellItem::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLSysWellItem::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL res = LLPanel::handleMouseDown(x, y, mask);
+	bool res = LLPanel::handleMouseDown(x, y, mask);
 	if(!mCloseBtn->getRect().pointInRect(x, y))
 		mOnItemClick(this);
 

--- a/indra/newview/llsyswellitem.h
+++ b/indra/newview/llsyswellitem.h
@@ -55,7 +55,7 @@ public:
 	LLUUID getID() { return mID; }
 
 	// handlers
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual void onMouseEnter(S32 x, S32 y, MASK mask);
 	virtual void onMouseLeave(S32 x, S32 y, MASK mask);
 

--- a/indra/newview/llsyswellwindow.cpp
+++ b/indra/newview/llsyswellwindow.cpp
@@ -277,20 +277,20 @@ void LLIMWellWindow::ObjectRowPanel::onMouseLeave(S32 x, S32 y, MASK mask)
 
 //---------------------------------------------------------------------------------
 // virtual
-BOOL LLIMWellWindow::ObjectRowPanel::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLIMWellWindow::ObjectRowPanel::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Pass the mouse down event to the chiclet (EXT-596).
 	if (!mChiclet->pointInView(x, y) && !mCloseBtn->getRect().pointInRect(x, y)) // prevent double call of LLIMChiclet::onMouseDown()
 	{
 		mChiclet->onMouseDown();
-		return TRUE;
+		return true;
 	}
 
 	return LLPanel::handleMouseDown(x, y, mask);
 }
 
 // virtual
-BOOL LLIMWellWindow::ObjectRowPanel::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLIMWellWindow::ObjectRowPanel::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	return mChiclet->handleRightMouseDown(x, y, mask);
 }

--- a/indra/newview/llsyswellwindow.h
+++ b/indra/newview/llsyswellwindow.h
@@ -133,8 +133,8 @@ private:
 		virtual ~ObjectRowPanel();
 		/*virtual*/ void onMouseEnter(S32 x, S32 y, MASK mask);
 		/*virtual*/ void onMouseLeave(S32 x, S32 y, MASK mask);
-		/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-		/*virtual*/ BOOL handleRightMouseDown(S32 x, S32 y, MASK mask);
+		/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+		/*virtual*/ bool handleRightMouseDown(S32 x, S32 y, MASK mask);
 
 	private:
 		void onClosePanel();

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -1875,16 +1875,16 @@ public:
 	}
 };
 
-BOOL LLTextureCtrl::handleHover(S32 x, S32 y, MASK mask)
+bool LLTextureCtrl::handleHover(S32 x, S32 y, MASK mask)
 {
 	getWindow()->setCursor(mBorder->parentPointInView(x,y) ? UI_CURSOR_HAND : UI_CURSOR_ARROW);
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLTextureCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextureCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLUICtrl::handleMouseDown( x, y , mask );
+	bool handled = LLUICtrl::handleMouseDown( x, y , mask );
 
 	if (!handled && mBorder->parentPointInView(x, y))
 	{
@@ -1906,7 +1906,7 @@ BOOL LLTextureCtrl::handleMouseDown(S32 x, S32 y, MASK mask)
             {
                 LLInventoryModelBackgroundFetch::instance().start();
             }
-			handled = TRUE;
+			handled = true;
 		}
 		else
 		{
@@ -2324,12 +2324,12 @@ BOOL LLTextureCtrl::doDrop(LLInventoryItem* item)
 	return TRUE;
 }
 
-BOOL LLTextureCtrl::handleUnicodeCharHere(llwchar uni_char)
+bool LLTextureCtrl::handleUnicodeCharHere(llwchar uni_char)
 {
 	if( ' ' == uni_char )
 	{
 		showPicker(TRUE);
-		return TRUE;
+		return true;
 	}
 	return LLUICtrl::handleUnicodeCharHere(uni_char);
 }

--- a/indra/newview/lltexturectrl.h
+++ b/indra/newview/lltexturectrl.h
@@ -136,13 +136,13 @@ public:
 
 	// LLView interface
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual BOOL	handleDragAndDrop(S32 x, S32 y, MASK mask,
 						BOOL drop, EDragAndDropType cargo_type, void *cargo_data,
 						EAcceptance *accept,
 						std::string& tooltip_msg);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleUnicodeCharHere(llwchar uni_char);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleUnicodeCharHere(llwchar uni_char);
 
 	virtual void	draw();
 	virtual void	setVisible( BOOL visible );

--- a/indra/newview/lltextureview.cpp
+++ b/indra/newview/lltextureview.cpp
@@ -107,7 +107,7 @@ public:
 	{}
 
 	virtual void draw();
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual LLRect getRequiredRect();	// Return the height of this object, given the set options.
 
 // Used for sorting
@@ -343,12 +343,12 @@ void LLTextureBar::draw()
 
 }
 
-BOOL LLTextureBar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextureBar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if ((mask & (MASK_CONTROL|MASK_SHIFT|MASK_ALT)) == MASK_ALT)
 	{
 		LLAppViewer::getTextureFetch()->mDebugID = mImagep->getID();
-		return TRUE;
+		return true;
 	}
 	return LLView::handleMouseDown(x,y,mask);
 }
@@ -384,7 +384,7 @@ public:
 	{}
 
 	virtual void draw();	
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual LLRect getRequiredRect();	// Return the height of this object, given the set options.
 
 private:
@@ -440,9 +440,9 @@ void LLAvatarTexBar::draw()
 											 header_color, LLFontGL::LEFT, LLFontGL::TOP, LLFontGL::BOLD, LLFontGL::DROP_SHADOW_SOFT);
 }
 
-BOOL LLAvatarTexBar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLAvatarTexBar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 LLRect LLAvatarTexBar::getRequiredRect()
@@ -475,7 +475,7 @@ public:
 	{}
 
 	virtual void draw();	
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 	virtual LLRect getRequiredRect();	// Return the height of this object, given the set options.
 
 private:
@@ -644,9 +644,9 @@ void LLGLTexMemBar::draw()
 									 text_color, LLFontGL::LEFT, LLFontGL::TOP);
 }
 
-BOOL LLGLTexMemBar::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLGLTexMemBar::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 LLRect LLGLTexMemBar::getRequiredRect()
@@ -995,34 +995,34 @@ BOOL LLTextureView::addBar(LLViewerFetchedTexture *imagep, S32 hilite)
 	return TRUE;
 }
 
-BOOL LLTextureView::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTextureView::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if ((mask & (MASK_CONTROL|MASK_SHIFT|MASK_ALT)) == (MASK_ALT|MASK_SHIFT))
 	{
 		mPrintList = TRUE;
-		return TRUE;
+		return true;
 	}
 	if ((mask & (MASK_CONTROL|MASK_SHIFT|MASK_ALT)) == (MASK_CONTROL|MASK_SHIFT))
 	{
 		LLAppViewer::getTextureFetch()->mDebugPause = !LLAppViewer::getTextureFetch()->mDebugPause;
-		return TRUE;
+		return true;
 	}
 	if (mask & MASK_SHIFT)
 	{
 		mFreezeView = !mFreezeView;
-		return TRUE;
+		return true;
 	}
 	if (mask & MASK_CONTROL)
 	{
 		mOrderFetch = !mOrderFetch;
-		return TRUE;
+		return true;
 	}
 	return LLView::handleMouseDown(x,y,mask);
 }
 
-BOOL LLTextureView::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTextureView::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	return FALSE;
+	return false;
 }
 
 BOOL LLTextureView::handleKey(KEY key, MASK mask, BOOL called_from_parent)

--- a/indra/newview/lltextureview.h
+++ b/indra/newview/lltextureview.h
@@ -46,8 +46,8 @@ public:
 	~LLTextureView();
 
 	/*virtual*/ void draw();
-	/*virtual*/ BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool handleMouseUp(S32 x, S32 y, MASK mask);
 	/*virtual*/ BOOL handleKey(KEY key, MASK mask, BOOL called_from_parent);
 
 	static void addDebugImage(LLViewerFetchedTexture* image) { sDebugImages.insert(image); }

--- a/indra/newview/llthumbnailctrl.cpp
+++ b/indra/newview/llthumbnailctrl.cpp
@@ -212,12 +212,12 @@ void LLThumbnailCtrl::setValue(const LLSD& value)
     }
 }
 
-BOOL LLThumbnailCtrl::handleHover(S32 x, S32 y, MASK mask)
+bool LLThumbnailCtrl::handleHover(S32 x, S32 y, MASK mask)
 {
     if (mInteractable && getEnabled())
     {
         getWindow()->setCursor(UI_CURSOR_HAND);
-        return TRUE;
+        return true;
     }
     return LLUICtrl::handleHover(x, y, mask);
 }

--- a/indra/newview/llthumbnailctrl.h
+++ b/indra/newview/llthumbnailctrl.h
@@ -70,7 +70,7 @@ public:
     void setInitImmediately(bool val) { mInitImmediately = val; }
     void clearTexture();
     
-    virtual BOOL handleHover(S32 x, S32 y, MASK mask) override;
+    virtual bool handleHover(S32 x, S32 y, MASK mask) override;
 
 protected:
     void initImage();

--- a/indra/newview/lltoast.cpp
+++ b/indra/newview/lltoast.cpp
@@ -583,7 +583,7 @@ void LLNotificationsUI::LLToast::startTimer()
 
 //--------------------------------------------------------------------------
 
-BOOL LLToast::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToast::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if(mHideBtn && mHideBtn->getEnabled())
 	{

--- a/indra/newview/lltoast.h
+++ b/indra/newview/lltoast.h
@@ -118,7 +118,7 @@ public:
 	/*virtual*/ void reshape(S32 width, S32 height, BOOL called_from_parent = TRUE);
 
 	// Toast handlers
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
 
 	//Fading
 

--- a/indra/newview/lltoastimpanel.cpp
+++ b/indra/newview/lltoastimpanel.cpp
@@ -117,18 +117,18 @@ LLToastIMPanel::~LLToastIMPanel()
 }
 
 //virtual
-BOOL LLToastIMPanel::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToastIMPanel::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (LLPanel::handleMouseUp(x,y,mask) == FALSE)
 	{
 		mNotification->respond(mNotification->getResponseTemplate());
 	}
 
-	return TRUE;
+	return true;
 }
 
 //virtual
-BOOL LLToastIMPanel::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLToastIMPanel::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	// It's not our direct child, so parentPointInView() doesn't work.
 	LLRect ctrl_rect;
@@ -137,14 +137,14 @@ BOOL LLToastIMPanel::handleToolTip(S32 x, S32 y, MASK mask)
 	if (ctrl_rect.pointInRect(x, y))
 	{
 		spawnNameToolTip();
-		return TRUE;
+		return true;
 	}
 
 	mGroupIcon->localRectToOtherView(mGroupIcon->getLocalRect(), &ctrl_rect, this);
 	if(mGroupIcon->getVisible() && ctrl_rect.pointInRect(x, y))
 	{
 		spawnGroupIconToolTip();
-		return TRUE;
+		return true;
 	}
 
 	return LLToastPanel::handleToolTip(x, y, mask);

--- a/indra/newview/lltoastimpanel.h
+++ b/indra/newview/lltoastimpanel.h
@@ -52,8 +52,8 @@ public:
 
 	LLToastIMPanel(LLToastIMPanel::Params &p);
 	virtual ~LLToastIMPanel();
-	/*virtual*/ BOOL 	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool 	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleToolTip(S32 x, S32 y, MASK mask);
 private:
 	void showInspector();
 

--- a/indra/newview/lltool.cpp
+++ b/indra/newview/lltool.cpp
@@ -40,7 +40,7 @@
 #include "llagent.h"
 #include "llviewerjoystick.h"
 
-extern BOOL gDebugClicks;
+extern bool gDebugClicks;
 
 //static
 const std::string LLTool::sNameNull("null");
@@ -60,9 +60,9 @@ LLTool::~LLTool()
 	}
 }
 
-BOOL LLTool::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down)
+bool LLTool::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down)
 {
-	BOOL result = LLMouseHandler::handleAnyMouseClick(x, y, mask, clicktype, down);
+	bool result = LLMouseHandler::handleAnyMouseClick(x, y, mask, clicktype, down);
 	
 	// This behavior was moved here from LLViewerWindow::handleAnyMouseClick, so it can be selectively overridden by LLTool subclasses.
 	if(down && result)
@@ -76,7 +76,7 @@ BOOL LLTool::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clickt
 	return result;
 }
 
-BOOL LLTool::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLTool::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (gDebugClicks)
 	{
@@ -85,10 +85,10 @@ BOOL LLTool::handleMouseDown(S32 x, S32 y, MASK mask)
 	// by default, didn't handle it
 	// AGENT_CONTROL_LBUTTON_DOWN is handled by scanMouse() and scanKey()
 	// LL_INFOS() << "LLTool::handleMouseDown" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTool::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if (gDebugClicks) 
 	{
@@ -97,70 +97,70 @@ BOOL LLTool::handleMouseUp(S32 x, S32 y, MASK mask)
 	// by default, didn't handle it
 	// AGENT_CONTROL_LBUTTON_UP is handled by scanMouse() and scanKey()
 	// LL_INFOS() << "LLTool::handleMouseUp" << LL_ENDL;
-	return TRUE;
+	return true;
 }
 
-BOOL LLTool::handleHover(S32 x, S32 y, MASK mask)
+bool LLTool::handleHover(S32 x, S32 y, MASK mask)
 {
 	gViewerWindow->setCursor(UI_CURSOR_ARROW);
 	LL_DEBUGS("UserInput") << "hover handled by a tool" << LL_ENDL;		
 	// by default, do nothing, say we handled it
-	return TRUE;
+	return true;
 }
 
-BOOL LLTool::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLTool::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleScrollWheel" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLTool::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
     // by default, didn't handle it
-    return FALSE;
+    return false;
 }
 
-BOOL LLTool::handleDoubleClick(S32 x,S32 y,MASK mask)
+bool LLTool::handleDoubleClick(S32 x,S32 y,MASK mask)
 {
 	// LL_INFOS() << "LLTool::handleDoubleClick" << LL_ENDL;
 	// by default, pretend it's a left click
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleRightMouseDown(S32 x,S32 y,MASK mask)
+bool LLTool::handleRightMouseDown(S32 x,S32 y,MASK mask)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleRightMouseDown" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLTool::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleRightMouseDown" << LL_ENDL;
-	return FALSE;
+	return false;
 }
  
-BOOL LLTool::handleMiddleMouseDown(S32 x,S32 y,MASK mask)
+bool LLTool::handleMiddleMouseDown(S32 x,S32 y,MASK mask)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleMiddleMouseDown" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
+bool LLTool::handleMiddleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleMiddleMouseUp" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
-BOOL LLTool::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLTool::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	// by default, didn't handle it
 	// LL_INFOS() << "LLTool::handleToolTip" << LL_ENDL;
-	return FALSE;
+	return false;
 }
 
 void LLTool::setMouseCapture( BOOL b )
@@ -180,7 +180,7 @@ void LLTool::setMouseCapture( BOOL b )
 void LLTool::draw()
 { }
 
-BOOL LLTool::hasMouseCapture()
+bool LLTool::hasMouseCapture()
 {
 	return gFocusMgr.getMouseCapture() == (mComposite ? mComposite : this);
 }

--- a/indra/newview/lltool.h
+++ b/indra/newview/lltool.h
@@ -49,19 +49,19 @@ public:
 	virtual BOOL isView() const { return FALSE; }
 
 	// Virtual functions inherited from LLMouseHandler
-	virtual BOOL	handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down);
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMiddleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleMiddleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMiddleMouseUp(S32 x, S32 y, MASK mask);
 
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool	handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleRightMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleToolTip(S32 x, S32 y, MASK mask);
 
 		// Return FALSE to allow context menu to be shown.
 	virtual void	screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const
@@ -95,7 +95,7 @@ public:
 
 	// Note: NOT virtual.  Subclasses should call this version.
 	void					setMouseCapture(BOOL b);
-	BOOL					hasMouseCapture();
+	bool					hasMouseCapture();
 	virtual void			onMouseCaptureLost() {}  // override this one as needed.
 
 protected:

--- a/indra/newview/lltoolbrush.cpp
+++ b/indra/newview/lltoolbrush.cpp
@@ -360,9 +360,9 @@ void LLToolBrushLand::brush( void )
 	}
 }
 
-BOOL LLToolBrushLand::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolBrushLand::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	// Find the z value of the initial click. 
 	LLVector3d spot;
@@ -378,7 +378,7 @@ BOOL LLToolBrushLand::handleMouseDown(S32 x, S32 y, MASK mask)
 		if (!canTerraformRegion(regionp))
 		{
 			alertNoTerraformRegion(regionp);
-			return TRUE;
+			return true;
 		}
 
 		if (!canTerraformParcel(regionp))
@@ -397,13 +397,13 @@ BOOL LLToolBrushLand::handleMouseDown(S32 x, S32 y, MASK mask)
 		setMouseCapture( TRUE );
 
 		LLViewerParcelMgr::getInstance()->setSelectionVisible(FALSE);
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
-BOOL LLToolBrushLand::handleHover( S32 x, S32 y, MASK mask )
+bool LLToolBrushLand::handleHover( S32 x, S32 y, MASK mask )
 {
 	LL_DEBUGS("UserInput") << "hover handled by LLToolBrushLand ("
 								<< (hasMouseCapture() ? "active":"inactive")
@@ -422,12 +422,12 @@ BOOL LLToolBrushLand::handleHover( S32 x, S32 y, MASK mask )
 
 		LLViewerParcelMgr::getInstance()->setHoverParcel(spot);
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLToolBrushLand::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolBrushLand::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	mLastAffectedRegions.clear();
 	if( hasMouseCapture() )
 	{
@@ -437,7 +437,7 @@ BOOL LLToolBrushLand::handleMouseUp(S32 x, S32 y, MASK mask)
 		LLViewerParcelMgr::getInstance()->setSelectionVisible(TRUE);
 
 		gIdleCallbacks.deleteFunction( &LLToolBrushLand::onIdle, (void*)this );
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;

--- a/indra/newview/lltoolbrush.h
+++ b/indra/newview/lltoolbrush.h
@@ -49,9 +49,9 @@ class LLToolBrushLand : public LLTool, public LLEditMenuHandler, public LLSingle
 public:
 	
 	// x,y in window coords, 0,0 = left,bot
-	virtual BOOL handleMouseDown( S32 x, S32 y, MASK mask );
-	virtual BOOL handleMouseUp( S32 x, S32 y, MASK mask );		
-	virtual BOOL handleHover( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseDown( S32 x, S32 y, MASK mask );
+	virtual bool handleMouseUp( S32 x, S32 y, MASK mask );
+	virtual bool handleHover( S32 x, S32 y, MASK mask );
 	virtual void handleSelect();
 	virtual void handleDeselect();
 

--- a/indra/newview/lltoolcomp.cpp
+++ b/indra/newview/lltoolcomp.cpp
@@ -89,9 +89,9 @@ LLToolComposite::LLToolComposite(const std::string& name)
 }
 
 // Returns to the default tool
-BOOL LLToolComposite::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolComposite::handleMouseUp(S32 x, S32 y, MASK mask)
 { 
-	BOOL handled = mCur->handleMouseUp( x, y, mask );
+	bool handled = mCur->handleMouseUp( x, y, mask );
 	if( handled )
 	{
 		setCurrentTool( mDefault );
@@ -147,9 +147,9 @@ LLToolCompInspect::~LLToolCompInspect()
 	mSelectRect = NULL;
 }
 
-BOOL LLToolCompInspect::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompInspect::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if (mCur == LLToolCamera::getInstance())
 	{
@@ -159,15 +159,15 @@ BOOL LLToolCompInspect::handleMouseDown(S32 x, S32 y, MASK mask)
 	{
 		mMouseDown = TRUE;
 		gViewerWindow->pickAsync(x, y, mask, pickCallback);
-		handled = TRUE;	
+		handled = true;	
 	}
 
 	return handled;
 }
 
-BOOL LLToolCompInspect::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompInspect::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLToolComposite::handleMouseUp(x, y, mask);
+	bool handled = LLToolComposite::handleMouseUp(x, y, mask);
 	mIsToolCameraActive = getCurrentTool() == LLToolCamera::getInstance();
 	return handled;
 }
@@ -194,9 +194,9 @@ void LLToolCompInspect::pickCallback(const LLPickInfo& pick_info)
 	tool_inspectp->mSelectRect->handlePick( pick_info );
 }
 
-BOOL LLToolCompInspect::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompInspect::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	return TRUE;
+	return true;
 }
 
 BOOL LLToolCompInspect::handleKey(KEY key, MASK mask)
@@ -255,7 +255,7 @@ LLToolCompTranslate::~LLToolCompTranslate()
 	mSelectRect = NULL;
 }
 
-BOOL LLToolCompTranslate::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolCompTranslate::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( !mCur->hasMouseCapture() )
 	{
@@ -265,12 +265,12 @@ BOOL LLToolCompTranslate::handleHover(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolCompTranslate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompTranslate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = TRUE;
     gViewerWindow->pickAsync(x, y, mask, pickCallback, /*BOOL pick_transparent*/ FALSE, LLFloaterReg::instanceVisible("build"), FALSE,
         gSavedSettings.getBOOL("SelectReflectionProbes"));;
-	return TRUE;
+	return true;
 }
 
 void LLToolCompTranslate::pickCallback(const LLPickInfo& pick_info)
@@ -315,7 +315,7 @@ void LLToolCompTranslate::pickCallback(const LLPickInfo& pick_info)
 	}
 }
 
-BOOL LLToolCompTranslate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompTranslate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = FALSE;
 	return LLToolComposite::handleMouseUp(x, y, mask);
@@ -334,14 +334,14 @@ LLTool* LLToolCompTranslate::getOverrideTool(MASK mask)
 	return LLToolComposite::getOverrideTool(mask);
 }
 
-BOOL LLToolCompTranslate::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompTranslate::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (mManip->getSelection()->isEmpty() && mManip->getHighlightedPart() == LLManip::LL_NO_PART)
 	{
 		// You should already have an object selected from the mousedown.
 		// If so, show its properties
 		LLFloaterReg::showInstance("build", "Content");
-		return TRUE;
+		return true;
 	}
 	// Nothing selected means the first mouse click was probably
 	// bad, so try again.
@@ -382,7 +382,7 @@ LLToolCompScale::~LLToolCompScale()
 	delete mSelectRect;
 }
 
-BOOL LLToolCompScale::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolCompScale::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( !mCur->hasMouseCapture() )
 	{
@@ -392,11 +392,11 @@ BOOL LLToolCompScale::handleHover(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolCompScale::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompScale::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = TRUE;
 	gViewerWindow->pickAsync(x, y, mask, pickCallback);
-	return TRUE;
+	return true;
 }
 
 void LLToolCompScale::pickCallback(const LLPickInfo& pick_info)
@@ -436,7 +436,7 @@ void LLToolCompScale::pickCallback(const LLPickInfo& pick_info)
 	}
 }
 
-BOOL LLToolCompScale::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompScale::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = FALSE;
 	return LLToolComposite::handleMouseUp(x, y, mask);
@@ -453,14 +453,14 @@ LLTool* LLToolCompScale::getOverrideTool(MASK mask)
 }
 
 
-BOOL LLToolCompScale::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompScale::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (!mManip->getSelection()->isEmpty() && mManip->getHighlightedPart() == LLManip::LL_NO_PART)
 	{
 		// You should already have an object selected from the mousedown.
 		// If so, show its properties
 		LLFloaterReg::showInstance("build", "Content");
-		return TRUE;
+		return true;
 	}
 	else
 	{
@@ -504,15 +504,15 @@ LLToolCompCreate::~LLToolCompCreate()
 }
 
 
-BOOL LLToolCompCreate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompCreate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 	mMouseDown = TRUE;
 
 	if ( (mask == MASK_SHIFT) || (mask == MASK_CONTROL) )
 	{
 		gViewerWindow->pickAsync(x, y, mask, pickCallback);
-		handled = TRUE;
+		handled = true;
 	}
 	else
 	{
@@ -536,14 +536,14 @@ void LLToolCompCreate::pickCallback(const LLPickInfo& pick_info)
 	LLToolCompCreate::getInstance()->mSelectRect->handlePick( pick_info );
 }
 
-BOOL LLToolCompCreate::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompCreate::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	return handleMouseDown(x, y, mask);
 }
 
-BOOL LLToolCompCreate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompCreate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if ( mMouseDown && !mObjectPlacedOnMouseDown && !(mask == MASK_SHIFT) && !(mask == MASK_CONTROL) )
 	{
@@ -582,7 +582,7 @@ LLToolCompRotate::~LLToolCompRotate()
 	delete mSelectRect;
 }
 
-BOOL LLToolCompRotate::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolCompRotate::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( !mCur->hasMouseCapture() )
 	{
@@ -592,11 +592,11 @@ BOOL LLToolCompRotate::handleHover(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolCompRotate::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompRotate::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = TRUE;
 	gViewerWindow->pickAsync(x, y, mask, pickCallback);
-	return TRUE;
+	return true;
 }
 
 void LLToolCompRotate::pickCallback(const LLPickInfo& pick_info)
@@ -635,7 +635,7 @@ void LLToolCompRotate::pickCallback(const LLPickInfo& pick_info)
 	}
 }
 
-BOOL LLToolCompRotate::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompRotate::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mMouseDown = FALSE;
 	return LLToolComposite::handleMouseUp(x, y, mask);
@@ -650,14 +650,14 @@ LLTool* LLToolCompRotate::getOverrideTool(MASK mask)
 	return LLToolComposite::getOverrideTool(mask);
 }
 
-BOOL LLToolCompRotate::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompRotate::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (!mManip->getSelection()->isEmpty() && mManip->getHighlightedPart() == LLManip::LL_NO_PART)
 	{
 		// You should already have an object selected from the mousedown.
 		// If so, show its properties
 		LLFloaterReg::showInstance("build", "Content");
-		return TRUE;
+		return true;
 	}
 	else
 	{
@@ -708,7 +708,7 @@ LLToolCompGun::~LLToolCompGun()
 	mNull = NULL;
 }
 
-BOOL LLToolCompGun::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolCompGun::handleHover(S32 x, S32 y, MASK mask)
 {
 	// *NOTE: This hack is here to make mouselook kick in again after
 	// item selected from context menu.
@@ -740,17 +740,17 @@ BOOL LLToolCompGun::handleHover(S32 x, S32 y, MASK mask)
 		}
 	}
 
-	return TRUE; 
+	return true; 
 }
 
 
-BOOL LLToolCompGun::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompGun::handleMouseDown(S32 x, S32 y, MASK mask)
 { 
 	// if the left button is grabbed, don't put up the pie menu
 	if (gAgent.leftButtonGrabbed() && gViewerInput.isLMouseHandlingDefault(MODE_FIRST_PERSON))
 	{
 		gAgent.setControlFlags(AGENT_CONTROL_ML_LBUTTON_DOWN);
-		return FALSE;
+		return false;
 	}
 
 	// On mousedown, start grabbing
@@ -761,13 +761,13 @@ BOOL LLToolCompGun::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolCompGun::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolCompGun::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	// if the left button is grabbed, don't put up the pie menu
 	if (gAgent.leftButtonGrabbed() && gViewerInput.isLMouseHandlingDefault(MODE_FIRST_PERSON))
 	{
 		gAgent.setControlFlags(AGENT_CONTROL_ML_LBUTTON_DOWN);
-		return FALSE;
+		return false;
 	}
 
 	// On mousedown, start grabbing
@@ -778,7 +778,7 @@ BOOL LLToolCompGun::handleDoubleClick(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolCompGun::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCompGun::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
 	/* JC - suppress context menu 8/29/2002
 
@@ -788,22 +788,22 @@ BOOL LLToolCompGun::handleRightMouseDown(S32 x, S32 y, MASK mask)
 
 	// This should return FALSE, meaning the context menu will
 	// be shown.
-	return FALSE;
+	return false;
 	*/
 
 	// Returning true will suppress the context menu
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLToolCompGun::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCompGun::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if (gViewerInput.isLMouseHandlingDefault(MODE_FIRST_PERSON))
     {
         gAgent.setControlFlags(AGENT_CONTROL_ML_LBUTTON_UP);
     }
 	setCurrentTool( (LLTool*) mGun );
-	return TRUE;
+	return true;
 }
 
 void LLToolCompGun::onMouseCaptureLost()
@@ -829,12 +829,12 @@ void	LLToolCompGun::handleDeselect()
 }
 
 
-BOOL LLToolCompGun::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLToolCompGun::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
 	if (clicks > 0)
 	{
 		gAgentCamera.changeCameraToDefault();
 
 	}
-	return TRUE;
+	return true;
 }

--- a/indra/newview/lltoolcomp.h
+++ b/indra/newview/lltoolcomp.h
@@ -45,14 +45,14 @@ class LLToolComposite : public LLTool
 public:
 	LLToolComposite(const std::string& name);
 
-    virtual BOOL			handleMouseDown(S32 x, S32 y, MASK mask) = 0;	// Sets the current tool
-    virtual BOOL			handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
-	virtual BOOL			handleDoubleClick(S32 x, S32 y, MASK mask) = 0;
+    virtual bool			handleMouseDown(S32 x, S32 y, MASK mask) = 0;	// Sets the current tool
+    virtual bool			handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
+	virtual bool			handleDoubleClick(S32 x, S32 y, MASK mask) = 0;
 
 	// Map virtual functions to the currently active internal tool
-    virtual BOOL			handleHover(S32 x, S32 y, MASK mask)			{ return mCur->handleHover( x, y, mask ); }
-	virtual BOOL			handleScrollWheel(S32 x, S32 y, S32 clicks)		{ return mCur->handleScrollWheel( x, y, clicks ); }
-	virtual BOOL			handleRightMouseDown(S32 x, S32 y, MASK mask)	{ return mCur->handleRightMouseDown( x, y, mask ); }
+    virtual bool			handleHover(S32 x, S32 y, MASK mask)			{ return mCur->handleHover( x, y, mask ); }
+	virtual bool			handleScrollWheel(S32 x, S32 y, S32 clicks)		{ return mCur->handleScrollWheel( x, y, clicks ); }
+	virtual bool			handleRightMouseDown(S32 x, S32 y, MASK mask)	{ return mCur->handleRightMouseDown( x, y, mask ); }
 
 	virtual LLViewerObject*	getEditingObject()								{ return mCur->getEditingObject(); }
 	virtual LLVector3d		getEditingPointGlobal()							{ return mCur->getEditingPointGlobal(); }
@@ -108,9 +108,9 @@ class LLToolCompInspect : public LLToolComposite, public LLSingleton<LLToolCompI
 public:
 
 	// Overridden from LLToolComposite
-    virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
+    virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
 	virtual BOOL		handleKey(KEY key, MASK mask);
 	virtual void		onMouseCaptureLost();
 			void		keyUp(KEY key, MASK mask);
@@ -133,10 +133,10 @@ class LLToolCompTranslate : public LLToolComposite, public LLSingleton<LLToolCom
 public:
 
 	// Overridden from LLToolComposite
-	virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
+	virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool		handleHover(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
 	virtual void		render();
 
 	virtual LLTool*		getOverrideTool(MASK mask);
@@ -154,10 +154,10 @@ class LLToolCompScale : public LLToolComposite, public LLSingleton<LLToolCompSca
 public:
 
 	// Overridden from LLToolComposite
-    virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
+    virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+    virtual bool		handleHover(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);			// Returns to the default tool
 	virtual void		render();
 
 	virtual LLTool*		getOverrideTool(MASK mask);
@@ -176,10 +176,10 @@ class LLToolCompRotate : public LLToolComposite, public LLSingleton<LLToolCompRo
 public:
 
 	// Overridden from LLToolComposite
-    virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+    virtual bool		handleHover(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
 	virtual void		render();
 
 	virtual LLTool*		getOverrideTool(MASK mask);
@@ -199,9 +199,9 @@ class LLToolCompCreate : public LLToolComposite, public LLSingleton<LLToolCompCr
 public:
 
 	// Overridden from LLToolComposite
-    virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-    virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
+    virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+    virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
 	
 	static void pickCallback(const LLPickInfo& pick_info);
 protected:
@@ -224,12 +224,12 @@ class LLToolCompGun : public LLToolComposite, public LLSingleton<LLToolCompGun>
 public:
 
 	// Overridden from LLToolComposite
-    virtual BOOL			handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL			handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL			handleDoubleClick(S32 x, S32 y, MASK mask);
-	virtual BOOL			handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL			handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL			handleScrollWheel(S32 x, S32 y, S32 clicks);
+    virtual bool			handleHover(S32 x, S32 y, MASK mask);
+	virtual bool			handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool			handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool			handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool			handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool			handleScrollWheel(S32 x, S32 y, S32 clicks);
 	virtual void			onMouseCaptureLost();
 	virtual void			handleSelect();
 	virtual void			handleDeselect();

--- a/indra/newview/lltooldraganddrop.cpp
+++ b/indra/newview/lltooldraganddrop.cpp
@@ -473,7 +473,7 @@ void LLToolDragAndDrop::onMouseCaptureLost()
 	mCustomMsg.clear();
 }
 
-BOOL LLToolDragAndDrop::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLToolDragAndDrop::handleMouseUp( S32 x, S32 y, MASK mask )
 {
 	if (hasMouseCapture())
 	{
@@ -481,7 +481,7 @@ BOOL LLToolDragAndDrop::handleMouseUp( S32 x, S32 y, MASK mask )
 		dragOrDrop( x, y, mask, TRUE, &acceptance );
 		endDrag();
 	}
-	return TRUE;
+	return true;
 }
 
 ECursorType LLToolDragAndDrop::acceptanceToCursor( EAcceptance acceptance )
@@ -554,7 +554,7 @@ ECursorType LLToolDragAndDrop::acceptanceToCursor( EAcceptance acceptance )
 	return mCursor;
 }
 
-BOOL LLToolDragAndDrop::handleHover( S32 x, S32 y, MASK mask )
+bool LLToolDragAndDrop::handleHover( S32 x, S32 y, MASK mask )
 {
 	EAcceptance acceptance = ACCEPT_NO;
 	dragOrDrop( x, y, mask, FALSE, &acceptance );
@@ -563,7 +563,7 @@ BOOL LLToolDragAndDrop::handleHover( S32 x, S32 y, MASK mask )
 	gViewerWindow->getWindow()->setCursor( cursor );
 
 	LL_DEBUGS("UserInput") << "hover handled by LLToolDragAndDrop" << LL_ENDL;
-	return TRUE;
+	return true;
 }
 
 BOOL LLToolDragAndDrop::handleKey(KEY key, MASK mask)
@@ -578,7 +578,7 @@ BOOL LLToolDragAndDrop::handleKey(KEY key, MASK mask)
 	return FALSE;
 }
 
-BOOL LLToolDragAndDrop::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLToolDragAndDrop::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if (!mToolTipMsg.empty())
 	{
@@ -586,9 +586,9 @@ BOOL LLToolDragAndDrop::handleToolTip(S32 x, S32 y, MASK mask)
 		LLToolTipMgr::instance().show(LLToolTip::Params()
 			.message(mToolTipMsg)
 			.delay_time(gSavedSettings.getF32( "DragAndDropToolTipDelay" )));
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void LLToolDragAndDrop::handleDeselect()

--- a/indra/newview/lltooldraganddrop.h
+++ b/indra/newview/lltooldraganddrop.h
@@ -48,10 +48,10 @@ public:
 	typedef boost::signals2::signal<void ()> enddrag_signal_t;
 
 	// overridden from LLTool
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual BOOL	handleKey(KEY key, MASK mask);
-	virtual BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool	handleToolTip(S32 x, S32 y, MASK mask);
 	virtual void	onMouseCaptureLost();
 	virtual void	handleDeselect();
 

--- a/indra/newview/lltoolface.cpp
+++ b/indra/newview/lltoolface.cpp
@@ -53,28 +53,28 @@ LLToolFace::~LLToolFace()
 { }
 
 
-BOOL LLToolFace::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolFace::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (!LLSelectMgr::getInstance()->getSelection()->isEmpty())
 	{
 		// You should already have an object selected from the mousedown.
 		// If so, show its properties
 		LLFloaterReg::showInstance("build", "Texture");
-		return TRUE;
+		return true;
 	}
 	else
 	{
 		// Nothing selected means the first mouse click was probably
 		// bad, so try again.
-		return FALSE;
+		return false;
 	}
 }
 
 
-BOOL LLToolFace::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolFace::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	gViewerWindow->pickAsync(x, y, mask, pickCallback);
-	return TRUE;
+	return true;
 }
 
 void LLToolFace::pickCallback(const LLPickInfo& pick_info)

--- a/indra/newview/lltoolface.h
+++ b/indra/newview/lltoolface.h
@@ -39,8 +39,8 @@ class LLToolFace
 	virtual ~LLToolFace();
 public:
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask);
 	virtual void	handleSelect();
 	virtual void	handleDeselect();
 	virtual void	render();			// draw face highlights

--- a/indra/newview/lltoolfocus.cpp
+++ b/indra/newview/lltoolfocus.cpp
@@ -112,7 +112,7 @@ void LLToolCamera::handleDeselect()
 	}
 }
 
-BOOL LLToolCamera::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolCamera::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// Ensure a mouseup
 	setMouseCapture(TRUE);
@@ -143,7 +143,7 @@ BOOL LLToolCamera::handleMouseDown(S32 x, S32 y, MASK mask)
 
 	gViewerWindow->pickAsync(x, y, mask, pickCallback, /*BOOL pick_transparent*/ FALSE, /*BOOL pick_rigged*/ FALSE, /*BOOL pick_unselectable*/ TRUE);
 
-	return TRUE;
+	return true;
 }
 
 void LLToolCamera::pickCallback(const LLPickInfo& pick_info)
@@ -283,7 +283,7 @@ void LLToolCamera::releaseMouse()
 }
 
 
-BOOL LLToolCamera::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolCamera::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// Claim that we're mousing up somewhere
 	mMouseUpX = x;
@@ -331,11 +331,11 @@ BOOL LLToolCamera::handleMouseUp(S32 x, S32 y, MASK mask)
 		releaseMouse();
 	}
 
-	return TRUE;
+	return true;
 }
 
 
-BOOL LLToolCamera::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolCamera::handleHover(S32 x, S32 y, MASK mask)
 {
 	S32 dx = gViewerWindow->getCurrentMouseDX();
 	S32 dy = gViewerWindow->getCurrentMouseDY();
@@ -468,7 +468,7 @@ BOOL LLToolCamera::handleHover(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_TOOLZOOMIN);
 	}
 	
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/newview/lltoolfocus.h
+++ b/indra/newview/lltoolfocus.h
@@ -38,9 +38,9 @@ class LLToolCamera
 	virtual ~LLToolCamera();
 public:
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 
 	virtual void	onMouseCaptureLost();
 

--- a/indra/newview/lltoolgrab.cpp
+++ b/indra/newview/lltoolgrab.cpp
@@ -65,7 +65,7 @@ const S32 SLOP_DIST_SQ = 4;
 BOOL gGrabBtnVertical = FALSE;
 BOOL gGrabBtnSpin = FALSE;
 LLTool* gGrabTransientTool = NULL;
-extern BOOL gDebugClicks;
+extern bool gDebugClicks;
 
 //
 // Methods
@@ -124,17 +124,17 @@ void LLToolGrabBase::handleDeselect()
 
 }
 
-BOOL LLToolGrabBase::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolGrabBase::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (gDebugClicks)
 	{
 		LL_INFOS() << "LLToolGrab handleDoubleClick (becoming mouseDown)" << LL_ENDL;
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLToolGrabBase::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolGrabBase::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	if (gDebugClicks)
 	{
@@ -163,7 +163,7 @@ BOOL LLToolGrabBase::handleMouseDown(S32 x, S32 y, MASK mask)
         // Todo: LLToolGrabBase probably shouldn't consume the event if there is nothing
         // to grab in Mouselook, it intercepts handling in scanMouse
     }
-	return TRUE;
+	return true;
 }
 
 void LLToolGrabBase::pickCallback(const LLPickInfo& pick_info)
@@ -436,13 +436,13 @@ void LLToolGrabBase::startGrab()
 }
 
 
-BOOL LLToolGrabBase::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolGrabBase::handleHover(S32 x, S32 y, MASK mask)
 {
 	if (!gViewerWindow->getLeftMouseDown())
 	{
 		gViewerWindow->setCursor(UI_CURSOR_TOOLGRAB);
 		setMouseCapture(FALSE);
-		return TRUE;
+		return true;
 	}
 
 	// Do the right hover based on mode
@@ -470,7 +470,7 @@ BOOL LLToolGrabBase::handleHover(S32 x, S32 y, MASK mask)
 	mLastMouseX = x;
 	mLastMouseY = y;
 	
-	return TRUE;
+	return true;
 }
 
 const F32 GRAB_SENSITIVITY_X = 0.0075f;
@@ -964,7 +964,7 @@ void LLToolGrabBase::handleHoverFailed(S32 x, S32 y, MASK mask)
 
 
 
-BOOL LLToolGrabBase::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolGrabBase::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLTool::handleMouseUp(x, y, mask);
 
@@ -1001,7 +1001,7 @@ BOOL LLToolGrabBase::handleMouseUp(S32 x, S32 y, MASK mask)
 
 	//gAgent.setObjectTracking(gSavedSettings.getBOOL("TrackFocusObject"));
 
-	return TRUE;
+	return true;
 } 
 
 void LLToolGrabBase::stopEditing()

--- a/indra/newview/lltoolgrab.h
+++ b/indra/newview/lltoolgrab.h
@@ -58,10 +58,10 @@ public:
 	LLToolGrabBase(LLToolComposite* composite=NULL);
 	~LLToolGrabBase();
 
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask);
 	/*virtual*/ void	render();		// 3D elements
 	/*virtual*/ void	draw();			// 2D elements
 

--- a/indra/newview/lltoolgun.cpp
+++ b/indra/newview/lltoolgun.cpp
@@ -68,7 +68,7 @@ void LLToolGun::handleDeselect()
 	mIsSelected = FALSE;
 }
 
-BOOL LLToolGun::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolGun::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	gGrabTransientTool = this;
 	LLToolMgr::getInstance()->getCurrentToolset()->selectTool( LLToolGrab::getInstance() );
@@ -76,7 +76,7 @@ BOOL LLToolGun::handleMouseDown(S32 x, S32 y, MASK mask)
 	return LLToolGrab::getInstance()->handleMouseDown(x, y, mask);
 }
 
-BOOL LLToolGun::handleHover(S32 x, S32 y, MASK mask) 
+bool LLToolGun::handleHover(S32 x, S32 y, MASK mask)
 {
 	if( gAgentCamera.cameraMouselook() && mIsSelected )
 	{
@@ -133,7 +133,7 @@ BOOL LLToolGun::handleHover(S32 x, S32 y, MASK mask)
 	// HACK to avoid assert: error checking system makes sure that the cursor is set during every handleHover.  This is actually a no-op since the cursor is hidden.
 	gViewerWindow->setCursor(UI_CURSOR_ARROW);  
 
-	return TRUE;
+	return true;
 }
 
 void LLToolGun::draw()

--- a/indra/newview/lltoolgun.h
+++ b/indra/newview/lltoolgun.h
@@ -41,8 +41,8 @@ public:
 	virtual void	handleSelect();
 	virtual void	handleDeselect();
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 
 	virtual LLTool*	getOverrideTool(MASK mask) { return NULL; }
 	virtual BOOL	clipMouseWhenDown()		{ return FALSE; }

--- a/indra/newview/lltoolindividual.cpp
+++ b/indra/newview/lltoolindividual.cpp
@@ -66,10 +66,10 @@ LLToolIndividual::~LLToolIndividual()
 {
 }
 
-BOOL LLToolIndividual::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolIndividual::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	gViewerWindow->pickAsync(x, y, mask, pickCallback);
-	return TRUE;
+	return true;
 }
 
 void LLToolIndividual::pickCallback(const LLPickInfo& pick_info)
@@ -82,20 +82,20 @@ void LLToolIndividual::pickCallback(const LLPickInfo& pick_info)
 	}
 }
 
-BOOL LLToolIndividual::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolIndividual::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if(!LLSelectMgr::getInstance()->getSelection()->isEmpty())
 	{
 		// You should already have an object selected from the mousedown.
 		// If so, show its inventory. 
 		LLFloaterReg::showInstance("build", "Content");
-		return TRUE;
+		return true;
 	}
 	else
 	{
 		// Nothing selected means the first mouse click was probably
 		// bad, so try again.
-		return FALSE;
+		return false;
 	}
 }
 

--- a/indra/newview/lltoolindividual.h
+++ b/indra/newview/lltoolindividual.h
@@ -43,8 +43,8 @@ class LLToolIndividual : public LLTool, public LLSingleton<LLToolIndividual>
 	virtual ~LLToolIndividual();
 public:
 
-	virtual BOOL handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool handleDoubleClick(S32 x, S32 y, MASK mask);
 	virtual void handleSelect();
 	//virtual void handleDeselect();
 	//virtual void render();

--- a/indra/newview/lltoolobjpicker.cpp
+++ b/indra/newview/lltoolobjpicker.cpp
@@ -55,10 +55,10 @@ LLToolObjPicker::LLToolObjPicker()
 
 
 // returns TRUE if an object was selected 
-BOOL LLToolObjPicker::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolObjPicker::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	LLRootView* viewp = gViewerWindow->getRootView();
-	BOOL handled = viewp->handleMouseDown(x, y, mask);
+	bool handled = viewp->handleMouseDown(x, y, mask);
 
 	mHitObjectID.setNull();
 
@@ -93,10 +93,10 @@ void LLToolObjPicker::pickCallback(const LLPickInfo& pick_info)
 }
 
 
-BOOL LLToolObjPicker::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolObjPicker::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLView* viewp = gViewerWindow->getRootView();
-	BOOL handled = viewp->handleHover(x, y, mask);
+	bool handled = viewp->handleHover(x, y, mask);
 	if (handled)
 	{
 		// let UI handle this
@@ -115,7 +115,7 @@ BOOL LLToolObjPicker::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolObjPicker::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolObjPicker::handleHover(S32 x, S32 y, MASK mask)
 {
 	LLView *viewp = gViewerWindow->getRootView();
 	BOOL handled = viewp->handleHover(x, y, mask);

--- a/indra/newview/lltoolobjpicker.h
+++ b/indra/newview/lltoolobjpicker.h
@@ -38,9 +38,9 @@ class LLToolObjPicker : public LLTool, public LLSingleton<LLToolObjPicker>
 	LLSINGLETON(LLToolObjPicker);
 public:
 
-	virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleHover(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool		handleHover(S32 x, S32 y, MASK mask);
 
 	virtual void 		handleSelect();
 	virtual void 		handleDeselect();

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -73,7 +73,7 @@
 #include "pipeline.h"	// setHighlightObject
 #include "lluiusage.h"
 
-extern BOOL gDebugClicks;
+extern bool gDebugClicks;
 
 static void handle_click_action_play();
 static void handle_click_action_open_media(LLPointer<LLViewerObject> objectp);
@@ -92,9 +92,9 @@ LLToolPie::LLToolPie()
 {
 }
 
-BOOL LLToolPie::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down)
+bool LLToolPie::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down)
 {
-	BOOL result = LLMouseHandler::handleAnyMouseClick(x, y, mask, clicktype, down);
+	bool result = LLMouseHandler::handleAnyMouseClick(x, y, mask, clicktype, down);
 	
 	// This override DISABLES the keyboard focus reset that LLTool::handleAnyMouseClick adds.
 	// LLToolPie will do the right thing in its pick callback.
@@ -102,7 +102,7 @@ BOOL LLToolPie::handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType cli
 	return result;
 }
 
-BOOL LLToolPie::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleMouseDown(S32 x, S32 y, MASK mask)
 {
     if (mDoubleClickTimer.getStarted())
     {
@@ -179,7 +179,7 @@ BOOL LLToolPie::handleMouseDown(S32 x, S32 y, MASK mask)
 
 // Spawn context menus on right mouse down so you can drag over and select
 // an item.
-BOOL LLToolPie::handleRightMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleRightMouseDown(S32 x, S32 y, MASK mask)
 {
     BOOL pick_reflection_probe = gSavedSettings.getBOOL("SelectReflectionProbes");
 
@@ -197,10 +197,10 @@ BOOL LLToolPie::handleRightMouseDown(S32 x, S32 y, MASK mask)
 	{
 		handleRightClickPick();
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLToolPie::handleRightMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleRightMouseUp(S32 x, S32 y, MASK mask)
 {
 	LLToolMgr::getInstance()->clearTransientTool();
 	return LLTool::handleRightMouseUp(x, y, mask);
@@ -223,12 +223,12 @@ BOOL LLToolPie::handleScrollWheelAny(S32 x, S32 y, S32 clicks_x, S32 clicks_y)
     return res;
 }
 
-BOOL LLToolPie::handleScrollWheel(S32 x, S32 y, S32 clicks)
+bool LLToolPie::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     return handleScrollWheelAny(x, y, 0, clicks);
 }
 
-BOOL LLToolPie::handleScrollHWheel(S32 x, S32 y, S32 clicks)
+bool LLToolPie::handleScrollHWheel(S32 x, S32 y, S32 clicks)
 {
     return handleScrollWheelAny(x, y, clicks, 0);
 }
@@ -736,9 +736,9 @@ void LLToolPie::selectionPropertiesReceived()
 	LLToolPie::getInstance()->resetSelection();
 }
 
-BOOL LLToolPie::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleHover(S32 x, S32 y, MASK mask)
 {
-    BOOL pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
+    bool pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
 	mHoverPick = gViewerWindow->pickImmediate(x, y, FALSE, pick_rigged);
 	LLViewerObject *parent = NULL;
 	LLViewerObject *object = mHoverPick.getObject();
@@ -815,7 +815,7 @@ BOOL LLToolPie::handleHover(S32 x, S32 y, MASK mask)
 	return TRUE;
 }
 
-BOOL LLToolPie::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleMouseUp(S32 x, S32 y, MASK mask)
 {
     if (!mDoubleClickTimer.getStarted())
     {
@@ -852,7 +852,7 @@ void LLToolPie::stopClickToWalk()
 	}
 }
 
-BOOL LLToolPie::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolPie::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	if (gDebugClicks)
 	{
@@ -861,17 +861,17 @@ BOOL LLToolPie::handleDoubleClick(S32 x, S32 y, MASK mask)
 
 	if (handleMediaDblClick(mPick))
 	{
-		return TRUE;
+		return true;
 	}
     
 	if (!mDoubleClickTimer.getStarted() || (mDoubleClickTimer.getElapsedTimeF32() > 0.3f))
 	{
 		mDoubleClickTimer.stop();
-		return FALSE;
+		return false;
 	}
 	mDoubleClickTimer.stop();
 
-	return FALSE;
+	return false;
 }
 
 static bool needs_tooltip(LLSelectNode* nodep)
@@ -1223,11 +1223,11 @@ BOOL LLToolPie::handleTooltipObject( LLViewerObject* hover_object, std::string l
 	return TRUE;
 }
 
-BOOL LLToolPie::handleToolTip(S32 local_x, S32 local_y, MASK mask)
+bool LLToolPie::handleToolTip(S32 local_x, S32 local_y, MASK mask)
 {
 	static LLCachedControl<bool> show_hover_tips(*LLUI::getInstance()->mSettingGroups["config"], "ShowHoverTips", true);
-	if (!show_hover_tips) return TRUE;
-	if (!mHoverPick.isValid()) return TRUE;
+	if (!show_hover_tips) return true;
+	if (!mHoverPick.isValid()) return true;
 
 	LLViewerObject* hover_object = mHoverPick.getObject();
 	
@@ -1247,7 +1247,7 @@ BOOL LLToolPie::handleToolTip(S32 local_x, S32 local_y, MASK mask)
 		handleTooltipLand(line, tooltip_msg);
 	}
 
-	return TRUE;
+	return true;
 }
 
 static void show_inspector(const char* inspector, const char* param, const LLUUID& source_id)

--- a/indra/newview/lltoolpie.h
+++ b/indra/newview/lltoolpie.h
@@ -42,17 +42,17 @@ class LLToolPie : public LLTool, public LLSingleton<LLToolPie>
 public:
 
 	// Virtual functions inherited from LLMouseHandler
-	virtual BOOL		handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, BOOL down);
-	virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleRightMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleRightMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
+	virtual bool		handleAnyMouseClick(S32 x, S32 y, MASK mask, EMouseClickType clicktype, bool down);
+	virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleRightMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool		handleRightMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool		handleHover(S32 x, S32 y, MASK mask);
+	virtual bool		handleDoubleClick(S32 x, S32 y, MASK mask);
 	BOOL				handleScrollWheelAny(S32 x, S32 y, S32 clicks_x, S32 clicks_y);
-	virtual BOOL		handleScrollWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL		handleScrollHWheel(S32 x, S32 y, S32 clicks);
-	virtual BOOL		handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool		handleScrollWheel(S32 x, S32 y, S32 clicks);
+	virtual bool		handleScrollHWheel(S32 x, S32 y, S32 clicks);
+	virtual bool		handleToolTip(S32 x, S32 y, MASK mask);
 
 	virtual void		render();
 

--- a/indra/newview/lltoolpipette.cpp
+++ b/indra/newview/lltoolpipette.cpp
@@ -57,41 +57,41 @@ LLToolPipette::~LLToolPipette()
 { }
 
 
-BOOL LLToolPipette::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolPipette::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	mSuccess = TRUE;
 	mTooltipMsg.clear();
 	setMouseCapture(TRUE);
 	gViewerWindow->pickAsync(x, y, mask, pickCallback);
-	return TRUE;
+	return true;
 }
 
-BOOL LLToolPipette::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolPipette::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mSuccess = TRUE;
 	LLSelectMgr::getInstance()->unhighlightAll();
 	// *NOTE: This assumes the pipette tool is a transient tool.
 	LLToolMgr::getInstance()->clearTransientTool();
 	setMouseCapture(FALSE);
-	return TRUE;
+	return true;
 }
 
-BOOL LLToolPipette::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolPipette::handleHover(S32 x, S32 y, MASK mask)
 {
 	gViewerWindow->setCursor(mSuccess ? UI_CURSOR_PIPETTE : UI_CURSOR_NO);
 	if (hasMouseCapture()) // mouse button is down
 	{
 		gViewerWindow->pickAsync(x, y, mask, pickCallback);
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLToolPipette::handleToolTip(S32 x, S32 y, MASK mask)
+bool LLToolPipette::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	if (mTooltipMsg.empty())
 	{
-		return FALSE;
+		return false;
 	}
 
 	LLRect sticky_rect;
@@ -100,7 +100,7 @@ BOOL LLToolPipette::handleToolTip(S32 x, S32 y, MASK mask)
 		.message(mTooltipMsg)
 		.sticky_rect(sticky_rect));
 
-	return TRUE;
+	return true;
 }
 
 void LLToolPipette::setTextureEntry(const LLTextureEntry* entry)

--- a/indra/newview/lltoolpipette.h
+++ b/indra/newview/lltoolpipette.h
@@ -47,10 +47,10 @@ class LLToolPipette
 	virtual ~LLToolPipette();
 
 public:
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleToolTip(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleToolTip(S32 x, S32 y, MASK mask);
 
 	// Note: Don't return connection; use boost::bind + boost::signals2::trackable to disconnect slots
 	typedef boost::signals2::signal<void (const LLTextureEntry& te)> signal_t;

--- a/indra/newview/lltoolplacer.cpp
+++ b/indra/newview/lltoolplacer.cpp
@@ -518,11 +518,11 @@ BOOL LLToolPlacer::placeObject(S32 x, S32 y, MASK mask)
 	return added;
 }
 
-BOOL LLToolPlacer::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolPlacer::handleHover(S32 x, S32 y, MASK mask)
 {
 	LL_DEBUGS("UserInput") << "hover handled by LLToolPlacer" << LL_ENDL;		
 	gViewerWindow->setCursor(UI_CURSOR_TOOLCREATE);
-	return TRUE;
+	return true;
 }
 
 void LLToolPlacer::handleSelect()

--- a/indra/newview/lltoolplacer.h
+++ b/indra/newview/lltoolplacer.h
@@ -43,7 +43,7 @@ public:
 	LLToolPlacer();
 
 	virtual BOOL	placeObject(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual void	handleSelect();	// do stuff when your tool is selected
 	virtual void	handleDeselect();	// clean up when your tool is deselected
 

--- a/indra/newview/lltoolselect.cpp
+++ b/indra/newview/lltoolselect.cpp
@@ -61,7 +61,7 @@ LLToolSelect::LLToolSelect( LLToolComposite* composite )
  }
 
 // True if you selected an object.
-BOOL LLToolSelect::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolSelect::handleMouseDown(S32 x, S32 y, MASK mask)
 {
 	// do immediate pick query
     BOOL pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
@@ -250,7 +250,7 @@ LLObjectSelectionHandle LLToolSelect::handleObjectSelection(const LLPickInfo& pi
 	return LLSelectMgr::getInstance()->getSelection();
 }
 
-BOOL LLToolSelect::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolSelect::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	mIgnoreGroup = gSavedSettings.getBOOL("EditLinkedParts");
 

--- a/indra/newview/lltoolselect.h
+++ b/indra/newview/lltoolselect.h
@@ -39,8 +39,8 @@ class LLToolSelect : public LLTool
 public:
 	LLToolSelect( LLToolComposite* composite );
 
-	virtual BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool		handleMouseUp(S32 x, S32 y, MASK mask);
 
 	virtual void		stopEditing();
 

--- a/indra/newview/lltoolselectland.cpp
+++ b/indra/newview/lltoolselectland.cpp
@@ -62,9 +62,9 @@ LLToolSelectLand::~LLToolSelectLand()
 }
 
 
-BOOL LLToolSelectLand::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolSelectLand::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL hit_land = gViewerWindow->mousePointOnLandGlobal(x, y, &mDragStartGlobal);
+	bool hit_land = gViewerWindow->mousePointOnLandGlobal(x, y, &mDragStartGlobal);
 	if (hit_land)
 	{
 		setMouseCapture( TRUE );
@@ -94,21 +94,21 @@ BOOL LLToolSelectLand::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolSelectLand::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLToolSelectLand::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
 	LLVector3d pos_global;
-	BOOL hit_land = gViewerWindow->mousePointOnLandGlobal(x, y, &pos_global);
+	bool hit_land = gViewerWindow->mousePointOnLandGlobal(x, y, &pos_global);
 	if (hit_land)
 	{
 		// Auto-select this parcel
 		LLViewerParcelMgr::getInstance()->selectParcelAt( pos_global );
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 
-BOOL LLToolSelectLand::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolSelectLand::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	if(	hasMouseCapture() )
 	{
@@ -135,13 +135,13 @@ BOOL LLToolSelectLand::handleMouseUp(S32 x, S32 y, MASK mask)
 		mMouseOutsideSlop = FALSE;
 		mDragEndValid = FALSE;
 		
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 
-BOOL LLToolSelectLand::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolSelectLand::handleHover(S32 x, S32 y, MASK mask)
 {
 	if(	hasMouseCapture() )
 	{
@@ -193,7 +193,7 @@ BOOL LLToolSelectLand::handleHover(S32 x, S32 y, MASK mask)
 		gViewerWindow->setCursor(UI_CURSOR_ARROW);
 	}
 
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/newview/lltoolselectland.h
+++ b/indra/newview/lltoolselectland.h
@@ -39,10 +39,10 @@ class LLToolSelectLand
 	virtual ~LLToolSelectLand();
 
 public:
-	/*virtual*/ BOOL		handleMouseDown(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleDoubleClick(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleMouseUp(S32 x, S32 y, MASK mask);
-	/*virtual*/ BOOL		handleHover(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMouseDown(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleDoubleClick(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool		handleHover(S32 x, S32 y, MASK mask);
 	/*virtual*/ void		render();				// draw the select rectangle
 	/*virtual*/ BOOL		isAlwaysRendered()		{ return TRUE; }
 

--- a/indra/newview/lltoolselectrect.cpp
+++ b/indra/newview/lltoolselectrect.cpp
@@ -69,9 +69,9 @@ LLToolSelectRect::LLToolSelectRect( LLToolComposite* composite )
 
 void dialog_refresh_all(void);
 
-BOOL LLToolSelectRect::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLToolSelectRect::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-    BOOL pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
+    bool pick_rigged = false; //gSavedSettings.getBOOL("AnimatedObjectsAllowLeftClick");
 	handlePick(gViewerWindow->pickImmediate(x, y, TRUE /* pick_transparent */, pick_rigged));
 
 	LLTool::handleMouseDown(x, y, mask);
@@ -95,7 +95,7 @@ void LLToolSelectRect::handlePick(const LLPickInfo& pick)
 }
 
 
-BOOL LLToolSelectRect::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLToolSelectRect::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	setMouseCapture( FALSE );
 
@@ -114,7 +114,7 @@ BOOL LLToolSelectRect::handleMouseUp(S32 x, S32 y, MASK mask)
 		{
 			LLSelectMgr::getInstance()->selectHighlightedObjects();
 		}
-		return TRUE;
+		return true;
 	}
 	else
 	{
@@ -123,7 +123,7 @@ BOOL LLToolSelectRect::handleMouseUp(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLToolSelectRect::handleHover(S32 x, S32 y, MASK mask)
+bool LLToolSelectRect::handleHover(S32 x, S32 y, MASK mask)
 {
 	if(	hasMouseCapture() )
 	{
@@ -153,7 +153,7 @@ BOOL LLToolSelectRect::handleHover(S32 x, S32 y, MASK mask)
 	}
 
 	gViewerWindow->setCursor(UI_CURSOR_ARROW);
-	return TRUE;
+	return true;
 }
 
 

--- a/indra/newview/lltoolselectrect.h
+++ b/indra/newview/lltoolselectrect.h
@@ -36,9 +36,9 @@ class LLToolSelectRect
 public:
 	LLToolSelectRect( LLToolComposite* composite );
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
 	virtual void	draw();							// draw the select rectangle
 
 	void handlePick(const LLPickInfo& pick);

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -2337,7 +2337,7 @@ void LLViewerMediaImpl::onMouseCaptureLost()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-BOOL LLViewerMediaImpl::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLViewerMediaImpl::handleMouseUp(S32 x, S32 y, MASK mask)
 {
 	// NOTE: this is called when the mouse is released when we have capture.
 	// Due to the way mouse coordinates are mapped to the object, we can't use the x and y coordinates that come in with the event.
@@ -2345,10 +2345,10 @@ BOOL LLViewerMediaImpl::handleMouseUp(S32 x, S32 y, MASK mask)
 	if(hasMouseCapture())
 	{
 		// Release the mouse -- this will also send a mouseup to the media
-		gFocusMgr.setMouseCapture( FALSE );
+		gFocusMgr.setMouseCapture( false );
 	}
 
-	return TRUE;
+	return true;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/indra/newview/llviewermedia.h
+++ b/indra/newview/llviewermedia.h
@@ -317,25 +317,25 @@ public:
 
 	// need these to handle mouseup...
 	/*virtual*/ void	onMouseCaptureLost();
-	/*virtual*/ BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
+	/*virtual*/ bool	handleMouseUp(S32 x, S32 y, MASK mask);
 
 	// Grr... the only thing I want as an LLMouseHandler are the onMouseCaptureLost and handleMouseUp calls.
 	// Sadly, these are all pure virtual, so I have to supply implementations here:
-	/*virtual*/ BOOL	handleMouseDown(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleHover(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleScrollWheel(S32 x, S32 y, S32 clicks) { return FALSE; };
-	/*virtual*/ BOOL	handleScrollHWheel(S32 x, S32 y, S32 clicks) { return FALSE; };
-	/*virtual*/ BOOL	handleDoubleClick(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleRightMouseDown(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleRightMouseUp(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleToolTip(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleMiddleMouseDown(S32 x, S32 y, MASK mask) { return FALSE; };
-	/*virtual*/ BOOL	handleMiddleMouseUp(S32 x, S32 y, MASK mask) {return FALSE; };
+	/*virtual*/ bool	handleMouseDown(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleHover(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleScrollWheel(S32 x, S32 y, S32 clicks) { return false; };
+	/*virtual*/ bool	handleScrollHWheel(S32 x, S32 y, S32 clicks) { return false; };
+	/*virtual*/ bool	handleDoubleClick(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleRightMouseDown(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleRightMouseUp(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleToolTip(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleMiddleMouseDown(S32 x, S32 y, MASK mask) { return false; };
+	/*virtual*/ bool	handleMiddleMouseUp(S32 x, S32 y, MASK mask) {return false; };
 	/*virtual*/ const std::string& getName() const;
 
 	/*virtual*/ void	screenPointToLocal(S32 screen_x, S32 screen_y, S32* local_x, S32* local_y) const {};
 	/*virtual*/ void	localPointToScreen(S32 local_x, S32 local_y, S32* screen_x, S32* screen_y) const {};
-	/*virtual*/ BOOL hasMouseCapture() { return gFocusMgr.getMouseCapture() == this; };
+	/*virtual*/ bool hasMouseCapture() { return gFocusMgr.getMouseCapture() == this; };
 
 	// Inherited from LLPluginClassMediaOwner
 	/*virtual*/ void handleMediaEvent(LLPluginClassMedia* plugin, LLPluginClassMediaOwner::EMediaEvent);

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -161,8 +161,8 @@ void handle_test_load_url(void*);
 //extern BOOL	gHideSelectedObjects;
 //extern BOOL gAllowSelectAvatar;
 //extern BOOL gDebugAvatarRotation;
-extern BOOL gDebugClicks;
-extern BOOL gDebugWindowProc;
+extern bool gDebugClicks;
+extern bool gDebugWindowProc;
 extern BOOL gShaderProfileFrame;
 
 //extern BOOL gDebugTextEditorTips;

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -141,7 +141,7 @@ const F32 CAMERA_POSITION_THRESHOLD_SQUARED = 0.001f * 0.001f;
 static const U32 LLREQUEST_PERMISSION_THROTTLE_LIMIT	= 5;     // requests
 static const F32 LLREQUEST_PERMISSION_THROTTLE_INTERVAL	= 10.0f; // seconds
 
-extern BOOL gDebugClicks;
+extern bool gDebugClicks;
 extern bool gShiftFrame;
 
 // function prototypes

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -240,12 +240,12 @@ public:
 	/*virtual*/ bool			canEdit() const { return false; }
 
 
-	/*virtual*/ BOOL			handleHover(S32 x, S32 y, MASK mask)
+	/*virtual*/ bool			handleHover(S32 x, S32 y, MASK mask)
 	{
 		LLUI::getInstance()->getWindow()->setCursor(UI_CURSOR_HAND);
-		return TRUE;
+		return true;
 	}
-	virtual BOOL				handleToolTip(S32 x, S32 y, MASK mask )
+	virtual bool				handleToolTip(S32 x, S32 y, MASK mask )
 	{ 
 		if (mItem->getThumbnailUUID().notNull())
 		{
@@ -259,15 +259,15 @@ public:
 					.create_callback(boost::bind(&LLInspectTextureUtil::createInventoryToolTip, _1))
 					.create_params(params));
 
-			return TRUE;
+			return true;
 		}
 
 		if (!mToolTip.empty())
 		{
 			LLToolTipMgr::instance().show(mToolTip);
-			return TRUE;
+			return true;
 		}
-		return FALSE; 
+		return false; 
 	}
 
 	/*virtual*/ LLStyleConstSP		getStyle() const { return mStyle; }
@@ -712,9 +712,9 @@ void LLViewerTextEditor::onVisibilityChange( BOOL new_visibility )
 	LLUICtrl::onVisibilityChange(new_visibility);
 }
 
-BOOL LLViewerTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
+bool LLViewerTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// Let scrollbar have first dibs
 	handled = LLView::childrenHandleMouseDown(x, y, mask) != NULL;
@@ -748,7 +748,7 @@ BOOL LLViewerTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 					setFocus( TRUE );
 				}
 
-				handled = TRUE;
+				handled = true;
 			}
 			else
 			{
@@ -766,9 +766,9 @@ BOOL LLViewerTextEditor::handleMouseDown(S32 x, S32 y, MASK mask)
 }
 
 
-BOOL LLViewerTextEditor::handleHover(S32 x, S32 y, MASK mask)
+bool LLViewerTextEditor::handleHover(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = LLTextEditor::handleHover(x, y, mask);
+	bool handled = LLTextEditor::handleHover(x, y, mask);
 
 	if(hasMouseCapture() && mDragItem)
 	{
@@ -788,16 +788,16 @@ BOOL LLViewerTextEditor::handleHover(S32 x, S32 y, MASK mask)
 			return LLToolDragAndDrop::getInstance()->handleHover( x, y, mask );
 		}
 		getWindow()->setCursor(UI_CURSOR_HAND);
-		handled = TRUE;
+		handled = true;
 	}
 
 	return handled;
 }
 
 
-BOOL LLViewerTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
+bool LLViewerTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 {
-	BOOL handled = FALSE;
+	bool handled = false;
 
 	if( hasMouseCapture() )
 	{
@@ -826,9 +826,9 @@ BOOL LLViewerTextEditor::handleMouseUp(S32 x, S32 y, MASK mask)
 	return handled;
 }
 
-BOOL LLViewerTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLViewerTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
-	BOOL	handled = FALSE;
+	bool	handled = false;
 
 	// let scrollbar have first dibs
 	handled = LLView::childrenHandleDoubleClick(x, y, mask) != NULL;
@@ -845,7 +845,7 @@ BOOL LLViewerTextEditor::handleDoubleClick(S32 x, S32 y, MASK mask)
 				{
 					deselect();
 					setFocus( FALSE );
-					return TRUE;
+					return true;
 				}
 			}
 		}

--- a/indra/newview/llviewertexteditor.h
+++ b/indra/newview/llviewertexteditor.h
@@ -50,10 +50,10 @@ public:
 	/*virtual*/ void onVisibilityChange( BOOL new_visibility );
 	
 	// mousehandler overrides
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleHover(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick(S32 x, S32 y, MASK mask );
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleHover(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick(S32 x, S32 y, MASK mask );
 
 	virtual BOOL	handleDragAndDrop(S32 x, S32 y, MASK mask,
 										BOOL drop, EDragAndDropType cargo_type, 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -224,7 +224,7 @@
 void render_ui(F32 zoom_factor = 1.f, int subfield = 0);
 void swap();
 
-extern BOOL gDebugClicks;
+extern bool gDebugClicks;
 extern BOOL gDisplaySwapBuffers;
 extern BOOL gDepthDirty;
 extern BOOL gResizeScreenTexture;
@@ -1162,9 +1162,9 @@ BOOL LLViewerWindow::handleAnyMouseClick(LLWindow *window, LLCoordGL pos, MASK m
 	return default_rtn;
 }
 
-BOOL LLViewerWindow::handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
-    mAllowMouseDragging = FALSE;
+    mAllowMouseDragging = false;
     if (!mMouseDownTimer.getStarted())
     {
         mMouseDownTimer.start();
@@ -1173,51 +1173,51 @@ BOOL LLViewerWindow::handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask
     {
         mMouseDownTimer.reset();
     }    
-    BOOL down = TRUE;
+    bool down = true;
     //handleMouse() loops back to LLViewerWindow::handleAnyMouseClick
     return gViewerInput.handleMouse(window, pos, mask, CLICK_LEFT, down);
 }
 
-BOOL LLViewerWindow::handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
 	// try handling as a double-click first, then a single-click if that
 	// wasn't handled.
-	BOOL down = TRUE;
+	bool down = true;
 	if (gViewerInput.handleMouse(window, pos, mask, CLICK_DOUBLELEFT, down))
 	{
-		return TRUE;
+		return true;
 	}
 	return handleMouseDown(window, pos, mask);
 }
 
-BOOL LLViewerWindow::handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
     if (mMouseDownTimer.getStarted())
     {
         mMouseDownTimer.stop();
     }
-    BOOL down = FALSE;
+    bool down = false;
     return gViewerInput.handleMouse(window, pos, mask, CLICK_LEFT, down);
 }
-BOOL LLViewerWindow::handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
-	BOOL down = TRUE;
+	bool down = true;
 	return gViewerInput.handleMouse(window, pos, mask, CLICK_RIGHT, down);
 }
 
-BOOL LLViewerWindow::handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
-	BOOL down = FALSE;
+	bool down = false;
  	return gViewerInput.handleMouse(window, pos, mask, CLICK_RIGHT, down);
 }
 
-BOOL LLViewerWindow::handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
-	BOOL down = TRUE;
+	bool down = true;
  	gViewerInput.handleMouse(window, pos, mask, CLICK_MIDDLE, down);
   
   	// Always handled as far as the OS is concerned.
-	return TRUE;
+	return true;
 }
 
 LLWindowCallbacks::DragNDropResult LLViewerWindow::handleDragNDrop( LLWindow *window, LLCoordGL pos, MASK mask, LLWindowCallbacks::DragNDropAction action, std::string data)
@@ -1365,13 +1365,13 @@ LLWindowCallbacks::DragNDropResult LLViewerWindow::handleDragNDrop( LLWindow *wi
 	return result;
 }
 
-BOOL LLViewerWindow::handleMiddleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
+bool LLViewerWindow::handleMiddleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask)
 {
-	BOOL down = FALSE;
+	bool down = false;
  	gViewerInput.handleMouse(window, pos, mask, CLICK_MIDDLE, down);
   
   	// Always handled as far as the OS is concerned.
-	return TRUE;
+	return true;
 }
 
 BOOL LLViewerWindow::handleOtherMouse(LLWindow *window, LLCoordGL pos, MASK mask, S32 button, bool down)
@@ -1392,14 +1392,14 @@ BOOL LLViewerWindow::handleOtherMouse(LLWindow *window, LLCoordGL pos, MASK mask
     return TRUE;
 }
 
-BOOL LLViewerWindow::handleOtherMouseDown(LLWindow *window, LLCoordGL pos, MASK mask, S32 button)
+bool LLViewerWindow::handleOtherMouseDown(LLWindow *window, LLCoordGL pos, MASK mask, S32 button)
 {
-    return handleOtherMouse(window, pos, mask, button, TRUE);
+    return handleOtherMouse(window, pos, mask, button, true);
 }
 
-BOOL LLViewerWindow::handleOtherMouseUp(LLWindow *window, LLCoordGL pos, MASK mask, S32 button)
+bool LLViewerWindow::handleOtherMouseUp(LLWindow *window, LLCoordGL pos, MASK mask, S32 button)
 {
-    return handleOtherMouse(window, pos, mask, button, FALSE);
+    return handleOtherMouse(window, pos, mask, button, false);
 }
 
 // WARNING: this is potentially called multiple times per frame
@@ -1457,13 +1457,13 @@ void LLViewerWindow::handleMouseLeave(LLWindow *window)
 	LLToolTipMgr::instance().blockToolTips();
 }
 
-BOOL LLViewerWindow::handleCloseRequest(LLWindow *window)
+bool LLViewerWindow::handleCloseRequest(LLWindow *window)
 {
 	// User has indicated they want to close, but we may need to ask
 	// about modified documents.
 	LLAppViewer::instance()->userQuit();
 	// Don't quit immediately
-	return FALSE;
+	return false;
 }
 
 void LLViewerWindow::handleQuit(LLWindow *window)
@@ -1536,7 +1536,7 @@ void LLViewerWindow::handleFocusLost(LLWindow *window)
 }
 
 
-BOOL LLViewerWindow::handleTranslatedKeyDown(KEY key,  MASK mask, BOOL repeated)
+bool LLViewerWindow::handleTranslatedKeyDown(KEY key,  MASK mask, bool repeated)
 {
     // Handle non-consuming global keybindings, like voice 
     // Never affects event processing.
@@ -1557,14 +1557,14 @@ BOOL LLViewerWindow::handleTranslatedKeyDown(KEY key,  MASK mask, BOOL repeated)
         // would like to know about the KEYDOWN for an enter key... so ask and pass it along.
         LLFocusableElement* keyboard_focus = gFocusMgr.getKeyboardFocus();
         if (keyboard_focus && !keyboard_focus->wantsReturnKey())
-    		return FALSE;
+    		return false;
 	}
 
     // remaps, handles ignored cases and returns back to viewer window.
     return gViewerInput.handleKey(key, mask, repeated);
 }
 
-BOOL LLViewerWindow::handleTranslatedKeyUp(KEY key,  MASK mask)
+bool LLViewerWindow::handleTranslatedKeyUp(KEY key,  MASK mask)
 {
     // Handle non-consuming global keybindings, like voice 
     // Never affects event processing.
@@ -1580,7 +1580,7 @@ BOOL LLViewerWindow::handleTranslatedKeyUp(KEY key,  MASK mask)
 	return gViewerInput.handleKeyUp(key, mask);
 }
 
-void LLViewerWindow::handleScanKey(KEY key, BOOL key_down, BOOL key_up, BOOL key_level)
+void LLViewerWindow::handleScanKey(KEY key, bool key_down, bool key_up, bool key_level)
 {
 	LLViewerJoystick::getInstance()->setCameraNeedsUpdate(true);
 	gViewerInput.scanKey(key, key_down, key_up, key_level);
@@ -1590,7 +1590,7 @@ void LLViewerWindow::handleScanKey(KEY key, BOOL key_down, BOOL key_up, BOOL key
 
 
 
-BOOL LLViewerWindow::handleActivate(LLWindow *window, BOOL activated)
+bool LLViewerWindow::handleActivate(LLWindow *window, bool activated)
 {
 	if (activated)
 	{
@@ -1622,15 +1622,15 @@ BOOL LLViewerWindow::handleActivate(LLWindow *window, BOOL activated)
 		// Mute audio
 		audio_update_volume();
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLViewerWindow::handleActivateApp(LLWindow *window, BOOL activating)
+bool LLViewerWindow::handleActivateApp(LLWindow *window, bool activating)
 {
 	//if (!activating) gAgentCamera.changeCameraToDefault();
 
 	LLViewerJoystick::getInstance()->setNeedsReset(true);
-	return FALSE;
+	return false;
 }
 
 
@@ -1639,7 +1639,7 @@ void LLViewerWindow::handleMenuSelect(LLWindow *window,  S32 menu_item)
 }
 
 
-BOOL LLViewerWindow::handlePaint(LLWindow *window,  S32 x,  S32 y, S32 width,  S32 height)
+bool LLViewerWindow::handlePaint(LLWindow *window,  S32 x,  S32 y, S32 width,  S32 height)
 {
 	// *TODO: Enable similar information output for other platforms?  DK 2011-02-18
 #if LL_WINDOWS
@@ -1676,10 +1676,10 @@ BOOL LLViewerWindow::handlePaint(LLWindow *window,  S32 x,  S32 y, S32 width,  S
 
 		TextOutA(hdc, 0, 50, "Set \"HeadlessClient FALSE\" in settings.ini file to reenable", 61);
 		EndPaint(window_handle, &ps); 
-		return TRUE;
+		return true;
 	}
 #endif
-	return FALSE;
+	return false;
 }
 
 
@@ -1723,49 +1723,49 @@ void LLViewerWindow::handleDataCopy(LLWindow *window, S32 data_type, void *data)
 	}
 }
 
-BOOL LLViewerWindow::handleTimerEvent(LLWindow *window)
+bool LLViewerWindow::handleTimerEvent(LLWindow *window)
 {
     //TODO: just call this every frame from gatherInput instead of using a convoluted 30fps timer callback
 	if (LLViewerJoystick::getInstance()->getOverrideCamera())
 	{
 		LLViewerJoystick::getInstance()->updateStatus();
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLViewerWindow::handleDeviceChange(LLWindow *window)
+bool LLViewerWindow::handleDeviceChange(LLWindow *window)
 {
 	// give a chance to use a joystick after startup (hot-plugging)
 	if (!LLViewerJoystick::getInstance()->isJoystickInitialized() )
 	{
 		LLViewerJoystick::getInstance()->init(true);
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
-BOOL LLViewerWindow::handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height)
+bool LLViewerWindow::handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height)
 {
     if (ui_scale_factor >= MIN_UI_SCALE && ui_scale_factor <= MAX_UI_SCALE)
     {
         LLViewerWindow::reshape(window_width, window_height);
         mResDirty = true;
-        return TRUE;
+        return true;
     }
     else
     {
         LL_WARNS() << "DPI change caused UI scale to go out of bounds: " << ui_scale_factor << LL_ENDL;
-        return FALSE;
+        return false;
     }
 }
 
-BOOL LLViewerWindow::handleWindowDidChangeScreen(LLWindow *window)
+bool LLViewerWindow::handleWindowDidChangeScreen(LLWindow *window)
 {
 	LLCoordScreen window_rect;
 	mWindow->getSize(&window_rect);
 	reshape(window_rect.mX, window_rect.mY);
-	return TRUE;
+	return true;
 }
 
 void LLViewerWindow::handlePingWatchdog(LLWindow *window, const char * msg)
@@ -3110,7 +3110,7 @@ BOOL LLViewerWindow::handleKey(KEY key, MASK mask)
 }
 
 
-BOOL LLViewerWindow::handleUnicodeChar(llwchar uni_char, MASK mask)
+bool LLViewerWindow::handleUnicodeChar(llwchar uni_char, MASK mask)
 {
 	// HACK:  We delay processing of return keys until they arrive as a Unicode char,
 	// so that if you're typing chat text at low frame rate, we don't send the chat
@@ -3128,24 +3128,24 @@ BOOL LLViewerWindow::handleUnicodeChar(llwchar uni_char, MASK mask)
 	}
 
 	// let menus handle navigation (jump) keys
-	if (gMenuBarView && gMenuBarView->handleUnicodeChar(uni_char, TRUE))
+	if (gMenuBarView && gMenuBarView->handleUnicodeChar(uni_char, true))
 	{
-		return TRUE;
+		return true;
 	}
 
 	// Traverses up the hierarchy
 	LLFocusableElement* keyboard_focus = gFocusMgr.getKeyboardFocus();
 	if( keyboard_focus )
 	{
-		if (keyboard_focus->handleUnicodeChar(uni_char, FALSE))
+		if (keyboard_focus->handleUnicodeChar(uni_char, false))
 		{
-			return TRUE;
+			return true;
 		}
 
-        return TRUE;
+        return true;
 	}
 
-	return FALSE;
+	return false;
 }
 
 

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -189,20 +189,20 @@ public:
 	//
 	// LLWindowCallback interface implementation
 	//
-	/*virtual*/ BOOL handleTranslatedKeyDown(KEY key,  MASK mask, BOOL repeated);
-	/*virtual*/ BOOL handleTranslatedKeyUp(KEY key,  MASK mask);
-	/*virtual*/ void handleScanKey(KEY key, BOOL key_down, BOOL key_up, BOOL key_level);
-	/*virtual*/ BOOL handleUnicodeChar(llwchar uni_char, MASK mask);	// NOT going to handle extended 
-	/*virtual*/ BOOL handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleCloseRequest(LLWindow *window);
+	/*virtual*/ bool handleTranslatedKeyDown(KEY key,  MASK mask, bool repeated);
+	/*virtual*/ bool handleTranslatedKeyUp(KEY key,  MASK mask);
+	/*virtual*/ void handleScanKey(KEY key, bool key_down, bool key_up, bool key_level);
+	/*virtual*/ bool handleUnicodeChar(llwchar uni_char, MASK mask);	// NOT going to handle extended 
+	/*virtual*/ bool handleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleCloseRequest(LLWindow *window);
 	/*virtual*/ void handleQuit(LLWindow *window);
-	/*virtual*/ BOOL handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleMiddleMouseUp(LLWindow *window, LLCoordGL pos, MASK mask);
-	/*virtual*/ BOOL handleOtherMouseDown(LLWindow *window, LLCoordGL pos, MASK mask, S32 button);
-	/*virtual*/ BOOL handleOtherMouseUp(LLWindow *window, LLCoordGL pos, MASK mask, S32 button);
+	/*virtual*/ bool handleRightMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleRightMouseUp(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleMiddleMouseDown(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleMiddleMouseUp(LLWindow *window, LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleOtherMouseDown(LLWindow *window, LLCoordGL pos, MASK mask, S32 button);
+	/*virtual*/ bool handleOtherMouseUp(LLWindow *window, LLCoordGL pos, MASK mask, S32 button);
 	BOOL handleOtherMouse(LLWindow *window, LLCoordGL pos, MASK mask, S32 button, bool down);
 	/*virtual*/ LLWindowCallbacks::DragNDropResult handleDragNDrop(LLWindow *window, LLCoordGL pos, MASK mask, LLWindowCallbacks::DragNDropAction action, std::string data);
 				void handleMouseMove(LLWindow *window,  LLCoordGL pos, MASK mask);
@@ -211,20 +211,20 @@ public:
 	/*virtual*/ void handleResize(LLWindow *window,  S32 x,  S32 y);
 	/*virtual*/ void handleFocus(LLWindow *window);
 	/*virtual*/ void handleFocusLost(LLWindow *window);
-	/*virtual*/ BOOL handleActivate(LLWindow *window, BOOL activated);
-	/*virtual*/ BOOL handleActivateApp(LLWindow *window, BOOL activating);
+	/*virtual*/ bool handleActivate(LLWindow *window, bool activated);
+	/*virtual*/ bool handleActivateApp(LLWindow *window, bool activating);
 	/*virtual*/ void handleMenuSelect(LLWindow *window,  S32 menu_item);
-	/*virtual*/ BOOL handlePaint(LLWindow *window,  S32 x,  S32 y,  S32 width,  S32 height);
+	/*virtual*/ bool handlePaint(LLWindow *window,  S32 x,  S32 y,  S32 width,  S32 height);
 	/*virtual*/ void handleScrollWheel(LLWindow *window,  S32 clicks);
 	/*virtual*/ void handleScrollHWheel(LLWindow *window,  S32 clicks);
-	/*virtual*/ BOOL handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask);
+	/*virtual*/ bool handleDoubleClick(LLWindow *window,  LLCoordGL pos, MASK mask);
 	/*virtual*/ void handleWindowBlock(LLWindow *window);
 	/*virtual*/ void handleWindowUnblock(LLWindow *window);
 	/*virtual*/ void handleDataCopy(LLWindow *window, S32 data_type, void *data);
-	/*virtual*/ BOOL handleTimerEvent(LLWindow *window);
-	/*virtual*/ BOOL handleDeviceChange(LLWindow *window);
-	/*virtual*/ BOOL handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
-	/*virtual*/ BOOL handleWindowDidChangeScreen(LLWindow *window);
+	/*virtual*/ bool handleTimerEvent(LLWindow *window);
+	/*virtual*/ bool handleDeviceChange(LLWindow *window);
+	/*virtual*/ bool handleDPIChanged(LLWindow *window, F32 ui_scale_factor, S32 window_width, S32 window_height);
+	/*virtual*/ bool handleWindowDidChangeScreen(LLWindow *window);
 
 	/*virtual*/ void handlePingWatchdog(LLWindow *window, const char * msg);
 	/*virtual*/ void handlePauseWatchdog(LLWindow *window);

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -118,7 +118,7 @@ BOOL LLPanelWearableOutfitItem::postBuild()
     return TRUE;
 }
 
-BOOL LLPanelWearableOutfitItem::handleDoubleClick(S32 x, S32 y, MASK mask)
+bool LLPanelWearableOutfitItem::handleDoubleClick(S32 x, S32 y, MASK mask)
 {
     if(!mShowWidgets)
     {
@@ -133,7 +133,7 @@ BOOL LLPanelWearableOutfitItem::handleDoubleClick(S32 x, S32 y, MASK mask)
     {
         onAddWearable();
     }
-    return TRUE;
+    return true;
 }
 
 void LLPanelWearableOutfitItem::onAddWearable()

--- a/indra/newview/llwearableitemslist.h
+++ b/indra/newview/llwearableitemslist.h
@@ -84,7 +84,7 @@ public:
     };
 
     BOOL postBuild();
-    BOOL handleDoubleClick(S32 x, S32 y, MASK mask);
+	bool handleDoubleClick(S32 x, S32 y, MASK mask);
 
 	static LLPanelWearableOutfitItem* create(LLViewerInventoryItem* item,
 											 bool worn_indication_enabled,

--- a/indra/newview/llwindowlistener.cpp
+++ b/indra/newview/llwindowlistener.cpp
@@ -330,7 +330,7 @@ void LLWindowListener::keyUp(LLSD const & evt)
 }
 
 // for WhichButton
-typedef BOOL (LLWindowCallbacks::*MouseMethod)(LLWindow *, LLCoordGL, MASK);
+typedef bool (LLWindowCallbacks::*MouseMethod)(LLWindow *, LLCoordGL, MASK);
 struct Actions
 {
 	Actions(const MouseMethod& d, const MouseMethod& u): down(d), up(u), valid(true) {}

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -1078,7 +1078,7 @@ LLVector3d LLWorldMapView::viewPosToGlobal( S32 x, S32 y )
 }
 
 
-BOOL LLWorldMapView::handleToolTip( S32 x, S32 y, MASK mask )
+bool LLWorldMapView::handleToolTip( S32 x, S32 y, MASK mask )
 {
 	LLVector3d pos_global = viewPosToGlobal(x, y);
 	U64 handle = to_region_handle(pos_global);
@@ -1131,7 +1131,7 @@ BOOL LLWorldMapView::handleToolTip( S32 x, S32 y, MASK mask )
 			.message(tooltip_msg)
 			.sticky_rect(sticky_rect_screen));
 	}
-	return TRUE;
+	return true;
 }
 
 // Pass relative Z of 0 to draw at same level.
@@ -1630,7 +1630,7 @@ void LLWorldMapView::handleClick(S32 x, S32 y, MASK mask,
 }
 
 
-BOOL LLWorldMapView::handleMouseDown( S32 x, S32 y, MASK mask )
+bool LLWorldMapView::handleMouseDown( S32 x, S32 y, MASK mask )
 {
 	gFocusMgr.setMouseCapture( this );
 
@@ -1639,10 +1639,10 @@ BOOL LLWorldMapView::handleMouseDown( S32 x, S32 y, MASK mask )
 	mMouseDownX = x;
 	mMouseDownY = y;
 	sHandledLastClick = TRUE;
-	return TRUE;
+	return true;
 }
 
-BOOL LLWorldMapView::handleMouseUp( S32 x, S32 y, MASK mask )
+bool LLWorldMapView::handleMouseUp( S32 x, S32 y, MASK mask )
 {
 	if (hasMouseCapture())
 	{
@@ -1672,9 +1672,9 @@ BOOL LLWorldMapView::handleMouseUp( S32 x, S32 y, MASK mask )
 		}
 		gViewerWindow->showCursor();
 		gFocusMgr.setMouseCapture( NULL );
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void LLWorldMapView::updateVisibleBlocks()
@@ -1708,7 +1708,7 @@ void LLWorldMapView::updateVisibleBlocks()
 	LLWorldMap::getInstance()->updateRegions(world_left, world_bottom, world_right, world_top);
 }
 
-BOOL LLWorldMapView::handleHover( S32 x, S32 y, MASK mask )
+bool LLWorldMapView::handleHover( S32 x, S32 y, MASK mask )
 {
 	if (hasMouseCapture())
 	{
@@ -1735,7 +1735,7 @@ BOOL LLWorldMapView::handleHover( S32 x, S32 y, MASK mask )
 
 		// doesn't matter, cursor should be hidden
 		gViewerWindow->setCursor(UI_CURSOR_CROSS );
-		return TRUE;
+		return true;
 	}
 	else
 	{
@@ -1751,12 +1751,12 @@ BOOL LLWorldMapView::handleHover( S32 x, S32 y, MASK mask )
 			gViewerWindow->setCursor( UI_CURSOR_CROSS );
 		}
 		LL_DEBUGS("UserInput") << "hover handled by LLWorldMapView" << LL_ENDL;		
-		return TRUE;
+		return true;
 	}
 }
 
 
-BOOL LLWorldMapView::handleDoubleClick( S32 x, S32 y, MASK mask )
+bool LLWorldMapView::handleDoubleClick( S32 x, S32 y, MASK mask )
 {
 	if( sHandledLastClick )
 	{
@@ -1820,9 +1820,9 @@ BOOL LLWorldMapView::handleDoubleClick( S32 x, S32 y, MASK mask )
 			}
 		};
 
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 // static

--- a/indra/newview/llworldmapview.h
+++ b/indra/newview/llworldmapview.h
@@ -58,11 +58,11 @@ public:
 	virtual void	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE );
 	virtual void	setVisible(BOOL visible);
 
-	virtual BOOL	handleMouseDown(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleMouseUp(S32 x, S32 y, MASK mask);
-	virtual BOOL	handleDoubleClick( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleHover( S32 x, S32 y, MASK mask );
-	virtual BOOL	handleToolTip( S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseDown(S32 x, S32 y, MASK mask);
+	virtual bool	handleMouseUp(S32 x, S32 y, MASK mask);
+	virtual bool	handleDoubleClick( S32 x, S32 y, MASK mask );
+	virtual bool	handleHover( S32 x, S32 y, MASK mask );
+	virtual bool	handleToolTip( S32 x, S32 y, MASK mask);
 
 	bool			checkItemHit(S32 x, S32 y, LLItemInfo& item, LLUUID* id, bool track);
 	void			handleClick(S32 x, S32 y, MASK mask, S32* hit_type, LLUUID* id);

--- a/indra/newview/tests/llviewercontrollistener_test.cpp
+++ b/indra/newview/tests/llviewercontrollistener_test.cpp
@@ -167,7 +167,7 @@ namespace tut
                 "boolvar",
                 llsd::map("name", "boolvar",
                           "type", "Boolean",
-                          "value", TRUE,
+                          "value", true,
                           "comment", "bool variable")));
     }
 } // namespace tut

--- a/indra/test/llpermissions_tut.cpp
+++ b/indra/test/llpermissions_tut.cpp
@@ -199,7 +199,7 @@ namespace tut
 	{
 		LLPermissions perm1;
 		LLUUID uuid;
-		BOOL is_group_owned = FALSE;
+		bool is_group_owned = false;
 		ensure("1:getOwnership:failed ", ! perm1.getOwnership(uuid,is_group_owned));
 		
 		LLPermissions perm;

--- a/indra/test/llsaleinfo_tut.cpp
+++ b/indra/test/llsaleinfo_tut.cpp
@@ -116,7 +116,7 @@ namespace tut
 		std::istringstream istream(ostream.str());
 		LLSaleInfo llsaleinfo1;
 		U32 perm_mask = 0;
-		BOOL has_perm_mask = FALSE;
+		bool has_perm_mask = false;
 		llsaleinfo1.importLegacyStream(istream, has_perm_mask, perm_mask);
 					
 		ensure("importStream() fn failed ",
@@ -133,7 +133,7 @@ namespace tut
 		LLSD sd_result = saleinfo.asLLSD();
 		
 		U32 perm_mask = 0 ;
-		BOOL has_perm_mask = FALSE;
+		bool has_perm_mask = false;
 
 		LLSaleInfo saleinfo1;
 		saleinfo1.fromLLSD( sd_result, has_perm_mask, perm_mask);	

--- a/indra/test/llsdmessagebuilder_tut.cpp
+++ b/indra/test/llsdmessagebuilder_tut.cpp
@@ -128,7 +128,7 @@ namespace tut
 	void LLSDMessageBuilderTestObject::test<2>()
 		 // BOOL
 	{
-	  BOOL outValue, inValue = TRUE;
+	  bool outValue, inValue = true;
 	  LLSDMessageBuilder builder = defaultBuilder();
 	  builder.addBOOL("var", inValue);
 	  LLSDMessageReader reader = setReader(builder);

--- a/indra/test/llsdmessagereader_tut.cpp
+++ b/indra/test/llsdmessagereader_tut.cpp
@@ -77,7 +77,7 @@ namespace tut
 		{
 			LLSDMessageReader msg;
 			msg.setMessage("fakename", msg_data);
-			BOOL test_data;
+			bool test_data;
 			msg.getBOOL(block.c_str(), var.c_str(), test_data, blocknum);
  			ensure_equals(	"Ensure bool field", test_data, expected);
  		}

--- a/indra/test/lltemplatemessagebuilder_tut.cpp
+++ b/indra/test/lltemplatemessagebuilder_tut.cpp
@@ -139,7 +139,7 @@ namespace tut
 	{
 		LLMessageTemplate messageTemplate = defaultTemplate();
 		messageTemplate.addBlock(defaultBlock(MVT_BOOL, 1));
-		BOOL outValue, inValue = TRUE;
+		bool outValue, inValue = true;
 		LLTemplateMessageBuilder* builder = defaultBuilder(messageTemplate);
 		builder->addBOOL(_PREHASH_Test0, inValue);
 		LLTemplateMessageReader* reader = setReader(messageTemplate, builder);
@@ -595,7 +595,7 @@ namespace tut
 	{
 		LLMessageTemplate messageTemplate = defaultTemplate();
 		messageTemplate.addBlock(defaultBlock(MVT_BOOL, 1));
-		BOOL outValue, inValue = TRUE;
+		bool outValue, inValue = true;
 		LLTemplateMessageBuilder* builder = defaultBuilder(messageTemplate);
 		builder->addBOOL(_PREHASH_Test0, inValue);
 		LLTemplateMessageReader* reader = setReader(


### PR DESCRIPTION
This replaces all BOOL with bool in llwindow except for Windows API calls and Objective-C (@larsnaesbye or maybe @marchcat  maybe you should look into those since I don't know anything about it and I can't tell if the changes are compiling on macOS right now).

This also resulted in a big chunk of dependent classes that inherited classes from llwindow and are overriding their methods.

Also fixed the broken unit tests that were failing after recent changes.