### PR TITLE
viewer#944 Make 'Debug Unicode' feature available for all LLViews

### DIFF
--- a/indra/llui/llbutton.h
+++ b/indra/llui/llbutton.h
@@ -251,7 +251,7 @@ public:
 	void			setFont(const LLFontGL *font)		
 		{ mGLFont = ( font ? font : LLFontGL::getFontSansSerif()); }
 	const LLFontGL* getFont() const { return mGLFont; }
-
+	const std::string& getText() const { return getCurrentLabel().getString(); }
 
 	S32				getLastDrawCharsCount() const { return mLastDrawCharsCount; }
 	bool			labelIsTruncated() const;

--- a/indra/llui/llcheckboxctrl.h
+++ b/indra/llui/llcheckboxctrl.h
@@ -117,7 +117,7 @@ public:
 	std::string			getLabel() const;
 
 	void				setFont( const LLFontGL* font ) { mFont = font; }
-	const LLFontGL*		getFont() { return mFont; }
+	const LLFontGL*		getFont() const { return mFont; }
 	
 	virtual void		setControlName(const std::string& control_name, LLView* context);
 

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -1762,19 +1762,6 @@ void LLLineEditor::drawBackground()
 }
 
 //virtual 
-const std::string LLLineEditor::getToolTip() const
-{
-    if (sDebugUnicode)
-    {
-        std::string text = getText();
-        std::string tooltip = utf8str_showBytesUTF8(text);
-        return tooltip;
-    }
-
-    return LLUICtrl::getToolTip();
-}
-
-//virtual 
 void LLLineEditor::draw()
 {
 	F32 alpha = getDrawContext().mAlpha;

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -176,7 +176,6 @@ public:
 	void				onSpellCheckSettingsChange();
 
 	// view overrides
-	/*virtual*/ const std::string getToolTip() const override;
 	/*virtual*/ void	draw() override;
 	/*virtual*/ void	reshape(S32 width, S32 height, BOOL called_from_parent = TRUE) override;
 	/*virtual*/ void	onFocusReceived() override;
@@ -204,7 +203,7 @@ public:
 
 	void			setText(const LLStringExplicit &new_text);
 
-	const std::string& getText() const		{ return mText.getString(); }
+	const std::string& getText() const override { return mText.getString(); }
 	LLWString       getWText() const	{ return mText.getWString(); }
 	LLWString getConvertedText() const; // trimmed text with paragraphs converted to newlines
 
@@ -236,7 +235,7 @@ public:
 	const LLColor4& getReadOnlyFgColor() const	{ return mReadOnlyFgColor.get(); }
 	const LLColor4& getTentativeFgColor() const { return mTentativeFgColor.get(); }
 
-	const LLFontGL* getFont() const { return mGLFont; }
+	const LLFontGL* getFont() const override { return mGLFont; }
 	void setFont(const LLFontGL* font);
 
 	void			setIgnoreArrowKeys(BOOL b)		{ mIgnoreArrowKeys = b; }

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1287,19 +1287,6 @@ BOOL LLTextBase::handleToolTip(S32 x, S32 y, MASK mask)
 }
 
 //virtual 
-const std::string LLTextBase::getToolTip() const
-{
-    if (sDebugUnicode)
-    {
-        std::string text = getText();
-        std::string tooltip = utf8str_showBytesUTF8(text);
-        return tooltip;
-    }
-
-    return LLUICtrl::getToolTip();
-}
-
-//virtual 
 void LLTextBase::reshape(S32 width, S32 height, BOOL called_from_parent)
 {
 	if (width != getRect().getWidth() || height != getRect().getHeight() || LLView::sForceReshape)
@@ -2182,10 +2169,10 @@ void LLTextBase::setText(const LLStringExplicit &utf8str, const LLStyle::Params&
 	onValueChange(0, getLength());
 }
 
-//virtual
-std::string LLTextBase::getText() const
+// virtual
+const std::string& LLTextBase::getText() const
 {
-	return getViewModel()->getValue().asString();
+	return getViewModel()->getStringValue();
 }
 
 // IDEVO - icons can be UI image names or UUID sent from

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -366,7 +366,6 @@ public:
 	/*virtual*/ BOOL		handleToolTip(S32 x, S32 y, MASK mask) override;
 
 	// LLView interface
-	/*virtual*/ const std::string getToolTip() const override;
 	/*virtual*/ void		reshape(S32 width, S32 height, BOOL called_from_parent = TRUE) override;
 	/*virtual*/ void		draw() override;
 
@@ -422,7 +421,7 @@ public:
 	// Text accessors
 	// TODO: add optional style parameter
 	virtual void			setText(const LLStringExplicit &utf8str , const LLStyle::Params& input_params = LLStyle::Params()); // uses default style
-	virtual std::string		getText() const;
+	/*virtual*/ const std::string& getText() const override;
 	void					setMaxTextLength(S32 length) { mMaxTextByteLength = length; }
 	S32						getMaxTextLength() { return mMaxTextByteLength; }
 
@@ -495,7 +494,7 @@ public:
 	bool					scrolledToStart();
 	bool					scrolledToEnd();
 
-	const LLFontGL*			getFont() const					{ return mFont; }
+	const LLFontGL*			getFont() const override { return mFont; }
 
 	virtual void			appendLineBreakSegment(const LLStyle::Params& style_params);
 	virtual void			appendImageSegment(const LLStyle::Params& style_params);

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -898,6 +898,34 @@ F32 LLView::getTooltipTimeout()
     : tooltip_delay);
 }
 
