### PR TITLE
SL-20429 Fix emoji categories having mixed translations

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -474,9 +474,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>7ac35da9b1b5c9a05954edeef3fe8e54</string>
+              <string>52c41a4547d2d9aceb4a9a1e9e1680c71e5ffa79</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
               <key>url</key>
-              <string>https://automated-builds-secondlife-com.s3.amazonaws.com/ct2/113242/980233/emoji_shortcodes-6.1.0.579438-darwin64-579438.tar.bz2</string>
+              <string>https://github.com/secondlife/3p-emoji-shortcodes/releases/download/v6.1.0.5413f58/emoji_shortcodes-6.1.0.5413f58-darwin64-5413f58.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -486,16 +488,18 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>087ce7e6d93dcd88b477b10d8e1ab259</string>
+              <string>3137e06d376767a631bc9626832d558c4d5e5aa9</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
               <key>url</key>
-              <string>https://automated-builds-secondlife-com.s3.amazonaws.com/ct2/113243/980244/emoji_shortcodes-6.1.0.579438-windows64-579438.tar.bz2</string>
+              <string>https://github.com/secondlife/3p-emoji-shortcodes/releases/download/v6.1.0.5413f58/emoji_shortcodes-6.1.0.5413f58-windows64-5413f58.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
           </map>
         </map>
         <key>version</key>
