### PR TITLE
Lua listen_events(), await_event() => get_event_pumps(), get_event_next().

### DIFF
--- a/indra/cmake/run_build_test.py
+++ b/indra/cmake/run_build_test.py
@@ -122,19 +122,17 @@ def main(command, arguments=[], libpath=[], vars={}):
     # Make sure we see all relevant output *before* child-process output.
     sys.stdout.flush()
     try:
-        return subprocess.call(command_list)
-    except OSError as err:
+        return subprocess.run(command_list).returncode
+    except FileNotFoundError as err:
         # If the caller is trying to execute a test program that doesn't
         # exist, we want to produce a reasonable error message rather than a
         # traceback. This happens when the build is halted by errors, but
         # CMake tries to proceed with testing anyway <eyeroll/>. However, do
         # NOT attempt to handle any error but "doesn't exist."
-        if err.errno != errno.ENOENT:
-            raise
         # In practice, the pathnames into CMake's build tree are so long as to
         # obscure the name of the test program. Just log its basename.
-        log.warn("No such program %s; check for preceding build errors" % \
-                 os.path.basename(command[0]))
+        log.warning("No such program %s; check for preceding build errors" %
+                    os.path.basename(command[0]))
         # What rc should we simulate for missing executable? Windows produces
         # 9009.
         return 9009

--- a/indra/llcommon/llevents.cpp
+++ b/indra/llcommon/llevents.cpp
@@ -43,6 +43,7 @@
 #include <typeinfo>
 #include <cmath>
 #include <cctype>
+#include <iomanip>                  // std::quoted
 // external library headers
 #include <boost/range/iterator_range.hpp>
 #if LL_WINDOWS

--- a/indra/llcommon/llevents.cpp
+++ b/indra/llcommon/llevents.cpp
@@ -189,8 +189,13 @@ bool LLEventPumps::post(const std::string&name, const LLSD&message)
     PumpMap::iterator found = mPumpMap.find(name);
 
     if (found == mPumpMap.end())
+    {
+        LL_DEBUGS("LLEventPumps") << "LLEventPump(" << std::quoted(name) << ") not found"
+                                  << LL_ENDL;
         return false;
+    }
 
+//  LL_DEBUGS("LLEventPumps") << "posting to " << name << ": " << message << LL_ENDL;
     return (*found).second->post(message);
 }
 