+// virtual
+const std::string LLView::getToolTip() const
+{
+    if (sDebugUnicode)
+    {
+        std::string text = getText();
+        if (!text.empty())
+        {
+            const std::string& name = getName();
+            std::string tooltip = llformat("Name: \"%s\"", name.c_str());
+
+            if (const LLFontGL* font = getFont())
+            {
+                tooltip += llformat("\nFont: %s (%s)",
+                    font->getFontDesc().getName().c_str(),
+                    font->getFontDesc().getSize().c_str()
+                );
+            }
+
+            tooltip += "\n\n" + utf8str_showBytesUTF8(text);
+
+            return tooltip;
+        }
+    }
+
+    return mToolTipMsg.getString();
+}
+
 BOOL LLView::handleToolTip(S32 x, S32 y, MASK mask)
 {
 	BOOL handled = FALSE;

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -243,8 +243,10 @@ public:
 
 	ECursorType	getHoverCursor() { return mHoverCursor; }
 
-    static F32 getTooltipTimeout();
-	virtual const std::string getToolTip() const			{ return mToolTipMsg.getString(); }
+	static F32 getTooltipTimeout();
+	virtual const std::string getToolTip() const;
+	virtual const std::string& getText() const { return LLStringUtil::null; }
+	virtual const LLFontGL* getFont() const { return nullptr; }
 
 	void		sendChildToFront(LLView* child);
 	void		sendChildToBack(LLView* child);

--- a/indra/llui/llviewmodel.cpp
+++ b/indra/llui/llviewmodel.cpp
@@ -81,7 +81,7 @@ void LLTextViewModel::setValue(const LLSD& value)
 {
 	// approximate LLSD storage usage
 	LLViewModel::setValue(value);
-    mDisplay = utf8str_to_wstring(value.asString());
+    mDisplay = utf8str_to_wstring(mStringValue = value.asString());
 
     // mDisplay and mValue agree
     mUpdateFromDisplay = false;
@@ -101,23 +101,34 @@ void LLTextViewModel::setDisplay(const LLWString& value)
     mUpdateFromDisplay = true;
 }
 
-LLSD LLTextViewModel::getValue() const
+inline void updateFromDisplayIfNeeded(const LLTextViewModel* model)
 {
-    // Has anyone called setDisplay() since the last setValue()? If so, have
-    // to convert mDisplay back to UTF8.
-    if (mUpdateFromDisplay)
+    // Has anyone called setDisplay() since the last setValue()?
+    // If so, have to convert mDisplay back to UTF8.
+    if (model->mUpdateFromDisplay)
     {
-        // The fact that we're lazily updating fields in this object should be
-        // transparent to clients, which is why this method is left
-        // conventionally const. Nor do we particularly want to make these
-        // members mutable. Just cast away constness in this one place.
-        LLTextViewModel* nthis = const_cast<LLTextViewModel*>(this);
+        // The fact that we're lazily updating fields
+        // in this object should be transparent to clients,
+        // which is why this method is left conventionally const.
+        // Nor do we particularly want to make these members mutable.
+        // Just cast away constness in this one place.
+        LLTextViewModel* nthis = const_cast<LLTextViewModel*>(model);
         nthis->mUpdateFromDisplay = false;
-        nthis->mValue = wstring_to_utf8str(mDisplay);
+        nthis->mValue = nthis->mStringValue = wstring_to_utf8str(model->mDisplay);
     }
-    return LLViewModel::getValue();
 }
 
+LLSD LLTextViewModel::getValue() const
+{
+    updateFromDisplayIfNeeded(this);
+    return mValue;
+}
+
+const std::string& LLTextViewModel::getStringValue() const
+{
+    updateFromDisplayIfNeeded(this);
+    return mStringValue;
+}
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/indra/llui/llviewmodel.h
+++ b/indra/llui/llviewmodel.h
@@ -100,6 +100,7 @@ public:
 	// LLViewModel functions
     virtual void setValue(const LLSD& value);
     virtual LLSD getValue() const;
+    const std::string& getStringValue() const;
 
 	// New functions
     /// Get the stored value in string form
@@ -114,12 +115,17 @@ public:
     void setDisplay(const LLWString& value);
 	
 private:
+    std::string mStringValue;
+
     /// To avoid converting every widget's stored value from LLSD to LLWString
     /// every frame, cache the converted value
     LLWString mDisplay;
+
     /// As the user edits individual characters (setDisplay()), defer
     /// LLWString-to-UTF8 conversions until s/he's done.
     bool mUpdateFromDisplay;
+
+    friend void updateFromDisplayIfNeeded(const LLTextViewModel* model);
 };
 
 /**

--- a/indra/newview/llexpandabletextbox.h
+++ b/indra/newview/llexpandabletextbox.h
@@ -121,7 +121,7 @@ public:
 	/**
 	 * Returns text
 	 */
