### PR TITLE
Strongly attenuate the blue hue seen on shiny materials

### DIFF
--- a/indra/llmath/v3color.h
+++ b/indra/llmath/v3color.h
@@ -77,6 +77,17 @@ public:
 
 	void setHSL(F32 hue, F32 saturation, F32 luminance);
 	void calcHSL(F32* hue, F32* saturation, F32* luminance) const;
+
+    // Desaturates the color by a given factor, also optionnally darkens it. HB
+    inline void desaturate(F32 factor, F32 darkening = 1.f)
+    {
+        if (factor > 1.f)
+        {
+            F32 h, s, l;
+            calcHSL(&h, &s, &l);
+            setHSL(h, s / factor, l / llmax(darkening, 1.f));
+        }
+    }
 	
 	const LLColor3&	setToBlack();					// Clears LLColor3 to (0, 0, 0)
 	const LLColor3&	setToWhite();					// Zero LLColor3 to (0, 0, 0)

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10744,6 +10744,29 @@
     <key>Value</key>
     <real>0.7</real>
   </map>
+
+  <key>RenderSkyReflectionDarkening</key>
+    <map>
+    <key>Comment</key>
+    <string>Darkening factor for the colors fed to the reflection probes shaders to attenuate the blue hue. 1 or less to disable.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>1.5</real>
+    </map>
+  <key>RenderSkyReflectionDesaturation</key>
+    <map>
+    <key>Comment</key>
+    <string>Desaturation factor for the colors fed to the reflection probes shaders to attenuate the blue hue. 1 or less to disable.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>F32</string>
+    <key>Value</key>
+    <real>2</real>
+    </map>
   
   <key>RenderReflectionProbeMaxLocalLightAmbiance</key>
   <map>

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -742,6 +742,8 @@ void LLSettingsVOSky::applySpecial(void *ptarget, bool force)
     static LLCachedControl<F32> auto_adjust_probe_ambiance(gSavedSettings, "RenderSkyAutoAdjustProbeAmbiance", 1.f);
     static LLCachedControl<F32> sunlight_scale(gSavedSettings, "RenderSkySunlightScale", 1.5f);
     static LLCachedControl<F32> ambient_scale(gSavedSettings, "RenderSkyAmbientScale", 1.5f);
+    static LLCachedControl<F32> desaturation(gSavedSettings, "RenderSkyReflectionDesaturation", 2.f);
+    static LLCachedControl<F32> darkening(gSavedSettings, "RenderSkyReflectionDarkening", 1.5f);
 
     shader->uniform1f(LLShaderMgr::SKY_SUNLIGHT_SCALE, sunlight_scale);
     shader->uniform1f(LLShaderMgr::SKY_AMBIENT_SCALE, ambient_scale);
@@ -766,6 +768,13 @@ void LLSettingsVOSky::applySpecial(void *ptarget, bool force)
             shader->uniform1f(LLShaderMgr::SKY_HDR_SCALE, auto_adjust_hdr_scale);
             LLColor3 blue_horizon = getBlueHorizon() * auto_adjust_blue_horizon_scale;
             LLColor3 blue_density = getBlueDensity() * auto_adjust_blue_density_scale;
+            if (gCubeSnapshot)
+            {
+                // Attenuate the blue hue if this is a reflection probe render
+                // pass. HB
+                blue_density.desaturate(desaturation, darkening);
+                blue_horizon.desaturate(desaturation, darkening);
+            }
             LLColor3 sun_diffuse = getSunDiffuse() * auto_adjust_sun_color_scale;
             
             shader->uniform3fv(LLShaderMgr::SUNLIGHT_COLOR, sun_diffuse.mV);


### PR DESCRIPTION
This a proposal for a workaround to attenuate the "ugly blue hue" badly impacting shiny materials (PBR and legacy alike) when they are not shielded from the sky by a reflection probe (meaning all shinies all over SL for now, since very few places only started the conversion to PBR and reflection probes).

It got the immense advantage of not needing to touch the existing environment settings (which won't suffice anyway to remove the blue hue, short of making the sky render grey).

The "strength" of this workaround can be adjusted via two new debug settings: "RenderSkyReflectionDesaturation" and "RenderSkyReflectionDarkening". They both affect the "blue horizon" and "blue density" colors as passed to shaders when rendering the reflections irradiance maps. "RenderSkyReflectionDesaturation" desaturates the colors (the higher the setting, the more desaturated; setting this to 1.0 or lower disables entirely the workaround), while "RenderSkyReflectionDarkening" darkens them. With the default values (2.0 and 1.5 respectively), I get acceptable/tolerable shinies in sky boxes or on sky platforms not shielded from the sky with a reflection probe, while not impacting too much outdoors mirror-like PBR materials which are reflecting the sky.

Note that this also improves a lot the water bodies color, making them appear less "sky-blue" and therefore more realistic.