### PR TITLE
Add keystroke event support and allow adding text lines to the line editor

### DIFF
--- a/indra/llui/llluafloater.cpp
+++ b/indra/llui/llluafloater.cpp
@@ -194,7 +194,7 @@ void LLLuaFloater::registerCallback(const std::string &ctrl_name, const std::str
         post(event.with("x", x).with("y", y)); 
     };
 
-    auto post_with_value = [this, data](LLSD& value)
+    auto post_with_value = [this, data](LLSD value)
     {
         LLSD event(data);
         post(event.with("value", value));
@@ -229,7 +229,7 @@ void LLLuaFloater::registerCallback(const std::string &ctrl_name, const std::str
         LLScrollListCtrl *list = dynamic_cast<LLScrollListCtrl *>(ctrl);
         if (list)
         {
-            list->setDoubleClickCallback( [this, post_with_value, list](){ post_with_value(LLSD(list->getCurrentID())); });
+            list->setDoubleClickCallback( [post_with_value, list](){ post_with_value(LLSD(list->getCurrentID())); });
         }
         else 
         {
@@ -241,12 +241,12 @@ void LLLuaFloater::registerCallback(const std::string &ctrl_name, const std::str
         LLTextEditor* text_editor = dynamic_cast<LLTextEditor*>(ctrl);
         if (text_editor)
         {
-            text_editor->setKeystrokeCallback([this, post_with_value](LLTextEditor *editor) { post_with_value(editor->getValue()); });
+            text_editor->setKeystrokeCallback([post_with_value](LLTextEditor *editor) { post_with_value(editor->getValue()); });
         }
         LLLineEditor* line_editor = dynamic_cast<LLLineEditor*>(ctrl);
         if (line_editor)
         {
-            line_editor->setKeystrokeCallback([this, post_with_value](LLLineEditor *editor, void* userdata) { post_with_value(editor->getValue()); }, NULL);
+            line_editor->setKeystrokeCallback([post_with_value](LLLineEditor *editor, void* userdata) { post_with_value(editor->getValue()); }, NULL);
         }
     }
     else 

--- a/indra/newview/scripts/lua/luafloater_demo.xml
+++ b/indra/newview/scripts/lua/luafloater_demo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <floater
  legacy_header_height="18"
- height="150"
+ height="300"
  layout="topleft"
  name="lua_demo"
  title="LUA"
@@ -79,4 +79,15 @@
      text_color="white"
      left_delta="15"
      name="time_lbl"/>
+    <text_editor
+     follows="top|left"
+     font="SansSerif"
+     height="140"
+     left="5"
+     enabled="false"
+     name="events_editor"
+     top_pad="15"
+     word_wrap="true"
+     max_length="65536"
+     width="310"/>
 </floater>

--- a/indra/newview/scripts/lua/test_luafloater_demo.lua
+++ b/indra/newview/scripts/lua/test_luafloater_demo.lua
@@ -2,6 +2,7 @@ XML_FILE_PATH = "luafloater_demo.xml"
 
 leap = require 'leap'
 coro = require 'coro'
+fiber = require 'fiber'
 
 --event pump for sending actions to the floater
 COMMAND_PUMP_NAME = ""
@@ -63,4 +64,4 @@ function process_events(waitfor)
   end
 end
 
-coro.launch(process_events, catch_events)
+fiber.launch("catch_events", process_events, catch_events)

--- a/indra/newview/scripts/lua/test_luafloater_demo.lua
+++ b/indra/newview/scripts/lua/test_luafloater_demo.lua
@@ -6,12 +6,7 @@ coro = require 'coro'
 --event pump for sending actions to the floater
 COMMAND_PUMP_NAME = ""
 --table of floater UI events
-event_list={}
-coro.launch(function ()
-  event_list = leap.request("LLFloaterReg", {op="getFloaterEvents"})["events"]
-  leap.done()
-end)
-leap.process()
+event_list=leap.request("LLFloaterReg", {op="getFloaterEvents"}).events
 
 local function _event(event_name)
   if not table.find(event_list, event_name) then
@@ -53,12 +48,7 @@ end
 local key = {xml_path = XML_FILE_PATH, op = "showLuaFloater"}
 --sign for additional events for defined control {<control_name>= {action1, action2, ...}}
 key.extra_events={show_time_lbl = {_event("right_mouse_down"), _event("double_click")}}
-coro.launch(function ()
-  --script received event pump name, after floater was built
-  COMMAND_PUMP_NAME = leap.request("LLFloaterReg", key)["command_name"]
-  leap.done()
-end)
-leap.process()
+COMMAND_PUMP_NAME = leap.request("LLFloaterReg", key).command_name
 
 catch_events = leap.WaitFor:new(-1, "all_events")
 function catch_events:filter(pump, data)
@@ -74,5 +64,3 @@ function process_events(waitfor)
 end
 
 coro.launch(process_events, catch_events)
-leap.process()
-print_warning("End of the script")

--- a/indra/newview/scripts/lua/test_luafloater_demo.lua
+++ b/indra/newview/scripts/lua/test_luafloater_demo.lua
@@ -2,7 +2,6 @@ XML_FILE_PATH = "luafloater_demo.xml"
 
 leap = require 'leap'
 coro = require 'coro'
-util = require 'util'
 
 --event pump for sending actions to the floater
 COMMAND_PUMP_NAME = ""
@@ -15,7 +14,7 @@ end)
 leap.process()
 
 local function _event(event_name)
-  if not util.contains(event_list, event_name) then
+  if not table.find(event_list, event_name) then
     print_warning("Incorrect event name: " .. event_name)
   end
   return event_name
@@ -31,6 +30,7 @@ function getCurrentTime()
 end
 
 function handleEvents(event_data)
+  post({action="add_text", ctrl_name="events_editor", value = event_data})
   if event_data.event == _event("commit") then
     if event_data.ctrl_name == "disable_ctrl" then
       post({action="set_enabled", ctrl_name="open_btn", value = (1 - event_data.value)})

--- a/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
+++ b/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
@@ -2,6 +2,7 @@ XML_FILE_PATH = "luafloater_gesture_list.xml"
 
 leap = require 'leap'
 coro = require 'coro'
+fiber = require 'fiber'
 LLGesture = require 'LLGesture'
 
 --event pump for sending actions to the floater
@@ -60,4 +61,4 @@ function process_events(waitfor)
   end
 end
 
-coro.launch(process_events, catch_events)
+fiber.launch("catch_events", process_events, catch_events)

--- a/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
+++ b/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
@@ -7,12 +7,7 @@ LLGesture = require 'LLGesture'
 --event pump for sending actions to the floater
 COMMAND_PUMP_NAME = ""
 --table of floater UI events
-event_list={}
-coro.launch(function ()
-  event_list = leap.request("LLFloaterReg", {op="getFloaterEvents"})["events"]
-  leap.done()
-end)
-leap.process()
+event_list=leap.request("LLFloaterReg", {op="getFloaterEvents"}).events
 
 local function _event(event_name)
   if not table.find(event_list, event_name) then
@@ -50,11 +45,7 @@ end
 local key = {xml_path = XML_FILE_PATH, op = "showLuaFloater"}
 --receive additional events for defined control {<control_name>= {action1, action2, ...}}
 key.extra_events={gesture_list = {_event("double_click")}}
-coro.launch(function ()
-  handleEvents(leap.request("LLFloaterReg", key))
-  leap.done()
-end)
-leap.process()
+handleEvents(leap.request("LLFloaterReg", key))
 
 catch_events = leap.WaitFor:new(-1, "all_events")
 function catch_events:filter(pump, data)
@@ -70,4 +61,3 @@ function process_events(waitfor)
 end
 
 coro.launch(process_events, catch_events)
-leap.process()

--- a/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
+++ b/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
@@ -2,7 +2,6 @@ XML_FILE_PATH = "luafloater_gesture_list.xml"
 
 leap = require 'leap'
 coro = require 'coro'
-util = require 'util'
 LLGesture = require 'LLGesture'
 
 --event pump for sending actions to the floater
@@ -16,7 +15,7 @@ end)
 leap.process()
 
 local function _event(event_name)
-  if not util.contains(event_list, event_name) then
+  if not table.find(event_list, event_name) then
     print_warning("Incorrect event name: " .. event_name)
   end
   return event_name

--- a/indra/newview/scripts/lua/util.lua
+++ b/indra/newview/scripts/lua/util.lua
@@ -36,14 +36,4 @@ function util.equal(t1, t2)
     return util.empty(temp)
 end
 
--- check if array-like table contains certain value
-function util.contains(t, v)
-    for _, value in ipairs(t) do
-        if value == v then
-            return true
-        end
-    end
-    return false
-end
-
 return util


### PR DESCRIPTION
The script can be signed for 'keystroke' event now.
Added the command for appending text line (text editor) from the script.
Script updates: 
Removed `util.contains` which is the same as `table.find` in luau; 
call leap.request() from LUA main thread.