-	virtual std::string getText() const { return mText; }
+	virtual const std::string& getText() const { return mText; }
 
 	/**
 	 * Sets text

--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -128,7 +128,7 @@ public:
         , const LLEmojiSearchResult& emoji)
         : LLScrollingPanel(panel_params)
         , mData(emoji)
-        , mText(LLWString(1, emoji.Character))
+        , mChar(LLWString(1, emoji.Character))
     {
     }
 
@@ -139,7 +139,7 @@ public:
         F32 x = getRect().getWidth() / 2;
         F32 y = getRect().getHeight() / 2;
         LLFontGL::getFontEmojiLarge()->render(
-            mText,                      // wstr
+            mChar,                      // wstr
             0,                          // begin_offset
             x,                          // x
             y,                          // y
@@ -154,11 +154,11 @@ public:
     virtual void updatePanel(BOOL allow_modify) override {}
 
     const LLEmojiSearchResult& getData() const { return mData; }
-    LLWString getText() const { return mText; }
+    const LLWString& getChar() const { return mChar; }
 
 private:
     const LLEmojiSearchResult mData;
-    const LLWString mText;
+    const LLWString mChar;
 };
 
 class LLEmojiPreviewPanel : public LLPanel
@@ -924,7 +924,7 @@ void LLFloaterEmojiPicker::onEmojiMouseUp(LLUICtrl* ctrl)
 
     if (LLEmojiGridIcon* icon = dynamic_cast<LLEmojiGridIcon*>(ctrl))
     {
-        LLSD value(wstring_to_utf8str(icon->getText()));
+        LLSD value(wstring_to_utf8str(icon->getChar()));
         setValue(value);
 
         onCommit();

--- a/indra/newview/lltoastnotifypanel.cpp
+++ b/indra/newview/lltoastnotifypanel.cpp
@@ -298,8 +298,8 @@ void LLToastNotifyPanel::init( LLRect rect, bool show_images )
     // init font variables
     if (!sFont)
     {
-        sFont = LLFontGL::getFontSansSerif();
-        sFontSmall = LLFontGL::getFontSansSerifSmall();
+        sFont = LLFontGL::getFontEmojiMedium();
+        sFontSmall = LLFontGL::getFontEmojiSmall();
     }
     // initialize
     setFocusRoot(!mIsTip);

--- a/indra/newview/skins/default/xui/en/panel_notification.xml
+++ b/indra/newview/skins/default/xui/en/panel_notification.xml
@@ -32,7 +32,7 @@
     <text
       border_visible="false"
       follows="left|right|top|bottom"
-      font="SansSerif"
+      font="Emoji"
       height="85"
       layout="topleft"
       left="10"
@@ -46,7 +46,7 @@
     <text
       border_visible="false"
       follows="left|right|top|bottom"
-      font="SansSerifBold"
+      font="EmojiBold"
       height="85"
       layout="topleft"
       left="10"
@@ -57,14 +57,14 @@
       width="285"
       wrap="true"/>
     <text_editor
-    	h_pad="0"
-	v_pad="0"
+      h_pad="0"
+      v_pad="0"
       bg_readonly_color="Transparent"
       border_visible="false"
       embedded_items="false"
       enabled="false"
       follows="left|right|top|bottom"
-      font="SansSerif"
+      font="Emoji"
       height="85" 
       layout="topleft"
       left="10"


### PR DESCRIPTION
Main steps:
1. Define functions getFont() and getText() in the class LLView to generalize their interface
2. Implement DebugUnicode feature in the class LLView using functions getName(), getFont() and getText()
3. Add to the tooltip debug output the control name and the font name and size if available

This works on text blocks and on buttons the same way as follows:
![image](https://github.com/secondlife/viewer/assets/124201357/b29282db-734c-479f-a97c-485bf421fdcf)
![image](https://github.com/secondlife/viewer/assets/124201357/b7fcd24f-293c-4a1d-b562-2c73c24514b6)
![image](https://github.com/secondlife/viewer/assets/124201357/1881c8a6-ba20-40fd-9f26-cc3358c6cee5)

After fixing the issue (the 2nd commit):
![image](https://github.com/secondlife/viewer/assets/124201357/0c73eac5-6737-4c65-a99f-f65c533e018d)
![image](https://github.com/secondlife/viewer/assets/124201357/131e4e91-3d17-41c4-abec-024b5284f305)
![image](https://github.com/secondlife/viewer/assets/124201357/7387e066-47db-4387-96bb-0efea5164e0e)

