### PR TITLE
More BOOL to bool conversion

### DIFF
--- a/indra/llcommon/CMakeLists.txt
+++ b/indra/llcommon/CMakeLists.txt
@@ -194,6 +194,7 @@ set(llcommon_HEADER_FILES
     llmetrics.h
     llmetricperformancetester.h
     llmortician.h
+    llmutex.h
     llnametable.h
     llpointer.h
     llprofiler.h

--- a/indra/llcommon/llmutex.h
+++ b/indra/llcommon/llmutex.h
@@ -64,7 +64,7 @@ protected:
 	mutable LLThread::id_t	mLockingThread;
 	
 #if MUTEX_DEBUG
-	std::unordered_map<LLThread::id_t, BOOL> mIsLocked;
+	std::unordered_map<LLThread::id_t, bool> mIsLocked;
 #endif
 };
 

--- a/indra/llinventory/llpermissions.cpp
+++ b/indra/llinventory/llpermissions.cpp
@@ -325,7 +325,7 @@ bool LLPermissions::deedToGroup(const LLUUID& agent, const LLUUID& group)
 
 bool LLPermissions::setBaseBits(const LLUUID& agent, bool set, PermissionMask bits)
 {
-	bool ownership = true;
+	bool ownership = false;
 	if(agent.isNull())
 	{
 		// only the system is always allowed to change base bits

--- a/indra/llmath/llbbox.h
+++ b/indra/llmath/llbbox.h
@@ -37,13 +37,13 @@
 class LLBBox
 {
 public:
-	LLBBox() {mEmpty = TRUE;}
+	LLBBox() {mEmpty = true;}
 	LLBBox( const LLVector3& pos_agent,
 		const LLQuaternion& rot,
 		const LLVector3& min_local,
 		const LLVector3& max_local )
 		:
-		mMinLocal( min_local ), mMaxLocal( max_local ), mPosAgent(pos_agent), mRotation( rot), mEmpty( TRUE )
+		mMinLocal( min_local ), mMaxLocal( max_local ), mPosAgent(pos_agent), mRotation( rot), mEmpty( true )
 		{}
 
 	// Default copy constructor is OK.

--- a/indra/llmath/llquaternion.cpp
+++ b/indra/llmath/llquaternion.cpp
@@ -653,14 +653,14 @@ LLQuaternion slerp( F32 u, const LLQuaternion &a, const LLQuaternion &b )
 	F32 cos_t = a.mQ[0]*b.mQ[0] + a.mQ[1]*b.mQ[1] + a.mQ[2]*b.mQ[2] + a.mQ[3]*b.mQ[3];
 	
 	// if b is on opposite hemisphere from a, use -a instead
-	int bflip;
+	bool bflip;
  	if (cos_t < 0.0f)
 	{
 		cos_t = -cos_t;
-		bflip = TRUE;
+		bflip = true;
 	}
 	else
-		bflip = FALSE;
+		bflip = false;
 
 	// if B is (within precision limits) the same as A,
 	// just linear interpolate between A and B.

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -62,38 +62,38 @@
 #define DEBUG_SILHOUETTE_NORMALS 0 // TomY: Use this to display normals using the silhouette
 #define DEBUG_SILHOUETTE_EDGE_MAP 0 // DaveP: Use this to display edge map using the silhouette
 
-const F32 MIN_CUT_DELTA = 0.02f;
+constexpr F32 MIN_CUT_DELTA = 0.02f;
 
-const F32 HOLLOW_MIN = 0.f;
-const F32 HOLLOW_MAX = 0.95f;
-const F32 HOLLOW_MAX_SQUARE	= 0.7f;
+constexpr F32 HOLLOW_MIN = 0.f;
+constexpr F32 HOLLOW_MAX = 0.95f;
+constexpr F32 HOLLOW_MAX_SQUARE	= 0.7f;
 
-const F32 TWIST_MIN = -1.f;
-const F32 TWIST_MAX =  1.f;
+constexpr F32 TWIST_MIN = -1.f;
+constexpr F32 TWIST_MAX =  1.f;
 
-const F32 RATIO_MIN = 0.f;
-const F32 RATIO_MAX = 2.f; // Tom Y: Inverted sense here: 0 = top taper, 2 = bottom taper
+constexpr F32 RATIO_MIN = 0.f;
+constexpr F32 RATIO_MAX = 2.f; // Tom Y: Inverted sense here: 0 = top taper, 2 = bottom taper
 
-const F32 HOLE_X_MIN= 0.05f;
-const F32 HOLE_X_MAX= 1.0f;
+constexpr F32 HOLE_X_MIN= 0.05f;
+constexpr F32 HOLE_X_MAX= 1.0f;
 
-const F32 HOLE_Y_MIN= 0.05f;
-const F32 HOLE_Y_MAX= 0.5f;
+constexpr F32 HOLE_Y_MIN= 0.05f;
+constexpr F32 HOLE_Y_MAX= 0.5f;
 
-const F32 SHEAR_MIN = -0.5f;
-const F32 SHEAR_MAX =  0.5f;
+constexpr F32 SHEAR_MIN = -0.5f;
+constexpr F32 SHEAR_MAX =  0.5f;
 
-const F32 REV_MIN = 1.f;
-const F32 REV_MAX = 4.f;
+constexpr F32 REV_MIN = 1.f;
+constexpr F32 REV_MAX = 4.f;
 
-const F32 TAPER_MIN = -1.f;
-const F32 TAPER_MAX =  1.f;
+constexpr F32 TAPER_MIN = -1.f;
+constexpr F32 TAPER_MAX =  1.f;
 
-const F32 SKEW_MIN	= -0.95f;
-const F32 SKEW_MAX	=  0.95f;
+constexpr F32 SKEW_MIN	= -0.95f;
+constexpr F32 SKEW_MAX	=  0.95f;
 
-const F32 SCULPT_MIN_AREA = 0.002f;
-const S32 SCULPT_MIN_AREA_DETAIL = 1;
+constexpr F32 SCULPT_MIN_AREA = 0.002f;
+constexpr S32 SCULPT_MIN_AREA_DETAIL = 1;
 
 bool gDebugGL = false; // See settings.xml "RenderDebugGL"
 
@@ -439,12 +439,12 @@ LLProfile::Face* LLProfile::addCap(S16 faceID)
 	face->mIndex = 0;
 	face->mCount = mTotal;
 	face->mScaleU= 1.0f;
-	face->mCap   = TRUE;
+	face->mCap   = true;
 	face->mFaceID = faceID;
 	return face;
 }
 
-LLProfile::Face* LLProfile::addFace(S32 i, S32 count, F32 scaleU, S16 faceID, BOOL flat)
+LLProfile::Face* LLProfile::addFace(S32 i, S32 count, F32 scaleU, S16 faceID, bool flat)
 {
 	Face *face   = vector_append(mFaces, 1);
 	
@@ -453,7 +453,7 @@ LLProfile::Face* LLProfile::addFace(S32 i, S32 count, F32 scaleU, S16 faceID, BO
 	face->mScaleU= scaleU;
 
 	face->mFlat = flat;
-	face->mCap   = FALSE;
+	face->mCap   = false;
 	face->mFaceID = faceID;
 	return face;
 }
@@ -528,7 +528,7 @@ void LLProfile::genNGon(const LLProfileParams& params, S32 sides, F32 offset, F3
 {
 	// Generate an n-sided "circular" path.
 	// 0 is (1,0), and we go counter-clockwise along a circular path from there.
-	static const F32 tableScale[] = { 1, 1, 1, 0.5f, 0.707107f, 0.53f, 0.525f, 0.5f };
+	constexpr F32 tableScale[] = { 1, 1, 1, 0.5f, 0.707107f, 0.53f, 0.525f, 0.5f };
 	F32 scale = 0.5f;
 	F32 t, t_step, t_first, t_fraction, ang, ang_step;
 	LLVector4a pt1,pt2;
@@ -628,13 +628,13 @@ void LLProfile::genNGon(const LLProfileParams& params, S32 sides, F32 offset, F3
 	{
 		if ((end - begin)*ang_scale > 0.5f)
 		{
-			mConcave = TRUE;
+			mConcave = true;
 		}
 		else
 		{
-			mConcave = FALSE;
+			mConcave = false;
 		}
-		mOpen = TRUE;
+		mOpen = true;
 		if (params.getHollow() <= 0)
 		{
 			// put center point if not hollow.
@@ -644,8 +644,8 @@ void LLProfile::genNGon(const LLProfileParams& params, S32 sides, F32 offset, F3
 	else
 	{
 		// The profile isn't open.
-		mOpen = FALSE;
-		mConcave = FALSE;
+		mOpen = false;
+		mConcave = false;
 	}
 
 	mTotal = mProfile.size();
@@ -654,7 +654,7 @@ void LLProfile::genNGon(const LLProfileParams& params, S32 sides, F32 offset, F3
 // Hollow is percent of the original bounding box, not of this particular
 // profile's geometry.  Thus, a swept triangle needs lower hollow values than
 // a swept square.
-LLProfile::Face* LLProfile::addHole(const LLProfileParams& params, BOOL flat, F32 sides, F32 offset, F32 box_hollow, F32 ang_scale, S32 split)
+LLProfile::Face* LLProfile::addHole(const LLProfileParams& params, bool flat, F32 sides, F32 offset, F32 box_hollow, F32 ang_scale, S32 split)
 {
 	// Note that addHole will NOT work for non-"circular" profiles, if we ever decide to use them.
 
@@ -693,8 +693,8 @@ LLProfile::Face* LLProfile::addHole(const LLProfileParams& params, BOOL flat, F3
 }
 
 //static
-S32 LLProfile::getNumPoints(const LLProfileParams& params, BOOL path_open,F32 detail, S32 split,
-						 BOOL is_sculpted, S32 sculpt_size)
+S32 LLProfile::getNumPoints(const LLProfileParams& params, bool path_open,F32 detail, S32 split,
+						 bool is_sculpted, S32 sculpt_size)
 { // this is basically LLProfile::generate stripped down to only operations that influence the number of points
 	if (detail < MIN_LOD)
 	{
@@ -850,7 +850,7 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 
 			for (i = llfloor(begin * 4.f); i < llfloor(end * 4.f + .999f); i++)
 			{
-				addFace((face_num++) * (split +1), split+2, 1, LL_FACE_OUTER_SIDE_0 << i, TRUE);
+				addFace((face_num++) * (split +1), split+2, 1, LL_FACE_OUTER_SIDE_0 << i, true);
 			}
 
 			LLVector4a scale(1,1,4,1);
@@ -868,16 +868,16 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 				{
 				case LL_PCODE_HOLE_TRIANGLE:
 					// This offset is not correct, but we can't change it now... DK 11/17/04
-				  	addHole(params, TRUE, 3, -0.375f, hollow, 1.f, split);
+				  	addHole(params, true, 3, -0.375f, hollow, 1.f, split);
 					break;
 				case LL_PCODE_HOLE_CIRCLE:
 					// TODO: Compute actual detail levels for cubes
-				  	addHole(params, FALSE, MIN_DETAIL_FACES * detail, -0.375f, hollow, 1.f);
+				  	addHole(params, false, MIN_DETAIL_FACES * detail, -0.375f, hollow, 1.f);
 					break;
 				case LL_PCODE_HOLE_SAME:
 				case LL_PCODE_HOLE_SQUARE:
 				default:
-					addHole(params, TRUE, 4, -0.375f, hollow, 1.f, split);
+					addHole(params, true, 4, -0.375f, hollow, 1.f, split);
 					break;
 				}
 			}
@@ -907,7 +907,7 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 
 			for (i = llfloor(begin * 3.f); i < llfloor(end * 3.f + .999f); i++)
 			{
-				addFace((face_num++) * (split +1), split+2, 1, LL_FACE_OUTER_SIDE_0 << i, TRUE);
+				addFace((face_num++) * (split +1), split+2, 1, LL_FACE_OUTER_SIDE_0 << i, true);
 			}
 			if (hollow)
 			{
@@ -919,15 +919,15 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 				{
 				case LL_PCODE_HOLE_CIRCLE:
 					// TODO: Actually generate level of detail for triangles
-					addHole(params, FALSE, MIN_DETAIL_FACES * detail, 0, triangle_hollow, 1.f);
+					addHole(params, false, MIN_DETAIL_FACES * detail, 0, triangle_hollow, 1.f);
 					break;
 				case LL_PCODE_HOLE_SQUARE:
-					addHole(params, TRUE, 4, 0, triangle_hollow, 1.f, split);
+					addHole(params, true, 4, 0, triangle_hollow, 1.f, split);
 					break;
 				case LL_PCODE_HOLE_SAME:
 				case LL_PCODE_HOLE_TRIANGLE:
 				default:
-					addHole(params, TRUE, 3, 0, triangle_hollow, 1.f, split);
+					addHole(params, true, 3, 0, triangle_hollow, 1.f, split);
 					break;
 				}
 			}
@@ -964,11 +964,11 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 
 			if (mOpen && !hollow)
 			{
-				addFace(0,mTotal-1,0,LL_FACE_OUTER_SIDE_0, FALSE);
+				addFace(0,mTotal-1,0,LL_FACE_OUTER_SIDE_0, false);
 			}
 			else
 			{
-				addFace(0,mTotal,0,LL_FACE_OUTER_SIDE_0, FALSE);
+				addFace(0,mTotal,0,LL_FACE_OUTER_SIDE_0, false);
 			}
 
 			if (hollow)
@@ -976,15 +976,15 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
 				switch (hole_type)
 				{
 				case LL_PCODE_HOLE_SQUARE:
-					addHole(params, TRUE, 4, 0, hollow, 1.f, split);
+					addHole(params, true, 4, 0, hollow, 1.f, split);
 					break;
 				case LL_PCODE_HOLE_TRIANGLE:
-					addHole(params, TRUE, 3, 0, hollow, 1.f, split);
+					addHole(params, true, 3, 0, hollow, 1.f, split);
 					break;
 				case LL_PCODE_HOLE_CIRCLE:
 				case LL_PCODE_HOLE_SAME:
 				default:
-					addHole(params, FALSE, circle_detail, 0, hollow, 1.f);
+					addHole(params, true, circle_detail, 0, hollow, 1.f);
 					break;
 				}
 			}
@@ -1291,7 +1291,7 @@ void LLPath::genNGon(const LLPathParams& params, S32 sides, F32 startOff, F32 en
 	LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME
 
 	// Generates a circular path, starting at (1, 0, 0), counterclockwise along the xz plane.
-	static const F32 tableScale[] = { 1, 1, 1, 0.5f, 0.707107f, 0.53f, 0.525f, 0.5f };
+	constexpr F32 tableScale[] = { 1, 1, 1, 0.5f, 0.707107f, 0.53f, 0.525f, 0.5f };
 
 	F32 revolutions = params.getRevolutions();
 	F32 skew		= params.getSkew();
@@ -2025,7 +2025,7 @@ LLProfile::~LLProfile()
 
 S32 LLVolume::sNumMeshPoints = 0;
 
-LLVolume::LLVolume(const LLVolumeParams &params, const F32 detail, const BOOL generate_single_face, const BOOL is_unique)
+LLVolume::LLVolume(const LLVolumeParams &params, const F32 detail, const bool generate_single_face, const bool is_unique)
 	: mParams(params)
 {
 	mUnique = is_unique;
@@ -2036,8 +2036,8 @@ LLVolume::LLVolume(const LLVolumeParams &params, const F32 detail, const BOOL ge
 	mIsMeshAssetLoaded = false;
     mIsMeshAssetUnavaliable = false;
 	mLODScaleBias.setVec(1,1,1);
-	mHullPoints = NULL;
-	mHullIndices = NULL;
+	mHullPoints = nullptr;
+	mHullIndices = nullptr;
 	mNumHullPoints = 0;
 	mNumHullIndices = 0;
 
@@ -2857,10 +2857,10 @@ void LLVolume::createVolumeFaces()
 	else
 	{
 		S32 num_faces = getNumFaces();
-		BOOL partial_build = TRUE;
+		bool partial_build = true;
 		if (num_faces != mVolumeFaces.size())
 		{
-			partial_build = FALSE;
+			partial_build = false;
 			mVolumeFaces.resize(num_faces);
 		}
 		// Initialize volume faces with parameter data
@@ -3095,9 +3095,9 @@ void LLVolume::sculptGenerateSpherePlaceholder()
 void LLVolume::sculptGenerateMapVertices(U16 sculpt_width, U16 sculpt_height, S8 sculpt_components, const U8* sculpt_data, U8 sculpt_type)
 {
 	U8 sculpt_stitching = sculpt_type & LL_SCULPT_TYPE_MASK;
-	BOOL sculpt_invert = sculpt_type & LL_SCULPT_FLAG_INVERT;
-	BOOL sculpt_mirror = sculpt_type & LL_SCULPT_FLAG_MIRROR;
-	BOOL reverse_horizontal = (sculpt_invert ? !sculpt_mirror : sculpt_mirror);  // XOR
+	bool sculpt_invert = sculpt_type & LL_SCULPT_FLAG_INVERT;
+	bool sculpt_mirror = sculpt_type & LL_SCULPT_FLAG_MIRROR;
+	bool reverse_horizontal = (sculpt_invert ? !sculpt_mirror : sculpt_mirror);  // XOR
 	
 	S32 sizeS = mPathp->mPath.size();
 	S32 sizeT = mProfilep->mProfile.size();
@@ -3182,14 +3182,13 @@ void LLVolume::sculptGenerateMapVertices(U16 sculpt_width, U16 sculpt_height, S8
 }
 
 
-const S32 SCULPT_REZ_1 = 6;  // changed from 4 to 6 - 6 looks round whereas 4 looks square
-const S32 SCULPT_REZ_2 = 8;
-const S32 SCULPT_REZ_3 = 16;
-const S32 SCULPT_REZ_4 = 32;
+constexpr S32 SCULPT_REZ_1 = 6;  // changed from 4 to 6 - 6 looks round whereas 4 looks square
+constexpr S32 SCULPT_REZ_2 = 8;
+constexpr S32 SCULPT_REZ_3 = 16;
+constexpr S32 SCULPT_REZ_4 = 32;
 
 S32 sculpt_sides(F32 detail)
 {
-
 	// detail is usually one of: 1, 1.5, 2.5, 4.0.
 	
 	if (detail <= 1.0)
@@ -3252,12 +3251,12 @@ void LLVolume::sculpt(U16 sculpt_width, U16 sculpt_height, S8 sculpt_components,
 {
 	U8 sculpt_type = mParams.getSculptType();
 
-	BOOL data_is_empty = FALSE;
+	bool data_is_empty = false;
 
 	if (sculpt_width == 0 || sculpt_height == 0 || sculpt_components < 3 || sculpt_data == NULL)
 	{
 		sculpt_level = -1;
-		data_is_empty = TRUE;
+		data_is_empty = true;
 	}
 
 	S32 requested_sizeS = 0;
@@ -3265,8 +3264,8 @@ void LLVolume::sculpt(U16 sculpt_width, U16 sculpt_height, S8 sculpt_components,
 
 	sculpt_calc_mesh_resolution(sculpt_width, sculpt_height, sculpt_type, mDetail, requested_sizeS, requested_sizeT);
 
-	mPathp->generate(mParams.getPathParams(), mDetail, 0, TRUE, requested_sizeS);
-	mProfilep->generate(mParams.getProfileParams(), mPathp->isOpen(), mDetail, 0, TRUE, requested_sizeT);
+	mPathp->generate(mParams.getPathParams(), mDetail, 0, true, requested_sizeS);
+	mProfilep->generate(mParams.getProfileParams(), mPathp->isOpen(), mDetail, 0, true, requested_sizeT);
 
 	S32 sizeS = mPathp->mPath.size();         // we requested a specific size, now see what we really got
 	S32 sizeT = mProfilep->mProfile.size();   // we requested a specific size, now see what we really got
@@ -3297,7 +3296,7 @@ void LLVolume::sculpt(U16 sculpt_width, U16 sculpt_height, S8 sculpt_components,
 
 			if (area < SCULPT_MIN_AREA || area > SCULPT_MAX_AREA)
 			{
-				data_is_empty = TRUE;
+				data_is_empty = true;
 				visible_placeholder = true;
 			}
 		}
@@ -3316,8 +3315,6 @@ void LLVolume::sculpt(U16 sculpt_width, U16 sculpt_height, S8 sculpt_components,
 		}
 	}
 
-
-	
 	for (S32 i = 0; i < (S32)mProfilep->mFaces.size(); i++)
 	{
 		mFaceMask |= mProfilep->mFaces[i].mFaceID;
@@ -3402,7 +3399,7 @@ void LLVolumeParams::copyParams(const LLVolumeParams &params)
 }
 
 // Less restricitve approx 0 for volumes
-const F32 APPROXIMATELY_ZERO = 0.001f;
+constexpr F32 APPROXIMATELY_ZERO = 0.001f;
 bool approx_zero( F32 f, F32 tolerance = APPROXIMATELY_ZERO)
 {
 	return (f >= -tolerance) && (f <= tolerance);
@@ -3658,7 +3655,7 @@ bool LLVolumeParams::setSkew(const F32 skew_value)
 	return valid;
 }
 
-bool LLVolumeParams::setSculptID(const LLUUID sculpt_id, U8 sculpt_type)
+bool LLVolumeParams::setSculptID(const LLUUID& sculpt_id, U8 sculpt_type)
 {
 	mSculptID = sculpt_id;
 	mSculptType = sculpt_type;
@@ -3888,7 +3885,6 @@ void LLVolume::generateSilhouetteVertices(std::vector<LLVector3> &vertices,
 		}
 		else
 		{
-
 			//==============================================
 			//DEBUG draw edge map instead of silhouette edge
 			//==============================================
@@ -3970,8 +3966,8 @@ void LLVolume::generateSilhouetteVertices(std::vector<LLVector3> &vertices,
 			//DEBUG
 			//==============================================
 
-			static const U8 AWAY = 0x01,
-							TOWARDS = 0x02;
+			constexpr U8 AWAY = 0x01,
+						 TOWARDS = 0x02;
 
 			//for each triangle
 			std::vector<U8> fFacing;
@@ -4241,7 +4237,7 @@ LLVertexIndexPair::LLVertexIndexPair(const LLVector3 &vertex, const S32 index)
 	mIndex = index;
 }
 
-const F32 VERTEX_SLOP = 0.00001f;
+constexpr F32 VERTEX_SLOP = 0.00001f;
 
 struct lessVertex
 {
@@ -4251,32 +4247,32 @@ struct lessVertex
 
 		if (a->mVertex.mV[0] + slop < b->mVertex.mV[0])
 		{
-			return TRUE;
+			return true;
 		}
 		else if (a->mVertex.mV[0] - slop > b->mVertex.mV[0])
 		{
-			return FALSE;
+			return false;
 		}
 		
 		if (a->mVertex.mV[1] + slop < b->mVertex.mV[1])
 		{
-			return TRUE;
+			return true;
 		}
 		else if (a->mVertex.mV[1] - slop > b->mVertex.mV[1])
 		{
-			return FALSE;
+			return false;
 		}
 		
 		if (a->mVertex.mV[2] + slop < b->mVertex.mV[2])
 		{
-			return TRUE;
+			return true;
 		}
 		else if (a->mVertex.mV[2] - slop > b->mVertex.mV[2])
 		{
-			return FALSE;
+			return false;
 		}
 		
-		return FALSE;
+		return false;
 	}
 };
 
@@ -4286,42 +4282,42 @@ struct lessTriangle
 	{
 		if (*a < *b)
 		{
-			return TRUE;
+			return true;
 		}
 		else if (*a > *b)
 		{
-			return FALSE;
+			return false;
 		}
 
 		if (*(a+1) < *(b+1))
 		{
-			return TRUE;
+			return true;
 		}
 		else if (*(a+1) > *(b+1))
 		{
-			return FALSE;
+			return false;
 		}
 
 		if (*(a+2) < *(b+2))
 		{
-			return TRUE;
+			return true;
 		}
 		else if (*(a+2) > *(b+2))
 		{
-			return FALSE;
+			return false;
 		}
 
-		return FALSE;
+		return false;
 	}
 };
 
-BOOL equalTriangle(const S32 *a, const S32 *b)
+bool equalTriangle(const S32 *a, const S32 *b)
 {
 	if ((*a == *b) && (*(a+1) == *(b+1)) && (*(a+2) == *(b+2)))
 	{
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 bool LLVolumeParams::importFile(LLFILE *fp)
@@ -4520,7 +4516,7 @@ bool LLVolumeParams::isConvex() const
 	}
 
 	F32 profile_length = mProfileParams.getEnd() - mProfileParams.getBegin();
-	BOOL same_hole = hollow == 0.f 
+	bool same_hole = hollow == 0.f 
 					 || (mProfileParams.getCurveType() & LL_PCODE_HOLE_MASK) == LL_PCODE_HOLE_SAME;
 
 	F32 min_profile_wedge = MIN_CONCAVE_PROFILE_WEDGE;
@@ -4531,7 +4527,7 @@ bool LLVolumeParams::isConvex() const
 		min_profile_wedge = 2.f * MIN_CONCAVE_PROFILE_WEDGE;
 	}
 
-	BOOL convex_profile = ( ( profile_length == 1.f
+	bool convex_profile = ( ( profile_length == 1.f
 						     || profile_length <= 0.5f )
 						   && hollow == 0.f )						// trivially convex
 						  || ( profile_length <= min_profile_wedge
@@ -4797,7 +4793,7 @@ LLVolumeFace::LLVolumeFace(const LLVolumeFace& src)
     mJustWeights(NULL),
     mJointIndices(NULL),
 #endif
-    mWeightsScrubbed(FALSE),
+    mWeightsScrubbed(false),
     mOctree(NULL),
     mOctreeTriangles(NULL)
 {
@@ -4864,14 +4860,14 @@ LLVolumeFace& LLVolumeFace::operator=(const LLVolumeFace& src)
 		{
             llassert(!mWeights); // don't orphan an old alloc here accidentally
 			allocateWeights(src.mNumVertices);
-			LLVector4a::memcpyNonAliased16((F32*) mWeights, (F32*) src.mWeights, vert_size);            
+			LLVector4a::memcpyNonAliased16((F32*) mWeights, (F32*) src.mWeights, vert_size);
             mWeightsScrubbed = src.mWeightsScrubbed;
 		}
 		else
 		{
-			ll_aligned_free_16(mWeights);            
-			mWeights = NULL;            
-            mWeightsScrubbed = FALSE;
+			ll_aligned_free_16(mWeights);
+			mWeights = NULL;
+            mWeightsScrubbed = false;
 		}   
 
     #if USE_SEPARATE_JOINT_INDICES_AND_WEIGHTS
@@ -4944,7 +4940,7 @@ void LLVolumeFace::freeData()
     destroyOctree();
 }
 
-bool LLVolumeFace::create(LLVolume* volume, BOOL partial_build)
+bool LLVolumeFace::create(LLVolume* volume, bool partial_build)
 {
 	LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME
 
@@ -5088,7 +5084,7 @@ void LLVolumeFace::optimize(F32 angle_cutoff)
 		LLVolumeFace::VertexData cv;
 		getVertexData(index, cv);
 		
-		BOOL found = FALSE;
+		bool found = false;
 
 		LLVector4a pos;
 		pos.setSub(mPositions[index], mExtents[0]);
@@ -5109,7 +5105,7 @@ void LLVolumeFace::optimize(F32 angle_cutoff)
 				LLVolumeFace::VertexData& tv = (point_iter->second)[j];
 				if (tv.compareNormal(cv, angle_cutoff))
 				{
-					found = TRUE;
+					found = true;
 					new_face.pushIndex((point_iter->second)[j].mIndex);
 					break;
 				}
@@ -5216,12 +5212,12 @@ public:
 	}
 };
 
-const F64 FindVertexScore_CacheDecayPower = 1.5;
-const F64 FindVertexScore_LastTriScore = 0.75;
-const F64 FindVertexScore_ValenceBoostScale = 2.0;
-const F64 FindVertexScore_ValenceBoostPower = 0.5;
-const U32 MaxSizeVertexCache = 32;
-const F64 FindVertexScore_Scaler = 1.0/(MaxSizeVertexCache-3);
+constexpr F64 FindVertexScore_CacheDecayPower = 1.5;
+constexpr F64 FindVertexScore_LastTriScore = 0.75;
+constexpr F64 FindVertexScore_ValenceBoostScale = 2.0;
+constexpr F64 FindVertexScore_ValenceBoostPower = 0.5;
+constexpr U32 MaxSizeVertexCache = 32;
+constexpr F64 FindVertexScore_Scaler = 1.0/(MaxSizeVertexCache-3);
 
 F64 find_vertex_score(LLVCacheVertexData& data)
 {
@@ -5491,7 +5487,7 @@ bool LLVolumeFace::cacheOptimize(bool gen_tangents)
 { //optimize for vertex cache according to Forsyth method: 
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
 	llassert(!mOptimized);
-	mOptimized = TRUE;
+	mOptimized = true;
 
     if (gen_tangents && mNormals && mTexCoords)
     { // generate mikkt space tangents before cache optimizing since the index buffer may change
@@ -6161,7 +6157,7 @@ bool LLVolumeFace::createCap(LLVolume* volume, bool partial_build)
 		
 	//if (partial_build)
 	//{
-	//	return TRUE;
+	//	return true;
 	//}
 
 	if (mTypeMask & HOLLOW_MASK)
@@ -6684,7 +6680,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 	num_vertices = mNumS*mNumT;
 	num_indices = (mNumS-1)*(mNumT-1)*6;
 
-	partial_build = (num_vertices > mNumVertices || num_indices > mNumIndices) ? FALSE : partial_build;
+	partial_build = (num_vertices > mNumVertices || num_indices > mNumIndices) ? false : partial_build;
 
 	if (!partial_build)
 	{
@@ -6855,7 +6851,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 
 	S32 cur_index = 0;
 	S32 cur_edge = 0;
-	BOOL flat_face = mTypeMask & FLAT_MASK;
+	bool flat_face = mTypeMask & FLAT_MASK;
 
 	if (!partial_build)
 	{
@@ -6875,7 +6871,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 				if (t < mNumT-2) {												//top right/top left neighbor face 
 					mEdge[cur_edge++] = (mNumS-1)*2*(t+1)+s*2+1;
 				}
-				else if (mNumT <= 3 || volume->getPath().isOpen() == TRUE) { //no neighbor
+				else if (mNumT <= 3 || volume->getPath().isOpen() == true) { //no neighbor
 					mEdge[cur_edge++] = -1;
 				}
 				else { //wrap on T
@@ -6884,7 +6880,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 				if (s > 0) {													//top left/bottom left neighbor face
 					mEdge[cur_edge++] = (mNumS-1)*2*t+s*2-1;
 				}
-				else if (flat_face ||  volume->getProfile().isOpen() == TRUE) { //no neighbor
+				else if (flat_face ||  volume->getProfile().isOpen() == true) { //no neighbor
 					mEdge[cur_edge++] = -1;
 				}
 				else {	//wrap on S
@@ -6894,7 +6890,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 				if (t > 0) {													//bottom left/bottom right neighbor face
 					mEdge[cur_edge++] = (mNumS-1)*2*(t-1)+s*2;
 				}
-				else if (mNumT <= 3 || volume->getPath().isOpen() == TRUE) { //no neighbor
+				else if (mNumT <= 3 || volume->getPath().isOpen() == true) { //no neighbor
 					mEdge[cur_edge++] = -1;
 				}
 				else { //wrap on T
@@ -6903,7 +6899,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 				if (s < mNumS-2) {												//bottom right/top right neighbor face
 					mEdge[cur_edge++] = (mNumS-1)*2*t+(s+1)*2;
 				}
-				else if (flat_face || volume->getProfile().isOpen() == TRUE) { //no neighbor
+				else if (flat_face || volume->getProfile().isOpen() == true) { //no neighbor
 					mEdge[cur_edge++] = -1;
 				}
 				else { //wrap on S
@@ -7046,7 +7042,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 
 	if (sculpt_stitching == LL_SCULPT_TYPE_NONE)  // logic for non-sculpt volumes
 	{
-		if (volume->getPath().isOpen() == FALSE)
+		if (volume->getPath().isOpen() == false)
 		{ //wrap normals on T
 			for (S32 i = 0; i < mNumS; i++)
 			{
@@ -7057,7 +7053,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
 			}
 		}
 
-		if ((volume->getProfile().isOpen() == FALSE) && !(s_bottom_converges))
+		if ((volume->getProfile().isOpen() == false) && !(s_bottom_converges))
 		{ //wrap normals on S
 			for (S32 i = 0; i < mNumT; i++)
 			{

--- a/indra/llmath/llvolume.h
+++ b/indra/llmath/llvolume.h
@@ -62,144 +62,144 @@ class LLVolumeTriangle;
 
 //============================================================================
 
-const S32 MIN_DETAIL_FACES = 6;
-const S32 MIN_LOD = 0;
-const S32 MAX_LOD = 3;
+constexpr S32 MIN_DETAIL_FACES = 6;
+constexpr S32 MIN_LOD = 0;
+constexpr S32 MAX_LOD = 3;
 
 // These are defined here but are not enforced at this level,
 // rather they are here for the convenience of code that uses
 // the LLVolume class.
-const F32 MIN_VOLUME_PROFILE_WIDTH 	= 0.05f;
-const F32 MIN_VOLUME_PATH_WIDTH 	= 0.05f;
+constexpr F32 MIN_VOLUME_PROFILE_WIDTH 	= 0.05f;
+constexpr F32 MIN_VOLUME_PATH_WIDTH 	= 0.05f;
 
-const F32 CUT_QUANTA    = 0.00002f;
-const F32 SCALE_QUANTA  = 0.01f;
-const F32 SHEAR_QUANTA  = 0.01f;
-const F32 TAPER_QUANTA  = 0.01f;
-const F32 REV_QUANTA    = 0.015f;
-const F32 HOLLOW_QUANTA = 0.00002f;
+constexpr F32 CUT_QUANTA    = 0.00002f;
+constexpr F32 SCALE_QUANTA  = 0.01f;
+constexpr F32 SHEAR_QUANTA  = 0.01f;
+constexpr F32 TAPER_QUANTA  = 0.01f;
+constexpr F32 REV_QUANTA    = 0.015f;
+constexpr F32 HOLLOW_QUANTA = 0.00002f;
 
-const S32 MAX_VOLUME_TRIANGLE_INDICES = 10000;
+constexpr S32 MAX_VOLUME_TRIANGLE_INDICES = 10000;
 
 //============================================================================
 
 // useful masks
-const LLPCode LL_PCODE_HOLLOW_MASK 	= 0x80;		// has a thickness
-const LLPCode LL_PCODE_SEGMENT_MASK = 0x40;		// segments (1 angle)
-const LLPCode LL_PCODE_PATCH_MASK 	= 0x20;		// segmented segments (2 angles)
-const LLPCode LL_PCODE_HEMI_MASK 	= 0x10;		// half-primitives get their own type per PR's dictum
-const LLPCode LL_PCODE_BASE_MASK 	= 0x0F;
+constexpr LLPCode LL_PCODE_HOLLOW_MASK 	= 0x80;		// has a thickness
+constexpr LLPCode LL_PCODE_SEGMENT_MASK = 0x40;		// segments (1 angle)
+constexpr LLPCode LL_PCODE_PATCH_MASK 	= 0x20;		// segmented segments (2 angles)
+constexpr LLPCode LL_PCODE_HEMI_MASK 	= 0x10;		// half-primitives get their own type per PR's dictum
+constexpr LLPCode LL_PCODE_BASE_MASK 	= 0x0F;
 
 	// primitive shapes
-const LLPCode	LL_PCODE_CUBE 			= 1;
-const LLPCode	LL_PCODE_PRISM 			= 2;
-const LLPCode	LL_PCODE_TETRAHEDRON 	= 3;
-const LLPCode	LL_PCODE_PYRAMID 		= 4;
-const LLPCode	LL_PCODE_CYLINDER 		= 5;
-const LLPCode	LL_PCODE_CONE 			= 6;
-const LLPCode	LL_PCODE_SPHERE 		= 7;
-const LLPCode	LL_PCODE_TORUS 			= 8;
-const LLPCode	LL_PCODE_VOLUME			= 9;
+constexpr LLPCode	LL_PCODE_CUBE 			= 1;
+constexpr LLPCode	LL_PCODE_PRISM 			= 2;
+constexpr LLPCode	LL_PCODE_TETRAHEDRON 	= 3;
+constexpr LLPCode	LL_PCODE_PYRAMID 		= 4;
+constexpr LLPCode	LL_PCODE_CYLINDER 		= 5;
+constexpr LLPCode	LL_PCODE_CONE 			= 6;
+constexpr LLPCode	LL_PCODE_SPHERE 		= 7;
+constexpr LLPCode	LL_PCODE_TORUS 			= 8;
+constexpr LLPCode	LL_PCODE_VOLUME			= 9;
 
 	// surfaces
-//const LLPCode	LL_PCODE_SURFACE_TRIANGLE 	= 10;
-//const LLPCode	LL_PCODE_SURFACE_SQUARE 	= 11;
-//const LLPCode	LL_PCODE_SURFACE_DISC 		= 12;
+//constexpr LLPCode	LL_PCODE_SURFACE_TRIANGLE 	= 10;
+//constexpr LLPCode	LL_PCODE_SURFACE_SQUARE 	= 11;
+//constexpr LLPCode	LL_PCODE_SURFACE_DISC 		= 12;
 
-const LLPCode	LL_PCODE_APP				= 14; // App specific pcode (for viewer/sim side only objects)
-const LLPCode	LL_PCODE_LEGACY				= 15;
+constexpr LLPCode	LL_PCODE_APP				= 14; // App specific pcode (for viewer/sim side only objects)
+constexpr LLPCode	LL_PCODE_LEGACY				= 15;
 
 // Pcodes for legacy objects
-//const LLPCode	LL_PCODE_LEGACY_ATOR =				0x10 | LL_PCODE_LEGACY; // ATOR
-const LLPCode	LL_PCODE_LEGACY_AVATAR =			0x20 | LL_PCODE_LEGACY; // PLAYER
-//const LLPCode	LL_PCODE_LEGACY_BIRD =				0x30 | LL_PCODE_LEGACY; // BIRD
-//const LLPCode	LL_PCODE_LEGACY_DEMON =				0x40 | LL_PCODE_LEGACY; // DEMON
-const LLPCode	LL_PCODE_LEGACY_GRASS =				0x50 | LL_PCODE_LEGACY; // GRASS
-const LLPCode	LL_PCODE_TREE_NEW =					0x60 | LL_PCODE_LEGACY; // new trees
-//const LLPCode	LL_PCODE_LEGACY_ORACLE =			0x70 | LL_PCODE_LEGACY; // ORACLE
-const LLPCode	LL_PCODE_LEGACY_PART_SYS =			0x80 | LL_PCODE_LEGACY; // PART_SYS
-const LLPCode	LL_PCODE_LEGACY_ROCK =				0x90 | LL_PCODE_LEGACY; // ROCK
-//const LLPCode	LL_PCODE_LEGACY_SHOT =				0xA0 | LL_PCODE_LEGACY; // BASIC_SHOT
-//const LLPCode	LL_PCODE_LEGACY_SHOT_BIG =			0xB0 | LL_PCODE_LEGACY;
-//const LLPCode	LL_PCODE_LEGACY_SMOKE =				0xC0 | LL_PCODE_LEGACY; // SMOKE
-//const LLPCode	LL_PCODE_LEGACY_SPARK =				0xD0 | LL_PCODE_LEGACY;// SPARK
-const LLPCode	LL_PCODE_LEGACY_TEXT_BUBBLE =		0xE0 | LL_PCODE_LEGACY; // TEXTBUBBLE
-const LLPCode	LL_PCODE_LEGACY_TREE =				0xF0 | LL_PCODE_LEGACY; // TREE
+//constexpr LLPCode	LL_PCODE_LEGACY_ATOR =				0x10 | LL_PCODE_LEGACY; // ATOR
+constexpr LLPCode	LL_PCODE_LEGACY_AVATAR =			0x20 | LL_PCODE_LEGACY; // PLAYER
+//constexpr LLPCode	LL_PCODE_LEGACY_BIRD =				0x30 | LL_PCODE_LEGACY; // BIRD
+//constexpr LLPCode	LL_PCODE_LEGACY_DEMON =				0x40 | LL_PCODE_LEGACY; // DEMON
+constexpr LLPCode	LL_PCODE_LEGACY_GRASS =				0x50 | LL_PCODE_LEGACY; // GRASS
+constexpr LLPCode	LL_PCODE_TREE_NEW =					0x60 | LL_PCODE_LEGACY; // new trees
+//constexpr LLPCode	LL_PCODE_LEGACY_ORACLE =			0x70 | LL_PCODE_LEGACY; // ORACLE
+constexpr LLPCode	LL_PCODE_LEGACY_PART_SYS =			0x80 | LL_PCODE_LEGACY; // PART_SYS
+constexpr LLPCode	LL_PCODE_LEGACY_ROCK =				0x90 | LL_PCODE_LEGACY; // ROCK
+//constexpr LLPCode	LL_PCODE_LEGACY_SHOT =				0xA0 | LL_PCODE_LEGACY; // BASIC_SHOT
+//constexpr LLPCode	LL_PCODE_LEGACY_SHOT_BIG =			0xB0 | LL_PCODE_LEGACY;
+//constexpr LLPCode	LL_PCODE_LEGACY_SMOKE =				0xC0 | LL_PCODE_LEGACY; // SMOKE
+//constexpr LLPCode	LL_PCODE_LEGACY_SPARK =				0xD0 | LL_PCODE_LEGACY;// SPARK
+constexpr LLPCode	LL_PCODE_LEGACY_TEXT_BUBBLE =		0xE0 | LL_PCODE_LEGACY; // TEXTBUBBLE
+constexpr LLPCode	LL_PCODE_LEGACY_TREE =				0xF0 | LL_PCODE_LEGACY; // TREE
 
 	// hemis
-const LLPCode	LL_PCODE_CYLINDER_HEMI =		LL_PCODE_CYLINDER	| LL_PCODE_HEMI_MASK;
-const LLPCode	LL_PCODE_CONE_HEMI =			LL_PCODE_CONE		| LL_PCODE_HEMI_MASK;
-const LLPCode	LL_PCODE_SPHERE_HEMI =			LL_PCODE_SPHERE		| LL_PCODE_HEMI_MASK;
-const LLPCode	LL_PCODE_TORUS_HEMI =			LL_PCODE_TORUS		| LL_PCODE_HEMI_MASK;
+constexpr LLPCode	LL_PCODE_CYLINDER_HEMI =		LL_PCODE_CYLINDER	| LL_PCODE_HEMI_MASK;
+constexpr LLPCode	LL_PCODE_CONE_HEMI =			LL_PCODE_CONE		| LL_PCODE_HEMI_MASK;
+constexpr LLPCode	LL_PCODE_SPHERE_HEMI =			LL_PCODE_SPHERE		| LL_PCODE_HEMI_MASK;
+constexpr LLPCode	LL_PCODE_TORUS_HEMI =			LL_PCODE_TORUS		| LL_PCODE_HEMI_MASK;
 
 
 // Volumes consist of a profile at the base that is swept around
 // a path to make a volume.
 // The profile code
-const U8	LL_PCODE_PROFILE_MASK		= 0x0f;
-const U8	LL_PCODE_PROFILE_MIN		= 0x00;
-const U8    LL_PCODE_PROFILE_CIRCLE		= 0x00;
-const U8    LL_PCODE_PROFILE_SQUARE		= 0x01;
-const U8	LL_PCODE_PROFILE_ISOTRI		= 0x02;
-const U8    LL_PCODE_PROFILE_EQUALTRI	= 0x03;
-const U8    LL_PCODE_PROFILE_RIGHTTRI	= 0x04;
-const U8	LL_PCODE_PROFILE_CIRCLE_HALF = 0x05;
-const U8	LL_PCODE_PROFILE_MAX		= 0x05;
+constexpr U8	LL_PCODE_PROFILE_MASK		= 0x0f;
+constexpr U8	LL_PCODE_PROFILE_MIN		= 0x00;
+constexpr U8    LL_PCODE_PROFILE_CIRCLE		= 0x00;
+constexpr U8    LL_PCODE_PROFILE_SQUARE		= 0x01;
+constexpr U8	LL_PCODE_PROFILE_ISOTRI		= 0x02;
+constexpr U8    LL_PCODE_PROFILE_EQUALTRI	= 0x03;
+constexpr U8    LL_PCODE_PROFILE_RIGHTTRI	= 0x04;
+constexpr U8	LL_PCODE_PROFILE_CIRCLE_HALF = 0x05;
+constexpr U8	LL_PCODE_PROFILE_MAX		= 0x05;
 
 // Stored in the profile byte
-const U8	LL_PCODE_HOLE_MASK		= 0xf0;
-const U8	LL_PCODE_HOLE_MIN		= 0x00;	  
-const U8	LL_PCODE_HOLE_SAME		= 0x00;		// same as outside profile
-const U8	LL_PCODE_HOLE_CIRCLE	= 0x10;
-const U8	LL_PCODE_HOLE_SQUARE	= 0x20;
-const U8	LL_PCODE_HOLE_TRIANGLE	= 0x30;
-const U8	LL_PCODE_HOLE_MAX		= 0x03;		// min/max needs to be >> 4 of real min/max
+constexpr U8	LL_PCODE_HOLE_MASK		= 0xf0;
+constexpr U8	LL_PCODE_HOLE_MIN		= 0x00;
+constexpr U8	LL_PCODE_HOLE_SAME		= 0x00;		// same as outside profile
+constexpr U8	LL_PCODE_HOLE_CIRCLE	= 0x10;
+constexpr U8	LL_PCODE_HOLE_SQUARE	= 0x20;
+constexpr U8	LL_PCODE_HOLE_TRIANGLE	= 0x30;
+constexpr U8	LL_PCODE_HOLE_MAX		= 0x03;		// min/max needs to be >> 4 of real min/max
 
-const U8    LL_PCODE_PATH_IGNORE    = 0x00;
-const U8	LL_PCODE_PATH_MIN		= 0x01;		// min/max needs to be >> 4 of real min/max
-const U8    LL_PCODE_PATH_LINE      = 0x10;
-const U8    LL_PCODE_PATH_CIRCLE    = 0x20;
-const U8    LL_PCODE_PATH_CIRCLE2   = 0x30;
-const U8    LL_PCODE_PATH_TEST      = 0x40;
-const U8    LL_PCODE_PATH_FLEXIBLE  = 0x80;
-const U8	LL_PCODE_PATH_MAX		= 0x08;
+constexpr U8    LL_PCODE_PATH_IGNORE    = 0x00;
+constexpr U8	LL_PCODE_PATH_MIN		= 0x01;		// min/max needs to be >> 4 of real min/max
+constexpr U8    LL_PCODE_PATH_LINE      = 0x10;
+constexpr U8    LL_PCODE_PATH_CIRCLE    = 0x20;
+constexpr U8    LL_PCODE_PATH_CIRCLE2   = 0x30;
+constexpr U8    LL_PCODE_PATH_TEST      = 0x40;
+constexpr U8    LL_PCODE_PATH_FLEXIBLE  = 0x80;
+constexpr U8	LL_PCODE_PATH_MAX		= 0x08;
 
 //============================================================================
 
 // face identifiers
 typedef U16 LLFaceID;
 
-const LLFaceID	LL_FACE_PATH_BEGIN		= 0x1 << 0;
-const LLFaceID	LL_FACE_PATH_END		= 0x1 << 1;
-const LLFaceID	LL_FACE_INNER_SIDE		= 0x1 << 2;
-const LLFaceID	LL_FACE_PROFILE_BEGIN	= 0x1 << 3;
-const LLFaceID	LL_FACE_PROFILE_END		= 0x1 << 4;
-const LLFaceID	LL_FACE_OUTER_SIDE_0	= 0x1 << 5;
-const LLFaceID	LL_FACE_OUTER_SIDE_1	= 0x1 << 6;
-const LLFaceID	LL_FACE_OUTER_SIDE_2	= 0x1 << 7;
-const LLFaceID	LL_FACE_OUTER_SIDE_3	= 0x1 << 8;
+constexpr LLFaceID	LL_FACE_PATH_BEGIN		= 0x1 << 0;
+constexpr LLFaceID	LL_FACE_PATH_END		= 0x1 << 1;
+constexpr LLFaceID	LL_FACE_INNER_SIDE		= 0x1 << 2;
+constexpr LLFaceID	LL_FACE_PROFILE_BEGIN	= 0x1 << 3;
+constexpr LLFaceID	LL_FACE_PROFILE_END		= 0x1 << 4;
+constexpr LLFaceID	LL_FACE_OUTER_SIDE_0	= 0x1 << 5;
+constexpr LLFaceID	LL_FACE_OUTER_SIDE_1	= 0x1 << 6;
+constexpr LLFaceID	LL_FACE_OUTER_SIDE_2	= 0x1 << 7;
+constexpr LLFaceID	LL_FACE_OUTER_SIDE_3	= 0x1 << 8;
 
 //============================================================================
 
 // sculpt types + flags
 
-const U8 LL_SCULPT_TYPE_NONE      = 0;
-const U8 LL_SCULPT_TYPE_SPHERE    = 1;
-const U8 LL_SCULPT_TYPE_TORUS     = 2;
-const U8 LL_SCULPT_TYPE_PLANE     = 3;
-const U8 LL_SCULPT_TYPE_CYLINDER  = 4;
-const U8 LL_SCULPT_TYPE_MESH      = 5;
-const U8 LL_SCULPT_TYPE_MASK      = LL_SCULPT_TYPE_SPHERE | LL_SCULPT_TYPE_TORUS | LL_SCULPT_TYPE_PLANE |
+constexpr U8 LL_SCULPT_TYPE_NONE      = 0;
+constexpr U8 LL_SCULPT_TYPE_SPHERE    = 1;
+constexpr U8 LL_SCULPT_TYPE_TORUS     = 2;
+constexpr U8 LL_SCULPT_TYPE_PLANE     = 3;
+constexpr U8 LL_SCULPT_TYPE_CYLINDER  = 4;
+constexpr U8 LL_SCULPT_TYPE_MESH      = 5;
+constexpr U8 LL_SCULPT_TYPE_MASK      = LL_SCULPT_TYPE_SPHERE | LL_SCULPT_TYPE_TORUS | LL_SCULPT_TYPE_PLANE |
 	LL_SCULPT_TYPE_CYLINDER | LL_SCULPT_TYPE_MESH;
 
 // for value checks, assign new value after adding new types
-const U8 LL_SCULPT_TYPE_MAX = LL_SCULPT_TYPE_MESH;
+constexpr U8 LL_SCULPT_TYPE_MAX = LL_SCULPT_TYPE_MESH;
 
-const U8 LL_SCULPT_FLAG_INVERT    = 64;
-const U8 LL_SCULPT_FLAG_MIRROR    = 128;
-const U8 LL_SCULPT_FLAG_MASK = LL_SCULPT_FLAG_INVERT | LL_SCULPT_FLAG_MIRROR;
+constexpr U8 LL_SCULPT_FLAG_INVERT    = 64;
+constexpr U8 LL_SCULPT_FLAG_MIRROR    = 128;
+constexpr U8 LL_SCULPT_FLAG_MASK = LL_SCULPT_FLAG_INVERT | LL_SCULPT_FLAG_MIRROR;
 
-const S32 LL_SCULPT_MESH_MAX_FACES = 8;
+constexpr S32 LL_SCULPT_MESH_MAX_FACES = 8;
 
 extern bool gDebugGL;
 
@@ -620,7 +620,7 @@ public:
 	bool setRevolutions(const F32 revolutions);	// 1 to 4
 	bool setRadiusOffset(const F32 radius_offset);
 	bool setSkew(const F32 skew);
-	bool setSculptID(const LLUUID sculpt_id, U8 sculpt_type);
+	bool setSculptID(const LLUUID& sculpt_id, U8 sculpt_type);
 
 	static bool validate(U8 prof_curve, F32 prof_begin, F32 prof_end, F32 hollow,
 		U8 path_curve, F32 path_begin, F32 path_end,
@@ -697,12 +697,12 @@ public:
 
 	S32	 getTotal() const								{ return mTotal; }
 	S32	 getTotalOut() const							{ return mTotalOut; }	// Total number of outside points
-	BOOL isFlat(S32 face) const							{ return (mFaces[face].mCount == 2); }
-	BOOL isOpen() const									{ return mOpen; }
-	void setDirty()										{ mDirty     = TRUE; }
+	bool isFlat(S32 face) const							{ return (mFaces[face].mCount == 2); }
+	bool isOpen() const									{ return mOpen; }
+	void setDirty()										{ mDirty = true; }
 
-	static S32 getNumPoints(const LLProfileParams& params, BOOL path_open, F32 detail = 1.0f, S32 split = 0,
-				  BOOL is_sculpted = FALSE, S32 sculpt_size = 0);
+	static S32 getNumPoints(const LLProfileParams& params, bool path_open, F32 detail = 1.0f, S32 split = 0,
+				  bool is_sculpted = false, S32 sculpt_size = 0);
 	bool generate(const LLProfileParams& params, bool path_open, F32 detail = 1.0f, S32 split = 0,
 				  bool is_sculpted = false, S32 sculpt_size = 0);
 	bool isConcave() const								{ return mConcave; }
@@ -712,8 +712,8 @@ public:
 		S32       mIndex;
 		S32       mCount;
 		F32       mScaleU;
-		BOOL      mCap;
-		BOOL      mFlat;
+		bool      mCap;
+		bool      mFlat;
 		LLFaceID  mFaceID;
 	};
 	
@@ -732,14 +732,14 @@ protected:
 	static S32 getNumNGonPoints(const LLProfileParams& params, S32 sides, F32 offset=0.0f, F32 bevel = 0.0f, F32 ang_scale = 1.f, S32 split = 0);
 	void genNGon(const LLProfileParams& params, S32 sides, F32 offset=0.0f, F32 bevel = 0.0f, F32 ang_scale = 1.f, S32 split = 0);
 
-	Face* addHole(const LLProfileParams& params, BOOL flat, F32 sides, F32 offset, F32 box_hollow, F32 ang_scale, S32 split = 0);
+	Face* addHole(const LLProfileParams& params, bool flat, F32 sides, F32 offset, F32 box_hollow, F32 ang_scale, S32 split = 0);
 	Face* addCap (S16 faceID);
-	Face* addFace(S32 index, S32 count, F32 scaleU, S16 faceID, BOOL flat);
+	Face* addFace(S32 index, S32 count, F32 scaleU, S16 faceID, bool flat);
 
 protected:
-	BOOL		  mOpen;
-	BOOL		  mConcave;
-	BOOL          mDirty;
+	bool		  mOpen;
+	bool		  mConcave;
+	bool          mDirty;
 
 	S32			  mTotalOut;
 	S32			  mTotal;
@@ -795,9 +795,9 @@ public:
 	virtual bool generate(const LLPathParams& params, F32 detail=1.0f, S32 split = 0,
 						  bool is_sculpted = false, S32 sculpt_size = 0);
 
-	BOOL isOpen() const						{ return mOpen; }
+	bool isOpen() const						{ return mOpen; }
 	F32 getStep() const						{ return mStep; }
-	void setDirty()							{ mDirty     = TRUE; }
+	void setDirty()							{ mDirty = true; }
 
 	S32 getPathLength() const				{ return (S32)mPath.size(); }
 
@@ -809,9 +809,9 @@ public:
 	LLAlignedArray<PathPt, 64> mPath;
 
 protected:
-	BOOL		  mOpen;
+	bool		  mOpen;
 	S32			  mTotal;
-	BOOL          mDirty;
+	bool          mDirty;
 	F32           mStep;
 };
 
@@ -870,7 +870,7 @@ private:
 	void freeData();
 public:
 
-	bool create(LLVolume* volume, BOOL partial_build = FALSE);
+	bool create(LLVolume* volume, bool partial_build = false);
 	void createTangents();
 	
 	void resizeVertices(S32 num_verts);
@@ -972,14 +972,14 @@ public:
     U8* mJointIndices;
 #endif
 
-    mutable BOOL mWeightsScrubbed;
+    mutable bool mWeightsScrubbed;
 
     // Which joints are rigged to, and the bounding box of any rigged
     // vertices per joint.
     LLJointRiggingInfoTab mJointRiggingInfoTab;
 
 	//whether or not face has been cache optimized
-	BOOL mOptimized;
+	bool mOptimized;
 
     // if this is a mesh asset, scale and translation that were applied
     // when encoding the source mesh into a unit cube
@@ -1014,7 +1014,7 @@ public:
 		S32 mCountT;
 	};
 
-	LLVolume(const LLVolumeParams &params, const F32 detail, const BOOL generate_single_face = FALSE, const BOOL is_unique = FALSE);
+	LLVolume(const LLVolumeParams &params, const F32 detail, const bool generate_single_face = false, const bool is_unique = false);
 	
 	U8 getProfileType()	const								{ return mParams.getProfileParams().getCurveType(); }
 	U8 getPathType() const									{ return mParams.getPathParams().getCurveType(); }
@@ -1047,7 +1047,7 @@ public:
 	
 	static void getLoDTriangleCounts(const LLVolumeParams& params, S32* counts);
 
-	S32 getNumTriangles(S32* vcount = NULL) const;
+	S32 getNumTriangles(S32* vcount = nullptr) const;
 
 	void generateSilhouetteVertices(std::vector<LLVector3> &vertices, 
 									std::vector<LLVector3> &normals, 
@@ -1061,10 +1061,10 @@ public:
 	//Line segment must be in volume space.
 	S32 lineSegmentIntersect(const LLVector4a& start, const LLVector4a& end,
 							 S32 face = -1,                          // which face to check, -1 = ALL_SIDES
-							 LLVector4a* intersection = NULL,         // return the intersection point
-							 LLVector2* tex_coord = NULL,            // return the texture coordinates of the intersection point
-							 LLVector4a* normal = NULL,               // return the surface normal at the intersection point
-							 LLVector4a* tangent = NULL             // return the surface tangent at the intersection point
+							 LLVector4a* intersection = nullptr,     // return the intersection point
+							 LLVector2* tex_coord = nullptr,         // return the texture coordinates of the intersection point
+							 LLVector4a* normal = nullptr,           // return the surface normal at the intersection point
+							 LLVector4a* tangent = nullptr           // return the surface tangent at the intersection point
 		);
 
 	LLFaceID generateFaceMask();
@@ -1115,7 +1115,7 @@ public:
     virtual bool isMeshAssetUnavaliable();
 
  protected:
-	BOOL mUnique;
+	bool mUnique;
 	F32 mDetail;
 	S32 mSculptLevel;
 	F32 mSurfaceArea; //unscaled surface area

--- a/indra/llmath/m3math.cpp
+++ b/indra/llmath/m3math.cpp
@@ -528,10 +528,10 @@ bool operator==(const LLMatrix3 &a, const LLMatrix3 &b)
 		for (j = 0; j < NUM_VALUES_IN_MAT3; j++)
 		{
 			if (a.mMatrix[j][i] != b.mMatrix[j][i])
-				return FALSE;
+				return false;
 		}
 	}
-	return TRUE;
+	return true;
 }
 
 bool operator!=(const LLMatrix3 &a, const LLMatrix3 &b)
@@ -542,10 +542,10 @@ bool operator!=(const LLMatrix3 &a, const LLMatrix3 &b)
 		for (j = 0; j < NUM_VALUES_IN_MAT3; j++)
 		{
 			if (a.mMatrix[j][i] != b.mMatrix[j][i])
-				return TRUE;
+				return true;
 		}
 	}
-	return FALSE;
+	return false;
 }
 
 const LLMatrix3& operator*=(LLMatrix3 &a, const LLMatrix3 &b)

--- a/indra/llmath/m4math.cpp
+++ b/indra/llmath/m4math.cpp
@@ -744,10 +744,10 @@ bool operator==(const LLMatrix4 &a, const LLMatrix4 &b)
 		for (j = 0; j < NUM_VALUES_IN_MAT4; j++)
 		{
 			if (a.mMatrix[j][i] != b.mMatrix[j][i])
-				return FALSE;
+				return false;
 		}
 	}
-	return TRUE;
+	return true;
 }
 
 bool operator!=(const LLMatrix4 &a, const LLMatrix4 &b)
@@ -758,10 +758,10 @@ bool operator!=(const LLMatrix4 &a, const LLMatrix4 &b)
 		for (j = 0; j < NUM_VALUES_IN_MAT4; j++)
 		{
 			if (a.mMatrix[j][i] != b.mMatrix[j][i])
-				return TRUE;
+				return true;
 		}
 	}
-	return FALSE;
+	return false;
 }
 
 bool operator<(const LLMatrix4& a, const LLMatrix4 &b)

--- a/indra/llmath/raytrace.cpp
+++ b/indra/llmath/raytrace.cpp
@@ -242,7 +242,7 @@ bool ray_cylinder(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 			   	if (dot > 0.0f)
 				{
 					// ray points away from cylinder bottom
-					return FALSE;
+					return false;
 				}
 				// ray hit bottom of cylinder from outside 
 				intersection = ray_point - shortest_distance * cyl_axis;

--- a/indra/llmath/raytrace.h
+++ b/indra/llmath/raytrace.h
@@ -105,7 +105,7 @@ bool ray_cylinder(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 				  LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-// this function doesn't just return a BOOL because the return is currently
+// this function doesn't just return a bool because the return is currently
 // used to decide how to break up boxes that have been hit by shots... 
 // a hack that will probably be changed later
 //
@@ -202,7 +202,7 @@ bool linesegment_cylinder(const LLVector3 &point_a, const LLVector3 &point_b,
 						  LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-// this function doesn't just return a BOOL because the return is currently
+// this function doesn't just return a bool because the return is currently
 // used to decide how to break up boxes that have been hit by shots... 
 // a hack that will probably be changed later
 //

--- a/indra/llmath/raytrace.h
+++ b/indra/llmath/raytrace.h
@@ -117,12 +117,12 @@ U32 ray_box(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 
 
 /* TODO
-BOOL ray_ellipsoid(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_ellipsoid(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 				   const LLVector3 &e_center, const LLVector3 &e_scale, const LLQuaternion &e_rotation,
 				   LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-BOOL ray_cone(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_cone(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 			  const LLVector3 &cone_tip, const LLVector3 &cone_bottom, 
 			  const LLVector3 &cone_scale, const LLQuaternion &cone_rotation,
 			  LLVector3 &intersection, LLVector3 &intersection_normal);
@@ -146,24 +146,24 @@ bool ray_pyramid(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 
 
 /* TODO
-BOOL ray_hemiellipsoid(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_hemiellipsoid(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 					   const LLVector3 &e_center, const LLVector3 &e_scale, const LLQuaternion &e_rotation,
 					   const LLVector3 &e_cut_normal,
 					   LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-BOOL ray_hemisphere(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_hemisphere(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 					const LLVector3 &sphere_center, F32 sphere_radius, const LLVector3 &sphere_cut_normal, 
 					LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-BOOL ray_hemicylinder(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_hemicylinder(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 					  const LLVector3 &cyl_top, const LLVector3 &cyl_bottom, F32 cyl_radius, 
 					  const LLVector3 &cyl_cut_normal,
 					  LLVector3 &intersection, LLVector3 &intersection_normal);
 
 
-BOOL ray_hemicone(const LLVector3 &ray_point, const LLVector3 &ray_direction,
+bool ray_hemicone(const LLVector3 &ray_point, const LLVector3 &ray_direction,
 				  const LLVector3 &cone_tip, const LLVector3 &cone_bottom, 
 				  const LLVector3 &cone_scale, const LLVector3 &cyl_cut_normal,
 				  LLVector3 &intersection, LLVector3 &intersection_normal);

--- a/indra/llmath/tests/xform_test.cpp
+++ b/indra/llmath/tests/xform_test.cpp
@@ -121,7 +121,7 @@ namespace tut
 		// Is that the expected behavior?
 	}
 
-	// test cases for inline BOOL setParent(LLXform *parent) and getParent() fn.
+	// test cases for inline bool setParent(LLXform *parent) and getParent() fn.
 	template<> template<>
 	void xform_test_object_t::test<3>()	
 	{		

--- a/indra/llmath/xform.cpp
+++ b/indra/llmath/xform.cpp
@@ -86,7 +86,7 @@ void LLXformMatrix::update()
 	}
 }
 
-void LLXformMatrix::updateMatrix(BOOL update_bounds)
+void LLXformMatrix::updateMatrix(bool update_bounds)
 {
 	update();
 

--- a/indra/llmath/xform.h
+++ b/indra/llmath/xform.h
@@ -30,12 +30,12 @@
 #include "m4math.h"
 #include "llquaternion.h"
 
-const F32 MAX_OBJECT_Z 		= 4096.f; // should match REGION_HEIGHT_METERS, Pre-havok4: 768.f
-const F32 MIN_OBJECT_Z 		= -256.f;
-const F32 DEFAULT_MAX_PRIM_SCALE = 64.f;
-const F32 DEFAULT_MAX_PRIM_SCALE_NO_MESH = 10.f;
-const F32 MIN_PRIM_SCALE = 0.01f;
-const F32 MAX_PRIM_SCALE = 65536.f;	// something very high but not near FLT_MAX
+constexpr F32 MAX_OBJECT_Z 		= 4096.f; // should match REGION_HEIGHT_METERS, Pre-havok4: 768.f
+constexpr F32 MIN_OBJECT_Z 		= -256.f;
+constexpr F32 DEFAULT_MAX_PRIM_SCALE = 64.f;
+constexpr F32 DEFAULT_MAX_PRIM_SCALE_NO_MESH = 10.f;
+constexpr F32 MIN_PRIM_SCALE = 0.01f;
+constexpr F32 MAX_PRIM_SCALE = 65536.f;	// something very high but not near FLT_MAX
 
 class LLXform
 {
@@ -52,7 +52,7 @@ protected:
 	LLXform*      mParent;
 	U32			  mChanged;
 
-	BOOL		  mScaleChildOffset;
+	bool		  mScaleChildOffset;
 
 public:
 	typedef enum e_changed_flags
@@ -78,7 +78,7 @@ public:
 		mScale.   setVec(1,1,1);
 		mWorldPosition.clearVec();
 		mWorldRotation.loadIdentity();
-		mScaleChildOffset = FALSE;
+		mScaleChildOffset = false;
 	}
 
 	 LLXform();
@@ -109,13 +109,13 @@ public:
 	void warn(const char* const msg);
 	
 	void 		setChanged(const U32 bits)					{ mChanged |= bits; }
-	BOOL		isChanged() const							{ return mChanged; }
-	BOOL 		isChanged(const U32 bits) const				{ return mChanged & bits; }
+	bool		isChanged() const							{ return mChanged; }
+	bool 		isChanged(const U32 bits) const				{ return mChanged & bits; }
 	void 		clearChanged()								{ mChanged = 0; }
 	void        clearChanged(U32 bits)                      { mChanged &= ~bits; }
 
-	void		setScaleChildOffset(BOOL scale)				{ mScaleChildOffset = scale; }
-	BOOL		getScaleChildOffset()						{ return mScaleChildOffset; }
+	void		setScaleChildOffset(bool scale)				{ mScaleChildOffset = scale; }
+	bool		getScaleChildOffset()						{ return mScaleChildOffset; }
 
 	LLXform* getParent() const { return mParent; }
 	LLXform* getRoot() const;
@@ -149,7 +149,7 @@ public:
 	}
 
 	void update();
-	void updateMatrix(BOOL update_bounds = TRUE);
+	void updateMatrix(bool update_bounds = true);
 	void getMinMax(LLVector3& min,LLVector3& max) const;
 
 protected:

--- a/indra/llplugin/slplugin/slplugin.cpp
+++ b/indra/llplugin/slplugin/slplugin.cpp
@@ -88,22 +88,6 @@ LONG WINAPI myWin32ExceptionHandler( struct _EXCEPTION_POINTERS* exception_infop
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
-// Taken from : http://blog.kalmbachnet.de/?postid=75
-// The MSVC 2005 CRT forces the call of the default-debugger (normally Dr.Watson)
-// even with the other exception handling code. This (terrifying) piece of code
-// patches things so that doesn't happen.
-LPTOP_LEVEL_EXCEPTION_FILTER WINAPI MyDummySetUnhandledExceptionFilter(
-	LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter )
-{
-	return NULL;
-}
-
-BOOL PreventSetUnhandledExceptionFilter()
-{
-	// remove the scary stuff that also isn't supported on 64 bit Windows
-	return TRUE;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 //	Hook our exception handler and replace the system one
 void initExceptionHandler()
@@ -112,7 +96,6 @@ void initExceptionHandler()
 
 	// save old exception handler in case we need to restore it at the end
 	prev_filter = SetUnhandledExceptionFilter( myWin32ExceptionHandler );
-	PreventSetUnhandledExceptionFilter();
 }
 
 bool checkExceptionHandler()
@@ -121,18 +104,16 @@ bool checkExceptionHandler()
 	LPTOP_LEVEL_EXCEPTION_FILTER prev_filter;
 	prev_filter = SetUnhandledExceptionFilter(myWin32ExceptionHandler);
 
-	PreventSetUnhandledExceptionFilter();
-
 	if (prev_filter != myWin32ExceptionHandler)
 	{
 		LL_WARNS("AppInit") << "Our exception handler (" << (void *)myWin32ExceptionHandler << ") replaced with " << prev_filter << "!" << LL_ENDL;
 		ok = false;
 	}
 
-	if (prev_filter == NULL)
+	if (prev_filter == nullptr)
 	{
-		ok = FALSE;
-		if (NULL == myWin32ExceptionHandler)
+		ok = false;
+		if (nullptr == myWin32ExceptionHandler)
 		{
 			LL_WARNS("AppInit") << "Exception handler uninitialized." << LL_ENDL;
 		}
@@ -245,7 +226,7 @@ int main(int argc, char **argv)
 		F64 elapsed = timer.getElapsedTimeF64();
 		F64 remaining = plugin->getSleepTime() - elapsed;
 
-		if(remaining <= 0.0f)
+		if(remaining <= 0.0)
 		{
 			// We've already used our full allotment.
 //			LL_INFOS("slplugin") << "elapsed = " << elapsed * 1000.0f << " ms, remaining = " << remaining * 1000.0f << " ms, not sleeping" << LL_ENDL;

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -243,7 +243,7 @@ LLModel::EModelStatus load_face_from_dom_triangles(
 								n[idx[i+norm_offset]*3+2]));
 		}
 		
-		BOOL found = FALSE;
+		bool found = false;
 			
 		LLVolumeFace::VertexMapData::PointMap::iterator point_iter;
 		point_iter = point_map.find(LLVector3(cv.getPosition().getF32ptr()));
@@ -498,7 +498,7 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 			
 			cur_idx += idx_stride;
 			
-			BOOL found = FALSE;
+			bool found = false;
 				
 			LLVolumeFace::VertexMapData::PointMap::iterator point_iter;
 			LLVector3 pos3(cv.getPosition().getF32ptr());
@@ -510,7 +510,7 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 				{
 					if ((point_iter->second)[k] == cv)
 					{
-						found = TRUE;
+						found = true;
 						U32 index = (point_iter->second)[k].mIndex;
 						if (j == 0)
 						{
@@ -2266,7 +2266,7 @@ std::map<std::string, LLImportMaterial> LLDAELoader::getMaterials(LLModel* model
 LLImportMaterial LLDAELoader::profileToMaterial(domProfile_COMMON* material, DAE* dae)
 {
 	LLImportMaterial mat;
-	mat.mFullbright = FALSE;
+	mat.mFullbright = false;
 
 	daeElement* diffuse = material->getDescendant("diffuse");
 	if (diffuse)
@@ -2351,7 +2351,7 @@ LLImportMaterial LLDAELoader::profileToMaterial(domProfile_COMMON* material, DAE
 		LLColor4 emission_color = getDaeColor(emission);
 		if (((emission_color[0] + emission_color[1] + emission_color[2]) / 3.0) > 0.25)
 		{
-			mat.mFullbright = TRUE;
+			mat.mFullbright = true;
 		}
 	}
 

--- a/indra/llprimitive/llmaterial.cpp
+++ b/indra/llprimitive/llmaterial.cpp
@@ -427,7 +427,7 @@ bool LLMaterial::operator != (const LLMaterial& rhs) const
 }
 
 
-U32 LLMaterial::getShaderMask(U32 alpha_mode, BOOL is_alpha)
+U32 LLMaterial::getShaderMask(U32 alpha_mode, bool is_alpha)
 { //NEVER incorporate this value into the message system -- this function will vary depending on viewer implementation
 
 	//two least significant bits are "diffuse alpha mode"

--- a/indra/llprimitive/llmaterial.h
+++ b/indra/llprimitive/llmaterial.h
@@ -122,7 +122,7 @@ public:
     bool        operator == (const LLMaterial& rhs) const;
     bool        operator != (const LLMaterial& rhs) const;
 
-    U32         getShaderMask(U32 alpha_mode, BOOL is_alpha);
+    U32         getShaderMask(U32 alpha_mode, bool is_alpha);
     LLUUID      getHash() const;
 
 protected:

--- a/indra/llprimitive/llmaterialtable.cpp
+++ b/indra/llprimitive/llmaterialtable.cpp
@@ -341,21 +341,21 @@ void LLMaterialTable::initBasicTable()
 	}
 }
 
-BOOL LLMaterialTable::add(U8 mcode, const std::string& name, const LLUUID &uuid)
+bool LLMaterialTable::add(U8 mcode, const std::string& name, const LLUUID &uuid)
 {
 	LLMaterialInfo *infop;
 
 	infop = new LLMaterialInfo(mcode,name,uuid);
-	if (!infop) return FALSE;
+	if (!infop) return false;
 
 	// Add at the end so the order in menus matches the order in this
 	// file.  JNC 11.30.01
 	mMaterialInfoList.push_back(infop);
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLMaterialTable::addCollisionSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
+bool LLMaterialTable::addCollisionSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 {
 	if (mCollisionSoundMatrix && (mcode < LL_MCODE_END) && (mcode2 < LL_MCODE_END))
 	{
@@ -365,10 +365,10 @@ BOOL LLMaterialTable::addCollisionSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 			mCollisionSoundMatrix[mcode2 * LL_MCODE_END + mcode] = uuid;		
 		}
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLMaterialTable::addSlidingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
+bool LLMaterialTable::addSlidingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 {
 	if (mSlidingSoundMatrix && (mcode < LL_MCODE_END) && (mcode2 < LL_MCODE_END))
 	{
@@ -378,10 +378,10 @@ BOOL LLMaterialTable::addSlidingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 			mSlidingSoundMatrix[mcode2 * LL_MCODE_END + mcode] = uuid;		
 		}
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLMaterialTable::addRollingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
+bool LLMaterialTable::addRollingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 {
 	if (mRollingSoundMatrix && (mcode < LL_MCODE_END) && (mcode2 < LL_MCODE_END))
 	{
@@ -391,10 +391,10 @@ BOOL LLMaterialTable::addRollingSound(U8 mcode, U8 mcode2, const LLUUID &uuid)
 			mRollingSoundMatrix[mcode2 * LL_MCODE_END + mcode] = uuid;		
 		}
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLMaterialTable::addShatterSound(U8 mcode, const LLUUID &uuid)
+bool LLMaterialTable::addShatterSound(U8 mcode, const LLUUID &uuid)
 {
 	for (info_list_t::iterator iter = mMaterialInfoList.begin();
 		 iter != mMaterialInfoList.end(); ++iter)
@@ -403,14 +403,14 @@ BOOL LLMaterialTable::addShatterSound(U8 mcode, const LLUUID &uuid)
 		if (mcode == infop->mMCode)
 		{
 			infop->mShatterSoundID = uuid;
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLMaterialTable::addDensity(U8 mcode, const F32 &density)
+bool LLMaterialTable::addDensity(U8 mcode, const F32 &density)
 {
 	for (info_list_t::iterator iter = mMaterialInfoList.begin();
 		 iter != mMaterialInfoList.end(); ++iter)
@@ -419,14 +419,14 @@ BOOL LLMaterialTable::addDensity(U8 mcode, const F32 &density)
 		if (mcode == infop->mMCode)
 		{
 			infop->mDensity = density;
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLMaterialTable::addRestitution(U8 mcode, const F32 &restitution)
+bool LLMaterialTable::addRestitution(U8 mcode, const F32 &restitution)
 {
 	for (info_list_t::iterator iter = mMaterialInfoList.begin();
 		 iter != mMaterialInfoList.end(); ++iter)
@@ -435,14 +435,14 @@ BOOL LLMaterialTable::addRestitution(U8 mcode, const F32 &restitution)
 		if (mcode == infop->mMCode)
 		{
 			infop->mRestitution = restitution;
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLMaterialTable::addFriction(U8 mcode, const F32 &friction)
+bool LLMaterialTable::addFriction(U8 mcode, const F32 &friction)
 {
 	for (info_list_t::iterator iter = mMaterialInfoList.begin();
 		 iter != mMaterialInfoList.end(); ++iter)
@@ -451,14 +451,14 @@ BOOL LLMaterialTable::addFriction(U8 mcode, const F32 &friction)
 		if (mcode == infop->mMCode)
 		{
 			infop->mFriction = friction;
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
-BOOL LLMaterialTable::addDamageAndEnergy(U8 mcode, const F32 &hp_mod, const F32 &damage_mod, const F32 &ep_mod)
+bool LLMaterialTable::addDamageAndEnergy(U8 mcode, const F32 &hp_mod, const F32 &damage_mod, const F32 &ep_mod)
 {
 	for (info_list_t::iterator iter = mMaterialInfoList.begin();
 		 iter != mMaterialInfoList.end(); ++iter)
@@ -469,11 +469,11 @@ BOOL LLMaterialTable::addDamageAndEnergy(U8 mcode, const F32 &hp_mod, const F32 
 			infop->mHPModifier = hp_mod;
 			infop->mDamageModifier = damage_mod;
 			infop->mEPModifier = ep_mod;
-			return TRUE;
+			return true;
 		}
 	}
 
-	return FALSE;
+	return false;
 }
 
 LLUUID LLMaterialTable::getDefaultTextureID(const std::string& name)

--- a/indra/llprimitive/llmaterialtable.h
+++ b/indra/llprimitive/llmaterialtable.h
@@ -106,15 +106,15 @@ public:
 
 	void initTableTransNames(std::map<std::string, std::string> namemap);
 	
-	BOOL add(U8 mcode, const std::string& name, const LLUUID &uuid);	                 
-	BOOL addCollisionSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
-	BOOL addSlidingSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
-	BOOL addRollingSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
-	BOOL addShatterSound(U8 mcode, const LLUUID &uuid);
-	BOOL addDensity(U8 mcode, const F32 &density);
-	BOOL addFriction(U8 mcode, const F32 &friction);
-	BOOL addRestitution(U8 mcode, const F32 &restitution);
-	BOOL addDamageAndEnergy(U8 mcode, const F32 &hp_mod, const F32 &damage_mod, const F32 &ep_mod);
+	bool add(U8 mcode, const std::string& name, const LLUUID &uuid);	                 
+	bool addCollisionSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
+	bool addSlidingSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
+	bool addRollingSound(U8 mcode, U8 mcode2, const LLUUID &uuid);
+	bool addShatterSound(U8 mcode, const LLUUID &uuid);
+	bool addDensity(U8 mcode, const F32 &density);
+	bool addFriction(U8 mcode, const F32 &friction);
+	bool addRestitution(U8 mcode, const F32 &restitution);
+	bool addDamageAndEnergy(U8 mcode, const F32 &hp_mod, const F32 &damage_mod, const F32 &ep_mod);
 
 	LLUUID getDefaultTextureID(const std::string& name);					// LLUUID::null if not found
 	LLUUID getDefaultTextureID(U8 mcode);					// LLUUID::null if not found

--- a/indra/llprimitive/llmodel.cpp
+++ b/indra/llprimitive/llmodel.cpp
@@ -662,11 +662,11 @@ LLSD LLModel::writeModel(
 	LLModel* low,
 	LLModel* impostor,
 	const LLModel::Decomposition& decomp,
-	BOOL upload_skin,
-	BOOL upload_joints,
-    BOOL lock_scale_if_joint_position,
-	BOOL nowrite,
-	BOOL as_slm,
+	bool upload_skin,
+	bool upload_joints,
+    bool lock_scale_if_joint_position,
+	bool nowrite,
+	bool as_slm,
 	int submodel_id)
 {
 	LLSD mdl;
@@ -947,7 +947,7 @@ LLSD LLModel::writeModel(
 	return writeModelToStream(ostr, mdl, nowrite, as_slm);
 }
 
-LLSD LLModel::writeModelToStream(std::ostream& ostr, LLSD& mdl, BOOL nowrite, BOOL as_slm)
+LLSD LLModel::writeModelToStream(std::ostream& ostr, LLSD& mdl, bool nowrite, bool as_slm)
 {
 	std::string::size_type cur_offset = 0;
 

--- a/indra/llprimitive/llmodel.h
+++ b/indra/llprimitive/llmodel.h
@@ -162,17 +162,17 @@ public:
 		LLModel* low,
 		LLModel* imposotr,
 		const LLModel::Decomposition& decomp,
-		BOOL upload_skin,
-		BOOL upload_joints,
-        BOOL lock_scale_if_joint_position,
-		BOOL nowrite = FALSE,
-		BOOL as_slm = FALSE,
+		bool upload_skin,
+		bool upload_joints,
+        bool lock_scale_if_joint_position,
+		bool nowrite = false,
+		bool as_slm = false,
 		int submodel_id = 0);
 
 	static LLSD writeModelToStream(
 		std::ostream& ostr,
 		LLSD& mdl,
-		BOOL nowrite = FALSE, BOOL as_slm = FALSE);
+		bool nowrite = false, bool as_slm = false);
 	
 	void ClearFacesAndMaterials() { mVolumeFaces.clear(); mMaterialList.clear(); }
 

--- a/indra/llprimitive/llmodelloader.cpp
+++ b/indra/llprimitive/llmodelloader.cpp
@@ -37,7 +37,7 @@
 
 std::list<LLModelLoader*> LLModelLoader::sActiveLoaderList;
 
-void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4a& max, BOOL& first_transform)
+void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4a& max, bool& first_transform)
 {
 	LLVector4a box[] =
 	{
@@ -74,7 +74,7 @@ void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4
 
 			if (first_transform)
 			{
-				first_transform = FALSE;
+				first_transform = false;
 				min = max = v;
 			}
 			else
@@ -85,7 +85,7 @@ void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4
 	}
 }
 
-void stretch_extents(LLModel* model, LLMatrix4& mat, LLVector3& min, LLVector3& max, BOOL& first_transform)
+void stretch_extents(LLModel* model, LLMatrix4& mat, LLVector3& min, LLVector3& max, bool& first_transform)
 {
 	LLVector4a mina, maxa;
 	LLMatrix4a mata;
@@ -121,7 +121,7 @@ LLModelLoader::LLModelLoader(
 , mFilename(filename)
 , mLod(lod)
 , mTrySLM(false)
-, mFirstTransform(TRUE)
+, mFirstTransform(true)
 , mNumOfFetchingTextures(0)
 , mLoadCallback(load_cb)
 , mJointLookupFunc(joint_lookup_func)
@@ -337,7 +337,7 @@ bool LLModelLoader::loadFromSLM(const std::string& filename)
 
 
 	//convert instance_list to mScene
-	mFirstTransform = TRUE;
+	mFirstTransform = true;
 	for (U32 i = 0; i < instance_list.size(); ++i)
 	{
 		LLModelInstance& cur_instance = instance_list[i];
@@ -478,7 +478,7 @@ bool LLModelLoader::isRigSuitableForJointPositionUpload( const std::vector<std::
 //called in the main thread
 void LLModelLoader::loadTextures()
 {
-	BOOL is_paused = isPaused() ;
+	bool is_paused = isPaused() ;
 	pause() ; //pause the loader 
 
 	for(scene::iterator iter = mScene.begin(); iter != mScene.end(); ++iter)

--- a/indra/llprimitive/llmodelloader.h
+++ b/indra/llprimitive/llmodelloader.h
@@ -104,7 +104,7 @@ public:
 	S32 mLod;
 	
 	LLMatrix4 mTransform;
-	BOOL mFirstTransform;
+	bool mFirstTransform;
 	LLVector3 mExtents[2];
 	
 	bool mTrySLM;
@@ -215,7 +215,7 @@ protected:
 	static bool isAlive(LLModelLoader* loader) ;
 };
 class LLMatrix4a;
-void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4a& max, BOOL& first_transform);
-void stretch_extents(LLModel* model, LLMatrix4& mat, LLVector3& min, LLVector3& max, BOOL& first_transform);
+void stretch_extents(LLModel* model, LLMatrix4a& mat, LLVector4a& min, LLVector4a& max, bool& first_transform);
+void stretch_extents(LLModel* model, LLMatrix4& mat, LLVector3& min, LLVector3& max, bool& first_transform);
 
 #endif  // LL_LLMODELLOADER_H

--- a/indra/llprimitive/llprimitive.cpp
+++ b/indra/llprimitive/llprimitive.cpp
@@ -115,8 +115,8 @@ const F32 FLEXIBLE_OBJECT_MAX_WIND_SENSITIVITY = 10.0f;
 const F32 FLEXIBLE_OBJECT_MAX_INTERNAL_TENSION_FORCE = 0.99f; 
 
 const F32 FLEXIBLE_OBJECT_DEFAULT_LENGTH = 1.0f;
-const BOOL FLEXIBLE_OBJECT_DEFAULT_USING_COLLISION_SPHERE = FALSE;
-const BOOL FLEXIBLE_OBJECT_DEFAULT_RENDERING_COLLISION_SPHERE = FALSE;
+const bool FLEXIBLE_OBJECT_DEFAULT_USING_COLLISION_SPHERE = false;
+const bool FLEXIBLE_OBJECT_DEFAULT_RENDERING_COLLISION_SPHERE = false;
 
 const char *SCULPT_DEFAULT_TEXTURE = "be293869-d0d9-0a69-5989-ad27f1946fd4"; // old inverted texture: "7595d345-a24c-e7ef-f0bd-78793792133e";
 
@@ -172,7 +172,7 @@ void LLPrimitive::setVolumeManager( LLVolumeMgr* volume_manager )
 // static
 bool LLPrimitive::cleanupVolumeManager()
 {
-	BOOL res = FALSE;
+	bool res = false;
 	if (sVolumeManager) 
 	{
 		res = sVolumeManager->cleanup();
@@ -770,16 +770,16 @@ S32	face_index_from_id(LLFaceID face_ID, const std::vector<LLProfile::Face>& fac
 	return -1;
 }
 
-BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume)
+bool LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume)
 {
 	if (NO_LOD == detail)
 	{
 		// build the new object
 		setChanged(GEOMETRY);
 		sVolumeManager->unrefVolume(mVolumep);
-		mVolumep = new LLVolume(volume_params, 1, TRUE, TRUE);
+		mVolumep = new LLVolume(volume_params, 1, true, true);
 		setNumTEs(mVolumep->getNumFaces());
-		return FALSE;
+		return false;
 	}
 
 	LLVolume *volumep;
@@ -788,9 +788,9 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 		F32 volume_detail = LLVolumeLODGroup::getVolumeScaleFromDetail(detail);
 		if (mVolumep.notNull() && volume_params == mVolumep->getParams() && (volume_detail == mVolumep->getDetail()))
 		{
-			return FALSE;
+			return false;
 		}
-		volumep = new LLVolume(volume_params, volume_detail, FALSE, TRUE);
+		volumep = new LLVolume(volume_params, volume_detail, false, true);
 	}
 	else
 	{
@@ -799,7 +799,7 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 			F32 volume_detail = LLVolumeLODGroup::getVolumeScaleFromDetail(detail);
 			if (volume_params == mVolumep->getParams() && (volume_detail == mVolumep->getDetail()))
 			{
-				return FALSE;
+				return false;
 			}
 		}
 
@@ -807,7 +807,7 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 		if (volumep == mVolumep)
 		{
 			sVolumeManager->unrefVolume( volumep );  // LLVolumeMgr::refVolume() creates a reference, but we don't need a second one.
-			return TRUE;
+			return true;
 		}
 	}
 
@@ -819,7 +819,7 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 		mVolumep = volumep;
 		//mFaceMask = mVolumep->generateFaceMask();
 		setNumTEs(mVolumep->getNumFaces());
-		return TRUE;
+		return true;
 	}
 	
 #if 0 
@@ -871,14 +871,14 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 	if (old_face_mask == new_face_mask) 
 	{
 		// nothing to do
-		return TRUE;
+		return true;
 	}
 
 	if (mVolumep->getNumFaces() == 0 && new_face_mask != 0)
 	{
 		LL_WARNS() << "Object with 0 faces found...INCORRECT!" << LL_ENDL;
 		setNumTEs(mVolumep->getNumFaces());
-		return TRUE;
+		return true;
 	}
 
 	// initialize face_mapping
@@ -1030,19 +1030,19 @@ BOOL LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
 
 	setNumTEs(mVolumep->getNumFaces());
 #endif
-	return TRUE;
+	return true;
 }
 
-BOOL LLPrimitive::setMaterial(U8 material)
+bool LLPrimitive::setMaterial(U8 material)
 {
 	if (material != mMaterial)
 	{
 		mMaterial = material;
-		return TRUE;
+		return true;
 	}
 	else
 	{
-		return FALSE;
+		return false;
 	}
 }
 
@@ -1058,12 +1058,12 @@ S32 LLPrimitive::packTEField(U8 *cur_ptr, U8 *data_ptr, U8 data_size, U8 last_fa
 	
 	for (face_index = last_face_index-1; face_index >= 0; face_index--)
 	{
-		BOOL already_sent = FALSE;
+		bool already_sent = false;
 		for (i = face_index+1; i <= last_face_index; i++)
 		{ 
 			if (!memcmp(data_ptr+(data_size *face_index), data_ptr+(data_size *i), data_size))
 			{
-				already_sent = TRUE;
+				already_sent = true;
 				break;
 			}
 		}
@@ -1201,7 +1201,7 @@ namespace
 // Pack information about all texture entries into container:
 // { TextureEntry Variable 2 }
 // Includes information about image ID, color, scale S,T, offset S,T and rotation
-BOOL LLPrimitive::packTEMessage(LLMessageSystem *mesgsys) const
+bool LLPrimitive::packTEMessage(LLMessageSystem *mesgsys) const
 {
 	const U32 MAX_TES = 45;
 
@@ -1282,11 +1282,11 @@ BOOL LLPrimitive::packTEMessage(LLMessageSystem *mesgsys) const
 	}
    	mesgsys->addBinaryDataFast(_PREHASH_TextureEntry, packed_buffer, (S32)(cur_ptr - packed_buffer));
 
-	return FALSE;
+	return true;
 }
 
 
-BOOL LLPrimitive::packTEMessage(LLDataPacker &dp) const
+bool LLPrimitive::packTEMessage(LLDataPacker &dp) const
 {
 	const U32 MAX_TES = 45;
 
@@ -1367,7 +1367,7 @@ BOOL LLPrimitive::packTEMessage(LLDataPacker &dp) const
 	}
 
 	dp.packBinaryData(packed_buffer, (S32)(cur_ptr - packed_buffer), "TextureEntry");
-	return FALSE;
+	return true;
 }
 
 S32 LLPrimitive::parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec)
@@ -1484,12 +1484,12 @@ S32 LLPrimitive::unpackTEMessage(LLDataPacker &dp)
 {
 	// use a negative block_num to indicate a single-block read (a non-variable block)
 	S32 retval = 0;
-	const U32 MAX_TES = 45;
+	constexpr U32 MAX_TES = 45;
 
 	// Avoid construction of 32 UUIDs per call
 	static LLMaterialID material_ids[MAX_TES];
 
-    const U32 MAX_TE_BUFFER = 4096;
+	constexpr U32 MAX_TE_BUFFER = 4096;
     U8 packed_buffer[MAX_TE_BUFFER];
     memset((void*)packed_buffer, 0, MAX_TE_BUFFER);
 
@@ -1685,7 +1685,7 @@ bool LLPrimitive::getTESTAxes(const U8 face, U32* s_axis, U32* t_axis)
 //============================================================================
 
 //static 
-BOOL LLNetworkData::isValid(U16 param_type, U32 size)
+bool LLNetworkData::isValid(U16 param_type, U32 size)
 {
 	// ew - better mechanism needed
 	
@@ -1707,7 +1707,7 @@ BOOL LLNetworkData::isValid(U16 param_type, U32 size)
         return (size == 9);
 	}
 	
-	return FALSE;
+	return false;
 }
 
 //============================================================================
@@ -1722,17 +1722,17 @@ LLLightParams::LLLightParams()
 	mType = PARAMS_LIGHT;
 }
 
-BOOL LLLightParams::pack(LLDataPacker &dp) const
+bool LLLightParams::pack(LLDataPacker &dp) const
 {
 	LLColor4U color4u(mColor);
 	dp.packColor4U(color4u, "color");
 	dp.packF32(mRadius, "radius");
 	dp.packF32(mCutoff, "cutoff");
 	dp.packF32(mFalloff, "falloff");
-	return TRUE;
+	return true;
 }
 
-BOOL LLLightParams::unpack(LLDataPacker &dp)
+bool LLLightParams::unpack(LLDataPacker &dp)
 {
 	LLColor4U color;
 	dp.unpackColor4U(color, "color");
@@ -1750,7 +1750,7 @@ BOOL LLLightParams::unpack(LLDataPacker &dp)
 	dp.unpackF32(falloff, "falloff");
 	setFalloff(falloff);
 	
-	return TRUE;
+	return true;
 }
 
 bool LLLightParams::operator==(const LLNetworkData& data) const
@@ -1830,15 +1830,15 @@ LLReflectionProbeParams::LLReflectionProbeParams()
     mType = PARAMS_REFLECTION_PROBE;
 }
 
-BOOL LLReflectionProbeParams::pack(LLDataPacker &dp) const
+bool LLReflectionProbeParams::pack(LLDataPacker &dp) const
 {
 	dp.packF32(mAmbiance, "ambiance");
     dp.packF32(mClipDistance, "clip_distance");
     dp.packU8(mFlags, "flags");
-	return TRUE;
+	return true;
 }
 
-BOOL LLReflectionProbeParams::unpack(LLDataPacker &dp)
+bool LLReflectionProbeParams::unpack(LLDataPacker &dp)
 {
 	F32 ambiance;
     F32 clip_distance;
@@ -1851,7 +1851,7 @@ BOOL LLReflectionProbeParams::unpack(LLDataPacker &dp)
 	
     dp.unpackU8(mFlags, "flags");
 	
-	return TRUE;
+	return true;
 }
 
 bool LLReflectionProbeParams::operator==(const LLNetworkData& data) const
@@ -1949,7 +1949,7 @@ LLFlexibleObjectData::LLFlexibleObjectData()
 	mType = PARAMS_FLEXIBLE;
 }
 
-BOOL LLFlexibleObjectData::pack(LLDataPacker &dp) const
+bool LLFlexibleObjectData::pack(LLDataPacker &dp) const
 {
 	// Custom, uber-svelte pack "softness" in upper bits of tension & drag
 	U8 bit1 = (mSimulateLOD & 2) << 6;
@@ -1959,10 +1959,10 @@ BOOL LLFlexibleObjectData::pack(LLDataPacker &dp) const
 	dp.packU8((U8)((mGravity+10.f)*10.01f), "gravity");
 	dp.packU8((U8)(mWindSensitivity*10.01f), "wind");
 	dp.packVector3(mUserForce, "userforce");
-	return TRUE;
+	return true;
 }
 
-BOOL LLFlexibleObjectData::unpack(LLDataPacker &dp)
+bool LLFlexibleObjectData::unpack(LLDataPacker &dp)
 {
 	U8 tension, friction, gravity, wind;
 	U8 bit1, bit2;
@@ -1981,7 +1981,7 @@ BOOL LLFlexibleObjectData::unpack(LLDataPacker &dp)
 	{
 		mUserForce.setVec(0.f, 0.f, 0.f);
 	}
-	return TRUE;
+	return true;
 }
 
 bool LLFlexibleObjectData::operator==(const LLNetworkData& data) const
@@ -2077,15 +2077,15 @@ LLSculptParams::LLSculptParams()
 	mSculptType = LL_SCULPT_TYPE_SPHERE;
 }
 
-BOOL LLSculptParams::pack(LLDataPacker &dp) const
+bool LLSculptParams::pack(LLDataPacker &dp) const
 {
 	dp.packUUID(mSculptTexture, "texture");
 	dp.packU8(mSculptType, "type");
 	
-	return TRUE;
+	return true;
 }
 
-BOOL LLSculptParams::unpack(LLDataPacker &dp)
+bool LLSculptParams::unpack(LLDataPacker &dp)
 {
 	U8 type;
 	LLUUID id;
@@ -2093,7 +2093,7 @@ BOOL LLSculptParams::unpack(LLDataPacker &dp)
 	dp.unpackU8(type, "type");
 
 	setSculptTexture(id, type);
-	return TRUE;
+	return true;
 }
 
 bool LLSculptParams::operator==(const LLNetworkData& data) const
@@ -2177,20 +2177,20 @@ LLLightImageParams::LLLightImageParams()
 	mParams.setVec(F_PI*0.5f, 0.f, 0.f);
 }
 
-BOOL LLLightImageParams::pack(LLDataPacker &dp) const
+bool LLLightImageParams::pack(LLDataPacker &dp) const
 {
 	dp.packUUID(mLightTexture, "texture");
 	dp.packVector3(mParams, "params");
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLLightImageParams::unpack(LLDataPacker &dp)
+bool LLLightImageParams::unpack(LLDataPacker &dp)
 {
 	dp.unpackUUID(mLightTexture, "texture");
 	dp.unpackVector3(mParams, "params");
 	
-	return TRUE;
+	return true;
 }
 
 bool LLLightImageParams::operator==(const LLNetworkData& data) const
@@ -2253,18 +2253,18 @@ LLExtendedMeshParams::LLExtendedMeshParams()
 	mFlags = 0;
 }
 
-BOOL LLExtendedMeshParams::pack(LLDataPacker &dp) const
+bool LLExtendedMeshParams::pack(LLDataPacker &dp) const
 {
 	dp.packU32(mFlags, "flags");
 
-	return TRUE;
+	return true;
 }
 
-BOOL LLExtendedMeshParams::unpack(LLDataPacker &dp)
+bool LLExtendedMeshParams::unpack(LLDataPacker &dp)
 {
 	dp.unpackU32(mFlags, "flags");
 	
-	return TRUE;
+	return true;
 }
 
 bool LLExtendedMeshParams::operator==(const LLNetworkData& data) const
@@ -2316,7 +2316,7 @@ LLRenderMaterialParams::LLRenderMaterialParams()
     mType = PARAMS_RENDER_MATERIAL;
 }
 
-BOOL LLRenderMaterialParams::pack(LLDataPacker& dp) const
+bool LLRenderMaterialParams::pack(LLDataPacker& dp) const
 {
     U8 count = (U8)llmin((S32)mEntries.size(), 14); //limited to 255 bytes, no more than 14 material ids
 
@@ -2327,10 +2327,10 @@ BOOL LLRenderMaterialParams::pack(LLDataPacker& dp) const
         dp.packUUID(entry.id, "id");
     }
 
-    return TRUE;
+    return true;
 }
 
-BOOL LLRenderMaterialParams::unpack(LLDataPacker& dp)
+bool LLRenderMaterialParams::unpack(LLDataPacker& dp)
 {
     U8 count;
     dp.unpackU8(count, "count");
@@ -2341,7 +2341,7 @@ BOOL LLRenderMaterialParams::unpack(LLDataPacker& dp)
         dp.unpackUUID(entry.id, "te_id");
     }
 
-    return TRUE;
+    return true;
 }
 
 bool LLRenderMaterialParams::operator==(const LLNetworkData& data) const

--- a/indra/llprimitive/llprimitive.h
+++ b/indra/llprimitive/llprimitive.h
@@ -114,11 +114,11 @@ public:
 public:
 	U16 mType;
 	virtual ~LLNetworkData() {};
-	virtual BOOL pack(LLDataPacker &dp) const = 0;
-	virtual BOOL unpack(LLDataPacker &dp) = 0;
+	virtual bool pack(LLDataPacker &dp) const = 0;
+	virtual bool unpack(LLDataPacker &dp) = 0;
 	virtual bool operator==(const LLNetworkData& data) const = 0;
 	virtual void copy(const LLNetworkData& data) = 0;
-	static BOOL isValid(U16 param_type, U32 size);
+	static bool isValid(U16 param_type, U32 size);
 };
 
 extern const F32 LIGHT_MIN_RADIUS;
@@ -141,8 +141,8 @@ private:
 
 public:
 	LLLightParams();
-	/*virtual*/ BOOL pack(LLDataPacker &dp) const;
-	/*virtual*/ BOOL unpack(LLDataPacker &dp);
+	/*virtual*/ bool pack(LLDataPacker &dp) const;
+	/*virtual*/ bool unpack(LLDataPacker &dp);
 	/*virtual*/ bool operator==(const LLNetworkData& data) const;
 	/*virtual*/ void copy(const LLNetworkData& data);
 	// LLSD implementations here are provided by Eddy Stryker.
@@ -195,8 +195,8 @@ protected:
 
 public:
     LLReflectionProbeParams();
-    /*virtual*/ BOOL pack(LLDataPacker& dp) const;
-    /*virtual*/ BOOL unpack(LLDataPacker& dp);
+    /*virtual*/ bool pack(LLDataPacker& dp) const;
+    /*virtual*/ bool unpack(LLDataPacker& dp);
     /*virtual*/ bool operator==(const LLNetworkData& data) const;
     /*virtual*/ void copy(const LLNetworkData& data);
     // LLSD implementations here are provided by Eddy Stryker.
@@ -255,8 +255,8 @@ extern const F32 FLEXIBLE_OBJECT_MAX_WIND_SENSITIVITY;
 extern const F32 FLEXIBLE_OBJECT_MAX_INTERNAL_TENSION_FORCE;
 
 extern const F32 FLEXIBLE_OBJECT_DEFAULT_LENGTH;
-extern const BOOL FLEXIBLE_OBJECT_DEFAULT_USING_COLLISION_SPHERE;
-extern const BOOL FLEXIBLE_OBJECT_DEFAULT_RENDERING_COLLISION_SPHERE;
+extern const bool FLEXIBLE_OBJECT_DEFAULT_USING_COLLISION_SPHERE;
+extern const bool FLEXIBLE_OBJECT_DEFAULT_RENDERING_COLLISION_SPHERE;
 
 
 class LLFlexibleObjectData : public LLNetworkData
@@ -268,8 +268,8 @@ protected:
 	F32			mWindSensitivity;	// interacts with tension, air friction, and gravity
 	F32			mTension;			//interacts in complex ways with other parameters
 	LLVector3	mUserForce;			// custom user-defined force vector
-	//BOOL		mUsingCollisionSphere;
-	//BOOL		mRenderingCollisionSphere;
+	//bool		mUsingCollisionSphere;
+	//bool		mRenderingCollisionSphere;
 
 public:
 	void		setSimulateLOD(S32 lod)			{ mSimulateLOD = llclamp(lod, (S32)FLEXIBLE_OBJECT_MIN_SECTIONS, (S32)FLEXIBLE_OBJECT_MAX_SECTIONS); }
@@ -288,8 +288,8 @@ public:
 
 	//------ the constructor for the structure ------------
 	LLFlexibleObjectData();
-	BOOL pack(LLDataPacker &dp) const;
-	BOOL unpack(LLDataPacker &dp);
+	bool pack(LLDataPacker &dp) const;
+	bool unpack(LLDataPacker &dp);
 	bool operator==(const LLNetworkData& data) const;
 	void copy(const LLNetworkData& data);
 	LLSD asLLSD() const;
@@ -307,8 +307,8 @@ protected:
 	
 public:
 	LLSculptParams();
-	/*virtual*/ BOOL pack(LLDataPacker &dp) const;
-	/*virtual*/ BOOL unpack(LLDataPacker &dp);
+	/*virtual*/ bool pack(LLDataPacker &dp) const;
+	/*virtual*/ bool unpack(LLDataPacker &dp);
 	/*virtual*/ bool operator==(const LLNetworkData& data) const;
 	/*virtual*/ void copy(const LLNetworkData& data);
 	LLSD asLLSD() const;
@@ -328,8 +328,8 @@ protected:
 	
 public:
 	LLLightImageParams();
-	/*virtual*/ BOOL pack(LLDataPacker &dp) const;
-	/*virtual*/ BOOL unpack(LLDataPacker &dp);
+	/*virtual*/ bool pack(LLDataPacker &dp) const;
+	/*virtual*/ bool unpack(LLDataPacker &dp);
 	/*virtual*/ bool operator==(const LLNetworkData& data) const;
 	/*virtual*/ void copy(const LLNetworkData& data);
 	LLSD asLLSD() const;
@@ -353,8 +353,8 @@ public:
 	static const U32 ANIMATED_MESH_ENABLED_FLAG = 0x1 << 0;
 
 	LLExtendedMeshParams();
-	/*virtual*/ BOOL pack(LLDataPacker &dp) const;
-	/*virtual*/ BOOL unpack(LLDataPacker &dp);
+	/*virtual*/ bool pack(LLDataPacker &dp) const;
+	/*virtual*/ bool unpack(LLDataPacker &dp);
 	/*virtual*/ bool operator==(const LLNetworkData& data) const;
 	/*virtual*/ void copy(const LLNetworkData& data);
 	LLSD asLLSD() const;
@@ -378,8 +378,8 @@ private:
 
 public:
     LLRenderMaterialParams();
-    BOOL pack(LLDataPacker& dp) const override;
-    BOOL unpack(LLDataPacker& dp) override;
+    bool pack(LLDataPacker& dp) const override;
+    bool unpack(LLDataPacker& dp) override;
     bool operator==(const LLNetworkData& data) const override;
     void copy(const LLNetworkData& data) override;
     
@@ -392,7 +392,7 @@ public:
 
 // This code is not naming-standards compliant. Leaving it like this for
 // now to make the connection to code in
-// 	BOOL packTEMessage(LLDataPacker &dp) const;
+// 	bool packTEMessage(LLDataPacker &dp) const;
 // more obvious. This should be refactored to remove the duplication, at which
 // point we can fix the names as well.
 // - Vir
@@ -454,10 +454,10 @@ public:
 	void setPCode(const LLPCode pcode);
 	const LLVolume *getVolumeConst() const { return mVolumep; }		// HACK for Windoze confusion about ostream operator in LLVolume
 	LLVolume *getVolume() const { return mVolumep; }
-	virtual BOOL setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume = false);
+	virtual bool setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume = false);
 	
 	// Modify texture entry properties
-	inline BOOL validTE(const U8 te_num) const;
+	inline bool validTE(const U8 te_num) const;
 	LLTextureEntry* getTE(const U8 te_num) const;
 
 	virtual void setNumTEs(const U8 num_tes);
@@ -486,17 +486,17 @@ public:
 	virtual S32 setTEGlow(const U8 te, const F32 glow);
 	virtual S32 setTEMaterialID(const U8 te, const LLMaterialID& pMaterialID);
     virtual S32 setTEMaterialParams(const U8 index, const LLMaterialPtr pMaterialParams);
-	virtual BOOL setMaterial(const U8 material); // returns TRUE if material changed
+	virtual bool setMaterial(const U8 material); // returns true if material changed
 	virtual void setTESelected(const U8 te, bool sel);
 
 	LLMaterialPtr getTEMaterialParams(const U8 index);
     
 	void copyTEs(const LLPrimitive *primitive);
 	S32 packTEField(U8 *cur_ptr, U8 *data_ptr, U8 data_size, U8 last_face_index, EMsgVariableType type) const;
-	BOOL packTEMessage(LLMessageSystem *mesgsys) const;
-	BOOL packTEMessage(LLDataPacker &dp) const;
+	bool packTEMessage(LLMessageSystem *mesgsys) const;
+	bool packTEMessage(LLDataPacker &dp) const;
 	S32 unpackTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num); // Variable num of blocks
-	BOOL unpackTEMessage(LLDataPacker &dp);
+	S32 unpackTEMessage(LLDataPacker &dp);
 	S32 parseTEMessage(LLMessageSystem* mesgsys, char const* block_name, const S32 block_num, LLTEContents& tec);
 	S32 applyParsedTEMessage(LLTEContents& tec);
 	
@@ -554,9 +554,9 @@ public:
 	// takes the contents of other_list and clears other_list
 	void takeTextureList(LLPrimTextureList& other_list);
 
-	inline BOOL	isAvatar() const;
-	inline BOOL	isSittingAvatar() const;
-	inline BOOL	isSittingAvatarOnGround() const;
+	inline bool	isAvatar() const;
+	inline bool	isSittingAvatar() const;
+	inline bool	isSittingAvatarOnGround() const;
 	inline bool hasBumpmap() const  { return mNumBumpmapTEs > 0;}
 	
 	void setFlags(U32 flags) { mMiscFlags = flags; }
@@ -569,10 +569,10 @@ public:
 	static U8 pCodeToLegacy(const LLPCode pcode);
 	static bool getTESTAxes(const U8 face, U32* s_axis, U32* t_axis);
 
-    BOOL hasRenderMaterialParams() const;
+    bool hasRenderMaterialParams() const;
 	
-	inline static BOOL isPrimitive(const LLPCode pcode);
-	inline static BOOL isApp(const LLPCode pcode);
+	inline static bool isPrimitive(const LLPCode pcode);
+	inline static bool isApp(const LLPCode pcode);
 
 private:
 	void updateNumBumpmap(const U8 index, const U8 bump);
@@ -598,39 +598,39 @@ public:
 	};
 };
 
-inline BOOL LLPrimitive::isAvatar() const
+inline bool LLPrimitive::isAvatar() const
 {
-	return ( LL_PCODE_LEGACY_AVATAR == mPrimitiveCode ) ? TRUE : FALSE;
+	return ( LL_PCODE_LEGACY_AVATAR == mPrimitiveCode ) ? true : false;
 }
 
-inline BOOL LLPrimitive::isSittingAvatar() const
+inline bool LLPrimitive::isSittingAvatar() const
 {
 	// this is only used server-side
 	return ( LL_PCODE_LEGACY_AVATAR == mPrimitiveCode 
-			 &&	 ((getFlags() & (PRIM_FLAG_SITTING | PRIM_FLAG_SITTING_ON_GROUND)) != 0) ) ? TRUE : FALSE;
+			 &&	 ((getFlags() & (PRIM_FLAG_SITTING | PRIM_FLAG_SITTING_ON_GROUND)) != 0) ) ? true : false;
 }
 
-inline BOOL LLPrimitive::isSittingAvatarOnGround() const
+inline bool LLPrimitive::isSittingAvatarOnGround() const
 {
 	// this is only used server-side
 	return ( LL_PCODE_LEGACY_AVATAR == mPrimitiveCode 
-			 &&	 ((getFlags() & PRIM_FLAG_SITTING_ON_GROUND) != 0) ) ? TRUE : FALSE;
+			 &&	 ((getFlags() & PRIM_FLAG_SITTING_ON_GROUND) != 0) ) ? true : false;
 }
 
 // static
-inline BOOL LLPrimitive::isPrimitive(const LLPCode pcode)
+inline bool LLPrimitive::isPrimitive(const LLPCode pcode)
 {
 	LLPCode base_type = pcode & LL_PCODE_BASE_MASK;
 
 	if (base_type && (base_type < LL_PCODE_APP))
 	{
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 // static
-inline BOOL LLPrimitive::isApp(const LLPCode pcode)
+inline bool LLPrimitive::isApp(const LLPCode pcode)
 {
 	LLPCode base_type = pcode & LL_PCODE_BASE_MASK;
 
@@ -786,7 +786,7 @@ void LLPrimitive::setAcceleration(const F32 x, const F32 y, const F32 z)
 }
 #endif // CHECK_FOR_FINITE
 
-inline BOOL LLPrimitive::validTE(const U8 te_num) const
+inline bool LLPrimitive::validTE(const U8 te_num) const
 {
 	return (mNumTEs && te_num < mNumTEs);
 }

--- a/indra/llprimitive/lltextureanim.cpp
+++ b/indra/llprimitive/lltextureanim.cpp
@@ -54,38 +54,38 @@ void LLTextureAnim::reset()
 	mRate = 1.f;
 }
 
-BOOL LLTextureAnim::equals(const LLTextureAnim &other) const
+bool LLTextureAnim::equals(const LLTextureAnim &other) const
 {
 	if (mMode != other.mMode)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mFace != other.mFace)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mSizeX != other.mSizeX)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mSizeY != other.mSizeY)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mStart != other.mStart)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mLength != other.mLength)
 	{
-		return FALSE;
+		return false;
 	}
 	if (mRate != other.mRate)
 	{
-		return FALSE;
+		return false;
 	}
 
-	return TRUE;
+	return true;
 }
 void LLTextureAnim::packTAMessage(LLMessageSystem *mesgsys) const
 {

--- a/indra/llprimitive/lltextureanim.h
+++ b/indra/llprimitive/lltextureanim.h
@@ -44,7 +44,7 @@ public:
 	void packTAMessage(LLDataPacker &dp) const;
 	void unpackTAMessage(LLMessageSystem *mesgsys, const S32 block_num);
 	void unpackTAMessage(LLDataPacker &dp);
-	BOOL equals(const LLTextureAnim &other) const;
+	bool equals(const LLTextureAnim &other) const;
 	LLSD asLLSD() const;
 	operator LLSD() const { return asLLSD(); }
 	bool fromLLSD(LLSD& sd);

--- a/indra/llrender/llcubemap.cpp
+++ b/indra/llrender/llcubemap.cpp
@@ -78,7 +78,7 @@ void LLCubeMap::initGL()
 			
 			for (int i = 0; i < 6; i++)
 			{
-				mImages[i] = new LLImageGL(RESOLUTION, RESOLUTION, 4, FALSE);
+				mImages[i] = new LLImageGL(RESOLUTION, RESOLUTION, 4, false);
             #if USE_SRGB_DECODE
                 if (mIssRGB) {
                     mImages[i]->setExplicitFormat(GL_SRGB8_ALPHA8, GL_RGBA);
@@ -176,7 +176,7 @@ void LLCubeMap::initReflectionMap(U32 resolution, U32 components)
 
     LLImageGL::generateTextures(1, &texname);
 
-    mImages[0] = new LLImageGL(resolution, resolution, components, TRUE);
+    mImages[0] = new LLImageGL(resolution, resolution, components, true);
     mImages[0]->setTexName(texname);
     mImages[0]->setTarget(mTargets[0], LLTexUnit::TT_CUBE_MAP);
     gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_CUBE_MAP, texname);
@@ -200,7 +200,7 @@ void LLCubeMap::initEnvironmentMap(const std::vector<LLPointer<LLImageRaw> >& ra
         llassert(rawimages[i]->getHeight() == resolution);
         llassert(rawimages[i]->getComponents() == components);
 
-        mImages[i] = new LLImageGL(resolution, resolution, components, TRUE);
+        mImages[i] = new LLImageGL(resolution, resolution, components, true);
         mImages[i]->setTarget(mTargets[i], LLTexUnit::TT_CUBE_MAP);
         mRawImages[i] = rawimages[i];
         mImages[i]->createGLTexture(0, mRawImages[i], texname);
@@ -224,8 +224,8 @@ void LLCubeMap::generateMipMaps()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 
-    mImages[0]->setUseMipMaps(TRUE);
-    mImages[0]->setHasMipMaps(TRUE);
+    mImages[0]->setUseMipMaps(true);
+    mImages[0]->setHasMipMaps(true);
     enableTexture(0);
     bind();
     mImages[0]->setFilteringOption(LLTexUnit::TFO_BILINEAR);

--- a/indra/llrender/llcubemaparray.h
+++ b/indra/llrender/llcubemaparray.h
@@ -51,7 +51,7 @@ public:
     // res - resolution of each cube face
     // components - number of components per pixel
     // count - number of cube maps in the array
-    // use_mips - if TRUE, mipmaps will be allocated for this cube map array and anisotropic filtering will be used
+    // use_mips - if true, mipmaps will be allocated for this cube map array and anisotropic filtering will be used
     void allocate(U32 res, U32 components, U32 count, bool use_mips = true);
 	void bind(S32 stage);
     void unbind();

--- a/indra/llrender/llfontbitmapcache.cpp
+++ b/indra/llrender/llfontbitmapcache.cpp
@@ -87,7 +87,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32 &pos_x, S32 &pos_y, S32& bitm
 			LLImageRaw *image_raw = getImageRaw(mBitmapNum);
 
 			// Make corresponding GL image.
-			mImageGLVec.push_back(new LLImageGL(FALSE));
+			mImageGLVec.push_back(new LLImageGL(false));
 			LLImageGL *image_gl = getImageGL(mBitmapNum);
 			
 			S32 image_width = mMaxCharWidth * 20;
@@ -122,7 +122,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32 &pos_x, S32 &pos_y, S32& bitm
 			// Attach corresponding GL texture.
 			image_gl->createGLTexture(0, image_raw);
 			gGL.getTexUnit(0)->bind(image_gl);
-			image_gl->setFilteringOption(LLTexUnit::TFO_POINT); // was setMipFilterNearest(TRUE, TRUE);
+			image_gl->setFilteringOption(LLTexUnit::TFO_POINT); // was setMipFilterNearest(true, true);
 		}
 		else
 		{

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -112,7 +112,7 @@ LLFontFreetype::LLFontFreetype()
 	pFileStream(NULL),
 	pFtStream(NULL),
 #endif
-	mIsFallback(FALSE),
+	mIsFallback(false),
 	mFTFace(NULL),
 	mRenderGlyphCount(0),
 	mAddGlyphCount(0),
@@ -156,7 +156,7 @@ void ft_close_cb(FT_Stream stream) {
 }
 #endif
 
-BOOL LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, BOOL is_fallback, S32 face_n)
+bool LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, bool is_fallback, S32 face_n)
 {
 	// Don't leak face objects.  This is also needed to deal with
 	// changed font file names.
@@ -181,7 +181,7 @@ BOOL LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
 #ifdef LL_WINDOWS
 		clearFontStreams();
 #endif
-		return FALSE;
+		return false;
 	}
 
 	mIsFallback = is_fallback;
@@ -201,7 +201,7 @@ BOOL LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
 		clearFontStreams();
 #endif
 		mFTFace = NULL;
-		return FALSE;
+		return false;
 	}
 
 	F32 y_max, y_min, x_max, x_min;
@@ -248,7 +248,7 @@ BOOL LLFontFreetype::loadFace(const std::string& filename, F32 point_size, F32 v
 		mStyle |= LLFontGL::ITALIC;
 	}
 
-	return TRUE;
+	return true;
 }
 
 S32 LLFontFreetype::getNumFaces(const std::string& filename)
@@ -414,7 +414,7 @@ F32 LLFontFreetype::getXKerning(const LLFontGlyphInfo* left_glyph_info, const LL
 	return delta.x*(1.f/64.f);
 }
 
-BOOL LLFontFreetype::hasGlyph(llwchar wch) const
+bool LLFontFreetype::hasGlyph(llwchar wch) const
 {
 	llassert(!mIsFallback);
 	return(mCharGlyphInfoMap.find(wch) != mCharGlyphInfoMap.end());
@@ -423,7 +423,7 @@ BOOL LLFontFreetype::hasGlyph(llwchar wch) const
 LLFontGlyphInfo* LLFontFreetype::addGlyph(llwchar wch) const
 {
 	if (mFTFace == NULL)
-		return FALSE;
+		return false;
 
 	llassert(!mIsFallback);
 	//LL_DEBUGS() << "Adding new glyph for " << wch << " to font" << LL_ENDL;
@@ -529,7 +529,7 @@ LLFontGlyphInfo* LLFontFreetype::addGlyphFromFont(const LLFontFreetype *fontp, l
 																	height,
 																	buffer_data,
 																	buffer_row_stride,
-																	TRUE);
+																	true);
 			break;
 		case 2:
 			setSubImageLuminanceAlpha(pos_x,	

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -84,7 +84,7 @@ public:
 
 	// is_fallback should be true for fallback fonts that aren't used
 	// to render directly (Unicode backup, primarily)
-	BOOL loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, BOOL is_fallback, S32 face_n = 0);
+	bool loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, bool is_fallback, S32 face_n = 0);
 
 	S32 getNumFaces(const std::string& filename);
 
@@ -151,7 +151,7 @@ public:
 private:
 	void resetBitmapCache();
 	void setSubImageLuminanceAlpha(U32 x, U32 y, U32 bitmap_num, U32 width, U32 height, U8 *data, S32 stride = 0) const;
-	BOOL hasGlyph(llwchar wch) const;		// Has a glyph for this character
+	bool hasGlyph(llwchar wch) const;		// Has a glyph for this character
 	LLFontGlyphInfo* addGlyph(llwchar wch) const;		// Add a new character to the font if necessary
 	LLFontGlyphInfo* addGlyphFromFont(const LLFontFreetype *fontp, llwchar wch, U32 glyph_index) const;	// Add a glyph from this font to the other (returns the glyph_index, 0 if not found)
 	void renderGlyph(U32 glyph_index) const;
@@ -173,7 +173,7 @@ private:
 	LLFT_Stream *pFtStream;
 #endif
 
-	BOOL mIsFallback;
+	bool mIsFallback;
 	font_vector_t mFallbackFonts; // A list of fallback fonts to look for glyphs in (for Unicode chars)
 
 	typedef boost::unordered_map<llwchar, LLFontGlyphInfo*> char_glyph_info_map_t;

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -58,7 +58,7 @@ F32 LLFontGL::sVertDPI = 96.f;
 F32 LLFontGL::sHorizDPI = 96.f;
 F32 LLFontGL::sScaleX = 1.f;
 F32 LLFontGL::sScaleY = 1.f;
-BOOL LLFontGL::sDisplayFont = TRUE ;
+bool LLFontGL::sDisplayFont = true ;
 std::string LLFontGL::sAppDir;
 
 LLColor4 LLFontGL::sShadowColor(0.f, 0.f, 0.f, 1.f);
@@ -89,7 +89,7 @@ void LLFontGL::destroyGL()
 	mFontFreetype->destroyGL();
 }
 
-BOOL LLFontGL::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, BOOL is_fallback, S32 face_n)
+bool LLFontGL::loadFace(const std::string& filename, F32 point_size, F32 vert_dpi, F32 horz_dpi, S32 components, bool is_fallback, S32 face_n)
 {
 	if(mFontFreetype == reinterpret_cast<LLFontFreetype*>(NULL))
 	{
@@ -110,14 +110,14 @@ S32 LLFontGL::getNumFaces(const std::string& filename)
 }
 
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRect& rect, const LLColor4 &color, HAlign halign, VAlign valign, U8 style,
-    ShadowType shadow, S32 max_chars, F32* right_x, BOOL use_ellipses) const
+    ShadowType shadow, S32 max_chars, F32* right_x, bool use_ellipses) const
 {
     LLRectf rect_float(rect.mLeft, rect.mTop, rect.mRight, rect.mBottom);
     return render(wstr, begin_offset, rect_float, color, halign, valign, style, shadow, max_chars, right_x, use_ellipses);
 }
 
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRectf& rect, const LLColor4 &color, HAlign halign, VAlign valign, U8 style, 
-					 ShadowType shadow, S32 max_chars, F32* right_x, BOOL use_ellipses) const
+					 ShadowType shadow, S32 max_chars, F32* right_x, bool use_ellipses) const
 {
 	F32 x = rect.mLeft;
 	F32 y = 0.f;
@@ -143,7 +143,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRectf& rec
 
 
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, const LLColor4 &color, HAlign halign, VAlign valign, U8 style, 
-					 ShadowType shadow, S32 max_chars, S32 max_pixels, F32* right_x, BOOL use_ellipses) const
+					 ShadowType shadow, S32 max_chars, S32 max_pixels, F32* right_x, bool use_ellipses) const
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 
@@ -255,7 +255,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 	const S32 LAST_CHARACTER = LLFontFreetype::LAST_CHAR_FULL;
 
 
-	BOOL draw_ellipses = FALSE;
+	bool draw_ellipses = false;
 	if (use_ellipses)
 	{
 		// check for too long of a string
@@ -265,7 +265,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 			// use four dots for ellipsis width to generate padding
 			const LLWString dots(utf8str_to_wstring(std::string("....")));
 			scaled_max_pixels = llmax(0, scaled_max_pixels - ll_round(getWidthF32(dots.c_str())));
-			draw_ellipses = TRUE;
+			draw_ellipses = true;
 		}
 	}
 
@@ -409,7 +409,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 				shadow,
 				S32_MAX, max_pixels,
 				right_x,
-				FALSE); 
+				false); 
 		gGL.popUIMatrix();
 	}
 
@@ -420,22 +420,22 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
 S32 LLFontGL::render(const LLWString &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color) const
 {
-	return render(text, begin_offset, x, y, color, LEFT, BASELINE, NORMAL, NO_SHADOW, S32_MAX, S32_MAX, NULL, FALSE);
+	return render(text, begin_offset, x, y, color, LEFT, BASELINE, NORMAL, NO_SHADOW, S32_MAX, S32_MAX, NULL, false);
 }
 
-S32 LLFontGL::renderUTF8(const std::string &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color, HAlign halign,  VAlign valign, U8 style, ShadowType shadow, S32 max_chars, S32 max_pixels,  F32* right_x, BOOL use_ellipses) const
+S32 LLFontGL::renderUTF8(const std::string &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color, HAlign halign,  VAlign valign, U8 style, ShadowType shadow, S32 max_chars, S32 max_pixels,  F32* right_x, bool use_ellipses) const
 {
 	return render(utf8str_to_wstring(text), begin_offset, x, y, color, halign, valign, style, shadow, max_chars, max_pixels, right_x, use_ellipses);
 }
 
 S32 LLFontGL::renderUTF8(const std::string &text, S32 begin_offset, S32 x, S32 y, const LLColor4 &color) const
 {
-	return renderUTF8(text, begin_offset, (F32)x, (F32)y, color, LEFT, BASELINE, NORMAL, NO_SHADOW, S32_MAX, S32_MAX, NULL, FALSE);
+	return renderUTF8(text, begin_offset, (F32)x, (F32)y, color, LEFT, BASELINE, NORMAL, NO_SHADOW, S32_MAX, S32_MAX, NULL, false);
 }
 
 S32 LLFontGL::renderUTF8(const std::string &text, S32 begin_offset, S32 x, S32 y, const LLColor4 &color, HAlign halign, VAlign valign, U8 style, ShadowType shadow) const
 {
-	return renderUTF8(text, begin_offset, (F32)x, (F32)y, color, halign, valign, style, shadow, S32_MAX, S32_MAX, NULL, FALSE);
+	return renderUTF8(text, begin_offset, (F32)x, (F32)y, color, halign, valign, style, shadow, S32_MAX, S32_MAX, NULL, false);
 }
 
 // font metrics - override for LLFontFreetype that returns units of virtual pixels
@@ -572,11 +572,11 @@ S32 LLFontGL::maxDrawableChars(const llwchar* wchars, F32 max_pixels, S32 max_ch
 	llassert(max_pixels >= 0.f);
 	llassert(max_chars >= 0);
 	
-	BOOL clip = FALSE;
+	bool clip = false;
 	F32 cur_x = 0;
 
 	S32 start_of_last_word = 0;
-	BOOL in_word = FALSE;
+	bool in_word = false;
 
 	// avoid S32 overflow when max_pixels == S32_MAX by staying in floating point
 	F32 scaled_max_pixels =	max_pixels * sScaleX;
@@ -601,18 +601,18 @@ S32 LLFontGL::maxDrawableChars(const llwchar* wchars, F32 max_pixels, S32 max_ch
 			{
 				if(wch !=(0x00A0))
 				{
-					in_word = FALSE;
+					in_word = false;
 				}
 			}
 			if (iswindividual(wch))
 			{
 				if (iswpunct(wchars[i+1]))
 				{
-					in_word=TRUE;
+					in_word=true;
 				}
 				else
 				{
-					in_word=FALSE;
+					in_word=false;
 					start_of_last_word = i;
 				}
 			}
@@ -622,7 +622,7 @@ S32 LLFontGL::maxDrawableChars(const llwchar* wchars, F32 max_pixels, S32 max_ch
 			start_of_last_word = i;
 			if (!iswspace(wch)||!iswindividual(wch))
 			{
-				in_word = TRUE;
+				in_word = true;
 			}
 		}
 		
@@ -648,7 +648,7 @@ S32 LLFontGL::maxDrawableChars(const llwchar* wchars, F32 max_pixels, S32 max_ch
 		// clip if current character runs past scaled_max_pixels (using width_padding)
 		if (scaled_max_pixels < cur_x + width_padding)
 		{
-			clip = TRUE;
+			clip = true;
 			break;
 		}
 
@@ -746,7 +746,7 @@ S32	LLFontGL::firstDrawableChar(const llwchar* wchars, F32 max_pixels, S32 text_
 	
 }
 
-S32 LLFontGL::charFromPixelOffset(const llwchar* wchars, S32 begin_offset, F32 target_x, F32 max_pixels, S32 max_chars, BOOL round) const
+S32 LLFontGL::charFromPixelOffset(const llwchar* wchars, S32 begin_offset, F32 target_x, F32 max_pixels, S32 max_chars, bool round) const
 {
 	if (!wchars || !wchars[0] || max_chars == 0)
 	{

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -87,7 +87,7 @@ public:
 
 	void destroyGL();
 
-	BOOL loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, const S32 components, BOOL is_fallback, S32 face_n = 0);
+	bool loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, const S32 components, bool is_fallback, S32 face_n = 0);
 
 	S32 getNumFaces(const std::string& filename);
 
@@ -98,7 +98,7 @@ public:
 				U8 style = NORMAL, ShadowType shadow = NO_SHADOW, 
 				S32 max_chars = S32_MAX,
 				F32* right_x=NULL, 
-				BOOL use_ellipses = FALSE) const;
+				bool use_ellipses = false) const;
 
 	S32 render(const LLWString &text, S32 begin_offset, 
 				const LLRectf& rect, 
@@ -107,7 +107,7 @@ public:
 				U8 style = NORMAL, ShadowType shadow = NO_SHADOW, 
 				S32 max_chars = S32_MAX,
 				F32* right_x=NULL, 
-				BOOL use_ellipses = FALSE) const;
+				bool use_ellipses = false) const;
 
 	S32 render(const LLWString &text, S32 begin_offset, 
 				F32 x, F32 y, 
@@ -116,12 +116,12 @@ public:
 				U8 style = NORMAL, ShadowType shadow = NO_SHADOW, 
 				S32 max_chars = S32_MAX, S32 max_pixels = S32_MAX, 
 				F32* right_x=NULL, 
-				BOOL use_ellipses = FALSE) const;
+				bool use_ellipses = false) const;
 
 	S32 render(const LLWString &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color) const;
 
 	// renderUTF8 does a conversion, so is slower!
-	S32 renderUTF8(const std::string &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color, HAlign halign,  VAlign valign, U8 style, ShadowType shadow, S32 max_chars, S32 max_pixels,  F32* right_x, BOOL use_ellipses) const;
+	S32 renderUTF8(const std::string &text, S32 begin_offset, F32 x, F32 y, const LLColor4 &color, HAlign halign,  VAlign valign, U8 style, ShadowType shadow, S32 max_chars, S32 max_pixels,  F32* right_x, bool use_ellipses) const;
 	S32 renderUTF8(const std::string &text, S32 begin_offset, S32 x, S32 y, const LLColor4 &color) const;
 	S32 renderUTF8(const std::string &text, S32 begin_offset, S32 x, S32 y, const LLColor4 &color, HAlign halign, VAlign valign, U8 style = NORMAL, ShadowType shadow = NO_SHADOW) const;
 
@@ -156,7 +156,7 @@ public:
 	S32	firstDrawableChar(const llwchar* wchars, F32 max_pixels, S32 text_len, S32 start_pos=S32_MAX, S32 max_chars = S32_MAX) const;
 
 	// Returns the index of the character closest to pixel position x (ignoring text to the right of max_pixels and max_chars)
-	S32 charFromPixelOffset(const llwchar* wchars, S32 char_offset, F32 x, F32 max_pixels=F32_MAX, S32 max_chars = S32_MAX, BOOL round = TRUE) const;
+	S32 charFromPixelOffset(const llwchar* wchars, S32 char_offset, F32 x, F32 max_pixels=F32_MAX, S32 max_chars = S32_MAX, bool round = true) const;
 
 	const LLFontDescriptor& getFontDesc() const;
 
@@ -185,7 +185,7 @@ public:
 	static std::string nameFromVAlign(LLFontGL::VAlign align);
 	static LLFontGL::VAlign vAlignFromName(const std::string& name);
 
-	static void setFontDisplay(BOOL flag) { sDisplayFont = flag; }
+	static void setFontDisplay(bool flag) { sDisplayFont = flag; }
 		
 	static LLFontGL* getFontMonospace();
 	static LLFontGL* getFontSansSerifSmall();
@@ -213,7 +213,7 @@ public:
 	static F32 sHorizDPI;
 	static F32 sScaleX;
 	static F32 sScaleY;
-	static BOOL sDisplayFont ;
+	static bool sDisplayFont ;
 	static std::string sAppDir;			// For loading fonts
 
 private:

--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -59,12 +59,12 @@
 #endif
 
 
-BOOL gDebugSession = FALSE;
-BOOL gDebugGLSession = FALSE;
-BOOL gClothRipple = FALSE;
-BOOL gHeadlessClient = FALSE;
-BOOL gNonInteractive = FALSE;
-BOOL gGLActive = FALSE;
+bool gDebugSession = false;
+bool gDebugGLSession = false;
+bool gClothRipple = false;
+bool gHeadlessClient = false;
+bool gNonInteractive = false;
+bool gGLActive = false;
 
 static const std::string HEADLESS_VENDOR_STRING("Linden Lab");
 static const std::string HEADLESS_RENDERER_STRING("Headless");
@@ -971,21 +971,21 @@ PFNGLPOLYGONOFFSETCLAMPPROC              glPolygonOffsetClamp = nullptr;
 LLGLManager gGLManager;
 
 LLGLManager::LLGLManager() :
-	mInited(FALSE),
-	mIsDisabled(FALSE),
+	mInited(false),
+	mIsDisabled(false),
 	mMaxSamples(0),
 	mNumTextureImageUnits(1),
 	mMaxSampleMaskWords(0),
 	mMaxColorTextureSamples(0),
 	mMaxDepthTextureSamples(0),
 	mMaxIntegerSamples(0),
-	mIsAMD(FALSE),
-	mIsNVIDIA(FALSE),
-	mIsIntel(FALSE),
+	mIsAMD(false),
+	mIsNVIDIA(false),
+	mIsIntel(false),
 #if LL_DARWIN
-	mIsMobileGF(FALSE),
+	mIsMobileGF(false),
 #endif
-	mHasRequirements(TRUE),
+	mHasRequirements(true),
 	mDriverVersionMajor(1),
 	mDriverVersionMinor(0),
 	mDriverVersionRelease(0),
@@ -1135,12 +1135,12 @@ bool LLGLManager::initGL()
 	{
 		mGLVendorShort = "AMD";
 		// *TODO: Fix this?
-		mIsAMD = TRUE;
+		mIsAMD = true;
 	}
 	else if (mGLVendor.find("NVIDIA ") != std::string::npos)
 	{
 		mGLVendorShort = "NVIDIA";
-		mIsNVIDIA = TRUE;
+		mIsNVIDIA = true;
 	}
 	else if (mGLVendor.find("INTEL") != std::string::npos
 #if LL_LINUX
@@ -1151,7 +1151,7 @@ bool LLGLManager::initGL()
 		 )
 	{
 		mGLVendorShort = "INTEL";
-		mIsIntel = TRUE;
+		mIsIntel = true;
 	}
 	else
 	{
@@ -1360,12 +1360,12 @@ void LLGLManager::shutdownGL()
 	{
 		glFinish();
 		stop_glerror();
-		mInited = FALSE;
+		mInited = false;
 	}
 }
 
 // these are used to turn software blending on. They appear in the Debug/Avatar menu
-// presence of vertex skinning/blending or vertex programs will set these to FALSE by default.
+// presence of vertex skinning/blending or vertex programs will set these to false by default.
 
 void LLGLManager::initExtensions()
 {
@@ -1397,7 +1397,7 @@ void LLGLManager::initExtensions()
 	glGetIntegerv(GL_MAX_ELEMENTS_INDICES, (GLint*) &mGLMaxIndexRange);
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, (GLint*) &mGLMaxTextureSize);
 
-    mInited = TRUE;
+    mInited = true;
 
 #if (LL_WINDOWS || LL_LINUX) && !LL_MESA_HEADLESS
 	LL_DEBUGS("RenderInit") << "GL Probe: Getting symbols" << LL_ENDL;
@@ -2285,10 +2285,10 @@ void do_assert_glerror()
 	//  Create or update texture to be used with this data 
 	GLenum error;
 	error = glGetError();
-	BOOL quit = FALSE;
+	bool quit = false;
 	if (LL_UNLIKELY(error))
 	{
-		quit = TRUE;
+		quit = true;
 		GLubyte const * gl_error_msg = gluErrorString(error);
 		if (NULL != gl_error_msg)
 		{
@@ -2408,7 +2408,7 @@ void LLGLState::dumpStates()
 	for (boost::unordered_map<LLGLenum, LLGLboolean>::iterator iter = sStateMap.begin();
 		 iter != sStateMap.end(); ++iter)
 	{
-		LL_INFOS("RenderState") << llformat(" 0x%04x : %s",(S32)iter->first,iter->second?"TRUE":"FALSE") << LL_ENDL;
+		LL_INFOS("RenderState") << llformat(" 0x%04x : %s",(S32)iter->first,iter->second?"true":"false") << LL_ENDL;
 	}
 }
 
@@ -2451,7 +2451,7 @@ void LLGLState::checkStates(GLboolean writeAlpha)
 ///////////////////////////////////////////////////////////////////////
 
 LLGLState::LLGLState(LLGLenum state, S32 enabled) :
-	mState(state), mWasEnabled(FALSE), mIsEnabled(FALSE)
+	mState(state), mWasEnabled(false), mIsEnabled(false)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_PIPELINE;
 
@@ -2470,15 +2470,15 @@ void LLGLState::setEnabled(S32 enabled)
 	}
 	if (enabled == CURRENT_STATE)
 	{
-		enabled = sStateMap[mState] == GL_TRUE ? TRUE : FALSE;
+		enabled = sStateMap[mState] == GL_TRUE ? ENABLED_STATE : DISABLED_STATE;
 	}
-	else if (enabled == TRUE && sStateMap[mState] != GL_TRUE)
+	else if (enabled == ENABLED_STATE && sStateMap[mState] != GL_TRUE)
 	{
 		gGL.flush();
 		glEnable(mState);
 		sStateMap[mState] = GL_TRUE;
 	}
-	else if (enabled == FALSE && sStateMap[mState] != GL_FALSE)
+	else if (enabled == DISABLED_STATE && sStateMap[mState] != GL_FALSE)
 	{
 		gGL.flush();
 		glDisable(mState);
@@ -2732,7 +2732,7 @@ LLGLDepthTest::LLGLDepthTest(GLboolean depth_enabled, GLboolean write_enabled, G
 	{ // always disable depth writes if depth testing is disabled
 	  // GL spec defines this as a requirement, but some implementations allow depth writes with testing disabled
 	  // The proper way to write to depth buffer with testing disabled is to enable testing and use a depth_func of GL_ALWAYS
-		write_enabled = FALSE;
+		write_enabled = false;
 	}
 
 	if (depth_enabled != sDepthEnabled)
@@ -2785,7 +2785,7 @@ void LLGLDepthTest::checkState()
 	if (gDebugGL)
 	{
 		GLint func = 0;
-		GLboolean mask = FALSE;
+		GLboolean mask = false;
 
 		glGetIntegerv(GL_DEPTH_FUNC, &func);
 		glGetBooleanv(GL_DEPTH_WRITEMASK, &mask);

--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -2732,7 +2732,7 @@ LLGLDepthTest::LLGLDepthTest(GLboolean depth_enabled, GLboolean write_enabled, G
 	{ // always disable depth writes if depth testing is disabled
 	  // GL spec defines this as a requirement, but some implementations allow depth writes with testing disabled
 	  // The proper way to write to depth buffer with testing disabled is to enable testing and use a depth_func of GL_ALWAYS
-		write_enabled = false;
+		write_enabled = GL_FALSE;
 	}
 
 	if (depth_enabled != sDepthEnabled)
@@ -2785,7 +2785,7 @@ void LLGLDepthTest::checkState()
 	if (gDebugGL)
 	{
 		GLint func = 0;
-		GLboolean mask = false;
+		GLboolean mask = GL_FALSE;
 
 		glGetIntegerv(GL_DEPTH_FUNC, &func);
 		glGetBooleanv(GL_DEPTH_WRITEMASK, &mask);

--- a/indra/llrender/llgl.h
+++ b/indra/llrender/llgl.h
@@ -46,8 +46,8 @@
 #include "glh/glh_linear.h"
 
 extern bool gDebugGL;
-extern BOOL gDebugSession;
-extern BOOL gDebugGLSession;
+extern bool gDebugSession;
+extern bool gDebugGLSession;
 extern llofstream gFailLog;
 
 #define LL_GL_ERRS LL_ERRS("RenderState")
@@ -73,8 +73,8 @@ public:
 
 	std::string getRawGLString(); // For sending to simulator
 
-	BOOL mInited;
-	BOOL mIsDisabled;
+	bool mInited;
+	bool mIsDisabled;
 
 	// OpenGL limits
 	S32 mMaxSamples;
@@ -97,17 +97,17 @@ public:
 	// Vendor-specific extensions
     bool mHasAMDAssociations = false;
 
-	BOOL mIsAMD;
-	BOOL mIsNVIDIA;
-	BOOL mIsIntel;
+	bool mIsAMD;
+	bool mIsNVIDIA;
+	bool mIsIntel;
 
 #if LL_DARWIN
 	// Needed to distinguish problem cards on older Macs that break with Materials
-	BOOL mIsMobileGF;
+	bool mIsMobileGF;
 #endif
 	
 	// Whether this version of GL is good enough for SL to use
-	BOOL mHasRequirements;
+	bool mHasRequirements;
 
 	S32 mDriverVersionMajor;
 	S32 mDriverVersionMinor;
@@ -241,16 +241,16 @@ protected:
 	static boost::unordered_map<LLGLenum, LLGLboolean> sStateMap;
 	
 public:
-	enum { CURRENT_STATE = -2 };
+	enum { CURRENT_STATE = -2, DISABLED_STATE = 0, ENABLED_STATE = 1 };
 	LLGLState(LLGLenum state, S32 enabled = CURRENT_STATE);
 	~LLGLState();
 	void setEnabled(S32 enabled);
-	void enable() { setEnabled(TRUE); }
-	void disable() { setEnabled(FALSE); }
+	void enable() { setEnabled(ENABLED_STATE); }
+	void disable() { setEnabled(DISABLED_STATE); }
 protected:
 	LLGLenum mState;
-	BOOL mWasEnabled;
-	BOOL mIsEnabled;
+	bool mWasEnabled;
+	bool mIsEnabled;
 };
 
 // New LLGLState class wrappers that don't depend on actual GL flags.
@@ -284,14 +284,14 @@ public:
 class LLGLEnable : public LLGLState
 {
 public:
-	LLGLEnable(LLGLenum state) : LLGLState(state, TRUE) {}
+	LLGLEnable(LLGLenum state) : LLGLState(state, ENABLED_STATE) {}
 };
 
 /// TODO: Being deprecated.
 class LLGLDisable : public LLGLState
 {
 public:
-	LLGLDisable(LLGLenum state) : LLGLState(state, FALSE) {}
+	LLGLDisable(LLGLenum state) : LLGLState(state, DISABLED_STATE) {}
 };
 
 /*
@@ -351,9 +351,9 @@ public:
 
 	static std::list<LLGLUpdate*> sGLQ;
 
-	BOOL mInQ;
+	bool mInQ;
 	LLGLUpdate()
-		: mInQ(FALSE)
+		: mInQ(false)
 	{
 	}
 	virtual ~LLGLUpdate()
@@ -405,10 +405,10 @@ void init_glstates();
 
 void parse_gl_version( S32* major, S32* minor, S32* release, std::string* vendor_specific, std::string* version_string );
 
-extern BOOL gClothRipple;
-extern BOOL gHeadlessClient;
-extern BOOL gNonInteractive;
-extern BOOL gGLActive;
+extern bool gClothRipple;
+extern bool gHeadlessClient;
+extern bool gNonInteractive;
+extern bool gGLActive;
 
 // Deal with changing glext.h definitions for newer SDK versions, specifically
 // with MAC OSX 10.5 -> 10.6

--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -309,7 +309,7 @@ LLGLSLShader::LLGLSLShader()
     mShaderLevel(0),
     mShaderGroup(SG_DEFAULT),
     mFeatures(),
-    mUniformsDirty(FALSE),
+    mUniformsDirty(false),
     mTimerQuery(0),
     mSamplesQuery(0),
     mPrimitivesQuery(0)
@@ -602,11 +602,11 @@ void LLGLSLShader::attachObjects(GLuint* objects, S32 count)
     }
 }
 
-BOOL LLGLSLShader::mapAttributes(const std::vector<LLStaticHashedString>* attributes)
+bool LLGLSLShader::mapAttributes(const std::vector<LLStaticHashedString>* attributes)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_SHADER;
 
-	BOOL res = TRUE;
+	bool res = true;
 	if (!mUsingBinaryProgram)
 	{
 		//before linking, make sure reserved attributes always have consistent locations
@@ -663,10 +663,10 @@ BOOL LLGLSLShader::mapAttributes(const std::vector<LLStaticHashedString>* attrib
             }
         }
 
-        return TRUE;
+        return true;
     }
 
-    return FALSE;
+    return false;
 }
 
 void LLGLSLShader::mapUniform(GLint index, const vector<LLStaticHashedString>* uniforms)
@@ -830,11 +830,11 @@ GLint LLGLSLShader::mapUniformTextureChannel(GLint location, GLenum type, GLint 
     return -1;
 }
 
-BOOL LLGLSLShader::mapUniforms(const vector<LLStaticHashedString>* uniforms)
+bool LLGLSLShader::mapUniforms(const vector<LLStaticHashedString>* uniforms)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_SHADER;
 
-    BOOL res = TRUE;
+    bool res = true;
 
     mTotalUniformSize = 0;
     mActiveTextureChannels = 0;
@@ -1001,11 +1001,11 @@ BOOL LLGLSLShader::mapUniforms(const vector<LLStaticHashedString>* uniforms)
 }
 
 
-BOOL LLGLSLShader::link(BOOL suppress_errors)
+bool LLGLSLShader::link(bool suppress_errors)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_SHADER;
 
-    BOOL success = LLShaderMgr::instance()->linkProgramObject(mProgramObject, suppress_errors);
+    bool success = LLShaderMgr::instance()->linkProgramObject(mProgramObject, suppress_errors);
 
     if (!success && !suppress_errors)
     {
@@ -1045,7 +1045,7 @@ void LLGLSLShader::bind()
     if (mUniformsDirty)
     {
         LLShaderMgr::instance()->updateShaderUniforms(this);
-        mUniformsDirty = FALSE;
+        mUniformsDirty = false;
     }
 }
 

--- a/indra/llrender/llglslshader.h
+++ b/indra/llrender/llglslshader.h
@@ -182,8 +182,8 @@ public:
     bool attachVertexObject(std::string object);
     void attachObject(GLuint object);
     void attachObjects(GLuint* objects = NULL, S32 count = 0);
-    BOOL mapAttributes(const std::vector<LLStaticHashedString>* attributes);
-    BOOL mapUniforms(const std::vector<LLStaticHashedString>*);
+    bool mapAttributes(const std::vector<LLStaticHashedString>* attributes);
+    bool mapUniforms(const std::vector<LLStaticHashedString>*);
     void mapUniform(GLint index, const std::vector<LLStaticHashedString>*);
     void uniform1i(U32 index, GLint i);
     void uniform1f(U32 index, GLfloat v);
@@ -251,7 +251,7 @@ public:
     S32 unbindTexture(const std::string& uniform, LLTexUnit::eTextureType mode = LLTexUnit::TT_TEXTURE);
     S32 unbindTexture(S32 uniform, LLTexUnit::eTextureType mode = LLTexUnit::TT_TEXTURE);
 
-    BOOL link(BOOL suppress_errors = FALSE);
+    bool link(bool suppress_errors = false);
     void bind();
     //helper to conditionally bind mRiggedVariant instead of this
     void bind(bool rigged);
@@ -289,7 +289,7 @@ public:
     S32 mActiveTextureChannels;
     S32 mShaderLevel;
     S32 mShaderGroup; // see LLGLSLShader::eGroup
-    BOOL mUniformsDirty;
+    bool mUniformsDirty;
     LLShaderFeatures mFeatures;
     std::vector< std::pair< std::string, GLenum > > mShaderFiles;
     std::string mName;

--- a/indra/llrender/llgltexture.cpp
+++ b/indra/llrender/llgltexture.cpp
@@ -27,13 +27,13 @@
 #include "llgltexture.h"
 
 
-LLGLTexture::LLGLTexture(BOOL usemipmaps)
+LLGLTexture::LLGLTexture(bool usemipmaps)
 {
 	init();
 	mUseMipMaps = usemipmaps;
 }
 
-LLGLTexture::LLGLTexture(const U32 width, const U32 height, const U8 components, BOOL usemipmaps)
+LLGLTexture::LLGLTexture(const U32 width, const U32 height, const U8 components, bool usemipmaps)
 {
 	init();
 	mFullWidth = width ;
@@ -43,7 +43,7 @@ LLGLTexture::LLGLTexture(const U32 width, const U32 height, const U8 components,
 	setTexelsPerImage();
 }
 
-LLGLTexture::LLGLTexture(const LLImageRaw* raw, BOOL usemipmaps)
+LLGLTexture::LLGLTexture(const LLImageRaw* raw, bool usemipmaps)
 {
 	init();
 	mUseMipMaps = usemipmaps ;
@@ -63,12 +63,12 @@ void LLGLTexture::init()
 	mFullWidth = 0;
 	mFullHeight = 0;
 	mTexelsPerImage = 0 ;
-	mUseMipMaps = FALSE ;
+	mUseMipMaps = false ;
 	mComponents = 0 ;
 
 	mTextureState = NO_DELETE ;
-	mDontDiscard = FALSE;
-	mNeedsGLTexture = FALSE ;
+	mDontDiscard = false;
+	mNeedsGLTexture = false ;
 }
 
 void LLGLTexture::cleanup()
@@ -136,7 +136,7 @@ LLImageGL* LLGLTexture::getGLTexture() const
 	return mGLTexturep ;
 }
 
-BOOL LLGLTexture::createGLTexture() 
+bool LLGLTexture::createGLTexture() 
 {
 	if(mGLTexturep.isNull())
 	{
@@ -146,11 +146,11 @@ BOOL LLGLTexture::createGLTexture()
 	return mGLTexturep->createGLTexture() ;
 }
 
-BOOL LLGLTexture::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename, BOOL to_create, S32 category, bool defer_copy, LLGLuint* tex_name)
+bool LLGLTexture::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename, bool to_create, S32 category, bool defer_copy, LLGLuint* tex_name)
 {
 	llassert(mGLTexturep.notNull());
 
-	BOOL ret = mGLTexturep->createGLTexture(discard_level, imageraw, usename, to_create, category, defer_copy, tex_name) ;
+	bool ret = mGLTexturep->createGLTexture(discard_level, imageraw, usename, to_create, category, defer_copy, tex_name) ;
 
 	if(ret)
 	{
@@ -163,7 +163,7 @@ BOOL LLGLTexture::createGLTexture(S32 discard_level, const LLImageRaw* imageraw,
 	return ret ;
 }
 
-void LLGLTexture::setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format, BOOL swap_bytes)
+void LLGLTexture::setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format, bool swap_bytes)
 {
 	llassert(mGLTexturep.notNull()) ;
 	
@@ -218,22 +218,22 @@ LLGLuint LLGLTexture::getTexName() const
 	return mGLTexturep->getTexName() ; 
 }
 
-BOOL LLGLTexture::hasGLTexture() const 
+bool LLGLTexture::hasGLTexture() const 
 {
 	if(mGLTexturep.notNull())
 	{
 		return mGLTexturep->getHasGLTexture() ;
 	}
-	return FALSE ;
+	return false ;
 }
 
-BOOL LLGLTexture::getBoundRecently() const
+bool LLGLTexture::getBoundRecently() const
 {
 	if(mGLTexturep.notNull())
 	{
 		return mGLTexturep->getBoundRecently() ;
 	}
-	return FALSE ;
+	return false ;
 }
 
 LLTexUnit::eTextureType LLGLTexture::getTarget(void) const
@@ -242,7 +242,7 @@ LLTexUnit::eTextureType LLGLTexture::getTarget(void) const
 	return mGLTexturep->getTarget() ;
 }
 
-BOOL LLGLTexture::setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name)
+bool LLGLTexture::setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 	llassert(mGLTexturep.notNull()) ;
@@ -250,7 +250,7 @@ BOOL LLGLTexture::setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, 
 	return mGLTexturep->setSubImage(imageraw, x_pos, y_pos, width, height, 0, use_name) ;
 }
 
-BOOL LLGLTexture::setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name)
+bool LLGLTexture::setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 	llassert(mGLTexturep.notNull()) ;
@@ -305,14 +305,14 @@ LLGLenum LLGLTexture::getPrimaryFormat() const
 	return mGLTexturep->getPrimaryFormat() ;
 }
 
-BOOL LLGLTexture::getIsAlphaMask() const
+bool LLGLTexture::getIsAlphaMask() const
 {
 	llassert(mGLTexturep.notNull()) ;
 
 	return mGLTexturep->getIsAlphaMask() ;
 }
 
-BOOL LLGLTexture::getMask(const LLVector2 &tc)
+bool LLGLTexture::getMask(const LLVector2 &tc)
 {
 	llassert(mGLTexturep.notNull()) ;
 
@@ -325,14 +325,14 @@ F32 LLGLTexture::getTimePassedSinceLastBound()
 
 	return mGLTexturep->getTimePassedSinceLastBound() ;
 }
-BOOL LLGLTexture::getMissed() const 
+bool LLGLTexture::getMissed() const 
 {
 	llassert(mGLTexturep.notNull()) ;
 
 	return mGLTexturep->getMissed() ;
 }
 
-BOOL LLGLTexture::isJustBound() const
+bool LLGLTexture::isJustBound() const
 {
 	llassert(mGLTexturep.notNull()) ;
 
@@ -360,7 +360,7 @@ U32 LLGLTexture::getTexelsInGLTexture() const
 	return mGLTexturep->getTexelsInGLTexture() ;
 }
 
-BOOL LLGLTexture::isGLTextureCreated() const
+bool LLGLTexture::isGLTextureCreated() const
 {
 	llassert(mGLTexturep.notNull()) ;
 

--- a/indra/llrender/llgltexture.h
+++ b/indra/llrender/llgltexture.h
@@ -93,9 +93,9 @@ protected:
 	LOG_CLASS(LLGLTexture);
 
 public:
-	LLGLTexture(BOOL usemipmaps = TRUE);
-	LLGLTexture(const LLImageRaw* raw, BOOL usemipmaps) ;
-	LLGLTexture(const U32 width, const U32 height, const U8 components, BOOL usemipmaps) ;
+	LLGLTexture(bool usemipmaps = true);
+	LLGLTexture(const LLImageRaw* raw, bool usemipmaps) ;
+	LLGLTexture(const U32 width, const U32 height, const U8 components, bool usemipmaps) ;
 
 	virtual void dump();	// debug info to LL_INFOS()
 
@@ -116,25 +116,25 @@ public:
 	/*virtual*/S32	       getWidth(S32 discard_level = -1) const;
 	/*virtual*/S32	       getHeight(S32 discard_level = -1) const;
 
-	BOOL       hasGLTexture() const ;
+	bool       hasGLTexture() const ;
 	LLGLuint   getTexName() const ;		
-	BOOL       createGLTexture() ;
+	bool       createGLTexture() ;
 	
     // Create a GL Texture from an image raw
     // discard_level - mip level, 0 for highest resultion mip
     // imageraw - the image to copy from
     // usename - explicit GL name override
-    // to_create - set to FALSE to force gl texture to not be created
+    // to_create - set to false to force gl texture to not be created
     // category - LLGLTexture category for this LLGLTexture
     // defer_copy - set to true to allocate GL texture but NOT initialize with imageraw data
     // tex_name - if not null, will be set to the GL name of the texture created
-    BOOL       createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename = 0, BOOL to_create = TRUE, S32 category = LLGLTexture::OTHER, bool defer_copy = false, LLGLuint* tex_name = nullptr);
+    bool       createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename = 0, bool to_create = true, S32 category = LLGLTexture::OTHER, bool defer_copy = false, LLGLuint* tex_name = nullptr);
 
 	void       setFilteringOption(LLTexUnit::eTextureFilterOptions option);
-	void       setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format = 0, BOOL swap_bytes = FALSE);
+	void       setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format = 0, bool swap_bytes = false);
 	void       setAddressMode(LLTexUnit::eTextureAddressMode mode);
-	BOOL       setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name = 0);
-	BOOL       setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name = 0);
+	bool       setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name = 0);
+	bool       setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, LLGLuint use_name = 0);
 	void       setGLTextureCreated (bool initialized);
 	void       setCategory(S32 category) ;
     void       setTexName(LLGLuint); // for forcing w/ externally created textures only
@@ -144,20 +144,20 @@ public:
 	S32        getMaxDiscardLevel() const;
 	S32        getDiscardLevel() const;
 	S8         getComponents() const;
-	BOOL       getBoundRecently() const;
+	bool       getBoundRecently() const;
 	S32Bytes   getTextureMemory() const ;
 	LLGLenum   getPrimaryFormat() const;
-	BOOL       getIsAlphaMask() const ;
+	bool       getIsAlphaMask() const ;
 	LLTexUnit::eTextureType getTarget(void) const ;
-	BOOL       getMask(const LLVector2 &tc);
+	bool       getMask(const LLVector2 &tc);
 	F32        getTimePassedSinceLastBound();
-	BOOL       getMissed() const ;
-	BOOL       isJustBound()const ;
+	bool       getMissed() const ;
+	bool       isJustBound()const ;
 	void       forceUpdateBindStats(void) const;
 
 	U32        getTexelsInAtlas() const ;
 	U32        getTexelsInGLTexture() const ;
-	BOOL       isGLTextureCreated() const ;
+	bool       isGLTextureCreated() const ;
 	S32        getDiscardLevelInAtlas() const ;
 	LLGLTextureState getTextureState() const { return mTextureState; }
 	
@@ -170,7 +170,7 @@ public:
 	void forceActive() ;
 	void setNoDelete() ;
 	void dontDiscard() { mDontDiscard = 1; mTextureState = NO_DELETE; }
-	BOOL getDontDiscard() const { return mDontDiscard; }
+	bool getDontDiscard() const { return mDontDiscard; }
 	//-----------------	
 
 private:
@@ -187,7 +187,7 @@ protected:
 	S32 mBoostLevel;				// enum describing priority level
 	U32 mFullWidth;
 	U32 mFullHeight;
-	BOOL mUseMipMaps;
+	bool mUseMipMaps;
 	S8  mComponents;
 	U32 mTexelsPerImage;			// Texels per image.
 	mutable S8  mNeedsGLTexture;

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -126,9 +126,9 @@ U32 LLImageGL::sUniqueCount				= 0;
 U32 LLImageGL::sBindCount				= 0;
 S32 LLImageGL::sCount					= 0;
 
-BOOL LLImageGL::sGlobalUseAnisotropic	= FALSE;
+bool LLImageGL::sGlobalUseAnisotropic	= false;
 F32 LLImageGL::sLastFrameTime			= 0.f;
-BOOL LLImageGL::sAllowReadBackRaw       = FALSE ;
+bool LLImageGL::sAllowReadBackRaw       = false ;
 LLImageGL* LLImageGL::sDefaultGLTexture = NULL ;
 bool LLImageGL::sCompressTextures = false;
 std::set<LLImageGL*> LLImageGL::sImageList;
@@ -147,7 +147,7 @@ S32 LLImageGL::sCurTexPickSize = -1 ;
 S32 LLImageGL::sMaxCategories = 1 ;
 
 //optimization for when we don't need to calculate mIsMask
-BOOL LLImageGL::sSkipAnalyzeAlpha;
+bool LLImageGL::sSkipAnalyzeAlpha;
 
 //------------------------
 //****************************************************************************************************
@@ -185,12 +185,12 @@ void LLImageGL::checkTexSize(bool forced) const
 
 		GLint texname;
 		glGetIntegerv(GL_TEXTURE_BINDING_2D, &texname);
-		BOOL error = FALSE;
+		bool error = false;
 		if (texname != mTexName)
 		{
 			LL_INFOS() << "Bound: " << texname << " Should bind: " << mTexName << " Default: " << LLImageGL::sDefaultGLTexture->getTexName() << LL_ENDL;
 
-			error = TRUE;
+			error = true;
 			if (gDebugSession)
 			{
 				gFailLog << "Invalid texture bound!" << std::endl;
@@ -213,7 +213,7 @@ void LLImageGL::checkTexSize(bool forced) const
 		}
 		if(x != (mWidth >> mCurrentDiscardLevel) || y != (mHeight >> mCurrentDiscardLevel))
 		{
-			error = TRUE;
+			error = true;
 			if (gDebugSession)
 			{
 				gFailLog << "wrong texture size and discard level!" << 
@@ -236,7 +236,7 @@ void LLImageGL::checkTexSize(bool forced) const
 //**************************************************************************************
 
 //----------------------------------------------------------------------------
-BOOL is_little_endian()
+bool is_little_endian()
 {
 	S32 a = 0x12345678;
     U8 *c = (U8*)(&a);
@@ -245,7 +245,7 @@ BOOL is_little_endian()
 }
 
 //static 
-void LLImageGL::initClass(LLWindow* window, S32 num_catagories, BOOL skip_analyze_alpha /* = false */, bool thread_texture_loads /* = false */, bool thread_media_updates /* = false */)
+void LLImageGL::initClass(LLWindow* window, S32 num_catagories, bool skip_analyze_alpha /* = false */, bool thread_texture_loads /* = false */, bool thread_media_updates /* = false */)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 	sSkipAnalyzeAlpha = skip_analyze_alpha;
@@ -356,7 +356,7 @@ void LLImageGL::updateStats(F32 current_time)
 //----------------------------------------------------------------------------
 
 //static 
-void LLImageGL::destroyGL(BOOL save_state)
+void LLImageGL::destroyGL(bool save_state)
 {
 	for (S32 stage = 0; stage < gGLManager.mNumTextureImageUnits; stage++)
 	{
@@ -401,7 +401,7 @@ void LLImageGL::restoreGL()
 		{
 			if (glimage->getComponents() && glimage->mSaveData->getComponents())
 			{
-				glimage->createGLTexture(glimage->mCurrentDiscardLevel, glimage->mSaveData, 0, TRUE, glimage->getCategory());
+				glimage->createGLTexture(glimage->mCurrentDiscardLevel, glimage->mSaveData, 0, true, glimage->getCategory());
 				stop_glerror();
 			}
 			glimage->mSaveData = NULL; // deletes data
@@ -425,30 +425,30 @@ void LLImageGL::dirtyTexOptions()
 
 //for server side use only.
 //static 
-BOOL LLImageGL::create(LLPointer<LLImageGL>& dest, BOOL usemipmaps)
+bool LLImageGL::create(LLPointer<LLImageGL>& dest, bool usemipmaps)
 {
 	dest = new LLImageGL(usemipmaps);
-	return TRUE;
+	return true;
 }
 
 //for server side use only.
-BOOL LLImageGL::create(LLPointer<LLImageGL>& dest, U32 width, U32 height, U8 components, BOOL usemipmaps)
+bool LLImageGL::create(LLPointer<LLImageGL>& dest, U32 width, U32 height, U8 components, bool usemipmaps)
 {
 	dest = new LLImageGL(width, height, components, usemipmaps);
-	return TRUE;
+	return true;
 }
 
 //for server side use only.
-BOOL LLImageGL::create(LLPointer<LLImageGL>& dest, const LLImageRaw* imageraw, BOOL usemipmaps)
+bool LLImageGL::create(LLPointer<LLImageGL>& dest, const LLImageRaw* imageraw, bool usemipmaps)
 {
 	dest = new LLImageGL(imageraw, usemipmaps);
-	return TRUE;
+	return true;
 }
 
 //----------------------------------------------------------------------------
 
-LLImageGL::LLImageGL(BOOL usemipmaps)
-:	mSaveData(0), mExternalTexture(FALSE)
+LLImageGL::LLImageGL(bool usemipmaps)
+:	mSaveData(0), mExternalTexture(false)
 {
 	init(usemipmaps);
 	setSize(0, 0, 0);
@@ -456,8 +456,8 @@ LLImageGL::LLImageGL(BOOL usemipmaps)
 	sCount++;
 }
 
-LLImageGL::LLImageGL(U32 width, U32 height, U8 components, BOOL usemipmaps)
-:	mSaveData(0), mExternalTexture(FALSE)
+LLImageGL::LLImageGL(U32 width, U32 height, U8 components, bool usemipmaps)
+:	mSaveData(0), mExternalTexture(false)
 {
 	llassert( components <= 4 );
 	init(usemipmaps);
@@ -466,8 +466,8 @@ LLImageGL::LLImageGL(U32 width, U32 height, U8 components, BOOL usemipmaps)
 	sCount++;
 }
 
-LLImageGL::LLImageGL(const LLImageRaw* imageraw, BOOL usemipmaps)
-:	mSaveData(0), mExternalTexture(FALSE)
+LLImageGL::LLImageGL(const LLImageRaw* imageraw, bool usemipmaps)
+:	mSaveData(0), mExternalTexture(false)
 {
 	init(usemipmaps);
 	setSize(0, 0, 0);
@@ -508,7 +508,7 @@ LLImageGL::~LLImageGL()
     }
 }
 
-void LLImageGL::init(BOOL usemipmaps)
+void LLImageGL::init(bool usemipmaps)
 {
 #if LL_IMAGEGL_THREAD_CHECK
     mActiveThread = LLThread::currentID();
@@ -525,14 +525,14 @@ void LLImageGL::init(BOOL usemipmaps)
 	mPickMaskWidth = 0;
 	mPickMaskHeight = 0;
 	mUseMipMaps = usemipmaps;
-	mHasExplicitFormat = FALSE;
+	mHasExplicitFormat = false;
 
-	mIsMask = FALSE;
-	mNeedsAlphaAndPickMask = TRUE ;
+	mIsMask = false;
+	mNeedsAlphaAndPickMask = true ;
 	mAlphaStride = 0 ;
 	mAlphaOffset = 0 ;
 
-	mGLTextureCreated = FALSE ;
+	mGLTextureCreated = false ;
 	mTexName = 0;
 	mWidth = 0;
 	mHeight	= 0;
@@ -561,10 +561,10 @@ void LLImageGL::init(BOOL usemipmaps)
 	mFormatInternal = -1;
 	mFormatPrimary = (LLGLenum) 0;
 	mFormatType = GL_UNSIGNED_BYTE;
-	mFormatSwapBytes = FALSE;
+	mFormatSwapBytes = false;
 
 #ifdef DEBUG_MISS
-	mMissed	= FALSE;
+	mMissed	= false;
 #endif
 
 	mCategory = -1;
@@ -682,12 +682,12 @@ void LLImageGL::forceUpdateBindStats(void) const
 	mLastBindTime = sLastFrameTime;
 }
 
-BOOL LLImageGL::updateBindStats() const
+bool LLImageGL::updateBindStats() const
 {	
 	if (mTexName != 0)
 	{
 #ifdef DEBUG_MISS
-		mMissed = ! getIsResident(TRUE);
+		mMissed = ! getIsResident(true);
 #endif
 		sBindCount++;
 		if (mLastBindTime != sLastFrameTime)
@@ -696,10 +696,10 @@ BOOL LLImageGL::updateBindStats() const
 			sUniqueCount++;
 			mLastBindTime = sLastFrameTime;
 
-			return TRUE ;
+			return true ;
 		}
 	}
-	return FALSE ;
+	return false ;
 }
 
 F32 LLImageGL::getTimePassedSinceLastBound()
@@ -707,11 +707,11 @@ F32 LLImageGL::getTimePassedSinceLastBound()
 	return sLastFrameTime - mLastBindTime ;
 }
 
-void LLImageGL::setExplicitFormat( LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format, BOOL swap_bytes )
+void LLImageGL::setExplicitFormat( LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format, bool swap_bytes )
 {
 	// Note: must be called before createTexture()
 	// Note: it's up to the caller to ensure that the format matches the number of components.
-	mHasExplicitFormat = TRUE;
+	mHasExplicitFormat = true;
 	mFormatInternal = internal_format;
 	mFormatPrimary = primary_format;
 	if(type_format == 0)
@@ -732,10 +732,10 @@ void LLImageGL::setImage(const LLImageRaw* imageraw)
 			 (imageraw->getHeight() == getHeight(mCurrentDiscardLevel)) &&
 			 (imageraw->getComponents() == getComponents()));
 	const U8* rawdata = imageraw->getData();
-	setImage(rawdata, FALSE);
+	setImage(rawdata, false);
 }
 
-BOOL LLImageGL::setImage(const U8* data_in, BOOL data_hasmips /* = FALSE */, S32 usename /* = 0 */)
+bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32 usename /* = 0 */)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 
@@ -917,7 +917,7 @@ BOOL LLImageGL::setImage(const U8* data_in, BOOL data_hasmips /* = FALSE */, S32
 							}
 							
 							mGLTextureCreated = false;
-							return FALSE;
+							return false;
 						}
 						else
 						{
@@ -1018,10 +1018,10 @@ BOOL LLImageGL::setImage(const U8* data_in, BOOL data_hasmips /* = FALSE */, S32
 	}
 	stop_glerror();
 	mGLTextureCreated = true;
-	return TRUE;
+	return true;
 }
 
-BOOL LLImageGL::preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image)
+bool LLImageGL::preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image)
 {
 	//not compatible with core GL profile
 	llassert(!LLRender::sGLCoreProfile);
@@ -1029,7 +1029,7 @@ BOOL LLImageGL::preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image)
 	if (gGLManager.mIsDisabled)
 	{
 		LL_WARNS() << "Trying to create a texture while GL is disabled!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	llassert(gGLManager.mInited);
 	stop_glerror();
@@ -1048,7 +1048,7 @@ BOOL LLImageGL::preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image)
 	if (!setSize(w, h, raw_image->getComponents(), discard_level))
 	{
 		LL_WARNS() << "Trying to create a texture with incorrect dimensions!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
     if (!mHasExplicitFormat)
@@ -1097,7 +1097,7 @@ BOOL LLImageGL::preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image)
 		stop_glerror();
 	}
 
-	return TRUE ;
+	return true ;
 }
 
 void LLImageGL::postAddToAtlas()
@@ -1167,31 +1167,31 @@ void sub_image_lines(U32 target, S32 miplevel, S32 x_offset, S32 y_offset, S32 w
     }
 }
 