@@ -405,7 +410,7 @@ LLBoundListener LLEventPump::listen_impl(const std::string& name, const LLEventL
 {
     if (!mSignal)
     {
-        LL_WARNS() << "Can't connect listener" << LL_ENDL;
+        LL_WARNS("LLEventPump") << "Can't connect listener" << LL_ENDL;
         // connect will fail, return dummy
         return LLBoundListener();
     }

--- a/indra/llcommon/llleaplistener.cpp
+++ b/indra/llcommon/llleaplistener.cpp
@@ -16,7 +16,6 @@
 // STL headers
 #include <algorithm>                // std::find_if
 #include <functional>
-#include <iomanip>                  // std::quoted
 #include <map>
 #include <set>
 // std headers

--- a/indra/llcommon/llleaplistener.h
+++ b/indra/llcommon/llleaplistener.h
@@ -13,10 +13,9 @@
 #define LL_LLLEAPLISTENER_H
 
 #include "lleventapi.h"
+#include <functional>
 #include <map>
 #include <string>
-#include <boost/function.hpp>
-#include <boost/ptr_container/ptr_map.hpp>
 
 /// Listener class implementing LLLeap query/control operations.
 /// See https://jira.lindenlab.com/jira/browse/DEV-31978.
@@ -24,17 +23,15 @@ class LLLeapListener: public LLEventAPI
 {
 public:
     /**
-     * Decouple LLLeap by dependency injection. Certain LLLeapListener
-     * operations must be able to cause LLLeap to listen on a specified
-     * LLEventPump with the LLLeap listener that wraps incoming events in an
-     * outer (pump=, data=) map and forwards them to the plugin. Very well,
-     * define the signature for a function that will perform that, and make
-     * our constructor accept such a function.
+     * Certain LLLeapListener operations listen on a specified LLEventPump.
+     * Accept a bool(pump, data) callback from our caller for when any such
+     * event is received.
      */
-    typedef boost::function<LLBoundListener(LLEventPump&, const std::string& listener)>
-            ConnectFunc;
-    LLLeapListener(const ConnectFunc& connect);
+    using Callback = std::function<bool(const std::string& pump, const LLSD& data)>;
+    LLLeapListener(const std::string_view& caller, const Callback& callback);
     ~LLLeapListener();
+
+    LLEventPump& getReplyPump() { return mReplyPump; }
 
     static LLSD getFeatures();
 
@@ -48,10 +45,16 @@ private:
     void getFeatures(const LLSD&) const;
     void getFeature(const LLSD&) const;
 
+    LLBoundListener connect(LLEventPump& pump, const std::string& listener);
     void saveListener(const std::string& pump_name, const std::string& listener_name,
                       const LLBoundListener& listener);
 
-    ConnectFunc mConnect;
+    // The relative order of these next declarations is important because the
+    // constructor will initialize in this order.
+    std::string mCaller;
+    Callback mCallback;
+    LLEventStream mReplyPump;
+    LLTempBoundListener mReplyConn;
 
     // In theory, listen() could simply call the relevant LLEventPump's
     // listen() method, stoplistening() likewise. Lifespan issues make us

--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -16,6 +16,7 @@
 // STL headers
 // std headers
 #include <algorithm>
+#include <iomanip>                  // std::quoted
 #include <map>
 #include <memory>                   // std::unique_ptr
 // external library headers
@@ -92,7 +93,6 @@ LLSD lua_tollsd(lua_State* L, int index)
 {
     LL_DEBUGS("Lua") << "lua_tollsd(" << index << ") of " << lua_gettop(L) << " stack entries: "
                      << lua_what(L, index) << LL_ENDL;
-    DebugExit log_exit("lua_tollsd()");
     switch (lua_type(L, index))
     {
     case LUA_TNONE:
@@ -784,12 +784,4 @@ std::ostream& operator<<(std::ostream& out, const lua_stack& self)
     }
     out << ']';
     return out;
-}
-
-/*****************************************************************************
-*   DebugExit
-*****************************************************************************/
-DebugExit::~DebugExit()
-{
-    LL_DEBUGS("Lua") << "exit " << mName << LL_ENDL;
 }

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -213,16 +213,4 @@ private:
     lua_State* L;
 };
 
-// log exit from any block declaring an instance of DebugExit, regardless of
-// how control leaves that block
-struct DebugExit
-{
-    DebugExit(const std::string& name): mName(name) {}
-    DebugExit(const DebugExit&) = delete;
-    DebugExit& operator=(const DebugExit&) = delete;
-    ~DebugExit();
-
-    std::string mName;
-};
-
 #endif /* ! defined(LL_LUA_FUNCTION_H) */

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -24,20 +24,23 @@
 #include "llleaplistener.h"
 #include "lua_function.h"
 
-LuaListener::LuaListener(lua_State* L):
-    super(getUniqueKey()),
-    mListener(
-        new LLLeapListener(
-            [L](LLEventPump& pump, const std::string& listener)
-            { return connect(L, pump, listener); }))
+const int MAX_QSIZE = 1000;
+
+std::ostream& operator<<(std::ostream& out, const LuaListener& self)
 {
-    mReplyConnection = connect(L, mReplyPump, "LuaListener");
+    return out << "LuaListener(" << self.getReplyName() << ", " << self.getCommandName() << ")";
 }
 
+LuaListener::LuaListener(lua_State* L):
+    super(getUniqueKey()),
+    mListener(new LLLeapListener(
+        "LuaListener",
+        [this](const std::string& pump, const LLSD& data)
+        { return queueEvent(pump, data); }))
+{}
+
 LuaListener::~LuaListener()
-{
-    LL_DEBUGS("Lua") << "~LuaListener('" << mReplyPump.getName() << "')" << LL_ENDL;
-}
+{}
 
 int LuaListener::getUniqueKey()
 {
@@ -54,50 +57,35 @@ int LuaListener::getUniqueKey()
     return key;
 }
 
-LLBoundListener LuaListener::connect(lua_State* L, LLEventPump& pump, const std::string& listener)
+std::string LuaListener::getReplyName() const
 {
-    return pump.listen(
-        listener,
-        [L, pumpname=pump.getName()](const LLSD& data)
-        { return call_lua(L, pumpname, data); });
-}
-
-bool LuaListener::call_lua(lua_State* L, const std::string& pump, const LLSD& data)
-{
-    LL_INFOS("Lua") << "LuaListener::call_lua('" << pump << "', " << data << ")" << LL_ENDL;
-    if (! lua_checkstack(L, 3))
-    {
-        LL_WARNS("Lua") << "Cannot extend Lua stack to call listen_events() callback"
-                        << LL_ENDL;
-        return false;
-    }
-    // push the registered Lua callback function stored in our registry as
-    // "event.function"
-    lua_getfield(L, LUA_REGISTRYINDEX, "event.function");
-    llassert(lua_isfunction(L, -1));
-    // pass pump name
-    lua_pushstdstring(L, pump);
-    // then the data blob
-    lua_pushllsd(L, data);
-    // call the registered Lua listener function; allow it to return bool;
-    // no message handler
-    auto status = lua_pcall(L, 2, 1, 0);
-    bool result{ false };
-    if (status != LUA_OK)
-    {
-        LL_WARNS("Lua") << "Error in listen_events() callback: "
-                        << lua_tostdstring(L, -1) << LL_ENDL;
-    }
-    else
-    {
-        result = lua_toboolean(L, -1);
-    }
-    // discard either the error message or the bool return value
-    lua_pop(L, 1);
-    return result;
+    return mListener->getReplyPump().getName();
 }
 
 std::string LuaListener::getCommandName() const
 {
     return mListener->getPumpName();
+}
+
+bool LuaListener::queueEvent(const std::string& pump, const LLSD& data)
+{
+    // Our Lua script might be stalled, or just fail to retrieve events. Don't
+    // grow this queue indefinitely. But don't set MAX_QSIZE as the queue
+    // capacity or we'd block the post() call trying to propagate this event!
+    if (auto size = mQueue.size(); size > MAX_QSIZE)
+    {
+        LL_WARNS("Lua") << "LuaListener queue for " << getReplyName()
+                        << " exceeds " << MAX_QSIZE << ": " << size
+                        << " -- discarding event" << LL_ENDL;
+    }
+    else
+    {
+        mQueue.push(decltype(mQueue)::value_type(pump, data));
+    }
+    return false;
+}
+
+LuaListener::PumpData LuaListener::getNext()
+{
+    return mQueue.pop();
 }

--- a/indra/llcommon/lualistener.h
+++ b/indra/llcommon/lualistener.h
@@ -14,7 +14,10 @@
 
 #include "llevents.h"
 #include "llinstancetracker.h"
+#include "llsd.h"
+#include "llthreadsafequeue.h"
 #include "lluuid.h"
+#include <iosfwd>
 #include <memory>                   // std::unique_ptr
 
 #ifdef LL_TEST
@@ -31,7 +34,6 @@ class LLLeapListener;
  * inconvenience malicious Lua scripts wanting to mess with others. The idea
  * is that a given lua_State stores in its Registry:
  * - "event.listener": the int key of the corresponding LuaListener, if any
- * - "event.function": the Lua function to be called with incoming events
  * The original thought was that LuaListener would itself store the Lua
  * function -- but surprisingly, there is no C/C++ type in the API that stores
  * a Lua function.
@@ -55,22 +57,25 @@ public:
 
     ~LuaListener();
 
-    std::string getReplyName() const { return mReplyPump.getName(); }
+    std::string getReplyName() const;
     std::string getCommandName() const;
+
+    /**
+     * LuaListener enqueues reply events from its LLLeapListener on mQueue.
+     * Call getNext() to retrieve the next such event. Blocks the calling
+     * coroutine if the queue is empty.
+     */
+    using PumpData = std::pair<std::string, LLSD>;
+    PumpData getNext();
+
+    friend std::ostream& operator<<(std::ostream& out, const LuaListener& self);
 
 private:
     static int getUniqueKey();
+    bool queueEvent(const std::string& pump, const LLSD& data);
 
-    static LLBoundListener connect(lua_State* L, LLEventPump& pump, const std::string& listener);
+    LLThreadSafeQueue<PumpData> mQueue;
 
-    static bool call_lua(lua_State* L, const std::string& pump, const LLSD& data);
-
-#ifndef LL_TEST
-    LLEventStream mReplyPump{ LLUUID::generateNewID().asString() };
-#else
-    LLEventLogProxyFor<LLEventStream> mReplyPump{ "luapump", false };
-#endif
-    LLTempBoundListener mReplyConnection;
     std::unique_ptr<LLLeapListener> mListener;
 };
 

--- a/indra/llcommon/lualistener.h
+++ b/indra/llcommon/lualistener.h
@@ -12,17 +12,13 @@
 #if ! defined(LL_LUALISTENER_H)
 #define LL_LUALISTENER_H
 
-#include "llevents.h"
 #include "llinstancetracker.h"
 #include "llsd.h"
 #include "llthreadsafequeue.h"
-#include "lluuid.h"
-#include <iosfwd>
+#include <iosfwd>                   // std::ostream
 #include <memory>                   // std::unique_ptr
-
-#ifdef LL_TEST
-#include "lleventfilter.h"
-#endif
+#include <string>
+#include <utility>                  // std::pair
 
 struct lua_State;
 class LLLeapListener;

--- a/indra/llcommon/tests/lleventcoro_test.cpp
+++ b/indra/llcommon/tests/lleventcoro_test.cpp
@@ -113,7 +113,7 @@ namespace tut
 
     void test_data::explicit_wait(boost::shared_ptr<LLCoros::Promise<std::string>>& cbp)
     {
-        BEGIN
+        DEBUGIN
         {
             mSync.bump();
             // The point of this test is to verify / illustrate suspending a
@@ -136,7 +136,7 @@ namespace tut
             mSync.bump();
             ensure_equals("Got it", stringdata, "received");
         }
-        END
+        DEBUGEND
     }
 
     template<> template<>
@@ -163,13 +163,13 @@ namespace tut
 
     void test_data::waitForEventOn1()
     {
-        BEGIN
+        DEBUGIN
         {
             mSync.bump();
             result = suspendUntilEventOn("source");
             mSync.bump();
         }
-        END
+        DEBUGEND
     }
 
     template<> template<>
@@ -189,7 +189,7 @@ namespace tut
 
     void test_data::coroPump()
     {
-        BEGIN
+        DEBUGIN
         {
             mSync.bump();
             LLCoroEventPump waiter;
@@ -197,7 +197,7 @@ namespace tut
             result = waiter.suspend();
             mSync.bump();
         }
-        END
+        DEBUGEND
     }
 
     template<> template<>
@@ -217,7 +217,7 @@ namespace tut
 
     void test_data::postAndWait1()
     {
-        BEGIN
+        DEBUGIN
         {
             mSync.bump();
             result = postAndSuspend(LLSDMap("value", 17),       // request event
@@ -226,7 +226,7 @@ namespace tut
                                  "reply");                   // request["reply"] = name
             mSync.bump();
         }
-        END
+        DEBUGEND
     }
 
     template<> template<>
@@ -240,7 +240,7 @@ namespace tut
 
     void test_data::coroPumpPost()
     {
-        BEGIN
+        DEBUGIN
         {
             mSync.bump();
             LLCoroEventPump waiter;
@@ -248,7 +248,7 @@ namespace tut
                                         immediateAPI.getPump(), "reply");
             mSync.bump();
         }
-        END
+        DEBUGEND
     }
 
     template<> template<>

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -166,52 +166,31 @@ lua_function(post_on, "post_on(pumpname, data): post specified data to specified
     return 0;
 }
 
