### PR TITLE
Revert 326055ba82c22fedde186c6a56bafd4fe87e613a after 2f452d06e6964b0edf26b0b3f6eaa156e3fa2d48

### DIFF
--- a/indra/newview/lltoastnotifypanel.cpp
+++ b/indra/newview/lltoastnotifypanel.cpp
@@ -298,8 +298,8 @@ void LLToastNotifyPanel::init( LLRect rect, bool show_images )
     // init font variables
     if (!sFont)
     {
-        sFont = LLFontGL::getFontEmojiMedium();
-        sFontSmall = LLFontGL::getFontEmojiSmall();
+        sFont = LLFontGL::getFontSansSerif();
+        sFontSmall = LLFontGL::getFontSansSerifSmall();
     }
     // initialize
     setFocusRoot(!mIsTip);

--- a/indra/newview/skins/default/xui/en/panel_notification.xml
+++ b/indra/newview/skins/default/xui/en/panel_notification.xml
@@ -32,7 +32,7 @@
     <text
       border_visible="false"
       follows="left|right|top|bottom"
-      font="Emoji"
+      font="SansSerif"
       height="85"
       layout="topleft"
       left="10"
@@ -46,7 +46,7 @@
     <text
       border_visible="false"
       follows="left|right|top|bottom"
-      font="EmojiBold"
+      font="SansSerifBold"
       height="85"
       layout="topleft"
       left="10"
@@ -64,7 +64,7 @@
       embedded_items="false"
       enabled="false"
       follows="left|right|top|bottom"
-      font="Emoji"
+      font="SansSerif"
       height="85" 
       layout="topleft"
       left="10"


### PR DESCRIPTION
It is necessary to revert commit 326055ba82c22fedde186c6a56bafd4fe87e613a for 2f452d06e6964b0edf26b0b3f6eaa156e3fa2d48 to work its magic and repair script dialogs so that they render as they used to before the emojis fonts introduction.

Note that this revert won't prevent to use the new emojis should scripters want them in their new scripted dialogs: it just ensures existing scripted dialogs using special UTF-8 characters (which are not genuine emojis) will render as they used to, using the monochrome fallback fonts.