### PR TITLE
Remove obsolete LLSINGLETON_C11 and LLSINGLETON_EMPTY_CTOR_C11 macros

### DIFF
--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -807,17 +807,6 @@ private:                                                                \
     DERIVED_CLASS(__VA_ARGS__)
 
 /**
- * A slight variance from the above, but includes the "override" keyword
- */
-#define LLSINGLETON_C11(DERIVED_CLASS)                                  \
-private:                                                                \
-    /* implement LLSingleton pure virtual method whose sole purpose */  \
-    /* is to remind people to use this macro */                         \
-    virtual void you_must_use_LLSINGLETON_macro() override {}           \
-    friend class LLSingleton<DERIVED_CLASS>;                            \
-    DERIVED_CLASS()
-
-/**
  * Use LLSINGLETON_EMPTY_CTOR(Foo); at the start of an LLSingleton<Foo>
  * subclass body when the constructor is trivial:
  *
@@ -834,10 +823,6 @@ private:                                                                \
 #define LLSINGLETON_EMPTY_CTOR(DERIVED_CLASS)                           \
     /* LLSINGLETON() is carefully implemented to permit exactly this */ \
     LLSINGLETON(DERIVED_CLASS) {}
-
-#define LLSINGLETON_EMPTY_CTOR_C11(DERIVED_CLASS)                       \
-    /* LLSINGLETON() is carefully implemented to permit exactly this */ \
-    LLSINGLETON_C11(DERIVED_CLASS) {}
 
 // Relatively unsafe singleton implementation that is much faster
 // and simpler than LLSingleton, but has no dependency tracking

--- a/indra/newview/llchicletbar.h
+++ b/indra/newview/llchicletbar.h
@@ -38,7 +38,7 @@ class LLChicletBar
 	: public LLSingleton<LLChicletBar>
 	, public LLPanel
 {
-	LLSINGLETON_C11(LLChicletBar);
+	LLSINGLETON(LLChicletBar);
 	LOG_CLASS(LLChicletBar);
 
 public:

--- a/indra/newview/llpaneltopinfobar.h
+++ b/indra/newview/llpaneltopinfobar.h
@@ -37,7 +37,7 @@ class LLParcelChangeObserver;
 
 class LLPanelTopInfoBar : public LLPanel, public LLSingleton<LLPanelTopInfoBar>, private LLDestroyClass<LLPanelTopInfoBar>
 {
-	LLSINGLETON_C11(LLPanelTopInfoBar);
+	LLSINGLETON(LLPanelTopInfoBar);
 	~LLPanelTopInfoBar();
 	LOG_CLASS(LLPanelTopInfoBar);
 

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -492,7 +492,7 @@ protected:
  **/
 class LLSpeakerVolumeStorage : public LLSingleton<LLSpeakerVolumeStorage>
 {
-	LLSINGLETON_C11(LLSpeakerVolumeStorage);
+	LLSINGLETON(LLSpeakerVolumeStorage);
 	~LLSpeakerVolumeStorage();
 	LOG_CLASS(LLSpeakerVolumeStorage);
 


### PR DESCRIPTION
@marchcat LLSINGLETON was changed to include the override keyword, this makes LLSINGLETON_C11 redundant and obsolete.