### PR TITLE
Fix for deferred avatar eyes shader failing to link on Intel GPU

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/avatarEyesV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarEyesV.glsl
@@ -26,6 +26,7 @@
 uniform mat3 normal_matrix;
 uniform mat4 texture_matrix0;
 uniform mat4 modelview_projection_matrix;
+uniform mat4 modelview_matrix;
 
 in vec3 position;
 in vec3 normal;
@@ -35,10 +36,12 @@ in vec2 texcoord0;
 out vec3 vary_normal;
 out vec4 vertex_color;
 out vec2 vary_texcoord0;
+out vec3 vary_position;
 
 void main()
 {
 	//transform vertex
+	vary_position = (modelview_matrix * vec4(position.xyz, 1.0)).xyz;
 	gl_Position = modelview_projection_matrix * vec4(position.xyz, 1.0); 
 	vary_texcoord0 = (texture_matrix0 * vec4(texcoord0,0,1)).xy;
 	


### PR DESCRIPTION
vary_position was being read by the diffuseF.glsl shader for mirror clipping, but had not been written by the vertex shader