### PR TITLE
Convert remaining BOOLs in llxml and introduce std::string_view

### DIFF
--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -765,7 +765,7 @@ std::wstring windows_message<std::wstring>(DWORD error)
     return out.str();
 }
 
-boost::optional<std::wstring> llstring_getoptenv(const std::string& key)
+std::optional<std::wstring> llstring_getoptenv(const std::string& key)
 {
     auto wkey = ll_convert_string_to_wide(key);
     // Take a wild guess as to how big the buffer should be.
@@ -783,8 +783,8 @@ boost::optional<std::wstring> llstring_getoptenv(const std::string& key)
     // did that (ultimately) succeed?
     if (n)
     {
-        // great, return populated boost::optional
-        return boost::optional<std::wstring>(&buffer[0]);
+        // great, return populated std::optional
+        return std::make_optional<std::wstring>(&buffer[0]);
     }
 
     // not successful
@@ -795,7 +795,7 @@ boost::optional<std::wstring> llstring_getoptenv(const std::string& key)
         LL_WARNS() << "GetEnvironmentVariableW('" << key << "') failed: "
                    << windows_message<std::string>(last_error) << LL_ENDL;
     }
-    // return empty boost::optional
+    // return empty std::optional
     return {};
 }
 
@@ -806,12 +806,12 @@ boost::optional<std::string> llstring_getoptenv(const std::string& key)
     auto found = getenv(key.c_str());
     if (found)
     {
-        // return populated boost::optional
-        return boost::optional<std::string>(found);
+        // return populated std::optional
+        return std::make_optional<std::string>(found);
     }
     else
     {
-        // return empty boost::optional
+        // return empty std::optional
         return {};
     }
 }

--- a/indra/llcommon/llstring.h
+++ b/indra/llcommon/llstring.h
@@ -28,8 +28,9 @@
 #define LL_LLSTRING_H
 
 #include <boost/call_traits.hpp>
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <cstdio>
 #include <cwchar>                   // std::wcslen()
 //#include <locale>
@@ -345,7 +346,7 @@ public:
 	 * (key is always UTF-8)
 	 * detect absence by (! return value)
 	 */
-	static boost::optional<string_type> getoptenv(const std::string& key);
+	static std::optional<string_type> getoptenv(const std::string& key);
 
 	static void	addCRLF(string_type& string);
 	static void	removeCRLF(string_type& string);
@@ -819,11 +820,11 @@ STRING windows_message() { return windows_message<STRING>(GetLastError()); }
 
 //@}
 
-LL_COMMON_API boost::optional<std::wstring> llstring_getoptenv(const std::string& key);
+LL_COMMON_API std::optional<std::wstring> llstring_getoptenv(const std::string& key);
 
 #else // ! LL_WINDOWS
 
-LL_COMMON_API boost::optional<std::string>  llstring_getoptenv(const std::string& key);
+LL_COMMON_API std::optional<std::string>  llstring_getoptenv(const std::string& key);
 
 #endif // ! LL_WINDOWS
 
@@ -1773,17 +1774,17 @@ bool LLStringUtilBase<T>::endsWith(
 
 // static
 template<class T>
-auto LLStringUtilBase<T>::getoptenv(const std::string& key) -> boost::optional<string_type>
+auto LLStringUtilBase<T>::getoptenv(const std::string& key) -> std::optional<string_type>
 {
     auto found(llstring_getoptenv(key));
     if (found)
     {
-        // return populated boost::optional
+        // return populated std::optional
         return { ll_convert<string_type>(*found) };
     }
     else
     {
-        // empty boost::optional
+        // empty std::optional
         return {};
     }
 }

--- a/indra/llfilesystem/lldir_win32.cpp
+++ b/indra/llfilesystem/lldir_win32.cpp
@@ -56,7 +56,7 @@ namespace
 
     void prelog(const std::string& message)
     {
-        boost::optional<std::string> prelog_name;
+        std::optional<std::string> prelog_name;
 
         switch (state)
         {

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -219,7 +219,7 @@ LLNotificationForm::LLNotificationForm(const std::string& name, const LLNotifica
 		bool show_notification = true;
 		if (p.ignore.control.isProvided())
 		{
-			mIgnoreSetting = ui_inst->mSettingGroups["config"]->getControl(p.ignore.control);
+			mIgnoreSetting = ui_inst->mSettingGroups["config"]->getControl(p.ignore.control());
 			mInvertSetting = p.ignore.invert_control;
 		}
 		else if (mIgnore > IGNORE_NO)

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -77,19 +77,19 @@ template <> LLSD convert_to_llsd<LLColor4>(const LLColor4& in);
 template <> LLSD convert_to_llsd<LLColor3>(const LLColor3& in);
 template <> LLSD convert_to_llsd<LLColor4U>(const LLColor4U& in);
 
-template <> bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLColor4U convert_from_llsd<LLColor4U>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, const std::string& control_name);
-template <> LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, const std::string& control_name);
+template <> bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLColor4U convert_from_llsd<LLColor4U>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, std::string_view control_name);
+template <> LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, std::string_view control_name);
 
 //this defines the current version of the settings file
 const S32 CURRENT_VERSION = 101;
