### PR TITLE
Run each script file with new LuaState

### DIFF
--- a/indra/newview/llfloaterluadebug.cpp
+++ b/indra/newview/llfloaterluadebug.cpp
@@ -111,8 +111,7 @@ void LLFloaterLUADebug::runSelectedScript(const std::vector<std::string> &filena
     if (!filepath.empty())
     {
         mScriptPath->setText(filepath);
-        cleanLuaState(); 
-        LLLUAmanager::runScriptFile(mState, filepath, [this](int count, const LLSD& result)
+        LLLUAmanager::runScriptFile(filepath, [this](int count, const LLSD &result)
         {
             completion(count, result);
         });

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -195,61 +195,50 @@ lua_function(get_event_next,
     return 2;
 }
 
-void LLLUAmanager::runScriptFile(const std::string& filename, script_finished_fn cb)
-{
-    // A script_finished_fn is used to initialize the LuaState.
-    // It will be called when the LuaState is destroyed.
-    LuaState L(cb);
-    runScriptFile(L, filename);
-}
-
-void LLLUAmanager::runScriptFile(const std::string& filename, script_result_fn cb)
-{
-    LuaState L;
-    // A script_result_fn will be called when LuaState::expr() completes.
-    runScriptFile(L, filename, cb);
-}
-
 LLCoros::Future<std::pair<int, LLSD>>
-LLLUAmanager::startScriptFile(LuaState& L, const std::string& filename)
+LLLUAmanager::startScriptFile(const std::string& filename)
 {
     // Despite returning from startScriptFile(), we need this Promise to
     // remain alive until the callback has fired.
     auto promise{ std::make_shared<LLCoros::Promise<std::pair<int, LLSD>>>() };
-    runScriptFile(L, filename,
+    runScriptFile(filename,
                   [promise](int count, LLSD result)
                   { promise->set_value({ count, result }); });
     return LLCoros::getFuture(*promise);
 }
 
-std::pair<int, LLSD> LLLUAmanager::waitScriptFile(LuaState& L, const std::string& filename)
+std::pair<int, LLSD> LLLUAmanager::waitScriptFile(const std::string& filename)
 {
-    return startScriptFile(L, filename).get();
+    return startScriptFile(filename).get();
 }
 
-void LLLUAmanager::runScriptFile(LuaState& L, const std::string& filename, script_result_fn cb)
+void LLLUAmanager::runScriptFile(const std::string &filename, script_result_fn result_cb, script_finished_fn finished_cb)
 {
-    LLCoros::instance().launch(filename, [&L, filename, cb]()
+    // A script_result_fn will be called when LuaState::expr() completes.
+    LLCoros::instance().launch(filename, [filename, result_cb, finished_cb]()
     {
         llifstream in_file;
         in_file.open(filename.c_str());
 
         if (in_file.is_open()) 
         {
+            // A script_finished_fn is used to initialize the LuaState.
+            // It will be called when the LuaState is destroyed.
+            LuaState L(finished_cb);
             std::string text{std::istreambuf_iterator<char>(in_file), {}};
             auto [count, result] = L.expr(filename, text);
-            if (cb)
+            if (result_cb)
             {
-                cb(count, result);
+                result_cb(count, result);
             }
         }
         else
         {
             auto msg{ stringize("unable to open script file '", filename, "'") };
             LL_WARNS("Lua") << msg << LL_ENDL;
-            if (cb)
+            if (result_cb)
             {
-                cb(-1, msg);
+                result_cb(-1, msg);
             }
         }
     });

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -53,19 +53,17 @@ public:
     //            results, represented as the entries of the result array.
     typedef std::function<void(int count, const LLSD& result)> script_result_fn;
 
-    static void runScriptFile(const std::string &filename, script_finished_fn cb = {});
-    static void runScriptFile(const std::string &filename, script_result_fn cb);
-    static void runScriptFile(LuaState& L, const std::string &filename, script_result_fn cb = {});
+    static void runScriptFile(const std::string &filename, script_result_fn result_cb = {}, script_finished_fn finished_cb = {});
     // Start running a Lua script file, returning an LLCoros::Future whose
     // get() method will pause the calling coroutine until it can deliver the
     // (count, result) pair described above. Between startScriptFile() and
     // Future::get(), the caller and the Lua script coroutine will run
     // concurrently.
     static LLCoros::Future<std::pair<int, LLSD>>
-        startScriptFile(LuaState& L, const std::string& filename);
+        startScriptFile(const std::string& filename);
     // Run a Lua script file, and pause the calling coroutine until it completes.
     // The return value is the (count, result) pair described above.
-    static std::pair<int, LLSD> waitScriptFile(LuaState& L, const std::string& filename);
+    static std::pair<int, LLSD> waitScriptFile(const std::string& filename);
 
     static void runScriptLine(const std::string &chunk, script_finished_fn cb = {});
     static void runScriptLine(const std::string &chunk, script_result_fn cb);

--- a/indra/newview/scripts/lua/test_LLFloaterAbout.lua
+++ b/indra/newview/scripts/lua/test_LLFloaterAbout.lua
@@ -1,14 +1,6 @@
 -- test LLFloaterAbout
 
 LLFloaterAbout = require('LLFloaterAbout')
-leap = require('leap')
-coro = require('coro')
 inspect = require('inspect')
 
-coro.launch(function ()
-    print(inspect(LLFloaterAbout.getInfo()))
-    leap.done()
-end)
-
-leap.process()
-
+print(inspect(LLFloaterAbout.getInfo()))

--- a/indra/newview/scripts/lua/test_LLGesture.lua
+++ b/indra/newview/scripts/lua/test_LLGesture.lua
@@ -2,31 +2,25 @@
 
 LLGesture = require 'LLGesture'
 inspect = require 'inspect'
-coro = require 'coro'
-leap = require 'leap'
 
-coro.launch(function()
-        -- getActiveGestures() returns {<UUID>: {name, playing, trigger}}
-        gestures_uuid = LLGesture.getActiveGestures()
-        -- convert to {<name>: <uuid>}
-        gestures = {}
-        for uuid, info in pairs(gestures_uuid) do
-            gestures[info.name] = uuid
-        end
-        -- now run through the list
-        for name, uuid in pairs(gestures) do
-            if name == 'afk' then
-                -- afk has a long timeout, and isn't interesting to look at
-                continue
-            end
-            print(name)
-            LLGesture.startGesture(uuid)
-            repeat
-                LL.sleep(1)
-            until not LLGesture.isGesturePlaying(uuid)
-        end
-        print('Done.')
-        leap.done()
-end)
 
-leap.process()
+-- getActiveGestures() returns {<UUID>: {name, playing, trigger}}
+gestures_uuid = LLGesture.getActiveGestures()
+-- convert to {<name>: <uuid>}
+gestures = {}
+for uuid, info in pairs(gestures_uuid) do
+    gestures[info.name] = uuid
+end
+-- now run through the list
+for name, uuid in pairs(gestures) do
+    if name == 'afk' then
+    -- afk has a long timeout, and isn't interesting to look at
+        continue
+    end
+    print(name)
+    LLGesture.startGesture(uuid)
+    repeat
+        LL.sleep(1)
+    until not LLGesture.isGesturePlaying(uuid)
+end
+print('Done.')


### PR DESCRIPTION
Run a script file with its own new LuaState.
Update the rest of test scripts to do all the work without creating a coro.

Fixes https://github.com/secondlife/viewer-private/issues/221