### PR TITLE
BUG-134040: Fix broken SOCKS5 proxy

### DIFF
--- a/indra/llmessage/llproxy.cpp
+++ b/indra/llmessage/llproxy.cpp
@@ -465,7 +465,7 @@ void LLProxy::applyProxySettings(CURL* handle)
 /**
  * @brief Send one TCP packet and receive one in return.
  *
- * This operation is done synchronously with a 1000ms timeout. Therefore, it should not be used when a blocking
+ * This operation is done synchronously with a 100ms timeout. Therefore, it should not be used when a blocking
  * operation would impact the operation of the viewer.
  *
  * @param handle_ptr 	Pointer to a connected LLSocket of type STREAM_TCP.
@@ -482,7 +482,7 @@ static apr_status_t tcp_blocking_handshake(LLSocket::ptr_t handle, char * dataou
 
 	apr_size_t expected_len = outlen;
 
-	handle->setBlocking(1000);
+	handle->setBlocking(100000); // 100ms, 100000us. Should be sufficient for localhost, nearby network
 
   	rv = apr_socket_send(apr_socket, dataout, &outlen);
 	if (APR_SUCCESS != rv)
@@ -497,8 +497,6 @@ static apr_status_t tcp_blocking_handshake(LLSocket::ptr_t handle, char * dataou
 				" Sent: " << outlen << LL_ENDL;
 		rv = -1;
 	}
-
-	ms_sleep(1);
 
 	if (APR_SUCCESS == rv)
 	{


### PR DESCRIPTION
Up the handshake between the viewer and SOCKS5 proxy from 1ms to 100ms. The Second Life's SOCKS5 proxy has been broken on many systems for some time to a possible conflation of milliseconds and microseconds in the APR timeout value used when attempting to ping the proxy.

closes https://github.com/secondlife/jira-archive/issues/2108

## Testing Steps:

**Given:** You have a working SOCKS5 proxy which is prepared to proxy Second Life traffic.

1. Attempt to configure a SOCKS5 proxy via `Preferences -> Setup -> Adjust proxy settings`
2. Attempt to use Second Life

**Expected:** The viewer is able to proxy UDP traffic through SOCKS5
**Actual:** Proxy does not work

Note, this problem appears to be from a race condition when performing a handshake between the proxy and viewer. This may succeed on some machines and fail on others. The previous viewer code allowed 1ms for the handshake to complete