### PR TITLE
enable tracy for linux and build fix

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2564,6 +2564,20 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>name</key>
             <string>windows64</string>
           </map>
+          <key>linux64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>0cac6af362861d90cdd3dc4adfff95f54e619f4a</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/3p-tracy/releases/download/v0.8.1%2Br1/tracy-v0.8.1.38bf5f3-linux64-38bf5f3.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>linux64</string>
+          </map>
         </map>
         <key>license</key>
         <string>bsd</string>

--- a/indra/llcommon/llprofiler.h
+++ b/indra/llcommon/llprofiler.h
@@ -74,6 +74,10 @@
 #define LL_PROFILER_CONFIGURATION           LL_PROFILER_CONFIG_FAST_TIMER
 #endif
 
+#if LL_PROFILER_CONFIGURATION == LL_PROFILER_CONFIG_TRACY || LL_PROFILER_CONFIGURATION == LL_PROFILER_CONFIG_TRACY_FAST_TIMER
+    #include "Tracy.hpp"
+#endif
+
 extern thread_local bool gProfilerEnabled;
 
 #if defined(LL_PROFILER_CONFIGURATION) && (LL_PROFILER_CONFIGURATION > LL_PROFILER_CONFIG_NONE)
@@ -84,7 +88,6 @@ extern thread_local bool gProfilerEnabled;
 //      #define TRACY_NO_BROADCAST   1
 //      #define TRACY_ONLY_LOCALHOST 1
         #define TRACY_ONLY_IPV4      1
-        #include "Tracy.hpp"
 
         // Enable OpenGL profiling
         #define LL_PROFILER_ENABLE_TRACY_OPENGL 0


### PR DESCRIPTION
Allows tracy to be enabled on Linux.

This may be incorrect because it was modified based on the Firestorm Viewer source code.
That's why it's a draft.

I could not build it without modifying indra/llcommon/llprofiler.h .
I don't know of any other way to fix it.