### PR TITLE
SL-18721 Restore release behavior

### DIFF
--- a/indra/llcommon/threadpool.h
+++ b/indra/llcommon/threadpool.h
@@ -55,7 +55,7 @@ namespace LL
          * ThreadPool listens for application shutdown messages on the "LLApp"
          * LLEventPump. Call close() to shut down this ThreadPool early.
          */
-        void close();
+        virtual void close();
 
         std::string getName() const { return mName; }
         size_t getWidth() const { return mThreads.size(); }


### PR DESCRIPTION
Closing window correctly caused a significant amount of logout freezes with no known reproes. Temporarily returning to old behavior were thread was killes without closing window and will reenable in later maints to hopefully get a scenario or at least more data of what is causing the freeze.