@@ -218,12 +218,12 @@ void LLControlVariable::setValue(const LLSD& new_value, bool saved_value)
 	
 	LLSD storable_value = getComparableValue(new_value);
 	LLSD original_value = getValue();
-	bool value_changed = llsd_compare(original_value, storable_value) == FALSE;
+	bool value_changed = llsd_compare(original_value, storable_value) == false;
 	if(saved_value)
 	{
     	// If we're going to save this value, return to default but don't fire
 		resetToDefault(false);
-	    if (llsd_compare(mValues.back(), storable_value) == FALSE)
+	    if (llsd_compare(mValues.back(), storable_value) == false)
 	    {
 		    mValues.push_back(storable_value);
 	    }
@@ -233,7 +233,7 @@ void LLControlVariable::setValue(const LLSD& new_value, bool saved_value)
         // This is an unsaved value. Its needs to reside at
         // mValues[2] (or greater). It must not affect 
         // the result of getSaveValue()
-	    if (llsd_compare(mValues.back(), storable_value) == FALSE)
+	    if (llsd_compare(mValues.back(), storable_value) == false)
 	    {
             while(mValues.size() > 2)
             {
@@ -267,7 +267,7 @@ void LLControlVariable::setDefaultValue(const LLSD& value)
 
 	LLSD comparable_value = getComparableValue(value);
 	LLSD original_value = getValue();
-	bool value_changed = (llsd_compare(original_value, comparable_value) == FALSE);
+	bool value_changed = (llsd_compare(original_value, comparable_value) == false);
 	resetToDefault(false);
 	mValues[0] = comparable_value;
 	if(value_changed)
@@ -341,14 +341,14 @@ LLSD LLControlVariable::getSaveValue() const
 	return mValues[0];
 }
 
-LLPointer<LLControlVariable> LLControlGroup::getControl(const std::string& name)
+LLPointer<LLControlVariable> LLControlGroup::getControl(std::string_view name)
 {
 	if (mSettingsProfile)
 	{
 		incrCount(name);
 	}
 
-	ctrl_name_table_t::iterator iter = mNameTable.find(name);
+	ctrl_name_table_t::iterator iter = mNameTable.find(name.data());
 	return iter == mNameTable.end() ? LLPointer<LLControlVariable>() : iter->second;
 }
 
@@ -551,46 +551,46 @@ LLControlVariable* LLControlGroup::declareLLSD(const std::string& name, const LL
 	return declareControl(name, TYPE_LLSD, initial_val, comment, persist);
 }
 
-void LLControlGroup::incrCount(const std::string& name)
+void LLControlGroup::incrCount(std::string_view name)
 {
 	if (0.0 == start_time)
 	{
 		start_time = LLTimer::getTotalSeconds();
 	}
-	getCount[name] = getCount[name].asInteger() + 1;
+	getCount[name.data()] = getCount[name.data()].asInteger() + 1;
 }
 
-bool LLControlGroup::getBOOL(const std::string& name)
+bool LLControlGroup::getBOOL(std::string_view name)
 {
 	return get<bool>(name);
 }
 
-S32 LLControlGroup::getS32(const std::string& name)
+S32 LLControlGroup::getS32(std::string_view name)
 {
 	return get<S32>(name);
 }
 
-U32 LLControlGroup::getU32(const std::string& name)
+U32 LLControlGroup::getU32(std::string_view name)
 {
 	return get<U32>(name);
 }
 
-F32 LLControlGroup::getF32(const std::string& name)
+F32 LLControlGroup::getF32(std::string_view name)
 {
 	return get<F32>(name);
 }
 
-std::string LLControlGroup::getString(const std::string& name)
+std::string LLControlGroup::getString(std::string_view name)
 {
 	return get<std::string>(name);
 }
 
-LLWString LLControlGroup::getWString(const std::string& name)
+LLWString LLControlGroup::getWString(std::string_view name)
 {
 	return get<LLWString>(name);
 }
 
-std::string LLControlGroup::getText(const std::string& name)
+std::string LLControlGroup::getText(std::string_view name)
 {
 	std::string utf8_string = getString(name);
 	LLStringUtil::replaceChar(utf8_string, '^', '\n');
@@ -598,43 +598,43 @@ std::string LLControlGroup::getText(const std::string& name)
 	return (utf8_string);
 }
 
-LLVector3 LLControlGroup::getVector3(const std::string& name)
+LLVector3 LLControlGroup::getVector3(std::string_view name)
 {
 	return get<LLVector3>(name);
 }
 
-LLVector3d LLControlGroup::getVector3d(const std::string& name)
+LLVector3d LLControlGroup::getVector3d(std::string_view name)
 {
 	return get<LLVector3d>(name);
 }
 
-LLQuaternion LLControlGroup::getQuaternion(const std::string& name)
+LLQuaternion LLControlGroup::getQuaternion(std::string_view name)
 {
 	return get<LLQuaternion>(name);
 }
 
-LLRect LLControlGroup::getRect(const std::string& name)
+LLRect LLControlGroup::getRect(std::string_view name)
 {
 	return get<LLRect>(name);
 }
 
 
-LLColor4 LLControlGroup::getColor(const std::string& name)
+LLColor4 LLControlGroup::getColor(std::string_view name)
 {
 	return get<LLColor4>(name);
 }
 
-LLColor4 LLControlGroup::getColor4(const std::string& name)
+LLColor4 LLControlGroup::getColor4(std::string_view name)
 {
 	return get<LLColor4>(name);
 }
 
-LLColor3 LLControlGroup::getColor3(const std::string& name)
+LLColor3 LLControlGroup::getColor3(std::string_view name)
 {
 	return get<LLColor3>(name);
 }
 
-LLSD LLControlGroup::getLLSD(const std::string& name)
+LLSD LLControlGroup::getLLSD(std::string_view name)
 {
 	return get<LLSD>(name);
 }
@@ -668,67 +668,67 @@ bool LLControlGroup::controlExists(const std::string& name)
 // Set functions
 //-------------------------------------------------------------------
 
-void LLControlGroup::setBOOL(const std::string& name, bool val)
+void LLControlGroup::setBOOL(std::string_view name, bool val)
 {
 	set<bool>(name, val);
 }
 
 
-void LLControlGroup::setS32(const std::string& name, S32 val)
+void LLControlGroup::setS32(std::string_view name, S32 val)
 {
 	set(name, val);
 }
 
 
-void LLControlGroup::setF32(const std::string& name, F32 val)
+void LLControlGroup::setF32(std::string_view name, F32 val)
 {
 	set(name, val);
 }
 
 
-void LLControlGroup::setU32(const std::string& name, U32 val)
+void LLControlGroup::setU32(std::string_view name, U32 val)
 {
 	set(name, val);
 }
 
 
-void LLControlGroup::setString(const std::string& name, const std::string &val)
+void LLControlGroup::setString(std::string_view name, const std::string &val)
 {
 	set(name, val);
 }
 
 
-void LLControlGroup::setVector3(const std::string& name, const LLVector3 &val)
+void LLControlGroup::setVector3(std::string_view name, const LLVector3 &val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setVector3d(const std::string& name, const LLVector3d &val)
+void LLControlGroup::setVector3d(std::string_view name, const LLVector3d &val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setQuaternion(const std::string& name, const LLQuaternion &val)
+void LLControlGroup::setQuaternion(std::string_view name, const LLQuaternion &val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setRect(const std::string& name, const LLRect &val)
+void LLControlGroup::setRect(std::string_view name, const LLRect &val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setColor4(const std::string& name, const LLColor4 &val)
+void LLControlGroup::setColor4(std::string_view name, const LLColor4 &val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setLLSD(const std::string& name, const LLSD& val)
+void LLControlGroup::setLLSD(std::string_view name, const LLSD& val)
 {
 	set(name, val);
 }
 
-void LLControlGroup::setUntypedValue(const std::string& name, const LLSD& val)
+void LLControlGroup::setUntypedValue(std::string_view name, const LLSD& val)
 {
 	if (name.empty())
 	{
@@ -1305,19 +1305,19 @@ template <> LLSD convert_to_llsd<LLColor4U>(const LLColor4U& in)
 
 
 template<>
-bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, const std::string& control_name)
+bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_BOOLEAN)
 		return sd.asBoolean();
 	else
 	{
 		CONTROL_ERRS << "Invalid BOOL value for " << control_name << ": " << LLControlGroup::typeEnumToString(type) << " " << sd << LL_ENDL;
-		return FALSE;
+		return false;
 	}
 }
 
 template<>
-S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, const std::string& control_name)
+S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_S32)
 		return sd.asInteger();
@@ -1329,7 +1329,7 @@ S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, const std::string&
 }
 
 template<>
-U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, const std::string& control_name)
+U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_U32)	
 		return sd.asInteger();
@@ -1341,7 +1341,7 @@ U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, const std::string&
 }
 
 template<>
