### PR TITLE
Terminate Lua scripts hanging in `LL.get_event_next()`.

### DIFF
--- a/indra/llcommon/llevents.h
+++ b/indra/llcommon/llevents.h
@@ -48,26 +48,12 @@
 	#pragma warning (pop)
 #endif
 
-#include <boost/bind.hpp>
-#include <boost/utility.hpp>        // noncopyable
 #include <boost/optional/optional.hpp>
-#include <boost/visit_each.hpp>
-#include <boost/ref.hpp>            // reference_wrapper
-#include <boost/type_traits/is_pointer.hpp>
-#include <boost/static_assert.hpp>
 #include "llsd.h"
 #include "llsingleton.h"
 #include "lldependencies.h"
-#include "llstl.h"
 #include "llexception.h"
 #include "llhandle.h"
-
-/*==========================================================================*|
-// override this to allow binding free functions with more parameters
-#ifndef LLEVENTS_LISTENER_ARITY
-#define LLEVENTS_LISTENER_ARITY 10
-#endif
-|*==========================================================================*/
 
 // hack for testing
 #ifndef testable

--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -31,6 +31,9 @@
 #include "lualistener.h"
 #include "stringize.h"
 
+#define lua_register(L, n, f) (lua_pushcfunction(L, (f), n), lua_setglobal(L, (n)))
+#define lua_rawlen lua_objlen
+
 /*****************************************************************************
 *   luau namespace
 *****************************************************************************/

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -23,9 +23,6 @@
 
 class LuaListener;
 
-#define lua_register(L, n, f) (lua_pushcfunction(L, (f), n), lua_setglobal(L, (n)))
-#define lua_rawlen lua_objlen
-
 namespace lluau
 {
     // luau defines luaL_error() as void, but we want to use the Lua idiom of

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -108,7 +108,7 @@ LuaListener::PumpData LuaListener::getNext()
     {
         return mQueue.pop();
     }
-    catch (const LLThreadSafeQueueInterrupt& exc)
+    catch (const LLThreadSafeQueueInterrupt&)
     {
         // mQueue has been closed. The only way that happens is when we detect
         // viewer shutdown. Terminate the calling coroutine.

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -43,13 +43,11 @@ LuaListener::LuaListener(lua_State* L):
             LLEventPump::inventName("LuaState"),
             [this](const LLSD& status)
             {
-                LL_DEBUGS("LuaListener") << "caught " << status << LL_ENDL;
                 const auto& statsd = status["status"];
                 if (statsd.asString() != "running")
                 {
                     // If a Lua script is still blocked in getNext() during
                     // viewer shutdown, close the queue to wake up getNext().
-                    LL_DEBUGS("LuaListener") << "closing queue" << LL_ENDL;
                     mQueue.close();
                 }
                 return false;

--- a/indra/llcommon/lualistener.h
+++ b/indra/llcommon/lualistener.h
@@ -12,6 +12,7 @@
 #if ! defined(LL_LUALISTENER_H)
 #define LL_LUALISTENER_H
 
+#include "llevents.h"
 #include "llinstancetracker.h"
 #include "llsd.h"
 #include "llthreadsafequeue.h"
@@ -73,6 +74,7 @@ private:
     LLThreadSafeQueue<PumpData> mQueue;
 
     std::unique_ptr<LLLeapListener> mListener;
+    LLTempBoundListener mShutdownConnection;
 };
 
 #endif /* ! defined(LL_LUALISTENER_H) */

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -35,16 +35,6 @@
 #include "lualistener.h"
 #include "stringize.h"
 
-// skip all these link dependencies for integration testing
-#ifndef LL_TEST
-#include "lluilistener.h"
-#include "llviewercontrol.h"
-
-// FIXME extremely hacky way to get to the UI Listener framework. There's
-// a cleaner way.
-extern LLUIListener sUIListener;
-#endif // ! LL_TEST
-
 #include <boost/algorithm/string/replace.hpp>
 #include <filesystem>
 

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -31,6 +31,7 @@
 #include "llcoros.h"
 #include "llerror.h"
 #include "lleventcoro.h"
+#include "llviewercontrol.h"
 #include "lua_function.h"
 #include "lualistener.h"
 #include "stringize.h"
@@ -115,37 +116,6 @@ lua_function(print_warning, "print_warning(args...): WARNING level logging")
     LL_WARNS("Lua") << lua_print_msg(L, "WARN") << LL_ENDL;
     return 0;
 }
-
-#ifndef LL_TEST
-
-lua_function(run_ui_command,
-             "run_ui_command(name [, parameter]): "
-             "call specified UI command with specified parameter")
-{
-	int top = lua_gettop(L);
-	std::string func_name;
-	if (top >= 1)
-	{
-		func_name = lua_tostring(L,1);
-	}
-	std::string parameter;
-	if (top >= 2)
-	{
-		parameter = lua_tostring(L,2);
-	}
-	LL_WARNS("LUA") << "running ui func " << func_name << " parameter " << parameter << LL_ENDL;
-	LLSD event;
-	event["function"] = func_name;
-	if (!parameter.empty())
-	{
-		event["parameter"] = parameter; 
-	}
-	sUIListener.call(event);
-
-	lua_settop(L, 0);
-	return 0;
-}
-#endif // ! LL_TEST
 
 lua_function(post_on, "post_on(pumpname, data): post specified data to specified LLEventPump")
 {

--- a/indra/newview/tests/llluamanager_test.cpp
+++ b/indra/newview/tests/llluamanager_test.cpp
@@ -430,13 +430,12 @@ namespace tut
         );
         LuaState L;
         auto future = LLLUAmanager::startScriptLine(L, lua);
-        // The problem with this test is that the LuaState is destroyed
-        // (disconnecting the listener) before the LLTestApp instance mApp is
-        // destroyed (sending the shutdown event). Explicitly simulate LLApp's
-        // event.
-        LLEventPumps::instance().obtain("LLApp").post(llsd::map("status", "quitting"));
+        // Poke LLTestApp to send its preliminary shutdown message.
+        mApp.setQuitting();
         // but now we have to give the startScriptLine() coroutine a chance to run
         auto [count, result] = future.get();
-        ensure_equals(result.asString(), count, 0);
+        ensure_equals("killed Lua script terminated normally", count, -1);
+        ensure_equals("unexpected killed Lua script error",
+                      result.asString(), "viewer is stopping");
     }
 } // namespace tut


### PR DESCRIPTION
Make `LuaListener` listen for `"LLApp"` viewer shutdown events. On receiving such,
it closes its queue. Then the C++ coroutine calling `getNext()` wakes up with an
`LLThreadSafeQueue` exception, and calls `LLCoros::checkStop()` to throw one of
the exceptions recognized by `LLCoros::toplevel()`.

Add an `llluamanager_test.cpp` test to verify this behavior.

Fixes secondlife/viewer-private#223.