### PR TITLE
newer enum for modal OK response

### DIFF
--- a/indra/newview/llfilepicker_mac.mm
+++ b/indra/newview/llfilepicker_mac.mm
@@ -121,7 +121,7 @@ void doLoadDialogModeless(const std::vector<std::string>* allowed_types,
         [panel beginWithCompletionHandler:^(NSModalResponse result)
         {
             std::vector<std::string> outfiles;
-            if (result == NSOKButton)
+            if (result == NSModalResponseOK)
             {
                 NSArray *filesToOpen = [panel URLs];
                 int i, count = [filesToOpen count];


### PR DESCRIPTION
`NSOKButton` is deprecated in favour of `NSModalResponseOK` - no functionality changed.