-BOOL LLImageGL::setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, BOOL force_fast_update /* = FALSE */, LLGLuint use_name)
+bool LLImageGL::setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, bool force_fast_update /* = false */, LLGLuint use_name)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 	if (!width || !height)
 	{
-		return TRUE;
+		return true;
 	}
     LLGLuint tex_name = use_name != 0 ? use_name : mTexName;
 	if (0 == tex_name)
 	{
 		// *TODO: Re-enable warning?  Ran into thread locking issues? DK 2011-02-18
 		//LL_WARNS() << "Setting subimage on image without GL texture" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	if (datap == NULL)
 	{
 		// *TODO: Re-enable warning?  Ran into thread locking issues? DK 2011-02-18
 		//LL_WARNS() << "Setting subimage on image with NULL datap" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	
 	// HACK: allow the caller to explicitly force the fast path (i.e. using glTexSubImage2D here instead of calling setImage) even when updating the full texture.
 	if (!force_fast_update && x_pos == 0 && y_pos == 0 && width == getWidth() && height == getHeight() && data_width == width && data_height == height)
 	{
-		setImage(datap, FALSE, tex_name);
+		setImage(datap, false, tex_name);
 	}
 	else
 	{
@@ -1243,7 +1243,7 @@ BOOL LLImageGL::setSubImage(const U8* datap, S32 data_width, S32 data_height, S3
 
 		const U8* sub_datap = datap + (y_pos * data_width + x_pos) * getComponents();
 		// Update the GL texture
-		BOOL res = gGL.getTexUnit(0)->bindManual(mBindTarget, tex_name);
+		bool res = gGL.getTexUnit(0)->bindManual(mBindTarget, tex_name);
 		if (!res) LL_ERRS() << "LLImageGL::setSubImage(): bindTexture failed" << LL_ENDL;
 		stop_glerror();
 
@@ -1273,28 +1273,28 @@ BOOL LLImageGL::setSubImage(const U8* datap, S32 data_width, S32 data_height, S3
 		stop_glerror();
 		mGLTextureCreated = true;
 	}
-	return TRUE;
+	return true;
 }
 
-BOOL LLImageGL::setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, BOOL force_fast_update /* = FALSE */, LLGLuint use_name)
+bool LLImageGL::setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, bool force_fast_update /* = false */, LLGLuint use_name)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 	return setSubImage(imageraw->getData(), imageraw->getWidth(), imageraw->getHeight(), x_pos, y_pos, width, height, force_fast_update, use_name);
 }
 
 // Copy sub image from frame buffer
