### PR TITLE
viewer#1000 Textures on large prims lose resolution

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -902,7 +902,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     // scale desired texture resolution higher or lower depending on texture scale
                     const LLTextureEntry* te = face->getTextureEntry();
                     F32 min_scale = te ? llmin(fabsf(te->getScaleS()), fabsf(te->getScaleT())) : 1.f;
-                    min_scale = llmax(min_scale*min_scale, 0.1f);
+                    min_scale = llclamp(min_scale*min_scale, 0.1f, 25.f);
 
                     vsize /= min_scale;
                     vsize /= LLViewerTexture::sDesiredDiscardBias;


### PR DESCRIPTION
Add upper limit to scale based 'pixel area' factor.

Value was selected experimentally. I suspect it needs to be even smaller or needs to take face's size (extents) into account, but lack test cases. Will ask QA to experiment around with scaling, for now this is good enough.