### PR TITLE
WebRTC: Throw 'area full' message when voice server indicates the channel is at capacity.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2374,7 +2374,7 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
     LLSD body;
     body["logout"]         = TRUE;
     body["viewer_session"] = mViewerSession;
-    body["voice_server_type"] = REPORTED_VOICE_SERVER_TYPE;
+    body["voice_server_type"] = WEBRTC_VOICE_SERVER_TYPE;
 
     LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t httpAdapter(
         new LLCoreHttpUtil::HttpCoroutineAdapter("LLVoiceWebRTCAdHocConnection::breakVoiceConnection",
@@ -2437,9 +2437,7 @@ void LLVoiceWebRTCSpatialConnection::requestVoiceConnection()
     LLSD body;
     LLSD jsep;
     jsep["type"] = "offer";
-    {
-        jsep["sdp"] = mChannelSDP;
-    }
+    jsep["sdp"] = mChannelSDP;
     body["jsep"] = jsep;
     if (mParcelLocalID != INVALID_PARCEL_ID)
     {

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -203,7 +203,9 @@ public:
 
     void OnConnectionEstablished(const std::string& channelID, const LLUUID& regionID);
     void OnConnectionShutDown(const std::string &channelID, const LLUUID &regionID);
-    void OnConnectionFailure(const std::string &channelID, const LLUUID& regionID);
+    void OnConnectionFailure(const std::string &channelID,
+        const LLUUID &regionID,
+        LLVoiceClientStatusObserver::EStatusType status_type = LLVoiceClientStatusObserver::ERROR_UNKNOWN);
     void sendPositionUpdate(bool force);
     void updateOwnVolume();
 
@@ -674,6 +676,8 @@ class LLVoiceWebRTCConnection :
     void requestVoiceConnectionCoro() { requestVoiceConnection(); }
 
     void breakVoiceConnectionCoro();
+
+    LLVoiceClientStatusObserver::EStatusType mCurrentStatus;
 
     LLUUID mRegionID;
     LLUUID mViewerSession;


### PR DESCRIPTION
Also, fix an issue where proper voice server type was not being sent when disconnecting.