### PR TITLE
[DO NOT MERGE] Remove BOOL/TRUE/FALSE definitions

### DIFF
--- a/indra/llcommon/llpointer.h
+++ b/indra/llcommon/llpointer.h
@@ -83,7 +83,6 @@ public:
 	const Type&	operator*() const				{ return *mPointer; }
 	Type&	operator*()							{ return *mPointer; }
 
-	operator BOOL()  const						{ return (mPointer != NULL); }
 	operator bool()  const						{ return (mPointer != NULL); }
 	bool operator!() const						{ return (mPointer == NULL); }
 	bool isNull() const							{ return (mPointer == NULL); }
@@ -203,7 +202,6 @@ public:
 	const Type*	operator->() const				{ return mPointer; }
 	const Type&	operator*() const				{ return *mPointer; }
 
-	operator BOOL()  const						{ return (mPointer != NULL); }
 	operator bool()  const						{ return (mPointer != NULL); }
 	bool operator!() const						{ return (mPointer == NULL); }
 	bool isNull() const							{ return (mPointer == NULL); }

--- a/indra/llcommon/llsafehandle.h
+++ b/indra/llcommon/llsafehandle.h
@@ -101,7 +101,6 @@ public:
 	//const Type&	operator*() const			{ return *nonNull(mPointer); }
 	//Type&	operator*()							{ return *nonNull(mPointer); }
 
-	operator BOOL()  const						{ return mPointer != NULL; }
 	operator bool()  const						{ return mPointer != NULL; }
 	bool operator!() const						{ return mPointer == NULL; }
 	bool isNull() const							{ return mPointer == NULL; }

--- a/indra/llcommon/stdtypes.h
+++ b/indra/llcommon/stdtypes.h
@@ -80,7 +80,6 @@ typedef long long unsigned int		U64;
 typedef float				F32;
 typedef double				F64;
 
-typedef S32				BOOL;
 typedef U8				KEY;
 typedef U32				MASK;
 typedef U32				TPACKETID;
@@ -104,14 +103,6 @@ typedef U32				TPACKETID;
 #define F32_MIN		(FLT_MIN)
 #define F64_MIN		(DBL_MIN)
 
-
-#ifndef TRUE
-#define TRUE			(1)
-#endif
-
-#ifndef FALSE
-#define FALSE			(0)
-#endif
 
 #ifndef NULL
 #define NULL			(0)


### PR DESCRIPTION
This is more of a way to start a discussion about either removing the definitions for the fake booleans or finding a way to prevent them being sprinkled into the codebase especially by merging releases that are in queue before this maintenance release.

The easiest way to prevent this from happening would be to remove the definitions as suggested in this PR. However, one case of BOOL is used in LLPathingLib being part of the llphysicsextensionsstub 3p library - the viewer builds successfully after manually injecting the BOOL definition into the header it is used. So it would have to be updated and rebuilt. But this also might mean there is the risk of the actual Havok lib being affected as well, which would then mean to also provide an updated version to TPVs.

If the definitions should remain for now, what can be done to prevent further usage of them?

@marchcat @larsnaesbye @nat-goodspeed what are your thoughts/ideas on this?