-BOOL LLImageGL::setSubImageFromFrameBuffer(S32 fb_x, S32 fb_y, S32 x_pos, S32 y_pos, S32 width, S32 height)
+bool LLImageGL::setSubImageFromFrameBuffer(S32 fb_x, S32 fb_y, S32 x_pos, S32 y_pos, S32 width, S32 height)
 {
 	if (gGL.getTexUnit(0)->bind(this, false, true))
 	{
 		glCopyTexSubImage2D(GL_TEXTURE_2D, 0, fb_x, fb_y, x_pos, y_pos, width, height);
 		mGLTextureCreated = true;
 		stop_glerror();
-		return TRUE;
+		return true;
 	}
 	else
 	{
-		return FALSE;
+		return false;
 	}
 }
 
@@ -1508,7 +1508,7 @@ void LLImageGL::setManualImage(U32 target, S32 miplevel, S32 intformat, S32 widt
 
 //create an empty GL texture: just create a texture name
 //the texture is assiciate with some image by calling glTexImage outside LLImageGL
-BOOL LLImageGL::createGLTexture()
+bool LLImageGL::createGLTexture()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
     checkActiveThread();
@@ -1516,7 +1516,7 @@ BOOL LLImageGL::createGLTexture()
 	if (gGLManager.mIsDisabled)
 	{
 		LL_WARNS() << "Trying to create a texture while GL is disabled!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 	
 	mGLTextureCreated = false ; //do not save this texture when gl is destroyed.
@@ -1536,13 +1536,13 @@ BOOL LLImageGL::createGLTexture()
 	if (!mTexName)
 	{
 		LL_WARNS() << "LLImageGL::createGLTexture failed to make an empty texture" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
-	return TRUE ;
+	return true ;
 }
 
-BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename/*=0*/, BOOL to_create, S32 category, bool defer_copy, LLGLuint* tex_name)
+bool LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename/*=0*/, bool to_create, S32 category, bool defer_copy, LLGLuint* tex_name)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
     checkActiveThread();
