### PR TITLE
BUG-234595/Jira-public-Issue#11494 Mac texture loading/unloading

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -905,10 +905,6 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     min_scale = llmax(min_scale*min_scale, 0.1f);
 
                     vsize /= min_scale;
-
-#if LL_DARWIN
-                    vsize /= 1.f + LLViewerTexture::sDesiredDiscardBias*(1.f+face->getDrawable()->mDistanceWRTCamera*bias_distance_scale);
-#else
                     vsize /= LLViewerTexture::sDesiredDiscardBias;
                     vsize /= llmax(1.f, (LLViewerTexture::sDesiredDiscardBias-1.f) * (1.f + face->getDrawable()->mDistanceWRTCamera * bias_distance_scale));
 
@@ -919,7 +915,6 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     { // further reduce by discard bias when off screen or occluded
                         vsize /= LLViewerTexture::sDesiredDiscardBias;
                     }
-#endif
                     // if a GLTF material is present, ignore that face
                     // as far as this texture stats go, but update the GLTF material 
                     // stats


### PR DESCRIPTION
This removes the "special case" for Mac which was resulting in values a few orders of magnitude smaller than on windows.

My guess is that the MacOS case was written/tested on HiDpi which allows the values to be close enough to Windows/Linux that the effect is not noticed (hence it only affects some Mac users). However, the fact that there was ever a "special" handler makes me wonder if by removing it I am reverting a previous issue that was not clear from the commit history. 

TL;DR This works, tested by Intel and ARM Mac users who had seen the issue. No side effects have been identified so far.