-lua_function(listen_events,
-             "listen_events(callback): call callback(pumpname, data) with events received\n"
-             "on this Lua chunk's replypump.\n"
-             "Returns replypump, commandpump: names of LLEventPumps specific to this chunk.")
+lua_function(get_event_pumps,
+             "get_event_pumps():\n"
+             "Returns replypump, commandpump: names of LLEventPumps specific to this chunk.\n"
+             "Events posted to replypump are queued for get_event_next().\n"
+             "post_on(commandpump, ...) to engage LLEventAPI operations (see helpleap()).")
 {
-    if (! lua_isfunction(L, 1))
-    {
-        luaL_typeerror(L, 1, "function");
-        return 0;
-    }
     luaL_checkstack(L, 2, nullptr);
-
-/*==========================================================================*|
-    // Get the lua_State* for the main thread of this state, in case we were
-    // called from a coroutine thread. We're going to make callbacks into Lua
-    // code, and we want to do it on the main thread rather than a (possibly
-    // suspended) coroutine thread.
-    // Registry table is at pseudo-index LUA_REGISTRYINDEX
-    // Main thread is at registry key LUA_RIDX_MAINTHREAD
-    auto regtype {lua_rawgeti(L, LUA_REGISTRYINDEX, LUA_RIDX_MAINTHREAD)};
-    // Not finding the main thread at the documented place isn't a user error,
-    // it's a Problem
-    llassert_always(regtype == LUA_TTHREAD);
-    lua_State* mainthread{ lua_tothread(L, -1) };
-    // pop the main thread
-    lua_pop(L, 1);
-|*==========================================================================*/
-    // Luau is based on Lua 5.1, and Lua 5.1 apparently provides no way to get
-    // back to the main thread from a coroutine thread?
-    lua_State* mainthread{ L };
-
-    auto listener{ LuaState::obtainListener(mainthread) };
-
-    // Now that we've found or created our LuaListener, store the passed Lua
-    // function as the callback. Beware: our caller passed the function on L's
-    // stack, but we want to store it on the mainthread registry.
-    if (L != mainthread)
-    {
-        // push 1 value (the Lua function) from L's stack to mainthread's
-        lua_xmove(L, mainthread, 1);
-    }
-    lua_setfield(mainthread, LUA_REGISTRYINDEX, "event.function");
-
+    auto listener{ LuaState::obtainListener(L) };
     // return the reply pump name and the command pump name on caller's lua_State
     lua_pushstdstring(L, listener->getReplyName());
     lua_pushstdstring(L, listener->getCommandName());
+    return 2;
+}
+
+lua_function(get_event_next,
+             "get_event_next():\n"
+             "Returns the next (pumpname, data) pair from the replypump whose name\n"
+             "is returned by get_event_pumps(). Blocks the calling chunk until an\n"
+             "event becomes available.")
+{
+    luaL_checkstack(L, 2, nullptr);
+    auto listener{ LuaState::obtainListener(L) };
+    const auto& [pump, data]{ listener->getNext() };
+    lua_pushstdstring(L, pump);
+    lua_pushllsd(L, data);
     return 2;
 }
 