@@ -1550,7 +1550,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S
 	if (gGLManager.mIsDisabled)
 	{
 		LL_WARNS() << "Trying to create a texture while GL is disabled!" << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 
 	llassert(gGLManager.mInited);
@@ -1560,7 +1560,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S
 	{
 		LL_WARNS() << "Trying to create a texture from invalid image data" << LL_ENDL;
         mGLTextureCreated = false;
-		return FALSE;
+		return false;
 	}
 
 	if (discard_level < 0)
@@ -1581,7 +1581,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S
 	{
 		LL_WARNS() << "Trying to create a texture with incorrect dimensions!" << LL_ENDL;
         mGLTextureCreated = false;
-		return FALSE;
+		return false;
 	}
 
 	if (mHasExplicitFormat && 
@@ -1590,7 +1590,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S
 
 	{
 		LL_WARNS()  << "Incorrect format: " << std::hex << mFormatPrimary << " components: " << (U32)mComponents <<  LL_ENDL;		
-		mHasExplicitFormat = FALSE;
+		mHasExplicitFormat = false;
 	}
 
 	if( !mHasExplicitFormat )
@@ -1632,15 +1632,15 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S
 		mCurrentDiscardLevel = discard_level;	
 		mLastBindTime = sLastFrameTime;
         mGLTextureCreated = false;
-		return TRUE ;
+		return true ;
 	}
 
 	setCategory(category);
  	const U8* rawdata = imageraw->getData();
-	return createGLTexture(discard_level, rawdata, FALSE, usename, defer_copy, tex_name);
+	return createGLTexture(discard_level, rawdata, false, usename, defer_copy, tex_name);
 }
 
