### PR TITLE
 Refactor `require()` to make it easier to reason about Lua stack usage.

### DIFF
--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -789,7 +789,8 @@ std::ostream& operator<<(std::ostream& out, const lua_what& self)
 *****************************************************************************/
 std::ostream& operator<<(std::ostream& out, const lua_stack& self)
 {
-    const char* sep = "stack: [";
+    out << "stack: [";
+    const char* sep = "";
     for (int index = 1; index <= lua_gettop(self.L); ++index)
     {
         out << sep << lua_what(self.L, index);

--- a/indra/llcommon/tests/lleventcoro_test.cpp
+++ b/indra/llcommon/tests/lleventcoro_test.cpp
@@ -113,30 +113,27 @@ namespace tut
 
     void test_data::explicit_wait(boost::shared_ptr<LLCoros::Promise<std::string>>& cbp)
     {
-        DEBUGIN
-        {
-            mSync.bump();
-            // The point of this test is to verify / illustrate suspending a
-            // coroutine for something other than an LLEventPump. In other
-            // words, this shows how to adapt to any async operation that
-            // provides a callback-style notification (and prove that it
-            // works).
+        DEBUG;
+        mSync.bump();
+        // The point of this test is to verify / illustrate suspending a
+        // coroutine for something other than an LLEventPump. In other
+        // words, this shows how to adapt to any async operation that
+        // provides a callback-style notification (and prove that it
+        // works).
 
-            // Perhaps we would send a request to a remote server and arrange
-            // for cbp->set_value() to be called on response.
-            // For test purposes, instead of handing 'callback' (or an
-            // adapter) off to some I/O subsystem, we'll just pass it back to
-            // our caller.
-            cbp = boost::make_shared<LLCoros::Promise<std::string>>();
-            LLCoros::Future<std::string> future = LLCoros::getFuture(*cbp);
+        // Perhaps we would send a request to a remote server and arrange
+        // for cbp->set_value() to be called on response.
+        // For test purposes, instead of handing 'callback' (or an
+        // adapter) off to some I/O subsystem, we'll just pass it back to
+        // our caller.
+        cbp = boost::make_shared<LLCoros::Promise<std::string>>();
+        LLCoros::Future<std::string> future = LLCoros::getFuture(*cbp);
 
-            // calling get() on the future causes us to suspend
-            debug("about to suspend");
-            stringdata = future.get();
-            mSync.bump();
-            ensure_equals("Got it", stringdata, "received");
-        }
-        DEBUGEND
+        // calling get() on the future causes us to suspend
+        debug("about to suspend");
+        stringdata = future.get();
+        mSync.bump();
+        ensure_equals("Got it", stringdata, "received");
     }
 
     template<> template<>
@@ -163,13 +160,9 @@ namespace tut
 
     void test_data::waitForEventOn1()
     {
-        DEBUGIN
-        {
-            mSync.bump();
-            result = suspendUntilEventOn("source");
-            mSync.bump();
-        }
-        DEBUGEND
+        mSync.bump();
+        result = suspendUntilEventOn("source");
+        mSync.bump();
     }
 
     template<> template<>
@@ -189,15 +182,11 @@ namespace tut
 
     void test_data::coroPump()
     {
-        DEBUGIN
-        {
-            mSync.bump();
-            LLCoroEventPump waiter;
-            replyName = waiter.getName();
-            result = waiter.suspend();
-            mSync.bump();
-        }
-        DEBUGEND
+        mSync.bump();
+        LLCoroEventPump waiter;
+        replyName = waiter.getName();
+        result = waiter.suspend();
+        mSync.bump();
     }
 
     template<> template<>
@@ -217,16 +206,12 @@ namespace tut
 
     void test_data::postAndWait1()
     {
-        DEBUGIN
-        {
-            mSync.bump();
-            result = postAndSuspend(LLSDMap("value", 17),       // request event
-                                 immediateAPI.getPump(),     // requestPump
-                                 "reply1",                   // replyPump
-                                 "reply");                   // request["reply"] = name
-            mSync.bump();
-        }
-        DEBUGEND
+        mSync.bump();
+        result = postAndSuspend(LLSDMap("value", 17),       // request event
+                                immediateAPI.getPump(),     // requestPump
+                                "reply1",                   // replyPump
+                                "reply");                   // request["reply"] = name
+        mSync.bump();
     }
 
     template<> template<>
@@ -240,15 +225,11 @@ namespace tut
 
     void test_data::coroPumpPost()
     {
-        DEBUGIN
-        {
-            mSync.bump();
-            LLCoroEventPump waiter;
-            result = waiter.postAndSuspend(LLSDMap("value", 17),
-                                        immediateAPI.getPump(), "reply");
-            mSync.bump();
-        }
-        DEBUGEND
+        mSync.bump();
+        LLCoroEventPump waiter;
+        result = waiter.postAndSuspend(LLSDMap("value", 17),
+                                       immediateAPI.getPump(), "reply");
+        mSync.bump();
     }
 
     template<> template<>

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -463,7 +463,7 @@ bool LLRequireResolver::findModuleImpl(const std::string& absolutePath)
     for (const auto& suffixedPath : possibleSuffixedPaths)
     {
          // Check _MODULES cache for module
-        lua_getfield(L, -1, suffixedPath.c_str());
+        lua_getfield(L, -1, suffixedPath.data());
         if (!lua_isnil(L, -1))
         {
             return true;
@@ -485,7 +485,7 @@ bool LLRequireResolver::findModuleImpl(const std::string& absolutePath)
             // duplicate the new module: _MODULES newmodule newmodule
             lua_pushvalue(L, -1);
             // store _MODULES[found path] = newmodule
-            lua_setfield(L, -3, source.data());
+            lua_setfield(L, -3, suffixedPath.data());
 
             return true;
         }

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -87,24 +87,7 @@ public:
 class LLRequireResolver
 {
  public:
-    enum class ModuleStatus
-    {
-        Cached,
-        FileRead,
-        NotFound
-    };
-
-    struct ResolvedRequire
-    {
-        ModuleStatus status;
-        std::string absolutePath;
-        std::string sourceCode;
-    };
-
-    [[nodiscard]] ResolvedRequire static resolveRequire(lua_State *L, std::string path);
-
-    std::string mAbsolutePath;
-    std::string mSourceCode;
+    static void resolveRequire(lua_State *L, std::string path);
 
  private:
     std::string mPathToResolve;
@@ -112,10 +95,10 @@ class LLRequireResolver
 
     LLRequireResolver(lua_State *L, const std::string& path);
 
-    ModuleStatus findModule();
+    void findModule();
     lua_State *L;
 
-    void resolveAndStoreDefaultPaths();
-    ModuleStatus findModuleImpl();
+    bool findModuleImpl(const std::string& absolutePath);
+    void runModule(const std::string& desc, const std::string& code);
 };
 #endif

--- a/indra/newview/scripts/lua/Queue.lua
+++ b/indra/newview/scripts/lua/Queue.lua
@@ -1,0 +1,40 @@
+-- from https://create.roblox.com/docs/luau/queues#implementing-queues
+
+local Queue = {}
+Queue.__index = Queue
+
+function Queue.new()
+	local self = setmetatable({}, Queue)
+
+	self._first = 0
+	self._last = -1
+	self._queue = {}
+
+	return self
+end
+
+-- Check if the queue is empty
+function Queue:IsEmpty()
+	return self._first > self._last
+end
+
+-- Add a value to the queue
+function Queue:Enqueue(value)
+	local last = self._last + 1
+	self._last = last
+	self._queue[last] = value
+end
+
+-- Remove a value from the queue
+function Queue:Dequeue()
+	local first = self._first
+	if self:IsEmpty() then
+		return nil
+	end
+	local value = self._queue[first]
+	self._queue[first] = nil
+	self._first = first + 1
+	return value
+end
+
+return Queue

--- a/indra/newview/scripts/lua/testmod.lua
+++ b/indra/newview/scripts/lua/testmod.lua
@@ -1,0 +1,2 @@
+print('scripts/lua/testmod.lua')
+return function () return 'hello from scripts/lua/testmod.lua' end

--- a/indra/newview/scripts/lua/testmod.lua
+++ b/indra/newview/scripts/lua/testmod.lua
@@ -1,2 +1,2 @@
-print('scripts/lua/testmod.lua')
+print('loaded scripts/lua/testmod.lua')
 return function () return 'hello from scripts/lua/testmod.lua' end

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -166,6 +166,9 @@ class ViewerManifest(LLManifest):
                         self.path("*/*/*/*.js")
                         self.path("*/*/*.html")
 
+            with self.prefix(src_dst="scripts/lua"):
+                self.path("*.lua")
+
             #build_data.json.  Standard with exception handling is fine.  If we can't open a new file for writing, we have worse problems
             #platform is computed above with other arg parsing
             build_data_dict = {"Type":"viewer","Version":'.'.join(self.args['version']),

--- a/indra/test/debug.h
+++ b/indra/test/debug.h
@@ -31,6 +31,7 @@
 
 #include "print.h"
 #include "stringize.h"
+#include <exception>                // std::uncaught_exceptions()
 
 /*****************************************************************************
 *   Debugging stuff
@@ -65,10 +66,12 @@ public:
 
     // non-copyable
     Debug(const Debug&) = delete;
+    Debug& operator=(const Debug&) = delete;
 
     ~Debug()
     {
-        (*this)("exit");
+        auto exceptional{ std::uncaught_exceptions()? "exceptional " : "" };
+        (*this)(exceptional, "exit");
     }
 
     template <typename... ARGS>
@@ -89,21 +92,5 @@ private:
 // It's often convenient to use the name of the enclosing function as the name
 // of the Debug block.
 #define DEBUG Debug debug(LL_PRETTY_FUNCTION)
-
-// These DEBUGIN/DEBUGEND macros are specifically for debugging output --
-// please don't assume you must use such for coroutines in general! They only
-// help to make control flow (as well as exception exits) explicit.
-#define DEBUGIN                                 \
-{                                               \
-    DEBUG;                                      \
-    try
-
-#define DEBUGEND                                \
-    catch (...)                                 \
-    {                                           \
-        debug("*** exceptional ");              \
-        throw;                                  \
-    }                                           \
-}
 
 #endif /* ! defined(LL_DEBUG_H) */


### PR DESCRIPTION
Push throwing Lua errors down into `LLRequireResolver::findModule()` and
`findModuleImpl()` so their callers don't have to handle the error case. That
eliminates `finishrequire()`.

`require()` itself now only retrieves (and pops) the passed module name and
calls `LLRequireResolver::resolveRequire()` to do the actual work.

`resolveRequire()` is now `void`. It only instantiates `LLRequireResolver` and calls
its `findModule()` method.

`findModule()` is now also `void`. It's guaranteed to either push the loaded Lua
module or throw a Lua error. In particular, when `findModuleImpl()` cannot find
the specified module, `findModule()` throws an error. That replaces
`ModuleStatus::NotFound`.

Since `std::filesystem::path::append()` aka `operator/()` detects when its right
operand is absolute and, in that case, discards the left operand, we no longer
need `resolveAndStoreDefaultPaths()`: we can just invoke that operation inline.

When `findModule()` pushes `_MODULES` on the Lua stack, it uses `LuaRemover` (below)
to ensure that `_MODULES` is removed again no matter how `findModules()` exits.

`findModuleImpl()` now accepts the candidate pathname as its argument. That
eliminates `mAbsolutePath`.

`findModuleImpl()` now returns only `bool`: `true` means the module was found and
loaded and pushed on the Lua stack, `false` means not found and nothing was
pushed; no return means an error was reported.

Push running a newly found module's source file down into `findModuleImpl()`.
That eliminates the distinction between `Cached` and `FileRead`, which obviates
`ModuleStatus`: a `true` return means either "previously cached" or "we read it,
compiled it, loaded it and ran it." That also eliminates the need to store the
module's textual content in `mSourceCode`.

Similarly, once loading the module succeeds, `findModuleImpl()` caches it in
`_MODULES` right away. That eliminates `ResolvedRequire` since we need not pass
the full pathname of the found module (or its contents) back up through the
call chain.

Move `require()` code that runs the new module into private `runModule()`method,
called by `findModuleImpl()` in the not-cached case. `runModule()` is the only
remaining method that can push either a string error message or the desired
module, because of its funny stack manipulations. That means the check for a
string error message on the stack top can move down to `findModuleImpl()`.

Add `LuaRemover` class to ensure that on exit from some particular C++ block,
the specified Lua stack entry will definitely be removed. This is different
from `LuaPopper` in that it engages `lua_remove()` rather than `lua_pop()`.

Also ditch obsolete `await_event()` Lua entry point.