@@ -343,7 +322,7 @@ void LLLUAmanager::runScriptLine(LuaState& L, const std::string& chunk, script_r
     if (shortchunk.length() > shortlen)
         shortchunk = stringize(shortchunk.substr(0, shortlen), "...");
 
-    std::string desc{ stringize("runScriptLine('", shortchunk, "')") };
+    std::string desc{ stringize("lua: ", shortchunk) };
     LLCoros::instance().launch(desc, [&L, desc, chunk, cb]()
     {
         auto [count, result] = L.expr(desc, chunk);

--- a/indra/test/debug.h
+++ b/indra/test/debug.h
@@ -30,6 +30,7 @@
 #define LL_DEBUG_H
 
 #include "print.h"
+#include "stringize.h"
 
 /*****************************************************************************
 *   Debugging stuff
@@ -52,8 +53,9 @@
 class Debug
 {
 public:
-    Debug(const std::string& block):
-        mBlock(block),
+    template <typename... ARGS>
+    Debug(ARGS&&... args):
+        mBlock(stringize(std::forward<ARGS>(args)...)),
         mLOGTEST(getenv("LOGTEST")),
         // debug output enabled when LOGTEST is set AND non-empty
         mEnabled(mLOGTEST && *mLOGTEST)

--- a/indra/test/debug.h
+++ b/indra/test/debug.h
@@ -90,15 +90,15 @@ private:
 // of the Debug block.
 #define DEBUG Debug debug(LL_PRETTY_FUNCTION)
 
-// These BEGIN/END macros are specifically for debugging output -- please
-// don't assume you must use such for coroutines in general! They only help to
-// make control flow (as well as exception exits) explicit.
-#define BEGIN                                   \
+// These DEBUGIN/DEBUGEND macros are specifically for debugging output --
+// please don't assume you must use such for coroutines in general! They only
+// help to make control flow (as well as exception exits) explicit.
+#define DEBUGIN                                 \
 {                                               \
     DEBUG;                                      \
     try
 
-#define END                                     \
+#define DEBUGEND                                \
     catch (...)                                 \
     {                                           \
         debug("*** exceptional ");              \

--- a/indra/test/lltut.h
+++ b/indra/test/lltut.h
@@ -31,6 +31,8 @@
 
 #include "is_approx_equal_fraction.h" // instead of llmath.h
 #include <cstring>
+#include <string>
+#include <vector>
 
 class LLDate;
 class LLSD;

--- a/indra/test/print.h
+++ b/indra/test/print.h
@@ -23,7 +23,9 @@ struct NONL_t {};
 inline
 void print()
 {
+#ifdef LL_TEST
     std::cerr << std::endl;
+#endif
 }
 
 // print(NONL) is a no-op
@@ -35,8 +37,10 @@ void print(NONL_t)
 template <typename T, typename... ARGS>
 void print(T&& first, ARGS&&... rest)
 {
+#ifdef LL_TEST
     std::cerr << first;
     print(std::forward<ARGS>(rest)...);
+#endif
 }
 
 #endif /* ! defined(LL_PRINT_H) */


### PR DESCRIPTION
Don't set up a Lua callback to receive incoming events, a la listen_events().
Don't listen on an arbitrary event pump, a la await_event().

Instead, the new get_event_pumps() entry point simply delivers the reply pump
and command pump names (as listen_events() did) without storing a Lua
callback.

Make LuaListener capture incoming events on the reply pump in a queue. This
avoids the problem of multiple events arriving too quickly for the Lua script
to retrieve. If the queue gets too big, discard the excess instead of blocking
the caller of post().

Then the new get_event_next() entry point retrieves the next (pump, data) pair
from the queue, blocking the Lua script until a suitable event arrives. This
is closer to the use of stdin for a LEAP plugin. It also addresses the
question: what should the Lua script's C++ coroutine do while waiting for an
incoming reply pump event?

Recast llluamanager_test.cpp for this new, more straightforward API.

Move LLLeap's and LuaListener's reply LLEventPump into LLLeapListener, which
they both use. This simplifies LLLeapListener's API, which was a little
convoluted: the caller supplied a connect callback to allow LLLeapListener to
connect some listener to the caller's reply pump. Now, instead, the caller
simply passes a bool(pumpname, data) callback to receive events incoming on
LLLeapListener's own reply pump.

Fix a latent bug in LLLeapListener: if a plugin called listen() more than once
with the same listener name, the new connection would not have been saved.

While at it, replace some older Boost features in LLLeapListener and LLLeap.