### PR TITLE
Converted remaining BOOLs into bool in llinventory and llmessage

### DIFF
--- a/indra/llcharacter/llkeyframemotion.cpp
+++ b/indra/llcharacter/llkeyframemotion.cpp
@@ -1339,12 +1339,14 @@ bool LLKeyframeMotion::deserialize(LLDataPacker& dp, const LLUUID& asset_id, boo
 		return false;
 	}
 
-	if (!dp.unpackS32(joint_motion_list->mLoop, "loop"))
+	S32 loop{ 0 };
+	if (!dp.unpackS32(loop, "loop"))
 	{
 		LL_WARNS() << "can't read loop"
                    << " for animation " << asset_id << LL_ENDL;
 		return false;
 	}
+	joint_motion_list->mLoop = static_cast<bool>(loop);
 
 	//SL-17206 hack to alter Female_land loop setting, while current behavior won't be changed serverside
 	LLUUID const female_land_anim("ca1baf4d-0a18-5a1f-0330-e4bd1e71f09e");

--- a/indra/llcharacter/llkeyframemotion.h
+++ b/indra/llcharacter/llkeyframemotion.h
@@ -398,7 +398,7 @@ public:
 	public:
 		std::vector<JointMotion*> mJointMotionArray;
 		F32						mDuration;
-		BOOL					mLoop;
+		bool					mLoop;
 		F32						mLoopInPoint;
 		F32						mLoopOutPoint;
 		F32						mEaseInDuration;

--- a/indra/llcommon/llstringtable.h
+++ b/indra/llcommon/llstringtable.h
@@ -51,7 +51,7 @@ public:
 	~LLStringTableEntry();
 
 	void incCount()		{ mCount++; }
-	BOOL decCount()		{ return --mCount; }
+	bool decCount()		{ return --mCount != 0; }
 
 	char *mString;
 	S32  mCount;

