### PR TITLE
WebRTC: Make callbacks from webrtc-proper launch workqueue jobs to run code on the main thread, instead of relying on mutexes and such.

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2901,14 +2901,28 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>8b0191fae0860782a3e79b886364129c433cfd6b</string>
+              <string>a49fb3bb8aaf8325e7c6c4b6036db3da16afa2c9</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-webrtc-build/releases/assets/157215889</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.53/webrtc-m114.5735.08.53.8337236647-darwin64-8337236647.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
+          </map>
+          <key>linux64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>598baa054f63624a8e16883541c1f3dc7aa15a8a</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.53/webrtc-m114.5735.08.53.8337236647-linux64-8337236647.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>linux64</string>
           </map>
           <key>windows64</key>
           <map>
@@ -2917,11 +2931,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>64eccac933cee532dc065d9f9729a21d8347aae4</string>
+              <string>59d5f2e40612ab7b0b1a5da8ba288f48d5979216</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/3p-webrtc-build/releases/assets/157215892</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.53/webrtc-m114.5735.08.53.8337236647-windows64-8337236647.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2934,7 +2948,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>vcs_url</key>
         <string>https://github.com/secondlife/3p-webrtc-build</string>
         <key>version</key>
-        <string>m114.5735.08.52.8319849783</string>
+        <string>m114.5735.08.53.8337236647</string>
       </map>
       <key>xmlrpc-epi</key>
       <map>

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -580,7 +580,7 @@ void LLWebRTCPeerConnectionImpl::init(LLWebRTCImpl * webrtc_impl)
 }
 void LLWebRTCPeerConnectionImpl::terminate()
 {
-    mWebRTCImpl->SignalingBlockingCall(
+    mWebRTCImpl->PostSignalingTask(
         [this]()
         {
             if (mPeerConnection)

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -562,8 +562,10 @@ void LLWebRTCImpl::freePeerConnection(LLWebRTCPeerConnectionInterface* peer_conn
 // Most peer connection (signaling) happens on
 // the signaling thread.
 
-LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
+LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() : 
     mWebRTCImpl(nullptr),
+    mClosing(false),
+    mPeerConnection(nullptr),
     mMute(false),
     mAnswerReceived(false)
 {
@@ -580,13 +582,24 @@ void LLWebRTCPeerConnectionImpl::init(LLWebRTCImpl * webrtc_impl)
 }
 void LLWebRTCPeerConnectionImpl::terminate()
 {
+    rtc::scoped_refptr<webrtc::PeerConnectionInterface> connection;
+    mPeerConnection.swap(connection);
+    rtc::scoped_refptr<webrtc::DataChannelInterface> dataChannel;
+    mDataChannel.swap(dataChannel);
+    rtc::scoped_refptr<webrtc::MediaStreamInterface> localStream;
+    mLocalStream.swap(localStream);
+
     mWebRTCImpl->PostSignalingTask(
-        [this]()
+        [=]()
         {
-            if (mPeerConnection)
+            if (connection)
             {
-                mPeerConnection->Close();
-                mPeerConnection = nullptr;
+                connection->Close();
+            }
+            if (dataChannel)
+            {
+                dataChannel->UnregisterObserver();
+                dataChannel->Close();
             }
         });
 }
@@ -710,24 +723,9 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection()
 
 bool LLWebRTCPeerConnectionImpl::shutdownConnection()
 {
-    if (mPeerConnection)
-    {
-        mWebRTCImpl->PostSignalingTask(
-            [this]()
-            {
-                if (mPeerConnection)
-                {
-                    mPeerConnection->Close();
-                    mPeerConnection = nullptr;
-                }
-                for (auto &observer : mSignalingObserverList)
-                {
-                    observer->OnPeerConnectionShutdown();
-                }
-            });
-        return true;
-    }
-    return false;
+    mClosing = true;
+    terminate();
+    return true;
 }
 
 void LLWebRTCPeerConnectionImpl::enableSenderTracks(bool enable)
@@ -1057,14 +1055,16 @@ void LLWebRTCPeerConnectionImpl::OnSuccess(webrtc::SessionDescriptionInterface *
     }
 
     RTC_LOG(LS_INFO) << __FUNCTION__ << " Local SDP: " << sdp_mangled_stream.str();
-
+    std::string mangled_sdp = sdp_mangled_stream.str();
     for (auto &observer : mSignalingObserverList)
     {
-        observer->OnOfferAvailable(sdp_mangled_stream.str());
+        observer->OnOfferAvailable(mangled_sdp);
     }
+    
+   mPeerConnection->SetLocalDescription(std::unique_ptr<webrtc::SessionDescriptionInterface>(
+                                                     webrtc::CreateSessionDescription(webrtc::SdpType::kOffer, mangled_sdp)),
+                                                 rtc::scoped_refptr<webrtc::SetLocalDescriptionObserverInterface>(this));
 
-    mPeerConnection->SetLocalDescription(std::unique_ptr<webrtc::SessionDescriptionInterface>(webrtc::CreateSessionDescription(webrtc::SdpType::kOffer, sdp_mangled_stream.str())),
-                                         rtc::scoped_refptr<webrtc::SetLocalDescriptionObserverInterface>(this));
 }
 
 void LLWebRTCPeerConnectionImpl::OnFailure(webrtc::RTCError error)
@@ -1135,6 +1135,14 @@ void LLWebRTCPeerConnectionImpl::OnStateChange()
             break;
         case webrtc::DataChannelInterface::kClosed:
             RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State closed";
+            // if the data channel is up, we need to shut it down, holding off
+            // on termination of the peer connection until it's been closed.
+            if (mClosing)
+            {
+                // a close was requested, and the data channel has closed,
+                // so go ahead and call shutdownConnection again to clean up.
+                shutdownConnection();
+            }
             break;
         default:
             break;

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -1135,14 +1135,6 @@ void LLWebRTCPeerConnectionImpl::OnStateChange()
             break;
         case webrtc::DataChannelInterface::kClosed:
             RTC_LOG(LS_INFO) << __FUNCTION__ << " Data Channel State closed";
-            // if the data channel is up, we need to shut it down, holding off
-            // on termination of the peer connection until it's been closed.
-            if (mClosing)
-            {
-                // a close was requested, and the data channel has closed,
-                // so go ahead and call shutdownConnection again to clean up.
-                shutdownConnection();
-            }
             break;
         default:
             break;

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -192,9 +192,6 @@ class LLWebRTCSignalingObserver
     // Called when the data channel has been established and data
     // transfer can begin.
     virtual void OnDataChannelReady(LLWebRTCDataInterface *data_interface) = 0;
-
-    // Called when a peer connection has finished shutting down.
-    virtual void OnPeerConnectionShutdown() = 0;
 };
 
 

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -346,21 +346,23 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 
     LLWebRTCImpl * mWebRTCImpl;
 
+    bool mClosing;
+
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
 
-    bool                                                       mMute;
+    bool mMute;
 
     // signaling
-    std::vector<LLWebRTCSignalingObserver *>                   mSignalingObserverList;
+    std::vector<LLWebRTCSignalingObserver *>  mSignalingObserverList;
     std::vector<std::unique_ptr<webrtc::IceCandidateInterface>>  mCachedIceCandidates;
-    bool                                                       mAnswerReceived;
+    bool mAnswerReceived;
 
-    rtc::scoped_refptr<webrtc::PeerConnectionInterface>        mPeerConnection;
-    rtc::scoped_refptr<webrtc::MediaStreamInterface>           mLocalStream;
+    rtc::scoped_refptr<webrtc::PeerConnectionInterface> mPeerConnection;
+    rtc::scoped_refptr<webrtc::MediaStreamInterface> mLocalStream;
 
     // data
-    std::vector<LLWebRTCDataObserver *>                        mDataObserverList;
-    rtc::scoped_refptr<webrtc::DataChannelInterface>           mDataChannel;
+    std::vector<LLWebRTCDataObserver *> mDataObserverList;
+    rtc::scoped_refptr<webrtc::DataChannelInterface> mDataChannel;
 };
 
 }

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -588,15 +588,7 @@ class LLVoiceWebRTCConnection :
     void OnOfferAvailable(const std::string &sdp) override;
     void OnRenegotiationNeeded() override;
     void OnAudioEstablished(llwebrtc::LLWebRTCAudioInterface *audio_interface) override;
-    void OnPeerConnectionShutdown() override;
     //@}
-
-    void OnIceGatheringStateImpl(EIceGatheringState state);
-    void OnIceCandidateImpl(const llwebrtc::LLWebRTCIceCandidate &candidate);
-    void OnOfferAvailableImpl(const std::string &sdp);
-    void OnRenegotiationNeededImpl();
-    void OnAudioEstablishedImpl(llwebrtc::LLWebRTCAudioInterface *audio_interface);
-    void OnPeerConnectionShutdownImpl();
 
     /////////////////////////
     /// @name Data Notification
@@ -607,7 +599,6 @@ class LLVoiceWebRTCConnection :
     //@}
 
     void OnDataReceivedImpl(const std::string &data, bool binary);
-    void OnDataChannelReadyImpl(llwebrtc::LLWebRTCDataInterface *data_interface);
 
     void sendJoin();
     void sendData(const std::string &data);
@@ -635,7 +626,6 @@ class LLVoiceWebRTCConnection :
     }
 
     void OnVoiceConnectionRequestSuccess(const LLSD &body);
