### PR TITLE
Generate release notes from tag `release` to the built tag.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -382,7 +382,7 @@ jobs:
             ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
-          target_commitish: ${{ github.ref }}
+          target_commitish: ${{ github.ref_name }}
           append_body: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -369,20 +369,21 @@ jobs:
       # forked from softprops/action-gh-release
       - name: Create GitHub release
         id: release
-        uses: secondlife-3p/action-gh-release@v1
+        uses: secondlife-3p/action-gh-release@feat/add-generateReleaseNotes
         with:
           # name the release page for the branch
           name: "${{ needs.build.outputs.viewer_branch }}"
           # SL-20546: want the channel and version to be visible on the
           # release page
           body: |
-            Build ${{ github.repositoryUrl }}/actions/runs/${{ github.run_id }}
+            Build ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             ${{ needs.build.outputs.viewer_channel }}
             ${{ needs.build.outputs.viewer_version }}
             ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
           target_commitish: ${{ github.sha }}
+          previous_tag: 7.1.2-release
           append_body: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -383,7 +383,7 @@ jobs:
           prerelease: true
           generate_release_notes: true
           target_commitish: ${{ github.sha }}
-          previous_tag: 7.1.2-release
+          previous_tag: release
           append_body: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -367,25 +367,30 @@ jobs:
           mv newview/viewer_version.txt macOS-viewer_version.txt
 
       # forked from softprops/action-gh-release
-      - uses: secondlife-3p/action-gh-release@v1
+      - name: Create GitHub release
+        id: release
+        uses: secondlife-3p/action-gh-release@v1
         with:
-          # name the release page for the build number so we can find it
-          # easily (analogous to looking up a codeticket build page)
-          name: "v${{ github.run_id }}"
+          # name the release page for the branch
+          name: "${{ needs.build.outputs.viewer_branch }}"
           # SL-20546: want the channel and version to be visible on the
           # release page
           body: |
+            Build ${{ github.repositoryUrl }}/actions/runs/${{ github.run_id }}
             ${{ needs.build.outputs.viewer_channel }}
             ${{ needs.build.outputs.viewer_version }}
-            ${{ needs.build.outputs.viewer_branch }}
             ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
+          target_commitish: ${{ github.ref }}
           append_body: true
-          # the only reason we generate a GH release is to post build products
           fail_on_unmatched_files: true
           files: |
             *.dmg 
             *.exe
             *-autobuild-package.xml
             *-viewer_version.txt
+
+      - name: post release URL
+        run: |
+          echo "::notice::Release ${{ steps.release.outputs.url }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -382,7 +382,7 @@ jobs:
             ${{ needs.build.outputs.relnotes }}
           prerelease: true
           generate_release_notes: true
-          target_commitish: ${{ github.ref_name }}
+          target_commitish: ${{ github.sha }}
           append_body: true
           fail_on_unmatched_files: true
           files: |


### PR DESCRIPTION
Explicitly specify both `target_commitish` and `previous_tag` inputs to the GitHub release-notes generator. Unless they're both explicitly passed, action-gh-release guesses wrong about the range of commits to consider for release notes generation.

This change uses the new action-gh-release feature `previous_tag` (secondlife-3p/action-gh-release#2). Once that PR is merged, we can revert to referencing `secondlife-3p/action-gh-release@v1`.

This behavior also depends on maintaining a new viewer tag `release` to track the most recent release, updating it every time we promote a new default download viewer.

Also add cross-links between the build page and the corresponding release page.

relnotes:
This text should be copied to the release page.

It should include everything after the `relnotes:` line.