--- a/indra/llinventory/llfoldertype.cpp
+++ b/indra/llinventory/llfoldertype.cpp
@@ -84,47 +84,47 @@ protected:
 LLFolderDictionary::LLFolderDictionary()
 {
 	//       													    TYPE NAME, PROTECTED, AUTOMATIC, SINGLETON
-	addEntry(LLFolderType::FT_TEXTURE, 				new FolderEntry("texture",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_SOUND, 				new FolderEntry("sound",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_CALLINGCARD, 			new FolderEntry("callcard",	TRUE, TRUE, FALSE));
-	addEntry(LLFolderType::FT_LANDMARK, 			new FolderEntry("landmark",	TRUE, FALSE, FALSE));
-	addEntry(LLFolderType::FT_CLOTHING, 			new FolderEntry("clothing",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_OBJECT, 				new FolderEntry("object",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_NOTECARD, 			new FolderEntry("notecard",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_ROOT_INVENTORY, 		new FolderEntry("root_inv",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_LSL_TEXT, 			new FolderEntry("lsltext",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_BODYPART, 			new FolderEntry("bodypart",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_TRASH, 				new FolderEntry("trash",	TRUE, FALSE, TRUE));
-	addEntry(LLFolderType::FT_SNAPSHOT_CATEGORY, 	new FolderEntry("snapshot", TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_LOST_AND_FOUND, 		new FolderEntry("lstndfnd",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_ANIMATION, 			new FolderEntry("animatn",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_GESTURE, 				new FolderEntry("gesture",	TRUE, TRUE, TRUE));
-	addEntry(LLFolderType::FT_FAVORITE, 			new FolderEntry("favorite",	TRUE, FALSE, TRUE));
+	addEntry(LLFolderType::FT_TEXTURE, 				new FolderEntry("texture",	true, true, true));
+	addEntry(LLFolderType::FT_SOUND, 				new FolderEntry("sound",	true, true, true));
+	addEntry(LLFolderType::FT_CALLINGCARD, 			new FolderEntry("callcard",	true, true, false));
+	addEntry(LLFolderType::FT_LANDMARK, 			new FolderEntry("landmark",	true, false, false));
+	addEntry(LLFolderType::FT_CLOTHING, 			new FolderEntry("clothing",	true, true, true));
+	addEntry(LLFolderType::FT_OBJECT, 				new FolderEntry("object",	true, true, true));
+	addEntry(LLFolderType::FT_NOTECARD, 			new FolderEntry("notecard",	true, true, true));
+	addEntry(LLFolderType::FT_ROOT_INVENTORY, 		new FolderEntry("root_inv",	true, true, true));
+	addEntry(LLFolderType::FT_LSL_TEXT, 			new FolderEntry("lsltext",	true, true, true));
+	addEntry(LLFolderType::FT_BODYPART, 			new FolderEntry("bodypart",	true, true, true));
+	addEntry(LLFolderType::FT_TRASH, 				new FolderEntry("trash",	true, false, true));
+	addEntry(LLFolderType::FT_SNAPSHOT_CATEGORY, 	new FolderEntry("snapshot", true, true, true));
+	addEntry(LLFolderType::FT_LOST_AND_FOUND, 		new FolderEntry("lstndfnd",	true, true, true));
+	addEntry(LLFolderType::FT_ANIMATION, 			new FolderEntry("animatn",	true, true, true));
+	addEntry(LLFolderType::FT_GESTURE, 				new FolderEntry("gesture",	true, true, true));
+	addEntry(LLFolderType::FT_FAVORITE, 			new FolderEntry("favorite",	true, false, true));
 	
 	for (S32 ensemble_num = S32(LLFolderType::FT_ENSEMBLE_START); ensemble_num <= S32(LLFolderType::FT_ENSEMBLE_END); ensemble_num++)
 	{
-		addEntry(LLFolderType::EType(ensemble_num), new FolderEntry("ensemble", FALSE, FALSE, FALSE)); // Not used
+		addEntry(LLFolderType::EType(ensemble_num), new FolderEntry("ensemble", false, false, false)); // Not used
 	}
 
-	addEntry(LLFolderType::FT_CURRENT_OUTFIT, 		new FolderEntry("current",	TRUE, FALSE, TRUE));
-	addEntry(LLFolderType::FT_OUTFIT, 				new FolderEntry("outfit",	FALSE, FALSE, FALSE));
-	addEntry(LLFolderType::FT_MY_OUTFITS, 			new FolderEntry("my_otfts",	TRUE, FALSE, TRUE));
+	addEntry(LLFolderType::FT_CURRENT_OUTFIT, 		new FolderEntry("current",	true, false, true));
+	addEntry(LLFolderType::FT_OUTFIT, 				new FolderEntry("outfit",	false, false, false));
+	addEntry(LLFolderType::FT_MY_OUTFITS, 			new FolderEntry("my_otfts",	true, false, true));
 
-	addEntry(LLFolderType::FT_MESH, 				new FolderEntry("mesh",		TRUE, FALSE, FALSE)); // Not used?
+	addEntry(LLFolderType::FT_MESH, 				new FolderEntry("mesh",		true, false, false)); // Not used?
 
-	addEntry(LLFolderType::FT_INBOX, 				new FolderEntry("inbox",	TRUE, FALSE, TRUE));
-	addEntry(LLFolderType::FT_OUTBOX, 				new FolderEntry("outbox",	TRUE, FALSE, FALSE));
+	addEntry(LLFolderType::FT_INBOX, 				new FolderEntry("inbox",	true, false, true));
+	addEntry(LLFolderType::FT_OUTBOX, 				new FolderEntry("outbox",	true, false, false));
 	
-	addEntry(LLFolderType::FT_BASIC_ROOT,			new FolderEntry("basic_rt", TRUE, FALSE, FALSE)); 
+	addEntry(LLFolderType::FT_BASIC_ROOT,			new FolderEntry("basic_rt", true, false, false)); 
 
-	addEntry(LLFolderType::FT_MARKETPLACE_LISTINGS, new FolderEntry("merchant", FALSE, FALSE, FALSE));
-	addEntry(LLFolderType::FT_MARKETPLACE_STOCK,    new FolderEntry("stock",    FALSE, FALSE, FALSE));
-	addEntry(LLFolderType::FT_MARKETPLACE_VERSION,  new FolderEntry("version",  FALSE, FALSE, FALSE));
+	addEntry(LLFolderType::FT_MARKETPLACE_LISTINGS, new FolderEntry("merchant", false, false, false));
+	addEntry(LLFolderType::FT_MARKETPLACE_STOCK,    new FolderEntry("stock",    false, false, false));
+	addEntry(LLFolderType::FT_MARKETPLACE_VERSION,  new FolderEntry("version",  false, false, false));
 		 
-    addEntry(LLFolderType::FT_SETTINGS,             new FolderEntry("settings", TRUE, FALSE, TRUE));
-    addEntry(LLFolderType::FT_MATERIAL,             new FolderEntry("material", TRUE, FALSE, TRUE));
+    addEntry(LLFolderType::FT_SETTINGS,             new FolderEntry("settings", true, false, true));
+    addEntry(LLFolderType::FT_MATERIAL,             new FolderEntry("material", true, false, true));
 
-	addEntry(LLFolderType::FT_NONE, 				new FolderEntry("-1",		FALSE, FALSE, FALSE));
+	addEntry(LLFolderType::FT_NONE, 				new FolderEntry("-1",		false, false, false));
 };
 
 // static

--- a/indra/llinventory/llinventory.h
+++ b/indra/llinventory/llinventory.h
@@ -268,7 +268,7 @@ public:
 	//--------------------------------------------------------------------
 public:
 	virtual bool importLegacyStream(std::istream& input_stream);
-	virtual bool exportLegacyStream(std::ostream& output_stream, bool include_asset_key = TRUE) const;
+	virtual bool exportLegacyStream(std::ostream& output_stream, bool include_asset_key = true) const;
 
 	LLSD exportLLSD() const;
 	bool importLLSD(const LLSD& cat_data);

--- a/indra/llinventory/llparcel.cpp
+++ b/indra/llinventory/llparcel.cpp
@@ -119,7 +119,7 @@ LLParcel::ECategory category_ui_string_to_category(const std::string& s);
 
 LLParcel::LLParcel()
 {
-    init(LLUUID::null, TRUE, FALSE, FALSE, 0, 0, 0, 0, 0, 1.f, 0);
+    init(LLUUID::null, true, false, false, 0, 0, 0, 0, 0, 1.f, 0);
 }
 
 
@@ -191,13 +191,13 @@ void LLParcel::init(const LLUUID &owner_id,
 	setMediaType(LLStringUtil::null);
 	mMediaID.setNull();
 	mMediaAutoScale = 0;
-	mMediaLoop = TRUE;
+	mMediaLoop = 1;
 	mMediaWidth = 0;
 	mMediaHeight = 0;
 	setMediaCurrentURL(LLStringUtil::null);
-	mMediaAllowNavigate = TRUE;
+	mMediaAllowNavigate = 1;
 	mMediaURLTimeout = 0.0f;
-	mMediaPreventCameraZoom = FALSE;
+	mMediaPreventCameraZoom = 0;
 
 	mGroupID.setNull();
 
@@ -219,20 +219,20 @@ void LLParcel::init(const LLUUID &owner_id,
 	setSelectedPrimCount(0);
 	setTempPrimCount(0);
 	setCleanOtherTime(0);
-    setRegionPushOverride(FALSE);
-    setRegionDenyAnonymousOverride(FALSE);
-    setRegionDenyAgeUnverifiedOverride(FALSE);
+    setRegionPushOverride(false);
+    setRegionDenyAnonymousOverride(false);
+    setRegionDenyAgeUnverifiedOverride(false);
 	setParcelPrimBonus(parcel_object_bonus);
 
 	setPreviousOwnerID(LLUUID::null);
-	setPreviouslyGroupOwned(FALSE);
+	setPreviouslyGroupOwned(false);
 
-	setSeeAVs(TRUE);
-	setAllowGroupAVSounds(TRUE);
-	setAllowAnyAVSounds(TRUE);
-	setHaveNewParcelLimitData(FALSE);
+	setSeeAVs(true);
+	setAllowGroupAVSounds(true);
+	setAllowAnyAVSounds(true);
+	setHaveNewParcelLimitData(false);
 
-    setRegionAllowEnvironmentOverride(FALSE);
+    setRegionAllowEnvironmentOverride(false);
     setParcelEnvironmentVersion(INVALID_PARCEL_ENVIRONMENT_VERSION);
 
     setObscureMOAP(false);
@@ -949,7 +949,7 @@ const std::string& LLParcel::getActionString(LLParcel::EAction action)
 
 bool LLParcel::isSaleTimerExpired(const U64& time)
 {
-    if (mSaleTimerExpires.getStarted() == FALSE)
+    if (mSaleTimerExpires.getStarted() == false)
     {
         return false;
     }
@@ -1011,11 +1011,11 @@ void LLParcel::expireSale(
     mSaleTimerExpires.setTimerExpirySec(0.0);
     mSaleTimerExpires.stop();
     setPreviousOwnerID(LLUUID::null);
-    setPreviouslyGroupOwned(FALSE);
-    setSellWithObjects(FALSE);
+    setPreviouslyGroupOwned(false);
+    setSellWithObjects(false);
     type = TRANS_LAND_RELEASE;
     mStatus = OS_NONE;
-    flags = pack_transaction_flags(mGroupOwned, FALSE);
+    flags = pack_transaction_flags(mGroupOwned, false);
     mAuthBuyerID.setNull();
     from_id = mOwnerID;
     mOwnerID.setNull();
@@ -1037,7 +1037,7 @@ void LLParcel::completeSale(
 
 	// Purchased parcels are assumed to no longer be for sale.
 	// Otherwise someone can snipe the sale.
-	setForSale(FALSE);
+	setForSale(false);
 	setAuctionID(0);
 
 	// Turn off show directory, since it's a recurring fee that
@@ -1062,11 +1062,11 @@ void LLParcel::clearSale()
 		mStatus = OS_LEASED;
 	}
 	mAuthBuyerID.setNull();
-	setForSale(FALSE);
+	setForSale(false);
 	setAuctionID(0);
 	setPreviousOwnerID(LLUUID::null);
-	setPreviouslyGroupOwned(FALSE);
-	setSellWithObjects(FALSE);
+	setPreviouslyGroupOwned(false);
+	setSellWithObjects(false);
 }
 
 bool LLParcel::isPublic() const
@@ -1093,15 +1093,15 @@ void LLParcel::clearParcel()
 	setMediaID(LLUUID::null);
     setMediaDesc(LLStringUtil::null);
 	setMediaAutoScale(0);
-	setMediaLoop(TRUE);
+	setMediaLoop(1);
 	mMediaWidth = 0;
 	mMediaHeight = 0;
 	setMediaCurrentURL(LLStringUtil::null);
-	setMediaAllowNavigate(TRUE);
-	setMediaPreventCameraZoom(FALSE);
+	setMediaAllowNavigate(1);
+	setMediaPreventCameraZoom(0);
 	setMediaURLTimeout(0.0f);
 	setMusicURL(LLStringUtil::null);
-	setInEscrow(FALSE);
+	setInEscrow(false);
 	setAuthorizedBuyerID(LLUUID::null);
 	setCategory(C_NONE);
 	setSnapshotID(LLUUID::null);

--- a/indra/llinventory/llparcel.h
+++ b/indra/llinventory/llparcel.h
@@ -277,7 +277,7 @@ public:
 	void setUserLocation(const LLVector3& pos)	{ mUserLocation = pos; }
 	void setUserLookAt(const LLVector3& rot)	{ mUserLookAt = rot; }
 	void setLandingType(const ELandingType type) { mLandingType = type; }
-	void setSeeAVs(BOOL see_avs)	{ mSeeAVs = see_avs;	}
+	void setSeeAVs(bool see_avs)	{ mSeeAVs = see_avs;	}
 	void setHaveNewParcelLimitData(bool have_new_parcel_data)		{ mHaveNewParcelLimitData = have_new_parcel_data;		}		// Remove this once hidden AV feature is fully available grid-wide
 
 	void setAuctionID(U32 auction_id) { mAuctionID = auction_id;}
@@ -288,24 +288,24 @@ public:
 	virtual void setArea(S32 area, S32 sim_object_limit);
 	void	setDiscountRate(F32 rate);
 
-	void	setAllowModify(BOOL b)	{ setParcelFlag(PF_CREATE_OBJECTS, b); }
-	void	setAllowGroupModify(BOOL b)	{ setParcelFlag(PF_CREATE_GROUP_OBJECTS, b); }
-	void	setAllowAllObjectEntry(BOOL b)	{ setParcelFlag(PF_ALLOW_ALL_OBJECT_ENTRY, b); }
-	void	setAllowGroupObjectEntry(BOOL b)	{ setParcelFlag(PF_ALLOW_GROUP_OBJECT_ENTRY, b); }
-	void	setAllowTerraform(BOOL b){setParcelFlag(PF_ALLOW_TERRAFORM, b); }
-	void	setAllowDamage(BOOL b)	{ setParcelFlag(PF_ALLOW_DAMAGE, b); }
-	void	setAllowFly(BOOL b)		{ setParcelFlag(PF_ALLOW_FLY, b); }
-	void	setAllowGroupScripts(BOOL b)	{ setParcelFlag(PF_ALLOW_GROUP_SCRIPTS, b); }
-	void	setAllowOtherScripts(BOOL b)	{ setParcelFlag(PF_ALLOW_OTHER_SCRIPTS, b); }
-	void	setAllowDeedToGroup(BOOL b) { setParcelFlag(PF_ALLOW_DEED_TO_GROUP, b); }
-	void    setContributeWithDeed(BOOL b) { setParcelFlag(PF_CONTRIBUTE_WITH_DEED, b); }
-	void	setForSale(BOOL b)		{ setParcelFlag(PF_FOR_SALE, b); }
-	void	setSoundOnly(BOOL b)	{ setParcelFlag(PF_SOUND_LOCAL, b); }
-	void	setDenyAnonymous(BOOL b) { setParcelFlag(PF_DENY_ANONYMOUS, b); }
-	void	setDenyAgeUnverified(BOOL b) { setParcelFlag(PF_DENY_AGEUNVERIFIED, b); }
-	void	setRestrictPushObject(BOOL b) { setParcelFlag(PF_RESTRICT_PUSHOBJECT, b); }
-	void	setAllowGroupAVSounds(BOOL b)	{ mAllowGroupAVSounds = b;		}
-	void	setAllowAnyAVSounds(BOOL b)		{ mAllowAnyAVSounds = b;		}
+	void	setAllowModify(bool b)	{ setParcelFlag(PF_CREATE_OBJECTS, b); }
+	void	setAllowGroupModify(bool b)	{ setParcelFlag(PF_CREATE_GROUP_OBJECTS, b); }
+	void	setAllowAllObjectEntry(bool b)	{ setParcelFlag(PF_ALLOW_ALL_OBJECT_ENTRY, b); }
+	void	setAllowGroupObjectEntry(bool b)	{ setParcelFlag(PF_ALLOW_GROUP_OBJECT_ENTRY, b); }
+	void	setAllowTerraform(bool b){setParcelFlag(PF_ALLOW_TERRAFORM, b); }
+	void	setAllowDamage(bool b)	{ setParcelFlag(PF_ALLOW_DAMAGE, b); }
+	void	setAllowFly(bool b)		{ setParcelFlag(PF_ALLOW_FLY, b); }
+	void	setAllowGroupScripts(bool b)	{ setParcelFlag(PF_ALLOW_GROUP_SCRIPTS, b); }
+	void	setAllowOtherScripts(bool b)	{ setParcelFlag(PF_ALLOW_OTHER_SCRIPTS, b); }
+	void	setAllowDeedToGroup(bool b) { setParcelFlag(PF_ALLOW_DEED_TO_GROUP, b); }
+	void    setContributeWithDeed(bool b) { setParcelFlag(PF_CONTRIBUTE_WITH_DEED, b); }
+	void	setForSale(bool b)		{ setParcelFlag(PF_FOR_SALE, b); }
+	void	setSoundOnly(bool b)	{ setParcelFlag(PF_SOUND_LOCAL, b); }
+	void	setDenyAnonymous(bool b) { setParcelFlag(PF_DENY_ANONYMOUS, b); }
+	void	setDenyAgeUnverified(bool b) { setParcelFlag(PF_DENY_AGEUNVERIFIED, b); }
+	void	setRestrictPushObject(bool b) { setParcelFlag(PF_RESTRICT_PUSHOBJECT, b); }
+	void	setAllowGroupAVSounds(bool b)	{ mAllowGroupAVSounds = b;		}
+	void	setAllowAnyAVSounds(bool b)		{ mAllowAnyAVSounds = b;		}
     void    setObscureMOAP(bool b)  { mObscureMOAP = b; }
 
 	void	setDrawDistance(F32 dist)	{ mDrawDistance = dist; }
@@ -315,9 +315,9 @@ public:
 	void	setPassPrice(S32 price)				{ mPassPrice = price; }
 	void	setPassHours(F32 hours)				{ mPassHours = hours; }
 
-//	BOOL	importStream(std::istream& input_stream);
+//	bool	importStream(std::istream& input_stream);
 	bool	importAccessEntry(std::istream& input_stream, LLAccessEntry* entry);
-	// BOOL	exportStream(std::ostream& output_stream);
+	// bool	exportStream(std::ostream& output_stream);
 
 	void	packMessage(LLMessageSystem* msg);
 	void	packMessage(LLSD& msg);
@@ -372,7 +372,7 @@ public:
 	const LLUUID&	getGroupID() const			{ return mGroupID; }
 	S32				getPassPrice() const		{ return mPassPrice; }
 	F32				getPassHours() const		{ return mPassHours; }
-	BOOL			getIsGroupOwned() const		{ return mGroupOwned; }
+	bool			getIsGroupOwned() const		{ return mGroupOwned; }
 
 	U32 getAuctionID() const	{ return mAuctionID; }
 	bool isInEscrow() const		{ return mInEscrow; }
@@ -462,62 +462,62 @@ public:
 					{ return (mParcelFlags & PF_ALLOW_DEED_TO_GROUP) ? true : false; }
 
 	// Does the owner want to make a contribution along with the deed.
-	BOOL getContributeWithDeed() const
-	{ return (mParcelFlags & PF_CONTRIBUTE_WITH_DEED) ? TRUE : FALSE; }
+	bool getContributeWithDeed() const
+	{ return (mParcelFlags & PF_CONTRIBUTE_WITH_DEED) ? true : false; }
 
 	// heightfield can be modified
-	BOOL	getAllowTerraform() const
-					{ return (mParcelFlags & PF_ALLOW_TERRAFORM) ? TRUE : FALSE; }
+	bool	getAllowTerraform() const
+					{ return (mParcelFlags & PF_ALLOW_TERRAFORM) ? true : false; }
 
 	// avatars can be hurt here
-	BOOL	getAllowDamage() const
-					{ return (mParcelFlags & PF_ALLOW_DAMAGE) ? TRUE : FALSE; }
+	bool	getAllowDamage() const
+					{ return (mParcelFlags & PF_ALLOW_DAMAGE) ? true : false; }
 
-	BOOL	getAllowFly() const
-					{ return (mParcelFlags & PF_ALLOW_FLY) ? TRUE : FALSE; }
+	bool	getAllowFly() const
+					{ return (mParcelFlags & PF_ALLOW_FLY) ? true : false; }
 
-	BOOL	getAllowGroupScripts() const
-					{ return (mParcelFlags & PF_ALLOW_GROUP_SCRIPTS) ? TRUE : FALSE; }
+	bool	getAllowGroupScripts() const
+					{ return (mParcelFlags & PF_ALLOW_GROUP_SCRIPTS) ? true : false; }
 
-	BOOL	getAllowOtherScripts() const
-					{ return (mParcelFlags & PF_ALLOW_OTHER_SCRIPTS) ? TRUE : FALSE; }
+	bool	getAllowOtherScripts() const
+					{ return (mParcelFlags & PF_ALLOW_OTHER_SCRIPTS) ? true : false; }
 
-	BOOL	getAllowAllObjectEntry() const
-					{ return (mParcelFlags & PF_ALLOW_ALL_OBJECT_ENTRY) ? TRUE : FALSE; }
+	bool	getAllowAllObjectEntry() const
+					{ return (mParcelFlags & PF_ALLOW_ALL_OBJECT_ENTRY) ? true : false; }
 
-	BOOL	getAllowGroupObjectEntry() const
-					{ return (mParcelFlags & PF_ALLOW_GROUP_OBJECT_ENTRY) ? TRUE : FALSE; }
+	bool	getAllowGroupObjectEntry() const
+					{ return (mParcelFlags & PF_ALLOW_GROUP_OBJECT_ENTRY) ? true : false; }
 
-	BOOL	getForSale() const
-					{ return (mParcelFlags & PF_FOR_SALE) ? TRUE : FALSE; }
-	BOOL	getSoundLocal() const
-					{ return (mParcelFlags & PF_SOUND_LOCAL) ? TRUE : FALSE; }
-	BOOL	getParcelFlagAllowVoice() const
-					{ return (mParcelFlags & PF_ALLOW_VOICE_CHAT) ? TRUE : FALSE; }
-	BOOL	getParcelFlagUseEstateVoiceChannel() const
-					{ return (mParcelFlags & PF_USE_ESTATE_VOICE_CHAN) ? TRUE : FALSE; }
-	BOOL	getAllowPublish() const
-					{ return (mParcelFlags & PF_ALLOW_PUBLISH) ? TRUE : FALSE; }
-	BOOL	getMaturePublish() const
-					{ return (mParcelFlags & PF_MATURE_PUBLISH) ? TRUE : FALSE; }
-	BOOL	getRestrictPushObject() const
-					{ return (mParcelFlags & PF_RESTRICT_PUSHOBJECT) ? TRUE : FALSE; }
-	BOOL	getRegionPushOverride() const
+	bool	getForSale() const
+					{ return (mParcelFlags & PF_FOR_SALE) ? true : false; }
+	bool	getSoundLocal() const
+					{ return (mParcelFlags & PF_SOUND_LOCAL) ? true : false; }
+	bool	getParcelFlagAllowVoice() const
+					{ return (mParcelFlags & PF_ALLOW_VOICE_CHAT) ? true : false; }
+	bool	getParcelFlagUseEstateVoiceChannel() const
+					{ return (mParcelFlags & PF_USE_ESTATE_VOICE_CHAN) ? true : false; }
+	bool	getAllowPublish() const
+					{ return (mParcelFlags & PF_ALLOW_PUBLISH) ? true : false; }
+	bool	getMaturePublish() const
+					{ return (mParcelFlags & PF_MATURE_PUBLISH) ? true : false; }
+	bool	getRestrictPushObject() const
+					{ return (mParcelFlags & PF_RESTRICT_PUSHOBJECT) ? true : false; }
+	bool	getRegionPushOverride() const
 					{ return mRegionPushOverride; }
-	BOOL	getRegionDenyAnonymousOverride() const
+	bool	getRegionDenyAnonymousOverride() const
 					{ return mRegionDenyAnonymousOverride; }
-	BOOL	getRegionDenyAgeUnverifiedOverride() const
+	bool	getRegionDenyAgeUnverifiedOverride() const
 					{ return mRegionDenyAgeUnverifiedOverride; }
-    BOOL    getRegionAllowAccessOverride() const
+    bool    getRegionAllowAccessOverride() const
                     { return mRegionAllowAccessoverride; }
-    BOOL    getRegionAllowEnvironmentOverride() const
+    bool    getRegionAllowEnvironmentOverride() const
                     { return mRegionAllowEnvironmentOverride; }
     S32     getParcelEnvironmentVersion() const 
                     { return mCurrentEnvironmentVersion; }
 
 
-	BOOL	getAllowGroupAVSounds()	const	{ return mAllowGroupAVSounds;	} 
-	BOOL	getAllowAnyAVSounds()	const	{ return mAllowAnyAVSounds;		}
+	bool	getAllowGroupAVSounds()	const	{ return mAllowGroupAVSounds;	}
+	bool	getAllowAnyAVSounds()	const	{ return mAllowAnyAVSounds;		}
  
     bool    getObscureMOAP() const { return mObscureMOAP; }
 
@@ -582,30 +582,30 @@ public:
 	void	setParcelPrimBonus(F32 bonus) 	{ mParcelPrimBonus = bonus; }
 
 	void	setCleanOtherTime(S32 time)					{ mCleanOtherTime = time; }
-	void	setRegionPushOverride(BOOL override) {mRegionPushOverride = override; }
-	void	setRegionDenyAnonymousOverride(BOOL override)	{ mRegionDenyAnonymousOverride = override; }
-	void	setRegionDenyAgeUnverifiedOverride(BOOL override)	{ mRegionDenyAgeUnverifiedOverride = override; }
-    void    setRegionAllowAccessOverride(BOOL override) { mRegionAllowAccessoverride = override; }
-    void    setRegionAllowEnvironmentOverride(BOOL override) { mRegionAllowEnvironmentOverride = override; }
+	void	setRegionPushOverride(bool override) {mRegionPushOverride = override; }
+	void	setRegionDenyAnonymousOverride(bool override)	{ mRegionDenyAnonymousOverride = override; }
+	void	setRegionDenyAgeUnverifiedOverride(bool override)	{ mRegionDenyAgeUnverifiedOverride = override; }
+    void    setRegionAllowAccessOverride(bool override) { mRegionAllowAccessoverride = override; }
+    void    setRegionAllowEnvironmentOverride(bool override) { mRegionAllowEnvironmentOverride = override; }
 
     void    setParcelEnvironmentVersion(S32 version) { mCurrentEnvironmentVersion = version; }
 
 	// Accessors for parcel sellWithObjects
 	void	setPreviousOwnerID(LLUUID prev_owner)	{ mPreviousOwnerID = prev_owner; }
-	void	setPreviouslyGroupOwned(BOOL b)			{ mPreviouslyGroupOwned = b; }
-	void	setSellWithObjects(BOOL b)				{ setParcelFlag(PF_SELL_PARCEL_OBJECTS, b); }
+	void	setPreviouslyGroupOwned(bool b)			{ mPreviouslyGroupOwned = b; }
+	void	setSellWithObjects(bool b)				{ setParcelFlag(PF_SELL_PARCEL_OBJECTS, b); }
 
 	LLUUID	getPreviousOwnerID() const		{ return mPreviousOwnerID; }
-	BOOL	getPreviouslyGroupOwned() const	{ return mPreviouslyGroupOwned; }
-	BOOL	getSellWithObjects() const		{ return (mParcelFlags & PF_SELL_PARCEL_OBJECTS) ? TRUE : FALSE; }
+	bool	getPreviouslyGroupOwned() const	{ return mPreviouslyGroupOwned; }
+	bool	getSellWithObjects() const		{ return (mParcelFlags & PF_SELL_PARCEL_OBJECTS) ? true : false; }
 
 protected:
 	LLUUID mID;
 	LLUUID				mOwnerID;
 	LLUUID				mGroupID;
-	BOOL				mGroupOwned; // TRUE if mOwnerID is a group_id
+	bool				mGroupOwned; // true if mOwnerID is a group_id
 	LLUUID				mPreviousOwnerID;
-	BOOL				mPreviouslyGroupOwned;
+	bool				mPreviouslyGroupOwned;
 
 	EOwnershipStatus mStatus;
 	ECategory mCategory;
@@ -614,8 +614,8 @@ protected:
 	LLVector3 mUserLocation;
 	LLVector3 mUserLookAt;
 	ELandingType mLandingType;
-	BOOL mSeeAVs;							// Avatars on this parcel are visible from outside it
-	BOOL mHaveNewParcelLimitData;			// Remove once hidden AV feature is grid-wide
+	bool mSeeAVs;							// Avatars on this parcel are visible from outside it
+	bool mHaveNewParcelLimitData;			// Remove once hidden AV feature is grid-wide
 	LLTimer mSaleTimerExpires;
 	LLTimer mMediaResetTimer;
 
@@ -666,13 +666,13 @@ protected:
 	S32					mTempPrimCount;
 	F32					mParcelPrimBonus;
 	S32					mCleanOtherTime;
-	BOOL				mRegionPushOverride;
-	BOOL				mRegionDenyAnonymousOverride;
-	BOOL				mRegionDenyAgeUnverifiedOverride;
-    BOOL                mRegionAllowAccessoverride;
-    BOOL                mRegionAllowEnvironmentOverride;
-	BOOL				mAllowGroupAVSounds;
-	BOOL				mAllowAnyAVSounds;
+	bool				mRegionPushOverride;
+	bool				mRegionDenyAnonymousOverride;
+	bool				mRegionDenyAgeUnverifiedOverride;
+    bool                mRegionAllowAccessoverride;
+    bool                mRegionAllowEnvironmentOverride;
+	bool				mAllowGroupAVSounds;
+	bool				mAllowAnyAVSounds;
     bool                mObscureMOAP;
     S32                 mCurrentEnvironmentVersion;
 	
@@ -692,13 +692,11 @@ public:
 
 	void setExperienceKeyType(const LLUUID& experience_key, U32 type);
 	U32 countExperienceKeyType(U32 type);
-	U32 getExperienceKeyType(const LLUUID& experience_key)const;
 	LLAccessEntry::map getExperienceKeysByType(U32 type)const;
 	void clearExperienceKeysByType(U32 type);
 
 private:
 	xp_type_map_t mExperienceKeys;
-
 };
 
 

--- a/indra/llinventory/llpermissions.h
+++ b/indra/llinventory/llpermissions.h
@@ -285,20 +285,20 @@ public:
 	// They also return true if the object isn't owned, or the
 	// requesting agent is a system agent.  See llpermissionsflags.h
 	// for bits.
-	//BOOL	allowDeleteBy(const LLUUID& agent_id) 	const		{ return allowModifyBy(agent_id); }
-	//BOOL	allowEditBy(const LLUUID& agent_id) 	const		{ return allowModifyBy(agent_id); }
+	//bool	allowDeleteBy(const LLUUID& agent_id) 	const		{ return allowModifyBy(agent_id); }
+	//bool	allowEditBy(const LLUUID& agent_id) 	const		{ return allowModifyBy(agent_id); }
 	// saves last owner and sets current owner
-	//BOOL setOwner(const LLUUID& agent, const LLUUID& owner);	
+	//bool setOwner(const LLUUID& agent, const LLUUID& owner);	
 	// This method saves the last owner, sets the current owner to the
 	// one provided, and sets the base mask as indicated.
-	//BOOL setOwner(const LLUUID& agent, const LLUUID& owner, U32 new_base_mask);
+	//bool setOwner(const LLUUID& agent, const LLUUID& owner, U32 new_base_mask);
 
 	// Attempt to set or clear the given bitmask.  Returns TRUE if you
 	// are allowed to modify the permissions.  If you attempt to turn
 	// on bits not allowed by the base bits, the function will return
 	// TRUE, but those bits will not be set.
-	//BOOL setGroupBits( const LLUUID& agent, BOOL set, PermissionMask bits);
-	//BOOL setEveryoneBits(const LLUUID& agent, BOOL set, PermissionMask bits);
+	//bool setGroupBits( const LLUUID& agent, bool set, PermissionMask bits);
+	//bool setEveryoneBits(const LLUUID& agent, bool set, PermissionMask bits);
 
 	//
 	// MISC METHODS and OPERATORS
@@ -361,7 +361,7 @@ bool LLPermissions::allowTransferTo(const LLUUID &agent_id) const
 	}
 	else
 	{
-		return ((mOwner == agent_id) ? TRUE : allowOperationBy(PERM_TRANSFER, mOwner));
+		return ((mOwner == agent_id) ? true : allowOperationBy(PERM_TRANSFER, mOwner));
 	}
 }
 

--- a/indra/llinventory/llsaleinfo.cpp
+++ b/indra/llinventory/llsaleinfo.cpp
@@ -163,7 +163,7 @@ bool LLSaleInfo::importLegacyStream(std::istream& input_stream, bool& has_perm_m
 		else if (!strcmp("perm_mask", keyword))
 		{
 			//LL_INFOS() << "found deprecated keyword perm_mask" << LL_ENDL;
-			has_perm_mask = TRUE;
+			has_perm_mask = true;
 			sscanf(valuestr, "%x", &perm_mask);
 		}
 		else

--- a/indra/llinventory/lltransactionflags.cpp
+++ b/indra/llinventory/lltransactionflags.cpp
@@ -38,7 +38,7 @@ const U8 TRANSACTION_FLAG_OWNER_GROUP = 4;
 const U8 TRANSACTION_FLAG_SIMULTANEOUS_CONTRIBUTION = 8;
 const U8 TRANSACTION_FLAG_SIMULTANEOUS_CONTRIBUTION_REMOVAL = 16;
 
-U8 pack_transaction_flags(BOOL is_source_group, BOOL is_dest_group)
+U8 pack_transaction_flags(bool is_source_group, bool is_dest_group)
 {
 	U8 rv = 0;
 	if(is_source_group) rv |= TRANSACTION_FLAG_SOURCE_GROUP;
@@ -46,17 +46,17 @@ U8 pack_transaction_flags(BOOL is_source_group, BOOL is_dest_group)
 	return rv;
 }
 
-BOOL is_tf_source_group(TransactionFlags flags)
+bool is_tf_source_group(TransactionFlags flags)
 {
 	return ((flags & TRANSACTION_FLAG_SOURCE_GROUP) == TRANSACTION_FLAG_SOURCE_GROUP);
 }
 
-BOOL is_tf_dest_group(TransactionFlags flags)
+bool is_tf_dest_group(TransactionFlags flags)
 {
 	return ((flags & TRANSACTION_FLAG_DEST_GROUP) == TRANSACTION_FLAG_DEST_GROUP);
 }
 
-BOOL is_tf_owner_group(TransactionFlags flags)
+bool is_tf_owner_group(TransactionFlags flags)
 {
 	return ((flags & TRANSACTION_FLAG_OWNER_GROUP) == TRANSACTION_FLAG_OWNER_GROUP);
 }
@@ -79,6 +79,7 @@ void append_reason(
 		break;
 	case TRANS_GROUP_LAND_DEED:
 		ostr << " for deeding land";
+		break;
 	default:
 		break;
 	}

--- a/indra/llinventory/lltransactionflags.h
+++ b/indra/llinventory/lltransactionflags.h
@@ -39,10 +39,10 @@ extern const TransactionFlags TRANSACTION_FLAG_SIMULTANEOUS_CONTRIBUTION;
 extern const TransactionFlags TRANSACTION_FLAG_SIMULTANEOUS_CONTRIBUTION_REMOVAL;
 
 // very simple helper functions
-TransactionFlags pack_transaction_flags(BOOL is_source_group, BOOL is_dest_group);
-BOOL is_tf_source_group(TransactionFlags flags);
-BOOL is_tf_dest_group(TransactionFlags flags);
-BOOL is_tf_owner_group(TransactionFlags flags);
+TransactionFlags pack_transaction_flags(bool is_source_group, bool is_dest_group);
+bool is_tf_source_group(TransactionFlags flags);
+bool is_tf_dest_group(TransactionFlags flags);
+bool is_tf_owner_group(TransactionFlags flags);
 
 // stupid helper functions which should be replaced with some kind of
 // internationalizeable message.

--- a/indra/llmessage/llassetstorage.cpp
+++ b/indra/llmessage/llassetstorage.cpp
@@ -198,14 +198,14 @@ LLBaseDownloadRequest::LLBaseDownloadRequest(const LLUUID &uuid, const LLAssetTy
       mDownCallback(),
       mUserData(NULL),
       mHost(),
-      mIsTemp(FALSE),
-      mIsPriority(FALSE),
-      mDataSentInFirstPacket(FALSE),
-      mDataIsInCache(FALSE)
+      mIsTemp(false),
+      mIsPriority(false),
+      mDataSentInFirstPacket(false),
+      mDataIsInCache(false)
 {
     // Need to guarantee that this time is up to date, we may be creating a circuit even though we haven't been
     //  running a message system loop.
-    mTime = LLMessageSystem::getMessageTimeSeconds(TRUE);
+    mTime = LLMessageSystem::getMessageTimeSeconds(true);
 }
 
 // virtual
@@ -228,8 +228,8 @@ LLAssetRequest::LLAssetRequest(const LLUUID &uuid, const LLAssetType::EType type
     :   LLBaseDownloadRequest(uuid, type),
         mUpCallback(),
         mInfoCallback( NULL ),
-        mIsLocal(FALSE),
-        mIsUserWaiting(FALSE),
+        mIsLocal(false),
+        mIsUserWaiting(false),
         mTimeout(LL_ASSET_STORAGE_TIMEOUT),
         mBytesFetched(0)
 {
@@ -344,7 +344,7 @@ void LLAssetStorage::_init(LLMessageSystem *msg,
                            LLXferManager *xfer,
                            const LLHost &upstream_host)
 {
-    mShutDown = FALSE;
+    mShutDown = false;
     mMessageSys = msg;
     mXferManager = xfer;
 

--- a/indra/llmessage/llassetstorage.h
+++ b/indra/llmessage/llassetstorage.h
@@ -122,11 +122,11 @@ public:
 
     void	*mUserData;
     LLHost  mHost;
-    BOOL	mIsTemp;
+    bool	mIsTemp;
     F64Seconds		mTime;				// Message system time
-    BOOL    mIsPriority;
-    BOOL	mDataSentInFirstPacket;
-    BOOL	mDataIsInCache;
+    bool    mIsPriority;
+    bool	mDataSentInFirstPacket;
+    bool	mDataIsInCache;
 };
 
 class LLAssetRequest : public LLBaseDownloadRequest
@@ -143,8 +143,8 @@ public:
 //	void	(*mUpCallback)(const LLUUID&, void *, S32, LLExtStat);
 	void	(*mInfoCallback)(LLAssetInfo *, void *, S32);
 
-	BOOL	mIsLocal;
-	BOOL	mIsUserWaiting;		// We don't want to try forever if a user is waiting for a result.
+	bool	mIsLocal;
+	bool	mIsUserWaiting;		// We don't want to try forever if a user is waiting for a result.
 	F64Seconds		mTimeout;			// Amount of time before timing out.
 	LLUUID	mRequestingAgentID;	// Only valid for uploads from an agent
     F64	mBytesFetched;
@@ -209,7 +209,7 @@ public:
 	};
 
 protected:
-	BOOL mShutDown;
+	bool mShutDown;
 	LLHost mUpstreamHost;
 	
 	LLMessageSystem *mMessageSys;

--- a/indra/llmessage/llblowfishcipher.h
+++ b/indra/llmessage/llblowfishcipher.h
@@ -46,7 +46,7 @@ public:
 	/*virtual*/ U32 requiredEncryptionSpace(U32 src_len) const;
 
 #ifdef _DEBUG
-	static BOOL testHarness();
+	static bool testHarness();
 #endif
 
 private:

--- a/indra/llmessage/llcachename.cpp
+++ b/indra/llmessage/llcachename.cpp
@@ -99,7 +99,7 @@ public:
 	}
 	
 	void done()			{ mID.setNull(); }
-	bool isDone() const	{ return mID.isNull() != FALSE; }
+	bool isDone() const	{ return mID.isNull() != false; }
 };
 
 class ReplySender

--- a/indra/llmessage/llcircuit.cpp
+++ b/indra/llmessage/llcircuit.cpp
@@ -73,10 +73,10 @@ LLCircuitData::LLCircuitData(const LLHost &host, TPACKETID in_id,
 	mHighestPacketID(in_id),
 	mTimeoutCallback(NULL),
 	mTimeoutUserData(NULL),
-	mTrusted(FALSE),
-	mbAllowTimeout(TRUE),
-	mbAlive(TRUE),
-	mBlocked(FALSE),
+	mTrusted(false),
+	mbAllowTimeout(true),
+	mbAlive(true),
+	mBlocked(false),
 	mPingTime(0.0),
 	mLastPingSendTime(0.0),
 	mLastPingReceivedTime(0.0),
@@ -111,7 +111,7 @@ LLCircuitData::LLCircuitData(const LLHost &host, TPACKETID in_id,
 {
 	// Need to guarantee that this time is up to date, we may be creating a circuit even though we haven't been
 	//  running a message system loop.
-	F64Seconds mt_sec = LLMessageSystem::getMessageTimeSeconds(TRUE);
+	F64Seconds mt_sec = LLMessageSystem::getMessageTimeSeconds(true);
 	F32 distribution_offset = ll_frand();
 	
 	mPingTime = mt_sec;
@@ -1273,7 +1273,7 @@ void LLCircuitData::pingTimerStop(const U8 ping_id)
 	{
 		// Ack, we got our ping response on the same frame! Sigh, let's get a real time otherwise
 		// all of our ping calculations will be skewed.
-		mt_secs = LLMessageSystem::getMessageTimeSeconds(TRUE);
+		mt_secs = LLMessageSystem::getMessageTimeSeconds(true);
 	}
 	mLastPingReceivedTime = mt_secs;
 
@@ -1291,7 +1291,7 @@ void LLCircuitData::pingTimerStop(const U8 ping_id)
 	mPingsInTransit = delta_ping;
 	if (mBlocked && (mPingsInTransit <= PING_RELEASE_BLOCK))
 	{
-		mBlocked = FALSE;
+		mBlocked = false;
 	}
 }
 

--- a/indra/llmessage/llclassifiedflags.h
+++ b/indra/llmessage/llclassifiedflags.h
@@ -53,7 +53,7 @@ const S32 MAX_CLASSIFIEDS = 100;
 // we can revert back to ClassifiedFlags pack_classified_flags and get rider of this one.
 ClassifiedFlags pack_classified_flags_request(bool auto_renew, bool is_pg, bool is_mature, bool is_adult);
 
-ClassifiedFlags pack_classified_flags(BOOL auto_renew, BOOL is_pg, BOOL is_mature, BOOL is_adult);
+ClassifiedFlags pack_classified_flags(bool auto_renew, bool is_pg, bool is_mature, bool is_adult);
 bool is_cf_mature(ClassifiedFlags flags);
 //bool is_cf_enabled(ClassifiedFlags flags);
 bool is_cf_update_time(ClassifiedFlags flags);

--- a/indra/llmessage/llmessagetemplate.h
+++ b/indra/llmessage/llmessagetemplate.h
@@ -361,14 +361,14 @@ public:
 		mUserData = user_data;
 	}
 
-	BOOL callHandlerFunc(LLMessageSystem *msgsystem) const
+	bool callHandlerFunc(LLMessageSystem *msgsystem) const
 	{
 		if (mHandlerFunc)
 		{
 			mHandlerFunc(msgsystem, mUserData);
-			return TRUE;
+			return true;
 		}
-		return FALSE;
+		return false;
 	}
 
 	bool isUdpBanned() const

--- a/indra/llmessage/llmessagetemplateparser.cpp
+++ b/indra/llmessage/llmessagetemplateparser.cpp
@@ -180,12 +180,12 @@ bool	b_check_token(const char *token, const char *regexp)
 		if (current_checker == -1)
 		{
 			LL_ERRS() << "Input exceeds regular expression!\nDid you forget a *?" << LL_ENDL;
-			return FALSE;
+			return false;
 		}
 
 		if (!gParseCheckCharacters[current_checker](token[tptr]))
 		{
-			return FALSE;
+			return false;
 		}
 		if (next_checker != 9999)
 		{

--- a/indra/llmessage/llpacketack.h
+++ b/indra/llmessage/llpacketack.h
@@ -35,7 +35,7 @@ class LLReliablePacketParams
 public:
 	LLHost mHost;
 	S32 mRetries;
-	BOOL mPingBasedRetry;
+	bool mPingBasedRetry;
 	F32Seconds mTimeout;
 	void (*mCallback)(void **,S32);
 	void** mCallbackData;
@@ -53,7 +53,7 @@ public:
 	{
 		mHost.invalidate();
 		mRetries = 0;
-		mPingBasedRetry = TRUE;
+		mPingBasedRetry = true;
 		mTimeout = F32Seconds(0.f);
 		mCallback = NULL;
 		mCallbackData = NULL;
@@ -63,7 +63,7 @@ public:
 	void set(
 		const LLHost& host,
 		S32 retries,
-		BOOL ping_based_retry,
+		bool ping_based_retry,
 		F32Seconds timeout, 
 		void (*callback)(void**,S32),
 		void** callback_data, char* name)
@@ -98,7 +98,7 @@ protected:
 	S32 mSocket;
 	LLHost mHost;
 	S32 mRetries;
-	BOOL mPingBasedRetry;
+	bool mPingBasedRetry;
 	F32Seconds mTimeout;
 	void (*mCallback)(void**,S32);
 	void** mCallbackData;

--- a/indra/llmessage/llpacketring.cpp
+++ b/indra/llmessage/llpacketring.cpp
@@ -45,8 +45,8 @@
 
 ///////////////////////////////////////////////////////////
 LLPacketRing::LLPacketRing () :
-	mUseInThrottle(FALSE),
-	mUseOutThrottle(FALSE),
+	mUseInThrottle(false),
+	mUseOutThrottle(false),
 	mInThrottle(256000.f),
 	mOutThrottle(64000.f),
 	mActualBitsIn(0),

--- a/indra/llmessage/llregionflags.h
+++ b/indra/llmessage/llregionflags.h
@@ -106,7 +106,7 @@ const U64 REGION_FLAGS_ESTATE_MASK = REGION_FLAGS_EXTERNALLY_VISIBLE
 									 | REGION_FLAGS_DENY_ANONYMOUS
 									 | REGION_FLAGS_DENY_AGEUNVERIFIED;
 
-inline BOOL is_prelude( U64 flags )
+inline bool is_prelude( U64 flags )
 {
 	// definition of prelude does not depend on fixed-sun
 	return 0 == (flags & REGION_FLAGS_PRELUDE_UNSET)

--- a/indra/llmessage/llregionhandle.h
+++ b/indra/llmessage/llregionhandle.h
@@ -63,13 +63,13 @@ inline U64 to_region_handle_global(const F32 x_global, const F32 y_global)
 	return region_handle;
 }
 
-inline BOOL to_region_handle(const F32 x_pos, const F32 y_pos, U64 *region_handle)
+inline bool to_region_handle(const F32 x_pos, const F32 y_pos, U64 *region_handle)
 {
 	U32 x_int, y_int;
 	if (x_pos < 0.f)
 	{
 //		LL_WARNS() << "to_region_handle:Clamping negative x position " << x_pos << " to zero!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	else
 	{
@@ -78,14 +78,14 @@ inline BOOL to_region_handle(const F32 x_pos, const F32 y_pos, U64 *region_handl
 	if (y_pos < 0.f)
 	{
 //		LL_WARNS() << "to_region_handle:Clamping negative y position " << y_pos << " to zero!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	else
 	{
 		y_int = (U32)ll_round(y_pos);
 	}
 	*region_handle = to_region_handle(x_int, y_int);
-	return TRUE;
+	return true;
 }
 
 // stuff the word-frame XY location of sim's SouthWest corner in x_pos, y_pos

--- a/indra/llmessage/llsdmessagebuilder.cpp
+++ b/indra/llmessage/llsdmessagebuilder.cpp
@@ -44,8 +44,8 @@ LLSDMessageBuilder::LLSDMessageBuilder() :
 	mCurrentBlock(NULL),
 	mCurrentMessageName(""),
 	mCurrentBlockName(""),
-	mbSBuilt(FALSE),
-	mbSClear(TRUE)
+	mbSBuilt(false),
+	mbSClear(true)
 {
 }
 
@@ -58,8 +58,8 @@ LLSDMessageBuilder::~LLSDMessageBuilder()
 // virtual
 void LLSDMessageBuilder::newMessage(const char* name)
 {
-	mbSBuilt = FALSE;
-	mbSClear = FALSE;
+	mbSBuilt = false;
+	mbSClear = false;
 
 	mCurrentMessage = LLSD::emptyMap();
 	mCurrentMessageName = (char*)name;
@@ -170,7 +170,7 @@ void LLSDMessageBuilder::addIPPort(const char* varname, U16 v)
 
 void LLSDMessageBuilder::addBOOL(const char* varname, bool v)
 {
-	(*mCurrentBlock)[varname] = (v == true);
+	(*mCurrentBlock)[varname] = v;
 }
 
 void LLSDMessageBuilder::addString(const char* varname, const char* v)
@@ -354,7 +354,7 @@ void LLSDMessageBuilder::copyFromMessageData(const LLMsgData& data)
 				break;	
 
 			case MVT_BOOL:
-				addBOOL(varname, *(BOOL*)mvci.getData());
+				addBOOL(varname, *(bool*)mvci.getData());
 				break;
 
 			case MVT_IP_ADDR:

--- a/indra/llmessage/llsdmessagebuilder.h
+++ b/indra/llmessage/llsdmessagebuilder.h
@@ -119,8 +119,8 @@ private:
 	LLSD* mCurrentBlock;
 	std::string mCurrentMessageName;
 	std::string mCurrentBlockName;
-	BOOL mbSBuilt;
-	BOOL mbSClear;
+	bool mbSBuilt;
+	bool mbSClear;
 };
 
 #endif // LL_LLSDMESSAGEBUILDER_H

--- a/indra/llmessage/lltemplatemessagebuilder.cpp
+++ b/indra/llmessage/lltemplatemessagebuilder.cpp
@@ -42,8 +42,8 @@ LLTemplateMessageBuilder::LLTemplateMessageBuilder(const message_template_name_m
 	mCurrentSDataBlock(NULL),
 	mCurrentSMessageName(NULL),
 	mCurrentSBlockName(NULL),
-	mbSBuilt(FALSE),
-	mbSClear(TRUE),
+	mbSBuilt(false),
+	mbSClear(true),
 	mCurrentSendTotal(0),
 	mMessageTemplates(name_template_map)
 {
@@ -59,8 +59,8 @@ LLTemplateMessageBuilder::~LLTemplateMessageBuilder()
 // virtual
 void LLTemplateMessageBuilder::newMessage(const char *name)
 {
-	mbSBuilt = FALSE;
-	mbSClear = FALSE;
+	mbSBuilt = false;
+	mbSClear = false;
 
 	mCurrentSendTotal = 0;
 
@@ -103,8 +103,8 @@ void LLTemplateMessageBuilder::newMessage(const char *name)
 // virtual
 void LLTemplateMessageBuilder::clearMessage()
 {
-	mbSBuilt = FALSE;
-	mbSClear = TRUE;
+	mbSBuilt = false;
+	mbSClear = true;
 
 	mCurrentSendTotal = 0;
 
@@ -447,8 +447,6 @@ void LLTemplateMessageBuilder::addIPPort(const char *varname, U16 u)
 
 void LLTemplateMessageBuilder::addBOOL(const char* varname, bool b)
 {
-	// Can't just cast a BOOL (actually a U32) to a U8.
-	// In some cases the low order bits will be zero.
 	U8 temp = (b != 0);
 	addData(varname, &temp, MVT_BOOL, sizeof(temp));
 }
@@ -823,7 +821,7 @@ U32 LLTemplateMessageBuilder::buildMessage(
 	{
 		result += buildBlock(buffer + result, buffer_size - result, *iter, mCurrentSMessageData);
 	}
-	mbSBuilt = TRUE;
+	mbSBuilt = true;
 
 	return result;
 }

--- a/indra/llmessage/lltemplatemessagebuilder.h
+++ b/indra/llmessage/lltemplatemessagebuilder.h
@@ -106,8 +106,8 @@ private:
 	LLMsgBlkData* mCurrentSDataBlock;
 	char* mCurrentSMessageName;
 	char* mCurrentSBlockName;
-	BOOL mbSBuilt;
-	BOOL mbSClear;
+	bool mbSBuilt;
+	bool mbSClear;
 	S32	 mCurrentSendTotal;
 	const message_template_name_map_t& mMessageTemplates;
 };

--- a/indra/llmessage/llthrottle.cpp
+++ b/indra/llmessage/llthrottle.cpp
@@ -37,7 +37,7 @@ LLThrottle::LLThrottle(const F32 rate)
 	mRate = rate;
 	mAvailable = 0.f;
 	mLookaheadSecs = 0.25f;
-	mLastSendTime = LLMessageSystem::getMessageTimeSeconds(TRUE);
+	mLastSendTime = LLMessageSystem::getMessageTimeSeconds(true);
 }
 
 

--- a/indra/llmessage/lltransfermanager.cpp
+++ b/indra/llmessage/lltransfermanager.cpp
@@ -49,7 +49,7 @@ LLTransferSource::stype_scfunc_map LLTransferSource::sSourceCreateMap;
 //
 
 LLTransferManager::LLTransferManager() :
-	mValid(FALSE)
+	mValid(false)
 {
 	S32 i;
 	for (i = 0; i < LLTTT_NUM_TYPES; i++)
@@ -78,7 +78,7 @@ void LLTransferManager::init()
 	{
 		LL_ERRS() << "Double initializing LLTransferManager!" << LL_ENDL;
 	}
-	mValid = TRUE;
+	mValid = true;
 
 	// Register message system handlers
 	gMessageSystem->setHandlerFunc("TransferRequest", processTransferRequest, NULL);
@@ -90,7 +90,7 @@ void LLTransferManager::init()
 
 void LLTransferManager::cleanup()
 {
-	mValid = FALSE;
+	mValid = false;
 
 	host_tc_map::iterator iter;
 	for (iter = mTransferConnections.begin(); iter != mTransferConnections.end(); iter++)
@@ -342,7 +342,7 @@ void LLTransferManager::processTransferInfo(LLMessageSystem *msgp, void **)
 
 	//LL_INFOS() << "Receiving " << transfer_id << ", size " << size << " bytes" << LL_ENDL;
 	ttp->setSize(size);
-	ttp->setGotInfo(TRUE);
+	ttp->setGotInfo(true);
 
 	// OK, at this point we to handle any delayed transfer packets (which could happen
 	// if this packet was lost)
@@ -557,7 +557,7 @@ void LLTransferManager::processTransferPacket(LLMessageSystem *msgp, void **)
 		else
 		{
 			// No matching delayed packet, abort it.
-			done = TRUE;
+			done = true;
 		}
 	}
 }
@@ -822,7 +822,7 @@ void LLTransferSourceChannel::updateTransfers()
 		gMessageSystem->addS32("Status", status);
 		gMessageSystem->addBinaryData("Data", datap, data_size);
 		sent_bytes = gMessageSystem->getCurrentSendTotal();
-		gMessageSystem->sendReliable(getHost(), LL_DEFAULT_RELIABLE_RETRIES, TRUE, F32Seconds(0.f),
+		gMessageSystem->sendReliable(getHost(), LL_DEFAULT_RELIABLE_RETRIES, true, F32Seconds(0.f),
 									 LLTransferManager::reliablePacketCallback, (void**)cb_uuid);
 
 		// Do bookkeeping for the throttle
@@ -1207,7 +1207,7 @@ LLTransferTarget::LLTransferTarget(
 	mSourceType(source_type),
 	mID(transfer_id),
 	mChannelp(NULL),
-	mGotInfo(FALSE),
+	mGotInfo(false),
 	mSize(0),
 	mLastPacketID(-1)
 {

--- a/indra/llmessage/lltransfermanager.h
+++ b/indra/llmessage/lltransfermanager.h
@@ -121,7 +121,7 @@ public:
 
 	LLTransferSource *findTransferSource(const LLUUID &transfer_id);
 
-	BOOL						isValid() const			{ return mValid; }
+	bool						isValid() const			{ return mValid; }
 
 	static void processTransferRequest(LLMessageSystem *mesgsys, void **);
 	static void processTransferInfo(LLMessageSystem *mesgsys, void **);
@@ -138,13 +138,13 @@ public:
 	void addTransferBitsOut(const LLTransferChannelType tctype, const S32 bits)	{ mTransferBitsOut[tctype] += bits; }
 protected:
 	LLTransferConnection		*getTransferConnection(const LLHost &host);
-	BOOL						removeTransferConnection(const LLHost &host);
+	bool						removeTransferConnection(const LLHost &host);
 
 protected:
 	// Convenient typedefs
 	typedef std::map<LLHost, LLTransferConnection *> host_tc_map;
 
-	BOOL	mValid;
+	bool	mValid;
 	LLHost	mHost;
 
 	S32		mTransferBitsIn[LLTTT_NUM_TYPES];
@@ -408,8 +408,8 @@ protected:
 	virtual S32				getNextPacketID()						{ return mLastPacketID + 1; }
 	virtual void			setLastPacketID(const S32 packet_id)	{ mLastPacketID = packet_id; }
 	void					setSize(const S32 size)					{ mSize = size; }
-	void					setGotInfo(const BOOL got_info)			{ mGotInfo = got_info; }
-	BOOL					gotInfo() const							{ return mGotInfo; }
+	void					setGotInfo(const bool got_info)			{ mGotInfo = got_info; }
+	bool					gotInfo() const							{ return mGotInfo; }
 
 	bool addDelayedPacket(
 		const S32 packet_id,
@@ -425,7 +425,7 @@ protected:
 	LLTransferSourceType mSourceType;
 	LLUUID					mID;
 	LLTransferTargetChannel *mChannelp;
-	BOOL					mGotInfo;
+	bool					mGotInfo;
 	S32						mSize;
 	S32						mLastPacketID;
 

--- a/indra/llmessage/lltransfersourceasset.cpp
+++ b/indra/llmessage/lltransfersourceasset.cpp
@@ -36,7 +36,7 @@
 
 LLTransferSourceAsset::LLTransferSourceAsset(const LLUUID &request_id, const F32 priority) :
 	LLTransferSource(LLTST_ASSET, request_id, priority),
-	mGotResponse(FALSE),
+	mGotResponse(false),
 	mCurPos(0)
 {
 }
@@ -120,7 +120,7 @@ LLTSCode LLTransferSourceAsset::dataCallback(const S32 packet_id,
 		return LLTS_ERROR;
 	}
 	
-	delete_returned = TRUE;
+	delete_returned = true;
 	U8 *tmpp = new U8[max_bytes];
 	*data_handle = tmpp;
 	if (!vf.read(tmpp, max_bytes))		/* Flawfinder: Ignore */
@@ -129,7 +129,7 @@ LLTSCode LLTransferSourceAsset::dataCallback(const S32 packet_id,
 		delete[] tmpp;
 		*data_handle = NULL;
 		returned_bytes = 0;
-		delete_returned = FALSE;
+		delete_returned = false;
 		return LLTS_ERROR;
 	}
 
@@ -144,7 +144,7 @@ LLTSCode LLTransferSourceAsset::dataCallback(const S32 packet_id,
 			delete[] tmpp;
 			*data_handle = NULL;
 			returned_bytes = 0;
-			delete_returned = FALSE;
+			delete_returned = false;
 		}
 		return LLTS_DONE;
 	}
@@ -194,7 +194,7 @@ void LLTransferSourceAsset::responderCallback(const LLUUID& uuid, LLAssetType::E
 
 	LLTSCode status;
 
-	tsap->mGotResponse = TRUE;
+	tsap->mGotResponse = true;
 	if (LL_ERR_NOERR == result)
 	{
 		// Everything's OK.

--- a/indra/llmessage/lltransfersourcefile.cpp
+++ b/indra/llmessage/lltransfersourcefile.cpp
@@ -102,7 +102,7 @@ LLTSCode LLTransferSourceFile::dataCallback(const S32 packet_id,
 	}
 
 	// Grab up until the max number of bytes from the file.
-	delete_returned = TRUE;
+	delete_returned = true;
 	U8 *tmpp = new U8[max_bytes];
 	*data_handle = tmpp;
 	returned_bytes = (S32)fread(tmpp, 1, max_bytes, mFP);
@@ -111,7 +111,7 @@ LLTSCode LLTransferSourceFile::dataCallback(const S32 packet_id,
 		delete[] tmpp;
 		*data_handle = NULL;
 		returned_bytes = 0;
-		delete_returned = FALSE;
+		delete_returned = false;
 		return LLTS_DONE;
 	}
 

--- a/indra/llmessage/lltransfersourcefile.h
+++ b/indra/llmessage/lltransfersourcefile.h
@@ -40,12 +40,12 @@ public:
 	void setFilename(const std::string &filename)		{ mFilename = filename; }
 	std::string getFilename() const					{ return mFilename; }
 
-	void setDeleteOnCompletion(BOOL enabled)		{ mDeleteOnCompletion = enabled; }
-	BOOL getDeleteOnCompletion()					{ return mDeleteOnCompletion; }
+	void setDeleteOnCompletion(bool enabled)		{ mDeleteOnCompletion = enabled; }
+	bool getDeleteOnCompletion()					{ return mDeleteOnCompletion; }
 protected:
 	std::string mFilename;
 	// ONLY DELETE THINGS OFF THE SIM IF THE FILENAME BEGINS IN 'TEMP'
-	BOOL mDeleteOnCompletion;
+	bool mDeleteOnCompletion;
 };
 
 class LLTransferSourceFile : public LLTransferSource

--- a/indra/llmessage/lltransfertargetvfile.cpp
+++ b/indra/llmessage/lltransfertargetvfile.cpp
@@ -94,7 +94,7 @@ LLTransferTargetVFile::LLTransferTargetVFile(
 	const LLUUID& uuid,
 	LLTransferSourceType src_type) :
 	LLTransferTarget(LLTTT_VFILE, uuid, src_type),
-	mNeedsCreate(TRUE)
+	mNeedsCreate(true)
 {
 	mTempID.generate();
 }
@@ -141,7 +141,7 @@ LLTSCode LLTransferTargetVFile::dataCallback(const S32 packet_id, U8 *in_datap, 
 	LLFileSystem vf(mTempID, mParams.getAssetType(), LLFileSystem::APPEND);
 	if (mNeedsCreate)
 	{
-		mNeedsCreate = FALSE;
+		mNeedsCreate = false;
 	}
 
 	if (!in_size)

--- a/indra/llmessage/lltransfertargetvfile.h
+++ b/indra/llmessage/lltransfertargetvfile.h
@@ -86,7 +86,7 @@ protected:
 
 	LLTransferTargetParamsVFile mParams;
 
-	BOOL mNeedsCreate;
+	bool mNeedsCreate;
 	LLUUID mTempID;
 };
 

--- a/indra/llmessage/lluseroperation.cpp
+++ b/indra/llmessage/lluseroperation.cpp
@@ -41,7 +41,7 @@ LLUserOperationMgr* gUserOperationMgr = NULL;
 LLUserOperation::LLUserOperation(const LLUUID& agent_id)
 :	mAgentID(agent_id),
 	mTimer(),
-	mNoExpire(FALSE)
+	mNoExpire(false)
 {
 	mTransactionID.generate();
 }
@@ -51,7 +51,7 @@ LLUserOperation::LLUserOperation(const LLUUID& agent_id,
 	mAgentID(agent_id),
 	mTransactionID(transaction_id),
 	mTimer(),
-	mNoExpire(FALSE)
+	mNoExpire(false)
 {
 }
 
@@ -59,7 +59,7 @@ LLUserOperation::LLUserOperation(const LLUUID& agent_id,
 // transaction, agent, et. after construction.
 LLUserOperation::LLUserOperation() :
 	mTimer(),
-	mNoExpire(FALSE)
+	mNoExpire(false)
 {
 }
 
@@ -67,7 +67,7 @@ LLUserOperation::~LLUserOperation()
 {
 }
 
-void LLUserOperation::SetNoExpireFlag(const BOOL flag)
+void LLUserOperation::SetNoExpireFlag(const bool flag)
 {
 	mNoExpire = flag;
 }

--- a/indra/llmessage/lluseroperation.h
+++ b/indra/llmessage/lluseroperation.h
@@ -47,14 +47,14 @@ public:
 	virtual bool isExpired();
 
 	// ability to mark this operation as never expiring.
-	void SetNoExpireFlag(const BOOL flag);
+	void SetNoExpireFlag(const bool flag);
 
 	// Send request to the dataserver
 	virtual void sendRequest() = 0;
 
 	// Run the operation. This will only be called in the case of an
 	// actual success or failure of the operation.
-	virtual bool execute(BOOL transaction_success) = 0;
+	virtual bool execute(bool transaction_success) = 0;
 
 	// This method is called when the user op has expired, and is
 	// about to be deleted by the manager. This gives the user op the

--- a/indra/llmessage/llxfer.cpp
+++ b/indra/llmessage/llxfer.cpp
@@ -63,13 +63,13 @@ void LLXfer::init (S32 chunk_size)
 	mXferSize = 0;
 
 	mStatus = e_LL_XFER_UNINITIALIZED;
-	mWaitingForACK = FALSE;
+	mWaitingForACK = false;
 	
 	mCallback = NULL;
 	mCallbackDataHandle = NULL;
 	mCallbackResult = 0;
 
-	mBufferContainsEOF = FALSE;
+	mBufferContainsEOF = false;
 	mBuffer = NULL;
 	mBufferLength = 0;
 	mBufferStartOffset = 0;
@@ -187,7 +187,7 @@ void LLXfer::sendPacket(S32 packet_num)
 {
 	char fdata_buf[LL_XFER_LARGE_PAYLOAD+4];		/* Flawfinder: ignore */
 	S32 fdata_size = mChunkSize;
-	BOOL last_packet = FALSE;
+	bool last_packet = false;
 	S32 num_copy = 0;
 
 	// if the desired packet is not in our current buffered excerpt from the file. . . 
@@ -217,7 +217,7 @@ void LLXfer::sendPacket(S32 packet_num)
 
 	if (((U32)(desired_read_position + fdata_size) >= (U32)mBufferLength) && (mBufferContainsEOF))
 	{
-		last_packet = TRUE;
+		last_packet = true;
 	}
 		
 	if (packet_num)
@@ -270,7 +270,7 @@ void LLXfer::sendPacket(S32 packet_num)
 		}
 
 		ACKTimer.reset();
-		mWaitingForACK = TRUE;
+		mWaitingForACK = true;
 	}
 	if (last_packet)
 	{

--- a/indra/llmessage/llxfer.h
+++ b/indra/llmessage/llxfer.h
@@ -63,11 +63,11 @@ class LLXfer
 	char *mBuffer;
 	U32 mBufferLength;			// Size of valid data, not actual allocated buffer size
 	U32 mBufferStartOffset;
-	BOOL mBufferContainsEOF;
+	bool mBufferContainsEOF;
 
 	ELLXferStatus mStatus;
 
-	BOOL mWaitingForACK;
+	bool mWaitingForACK;
 
 	void (*mCallback)(void **,S32,LLExtStat);	
 	void **mCallbackDataHandle;

--- a/indra/llmessage/llxfer_file.cpp
+++ b/indra/llmessage/llxfer_file.cpp
@@ -49,10 +49,10 @@ S32 copy_file(const std::string& from, const std::string& to);
 LLXfer_File::LLXfer_File (S32 chunk_size)
 : LLXfer(chunk_size)
 {
-	init(LLStringUtil::null, FALSE, chunk_size);
+	init(LLStringUtil::null, false, chunk_size);
 }
 
-LLXfer_File::LLXfer_File (const std::string& local_filename, BOOL delete_local_on_completion, S32 chunk_size)
+LLXfer_File::LLXfer_File (const std::string& local_filename, bool delete_local_on_completion, S32 chunk_size)
 : LLXfer(chunk_size)
 {
 	init(local_filename, delete_local_on_completion, chunk_size);
@@ -67,7 +67,7 @@ LLXfer_File::~LLXfer_File ()
 
 ///////////////////////////////////////////////////////////
 
-void LLXfer_File::init (const std::string& local_filename, BOOL delete_local_on_completion, S32 chunk_size)
+void LLXfer_File::init (const std::string& local_filename, bool delete_local_on_completion, S32 chunk_size)
 {
 
 	mFp = NULL;
@@ -75,8 +75,8 @@ void LLXfer_File::init (const std::string& local_filename, BOOL delete_local_on_
 	mRemoteFilename.clear();
 	mRemotePath = LL_PATH_NONE;
 	mTempFilename.clear();
-	mDeleteLocalOnCompletion = FALSE;
-	mDeleteRemoteOnCompletion = FALSE;
+	mDeleteLocalOnCompletion = false;
+	mDeleteRemoteOnCompletion = false;
 
 	if (!local_filename.empty())
 	{
@@ -120,7 +120,7 @@ S32 LLXfer_File::initializeRequest(U64 xfer_id,
 				   const std::string& remote_filename,
 				   ELLPath remote_path,
 				   const LLHost& remote_host,
-				   BOOL delete_remote_on_completion,
+				   bool delete_remote_on_completion,
 				   void (*callback)(void**,S32,LLExtStat),
 				   void** user_data)
 {
@@ -174,7 +174,7 @@ S32 LLXfer_File::startDownload()
 		gMessageSystem->addStringFast(_PREHASH_Filename, mRemoteFilename);
 		gMessageSystem->addU8("FilePath", (U8) mRemotePath);
 		gMessageSystem->addBOOL("DeleteOnCompletion", mDeleteRemoteOnCompletion);
-		gMessageSystem->addBOOL("UseBigPackets", BOOL(mChunkSize == LL_XFER_LARGE_PAYLOAD));
+		gMessageSystem->addBOOL("UseBigPackets", mChunkSize == LL_XFER_LARGE_PAYLOAD);
 		gMessageSystem->addUUIDFast(_PREHASH_VFileID, LLUUID::null);
 		gMessageSystem->addS16Fast(_PREHASH_VFileType, -1);
 	
@@ -287,11 +287,11 @@ S32 LLXfer_File::suck(S32 start_position)
 			
 		if (feof(mFp))
 		{
-			mBufferContainsEOF = TRUE;
+			mBufferContainsEOF = true;
 		}
 		else
 		{
-			mBufferContainsEOF = FALSE;
+			mBufferContainsEOF = false;
 		}		
 	}
 	else

--- a/indra/llmessage/llxfer_file.h
+++ b/indra/llmessage/llxfer_file.h
@@ -39,15 +39,15 @@ class LLXfer_File : public LLXfer
 	ELLPath mRemotePath;
 	std::string mTempFilename;
 
-	BOOL mDeleteLocalOnCompletion;
-	BOOL mDeleteRemoteOnCompletion;
+	bool mDeleteLocalOnCompletion;
+	bool mDeleteRemoteOnCompletion;
 
  public:
 	LLXfer_File (S32 chunk_size);
-	LLXfer_File (const std::string& local_filename, BOOL delete_local_on_completion, S32 chunk_size);
+	LLXfer_File (const std::string& local_filename, bool delete_local_on_completion, S32 chunk_size);
 	virtual ~LLXfer_File();
 
-	virtual void init(const std::string& local_filename, BOOL delete_local_on_completion, S32 chunk_size);
+	virtual void init(const std::string& local_filename, bool delete_local_on_completion, S32 chunk_size);
 	virtual void cleanup();
 
 	virtual S32 initializeRequest(U64 xfer_id,
@@ -55,7 +55,7 @@ class LLXfer_File : public LLXfer
 								  const std::string& remote_filename,
 								  ELLPath remote_path,
 								  const LLHost& remote_host,
-								  BOOL delete_remote_on_completion,
+								  bool delete_remote_on_completion,
 								  void (*callback)(void**,S32,LLExtStat),
 								  void** user_data);
 	virtual S32 startDownload();

--- a/indra/llmessage/llxfer_mem.cpp
+++ b/indra/llmessage/llxfer_mem.cpp
@@ -52,7 +52,7 @@ void LLXfer_Mem::init ()
 {
 	mRemoteFilename.clear();
 	mRemotePath = LL_PATH_NONE;
-	mDeleteRemoteOnCompletion = FALSE;
+	mDeleteRemoteOnCompletion = false;
 }
 	
 ///////////////////////////////////////////////////////////
@@ -73,7 +73,7 @@ void LLXfer_Mem::setXferSize (S32 xfer_size)
 	
 	mBufferLength = 0;
 	mBufferStartOffset = 0;	
-	mBufferContainsEOF = TRUE;
+	mBufferContainsEOF = true;
 
 //	cout << "starting transfer of size: " << xfer_size << endl;
 }
@@ -124,7 +124,7 @@ S32 LLXfer_Mem::initializeRequest(U64 xfer_id,
 								  const std::string& remote_filename,
 								  ELLPath remote_path,
 								  const LLHost& remote_host,
-								  BOOL delete_remote_on_completion,
+								  bool delete_remote_on_completion,
 								  void (*callback)(void*,S32,void**,S32,LLExtStat),
 								  void** user_data)
 {
@@ -164,7 +164,7 @@ S32 LLXfer_Mem::startDownload()
 	gMessageSystem->addStringFast(_PREHASH_Filename, mRemoteFilename);
 	gMessageSystem->addU8("FilePath", (U8) mRemotePath);
 	gMessageSystem->addBOOL("DeleteOnCompletion", mDeleteRemoteOnCompletion);
-	gMessageSystem->addBOOL("UseBigPackets", BOOL(mChunkSize == LL_XFER_LARGE_PAYLOAD));
+	gMessageSystem->addBOOL("UseBigPackets", mChunkSize == LL_XFER_LARGE_PAYLOAD);
 	gMessageSystem->addUUIDFast(_PREHASH_VFileID, LLUUID::null);
 	gMessageSystem->addS16Fast(_PREHASH_VFileType, -1);
 

--- a/indra/llmessage/llxfer_mem.h
+++ b/indra/llmessage/llxfer_mem.h
@@ -39,7 +39,7 @@ class LLXfer_Mem : public LLXfer
 	void (*mCallback)(void *, S32, void **, S32, LLExtStat);	
 	std::string mRemoteFilename;
 	ELLPath mRemotePath;
-	BOOL mDeleteRemoteOnCompletion;
+	bool mDeleteRemoteOnCompletion;
 
  public:
 
@@ -59,7 +59,7 @@ class LLXfer_Mem : public LLXfer
 								  const std::string& remote_filename,
 								  ELLPath remote_path,
 								  const LLHost& remote_host,
-								  BOOL delete_remote_on_completion,
+								  bool delete_remote_on_completion,
 								  void (*callback)(void*,S32,void**,S32,LLExtStat),
 								  void** user_data);
 	virtual S32 startDownload();

--- a/indra/llmessage/llxfer_vfile.cpp
+++ b/indra/llmessage/llxfer_vfile.cpp
@@ -138,7 +138,7 @@ S32 LLXfer_VFile::initializeRequest(U64 xfer_id,
 	mBufferLength = 0;
 	mPacketNum = 0;
 	mTempID.generate();
-	mDeleteTempFile = TRUE;
+	mDeleteTempFile = true;
  	mStatus = e_LL_XFER_PENDING;
 	return retval;
 }
@@ -156,8 +156,8 @@ S32 LLXfer_VFile::startDownload()
 	gMessageSystem->addU64Fast(_PREHASH_ID, mID);
 	gMessageSystem->addStringFast(_PREHASH_Filename, "");
 	gMessageSystem->addU8("FilePath", (U8) LL_PATH_NONE);
-	gMessageSystem->addBOOL("DeleteOnCompletion", FALSE);
-	gMessageSystem->addBOOL("UseBigPackets", BOOL(mChunkSize == LL_XFER_LARGE_PAYLOAD));
+	gMessageSystem->addBOOL("DeleteOnCompletion", false);
+	gMessageSystem->addBOOL("UseBigPackets", mChunkSize == LL_XFER_LARGE_PAYLOAD);
 	gMessageSystem->addUUIDFast(_PREHASH_VFileID, mRemoteID);
 	gMessageSystem->addS16Fast(_PREHASH_VFileType, (S16)mType);
 
@@ -345,7 +345,7 @@ S32 LLXfer_VFile::processEOF()
 			{									
 				// Rename worked: the original file is gone.   Clear mDeleteTempFile
 				// so we don't attempt to delete the file in cleanup()
-				mDeleteTempFile = FALSE;
+				mDeleteTempFile = false;
 			}
 		}
 		else

--- a/indra/llmessage/llxfer_vfile.h
+++ b/indra/llmessage/llxfer_vfile.h
@@ -44,7 +44,7 @@ class LLXfer_VFile : public LLXfer
 
 	std::string mName;
 
-	BOOL	mDeleteTempFile;
+	bool	mDeleteTempFile;
 
  public:
 	LLXfer_VFile ();

--- a/indra/llmessage/llxfermanager.cpp
+++ b/indra/llmessage/llxfermanager.cpp
@@ -79,7 +79,7 @@ void LLXferManager::init()
 	setMaxIncomingXfers(LL_DEFAULT_MAX_REQUEST_FIFO_XFERS);
 
 	// Turn on or off ack throttling
-	mUseAckThrottling = FALSE;
+	mUseAckThrottling = false;
 	setAckThrottleBPS(100000);
 }
 	
@@ -116,7 +116,7 @@ void LLXferManager::setHardLimitOutgoingXfersPerCircuit(S32 max_num)
 	mHardLimitOutgoingXfersPerCircuit = max_num;
 }
 
-void LLXferManager::setUseAckThrottling(const BOOL use)
+void LLXferManager::setUseAckThrottling(const bool use)
 {
 	mUseAckThrottling = use;
 }
@@ -1005,7 +1005,7 @@ void LLXferManager::processConfirmation (LLMessageSystem *mesgsys, void ** /*use
 	if (xferp)
 	{
 //		cout << "confirmed packet #" << packetNum << " ping: "<< xferp->ACKTimer.getElapsedTimeF32() <<  endl;
-		xferp->mWaitingForACK = FALSE;
+		xferp->mWaitingForACK = false;
 		if (xferp->mStatus == e_LL_XFER_IN_PROGRESS)
 		{
 			xferp->sendNextPacket();

--- a/indra/llmessage/llxfermanager.h
+++ b/indra/llmessage/llxfermanager.h
@@ -76,7 +76,7 @@ class LLXferManager
 	S32    mHardLimitOutgoingXfersPerCircuit;	// At this limit, kill off the connection
 	S32    mMaxIncomingXfers;
 
-	BOOL	mUseAckThrottling; // Use ack throttling to cap file xfer bandwidth
+	bool	mUseAckThrottling; // Use ack throttling to cap file xfer bandwidth
 	std::deque<LLXferAckInfo> mXferAckQueue;
 	LLThrottle mAckThrottle;
  public:
@@ -85,8 +85,8 @@ class LLXferManager
 	// an xfer must happen asap.
 	enum
 	{
-		LOW_PRIORITY = FALSE,
-		HIGH_PRIORITY = TRUE,
+		LOW_PRIORITY = false,
+		HIGH_PRIORITY = true,
 	};
 
 	// Linked FIFO list, add to the front and pull from back
@@ -113,7 +113,7 @@ class LLXferManager
 	virtual void init();
 	virtual void cleanup();
 
-	void setUseAckThrottling(const BOOL use);
+	void setUseAckThrottling(const bool use);
 	void setAckThrottleBPS(const F32 bps);
 
 // list management routines

--- a/indra/llmessage/llxorcipher.h
+++ b/indra/llmessage/llxorcipher.h
@@ -43,18 +43,18 @@ public:
 	LLXORCipher& operator=(const LLXORCipher& cipher);
 
 	// Cipher functions
-	/*virtual*/ U32 encrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len);
-	/*virtual*/ U32 decrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len);
-	/*virtual*/ U32 requiredEncryptionSpace(U32 src_len) const;
+	U32 encrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len) override;
+	U32 decrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len) override;
+	U32 requiredEncryptionSpace(U32 src_len) const override;
 
 	// special syntactic-sugar since xor can be performed in place.
-	BOOL encrypt(U8* buf, U32 len) { return encrypt((const U8*)buf, len, buf, len); }
-	BOOL decrypt(U8* buf, U32 len) { return decrypt((const U8*)buf, len, buf, len); }
+	bool encrypt(U8* buf, U32 len) { return encrypt((const U8*)buf, len, buf, len) > 0; }
+	bool decrypt(U8* buf, U32 len) { return decrypt((const U8*)buf, len, buf, len) > 0; }
 
 #ifdef _DEBUG
 	// This function runs tests to make sure the crc is
-	// working. Returns TRUE if it is.
-	static BOOL testHarness();
+	// working. Returns true if it is.
+	static bool testHarness();
 #endif
 
 protected:

--- a/indra/llmessage/machine.h
+++ b/indra/llmessage/machine.h
@@ -65,7 +65,7 @@ public:
 	// The control port is the listen port of the parent process that
 	// launched this machine. 0 means none or not known.
 	const S32		&getControlPort() 	const { return mControlPort; }
-	BOOL			isValid()			const { return (mHost.getPort() != 0); }	// TRUE if corresponds to functioning machine
+	bool			isValid()			const { return (mHost.getPort() != 0); }	// TRUE if corresponds to functioning machine
 
 	// set functions
 	void			setMachineType(EMachineType machine_type)	{ mMachineType = machine_type; }

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -148,11 +148,11 @@ static const char* nullToEmpty(const char* s)
 void LLMessageSystem::init()
 {
 	// initialize member variables
-	mVerboseLog = FALSE;
+	mVerboseLog = false;
 
-	mbError = FALSE;
+	mbError = false;
 	mErrorCode = 0;
-	mSendReliable = FALSE;
+	mSendReliable = false;
 
 	mUnackedListDepth = 0;
 	mUnackedListSize = 0;
@@ -214,7 +214,7 @@ LLMessageSystem::LLMessageSystem(const std::string& filename, U32 port,
 	mVersionFlags = 0x0;
 
 	// default to not accepting packets from not alive circuits
-	mbProtected = TRUE;
+	mbProtected = true;
 
 	// default to blocking trusted connections on a public interface if one is specified
 	mBlockUntrustedInterface = true;
@@ -239,7 +239,7 @@ LLMessageSystem::LLMessageSystem(const std::string& filename, U32 port,
 	S32 error = start_net(mSocket, mPort);
 	if (error != 0)
 	{
-		mbError = TRUE;
+		mbError = true;
 		mErrorCode = error;
 	}
 //	LL_DEBUGS("Messaging") <<  << "*** port: " << mPort << LL_ENDL;
@@ -288,7 +288,7 @@ void LLMessageSystem::loadTemplateFile(const std::string& filename, bool failure
 	if(filename.empty())
 	{
 		LL_ERRS("Messaging") << "No template filename specified" << LL_ENDL;
-		mbError = TRUE;
+		mbError = true;
 		return;
 	}
 
@@ -300,7 +300,7 @@ void LLMessageSystem::loadTemplateFile(const std::string& filename, bool failure
 		} else {
 			LL_WARNS("Messaging") << "Failed to open template: " << filename << LL_ENDL;
 		}
-		mbError = TRUE;
+		mbError = true;
 		return;
 	}
 	
@@ -506,8 +506,8 @@ bool LLMessageSystem::checkMessages(LockMessageChecker&, S64 frame_count )
 	{
 		clearReceiveState();
 		
-		BOOL recv_reliable = false;
-		BOOL recv_resent = false;
+		bool recv_reliable = false;
+		bool recv_resent = false;
 		S32 acks = 0;
 		S32 true_rcv_size = 0;
 
@@ -768,7 +768,7 @@ void LLMessageSystem::processAcks(LockMessageChecker&, F32 collect_time)
 		}
 	}
 
-	BOOL dump = FALSE;
+	bool dump = false;
 	{
 		// Check the status of circuits
 		mCircuitInfo.updateWatchDogTimers(this);
@@ -793,17 +793,17 @@ void LLMessageSystem::processAcks(LockMessageChecker&, F32 collect_time)
 		{
 			if (mNumMessageCounts >= mMaxMessageCounts)
 			{
-				dump = TRUE;
+				dump = true;
 			}
 		}
 
 		if (mMaxMessageTime >= F32Seconds(0.f))
 		{
 			// This is one of the only places where we're required to get REAL message system time.
-			mReceiveTime = getMessageTimeSeconds(TRUE) - mMessageCountTime;
+			mReceiveTime = getMessageTimeSeconds(true) - mMessageCountTime;
 			if (mReceiveTime > mMaxMessageTime)
 			{
-				dump = TRUE;
+				dump = true;
 			}
 		}
 	}
@@ -833,7 +833,7 @@ void LLMessageSystem::copyMessageReceivedToSend()
 	{
 		mMessageBuilder = mLLSDMessageBuilder;
 	}
-	mSendReliable = FALSE;
+	mSendReliable = false;
 	mMessageBuilder->newMessage(mMessageReader->getMessageName());
 	mMessageReader->copyToBuilder(*mMessageBuilder);
 }
@@ -928,7 +928,7 @@ S32 LLMessageSystem::sendMessage(const LLHost &host, LLStoredMessagePtr message)
 
 void LLMessageSystem::clearMessage()
 {
-	mSendReliable = FALSE;
+	mSendReliable = false;
 	mMessageBuilder->clearMessage();
 }
 
@@ -968,7 +968,7 @@ bool LLMessageSystem::removeLastBlock()
 
 S32 LLMessageSystem::sendReliable(const LLHost &host)
 {
-	return sendReliable(host, LL_DEFAULT_RELIABLE_RETRIES, TRUE, LL_PING_BASED_TIMEOUT_DUMMY, NULL, NULL);
+	return sendReliable(host, LL_DEFAULT_RELIABLE_RETRIES, true, LL_PING_BASED_TIMEOUT_DUMMY, NULL, NULL);
 }
 
 
@@ -987,15 +987,15 @@ S32 LLMessageSystem::sendSemiReliable(const LLHost &host, void (*callback)(void 
 		timeout = LL_SEMIRELIABLE_TIMEOUT_FACTOR * LL_AVERAGED_PING_MAX;
 	}
 
-	const S32 retries = 0;
-	const BOOL ping_based_timeout = FALSE;
+	constexpr S32 retries = 0;
+	constexpr bool ping_based_timeout = false;
 	return sendReliable(host, retries, ping_based_timeout, timeout, callback, callback_data);
 }
 
 // send the message via a UDP packet
 S32 LLMessageSystem::sendReliable(	const LLHost &host, 
 									S32 retries, 
-									BOOL ping_based_timeout,
+									bool ping_based_timeout,
 									F32Seconds timeout, 
 									void (*callback)(void **,S32), 
 									void ** callback_data)
@@ -1013,7 +1013,7 @@ S32 LLMessageSystem::sendReliable(	const LLHost &host,
 	    }
 	}
 
-	mSendReliable = TRUE;
+	mSendReliable = true;
 	mReliablePacketParams.set(host, retries, ping_based_timeout, timeout, 
 		callback, callback_data, 
 		const_cast<char*>(mMessageBuilder->getMessageName()));
@@ -1040,7 +1040,7 @@ void LLMessageSystem::forwardReliable(const U32 circuit_code)
 
 S32 LLMessageSystem::forwardReliable(	const LLHost &host, 
 										S32 retries, 
-										BOOL ping_based_timeout,
+										bool ping_based_timeout,
 										F32Seconds timeout, 
 										void (*callback)(void **,S32), 
 										void ** callback_data)
@@ -1067,9 +1067,9 @@ S32 LLMessageSystem::flushSemiReliable(const LLHost &host, void (*callback)(void
 	S32 send_bytes = 0;
 	if (mMessageBuilder->getMessageSize())
 	{
-		mSendReliable = TRUE;
+		mSendReliable = true;
 		// No need for ping-based retry as not going to retry
-		mReliablePacketParams.set(host, 0, FALSE, timeout, callback, 
+		mReliablePacketParams.set(host, 0, false, timeout, callback, 
 								  callback_data, 
 								  const_cast<char*>(mMessageBuilder->getMessageName()));
 		send_bytes = sendMessage(host);
@@ -1169,7 +1169,7 @@ S32 LLMessageSystem::sendMessage(const LLHost &host)
             host.getUntrustedSimulatorCap(), 
             mLLSDMessageBuilder->getMessageName(), message, cb));
 
-		mSendReliable = FALSE;
+		mSendReliable = false;
 		mReliablePacketParams.clear();
 		return 1;
 	}
@@ -1218,7 +1218,7 @@ S32 LLMessageSystem::sendMessage(const LLHost &host)
 	// tack packet acks onto the end of this message
 	S32 space_left = (MTUBYTES - buffer_length) / sizeof(TPACKETID); // space left for packet ids
 	S32 ack_count = (S32)cdp->mAcks.size();
-	BOOL is_ack_appended = FALSE;
+	bool is_ack_appended = false;
 	std::vector<TPACKETID> acks;
 	if((space_left > 0) && (ack_count > 0) && 
 	   (mMessageBuilder->getMessageName() != _PREHASH_PacketAck))
@@ -1269,10 +1269,10 @@ S32 LLMessageSystem::sendMessage(const LLHost &host)
 		// tack the count in the final byte
 		U8 count = (U8)append_ack_count;
 		buf_ptr[buffer_length++] = count;
-		is_ack_appended = TRUE;
+		is_ack_appended = true;
 	}
 
-	BOOL success;
+	bool success;
 	success = mPacketRing.sendPacket(mSocket, (char *)buf_ptr, buffer_length, host);
 
 	if (!success)
@@ -1307,12 +1307,12 @@ S32 LLMessageSystem::sendMessage(const LLHost &host)
 	mPacketsOut++;
 	mTotalBytesOut += buffer_length;
 	
-	mSendReliable = FALSE;
+	mSendReliable = false;
 	mReliablePacketParams.clear();
 	return buffer_length;
 }
 
-void LLMessageSystem::logMsgFromInvalidCircuit( const LLHost& host, BOOL recv_reliable )
+void LLMessageSystem::logMsgFromInvalidCircuit( const LLHost& host, bool recv_reliable )
 {
 	if(mVerboseLog)
 	{
@@ -1339,7 +1339,7 @@ void LLMessageSystem::logMsgFromInvalidCircuit( const LLHost& host, BOOL recv_re
 		// TODO: babbage: work out if we need these
 		// mMessageCountList[mNumMessageCounts].mMessageNum = mCurrentRMessageTemplate->mMessageNumber;
 		mMessageCountList[mNumMessageCounts].mMessageBytes = mMessageReader->getMessageSize();
-		mMessageCountList[mNumMessageCounts].mInvalid = TRUE;
+		mMessageCountList[mNumMessageCounts].mInvalid = true;
 		mNumMessageCounts++;
 	}
 }
@@ -1392,12 +1392,12 @@ void LLMessageSystem::logTrustedMsgFromUntrustedCircuit( const LLHost& host )
 		//	= mCurrentRMessageTemplate->mMessageNumber;
 		mMessageCountList[mNumMessageCounts].mMessageBytes
 			= mMessageReader->getMessageSize();
-		mMessageCountList[mNumMessageCounts].mInvalid = TRUE;
+		mMessageCountList[mNumMessageCounts].mInvalid = true;
 		mNumMessageCounts++;
 	}
 }
 
-void LLMessageSystem::logValidMsg(LLCircuitData *cdp, const LLHost& host, BOOL recv_reliable, BOOL recv_resent, BOOL recv_acks )
+void LLMessageSystem::logValidMsg(LLCircuitData *cdp, const LLHost& host, bool recv_reliable, bool recv_resent, bool recv_acks )
 {
 	if (mNumMessageCounts >= MAX_MESSAGE_COUNT_NUM)
 	{
@@ -1408,7 +1408,7 @@ void LLMessageSystem::logValidMsg(LLCircuitData *cdp, const LLHost& host, BOOL r
 		// TODO: babbage: work out if we need these
 		//mMessageCountList[mNumMessageCounts].mMessageNum = mCurrentRMessageTemplate->mMessageNumber;
 		mMessageCountList[mNumMessageCounts].mMessageBytes = mMessageReader->getMessageSize();
-		mMessageCountList[mNumMessageCounts].mInvalid = FALSE;
+		mMessageCountList[mNumMessageCounts].mInvalid = false;
 		mNumMessageCounts++;
 	}
 
@@ -1502,7 +1502,7 @@ void LLMessageSystem::getCircuitInfo(LLSD& info) const
 }
 
 // returns whether the given host is on a trusted circuit
-BOOL    LLMessageSystem::getCircuitTrust(const LLHost &host)
+bool    LLMessageSystem::getCircuitTrust(const LLHost &host)
 {
 	LLCircuitData *cdp = mCircuitInfo.findCircuit(host);
 	if (cdp)
@@ -1510,12 +1510,12 @@ BOOL    LLMessageSystem::getCircuitTrust(const LLHost &host)
 		return cdp->getTrusted();
 	}
 
-	return FALSE;
+	return false;
 }
 
 // Activate a circuit, and set its trust level (TRUE if trusted,
 // FALSE if not).
-void LLMessageSystem::enableCircuit(const LLHost &host, BOOL trusted)
+void LLMessageSystem::enableCircuit(const LLHost &host, bool trusted)
 {
 	LLCircuitData *cdp = mCircuitInfo.findCircuit(host);
 	if (!cdp)
@@ -1576,7 +1576,7 @@ void LLMessageSystem::disableCircuit(const LLHost &host)
 }
 
 
-void LLMessageSystem::setCircuitAllowTimeout(const LLHost &host, BOOL allow)
+void LLMessageSystem::setCircuitAllowTimeout(const LLHost &host, bool allow)
 {
 	LLCircuitData *cdp = mCircuitInfo.findCircuit(host);
 	if (cdp)
@@ -1654,7 +1654,7 @@ bool LLMessageSystem::checkCircuitAlive(const LLHost &host)
 }
 
 
-void LLMessageSystem::setCircuitProtection(BOOL b_protect)
+void LLMessageSystem::setCircuitProtection(bool b_protect)
 {
 	mbProtected = b_protect;
 }
@@ -1782,7 +1782,7 @@ void	open_circuit(LLMessageSystem *msgsystem, void** /*user_data*/)
 	msgsystem->getIPPortFast(_PREHASH_CircuitInfo, _PREHASH_Port, port);
 
 	// By default, OpenCircuit's are untrusted
-	msgsystem->enableCircuit(LLHost(ip, port), FALSE);
+	msgsystem->enableCircuit(LLHost(ip, port), false);
 }
 
 void	close_circuit(LLMessageSystem *msgsystem, void** /*user_data*/)
@@ -1947,9 +1947,9 @@ void LLMessageSystem::processUseCircuitCode(LLMessageSystem* msg,
 		// passed the circuit code and session id check, so we will go
 		// ahead and persist the ID associated.
 		LLCircuitData *cdp = msg->mCircuitInfo.findCircuit(msg->getSender());
-		BOOL had_circuit_already = cdp ? TRUE : FALSE;
+		bool had_circuit_already = cdp ? true : false;
 
-		msg->enableCircuit(msg->getSender(), FALSE);
+		msg->enableCircuit(msg->getSender(), false);
 		cdp = msg->mCircuitInfo.findCircuit(msg->getSender());
 		if(cdp)
 		{
@@ -1973,7 +1973,7 @@ void LLMessageSystem::processUseCircuitCode(LLMessageSystem* msg,
 			// doesn't get properly duplicate suppressed.  Not a BIG deal, but it's somewhat confusing
 			// (and bad from a state point of view).  DJS 9/23/04
 			//
-			cdp->checkPacketInID(gMessageSystem->mCurrentRecvPacketID, FALSE ); // Since this is the first message on the circuit, by definition it's not resent.
+			cdp->checkPacketInID(gMessageSystem->mCurrentRecvPacketID, false ); // Since this is the first message on the circuit, by definition it's not resent.
 		}
 
 		msg->mIPPortToCircuitCode[ip_port_in] = circuit_code_in;
@@ -2460,13 +2460,13 @@ bool start_messaging_system(
 	if (!gMessageSystem)
 	{
 		LL_ERRS("AppInit") << "Messaging system initialization failed." << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
 	// bail if system encountered an error.
 	if(!gMessageSystem->isOK())
 	{
-		return FALSE;
+		return false;
 	}
 
 	if (b_dump_prehash_file)
@@ -2517,12 +2517,12 @@ bool start_messaging_system(
 	// Initialize the transfer manager
 	gTransferManager.init();
 
-	return TRUE;
+	return true;
 }
 
 void LLMessageSystem::startLogging()
 {
-	mVerboseLog = TRUE;
+	mVerboseLog = true;
 	std::ostringstream str;
 	str << "START MESSAGE LOG" << std::endl;
 	str << "Legend:" << std::endl;
@@ -2536,7 +2536,7 @@ void LLMessageSystem::stopLogging()
 {
 	if(mVerboseLog)
 	{
-		mVerboseLog = FALSE;
+		mVerboseLog = false;
 		LL_INFOS("Messaging") << "END MESSAGE LOG" << LL_ENDL;
 	}
 }
@@ -2757,7 +2757,7 @@ S32 LLMessageSystem::zeroCodeAdjustCurrentSendTotal()
 			0);
 	}
 	// TODO: babbage: remove this horror
-	mMessageBuilder->setBuilt(FALSE);
+	mMessageBuilder->setBuilt(false);
 
 	S32 count = mSendSize;
 	
@@ -3357,7 +3357,7 @@ void LLMessageSystem::dumpPacketToLog()
 
 
 //static
-U64Microseconds LLMessageSystem::getMessageTimeUsecs(const BOOL update)
+U64Microseconds LLMessageSystem::getMessageTimeUsecs(const bool update)
 {
 	if (gMessageSystem)
 	{
@@ -3374,7 +3374,7 @@ U64Microseconds LLMessageSystem::getMessageTimeUsecs(const BOOL update)
 }
 
 //static
-F64Seconds LLMessageSystem::getMessageTimeSeconds(const BOOL update)
+F64Seconds LLMessageSystem::getMessageTimeSeconds(const bool update)
 {
 	if (gMessageSystem)
 	{
@@ -3432,7 +3432,7 @@ void LLMessageSystem::newMessageFast(const char *name)
 			mMessageBuilder = mTemplateMessageBuilder;
 		}
 	}
-	mSendReliable = FALSE;
+	mSendReliable = false;
 	mMessageBuilder->newMessage(name);
 }
 	
@@ -3923,7 +3923,7 @@ void LLMessageSystem::getString(const char *block, const char *var,
 				  blocknum);
 }
 
-BOOL	LLMessageSystem::has(const char *blockname) const
+bool	LLMessageSystem::has(const char *blockname) const
 {
 	return getNumberOfBlocks(blockname) > 0;
 }

--- a/indra/llmessage/message.h
+++ b/indra/llmessage/message.h
@@ -74,7 +74,7 @@ public:
 	char *getString(const char *str);
 
 	U32	 mUsed;
-	BOOL mEmpty[MESSAGE_NUMBER_OF_HASH_BUCKETS];
+	bool mEmpty[MESSAGE_NUMBER_OF_HASH_BUCKETS];
 	char mString[MESSAGE_NUMBER_OF_HASH_BUCKETS][MESSAGE_MAX_STRINGS_LENGTH];	/* Flawfinder: ignore */
 };
 
@@ -296,7 +296,7 @@ class LLMessageSystem : public LLMessageSenderInterface
 	LLReliablePacketParams		mReliablePacketParams;
 
 	// Set this flag to TRUE when you want *very* verbose logs.
-	BOOL						mVerboseLog;
+	bool						mVerboseLog;
 
 	F32                         mMessageFileVersionNumber;
 
@@ -314,7 +314,7 @@ public:
 	S32					mSystemVersionServer;
 	U32					mVersionFlags;
 
-	BOOL				mbProtected;
+	bool				mbProtected;
 
 	U32					mNumberHighFreqMessages;
 	U32					mNumberMediumFreqMessages;
@@ -347,7 +347,7 @@ public:
 	S64					mTotalBytesIn;		    // total size of all uncompressed packets in
 	S64					mTotalBytesOut;		    // total size of all uncompressed packets out
 
-	BOOL                mSendReliable;              // does the outgoing message require a pos ack?
+	bool                mSendReliable;              // does the outgoing message require a pos ack?
 
 	LLCircuit 	 		mCircuitInfo;
 	F64Seconds			mCircuitPrintTime;	    // used to print circuit debug info every couple minutes
@@ -370,7 +370,7 @@ public:
 
 	~LLMessageSystem();
 
-	BOOL isOK() const { return !mbError; }
+	bool isOK() const { return !mbError; }
 	S32 getErrorCode() const { return mErrorCode; }
 
 	// Read file and build message templates filename must point to a
@@ -548,7 +548,7 @@ public:
 	// Use this one if you DON'T want automatic ping-based retry.
 	S32	sendReliable(	const LLHost &host, 
 							S32 retries, 
-							BOOL ping_based_retries,
+							bool ping_based_retries,
 							F32Seconds timeout, 
 							void (*callback)(void **,S32), 
 							void ** callback_data);
@@ -568,7 +568,7 @@ public:
 	S32 forwardReliable(
 		const LLHost &host, 
 		S32 retries, 
-		BOOL ping_based_timeout,
+		bool ping_based_timeout,
 		F32Seconds timeout, 
 		void (*callback)(void **,S32), 
 		void ** callback_data);
@@ -579,7 +579,7 @@ private:
 	S32		sendMessage(const LLHost &host, const char* name,
 						const LLSD& message);
 public:
-	// BOOL	decodeData(const U8 *buffer, const LLHost &host);
+	// bool	decodeData(const U8 *buffer, const LLHost &host);
 
 	/**
 	gets binary data from the current message.
@@ -659,7 +659,7 @@ public:
 
 	U32 getOurCircuitCode();
 	
-	void	enableCircuit(const LLHost &host, BOOL trusted);
+	void	enableCircuit(const LLHost &host, bool trusted);
 	void	disableCircuit(const LLHost &host);
 	
 	// Use this to establish trust on startup and in response to
@@ -712,20 +712,20 @@ public:
 
 	// returns whether the given host is on a trusted circuit
 	// Note:DaveH/Babbage some trusted messages can be received without a circuit
-	BOOL    getCircuitTrust(const LLHost &host);
+	bool    getCircuitTrust(const LLHost &host);
 	
-	void	setCircuitAllowTimeout(const LLHost &host, BOOL allow);
+	void	setCircuitAllowTimeout(const LLHost &host, bool allow);
 	void	setCircuitTimeoutCallback(const LLHost &host, void (*callback_func)(const LLHost &host, void *user_data), void *user_data);
 
 	bool	checkCircuitBlocked(const U32 circuit);
 	bool	checkCircuitAlive(const U32 circuit);
 	bool	checkCircuitAlive(const LLHost &host);
-	void	setCircuitProtection(BOOL b_protect);
+	void	setCircuitProtection(bool b_protect);
 	U32		findCircuitCode(const LLHost &host);
 	LLHost	findHost(const U32 circuit_code);
 	void	sanityCheck();
 
-	BOOL	has(const char *blockname) const;
+	bool	has(const char *blockname) const;
 	S32		getNumberOfBlocksFast(const char *blockname) const;
 	S32		getNumberOfBlocks(const char *blockname) const;
 	S32		getSizeFast(const char *blockname, const char *varname) const;
@@ -762,8 +762,8 @@ public:
 	void setMaxMessageTime(const F32 seconds);	// Max time to process messages before warning and dumping (neg to disable)
 	void setMaxMessageCounts(const S32 num);	// Max number of messages before dumping (neg to disable)
 	
-	static U64Microseconds getMessageTimeUsecs(const BOOL update = FALSE);	// Get the current message system time in microseconds
-	static F64Seconds getMessageTimeSeconds(const BOOL update = FALSE); // Get the current message system time in seconds
+	static U64Microseconds getMessageTimeUsecs(const bool update = false);	// Get the current message system time in microseconds
+	static F64Seconds getMessageTimeSeconds(const bool update = false); // Get the current message system time in seconds
 
 	static void setTimeDecodes(bool b);
 	static void setTimeDecodesSpamThreshold(F32 seconds);
@@ -839,11 +839,11 @@ private:
 	LLUUID mSessionID;
 	
 	void	addTemplate(LLMessageTemplate *templatep);
-	BOOL		decodeTemplate( const U8* buffer, S32 buffer_size, LLMessageTemplate** msg_template );
+	bool		decodeTemplate( const U8* buffer, S32 buffer_size, LLMessageTemplate** msg_template );
 
-	void		logMsgFromInvalidCircuit( const LLHost& sender, BOOL recv_reliable );
+	void		logMsgFromInvalidCircuit( const LLHost& sender, bool recv_reliable );
 	void		logTrustedMsgFromUntrustedCircuit( const LLHost& sender );
-	void		logValidMsg(LLCircuitData *cdp, const LLHost& sender, BOOL recv_reliable, BOOL recv_resent, BOOL recv_acks );
+	void		logValidMsg(LLCircuitData *cdp, const LLHost& sender, bool recv_reliable, bool recv_resent, bool recv_acks );
 	void		logRanOffEndOfPacket( const LLHost& sender );
 
 	class LLMessageCountInfo
@@ -851,7 +851,7 @@ private:
 	public:
 		U32 mMessageNum;
 		U32 mMessageBytes;
-		BOOL mInvalid;
+		bool mInvalid;
 	};
 
 	LLMessagePollInfo						*mPollInfop;
@@ -862,7 +862,7 @@ private:
 
 	// Must be valid during decode
 	
-	BOOL	mbError;
+	bool	mbError;
 	S32	mErrorCode;
 
 	F64Seconds										mResendDumpTime; // The last time we dumped resends
@@ -885,7 +885,7 @@ private:
 	LLTimer mMessageSystemTimer;
 
 	static F32 mTimeDecodesSpamThreshold;  // If mTimeDecodes is on, all this many seconds for each msg decode before spamming
-	static BOOL mTimeDecodes;  // Measure time for all message decodes if TRUE;
+	static bool mTimeDecodes;  // Measure time for all message decodes if TRUE;
 
 	msg_timing_callback mTimingCallback;
 	void* mTimingCallbackData;

--- a/indra/llmessage/message_string_table.cpp
+++ b/indra/llmessage/message_string_table.cpp
@@ -47,7 +47,7 @@ LLMessageStringTable::LLMessageStringTable()
 {
 	for (U32 i = 0; i < MESSAGE_NUMBER_OF_HASH_BUCKETS; i++)
 	{
-		mEmpty[i] = TRUE;
+		mEmpty[i] = true;
 		mString[i][0] = 0;
 	}
 }
@@ -75,7 +75,7 @@ char* LLMessageStringTable::getString(const char *str)
 	// not found, so add!
 	strncpy(mString[hash_value], str, MESSAGE_MAX_STRINGS_LENGTH);	/* Flawfinder: ignore */
 	mString[hash_value][MESSAGE_MAX_STRINGS_LENGTH - 1] = 0;
-	mEmpty[hash_value] = FALSE;
+	mEmpty[hash_value] = false;
 	mUsed++;
 	if (mUsed >= MESSAGE_NUMBER_OF_HASH_BUCKETS - 1)
 	{

--- a/indra/llmessage/net.cpp
+++ b/indra/llmessage/net.cpp
@@ -339,7 +339,7 @@ S32 receive_packet(int hSocket, char * receiveBuffer)
 }
 
 // Returns TRUE on success.
-BOOL send_packet(int hSocket, const char *sendBuffer, int size, U32 recipient, int nPort)
+bool send_packet(int hSocket, const char *sendBuffer, int size, U32 recipient, int nPort)
 {
 	//  Sends a packet to the address set in initNet
 	//  
@@ -364,7 +364,7 @@ BOOL send_packet(int hSocket, const char *sendBuffer, int size, U32 recipient, i
 				// assume it is.  JNC 2002.01.18
 				if (WSAECONNRESET == WSAGetLastError())
 				{
-					return TRUE;
+					return true;
 				}
 				LL_INFOS() << "sendto() failed to " << u32_to_ip_string(recipient) << ":" << nPort 
 					<< ", Error " << last_error << LL_ENDL;
@@ -598,11 +598,11 @@ int receive_packet(int hSocket, char * receiveBuffer)
 	return nRet;
 }
 
-BOOL send_packet(int hSocket, const char * sendBuffer, int size, U32 recipient, int nPort)
+bool send_packet(int hSocket, const char * sendBuffer, int size, U32 recipient, int nPort)
 {
 	int		ret;
-	BOOL	success;
-	BOOL	resend;
+	bool	success;
+	bool	resend;
 	S32		send_attempts = 0;
 
 	stDstAddr.sin_addr.s_addr = recipient;
@@ -616,34 +616,34 @@ BOOL send_packet(int hSocket, const char * sendBuffer, int size, U32 recipient, 
 		if (ret >= 0)
 		{
 			// successful send
-			success = TRUE;
-			resend = FALSE;
+			success = true;
+			resend = false;
 		}
 		else
 		{
 			// send failed, check to see if we should resend
-			success = FALSE;
+			success = false;
 
 			if (errno == EAGAIN)
 			{
 				// say nothing, just repeat send
 				LL_INFOS() << "sendto() reported buffer full, resending (attempt " << send_attempts << ")" << LL_ENDL;
 				LL_INFOS() << inet_ntoa(stDstAddr.sin_addr) << ":" << nPort << LL_ENDL;
-				resend = TRUE;
+				resend = true;
 			}
 			else if (errno == ECONNREFUSED)
 			{
 				// response to ICMP connection refused message on earlier send
 				LL_INFOS() << "sendto() reported connection refused, resending (attempt " << send_attempts << ")" << LL_ENDL;
 				LL_INFOS() << inet_ntoa(stDstAddr.sin_addr) << ":" << nPort << LL_ENDL;
-				resend = TRUE;
+				resend = true;
 			}
 			else
 			{
 				// some other error
 				LL_INFOS() << "sendto() failed: " << errno << ", " << strerror(errno) << LL_ENDL;
 				LL_INFOS() << inet_ntoa(stDstAddr.sin_addr) << ":" << nPort << LL_ENDL;
-				resend = FALSE;
+				resend = false;
 			}
 		}
 	}
@@ -652,7 +652,7 @@ BOOL send_packet(int hSocket, const char * sendBuffer, int size, U32 recipient, 
 	if (send_attempts >= 3)
 	{
 		LL_INFOS() << "sendPacket() bailed out of send!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
 	return success;

--- a/indra/llmessage/net.h
+++ b/indra/llmessage/net.h
@@ -43,7 +43,7 @@ void	end_net(S32& socket_out);
 // returns size of packet or -1 in case of error
 S32		receive_packet(int hSocket, char * receiveBuffer);
 
-BOOL	send_packet(int hSocket, const char *sendBuffer, int size, U32 recipient, int nPort);	// Returns TRUE on success.
+bool	send_packet(int hSocket, const char *sendBuffer, int size, U32 recipient, int nPort);	// Returns TRUE on success.
 
 //void	get_sender(char * tmp);
 LLHost	get_sender();

--- a/indra/llmessage/partsyspacket.cpp
+++ b/indra/llmessage/partsyspacket.cpp
@@ -89,7 +89,7 @@ void gSetInitDataDefaults(LLPartInitData *setMe)
 		setMe->mFlags[i] = 0x00;
 	}
 
-	setMe->createMe = TRUE;
+	setMe->createMe = true;
 
 	setMe->maxParticles = 25;
 	setMe->initialParticles = 25;
@@ -1168,7 +1168,7 @@ bool LLPartSysCompressedPacket::fromLLPartInitData(LLPartInitData *in, U32 &byte
 	
 //	llprintline("returning from \"fromLLPartInitData\" with %d bytes\n", bytesUsed);
 	
-	return TRUE;
+	return true;
 }
 
 bool LLPartSysCompressedPacket::toLLPartInitData(LLPartInitData *out, U32 *bytesUsed)

--- a/indra/llmessage/patch_code.cpp
+++ b/indra/llmessage/patch_code.cpp
@@ -130,7 +130,7 @@ void code_patch(LLBitPack &bitpack, S32 *patch, S32 postquant)
 {
 	S32		i, j, patch_size = gPatchSize, wbits = gWordBits;
 	S32		temp;
-	BOOL	b_eob;
+	bool	b_eob;
 
 	if (  (postquant > patch_size*patch_size)
 		||(postquant < 0))
@@ -143,16 +143,16 @@ void code_patch(LLBitPack &bitpack, S32 *patch, S32 postquant)
 
 	for (i = 0; i < patch_size*patch_size; i++)
 	{
-		b_eob = FALSE;
+		b_eob = false;
 		temp = patch[i];
 		if (!temp)
 		{
-			b_eob = TRUE;
+			b_eob = true;
 			for (j = i; j < patch_size*patch_size - postquant; j++)
 			{
 				if (patch[j])
 				{
-					b_eob = FALSE;
+					b_eob = false;
 					break;
 				}
 			}

--- a/indra/llmessage/patch_dct.cpp
+++ b/indra/llmessage/patch_dct.cpp
@@ -85,8 +85,8 @@ S32	gCopyMatrix[LARGE_PATCH_SIZE*LARGE_PATCH_SIZE];
 void build_copy_matrix(S32 size)
 {
 	S32 i, j, count;
-	BOOL	b_diag = FALSE;
-	BOOL	b_right = TRUE;
+	bool	b_diag = false;
+	bool	b_right = true;
 
 	i = 0;
 	j = 0;
@@ -107,8 +107,8 @@ void build_copy_matrix(S32 size)
 					i++;
 				else
 					j++;
-				b_right = FALSE;
-				b_diag = TRUE;
+				b_right = false;
+				b_diag = true;
 			}
 			else
 			{
@@ -116,8 +116,8 @@ void build_copy_matrix(S32 size)
 					j++;
 				else
 					i++;
-				b_right = TRUE;
-				b_diag = TRUE;
+				b_right = true;
+				b_diag = true;
 			}
 		}
 		else
@@ -129,7 +129,7 @@ void build_copy_matrix(S32 size)
 				if (  (i == size - 1)
 					||(j == 0))
 				{
-					b_diag = FALSE;
+					b_diag = false;
 				}
 			}
 			else
@@ -139,7 +139,7 @@ void build_copy_matrix(S32 size)
 				if (  (i == 0)
 					||(j == size - 1))
 				{
-					b_diag = FALSE;
+					b_diag = false;
 				}
 			}
 		}

--- a/indra/llmessage/patch_idct.cpp
+++ b/indra/llmessage/patch_idct.cpp
@@ -74,8 +74,8 @@ S32	gDeCopyMatrix[LARGE_PATCH_SIZE*LARGE_PATCH_SIZE];
 void build_decopy_matrix(S32 size)
 {
 	S32 i, j, count;
-	BOOL	b_diag = FALSE;
-	BOOL	b_right = TRUE;
+	bool	b_diag = false;
+	bool	b_right = true;
 
 	i = 0;
 	j = 0;
@@ -96,8 +96,8 @@ void build_decopy_matrix(S32 size)
 					i++;
 				else
 					j++;
-				b_right = FALSE;
-				b_diag = TRUE;
+				b_right = false;
+				b_diag = true;
 			}
 			else
 			{
@@ -105,8 +105,8 @@ void build_decopy_matrix(S32 size)
 					j++;
 				else
 					i++;
-				b_right = TRUE;
-				b_diag = TRUE;
+				b_right = true;
+				b_diag = true;
 			}
 		}
 		else
@@ -118,7 +118,7 @@ void build_decopy_matrix(S32 size)
 				if (  (i == size - 1)
 					||(j == 0))
 				{
-					b_diag = FALSE;
+					b_diag = false;
 				}
 			}
 			else
@@ -128,7 +128,7 @@ void build_decopy_matrix(S32 size)
 				if (  (i == 0)
 					||(j == size - 1))
 				{
-					b_diag = FALSE;
+					b_diag = false;
 				}
 			}
 		}
@@ -658,8 +658,8 @@ void decompress_patchv(LLVector3 *v, S32 *cpatch, LLPatchHeader *ph)
 	F32		mult = ooq*range;
 	F32		addval = mult*(F32)(1<<(prequant - 1))+hmin;
 
-//	BOOL	b_diag = FALSE;
-//	BOOL	b_right = TRUE;
+//	bool	b_diag = false;
+//	bool	b_right = true;
 
 	for (i = 0; i < size*size; i++)
 	{

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -2590,7 +2590,7 @@ void LLLineEditor::markAsPreedit(S32 position, S32 length)
 		mPreeditPositions[0] = position;
 		mPreeditPositions[1] = position + length;
 		mPreeditStandouts.resize(1);
-		mPreeditStandouts[0] = FALSE;
+		mPreeditStandouts[0] = false;
 	}
 	else
 	{

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -276,7 +276,7 @@ protected:
 	LLWString			mPreeditWString;
 	LLWString			mPreeditOverwrittenWString;
 	std::vector<S32> 	mPreeditPositions;
-	std::vector<bool> 	mPreeditStandouts;
+	LLPreeditor::standouts_t mPreeditStandouts;
 
 protected:
 	LLUIColor			mDefaultColor;

--- a/indra/llwindow/llpreeditor.h
+++ b/indra/llwindow/llpreeditor.h
@@ -34,7 +34,7 @@ class LLPreeditor
 public:
 
 	typedef std::vector<S32> segment_lengths_t;
-	typedef std::vector<bool> standouts_t;
+	typedef std::deque<bool> standouts_t;
 	
 	// We don't delete against LLPreeditor, but compilers complain without this...
 	

--- a/indra/newview/llpanellandmedia.cpp
+++ b/indra/newview/llpanellandmedia.cpp
@@ -149,14 +149,14 @@ void LLPanelLandMedia::refresh()
 		mMediaTypeCombo->setEnabled( can_change_media );
 		getChild<LLUICtrl>("mime_type")->setValue(mime_type);
 
-		mMediaAutoScaleCheck->set( parcel->getMediaAutoScale () );
+		mMediaAutoScaleCheck->set( static_cast<bool>(parcel->getMediaAutoScale()) );
 		mMediaAutoScaleCheck->setEnabled ( can_change_media );
 
 		// Special code to disable looping checkbox for HTML MIME type
 		// (DEV-10042 -- Parcel Media: "Loop Media" should be disabled for static media types)
 		bool allow_looping = LLMIMETypes::findAllowLooping( mime_type );
 		if ( allow_looping )
-			mMediaLoopCheck->set( parcel->getMediaLoop () );
+			mMediaLoopCheck->set( static_cast<bool>(parcel->getMediaLoop()) );
 		else
 			mMediaLoopCheck->set( false );
 		mMediaLoopCheck->setEnabled ( can_change_media && allow_looping );
@@ -275,8 +275,8 @@ void LLPanelLandMedia::onCommitAny(LLUICtrl*, void *userdata)
 	std::string media_url	= self->mMediaURLEdit->getText();
 	std::string media_desc	= self->mMediaDescEdit->getText();
 	std::string mime_type	= self->getChild<LLUICtrl>("mime_type")->getValue().asString();
-	U8 media_auto_scale		= self->mMediaAutoScaleCheck->get();
-	U8 media_loop           = self->mMediaLoopCheck->get();
+	U8 media_auto_scale		= static_cast<U8>(self->mMediaAutoScaleCheck->get());
+	U8 media_loop           = static_cast<U8>(self->mMediaLoopCheck->get());
 	S32 media_width			= (S32)self->mMediaWidthCtrl->get();
 	S32 media_height		= (S32)self->mMediaHeightCtrl->get();
 	LLUUID media_id			= self->mMediaTextureCtrl->getImageAssetID();

--- a/indra/newview/llviewermediafocus.cpp
+++ b/indra/newview/llviewermediafocus.cpp
@@ -125,7 +125,7 @@ void LLViewerMediaFocus::setFocusFace(LLPointer<LLViewerObject> objectp, S32 fac
 
 		if(mMediaControls.get())
 		{
-			if(face_auto_zoom && ! parcel->getMediaPreventCameraZoom())
+			if(face_auto_zoom && !static_cast<bool>(parcel->getMediaPreventCameraZoom()))
 			{
 				// Zoom in on this face
 				mMediaControls.get()->resetZoomLevel(false);

--- a/indra/newview/llviewerparcelmedia.cpp
+++ b/indra/newview/llviewerparcelmedia.cpp
@@ -400,8 +400,8 @@ void LLViewerParcelMedia::processParcelMediaUpdate( LLMessageSystem *msg)
 	std::string media_type;
 	S32 media_width = 0;
 	S32 media_height = 0;
-	U8 media_auto_scale = FALSE;
-	U8 media_loop = FALSE;
+	U8 media_auto_scale = 0;
+	U8 media_loop = 0;
 
 	msg->getUUID( "DataBlock", "MediaID", media_id );
 	char media_url_buffer[257];
@@ -420,16 +420,15 @@ void LLViewerParcelMedia::processParcelMediaUpdate( LLMessageSystem *msg)
 	}
 
 	LLParcel *parcel = LLViewerParcelMgr::getInstance()->getAgentParcel();
-	BOOL same = FALSE;
 	if (parcel)
 	{
-		same = ((parcel->getMediaURL() == media_url) &&
-				(parcel->getMediaType() == media_type) &&
-				(parcel->getMediaID() == media_id) &&
-				(parcel->getMediaWidth() == media_width) &&
-				(parcel->getMediaHeight() == media_height) &&
-				(parcel->getMediaAutoScale() == media_auto_scale) &&
-				(parcel->getMediaLoop() == media_loop));
+		bool same = ((parcel->getMediaURL() == media_url) &&
+					 (parcel->getMediaType() == media_type) &&
+					 (parcel->getMediaID() == media_id) &&
+					 (parcel->getMediaWidth() == media_width) &&
+					 (parcel->getMediaHeight() == media_height) &&
+					 (parcel->getMediaAutoScale() == media_auto_scale) &&
+					 (parcel->getMediaLoop() == media_loop));
 
 		if (!same)
 		{


### PR DESCRIPTION
Converted remaining BOOLs into bool in llinventory and llmessage.

Also changed LLPreeditor::standouts_t to std::deque since it got turned into std::vector<bool> previously, which is a implementation dependent specialization where some STL container functions will perform unexpectedly depending on the implementation.

@marchcat I'm a bit confused about llsdmessagebuilder.cpp line 357: Was casting to BOOL* even correct before? A bool in the message template is stored in a U8 while BOOL is an S32, so the size should be different!?