### PR TITLE
viewer#1033 Crash at syncFloaterTabOrder

### DIFF
--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -2406,8 +2406,7 @@ LLFloaterView::LLFloaterView (const Params& p)
 	mFocusCycleMode(FALSE),
 	mMinimizePositionVOffset(0),
 	mSnapOffsetBottom(0),
-	mSnapOffsetRight(0),
-	mFrontChild(NULL)
+	mSnapOffsetRight(0)
 {
 	mSnapView = getHandle();
 }
@@ -2563,7 +2562,8 @@ void LLFloaterView::bringToFront(LLFloater* child, BOOL give_focus, BOOL restore
 	if (!child)
 		return;
 
-	if (mFrontChild == child)
+    LLFloater* front_child = mFrontChildHandle.get();
+	if (front_child == child)
 	{
 		if (give_focus && child->canFocusStealFrontmost() && !gFocusMgr.childHasKeyboardFocus(child))
 		{
@@ -2572,12 +2572,12 @@ void LLFloaterView::bringToFront(LLFloater* child, BOOL give_focus, BOOL restore
 		return;
 	}
 
-	if (mFrontChild && !mFrontChild->isDead() && mFrontChild->getVisible())
+	if (front_child && front_child->getVisible())
 	{
-		mFrontChild->goneFromFront();
+        front_child->goneFromFront();
 	}
 
-	mFrontChild = child;
+    mFrontChildHandle = child->getHandle();
 
 	// *TODO: make this respect floater's mAutoFocus value, instead of
 	// using parameter
@@ -3076,7 +3076,8 @@ LLFloater *LLFloaterView::getBackmost() const
 
 void LLFloaterView::syncFloaterTabOrder()
 {
-	if (mFrontChild && !mFrontChild->isDead() && mFrontChild->getIsChrome())
+    LLFloater* front_child = mFrontChildHandle.get();
+	if (front_child && front_child->getIsChrome())
 		return;
 
 	// look for a visible modal dialog, starting from first
@@ -3114,11 +3115,12 @@ void LLFloaterView::syncFloaterTabOrder()
 			LLFloater* floaterp = dynamic_cast<LLFloater*>(*child_it);
 			if (gFocusMgr.childHasKeyboardFocus(floaterp))
 			{
-                if (mFrontChild != floaterp)
+                LLFloater* front_child = mFrontChildHandle.get();
+                if (front_child != floaterp)
                 {
                     // Grab a list of the top floaters that want to stay on top of the focused floater
 					std::list<LLFloater*> listTop;
-					if (mFrontChild && !mFrontChild->canFocusStealFrontmost())
+					if (front_child && !front_child->canFocusStealFrontmost())
                     {
                         for (LLView* childp : *getChildList())
                         {
@@ -3138,7 +3140,7 @@ void LLFloaterView::syncFloaterTabOrder()
 						{
 							sendChildToFront(childp);
 						}
-						mFrontChild = listTop.back();
+                        mFrontChildHandle = listTop.back()->getHandle();
 					}
                 }
 

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -506,7 +506,6 @@ void LLFloater::enableResizeCtrls(bool enable, bool width, bool height)
 
 void LLFloater::destroy()
 {
-	gFloaterView->onDestroyFloater(this);
 	// LLFloaterReg should be synchronized with "dead" floater to avoid returning dead instance before
 	// it was deleted via LLMortician::updateClass(). See EXT-8458.
 	LLFloaterReg::removeInstance(mInstanceName, mKey);
@@ -2573,7 +2572,7 @@ void LLFloaterView::bringToFront(LLFloater* child, BOOL give_focus, BOOL restore
 		return;
 	}
 
-	if (mFrontChild)
+	if (mFrontChild && !mFrontChild->isDead() && mFrontChild->getVisible())
 	{
 		mFrontChild->goneFromFront();
 	}
@@ -3233,14 +3232,6 @@ void LLFloaterView::setToolbarRect(LLToolBarEnums::EToolBarLocation tb, const LL
 		LL_WARNS() << "setToolbarRect() passed odd toolbar number " << (S32) tb << LL_ENDL;
 		break;
 	}
-}
-
-void LLFloaterView::onDestroyFloater(LLFloater* floater)
-{
-    if (mFrontChild == floater)
-    {
-        mFrontChild = nullptr;
-    }
 }
 
 void LLFloater::setInstanceName(const std::string& name)

--- a/indra/llui/llfloater.h
+++ b/indra/llui/llfloater.h
@@ -607,7 +607,6 @@ public:
 	LLFloater* getFrontmostClosableFloater(); 
 
 	void setToolbarRect(LLToolBarEnums::EToolBarLocation tb, const LLRect& toolbar_rect);
-	void onDestroyFloater(LLFloater* floater);
 
 private:
 	void hiddenFloaterClosed(LLFloater* floater);

--- a/indra/llui/llfloater.h
+++ b/indra/llui/llfloater.h
@@ -622,7 +622,7 @@ private:
 	S32				mMinimizePositionVOffset;
 	typedef std::vector<std::pair<LLHandle<LLFloater>, boost::signals2::connection> > hidden_floaters_t;
 	hidden_floaters_t mHiddenFloaters;
-	LLFloater *		mFrontChild;
+    LLHandle<LLFloater>	mFrontChildHandle;
 };
 
 //


### PR DESCRIPTION
Reverted previous fix, made a new one using handles.

A 'child' died without calling destroy(), which is expected for reusable instances.