-    void OnVoiceConnectionRequestFailure(std::string url, int retries, LLSD body, const LLSD &result);
 
   protected:
     typedef enum e_voice_connection_state
@@ -680,11 +670,10 @@ class LLVoiceWebRTCConnection :
         return mVoiceConnectionState;
     }
 
-    virtual bool requestVoiceConnection() = 0;
+    virtual void requestVoiceConnection() = 0;
+    void requestVoiceConnectionCoro() { requestVoiceConnection(); }
 
-    bool breakVoiceConnection(bool wait);
-    void OnVoiceDisconnectionRequestSuccess(const LLSD &body);
-    void OnVoiceDisconnectionRequestFailure(std::string url, int retries, LLSD body, const LLSD &result);
+    void breakVoiceConnection();
 
     LLUUID mRegionID;
     LLUUID mViewerSession;
@@ -731,7 +720,7 @@ class LLVoiceWebRTCSpatialConnection :
 
 protected:
 
-    bool requestVoiceConnection() override;
+    void requestVoiceConnection() override;
 
     S32    mParcelLocalID;
 };
@@ -746,7 +735,7 @@ class LLVoiceWebRTCAdHocConnection : public LLVoiceWebRTCConnection
     bool isSpatial() override { return false; }
 
   protected:
-    bool requestVoiceConnection() override;
+    void requestVoiceConnection() override;
 
     std::string mCredentials;
 };


### PR DESCRIPTION
Previous code relied on mutexes to run code on the webrtc threads, instead of running the code on the main thread. Interactions between those webrtc threads and the main thread were through mutexed sections of code (although those sections were small.) Now, we run that code in workqueue lambdas, minimizing the amount of work done of the webrtc threads.