### PR TITLE
triage#86 Use Emoji font in LineEditor by default

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -1030,7 +1030,21 @@ LLFontGL::VAlign LLFontGL::vAlignFromName(const std::string& name)
 }
 
 //static
-LLFontGL* LLFontGL::getFontEmoji()
+LLFontGL* LLFontGL::getFontEmojiSmall()
+{
+	static LLFontGL* fontp = getFont(LLFontDescriptor("Emoji", "Small", 0));
+	return fontp;;
+}
+
+//static
+LLFontGL* LLFontGL::getFontEmojiMedium()
+{
+	static LLFontGL* fontp = getFont(LLFontDescriptor("Emoji", "Medium", 0));
+	return fontp;;
+}
+
+//static
+LLFontGL* LLFontGL::getFontEmojiLarge()
 {
 	static LLFontGL* fontp = getFont(LLFontDescriptor("Emoji", "Large", 0));
 	return fontp;;

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -193,8 +193,10 @@ public:
 	static LLFontGL::VAlign vAlignFromName(const std::string& name);
 
 	static void setFontDisplay(BOOL flag) { sDisplayFont = flag; }
-		
-	static LLFontGL* getFontEmoji();
+
+	static LLFontGL* getFontEmojiSmall();
+	static LLFontGL* getFontEmojiMedium();
+	static LLFontGL* getFontEmojiLarge();
 	static LLFontGL* getFontEmojiHuge();
 	static LLFontGL* getFontMonospace();
 	static LLFontGL* getFontSansSerifSmall();

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -96,7 +96,7 @@ LLLineEditor::Params::Params()
 	commit_on_focus_lost("commit_on_focus_lost", true),
 	ignore_tab("ignore_tab", true),
 	is_password("is_password", false),
-	allow_emoji("allow_emoji"),
+	allow_emoji("allow_emoji", true),
 	cursor_color("cursor_color"),
 	use_bg_color("use_bg_color", false),
 	bg_color("bg_color"),

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -915,7 +915,7 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
 				if (!emoji_style)
 				{
 					emoji_style = new LLStyle(getStyleParams());
-					emoji_style->setFont(LLFontGL::getFontEmoji());
+					emoji_style->setFont(LLFontGL::getFontEmojiLarge());
 				}
 
 				S32 new_seg_start = pos + text_kitty;

--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -685,7 +685,7 @@ void LLTextEditor::insertEmoji(llwchar emoji)
 {
 	LL_INFOS() << "LLTextEditor::insertEmoji(" << wchar_utf8_preview(emoji) << ")" << LL_ENDL;
 	auto styleParams = LLStyle::Params();
-	styleParams.font = LLFontGL::getFontEmoji();
+	styleParams.font = LLFontGL::getFontEmojiLarge();
 	auto segment = new LLEmojiTextSegment(new LLStyle(styleParams), mCursorPos, mCursorPos + 1, *this);
 	insert(mCursorPos, LLWString(1, emoji), false, segment);
 	setCursorPos(mCursorPos + 1);

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -80,7 +80,7 @@ LLUICtrl::Params::Params()
 	mouseenter_callback("mouseenter_callback"),
 	mouseleave_callback("mouseleave_callback"),
 	control_name("control_name"),
-	font("font", LLFontGL::getFontSansSerif()),
+	font("font", LLFontGL::getFontEmojiMedium()),
 	font_halign("halign"),
 	font_valign("valign"),
 	length("length"), 	// ignore LLXMLNode cruft

--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -138,7 +138,7 @@ public:
 
         F32 x = getRect().getWidth() / 2;
         F32 y = getRect().getHeight() / 2;
-        LLFontGL::getFontEmoji()->render(
+        LLFontGL::getFontEmojiLarge()->render(
             mText,                      // wstr
             0,                          // begin_offset
             x,                          // x
@@ -229,7 +229,7 @@ protected:
     {
         F32 x0 = x;
         F32 x1 = max_pixels;
-        LLFontGL* font = LLFontGL::getFontEmoji();
+        LLFontGL* font = LLFontGL::getFontEmojiLarge();
         if (mBegin)
         {
             std::string text = mTitle.substr(0, mBegin);
@@ -423,7 +423,7 @@ void LLFloaterEmojiPicker::fillGroups()
     mGroupButtons.clear();
 
     LLButton::Params params;
-    params.font = LLFontGL::getFontEmoji();
+    params.font = LLFontGL::getFontEmojiLarge();
 
     LLRect rect;
     rect.mTop = mGroups->getRect().getHeight();

--- a/indra/newview/skins/default/xui/en/widgets/line_editor.xml
+++ b/indra/newview/skins/default/xui/en/widgets/line_editor.xml
@@ -15,5 +15,5 @@
 			 preedit_bg_color="White"
              mouse_opaque="true"
              name="line_editor"
-             font="SansSerifSmall">
+             font="EmojiSmall">
 </line_editor>


### PR DESCRIPTION
`getFontEmoji()` is renamed to `getFontEmojiLarge()`
`getFontEmojiSmall()` and `getFontEmojiMedium()` are added
`getFontEmojiMedium()` is used as default instead of `getFontSansSerif()` for LLUICtrl
"EmojiSmall" is used instead of "SansSerifSmall" for LLLineEditor
`allow_emogi` is set to `true` by default for LLLineEditor