-BOOL LLImageGL::createGLTexture(S32 discard_level, const U8* data_in, BOOL data_hasmips, S32 usename, bool defer_copy, LLGLuint* tex_name)
+bool LLImageGL::createGLTexture(S32 discard_level, const U8* data_in, bool data_hasmips, S32 usename, bool defer_copy, LLGLuint* tex_name)
 // Call with void data, vmem is allocated but unitialized
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
@@ -1713,7 +1713,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const U8* data_in, BOOL data_
         LL_PROFILE_ZONE_NAMED("cglt - late setImage");
         if (!setImage(data_in, data_hasmips, new_texname))
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -1751,7 +1751,7 @@ BOOL LLImageGL::createGLTexture(S32 discard_level, const U8* data_in, BOOL data_
     mLastBindTime = sLastFrameTime;
 
     checkActiveThread();
-    return TRUE;
+    return true;
 }
 
 void LLImageGL::syncToMainThread(LLGLuint new_tex_name)
@@ -1821,7 +1821,7 @@ void LLImageGL::syncTexName(LLGLuint texname)
     }
 }
 
-BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compressed_ok) const
+bool LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compressed_ok) const
 {
 	llassert_always(sAllowReadBackRaw) ;
 	//LL_ERRS() << "should not call this function!" << LL_ENDL ;
@@ -1833,7 +1833,7 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 	
 	if (mTexName == 0 || discard_level < mCurrentDiscardLevel || discard_level > mMaxDiscardLevel )
 	{
-		return FALSE;
+		return false;
 	}
 
 	S32 gl_discard = discard_level - mCurrentDiscardLevel;
@@ -1850,7 +1850,7 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 	if (glwidth == 0)
 	{
 		// No mip data smaller than current discard level
-		return FALSE;
+		return false;
 	}
 	
 	S32 width = getWidth(discard_level);
@@ -1858,14 +1858,14 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 	S32 ncomponents = getComponents();
 	if (ncomponents == 0)
 	{
-		return FALSE;
+		return false;
 	}
 	if(width < glwidth)
 	{
 		LL_WARNS() << "texture size is smaller than it should be." << LL_ENDL ;
 		LL_WARNS() << "width: " << width << " glwidth: " << glwidth << " mWidth: " << mWidth << 
 			" mCurrentDiscardLevel: " << (S32)mCurrentDiscardLevel << " discard_level: " << (S32)discard_level << LL_ENDL ;
-		return FALSE ;
+		return false ;
 	}
 
 	if (width <= 0 || width > 2048 || height <= 0 || height > 2048 || ncomponents < 1 || ncomponents > 4)
@@ -1897,7 +1897,7 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 		{
 			LL_WARNS() << "Memory allocation failed for reading back texture. Size is: " << glbytes << LL_ENDL ;
 			LL_WARNS() << "width: " << width << "height: " << height << "components: " << ncomponents << LL_ENDL ;
-			return FALSE ;
+			return false ;
 		}
 
 		glGetCompressedTexImage(mTarget, gl_discard, (GLvoid*)(imageraw->getData()));
@@ -1909,7 +1909,7 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 		{
 			LL_WARNS() << "Memory allocation failed for reading back texture." << LL_ENDL ;
 			LL_WARNS() << "width: " << width << "height: " << height << "components: " << ncomponents << LL_ENDL ;
-			return FALSE ;
+			return false ;
 		}
 		
 		glGetTexImage(GL_TEXTURE_2D, gl_discard, mFormatPrimary, mFormatType, (GLvoid*)(imageraw->getData()));		
@@ -1927,11 +1927,11 @@ BOOL LLImageGL::readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compre
 			LL_WARNS() << "GL Error happens after reading back texture. Error code: " << error << LL_ENDL ;
 		}
 
