### PR TITLE
Add LL.check_stop() entry point and call it in fiber scheduler().

### DIFF
--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -682,6 +682,15 @@ std::pair<LuaFunction::Registry&, LuaFunction::Lookup&> LuaFunction::getState()
 }
 
 /*****************************************************************************
+*   check_stop()
+*****************************************************************************/
+lua_function(check_stop, "ensure that a Lua script responds to viewer shutdown")
+{
+    LLCoros::checkStop();
+    return 0;
+}
+
+/*****************************************************************************
 *   help()
 *****************************************************************************/
 lua_function(help,

--- a/indra/newview/scripts/lua/fiber.lua
+++ b/indra/newview/scripts/lua/fiber.lua
@@ -222,8 +222,6 @@ local function scheduler()
     -- processing to the main thread. If called from a coroutine, pass control
     -- back to the main thread.
     if coroutine.running() then
-        -- seize the opportunity to make sure the viewer isn't shutting down
---      check_stop()
         -- this is a real coroutine, yield normally to main thread
         coroutine.yield()
         -- main certainly still exists
@@ -240,7 +238,7 @@ local function scheduler()
     repeat
         for co in live_ready_iter do
             -- seize the opportunity to make sure the viewer isn't shutting down
---          check_stop()
+            LL.check_stop()
             -- before we re-append co, is it the only remaining entry?
             others = next(ready)
             -- co is live, re-append it to the ready list


### PR DESCRIPTION
fiber.lua's scheduler() is greedy, in the sense that it wants to run every ready Lua fiber before retrieving the next incoming event from the viewer (and possibly blocking for some real time before it becomes available). But check for viewer shutdown before resuming any suspended-but-ready Lua fiber.