-F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, const std::string& control_name)
+F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_F32)
 		return (F32) sd.asReal();
@@ -1353,7 +1353,7 @@ F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, const std::string&
 }
 
 template<>
-std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, const std::string& control_name)
+std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_STRING)
 		return sd.asString();
@@ -1365,13 +1365,13 @@ std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, co
 }
 
 template<>
-LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	return utf8str_to_wstring(convert_from_llsd<std::string>(sd, type, control_name));
 }
 
 template<>
-LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_VEC3)
 		return (LLVector3)sd;
@@ -1383,7 +1383,7 @@ LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, const 
 }
 
 template<>
-LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_VEC3D)
 		return (LLVector3d)sd;
@@ -1395,7 +1395,7 @@ LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, cons
 }
 
 template<>
-LLQuaternion convert_from_llsd<LLQuaternion>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLQuaternion convert_from_llsd<LLQuaternion>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_QUAT)
 		return (LLQuaternion)sd;
@@ -1407,7 +1407,7 @@ LLQuaternion convert_from_llsd<LLQuaternion>(const LLSD& sd, eControlType type, 
 }
 
 template<>
-LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_RECT)
 		return LLRect(sd);
@@ -1420,7 +1420,7 @@ LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, const std::s
 
 
 template<>
-LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_COL4)
 	{
@@ -1452,7 +1452,7 @@ LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, const st
 }
 
 template<>
-LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	if (type == TYPE_COL3)
 		return sd;
@@ -1464,7 +1464,7 @@ LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, const st
 }
 
 template<>
-LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, const std::string& control_name)
+LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	return sd;
 }

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -144,7 +144,7 @@ public:
 	LLSD getSaveValue() const;
 
 	void set(const LLSD& val)	{ setValue(val); }
-	void setValue(const LLSD& value, bool saved_value = TRUE);
+	void setValue(const LLSD& value, bool saved_value = true);
 	void setDefaultValue(const LLSD& value);
 	void setPersist(ePersist);
 	void setHiddenFromSettingsEditor(bool hide);
@@ -177,7 +177,7 @@ LLSD convert_to_llsd(const T& in)
 }
 
 template <class T>
-T convert_from_llsd(const LLSD& sd, eControlType type, const std::string& control_name)
+T convert_from_llsd(const LLSD& sd, eControlType type, std::string_view control_name)
 {
 	// needs specialization
 	return T(sd);
@@ -201,7 +201,7 @@ public:
 	~LLControlGroup();
 	void cleanup();
 
-	LLControlVariablePtr getControl(const std::string& name);
+	LLControlVariablePtr getControl(std::string_view name);
 
 	struct ApplyFunctor
 	{
@@ -224,28 +224,28 @@ public:
 	LLControlVariable* declareColor3(const std::string& name, const LLColor3 &initial_val, const std::string& comment, LLControlVariable::ePersist persist = LLControlVariable::PERSIST_NONDFT);
 	LLControlVariable* declareLLSD(const std::string& name, const LLSD &initial_val, const std::string& comment, LLControlVariable::ePersist persist = LLControlVariable::PERSIST_NONDFT);
 
-	std::string getString(const std::string& name);
-	std::string getText(const std::string& name);
-	bool		getBOOL(const std::string& name);
-	S32			getS32(const std::string& name);
-	F32			getF32(const std::string& name);
-	U32			getU32(const std::string& name);
+	std::string getString(std::string_view name);
+	std::string getText(std::string_view name);
+	bool		getBOOL(std::string_view name);
+	S32			getS32(std::string_view name);
+	F32			getF32(std::string_view name);
+	U32			getU32(std::string_view name);
 	
-	LLWString	getWString(const std::string& name);
-	LLVector3	getVector3(const std::string& name);
-	LLVector3d	getVector3d(const std::string& name);	
-	LLRect		getRect(const std::string& name);
-	LLSD        getLLSD(const std::string& name);
-	LLQuaternion	getQuaternion(const std::string& name);
+	LLWString	getWString(std::string_view name);
+	LLVector3	getVector3(std::string_view name);
+	LLVector3d	getVector3d(std::string_view name);
+	LLRect		getRect(std::string_view name);
+	LLSD        getLLSD(std::string_view name);
+	LLQuaternion	getQuaternion(std::string_view name);
 
-	LLColor4	getColor(const std::string& name);
-	LLColor4	getColor4(const std::string& name);
-	LLColor3	getColor3(const std::string& name);
+	LLColor4	getColor(std::string_view name);
+	LLColor4	getColor4(std::string_view name);
+	LLColor3	getColor3(std::string_view name);
 
 	LLSD		asLLSD(bool diffs_only);
 	
 	// generic getter
-	template<typename T> T get(const std::string& name)
+	template<typename T> T get(std::string_view name)
 	{
         LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD;
 		LLControlVariable* control = getControl(name);
@@ -265,23 +265,23 @@ public:
 		return convert_from_llsd<T>(value, type, name);
 	}
 
-	void	setBOOL(const std::string& name, bool val);
-	void	setS32(const std::string& name, S32 val);
-	void	setF32(const std::string& name, F32 val);
-	void	setU32(const std::string& name, U32 val);
-	void	setString(const std::string&  name, const std::string& val);
-	void	setVector3(const std::string& name, const LLVector3 &val);
-	void	setVector3d(const std::string& name, const LLVector3d &val);
-	void	setQuaternion(const std::string& name, const LLQuaternion &val);
-	void	setRect(const std::string& name, const LLRect &val);
-	void	setColor4(const std::string& name, const LLColor4 &val);
-	void    setLLSD(const std::string& name, const LLSD& val);
+	void	setBOOL(std::string_view name, bool val);
+	void	setS32(std::string_view name, S32 val);
+	void	setF32(std::string_view name, F32 val);
+	void	setU32(std::string_view name, U32 val);
+	void	setString(std::string_view  name, const std::string& val);
+	void	setVector3(std::string_view name, const LLVector3 &val);
+	void	setVector3d(std::string_view name, const LLVector3d &val);
+	void	setQuaternion(std::string_view name, const LLQuaternion &val);
+	void	setRect(std::string_view name, const LLRect &val);
+	void	setColor4(std::string_view name, const LLColor4 &val);
+	void    setLLSD(std::string_view name, const LLSD& val);
 
 	// type agnostic setter that takes LLSD
-	void	setUntypedValue(const std::string& name, const LLSD& val);
+	void	setUntypedValue(std::string_view name, const LLSD& val);
 
 	// generic setter
-	template<typename T> void set(const std::string& name, const T& val)
+	template<typename T> void set(std::string_view name, const T& val)
 	{
 		LLControlVariable* control = getControl(name);
 	
@@ -304,7 +304,7 @@ public:
  	U32 saveToFile(const std::string& filename, bool nondefault_only);
  	U32	loadFromFile(const std::string& filename, bool default_values = false, bool save_values = true);
 	void	resetToDefaults();
-	void	incrCount(const std::string& name);
+	void	incrCount(std::string_view name);
 
 	bool	mSettingsProfile;
 };
@@ -452,19 +452,19 @@ template <> LLSD convert_to_llsd<LLRect>(const LLRect& in);
 template <> LLSD convert_to_llsd<LLColor4>(const LLColor4& in);
 template <> LLSD convert_to_llsd<LLColor3>(const LLColor3& in);
 
-template<> std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLQuaternion convert_from_llsd<LLQuaternion>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, const std::string& control_name);
-template<> LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, const std::string& control_name);
+template<> std::string convert_from_llsd<std::string>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLWString convert_from_llsd<LLWString>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLVector3 convert_from_llsd<LLVector3>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLVector3d convert_from_llsd<LLVector3d>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLQuaternion convert_from_llsd<LLQuaternion>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLRect convert_from_llsd<LLRect>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> bool convert_from_llsd<bool>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> S32 convert_from_llsd<S32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> F32 convert_from_llsd<F32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> U32 convert_from_llsd<U32>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLColor3 convert_from_llsd<LLColor3>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLColor4 convert_from_llsd<LLColor4>(const LLSD& sd, eControlType type, std::string_view control_name);
+template<> LLSD convert_from_llsd<LLSD>(const LLSD& sd, eControlType type, std::string_view control_name);
 
 //#define TEST_CACHED_CONTROL 1
 #ifdef TEST_CACHED_CONTROL

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2388,7 +2388,7 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
 				&& gSavedSettings.controlExists(file.file_name_setting))
 			{
 				// try to find filename stored in file_name_setting control
-				full_settings_path = gSavedSettings.getString(file.file_name_setting);
+				full_settings_path = gSavedSettings.getString(file.file_name_setting());
 				if (full_settings_path.empty())
 				{
 					continue;

--- a/indra/newview/llfirstuse.cpp
+++ b/indra/newview/llfirstuse.cpp
@@ -169,7 +169,7 @@ bool LLFirstUse::processNotification(const LLSD& notify)
 		if (notification)
 		{
 			// disable any future notifications
-			gWarningSettings.setBOOL(notification->getPayload()["control_var"], false);
+			gWarningSettings.setBOOL((std::string)notification->getPayload()["control_var"], false);
 		}
 	}
 	return false;

--- a/indra/newview/tests/llagentaccess_test.cpp
+++ b/indra/newview/tests/llagentaccess_test.cpp
@@ -55,12 +55,12 @@ LLControlVariable* LLControlGroup::declareU32(const std::string& name, U32 initi
 	return NULL;
 }
 
-void LLControlGroup::setU32(const std::string& name, U32 val)
+void LLControlGroup::setU32(std::string_view name, U32 val)
 {
 	test_preferred_maturity = val;
 }
 
-U32 LLControlGroup::getU32(const std::string& name)
+U32 LLControlGroup::getU32(std::string_view name)
 {
 	return test_preferred_maturity;
 }

--- a/indra/newview/tests/lllogininstance_test.cpp
+++ b/indra/newview/tests/lllogininstance_test.cpp
@@ -198,12 +198,12 @@ LLControlGroup gSavedSettings("Global");
 LLControlGroup::LLControlGroup(const std::string& name) :
 	LLInstanceTracker<LLControlGroup, std::string>(name){}
 LLControlGroup::~LLControlGroup() {}
-void LLControlGroup::setBOOL(const std::string& name, bool val) {}
-bool LLControlGroup::getBOOL(const std::string& name) { return false; }
-F32 LLControlGroup::getF32(const std::string& name) { return 0.0f; }
+void LLControlGroup::setBOOL(std::string_view name, bool val) {}
+bool LLControlGroup::getBOOL(std::string_view name) { return false; }
+F32 LLControlGroup::getF32(std::string_view name) { return 0.0f; }
 U32 LLControlGroup::saveToFile(const std::string& filename, bool nondefault_only) { return 1; }
-void LLControlGroup::setString(const std::string& name, const std::string& val) {}
-std::string LLControlGroup::getString(const std::string& name) { return "test_string"; }
+void LLControlGroup::setString(std::string_view name, const std::string& val) {}
+std::string LLControlGroup::getString(std::string_view name) { return "test_string"; }
 LLControlVariable* LLControlGroup::declareBOOL(const std::string& name, bool initial_val, const std::string& comment, LLControlVariable::ePersist persist) { return NULL; }
 LLControlVariable* LLControlGroup::declareString(const std::string& name, const std::string &initial_val, const std::string& comment, LLControlVariable::ePersist persist) { return NULL; }
 

--- a/indra/newview/tests/llsecapi_test.cpp
+++ b/indra/newview/tests/llsecapi_test.cpp
@@ -43,8 +43,8 @@ LLControlVariable* LLControlGroup::declareString(const std::string& name,
                                    const std::string& initial_val,
                                    const std::string& comment,
                                    LLControlVariable::ePersist persist) {return NULL;}
-void LLControlGroup::setString(const std::string& name, const std::string& val){}
-std::string LLControlGroup::getString(const std::string& name)
+void LLControlGroup::setString(std::string_view name, const std::string& val){}
+std::string LLControlGroup::getString(std::string_view name)
 {
 	return "";
 }

--- a/indra/newview/tests/llsechandler_basic_test.cpp
+++ b/indra/newview/tests/llsechandler_basic_test.cpp
@@ -78,8 +78,8 @@ LLControlVariable* LLControlGroup::declareString(const std::string& name,
                                    const std::string& initial_val,
                                    const std::string& comment,
                                    LLControlVariable::ePersist persist) {return NULL;}
-void LLControlGroup::setString(const std::string& name, const std::string& val){}
-std::string LLControlGroup::getString(const std::string& name)
+void LLControlGroup::setString(std::string_view name, const std::string& val){}
+std::string LLControlGroup::getString(std::string_view name)
 {
 
 	if (name == "FirstName")
@@ -90,7 +90,7 @@ std::string LLControlGroup::getString(const std::string& name)
 }
 
 // Stub for --no-verify-ssl-cert
-bool LLControlGroup::getBOOL(const std::string& name) { return false; }
+bool LLControlGroup::getBOOL(std::string_view name) { return false; }
 
 LLSD LLCredential::getLoginParams()
 {

--- a/indra/newview/tests/llslurl_test.cpp
+++ b/indra/newview/tests/llslurl_test.cpp
@@ -64,14 +64,14 @@ LLControlVariable* LLControlGroup::declareString(const std::string& name,
                                    const std::string& initial_val,
                                    const std::string& comment,
                                    LLControlVariable::ePersist persist) {return NULL;}
-void LLControlGroup::setString(const std::string& name, const std::string& val){}
+void LLControlGroup::setString(std::string_view name, const std::string& val){}
 
 std::string gCmdLineLoginURI;
 std::string gCmdLineGridChoice;
 std::string gCmdLineHelperURI;
 std::string gLoginPage;
 std::string gCurrentGrid;
-std::string LLControlGroup::getString(const std::string& name)
+std::string LLControlGroup::getString(std::string_view name)
 {
 	if (name == "CmdLineGridChoice")
 		return gCmdLineGridChoice;
@@ -84,7 +84,7 @@ std::string LLControlGroup::getString(const std::string& name)
 	return "";
 }
 
-LLSD LLControlGroup::getLLSD(const std::string& name)
+LLSD LLControlGroup::getLLSD(std::string_view name)
 {
 	if (name == "CmdLineLoginURI")
 	{
@@ -96,9 +96,9 @@ LLSD LLControlGroup::getLLSD(const std::string& name)
 	return LLSD();
 }
 
-LLPointer<LLControlVariable> LLControlGroup::getControl(const std::string& name)
+LLPointer<LLControlVariable> LLControlGroup::getControl(std::string_view name)
 {
-	ctrl_name_table_t::iterator iter = mNameTable.find(name);
+	ctrl_name_table_t::iterator iter = mNameTable.find(name.data());
 	return iter == mNameTable.end() ? LLPointer<LLControlVariable>() : iter->second;
 }
 

--- a/indra/newview/tests/llviewerhelputil_test.cpp
+++ b/indra/newview/tests/llviewerhelputil_test.cpp
@@ -53,8 +53,8 @@ LLControlVariable* LLControlGroup::declareString(const std::string& name,
 				   const std::string& initial_val,
 				   const std::string& comment,
 				   LLControlVariable::ePersist persist) {return NULL;}
-void LLControlGroup::setString(const std::string& name, const std::string& val){}
-std::string LLControlGroup::getString(const std::string& name)
+void LLControlGroup::setString(std::string_view name, const std::string& val){}
+std::string LLControlGroup::getString(std::string_view name)
 {
 	if (name == "HelpURLFormat")
 		return gHelpURL;

--- a/indra/newview/tests/llviewernetwork_test.cpp
+++ b/indra/newview/tests/llviewernetwork_test.cpp
@@ -73,14 +73,14 @@ LLControlVariable* LLControlGroup::declareString(const std::string& name,
                                    const std::string& initial_val,
                                    const std::string& comment,
                                    LLControlVariable::ePersist persist) {return NULL;}
-void LLControlGroup::setString(const std::string& name, const std::string& val){}
+void LLControlGroup::setString(std::string_view name, const std::string& val){}
 
 std::string gCmdLineLoginURI;
 std::string gCmdLineGridChoice;
 std::string gCmdLineHelperURI;
 std::string gLoginPage;
 std::string gCurrentGrid;
-std::string LLControlGroup::getString(const std::string& name)
+std::string LLControlGroup::getString(std::string_view name)
 {
 	if (name == "CmdLineGridChoice")
 		return gCmdLineGridChoice;
@@ -93,7 +93,7 @@ std::string LLControlGroup::getString(const std::string& name)
 	return "";
 }
 
-LLSD LLControlGroup::getLLSD(const std::string& name)
+LLSD LLControlGroup::getLLSD(std::string_view name)
 {
 	if (name == "CmdLineLoginURI")
 	{
@@ -105,9 +105,9 @@ LLSD LLControlGroup::getLLSD(const std::string& name)
 	return LLSD();
 }
 
-LLPointer<LLControlVariable> LLControlGroup::getControl(const std::string& name)
+LLPointer<LLControlVariable> LLControlGroup::getControl(std::string_view name)
 {
-	ctrl_name_table_t::iterator iter = mNameTable.find(name);
+	ctrl_name_table_t::iterator iter = mNameTable.find(name.data());
 	return iter == mNameTable.end() ? LLPointer<LLControlVariable>() : iter->second;
 }
 

--- a/indra/newview/tests/llworldmipmap_test.cpp
+++ b/indra/newview/tests/llworldmipmap_test.cpp
@@ -48,7 +48,7 @@ LLViewerFetchedTexture* LLViewerTextureManager::getFetchedTextureFromUrl(const s
 
 LLControlGroup::LLControlGroup(const std::string& name) : LLInstanceTracker<LLControlGroup, std::string>(name) { }
 LLControlGroup::~LLControlGroup() { }
-std::string LLControlGroup::getString(const std::string& ) { return std::string("test_url"); }
+std::string LLControlGroup::getString(std::string_view) { return std::string("test_url"); }
 LLControlGroup gSavedSettings("test_settings");
 
 // End Stubbing


### PR DESCRIPTION
For some reason, there were some stray FALSE/TRUE left in llxml. Used the opportunity to also introduce std::string_view to the viewer and make use of it for the viewer settings.