-		return FALSE ;
+		return false ;
 	}
 	//-----------------------------------------------------------------------------------------------
 
-	return TRUE ;
+	return true ;
 }
 
 void LLImageGL::destroyGLTexture()
@@ -1948,7 +1948,7 @@ void LLImageGL::destroyGLTexture()
 		LLImageGL::deleteTextures(1, &mTexName);
 		mCurrentDiscardLevel = -1 ; //invalidate mCurrentDiscardLevel.
 		mTexName = 0;		
-		mGLTextureCreated = FALSE ;
+		mGLTextureCreated = false ;
 	}
 }
 
@@ -1999,7 +1999,7 @@ void LLImageGL::setFilteringOption(LLTexUnit::eTextureFilterOptions option)
 	}
 }
 
-BOOL LLImageGL::getIsResident(BOOL test_now)
+bool LLImageGL::getIsResident(bool test_now)
 {
 	if (test_now)
 	{
@@ -2009,7 +2009,7 @@ BOOL LLImageGL::getIsResident(BOOL test_now)
 		}
 		else
 		{
-			mIsResident = FALSE;
+			mIsResident = false;
 		}
 	}
 
@@ -2077,12 +2077,12 @@ bool LLImageGL::isJustBound() const
 	return sLastFrameTime - mLastBindTime < 0.5f;
 }
 
