### PR TITLE
triage#86 Use Emoji font in LineEditor by default

### DIFF
--- a/indra/llcommon/llinitparam.h
+++ b/indra/llcommon/llinitparam.h
@@ -2798,6 +2798,11 @@ namespace LLInitParam
 
 	protected:
 
+		const value_t& getRawValue() const
+		{
+			return mValue;
+		}
+
 		// use this from within updateValueFromBlock() to set the value without making it authoritative
 		void updateValue(const value_t& value)
 		{

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -1037,6 +1037,13 @@ LLFontGL* LLFontGL::getFontEmoji()
 }
 
 //static
+LLFontGL* LLFontGL::getFontEmojiSmall()
+{
+    static LLFontGL* fontp = getFont(LLFontDescriptor("Emoji", "Small", 0));
+    return fontp;;
+}
+
+//static
 LLFontGL* LLFontGL::getFontEmojiHuge()
 {
 	static LLFontGL* fontp = getFont(LLFontDescriptor("Emoji", "Huge", 0));

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -195,6 +195,7 @@ public:
 	static void setFontDisplay(BOOL flag) { sDisplayFont = flag; }
 		
 	static LLFontGL* getFontEmoji();
+	static LLFontGL* getFontEmojiSmall();
 	static LLFontGL* getFontEmojiHuge();
 	static LLFontGL* getFontMonospace();
 	static LLFontGL* getFontSansSerifSmall();

--- a/indra/llui/llui.cpp
+++ b/indra/llui/llui.cpp
@@ -592,11 +592,13 @@ namespace LLInitParam
 	
 	void ParamValue<const LLFontGL*>::updateBlockFromValue(bool make_block_authoritative)
 	{
-		if (getValue())
+		// It is important to use getRawValue() instead of getValue() here
+		// because getValue() calls validateBlock() and updateValueFromBlock()
+		if (getRawValue())
 		{
-			name.set(LLFontGL::nameFromFont(getValue()), make_block_authoritative);
-			size.set(LLFontGL::sizeFromFont(getValue()), make_block_authoritative);
-			style.set(LLFontGL::getStringFromStyle(getValue()->getFontDesc().getStyle()), make_block_authoritative);
+			name.set(LLFontGL::nameFromFont(getRawValue()), make_block_authoritative);
+			size.set(LLFontGL::sizeFromFont(getRawValue()), make_block_authoritative);
+			style.set(LLFontGL::getStringFromStyle(getRawValue()->getFontDesc().getStyle()), make_block_authoritative);
 		}
 	}
 

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -80,7 +80,7 @@ LLUICtrl::Params::Params()
 	mouseenter_callback("mouseenter_callback"),
 	mouseleave_callback("mouseleave_callback"),
 	control_name("control_name"),
-	font("font", LLFontGL::getFontSansSerif()),
+	font("font", LLFontGL::getFontEmojiSmall()),
 	font_halign("halign"),
 	font_valign("valign"),
 	length("length"), 	// ignore LLXMLNode cruft

--- a/indra/newview/skins/default/xui/en/widgets/line_editor.xml
+++ b/indra/newview/skins/default/xui/en/widgets/line_editor.xml
@@ -14,6 +14,5 @@
 			 highlight_color="EmphasisColor"
 			 preedit_bg_color="White"
              mouse_opaque="true"
-             name="line_editor"
-             font="SansSerifSmall">
+             name="line_editor">
 </line_editor>


### PR DESCRIPTION
We can replace font SansSerif with Emoji for the whole UI
The difference between these fonts is only glyphs for emojis

Using SansSerifSmall in LineEditor:
![image](https://github.com/secondlife/viewer/assets/124201357/53497c8c-f32f-4abd-b28b-c4a87d2493d8)

Using EmojiSmall in LineEditor:
![image](https://github.com/secondlife/viewer/assets/124201357/69121f05-e172-405d-a00d-a8e9f9364126)