-        <string>6.1.0.579438</string>
+        <string>6.1.0.5413f58</string>
       </map>
       <key>expat</key>
       <map>

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1617,6 +1617,8 @@ set(viewer_APPSETTINGS_FILES
     app_settings/anim.ini
     app_settings/cmd_line.xml
     app_settings/commands.xml
+    app_settings/emoji_groups.xml
+    app_settings/foldertypes.xml
     app_settings/grass.xml
     app_settings/ignorable_dialogs.xml
     app_settings/key_bindings.xml

--- a/indra/newview/skins/default/xui/da/emoji_categories.xml
+++ b/indra/newview/skins/default/xui/da/emoji_categories.xml
@@ -5,13 +5,13 @@
       <key>Name</key>
       <string>smileys and emotion</string>
       <key>Category</key>
-      <string>smileys and følelser</string>
+      <string>smileys &amp; følelser</string>
     </map>
     <map>
       <key>Name</key>
       <string>people and body</string>
       <key>Category</key>
-      <string>mennesker and krop</string>
+      <string>mennesker &amp; krop</string>
     </map>
     <map>
       <key>Name</key>
@@ -23,19 +23,19 @@
       <key>Name</key>
       <string>animals and nature</string>
       <key>Category</key>
-      <string>dyr and natur</string>
+      <string>dyr &amp; natur</string>
     </map>
     <map>
       <key>Name</key>
       <string>food and drink</string>
       <key>Category</key>
-      <string>mad and drikke</string>
+      <string>mad &amp; drikke</string>
     </map>
     <map>
       <key>Name</key>
       <string>travel and places</string>
       <key>Category</key>
-      <string>rejser and steder</string>
+      <string>rejser &amp; steder</string>
     </map>
     <map>
       <key>Name</key>

--- a/indra/newview/skins/default/xui/de/emoji_categories.xml
+++ b/indra/newview/skins/default/xui/de/emoji_categories.xml
@@ -5,13 +5,13 @@
       <key>Name</key>
       <string>smileys and emotion</string>
       <key>Category</key>
-      <string>Smileys and Emotionen</string>
+      <string>Smileys &amp; Emotionen</string>
     </map>
     <map>
       <key>Name</key>
       <string>people and body</string>
       <key>Category</key>
-      <string>Menschen and Körper</string>
+      <string>Menschen &amp; Körper</string>
     </map>
     <map>
       <key>Name</key>
@@ -23,19 +23,19 @@
       <key>Name</key>
       <string>animals and nature</string>
       <key>Category</key>
-      <string>Tiere and Natur</string>
+      <string>Tiere &amp; Natur</string>
     </map>
     <map>
       <key>Name</key>
       <string>food and drink</string>
       <key>Category</key>
-      <string>Essen and Trinken</string>
+      <string>Essen &amp; Trinken</string>
     </map>
     <map>
       <key>Name</key>
       <string>travel and places</string>
       <key>Category</key>
-      <string>Reisen and Orte</string>
+      <string>Reisen &amp; Orte</string>
     </map>
     <map>
       <key>Name</key>

--- a/indra/newview/skins/default/xui/en/emoji_categories.xml
+++ b/indra/newview/skins/default/xui/en/emoji_categories.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0" ?>
 <llsd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="llsd.xsd">
+    <!-- WARNING: This file isn't directly localizable at the moment,
+                  translated variants Must match values provided by
+                  3p_emoji_shortcodes via emoji_characters for categories
+                  to work correctly-->
   <array>
     <map>
       <key>Name</key>
       <string>smileys and emotion</string>
       <key>Category</key>
-      <string>smileys and emotion</string>
+      <string>smileys &amp; emotion</string>
     </map>
     <map>
       <key>Name</key>
       <string>people and body</string>
       <key>Category</key>
-      <string>people and body</string>
+      <string>people &amp; body</string>
     </map>
     <map>
       <key>Name</key>
@@ -23,19 +27,19 @@
       <key>Name</key>
       <string>animals and nature</string>
       <key>Category</key>
-      <string>animals and nature</string>
+      <string>animals &amp; nature</string>
     </map>
     <map>
       <key>Name</key>
       <string>food and drink</string>
       <key>Category</key>
-      <string>food and drink</string>
+      <string>food &amp; drink</string>
     </map>
     <map>
       <key>Name</key>
       <string>travel and places</string>
       <key>Category</key>
-      <string>travel and places</string>
+      <string>travel &amp; places</string>
     </map>
     <map>
       <key>Name</key>

--- a/indra/newview/skins/default/xui/it/emoji_categories.xml
+++ b/indra/newview/skins/default/xui/it/emoji_categories.xml
@@ -5,7 +5,7 @@
       <key>Name</key>
       <string>smileys and emotion</string>
       <key>Category</key>
-      <string>smileys and emozione</string>
+      <string>smileys &amp; emozione</string>
     </map>
     <map>
       <key>Name</key>
@@ -23,7 +23,7 @@
       <key>Name</key>
       <string>animals and nature</string>
       <key>Category</key>
-      <string>animali and natura</string>
+      <string>animali &amp; natura</string>
     </map>
     <map>
       <key>Name</key>
@@ -35,7 +35,7 @@
       <key>Name</key>
       <string>travel and places</string>
       <key>Category</key>
-      <string>viaggi and luoghi</string>
+      <string>viaggi &amp; luoghi</string>
     </map>
     <map>
       <key>Name</key>

--- a/indra/newview/skins/default/xui/pl/emoji_categories.xml
+++ b/indra/newview/skins/default/xui/pl/emoji_categories.xml
@@ -5,13 +5,13 @@
       <key>Name</key>
       <string>smileys and emotion</string>
       <key>Category</key>
-      <string>buźki and emocje</string>
+      <string>buźki &amp; emocje</string>
     </map>
     <map>
       <key>Name</key>
       <string>people and body</string>
       <key>Category</key>
-      <string>ludzie and ciało</string>
+      <string>ludzie &amp; ciało</string>
     </map>
     <map>
       <key>Name</key>
@@ -23,7 +23,7 @@
       <key>Name</key>
       <string>animals and nature</string>
       <key>Category</key>
-      <string>zwierzęta and przyroda</string>
+      <string>zwierzęta &amp; przyroda</string>
     </map>
     <map>
       <key>Name</key>
@@ -35,7 +35,7 @@
       <key>Name</key>
       <string>travel and places</string>
       <key>Category</key>
-      <string>podróże and miejsca</string>
+      <string>podróże &amp; miejsca</string>
     </map>
     <map>
       <key>Name</key>


### PR DESCRIPTION
Issue: Various languages had mixed translations, like "Smileys **and** Emotionen" in german (instead of und or &)

Was caused by package substituting '&' with 'and' instead of '& amp;'
Package was fixed [here](https://github.com/secondlife/3p-emoji-shortcodes/commit/5413f581a6102749edf2df3165df61651ddcd5fc).

P.S. Ideally we need to make these files properly translatable, but focused on fixing 'and' for now.