-BOOL LLImageGL::getBoundRecently() const
+bool LLImageGL::getBoundRecently() const
 {
-	return (BOOL)(sLastFrameTime - mLastBindTime < MIN_TEXTURE_LIFETIME);
+	return (bool)(sLastFrameTime - mLastBindTime < MIN_TEXTURE_LIFETIME);
 }
 
-BOOL LLImageGL::getIsAlphaMask() const
+bool LLImageGL::getIsAlphaMask() const
 {
 	llassert_always(!sSkipAnalyzeAlpha);
 	return mIsMask;
@@ -2095,7 +2095,7 @@ void LLImageGL::setTarget(const LLGLenum target, const LLTexUnit::eTextureType b
 }
 
 const S8 INVALID_OFFSET = -99 ;
-void LLImageGL::setNeedsAlphaAndPickMask(BOOL need_mask) 
+void LLImageGL::setNeedsAlphaAndPickMask(bool need_mask) 
 {
 	if(mNeedsAlphaAndPickMask != need_mask)
 	{
@@ -2108,7 +2108,7 @@ void LLImageGL::setNeedsAlphaAndPickMask(BOOL need_mask)
 		else //do not need alpha mask
 		{
 			mAlphaOffset = INVALID_OFFSET ;
-			mIsMask = FALSE;
+			mIsMask = false;
 		}
 	}
 }
@@ -2133,8 +2133,8 @@ void LLImageGL::calcAlphaChannelOffsetAndStride()
     case GL_RED:
     case GL_RGB:
     case GL_SRGB:
-        mNeedsAlphaAndPickMask = FALSE;
-        mIsMask = FALSE;
+        mNeedsAlphaAndPickMask = false;
+        mIsMask = false;
         return; //no alpha channel.
     case GL_RGBA:
     case GL_SRGB_ALPHA:
@@ -2181,8 +2181,8 @@ void LLImageGL::calcAlphaChannelOffsetAndStride()
 	{
 		LL_WARNS() << "Cannot analyze alpha for image with format type " << std::hex << mFormatType << std::dec << LL_ENDL;
 
-		mNeedsAlphaAndPickMask = FALSE ;
-		mIsMask = FALSE;
+		mNeedsAlphaAndPickMask = false ;
+		mIsMask = false;
 	}
 }
 
@@ -2279,11 +2279,11 @@ void LLImageGL::analyzeAlpha(const void* data_in, U32 w, U32 h)
 	    (lowerhalftotal == length && alphatotal != 0) || // all close to transparent but not all totally transparent, or
 	    (upperhalftotal == length && alphatotal != 255*length)) // all close to opaque but not all totally opaque
 	{
-		mIsMask = FALSE; // not suitable for masking
+		mIsMask = false; // not suitable for masking
 	}
 	else
 	{
-		mIsMask = TRUE;
+		mIsMask = true;
 	}
 }
 
@@ -2383,9 +2383,9 @@ void LLImageGL::updatePickMask(S32 width, S32 height, const U8* data_in)
 	}
 }
 
-BOOL LLImageGL::getMask(const LLVector2 &tc)
+bool LLImageGL::getMask(const LLVector2 &tc)
 {
-	BOOL res = TRUE;
+	bool res = true;
 
 	if (mPickMask)
 	{
@@ -2429,13 +2429,13 @@ BOOL LLImageGL::getMask(const LLVector2 &tc)
 		S32 idx = y*mPickMaskWidth+x;
 		S32 offset = idx%8;
 
-		res = mPickMask[idx/8] & (1 << offset) ? TRUE : FALSE;
+		res = mPickMask[idx/8] & (1 << offset) ? true : false;
 	}
 	
 	return res;
 }
 
-void LLImageGL::setCurTexSizebar(S32 index, BOOL set_pick_size)
+void LLImageGL::setCurTexSizebar(S32 index, bool set_pick_size)
 {
 	sCurTexSizeBar = index ;
 

--- a/indra/llrender/llimagegl.h
+++ b/indra/llrender/llimagegl.h
@@ -68,7 +68,7 @@ public:
 	static S64 dataFormatBytes(S32 dataformat, S32 width, S32 height);
 	static S32 dataFormatComponents(S32 dataformat);
 
-	BOOL updateBindStats() const ;
+	bool updateBindStats() const ;
 	F32 getTimePassedSinceLastBound();
 	void forceUpdateBindStats(void) const;
 
@@ -76,7 +76,7 @@ public:
 	static void updateStats(F32 current_time);
 
 	// Save off / restore GL textures
-	static void destroyGL(BOOL save_state = TRUE);
+	static void destroyGL(bool save_state = true);
 	static void restoreGL();
 	static void dirtyTexOptions();
 
@@ -85,14 +85,14 @@ public:
 	//for server side use only.
 	// Not currently necessary for LLImageGL, but required in some derived classes,
 	// so include for compatability
-	static BOOL create(LLPointer<LLImageGL>& dest, BOOL usemipmaps = TRUE);
-	static BOOL create(LLPointer<LLImageGL>& dest, U32 width, U32 height, U8 components, BOOL usemipmaps = TRUE);
-	static BOOL create(LLPointer<LLImageGL>& dest, const LLImageRaw* imageraw, BOOL usemipmaps = TRUE);
+	static bool create(LLPointer<LLImageGL>& dest, bool usemipmaps = true);
+	static bool create(LLPointer<LLImageGL>& dest, U32 width, U32 height, U8 components, bool usemipmaps = true);
+	static bool create(LLPointer<LLImageGL>& dest, const LLImageRaw* imageraw, bool usemipmaps = true);
 		
 public:
-	LLImageGL(BOOL usemipmaps = TRUE);
-	LLImageGL(U32 width, U32 height, U8 components, BOOL usemipmaps = TRUE);
-	LLImageGL(const LLImageRaw* imageraw, BOOL usemipmaps = TRUE);
+	LLImageGL(bool usemipmaps = true);
+	LLImageGL(U32 width, U32 height, U8 components, bool usemipmaps = true);
+	LLImageGL(const LLImageRaw* imageraw, bool usemipmaps = true);
 
     // For wrapping textures created via GL elsewhere with our API only. Use with caution.
     LLImageGL(LLGLuint mTexName, U32 components, LLGLenum target, LLGLint  formatInternal, LLGLenum formatPrimary, LLGLenum formatType, LLTexUnit::eTextureAddressMode addressMode);
@@ -112,29 +112,29 @@ public:
 
 	static void setManualImage(U32 target, S32 miplevel, S32 intformat, S32 width, S32 height, U32 pixformat, U32 pixtype, const void *pixels, bool allow_compression = true);
     
-	BOOL createGLTexture() ;
-	BOOL createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename = 0, BOOL to_create = TRUE,
+	bool createGLTexture() ;
+	bool createGLTexture(S32 discard_level, const LLImageRaw* imageraw, S32 usename = 0, bool to_create = true,
 		S32 category = sMaxCategories-1, bool defer_copy = false, LLGLuint* tex_name = nullptr);
-	BOOL createGLTexture(S32 discard_level, const U8* data, BOOL data_hasmips = FALSE, S32 usename = 0, bool defer_copy = false, LLGLuint* tex_name = nullptr);
+	bool createGLTexture(S32 discard_level, const U8* data, bool data_hasmips = false, S32 usename = 0, bool defer_copy = false, LLGLuint* tex_name = nullptr);
 	void setImage(const LLImageRaw* imageraw);
-	BOOL setImage(const U8* data_in, BOOL data_hasmips = FALSE, S32 usename = 0);
+	bool setImage(const U8* data_in, bool data_hasmips = false, S32 usename = 0);
     // *TODO: This function may not work if the textures is compressed (i.e.
     // RenderCompressTextures is 0). Partial image updates do not work on
     // compressed textures.
-	BOOL setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, BOOL force_fast_update = FALSE, LLGLuint use_name = 0);
-	BOOL setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, BOOL force_fast_update = FALSE, LLGLuint use_name = 0);
-	BOOL setSubImageFromFrameBuffer(S32 fb_x, S32 fb_y, S32 x_pos, S32 y_pos, S32 width, S32 height);
+	bool setSubImage(const LLImageRaw* imageraw, S32 x_pos, S32 y_pos, S32 width, S32 height, bool force_fast_update = false, LLGLuint use_name = 0);
+	bool setSubImage(const U8* datap, S32 data_width, S32 data_height, S32 x_pos, S32 y_pos, S32 width, S32 height, bool force_fast_update = false, LLGLuint use_name = 0);
+	bool setSubImageFromFrameBuffer(S32 fb_x, S32 fb_y, S32 x_pos, S32 y_pos, S32 width, S32 height);
 
     // wait for gl commands to finish on current thread and push
     // a lambda to main thread to swap mNewTexName and mTexName
     void syncToMainThread(LLGLuint new_tex_name);
 
 	// Read back a raw image for this discard level, if it exists
-	BOOL readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compressed_ok) const;
+	bool readBackRaw(S32 discard_level, LLImageRaw* imageraw, bool compressed_ok) const;
 	void destroyGLTexture();
 	void forceToInvalidateGLTexture();
 
-	void setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format = 0, BOOL swap_bytes = FALSE);
+	void setExplicitFormat(LLGLint internal_format, LLGLenum primary_format, LLGLenum type_format = 0, bool swap_bytes = false);
 	void setComponents(S8 ncomponents) { mComponents = ncomponents; }
 
 	S32	 getDiscardLevel() const		{ return mCurrentDiscardLevel; }
@@ -147,18 +147,18 @@ public:
 	U8	 getComponents() const { return mComponents; }
 	S64  getBytes(S32 discard_level = -1) const;
 	S64  getMipBytes(S32 discard_level = -1) const;
-	BOOL getBoundRecently() const;
+	bool getBoundRecently() const;
 	bool isJustBound() const;
-	BOOL getHasExplicitFormat() const { return mHasExplicitFormat; }
+	bool getHasExplicitFormat() const { return mHasExplicitFormat; }
 	LLGLenum getPrimaryFormat() const { return mFormatPrimary; }
 	LLGLenum getFormatType() const { return mFormatType; }
 
-	BOOL getHasGLTexture() const { return mTexName != 0; }
+	bool getHasGLTexture() const { return mTexName != 0; }
 	LLGLuint getTexName() const { return mTexName; }
 
-	BOOL getIsAlphaMask() const;
+	bool getIsAlphaMask() const;
 
-	BOOL getIsResident(BOOL test_now = FALSE); // not const
+	bool getIsResident(bool test_now = false); // not const
 
 	void setTarget(const LLGLenum target, const LLTexUnit::eTextureType bind_target);
 
@@ -166,11 +166,11 @@ public:
 	bool isGLTextureCreated(void) const { return mGLTextureCreated ; }
 	void setGLTextureCreated (bool initialized) { mGLTextureCreated = initialized; }
 
-	BOOL getUseMipMaps() const { return mUseMipMaps; }
-	void setUseMipMaps(BOOL usemips) { mUseMipMaps = usemips; }	
-    void setHasMipMaps(BOOL hasmips) { mHasMipMaps = hasmips; }
+	bool getUseMipMaps() const { return mUseMipMaps; }
+	void setUseMipMaps(bool usemips) { mUseMipMaps = usemips; }	
+    void setHasMipMaps(bool hasmips) { mHasMipMaps = hasmips; }
 	void updatePickMask(S32 width, S32 height, const U8* data_in);
-	BOOL getMask(const LLVector2 &tc);
+	bool getMask(const LLVector2 &tc);
 
     void checkTexSize(bool forced = false) const ;
 	
@@ -192,12 +192,12 @@ public:
 	U32      getTexelsInGLTexture()const {return mTexelsInGLTexture;}
 
 	
-	void init(BOOL usemipmaps);
+	void init(bool usemipmaps);
 	virtual void cleanup(); // Clean up the LLImageGL so it can be reinitialized.  Be careful when using this in derived class destructors
 
-	void setNeedsAlphaAndPickMask(BOOL need_mask);
+	void setNeedsAlphaAndPickMask(bool need_mask);
 
-	BOOL preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image);
+	bool preAddToAtlas(S32 discard_level, const LLImageRaw* raw_image);
 	void postAddToAtlas() ;	
 
 #if LL_IMAGEGL_THREAD_CHECK
@@ -222,11 +222,11 @@ private:
 	U16 mPickMaskWidth;
 	U16 mPickMaskHeight;
 	S8 mUseMipMaps;
-	BOOL mHasExplicitFormat; // If false (default), GL format is f(mComponents)
+	bool mHasExplicitFormat; // If false (default), GL format is f(mComponents)
 	bool mAutoGenMips = false;
 
-	BOOL mIsMask;
-	BOOL mNeedsAlphaAndPickMask;
+	bool mIsMask;
+	bool mNeedsAlphaAndPickMask;
 	S8   mAlphaStride ;
 	S8   mAlphaOffset ;
 
@@ -261,9 +261,9 @@ protected:
 	LLGLint  mFormatInternal; // = GL internalformat
 	LLGLenum mFormatPrimary;  // = GL format (pixel data format)
 	LLGLenum mFormatType;
-	BOOL	 mFormatSwapBytes;// if true, use glPixelStorei(GL_UNPACK_SWAP_BYTES, 1)
+	bool	 mFormatSwapBytes;// if true, use glPixelStorei(GL_UNPACK_SWAP_BYTES, 1)
 	
-    BOOL mExternalTexture;
+    bool mExternalTexture;
 
 	// STATICS
 public:	
@@ -275,28 +275,28 @@ public:
 	// Global memory statistics
 	static U32 sBindCount;					// Tracks number of texture binds for current frame
 	static U32 sUniqueCount;				// Tracks number of unique texture binds for current frame
-	static BOOL sGlobalUseAnisotropic;
+	static bool sGlobalUseAnisotropic;
 	static LLImageGL* sDefaultGLTexture ;	
-	static BOOL sAutomatedTest;
+	static bool sAutomatedTest;
 	static bool sCompressTextures;			//use GL texture compression
 #if DEBUG_MISS
-	BOOL mMissed; // Missed on last bind?
-	BOOL getMissed() const { return mMissed; };
+	bool mMissed; // Missed on last bind?
+	bool getMissed() const { return mMissed; };
 #else
-	BOOL getMissed() const { return FALSE; };
+	bool getMissed() const { return false; };
 #endif
 
 public:
-	static void initClass(LLWindow* window, S32 num_catagories, BOOL skip_analyze_alpha = false, bool thread_texture_loads = false, bool thread_media_updates = false);
+	static void initClass(LLWindow* window, S32 num_catagories, bool skip_analyze_alpha = false, bool thread_texture_loads = false, bool thread_media_updates = false);
 	static void cleanupClass() ;
 
 private:
 	static S32 sMaxCategories;
-	static BOOL sSkipAnalyzeAlpha;
+	static bool sSkipAnalyzeAlpha;
 	
 	//the flag to allow to call readBackRaw(...).
 	//can be removed if we do not use that function at all.
-	static BOOL sAllowReadBackRaw ;
+	static bool sAllowReadBackRaw ;
 //
 //****************************************************************************************************
 //The below for texture auditing use only
@@ -317,7 +317,7 @@ public:
 	static S32 sCurTexSizeBar ;
 	static S32 sCurTexPickSize ;
 
-	static void setCurTexSizebar(S32 index, BOOL set_pick_size = TRUE) ;
+	static void setCurTexSizebar(S32 index, bool set_pick_size = true) ;
 	static void resetCurTexSizebar();
 
 //****************************************************************************************************

--- a/indra/llrender/llpostprocess.cpp
+++ b/indra/llrender/llpostprocess.cpp
@@ -165,7 +165,7 @@ void LLPostProcess::invalidate()
 	mSceneRenderTexture = NULL ;
 	mNoiseTexture = NULL ;
 	mTempBloomTexture = NULL ;
-	initialized = FALSE ;
+	initialized = false ;
 }
 
 void LLPostProcess::apply(unsigned int width, unsigned int height)
@@ -367,7 +367,7 @@ void LLPostProcess::createTexture(LLPointer<LLImageGL>& texture, unsigned int wi
 {
 	std::vector<GLubyte> data(width * height * 4, 0) ;
 
-	texture = new LLImageGL(FALSE) ;	
+	texture = new LLImageGL(false) ;	
 	if(texture->createGLTexture())
 	{
 		gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_TEXTURE, texture->getTexName());
@@ -387,7 +387,7 @@ void LLPostProcess::createNoiseTexture(LLPointer<LLImageGL>& texture)
 		}
 	}
 
-	texture = new LLImageGL(FALSE) ;
+	texture = new LLImageGL(false) ;
 	if(texture->createGLTexture())
 	{
 		gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_TEXTURE, texture->getTexName());

--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -1079,7 +1079,7 @@ void LLRender::syncMatrices()
             if (shader->getUniformLocation(LLShaderMgr::INVERSE_PROJECTION_MATRIX))
             {
 	            glh::matrix4f inv_proj = mat.inverse();
-	            shader->uniformMatrix4fv(LLShaderMgr::INVERSE_PROJECTION_MATRIX, 1, FALSE, inv_proj.m);
+	            shader->uniformMatrix4fv(LLShaderMgr::INVERSE_PROJECTION_MATRIX, 1, false, inv_proj.m);
             }
 
 			// Used by some full screen effects - such as full screen lights, glow, etc.

--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -91,13 +91,13 @@ void gl_draw_x(const LLRect& rect, const LLColor4& color)
 }
 
 
-void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, S32 pixel_offset, BOOL filled)
+void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, S32 pixel_offset, bool filled)
 {
 	gGL.color4fv(color.mV);
 	gl_rect_2d_offset_local(left, top, right, bottom, pixel_offset, filled);
 }
 
-void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, S32 pixel_offset, BOOL filled)
+void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, S32 pixel_offset, bool filled)
 {
 	gGL.pushUIMatrix();
 	left += LLFontGL::sCurOrigin.mX;
@@ -115,7 +115,7 @@ void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, S32 pixe
 }
 
 
-void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, BOOL filled )
+void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, bool filled )
 {
 	gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
 
@@ -143,14 +143,14 @@ void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, BOOL filled )
 	}
 }
 
-void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, BOOL filled )
+void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, bool filled )
 {
 	gGL.color4fv( color.mV );
 	gl_rect_2d( left, top, right, bottom, filled );
 }
 
 
-void gl_rect_2d( const LLRect& rect, const LLColor4& color, BOOL filled )
+void gl_rect_2d( const LLRect& rect, const LLColor4& color, bool filled )
 {
 	gGL.color4fv( color.mV );
 	gl_rect_2d( rect.mLeft, rect.mTop, rect.mRight, rect.mBottom, filled );
@@ -243,7 +243,7 @@ void gl_line_2d(S32 x1, S32 y1, S32 x2, S32 y2, const LLColor4 &color )
 	gGL.end();
 }
 
-void gl_triangle_2d(S32 x1, S32 y1, S32 x2, S32 y2, S32 x3, S32 y3, const LLColor4& color, BOOL filled)
+void gl_triangle_2d(S32 x1, S32 y1, S32 x2, S32 y2, S32 x3, S32 y3, const LLColor4& color, bool filled)
 {
 	gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
 
@@ -322,7 +322,7 @@ void gl_draw_scaled_image(S32 x, S32 y, S32 width, S32 height, LLTexture* image,
 	gl_draw_scaled_rotated_image( x, y, width, height, 0.f, image, color, uv_rect );
 }
 
-void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 border_width, S32 border_height, S32 width, S32 height, LLTexture* image, const LLColor4& color, BOOL solid_color, const LLRectf& uv_rect, bool scale_inner)
+void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 border_width, S32 border_height, S32 width, S32 height, LLTexture* image, const LLColor4& color, bool solid_color, const LLRectf& uv_rect, bool scale_inner)
 {
 	if (NULL == image)
 	{
@@ -338,7 +338,7 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 border_width, S32 border
 	gl_draw_scaled_image_with_border(x, y, width, height, image, color, solid_color, uv_rect, scale_rect, scale_inner);
 }
 
-void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTexture* image, const LLColor4& color, BOOL solid_color, const LLRectf& uv_outer_rect, const LLRectf& center_rect, bool scale_inner)
+void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTexture* image, const LLColor4& color, bool solid_color, const LLRectf& uv_outer_rect, const LLRectf& center_rect, bool scale_inner)
 {
 	stop_glerror();
 
@@ -729,7 +729,7 @@ void gl_line_3d( const LLVector3& start, const LLVector3& end, const LLColor4& c
 	LLRender2D::getInstance()->setLineWidth(1.f);
 }
 
-void gl_arc_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, BOOL filled, F32 start_angle, F32 end_angle)
+void gl_arc_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, bool filled, F32 start_angle, F32 end_angle)
 {
 	if (end_angle < start_angle)
 	{
@@ -772,7 +772,7 @@ void gl_arc_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, BOOL filled, F
 	gGL.popUIMatrix();
 }
 
-void gl_circle_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, BOOL filled)
+void gl_circle_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, bool filled)
 {
 	gGL.pushUIMatrix();
 	{
@@ -833,7 +833,7 @@ void gl_deep_circle( F32 radius, F32 depth, S32 steps )
 	gGL.end();
 }
 
-void gl_ring( F32 radius, F32 width, const LLColor4& center_color, const LLColor4& side_color, S32 steps, BOOL render_center )
+void gl_ring( F32 radius, F32 width, const LLColor4& center_color, const LLColor4& side_color, S32 steps, bool render_center )
 {
 	gGL.pushUIMatrix();
 	{

--- a/indra/llrender/llrender2dutils.h
+++ b/indra/llrender/llrender2dutils.h
@@ -48,25 +48,25 @@ void gl_state_for_2d(S32 width, S32 height);
 
 void gl_line_2d(S32 x1, S32 y1, S32 x2, S32 y2);
 void gl_line_2d(S32 x1, S32 y1, S32 x2, S32 y2, const LLColor4 &color );
-void gl_triangle_2d(S32 x1, S32 y1, S32 x2, S32 y2, S32 x3, S32 y3, const LLColor4& color, BOOL filled);
+void gl_triangle_2d(S32 x1, S32 y1, S32 x2, S32 y2, S32 x3, S32 y3, const LLColor4& color, bool filled);
 void gl_rect_2d_simple( S32 width, S32 height );
 
 void gl_draw_x(const LLRect& rect, const LLColor4& color);
 
-void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, BOOL filled = TRUE );
-void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, BOOL filled = TRUE );
-void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, S32 pixel_offset = 0, BOOL filled = TRUE );
-void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, S32 pixel_offset = 0, BOOL filled = TRUE );
-void gl_rect_2d(const LLRect& rect, BOOL filled = TRUE );
-void gl_rect_2d(const LLRect& rect, const LLColor4& color, BOOL filled = TRUE );
+void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, bool filled = true );
+void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, bool filled = true );
+void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &color, S32 pixel_offset = 0, bool filled = true );
+void gl_rect_2d_offset_local( S32 left, S32 top, S32 right, S32 bottom, S32 pixel_offset = 0, bool filled = true );
+void gl_rect_2d(const LLRect& rect, bool filled = true );
+void gl_rect_2d(const LLRect& rect, const LLColor4& color, bool filled = true );
 void gl_rect_2d_checkerboard(const LLRect& rect, GLfloat alpha = 1.0f);
 
 void gl_drop_shadow(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &start_color, S32 lines);
 
-void gl_circle_2d(F32 x, F32 y, F32 radius, S32 steps, BOOL filled);
-void gl_arc_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, BOOL filled, F32 start_angle, F32 end_angle);
+void gl_circle_2d(F32 x, F32 y, F32 radius, S32 steps, bool filled);
+void gl_arc_2d(F32 center_x, F32 center_y, F32 radius, S32 steps, bool filled, F32 start_angle, F32 end_angle);
 void gl_deep_circle( F32 radius, F32 depth );
-void gl_ring( F32 radius, F32 width, const LLColor4& center_color, const LLColor4& side_color, S32 steps, BOOL render_center );
+void gl_ring( F32 radius, F32 width, const LLColor4& center_color, const LLColor4& side_color, S32 steps, bool render_center );
 void gl_corners_2d(S32 left, S32 top, S32 right, S32 bottom, S32 length, F32 max_frac);
 void gl_washer_2d(F32 outer_radius, F32 inner_radius, S32 steps, const LLColor4& inner_color, const LLColor4& outer_color);
 void gl_washer_segment_2d(F32 outer_radius, F32 inner_radius, F32 start_radians, F32 end_radians, S32 steps, const LLColor4& inner_color, const LLColor4& outer_color);
