### PR TITLE
secondlife/viewer#988: Fix terrain composition label getting cut off

### DIFF
--- a/indra/newview/skins/default/xui/de/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/de/panel_region_terrain.xml
@@ -10,7 +10,7 @@
 	<spinner label="Obere Terraingrenze" name="terrain_raise_spin"/>
 	<spinner label="Untere Terraingrenze" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Terraintexturen (erfordert 24-Bit-.tga-Dateien mit einer Größe von 1024x1024)
+    Terraintexturen
   </text>
 	<text name="height_text_lbl">
 		1 (niedrig)

--- a/indra/newview/skins/default/xui/es/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/es/panel_region_terrain.xml
@@ -12,7 +12,7 @@ del terreno" name="terrain_raise_spin"/>
 	<spinner bottom_delta="-34" label="Límite de bajada del 
 terreno" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Texturas del terreno (requiere archivos .tga de 1024x1024, 24 bits)
+    Texturas del terreno
   </text>
 	<text name="height_text_lbl">
 		1 (bajo)

--- a/indra/newview/skins/default/xui/fr/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/fr/panel_region_terrain.xml
@@ -12,7 +12,7 @@ terrain" name="terrain_raise_spin"/>
 	<spinner bottom_delta="-34" label="Limite d&apos;abaissement 
 du terrain" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Textures du terrain (fichiers .tga 1024 x 1024, 24 bit requis)
+    Textures du terrain
   </text>
 	<text name="height_text_lbl">
 		1 (Bas)

--- a/indra/newview/skins/default/xui/it/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/it/panel_region_terrain.xml
@@ -12,7 +12,7 @@ terreno" name="terrain_raise_spin"/>
 	<spinner bottom_delta="-34" label="Limite di abbassamento 
 del terreno" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Texture terreno (richiede file 1024x1024, 24 bit .tga)
+    Texture terreno
   </text>
 	<text name="height_text_lbl">
 		1 (basso)

--- a/indra/newview/skins/default/xui/ja/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/ja/panel_region_terrain.xml
@@ -10,7 +10,7 @@
 	<spinner label="地形の上昇限度" name="terrain_raise_spin"/>
 	<spinner label="地形の下降限度" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-		地形テクスチャ（1024✕1024 の 24 bit .tga ファイル）
+		地形テクスチャ
 	</text>
 	<text name="height_text_lbl">
 		１（低）

--- a/indra/newview/skins/default/xui/pl/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/pl/panel_region_terrain.xml
@@ -7,7 +7,7 @@
 	<spinner label="Górny limit terenu" name="terrain_raise_spin" />
 	<spinner label="Dolny limit terenu" name="terrain_lower_spin" />
 	<text name="detail_texture_text">
-		Tekstury terenu (1024x1024, 24 bitowy plik .tga)
+		Tekstury terenu
 	</text>
 	<text name="height_text_lbl">
 		1 (Nisko)

--- a/indra/newview/skins/default/xui/pt/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/pt/panel_region_terrain.xml
@@ -12,7 +12,7 @@ terreno" name="terrain_raise_spin"/>
 	<spinner bottom_delta="-34" label="Limite mais baixo do 
 terreno" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Texturas de terreno (exige arquivos .tga 1024x1024, 24 bit)
+    Texturas de terreno
   </text>
 	<text name="height_text_lbl">
 		1 (Baixo)

--- a/indra/newview/skins/default/xui/ru/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/ru/panel_region_terrain.xml
@@ -10,7 +10,7 @@
 	<spinner label="Верх. точка ландшафта" name="terrain_raise_spin"/>
 	<spinner label="Ниж. точка ландшафта" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Текстуры ландшафта (требования: 1024x1024, 24-битные, TGA)
+    Текстуры ландшафта
   </text>
 	<text name="height_text_lbl">
 		1 (Низ)

--- a/indra/newview/skins/default/xui/tr/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/tr/panel_region_terrain.xml
@@ -10,7 +10,7 @@
 	<spinner label="Yüzey Yükslt. Limiti" name="terrain_raise_spin"/>
 	<spinner label="Yüzey Alçatma Limiti" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-    Yüzey Dokuları (1024x1024, 24 bit .tga dosyalar gerektirir)
+    Yüzey Dokuları
   </text>
 	<text name="height_text_lbl">
 		1 (Düşük)

--- a/indra/newview/skins/default/xui/zh/panel_region_terrain.xml
+++ b/indra/newview/skins/default/xui/zh/panel_region_terrain.xml
@@ -10,7 +10,7 @@
 	<spinner label="地形提升限制" name="terrain_raise_spin"/>
 	<spinner label="地形降低限制" name="terrain_lower_spin"/>
 	<text name="detail_texture_text">
-		地形材質（須 1024x1024，24 位元 .tga 檔格式）
+		地形材質
 	</text>
 	<text name="height_text_lbl">
 		1（低）


### PR DESCRIPTION
Normally I wouldn't mess with non-English translations. However, in the spirit of making sure that the terrain feature flag doesn't break anything when turned off, I checked the translations, and noticed that some text was cut off which wasn't before. I am thus providing this fix as a matter of due diligence.