### PR TITLE
Allow fading emojis characters in fading text.

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -276,6 +276,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 	LLColor4U colors[GLYPH_BATCH_SIZE * 4];
 
 	LLColor4U text_color(color);
+    // Preserve the transparency to render fading emojis in fading text (e.g.
+    // for the chat console)... HB
+    LLColor4U emoji_color(255, 255, 255, text_color.mV[VW]);
 
 	std::pair<EFontGlyphType, S32> bitmap_entry = std::make_pair(EFontGlyphType::Grayscale, -1);
 	S32 glyph_count = 0;
@@ -344,7 +347,11 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 			glyph_count = 0;
 		}
 
-		drawGlyph(glyph_count, vertices, uvs, colors, screen_rect, uv_rect, (bitmap_entry.first == EFontGlyphType::Grayscale) ? text_color : LLColor4U::white, style_to_add, shadow, drop_shadow_strength);
+        const LLColor4U& col =
+            bitmap_entry.first == EFontGlyphType::Grayscale ? text_color
+                                                            : emoji_color;
+		drawGlyph(glyph_count, vertices, uvs, colors, screen_rect, uv_rect,
+                  col, style_to_add, shadow, drop_shadow_strength);
 
 		chars_drawn++;
 		cur_x += fgi->mXAdvance;


### PR DESCRIPTION
In the recent emojis implementation, the text color alpha is ignored (emojis are always rendered with an opaque white color), causing them to fail and fade properly with the rest of the text they are printed with.

This trivial patch fixes this issue.