@@ -76,8 +76,8 @@ void gl_draw_scaled_target(S32 x, S32 y, S32 width, S32 height, LLRenderTarget* 
 void gl_draw_scaled_image(S32 x, S32 y, S32 width, S32 height, LLTexture* image, const LLColor4& color = UI_VERTEX_COLOR, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f));
 void gl_draw_rotated_image(S32 x, S32 y, F32 degrees, LLTexture* image, const LLColor4& color = UI_VERTEX_COLOR, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f));
 void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degrees, LLTexture* image, const LLColor4& color = UI_VERTEX_COLOR, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f), LLRenderTarget* target = NULL);
-void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 border_width, S32 border_height, S32 width, S32 height, LLTexture* image, const LLColor4 &color, BOOL solid_color = FALSE, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f), bool scale_inner = true);
-void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTexture* image, const LLColor4 &color, BOOL solid_color = FALSE, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f), const LLRectf& scale_rect = LLRectf(0.f, 1.f, 1.f, 0.f), bool scale_inner = true);
+void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 border_width, S32 border_height, S32 width, S32 height, LLTexture* image, const LLColor4 &color, bool solid_color = false, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f), bool scale_inner = true);
+void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTexture* image, const LLColor4 &color, bool solid_color = false, const LLRectf& uv_rect = LLRectf(0.f, 1.f, 1.f, 0.f), const LLRectf& scale_rect = LLRectf(0.f, 1.f, 1.f, 0.f), bool scale_inner = true);
 
 void gl_line_3d( const LLVector3& start, const LLVector3& end, const LLColor4& color); 
 
@@ -110,12 +110,12 @@ void gl_segmented_rect_2d_tex(const S32 left, const S32 top, const S32 right, co
 void gl_segmented_rect_2d_fragment_tex(const LLRect& rect, const S32 texture_width, const S32 texture_height, const S32 border_size, const F32 start_fragment, const F32 end_fragment, const U32 edges = ROUNDED_RECT_ALL);
 void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv_rect, const LLRectf& center_draw_rect, const LLVector3& width_vec, const LLVector3& height_vec);
 
-inline void gl_rect_2d( const LLRect& rect, BOOL filled )
+inline void gl_rect_2d( const LLRect& rect, bool filled )
 {
 	gl_rect_2d( rect.mLeft, rect.mTop, rect.mRight, rect.mBottom, filled );
 }
 
-inline void gl_rect_2d_offset_local( const LLRect& rect, S32 pixel_offset, BOOL filled)
+inline void gl_rect_2d_offset_local( const LLRect& rect, S32 pixel_offset, bool filled)
 {
 	gl_rect_2d_offset_local( rect.mLeft, rect.mTop, rect.mRight, rect.mBottom, pixel_offset, filled );
 }

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -65,14 +65,14 @@ LLShaderMgr * LLShaderMgr::instance()
 	return sInstance;
 }
 
-BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
+bool LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 {
 	llassert_always(shader != NULL);
 	LLShaderFeatures *features = & shader->mFeatures;
 
 	if (features->attachNothing)
 	{
-		return TRUE;
+		return true;
 	}
 	//////////////////////////////////////
 	// Attach Vertex Shader Features First
@@ -83,7 +83,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
 		if (!shader->attachVertexObject("windlight/atmosphericsVarsV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -91,7 +91,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
 		if (!shader->attachVertexObject("windlight/atmosphericsHelpersV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 		
@@ -101,40 +101,40 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 		{
             if (!shader->attachVertexObject("lighting/lightFuncSpecularV.glsl"))
 			{
-				return FALSE;
+				return false;
 			}
 		
 			if (!features->isAlphaLighting)
 			{
                 if (!shader->attachVertexObject("lighting/sumLightsSpecularV.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 			
             if (!shader->attachVertexObject("lighting/lightSpecularV.glsl"))
 			{
-				return FALSE;
+				return false;
 			}
 		}
 		else 
 		{
             if (!shader->attachVertexObject("lighting/lightFuncV.glsl"))
 			{
-				return FALSE;
+				return false;
 			}
 			
 			if (!features->isAlphaLighting)
 			{
                 if (!shader->attachVertexObject("lighting/sumLightsV.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 			
             if (!shader->attachVertexObject("lighting/lightV.glsl"))
 			{
-				return FALSE;
+				return false;
 			}
 		}
 	}
@@ -144,16 +144,16 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
     {
         if (!shader->attachVertexObject("environment/srgbF.glsl")) // NOTE -- "F" suffix is superfluous here, there is nothing fragment specific in srgbF
         {
-            return FALSE;
+            return false;
         }
 
         if (!shader->attachVertexObject("windlight/atmosphericsFuncs.glsl")) {
-            return FALSE;
+            return false;
         }
 
         if (!shader->attachVertexObject("windlight/atmosphericsV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -161,7 +161,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachVertexObject("avatar/avatarSkinV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -170,13 +170,13 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
         shader->mRiggedVariant = shader;
         if (!shader->attachVertexObject("avatar/objectSkinV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
     if (!shader->attachVertexObject("deferred/textureUtilV.glsl"))
     {
-        return FALSE;
+        return false;
     }
 	
 	///////////////////////////////////////
@@ -188,7 +188,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
     {
         if (!shader->attachFragmentObject("environment/srgbF.glsl"))
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -196,7 +196,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
 		if (!shader->attachFragmentObject("windlight/atmosphericsVarsF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -204,7 +204,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("windlight/atmosphericsHelpersF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -213,7 +213,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("deferred/deferredUtil.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -221,7 +221,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("deferred/screenSpaceReflUtil.glsl"))
         {
-            return FALSE;
+            return false;
         }
 	}
 
@@ -229,7 +229,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("deferred/shadowUtil.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -237,7 +237,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
     {
         if (!shader->attachFragmentObject("deferred/reflectionProbeF.glsl"))
         {
-            return FALSE;
+            return false;
         }
     }
 
@@ -245,7 +245,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("deferred/aoUtil.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -253,7 +253,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("windlight/gammaF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -261,19 +261,19 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("environment/encodeNormF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
 	if (features->hasAtmospherics || features->isDeferred)
     {
         if (!shader->attachFragmentObject("windlight/atmosphericsFuncs.glsl")) {
-            return FALSE;
+            return false;
         }
 
         if (!shader->attachFragmentObject("windlight/atmosphericsF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 	
@@ -282,7 +282,7 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
         if (!shader->attachFragmentObject("environment/waterFogF.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 	
@@ -294,14 +294,14 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 			{
                 if (!shader->attachFragmentObject("lighting/lightAlphaMaskNonIndexedF.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 			else
 			{
                 if (!shader->attachFragmentObject("lighting/lightNonIndexedF.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 		}
@@ -311,14 +311,14 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 			{
                 if (!shader->attachFragmentObject("lighting/lightAlphaMaskF.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 			else
 			{
                 if (!shader->attachFragmentObject("lighting/lightF.glsl"))
 				{
-					return FALSE;
+					return false;
 				}
 			}
 			shader->mFeatures.mIndexedTextureChannels = llmax(LLGLSLShader::sIndexedTextureChannels-1, 1);
@@ -329,18 +329,18 @@ BOOL LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
 	{
 		if (!shader->attachVertexObject("objects/nonindexedTextureV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 	else
 	{
         if (!shader->attachVertexObject("objects/indexedTextureV.glsl"))
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
-	return TRUE;
+	return true;
 }
 
 //============================================================================
@@ -414,7 +414,7 @@ void LLShaderMgr::dumpShaderSource(U32 shader_code_count, GLchar** shader_code_t
     LL_CONT << LL_ENDL;
 }
 
-void LLShaderMgr::dumpObjectLog(GLuint ret, BOOL warns, const std::string& filename)
+void LLShaderMgr::dumpObjectLog(GLuint ret, bool warns, const std::string& filename)
 {
     std::string log;
     log = get_object_log(ret);
@@ -853,7 +853,7 @@ GLuint LLShaderMgr::loadShaderFile(const std::string& filename, S32 & shader_lev
 		{
 			//an error occured, print log
 			LL_WARNS("ShaderLoading") << "GLSL Compilation Error:" << LL_ENDL;
-			dumpObjectLog(ret, TRUE, open_file_name);
+			dumpObjectLog(ret, true, open_file_name);
 			dumpShaderSource(shader_code_count, shader_code_text);
 			glDeleteShader(ret); //no longer need handle
 			ret = 0;
@@ -895,7 +895,7 @@ GLuint LLShaderMgr::loadShaderFile(const std::string& filename, S32 & shader_lev
 	return ret;
 }
 
-BOOL LLShaderMgr::linkProgramObject(GLuint obj, BOOL suppress_errors)
+bool LLShaderMgr::linkProgramObject(GLuint obj, bool suppress_errors)
 {
 	//check for errors
     {
@@ -912,7 +912,7 @@ BOOL LLShaderMgr::linkProgramObject(GLuint obj, BOOL suppress_errors)
         {
             //an error occured, print log
             LL_SHADER_LOADING_WARNS() << "GLSL Linker Error:" << LL_ENDL;
-            dumpObjectLog(obj, TRUE, "linker");
+            dumpObjectLog(obj, true, "linker");
             return success;
         }
     }
@@ -923,12 +923,12 @@ BOOL LLShaderMgr::linkProgramObject(GLuint obj, BOOL suppress_errors)
 	{
 		LL_SHADER_LOADING_WARNS() << "GLSL Linker: Running in Software:" << LL_ENDL;
 		success = GL_FALSE;
-		suppress_errors = FALSE;
+		suppress_errors = false;
 	}
 	return success;
 }
 
-BOOL LLShaderMgr::validateProgramObject(GLuint obj)
+bool LLShaderMgr::validateProgramObject(GLuint obj)
 {
 	//check program validity against current GL
 	glValidateProgram(obj);
@@ -941,7 +941,7 @@ BOOL LLShaderMgr::validateProgramObject(GLuint obj)
 	}
 	else
 	{
-		dumpObjectLog(obj, FALSE);
+		dumpObjectLog(obj, false);
 	}
 
 	return success;

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -296,11 +296,11 @@ public:
 
 	virtual void initAttribsAndUniforms(void);
 
-	BOOL attachShaderFeatures(LLGLSLShader * shader);
-	void dumpObjectLog(GLuint ret, BOOL warns = TRUE, const std::string& filename = "");
+	bool attachShaderFeatures(LLGLSLShader * shader);
+	void dumpObjectLog(GLuint ret, bool warns = true, const std::string& filename = "");
     void dumpShaderSource(U32 shader_code_count, GLchar** shader_code_text);
-	BOOL	linkProgramObject(GLuint obj, BOOL suppress_errors = FALSE);
-	BOOL	validateProgramObject(GLuint obj);
+	bool	linkProgramObject(GLuint obj, bool suppress_errors = false);
+	bool	validateProgramObject(GLuint obj);
 	GLuint loadShaderFile(const std::string& filename, S32 & shader_level, GLenum type, std::map<std::string, std::string>* defines = NULL, S32 texture_index_channels = -1);
 
 	// Implemented in the application to actually point to the shader directory.

--- a/indra/llrender/lltexturemanagerbridge.h
+++ b/indra/llrender/lltexturemanagerbridge.h
@@ -36,8 +36,8 @@ class LLTextureManagerBridge
 public:
     virtual ~LLTextureManagerBridge() {}
 
-	virtual LLPointer<LLGLTexture> getLocalTexture(BOOL usemipmaps = TRUE, BOOL generate_gl_tex = TRUE) = 0;
-	virtual LLPointer<LLGLTexture> getLocalTexture(const U32 width, const U32 height, const U8 components, BOOL usemipmaps, BOOL generate_gl_tex = TRUE) = 0;
+	virtual LLPointer<LLGLTexture> getLocalTexture(bool usemipmaps = true, bool generate_gl_tex = true) = 0;
+	virtual LLPointer<LLGLTexture> getLocalTexture(const U32 width, const U32 height, const U8 components, bool usemipmaps, bool generate_gl_tex = true) = 0;
 	virtual LLGLTexture* getFetchedTexture(const LLUUID &image_id) = 0;
 };
 

--- a/indra/llrender/lluiimage.inl
+++ b/indra/llrender/lluiimage.inl
@@ -36,7 +36,7 @@ void LLUIImage::draw(S32 x, S32 y, S32 width, S32 height, const LLColor4& color)
 		width, height, 
 		mImage, 
 		color,
-		FALSE,
+		false,
 		mClipRegion,
 		mScaleRegion,
 		mScaleStyle == SCALE_INNER);
@@ -49,7 +49,7 @@ void LLUIImage::drawSolid(S32 x, S32 y, S32 width, S32 height, const LLColor4& c
 		width, height, 
 		mImage, 
 		color, 
-		TRUE,
+		true,
 		mClipRegion,
 		mScaleRegion,
 		mScaleStyle == SCALE_INNER);

--- a/indra/llrender/llvertexbuffer.h
+++ b/indra/llrender/llvertexbuffer.h
@@ -253,7 +253,7 @@ private:
         : LLVertexBuffer(typemask)
     {}
 
-    bool	allocateBuffer(S32 nverts, S32 nindices, BOOL create) { return allocateBuffer(nverts, nindices); }
+    bool	allocateBuffer(S32 nverts, S32 nindices, bool create) { return allocateBuffer(nverts, nindices); }
 
 public:
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -943,7 +943,7 @@ bool LLAppViewer::init()
 	//
 	// Initialize the window
 	//
-	gGLActive = TRUE;
+	gGLActive = true;
 	initWindow();
 	LL_INFOS("InitInfo") << "Window is initialized." << LL_ENDL ;
 
@@ -1129,7 +1129,7 @@ bool LLAppViewer::init()
 	  LLNotificationsUtil::add("CorruptedProtectedDataStore");
 	}
 
-	gGLActive = FALSE;
+	gGLActive = false;
 
 #if LL_RELEASE_FOR_DOWNLOAD
     // Skip updater if this is a non-interactive instance
@@ -1510,7 +1510,7 @@ bool LLAppViewer::doFrame()
             {
                 LL_PROFILE_ZONE_NAMED_CATEGORY_APP("df Display");
                 pingMainloopTimeout("Main:Display");
-                gGLActive = TRUE;
+                gGLActive = true;
 
                 display();
 
@@ -1521,7 +1521,7 @@ bool LLAppViewer::doFrame()
                     gPipeline.mReflectionMapManager.update();
                     LLFloaterSnapshot::update(); // take snapshots
                     LLFloaterSimpleSnapshot::update();
-                    gGLActive = FALSE;
+                    gGLActive = false;
                 }
 
                 if (LLViewerStatsRecorder::instanceExists())
@@ -2738,7 +2738,7 @@ bool LLAppViewer::initConfiguration()
 	std::string test_name(gSavedSettings.getString("LogMetrics"));
 	if (! test_name.empty())
  	{
-		LLTrace::BlockTimer::sMetricLog = TRUE;
+		LLTrace::BlockTimer::sMetricLog = true;
 		// '--logmetrics' is specified with a named test metric argument so the data gathering is done only on that test
 		// In the absence of argument, every metric would be gathered (makes for a rather slow run and hard to decipher report...)
 		LL_INFOS() << "'--logmetrics' argument : " << test_name << LL_ENDL;
@@ -2762,16 +2762,16 @@ bool LLAppViewer::initConfiguration()
 
 	if (gSavedSettings.getBOOL("DebugSession"))
 	{
-		gDebugSession = TRUE;
-		gDebugGL = TRUE;
+		gDebugSession = true;
+		gDebugGL = true;
 
 		ll_init_fail_log(gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "test_failures.log"));
 	}
 
     if (gSavedSettings.getBOOL("RenderDebugGLSession"))
     {
-        gDebugGLSession = TRUE;
-        gDebugGL = TRUE;
+        gDebugGLSession = true;
+        gDebugGL = true;
         // gDebugGL can cause excessive logging
         // so it's limited to a single session
         gSavedSettings.setBOOL("RenderDebugGLSession", FALSE);
@@ -4642,13 +4642,13 @@ void LLAppViewer::idle()
 	if (LLStartUp::getStartupState() < STATE_STARTED)
 	{
 		// Skip rest if idle startup returns false (essentially, no world yet)
-		gGLActive = TRUE;
+		gGLActive = true;
 		if (!idle_startup())
 		{
-			gGLActive = FALSE;
+			gGLActive = false;
 			return;
 		}
-		gGLActive = FALSE;
+		gGLActive = false;
 	}
 
 
@@ -4989,7 +4989,7 @@ void LLAppViewer::idle()
 	// forcibly quit if it has taken too long
 	if (mQuitRequested)
 	{
-		gGLActive = TRUE;
+		gGLActive = true;
 		idleShutdown();
 	}
 }

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -529,7 +529,7 @@ int APIENTRY WINMAIN(HINSTANCE hInstance,
 		}
 #endif
 
-		gGLActive = TRUE;
+		gGLActive = true;
 
 		viewer_app_ptr->cleanup();
 

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -1104,7 +1104,7 @@ void LLBumpImageList::onSourceLoaded( BOOL success, LLViewerTexture *src_vi, LLI
                     //  Note: bump will still point at GPU copy of dst_image
                     bump_ptr->setExplicitFormat(GL_RGBA, GL_RGBA);
                     LLGLuint tex_name;
-                    img->createGLTexture(0, nullptr, 0, 0, true, &tex_name);
+                    img->createGLTexture(0, nullptr, false, 0, true, &tex_name);
 
                     // point render target at empty buffer
                     sRenderTarget.setColorAttachment(img, tex_name);

--- a/indra/newview/lldynamictexture.cpp
+++ b/indra/newview/lldynamictexture.cpp
@@ -100,7 +100,7 @@ void LLViewerDynamicTexture::generateGLTexture(LLGLint internal_format, LLGLenum
 	{
 		setExplicitFormat(internal_format, primary_format, type_format, swap_bytes);
 	}
-	createGLTexture(0, raw_image, 0, TRUE, LLGLTexture::DYNAMIC_TEX);
+	createGLTexture(0, raw_image, 0, true, LLGLTexture::DYNAMIC_TEX);
 	setAddressMode((mClamp) ? LLTexUnit::TAM_CLAMP : LLTexUnit::TAM_WRAP);
 	mGLTexturep->setGLTextureCreated(false);
 }

--- a/indra/newview/llfloaterreporter.cpp
+++ b/indra/newview/llfloaterreporter.cpp
@@ -917,7 +917,7 @@ void LLFloaterReporter::takeScreenshot(bool use_prev_screenshot)
 	// store in the image list so it doesn't try to fetch from the server
 	LLPointer<LLViewerFetchedTexture> image_in_list = 
 		LLViewerTextureManager::getFetchedTexture(mResourceDatap->mAssetInfo.mUuid);
-	image_in_list->createGLTexture(0, mImageRaw, 0, TRUE, LLGLTexture::OTHER);
+	image_in_list->createGLTexture(0, mImageRaw, 0, true, LLGLTexture::OTHER);
 	
 	// the texture picker then uses that texture
 	LLTextureCtrl* texture = getChild<LLTextureCtrl>("screenshot");

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -2980,7 +2980,7 @@ void LLViewerMediaImpl::doMediaTexUpdate(LLViewerMediaTexture* media_tex, U8* da
     // -Cosmic,2023-04-04
     // Allocate GL texture based on LLImageRaw but do NOT copy to GL
     LLGLuint tex_name = 0;
-    media_tex->createGLTexture(0, raw, 0, TRUE, LLGLTexture::OTHER, true, &tex_name);
+    media_tex->createGLTexture(0, raw, 0, true, LLGLTexture::OTHER, true, &tex_name);
 
     // copy just the subimage covered by the image raw to GL
     media_tex->setSubImage(data, data_width, data_height, x_pos, y_pos, width, height, tex_name);

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -4663,9 +4663,9 @@ void LLViewerObject::setMediaPassedWhitelist(BOOL passed)
 	}
 }
 
-BOOL LLViewerObject::setMaterial(const U8 material)
+bool LLViewerObject::setMaterial(const U8 material)
 {
-	BOOL res = LLPrimitive::setMaterial(material);
+	bool res = LLPrimitive::setMaterial(material);
 	if (res)
 	{
 		setChanged(TEXTURE);

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -370,7 +370,7 @@ public:
 	//
 	void refreshMaterials();
 
-	/*virtual*/	BOOL	setMaterial(const U8 material);
+	/*virtual*/	bool	setMaterial(const U8 material);
 	virtual		void	setTEImage(const U8 te, LLViewerTexture *imagep); // Not derived from LLPrimitive
 	virtual     void    changeTEImage(S32 index, LLViewerTexture* new_image)  ;
 	virtual     void    changeTENormalMap(S32 index, LLViewerTexture* new_image)  ;

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -342,12 +342,12 @@ LLViewerFetchedTexture* LLViewerTextureManager::getFetchedTextureFromHost(const 
 // Create a bridge to the viewer texture manager.
 class LLViewerTextureManagerBridge : public LLTextureManagerBridge
 {
-	/*virtual*/ LLPointer<LLGLTexture> getLocalTexture(BOOL usemipmaps = TRUE, BOOL generate_gl_tex = TRUE)
+	/*virtual*/ LLPointer<LLGLTexture> getLocalTexture(bool usemipmaps = true, bool generate_gl_tex = true)
 	{
 		return LLViewerTextureManager::getLocalTexture(usemipmaps, generate_gl_tex);
 	}
 
-	/*virtual*/ LLPointer<LLGLTexture> getLocalTexture(const U32 width, const U32 height, const U8 components, BOOL usemipmaps, BOOL generate_gl_tex = TRUE)
+	/*virtual*/ LLPointer<LLGLTexture> getLocalTexture(const U32 width, const U32 height, const U8 components, bool usemipmaps, bool generate_gl_tex = true)
 	{
 		return LLViewerTextureManager::getLocalTexture(width, height, components, usemipmaps, generate_gl_tex);
 	}
@@ -1355,7 +1355,7 @@ void LLViewerFetchedTexture::addToCreateTexture()
 	if(isForSculptOnly())
 	{
 		//just update some variables, not to create a real GL texture.
-		createGLTexture(mRawDiscardLevel, mRawImage, 0, FALSE);
+		createGLTexture(mRawDiscardLevel, mRawImage, 0, false);
 		mNeedsCreateTexture = false;
 		destroyRawImage();
 	}
@@ -1540,7 +1540,7 @@ BOOL LLViewerFetchedTexture::createTexture(S32 usename/*= 0*/)
         return FALSE;
     }
 
-	BOOL res = mGLTexturep->createGLTexture(mRawDiscardLevel, mRawImage, usename, TRUE, mBoostLevel);
+	BOOL res = mGLTexturep->createGLTexture(mRawDiscardLevel, mRawImage, usename, true, mBoostLevel);
     
 	return res;
 }

--- a/indra/newview/llvosky.cpp
+++ b/indra/newview/llvosky.cpp
@@ -207,7 +207,7 @@ void LLSkyTex::create()
 void LLSkyTex::createGLImage(S32 which)
 {
 	mTexture[which]->setExplicitFormat(GL_RGBA8, GL_RGBA);
-	mTexture[which]->createGLTexture(0, mImageRaw[which], 0, TRUE, LLGLTexture::LOCAL);
+	mTexture[which]->createGLTexture(0, mImageRaw[which], 0, true, LLGLTexture::LOCAL);
 	mTexture[which]->setAddressMode(LLTexUnit::TAM_CLAMP);
 }
 

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -917,9 +917,9 @@ BOOL LLVOVolume::isActive() const
 	return !mStatic;
 }
 
-BOOL LLVOVolume::setMaterial(const U8 material)
+bool LLVOVolume::setMaterial(const U8 material)
 {
-	BOOL res = LLViewerObject::setMaterial(material);
+	bool res = LLViewerObject::setMaterial(material);
 	
 	return res;
 }
@@ -1004,7 +1004,7 @@ LLDrawable *LLVOVolume::createDrawable(LLPipeline *pipeline)
 	return mDrawable;
 }
 
-BOOL LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bool unique_volume)
+bool LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bool unique_volume)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
 	LLVolumeParams volume_params = params_in;
@@ -1012,7 +1012,7 @@ BOOL LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bo
 	S32 last_lod = mVolumep.notNull() ? LLVolumeLODGroup::getVolumeDetailFromScale(mVolumep->getDetail()) : -1;
 	S32 lod = mLOD;
 
-	BOOL is404 = FALSE;
+	bool is404 = false;
 	
 	if (isSculpted())
 	{
@@ -1024,7 +1024,7 @@ BOOL LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bo
 				lod = gMeshRepo.getActualMeshLOD(volume_params, lod);
 				if (lod == -1)
 				{
-					is404 = TRUE;
+					is404 = true;
 					lod = 0;
 				}
 			}
@@ -1128,14 +1128,14 @@ BOOL LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bo
 			}
 		}
 
-        return TRUE;
+        return true;
 	}
 	else if (NO_LOD == lod) 
 	{
 		LLSculptIDSize::instance().resetSizeSum(volume_params.getSculptID());
 	}
 
-	return FALSE;
+	return false;
 }
 
 void LLVOVolume::updateSculptTexture()

--- a/indra/newview/llvovolume.h
+++ b/indra/newview/llvovolume.h
@@ -223,11 +223,11 @@ public:
 	/*virtual*/ S32		setTEScaleT(const U8 te, const F32 t) override;
 	/*virtual*/ S32		setTETexGen(const U8 te, const U8 texgen) override;
 	/*virtual*/ S32		setTEMediaTexGen(const U8 te, const U8 media) override;
-	/*virtual*/ BOOL 	setMaterial(const U8 material) override;
+	/*virtual*/ bool 	setMaterial(const U8 material) override;
 
 				void	setTexture(const S32 face);
 				S32     getIndexInTex(U32 ch) const {return mIndexInTex[ch];}
-	/*virtual*/ BOOL	setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume = false) override;
+	/*virtual*/ bool	setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume = false) override;
 				void	updateSculptTexture();
 				void    setIndexInTex(U32 ch, S32 index) { mIndexInTex[ch] = index ;}
 				void	sculpt();

--- a/indra/test/llpermissions_tut.cpp
+++ b/indra/test/llpermissions_tut.cpp
@@ -278,7 +278,7 @@ namespace tut
 		LLPermissions perm;
 		LLUUID agent;
 		LLUUID group("9c8eca51-53d5-42a7-bb58-cef070395db8");		
-		BOOL set = 1;
+		bool set = true;
 		U32 bits = 10;
 		ensure("setGroupBits():failed ", perm.setGroupBits(agent,group, set, bits));
 		ensure("setEveryoneBits():failed ", perm.setEveryoneBits(agent,group, set, bits));

--- a/indra/test/llsdmessagebuilder_tut.cpp
+++ b/indra/test/llsdmessagebuilder_tut.cpp
@@ -688,13 +688,13 @@ namespace tut
 	template<> template<>
 	void LLSDMessageBuilderTestObject::test<39>()
 	{
-	  BOOL valueTrue = true;
-	  BOOL valueFalse = false;
+	  bool valueTrue = true;
+	  bool valueFalse = false;
 
 	  LLMsgData* md = new LLMsgData("testMessage");
 	  LLMsgBlkData* mbd = new LLMsgBlkData("testBlock", 0);
-	  addValue(mbd, (char *)"testBoolFalse", &valueFalse, MVT_BOOL, sizeof(BOOL));
-	  addValue(mbd, (char *)"testBoolTrue", &valueTrue, MVT_BOOL, sizeof(BOOL));
+	  addValue(mbd, (char *)"testBoolFalse", &valueFalse, MVT_BOOL, sizeof(bool));
+	  addValue(mbd, (char *)"testBoolTrue", &valueTrue, MVT_BOOL, sizeof(bool));
 	  md->addBlock(mbd);
 	  LLSDMessageBuilder builder = defaultBuilder();
 	  

--- a/indra/test/llsdmessagereader_tut.cpp
+++ b/indra/test/llsdmessagereader_tut.cpp
@@ -73,7 +73,7 @@ namespace tut
 								const std::string& block,
 								const std::string& var,
 								S32 blocknum,
-								BOOL expected)
+								bool expected)
 		{
 			LLSDMessageReader msg;
 			msg.setMessage("fakename", msg_data);
@@ -118,8 +118,8 @@ namespace tut
  	{
  		LLSD message = LLSD::emptyMap();
  		message["block1"] = LLSD::emptyArray();
- 		BOOL bool_true = TRUE;
- 		BOOL bool_false = FALSE;
+ 		bool bool_true = true;
+ 		bool bool_false = false;
  		message["block1"][0] = LLSD::emptyMap();
  		message["block1"][0]["BoolField1"] = bool_true;
 		message["block1"][1] = LLSD::emptyMap();
@@ -127,9 +127,9 @@ namespace tut
  		message["block1"][1]["BoolField2"] = bool_true;
 
  		ensureMessageName("name3", message, "name3");
- 		ensureBool(message, "block1", "BoolField1", 0, TRUE);
- 		ensureBool(message, "block1", "BoolField1", 1, FALSE);
- 		ensureBool(message, "block1", "BoolField2", 1, TRUE);
+ 		ensureBool(message, "block1", "BoolField1", 0, true);
+ 		ensureBool(message, "block1", "BoolField1", 1, false);
+ 		ensureBool(message, "block1", "BoolField2", 1, true);
  		ensureNumberOfBlocks(message, "block1", 2);
  		ensureMessageSize(message, 0);
  	}


### PR DESCRIPTION
- Converted remaining cases of old fake BOOL in llmath and llprimitive.
- Also added missing llmutex.h to the respective CMake file.
- Fixed the cause of one failing unit test which @larsnaesbye accidentally introduced.
- Also changed the return value for LLPrimitive::packTEMessage methods from FALSE to true - these seemed to be strange and wrong, especially considering the following statement in LLVOAvatarSelf: `bool success = packTEMessage(mesgsys);`
