### PR TITLE
viewer#1061 Altitudes are invisible in region's environment

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_region_environment.xml
+++ b/indra/newview/skins/default/xui/en/panel_region_environment.xml
@@ -264,8 +264,7 @@
                                 top_pad="1"
                                 halign="right"
                                 name="txt_alt1">
-                            Sky [INDEX]
-                            [ALTITUDE]m
+                            Sky [INDEX]&#xA;[ALTITUDE]m
                         </text>
                         <line_editor
                                 follows="left|top"
@@ -310,8 +309,7 @@
                                 top_pad="1"
                                 halign="right"
                                 name="txt_alt2">
-                            Sky [INDEX]
-                            [ALTITUDE]m
+                            Sky [INDEX]&#xA;[ALTITUDE]m
                         </text>
                         <line_editor
                                 follows="left|top"
@@ -356,8 +354,7 @@
                                 top_pad="1"
                                 halign="right"
                                 name="txt_alt3">
-                            Sky [INDEX]
-                            [ALTITUDE]m
+                            Sky [INDEX]&#xA;[ALTITUDE]m
                         </text>
                         <line_editor
                                 follows="left|top"


### PR DESCRIPTION
Looks like at some point formating was reset which caused second part of the string to 'fly away', replaced with &#xA; to prevent repeats.