### PR TITLE
Issue#884 Crash on ~LLSearchEditor

### DIFF
--- a/indra/llui/llsearcheditor.cpp
+++ b/indra/llui/llsearcheditor.cpp
@@ -104,6 +104,13 @@ LLSearchEditor::LLSearchEditor(const LLSearchEditor::Params& p)
 	}
 }
 
+LLSearchEditor::~LLSearchEditor()
+{
+    mKeystrokeCallback = NULL;
+    mTextChangedCallback = NULL;
+    setCommitOnFocusLost(false);
+}
+
 //virtual
 void LLSearchEditor::draw()
 {

--- a/indra/llui/llsearcheditor.h
+++ b/indra/llui/llsearcheditor.h
@@ -74,7 +74,7 @@ protected:
 	friend class LLUICtrlFactory;
 
 public:
-	virtual ~LLSearchEditor() {}
+	virtual ~LLSearchEditor();
 
 	/*virtual*/ void	draw();
 

--- a/indra/newview/llfloaterimsessiontab.cpp
+++ b/indra/newview/llfloaterimsessiontab.cpp
@@ -470,7 +470,6 @@ void LLFloaterIMSessionTab::appendMessage(const LLChat& chat, const LLSD &args)
 	{
 		im_box->setTimeNow(mSessionID,chat.mFromID);
 	}
-	
 
 	LLChat& tmp_chat = const_cast<LLChat&>(chat);
 

--- a/indra/newview/llpanelgrouproles.cpp
+++ b/indra/newview/llpanelgrouproles.cpp
@@ -437,6 +437,7 @@ LLPanelGroupSubTab::LLPanelGroupSubTab()
 
 LLPanelGroupSubTab::~LLPanelGroupSubTab()
 {
+    mSearchCommitConnection.disconnect();
 }
 
 bool LLPanelGroupSubTab::postBuildSubTab(LLView* root) 
@@ -469,7 +470,8 @@ bool LLPanelGroupSubTab::postBuild()
 	mSearchEditor = findChild<LLFilterEditor>("filter_input", recurse);
 	if (mSearchEditor) // SubTab doesn't implement this, only some of derived classes
 	{
-		mSearchEditor->setCommitCallback(boost::bind(&LLPanelGroupSubTab::setSearchFilter, this, _2));
+        // panel 
+        mSearchCommitConnection = mSearchEditor->setCommitCallback(boost::bind(&LLPanelGroupSubTab::setSearchFilter, this, _2));
 	}
 
 	return LLPanelGroupTab::postBuild();

--- a/indra/newview/llpanelgrouproles.h
+++ b/indra/newview/llpanelgrouproles.h
@@ -136,6 +136,7 @@ protected:
 	LLPanel* mFooter;
 
 	LLFilterEditor*	mSearchEditor;
+    boost::signals2::connection mSearchCommitConnection;
 
 	std::string mSearchFilter;
 

--- a/indra/newview/llpanelpeople.cpp
+++ b/indra/newview/llpanelpeople.cpp
@@ -577,6 +577,11 @@ LLPanelPeople::~LLPanelPeople()
 	delete mFriendListUpdater;
 	delete mRecentListUpdater;
 
+    mNearbyFilterCommitConnection.disconnect();
+    mFriedsFilterCommitConnection.disconnect();
+    mGroupsFilterCommitConnection.disconnect();
+    mRecentFilterCommitConnection.disconnect();
+
 	if(LLVoiceClient::instanceExists())
 	{
 		LLVoiceClient::getInstance()->removeObserver(this);
@@ -613,10 +618,10 @@ bool LLPanelPeople::postBuild()
 {
 	S32 max_premium = LLAgentBenefitsMgr::get("Premium").getGroupMembershipLimit();
 
-	getChild<LLFilterEditor>("nearby_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
-	getChild<LLFilterEditor>("friends_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
-	getChild<LLFilterEditor>("groups_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
-	getChild<LLFilterEditor>("recent_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
+    mNearbyFilterCommitConnection = getChild<LLFilterEditor>("nearby_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
+    mFriedsFilterCommitConnection = getChild<LLFilterEditor>("friends_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
+    mGroupsFilterCommitConnection = getChild<LLFilterEditor>("groups_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
+    mRecentFilterCommitConnection = getChild<LLFilterEditor>("recent_filter_input")->setCommitCallback(boost::bind(&LLPanelPeople::onFilterEdit, this, _2));
 
 	if(LLAgentBenefitsMgr::current().getGroupMembershipLimit() < max_premium)
 	{

--- a/indra/newview/llpanelpeople.h
+++ b/indra/newview/llpanelpeople.h
@@ -147,6 +147,11 @@ private:
 	Updater*				mRecentListUpdater;
 	Updater*				mButtonsUpdater;
     LLHandle< LLFloater >	mPicker;
+
+    boost::signals2::connection mNearbyFilterCommitConnection;
+    boost::signals2::connection mFriedsFilterCommitConnection;
+    boost::signals2::connection mGroupsFilterCommitConnection;
+    boost::signals2::connection mRecentFilterCommitConnection;
 };
 
 #endif //LL_LLPANELPEOPLE_H


### PR DESCRIPTION
Crash seems to be specific to LLFilterEditor and only in a couple specific floaters. Based on older calltacks, commiting on exit was crashing. So I'm making sure that panels that potentially do not own the element in question clean the callback in case panels get deleted before the search editor.