### PR TITLE
Add `startup.lua` module with `startup.ensure()`, `startup.wait()` functions.

### DIFF
--- a/indra/llcommon/CMakeLists.txt
+++ b/indra/llcommon/CMakeLists.txt
@@ -127,6 +127,7 @@ set(llcommon_HEADER_FILES
     commoncontrol.h
     ctype_workaround.h
     fix_macros.h
+    fsyspath.h
     function_types.h
     indra_constants.h
     lazyeventapi.h

--- a/indra/llcommon/fsyspath.h
+++ b/indra/llcommon/fsyspath.h
@@ -1,0 +1,74 @@
+/**
+ * @file   fsyspath.h
+ * @author Nat Goodspeed
+ * @date   2024-04-03
+ * @brief  Adapt our UTF-8 std::strings for std::filesystem::path
+ * 
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Copyright (c) 2024, Linden Research, Inc.
+ * $/LicenseInfo$
+ */
+
+#if ! defined(LL_FSYSPATH_H)
+#define LL_FSYSPATH_H
+
+#include <filesystem>
+
+// While std::filesystem::path can be directly constructed from std::string on
+// both Posix and Windows, that's not what we want on Windows. Per
+// https://en.cppreference.com/w/cpp/filesystem/path/path:
+
+// ... the method of conversion to the native character set depends on the
+// character type used by source.
+// 
+// * If the source character type is char, the encoding of the source is
+//   assumed to be the native narrow encoding (so no conversion takes place on
+//   POSIX systems).
+// * If the source character type is char8_t, conversion from UTF-8 to native
+//   filesystem encoding is used. (since C++20)
+// * If the source character type is wchar_t, the input is assumed to be the
+//   native wide encoding (so no conversion takes places on Windows).
+
+// The trouble is that on Windows, from std::string ("source character type is
+// char"), the "native narrow encoding" isn't UTF-8, so file paths containing
+// non-ASCII characters get mangled.
+//
+// Once we're building with C++20, we could pass a UTF-8 std::string through a
+// vector<char8_t> to engage std::filesystem::path's own UTF-8 conversion. But
+// sigh, as of 2024-04-03 we're not yet there.
+//
+// Anyway, encapsulating the important UTF-8 conversions in our own subclass
+// allows us to migrate forward to C++20 conventions without changing
+// referencing code.
+
+class fsyspath: public std::filesystem::path
+{
+    using super = std::filesystem::path;
+
+public:
+    // default
+    fsyspath() {}
+    // construct from UTF-8 encoded std::string
+    fsyspath(const std::string& path): super(std::filesystem::u8path(path)) {}
+    // construct from UTF-8 encoded const char*
+    fsyspath(const char* path): super(std::filesystem::u8path(path)) {}
+    // construct from existing path
+    fsyspath(const super& path): super(path) {}
+
+    fsyspath& operator=(const super& p) { super::operator=(p); return *this; }
+    fsyspath& operator=(const std::string& p)
+    {
+        super::operator=(std::filesystem::u8path(p));
+        return *this;
+    }
+    fsyspath& operator=(const char* p)
+    {
+        super::operator=(std::filesystem::u8path(p));
+        return *this;
+    }
+
+    // shadow base-class string() method with UTF-8 aware method
+    std::string string() const { return super::u8string(); }
+};
+
+#endif /* ! defined(LL_FSYSPATH_H) */

--- a/indra/llcommon/llleaplistener.cpp
+++ b/indra/llcommon/llleaplistener.cpp
@@ -70,46 +70,46 @@ LLLeapListener::LLLeapListener(const std::string_view& caller, const Callback& c
 {
     LLSD need_name(LLSDMap("name", LLSD()));
     add("newpump",
-        "Instantiate a new LLEventPump named like [\"name\"] and listen to it.\n"
-        "[\"type\"] == \"LLEventStream\", \"LLEventMailDrop\" et al.\n"
-        "Events sent through new LLEventPump will be decorated with [\"pump\"]=name.\n"
-        "Returns actual name in [\"name\"] (may be different if collision).",
+R"-(Instantiate a new LLEventPump named like ["name"] and listen to it.
+["type"] == "LLEventStream", "LLEventMailDrop" et al.
+Events sent through new LLEventPump will be decorated with ["pump"]=name.
+Returns actual name in ["name"] (may be different if collision).)-",
         &LLLeapListener::newpump,
         need_name);
     LLSD need_source_listener(LLSDMap("source", LLSD())("listener", LLSD()));
     add("listen",
-        "Listen to an existing LLEventPump named [\"source\"], with listener name\n"
-        "[\"listener\"].\n"
-        "If [\"tweak\"] is specified as true, tweak listener name for uniqueness.\n"
-        "By default, send events on [\"source\"] to the plugin, decorated\n"
-        "with [\"pump\"]=[\"source\"].\n"
-        "If [\"dest\"] specified, send undecorated events on [\"source\"] to the\n"
-        "LLEventPump named [\"dest\"].\n"
-        "Returns [\"status\"] boolean indicating whether the connection was made,\n"
-        "plus [\"listener\"] reporting (possibly tweaked) listener name.",
+R"-(Listen to an existing LLEventPump named ["source"], with listener name
+["listener"].
+If ["tweak"] is specified as true, tweak listener name for uniqueness.
+By default, send events on ["source"] to the plugin, decorated
+with ["pump"]=["source"].
+If ["dest"] specified, send undecorated events on ["source"] to the
+LLEventPump named ["dest"].
+Returns ["status"] boolean indicating whether the connection was made,
+plus ["listener"] reporting (possibly tweaked) listener name.)-",
         &LLLeapListener::listen,
         need_source_listener);
     add("stoplistening",
-        "Disconnect a connection previously established by \"listen\".\n"
-        "Pass same [\"source\"] and [\"listener\"] arguments.\n"
-        "Returns [\"status\"] boolean indicating whether such a listener existed.",
+R"-(Disconnect a connection previously established by "listen".
+Pass same ["source"] and ["listener"] arguments.
+Returns ["status"] boolean indicating whether such a listener existed.)-",
         &LLLeapListener::stoplistening,
         need_source_listener);
     add("ping",
-        "No arguments, just a round-trip sanity check.",
+"No arguments, just a round-trip sanity check.",
         &LLLeapListener::ping);
     add("getAPIs",
-        "Enumerate all LLEventAPI instances by name and description.",
+"Enumerate all LLEventAPI instances by name and description.",
         &LLLeapListener::getAPIs);
     add("getAPI",
-        "Get name, description, dispatch key and operations for LLEventAPI [\"api\"].",
+R"-(Get name, description, dispatch key and operations for LLEventAPI ["api"].)-",
         &LLLeapListener::getAPI,
         LLSD().with("api", LLSD()));
     add("getFeatures",
-        "Return an LLSD map of feature strings (deltas from baseline LEAP protocol)",
+"Return an LLSD map of feature strings (deltas from baseline LEAP protocol)",
         static_cast<void (LLLeapListener::*)(const LLSD&) const>(&LLLeapListener::getFeatures));
     add("getFeature",
-        "Return the feature value with key [\"feature\"]",
+R"-(Return the feature value with key ["feature"])-",
         &LLLeapListener::getFeature,
         LLSD().with("feature", LLSD()));
 }

--- a/indra/llcommon/llstring.h
+++ b/indra/llcommon/llstring.h
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <vector>
 #include <map>
+#include <type_traits>
 #include "llformat.h"
 #include "stdtypes.h"
 
@@ -542,7 +543,7 @@ public:
     template <typename TO>
     inline operator TO() const
     {
-        return ll_convert_impl<TO, FROM>()(mRef);
+        return ll_convert_impl<TO, std::decay_t<const FROM>>()(mRef);
     }
 };
 
@@ -551,7 +552,7 @@ public:
 template<typename TO, typename FROM>
 TO ll_convert_to(const FROM& in)
 {
-    return ll_convert_impl<TO, FROM>()(in);
+    return ll_convert_impl<TO, std::decay_t<const FROM>>()(in);
 }
 
 // degenerate case

--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -68,6 +68,15 @@ int lluau::loadstring(lua_State *L, const std::string &desc, const std::string &
     return luau_load(L, desc.data(), bytecode.get(), bytecodeSize, 0);
 }
 
+std::filesystem::path lluau::source_path(lua_State* L)
+{
+    //Luau lua_Debug and lua_getinfo() are different compared to default Lua:
+    //see https://github.com/luau-lang/luau/blob/80928acb92d1e4b6db16bada6d21b1fb6fa66265/VM/include/lua.h
+    lua_Debug ar;
+    lua_getinfo(L, 1, "s", &ar);
+    return ar.source;
+}
+
 /*****************************************************************************
 *   Lua <=> C++ conversions
 *****************************************************************************/
@@ -484,11 +493,15 @@ bool LuaState::checkLua(const std::string& desc, int r)
 std::pair<int, LLSD> LuaState::expr(const std::string& desc, const std::string& text)
 {
     if (! checkLua(desc, lluau::dostring(mState, desc, text)))
+    {
+        LL_WARNS("Lua") << desc << " error: " << mError << LL_ENDL;
         return { -1, mError };
+    }
 
     // here we believe there was no error -- did the Lua fragment leave
     // anything on the stack?
     std::pair<int, LLSD> result{ lua_gettop(mState), {} };
+    LL_INFOS("Lua") << desc << " done, " << result.first << " results." << LL_ENDL;
     if (result.first)
     {
         // aha, at least one entry on the stack!
@@ -501,6 +514,7 @@ std::pair<int, LLSD> LuaState::expr(const std::string& desc, const std::string& 
             }
             catch (const std::exception& error)
             {
+                LL_WARNS("Lua") << desc << " error converting result: " << error.what() << LL_ENDL;
                 // lua_tollsd() is designed to be called from a lua_function(),
                 // that is, from a C++ function called by Lua. In case of error,
                 // it throws a Lua error to be caught by the Lua runtime. expr()
@@ -519,15 +533,18 @@ std::pair<int, LLSD> LuaState::expr(const std::string& desc, const std::string& 
         else
         {
             // multiple entries on the stack
+            int index;
             try
             {
-                for (int index = 1; index <= result.first; ++index)
+                for (index = 1; index <= result.first; ++index)
                 {
                     result.second.append(lua_tollsd(mState, index));
                 }
             }
             catch (const std::exception& error)
             {
+                LL_WARNS("Lua") << desc << " error converting result " << index << ": "
+                                << error.what() << LL_ENDL;
                 // see above comments regarding lua_State's error status
                 initLuaState();
                 return { -1, stringize(LLError::Log::classname(error), ": ", error.what()) };
@@ -577,9 +594,13 @@ std::pair<int, LLSD> LuaState::expr(const std::string& desc, const std::string& 
         {
             // there's a fiber.run() function sitting on the top of the stack
             // -- call it with no arguments, discarding anything it returns
-            LL_DEBUGS("Lua") << "Calling fiber.run()" << LL_ENDL;
+            LL_INFOS("Lua") << desc << " p.s. fiber.run()" << LL_ENDL;
             if (! checkLua(desc, lua_pcall(mState, 0, 0, 0)))
+            {
+                LL_WARNS("Lua") << desc << " p.s. fiber.run() error: " << mError << LL_ENDL;
                 return { -1, mError };
+            }
+            LL_INFOS("Lua") << desc << " p.s. done." << LL_ENDL;
         }
     }
     // pop everything again
@@ -682,6 +703,26 @@ std::pair<LuaFunction::Registry&, LuaFunction::Lookup&> LuaFunction::getState()
     static Registry registry;
     static Lookup lookup;
     return { registry, lookup };
+}
+
+/*****************************************************************************
+*   source_path()
+*****************************************************************************/
+lua_function(source_path, "return the source path of the running Lua script")
+{
+    luaL_checkstack(L, 1, nullptr);
+    lua_pushstdstring(L, lluau::source_path(L));
+    return 1;
+}
+
+/*****************************************************************************
+*   source_dir()
+*****************************************************************************/
+lua_function(source_dir, "return the source directory of the running Lua script")
+{
+    luaL_checkstack(L, 1, nullptr);
+    lua_pushstdstring(L, lluau::source_path(L).parent_path());
+    return 1;
 }
 
 /*****************************************************************************

--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -17,13 +17,13 @@
 // std headers
 #include <algorithm>
 #include <exception>
-#include <filesystem>
 #include <iomanip>                  // std::quoted
 #include <map>
 #include <memory>                   // std::unique_ptr
 #include <typeinfo>
 // external library headers
 // other Linden headers
+#include "fsyspath.h"
 #include "hexdump.h"
 #include "lleventcoro.h"
 #include "llsd.h"
@@ -68,7 +68,7 @@ int lluau::loadstring(lua_State *L, const std::string &desc, const std::string &
     return luau_load(L, desc.data(), bytecode.get(), bytecodeSize, 0);
 }
 
-std::filesystem::path lluau::source_path(lua_State* L)
+fsyspath lluau::source_path(lua_State* L)
 {
     //Luau lua_Debug and lua_getinfo() are different compared to default Lua:
     //see https://github.com/luau-lang/luau/blob/80928acb92d1e4b6db16bada6d21b1fb6fa66265/VM/include/lua.h
@@ -577,7 +577,7 @@ std::pair<int, LLSD> LuaState::expr(const std::string& desc, const std::string& 
         // the next call to lua_next."
         // https://www.lua.org/manual/5.1/manual.html#lua_next
         if (lua_type(mState, -2) == LUA_TSTRING &&
-            std::filesystem::path(lua_tostdstring(mState, -2)).stem() == "fiber")
+            fsyspath(lua_tostdstring(mState, -2)).stem() == "fiber")
         {
             found = true;
             break;

--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -711,7 +711,7 @@ std::pair<LuaFunction::Registry&, LuaFunction::Lookup&> LuaFunction::getState()
 lua_function(source_path, "return the source path of the running Lua script")
 {
     luaL_checkstack(L, 1, nullptr);
-    lua_pushstdstring(L, lluau::source_path(L));
+    lua_pushstdstring(L, lluau::source_path(L).u8string());
     return 1;
 }
 
@@ -721,7 +721,19 @@ lua_function(source_path, "return the source path of the running Lua script")
 lua_function(source_dir, "return the source directory of the running Lua script")
 {
     luaL_checkstack(L, 1, nullptr);
-    lua_pushstdstring(L, lluau::source_path(L).parent_path());
+    lua_pushstdstring(L, lluau::source_path(L).parent_path().u8string());
+    return 1;
+}
+
+/*****************************************************************************
+*   abspath()
+*****************************************************************************/
+lua_function(abspath,
+             "for given filesystem path relative to running script, return absolute path")
+{
+    auto path{ lua_tostdstring(L, 1) };
+    lua_pop(L, 1);
+    lua_pushstdstring(L, (lluau::source_path(L).parent_path() / path).u8string());
     return 1;
 }
 

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -16,9 +16,9 @@
 #include "luau/lua.h"
 #include "luau/luaconf.h"
 #include "luau/lualib.h"
+#include "fsyspath.h"
 #include "stringize.h"
 #include <exception>                // std::uncaught_exceptions()
-#include <filesystem>
 #include <memory>                   // std::shared_ptr
 #include <utility>                  // std::pair
 
@@ -51,7 +51,7 @@ namespace lluau
     int dostring(lua_State* L, const std::string& desc, const std::string& text);
     int loadstring(lua_State* L, const std::string& desc, const std::string& text);
 
-    std::filesystem::path source_path(lua_State* L);
+    fsyspath source_path(lua_State* L);
 } // namespace lluau
 
 std::string lua_tostdstring(lua_State* L, int index);

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -18,6 +18,7 @@
 #include "luau/lualib.h"
 #include "stringize.h"
 #include <exception>                // std::uncaught_exceptions()
+#include <filesystem>
 #include <memory>                   // std::shared_ptr
 #include <utility>                  // std::pair
 
@@ -49,6 +50,8 @@ namespace lluau
     // terminated char arrays.
     int dostring(lua_State* L, const std::string& desc, const std::string& text);
     int loadstring(lua_State* L, const std::string& desc, const std::string& text);
+
+    std::filesystem::path source_path(lua_State* L);
 } // namespace lluau
 
 std::string lua_tostdstring(lua_State* L, int index);

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -104,6 +104,7 @@ LuaListener::PumpData LuaListener::getNext()
 {
     try
     {
+        LLCoros::TempStatus status("get_event_next()");
         return mQueue.pop();
     }
     catch (const LLThreadSafeQueueInterrupt&)

--- a/indra/llui/llluafloater.cpp
+++ b/indra/llui/llluafloater.cpp
@@ -26,7 +26,7 @@
 
 #include "llluafloater.h"
 
-#include <filesystem>
+#include "fsyspath.h"
 #include "llevents.h"
 
 #include "llcheckboxctrl.h"
@@ -271,12 +271,12 @@ void LLLuaFloater::postEvent(LLSD data, const std::string &event_name)
 
 void LLLuaFloater::showLuaFloater(const LLSD &data)
 {
-    std::filesystem::path fs_path(data["xml_path"].asString());
-    std::string path = fs_path.lexically_normal().string();
+    fsyspath fs_path(data["xml_path"].asString());
+    std::string path = fs_path.lexically_normal().u8string();
     if (!fs_path.is_absolute()) 
     {
         std::string lib_path = gDirUtilp->getExpandedFilename(LL_PATH_SCRIPTS, "lua");
-        path = (std::filesystem::path(lib_path) / path).u8string();
+        path = (fsyspath(lib_path) / path).u8string();
     }
     
     LLLuaFloater *floater = new LLLuaFloater(data);

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -28,6 +28,7 @@
 #include "llviewerprecompiledheaders.h"
 #include "llluamanager.h"
 
+#include "fsyspath.h"
 #include "llcoros.h"
 #include "llerror.h"
 #include "lleventcoro.h"
@@ -37,7 +38,6 @@
 #include "stringize.h"
 
 #include <boost/algorithm/string/replace.hpp>
-#include <filesystem>
 
 #include "luau/luacode.h"
 #include "luau/lua.h"
@@ -314,7 +314,7 @@ void LLRequireResolver::resolveRequire(lua_State *L, std::string path)
 }
 
 LLRequireResolver::LLRequireResolver(lua_State *L, const std::string& path) :
-    mPathToResolve(std::filesystem::path(path).lexically_normal()),
+    mPathToResolve(fsyspath(path).lexically_normal()),
     L(L)
 {
     mSourceDir = lluau::source_path(L).parent_path();
@@ -377,12 +377,12 @@ void LLRequireResolver::findModule()
         fail();
     }
 
-    std::vector<std::filesystem::path> lib_paths
+    std::vector<fsyspath> lib_paths
     {
         gDirUtilp->getExpandedFilename(LL_PATH_SCRIPTS, "lua"),
 #ifdef LL_TEST
         // Build-time tests don't have the app bundle - use source tree.
-        std::filesystem::path(__FILE__).parent_path() / "scripts" / "lua",
+        fsyspath(__FILE__).parent_path() / "scripts" / "lua",
 #endif
     };
 

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -27,9 +27,9 @@
 #ifndef LL_LLLUAMANAGER_H
 #define LL_LLLUAMANAGER_H
 
+#include "fsyspath.h"
 #include "llcoros.h"
 #include "llsd.h"
-#include <filesystem>
 #include <functional>
 #include <string>
 #include <utility>                  // std::pair
@@ -89,8 +89,8 @@ class LLRequireResolver
     static void resolveRequire(lua_State *L, std::string path);
 
  private:
-    std::filesystem::path mPathToResolve;
-    std::filesystem::path mSourceDir;
+    fsyspath mPathToResolve;
+    fsyspath mSourceDir;
 
     LLRequireResolver(lua_State *L, const std::string& path);
 

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -29,6 +29,7 @@
 
 #include "llcoros.h"
 #include "llsd.h"
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <utility>                  // std::pair
@@ -88,8 +89,8 @@ class LLRequireResolver
     static void resolveRequire(lua_State *L, std::string path);
 
  private:
-    std::string mPathToResolve;
-    std::string mSourceChunkname;
+    std::filesystem::path mPathToResolve;
+    std::filesystem::path mSourceDir;
 
     LLRequireResolver(lua_State *L, const std::string& path);
 

--- a/indra/newview/scripts/lua/ErrorQueue.lua
+++ b/indra/newview/scripts/lua/ErrorQueue.lua
@@ -3,22 +3,22 @@
 -- raise that error.
 
 local WaitQueue = require('WaitQueue')
--- local debug = require('printf')
-local function debug(...) end
+-- local dbg = require('printf')
+local function dbg(...) end
 
 local ErrorQueue = WaitQueue:new()
 
 function ErrorQueue:Error(message)
     -- Setting Error() is a marker, like closing the queue. Once we reach the
     -- error, every subsequent Dequeue() call will raise the same error.
-    debug('Setting self._closed to %q', message)
+    dbg('Setting self._closed to %q', message)
     self._closed = message
     self:_wake_waiters()
 end
 
 function ErrorQueue:Dequeue()
     local value = WaitQueue.Dequeue(self)
-    debug('ErrorQueue:Dequeue: base Dequeue() got %s', value)
+    dbg('ErrorQueue:Dequeue: base Dequeue() got %s', value)
     if value ~= nil then
         -- queue not yet closed, show caller
         return value

--- a/indra/newview/scripts/lua/Queue.lua
+++ b/indra/newview/scripts/lua/Queue.lua
@@ -1,6 +1,12 @@
 -- from https://create.roblox.com/docs/luau/queues#implementing-queues,
 -- amended per https://www.lua.org/pil/16.1.html
 
+-- While coding some scripting in Lua
+-- I found that I needed a queua
+-- I thought of linked list
+-- But had to resist
+-- For fear it might be too obscua. 
+
 local Queue = {}
 
 function Queue:new()

--- a/indra/newview/scripts/lua/WaitQueue.lua
+++ b/indra/newview/scripts/lua/WaitQueue.lua
@@ -5,8 +5,8 @@
 local fiber = require('fiber')
 local Queue = require('Queue')
 
--- local debug = LL.print_debug
-local function debug(...) end
+-- local dbg = require('printf')
+local function dbg(...) end
 
 local WaitQueue = Queue:new()
 
@@ -60,17 +60,18 @@ function WaitQueue:Dequeue()
         -- the queue while there are still items left, and we want the
         -- consumer(s) to retrieve those last few items.
         if self._closed then
-            debug('WaitQueue:Dequeue(): closed')
+            dbg('WaitQueue:Dequeue(): closed')
             return nil
         end
-        debug('WaitQueue:Dequeue(): waiting')
+        dbg('WaitQueue:Dequeue(): waiting')
         -- add the running coroutine to the list of waiters
+        dbg('WaitQueue:Dequeue() running %s', tostring(coroutine.running() or 'main'))
         table.insert(self._waiters, fiber.running())
         -- then let somebody else run
         fiber.wait()
     end
     -- here we're sure this queue isn't empty
-    debug('WaitQueue:Dequeue() calling Queue.Dequeue()')
+    dbg('WaitQueue:Dequeue() calling Queue.Dequeue()')
     return Queue.Dequeue(self)
 end
 

--- a/indra/newview/scripts/lua/startup.lua
+++ b/indra/newview/scripts/lua/startup.lua
@@ -1,0 +1,101 @@
+-- query, wait for or mandate a particular viewer startup state
+
+-- During startup, the viewer steps through a sequence of numbered (and named)
+-- states. This can be used to detect when, for instance, the login screen is
+-- displayed, or when the viewer has finished logging in and is fully
+-- in-world.
+
+local fiber = require 'fiber'
+local leap = require 'leap'
+local inspect = require 'inspect'
+local function dbg(...) end
+-- local dbg = require 'printf'
+
+-- ---------------------------------------------------------------------------
+-- Get the list of startup states from the viewer.
+local bynum = leap.request('LLStartUp', {op='getStateTable'})['table']
+
+local byname = setmetatable(
+    {},
+    -- set metatable to throw an error if you look up invalid state name
+    {__index=function(t, k)
+         local v = t[k]
+         if v then
+             return v
+         end
+         error(string.format('startup module passed invalid state %q', k), 2)
+    end})
+
+-- derive byname as a lookup table to find the 0-based index for a given name
+for i, name in pairs(bynum) do
+    -- the viewer's states are 0-based, not 1-based like Lua indexes
+    byname[name] = i - 1
+end
+-- dbg('startup states: %s', inspect(byname))
+
+-- specialize a WaitFor to track the viewer's startup state
+local startup_pump = 'StartupState'
+local waitfor = leap.WaitFor:new(0, startup_pump)
+function waitfor:filter(pump, data)
+    if pump == self.name then
+        return data
+    end
+end
+
+function waitfor:process(data)
+    -- keep updating startup._state for interested parties
+    startup._state = data.str
+    dbg('startup updating state to %q', data.str)
+    -- now pass data along to base-class method to queue
+    leap.WaitFor.process(self, data)
+end
+
+-- listen for StartupState events
+leap.request(leap.cmdpump(),
+             {op='listen', source=startup_pump, listener='startup.lua', tweak=true})
+-- poke LLStartUp to make sure we get an event
+leap.send('LLStartUp', {op='postStartupState'})
+
+-- ---------------------------------------------------------------------------
+startup = {}
+
+-- wait for response from postStartupState
+while not startup._state do
+    dbg('startup.state() waiting for first StartupState event')
+    waitfor:wait()
+end
+
+-- return a list of all known startup states
+function startup.list()
+    return bynum
+end
+
+-- report whether state with string name 'left' is before string name 'right'
+function startup.before(left, right)
+    return byname[left] < byname[right]
+end
+
+-- report the viewer's current startup state
+function startup.state()
+    return startup._state
+end
+
+-- error if script is called before specified state string name
+function startup.ensure(state)
+    if startup.before(startup.state(), state) then
+        -- tell error() to pretend this error was thrown by our caller
+        error('must not be called before startup state ' .. state, 2)
+    end
+end
+
+-- block calling fiber until viewer has reached state with specified string name
+function startup.wait(state)
+    dbg('startup.wait(%q)', state)
+    while startup.before(startup.state(), state) do
+        local item = waitfor:wait()
+        dbg('startup.wait(%q) sees %s', state, item)
+    end
+end
+
+return startup
+

--- a/indra/newview/scripts/lua/test_luafloater_demo.lua
+++ b/indra/newview/scripts/lua/test_luafloater_demo.lua
@@ -1,4 +1,4 @@
-XML_FILE_PATH = LL.source_dir() .. "/luafloater_demo.xml"
+XML_FILE_PATH = LL.abspath("luafloater_demo.xml")
 
 scriptparts = string.split(LL.source_path(), '/')
 scriptname = scriptparts[#scriptparts]

--- a/indra/newview/scripts/lua/test_luafloater_demo.lua
+++ b/indra/newview/scripts/lua/test_luafloater_demo.lua
@@ -1,10 +1,16 @@
-XML_FILE_PATH = "luafloater_demo.xml"
+XML_FILE_PATH = LL.source_dir() .. "/luafloater_demo.xml"
+
+scriptparts = string.split(LL.source_path(), '/')
+scriptname = scriptparts[#scriptparts]
+print('Running ' .. scriptname)
 
 leap = require 'leap'
 fiber = require 'fiber'
+startup = require 'startup'
 
 --event pump for sending actions to the floater
-COMMAND_PUMP_NAME = ""
+local COMMAND_PUMP_NAME = ""
+local reqid
 --table of floater UI events
 event_list=leap.request("LLFloaterReg", {op="getFloaterEvents"}).events
 
@@ -41,24 +47,29 @@ function handleEvents(event_data)
     end
   elseif event_data.event == _event("floater_close") then
     LL.print_warning("Floater was closed")
-    leap.done()
+    return false
   end
+  return true
 end
 
+startup.wait('STATE_LOGIN_WAIT')
 local key = {xml_path = XML_FILE_PATH, op = "showLuaFloater"}
 --sign for additional events for defined control {<control_name>= {action1, action2, ...}}
 key.extra_events={show_time_lbl = {_event("right_mouse_down"), _event("double_click")}}
-COMMAND_PUMP_NAME = leap.request("LLFloaterReg", key).command_name
+local resp = leap.request("LLFloaterReg", key)
+COMMAND_PUMP_NAME = resp.command_name
+reqid = resp.reqid
 
 catch_events = leap.WaitFor:new(-1, "all_events")
 function catch_events:filter(pump, data)
-  return data
+  if data.reqid == reqid then
+    return data
+  end
 end
 
 function process_events(waitfor)
   event_data = waitfor:wait()
-  while event_data do
-    handleEvents(event_data)
+  while event_data and handleEvents(event_data) do
     event_data = waitfor:wait()
   end
 end

--- a/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
+++ b/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
@@ -1,11 +1,17 @@
-XML_FILE_PATH = "luafloater_gesture_list.xml"
+XML_FILE_PATH = LL.source_dir() .. "/luafloater_gesture_list.xml"
+
+scriptparts = string.split(LL.source_path(), '/')
+scriptname = scriptparts[#scriptparts]
+print('Running ' .. scriptname)
 
 leap = require 'leap'
 fiber = require 'fiber'
 LLGesture = require 'LLGesture'
+startup = require 'startup'
 
 --event pump for sending actions to the floater
-COMMAND_PUMP_NAME = ""
+local COMMAND_PUMP_NAME = ""
+local reqid
 --table of floater UI events
 event_list=leap.request("LLFloaterReg", {op="getFloaterEvents"}).events
 
@@ -22,9 +28,12 @@ end
 
 function handleEvents(event_data)
   if event_data.event == _event("floater_close") then
-    leap.done()
-  elseif event_data.event == _event("post_build") then
+    return false
+  end
+
+  if event_data.event == _event("post_build") then
     COMMAND_PUMP_NAME = event_data.command_name
+    reqid = event_data.reqid
     gestures_uuid = LLGesture.getActiveGestures()
     local action_data = {}
     action_data.action = "add_list_element"
@@ -40,8 +49,10 @@ function handleEvents(event_data)
       LLGesture.startGesture(event_data.value)
     end
   end
+  return true
 end
 
+startup.wait('STATE_STARTED')
 local key = {xml_path = XML_FILE_PATH, op = "showLuaFloater"}
 --receive additional events for defined control {<control_name>= {action1, action2, ...}}
 key.extra_events={gesture_list = {_event("double_click")}}
@@ -49,13 +60,14 @@ handleEvents(leap.request("LLFloaterReg", key))
 
 catch_events = leap.WaitFor:new(-1, "all_events")
 function catch_events:filter(pump, data)
-  return data
+  if data.reqid == reqid then
+    return data
+  end
 end
 
 function process_events(waitfor)
   event_data = waitfor:wait()
-  while event_data do
-    handleEvents(event_data)
+  while event_data and handleEvents(event_data) do
     event_data = waitfor:wait()
   end
 end

--- a/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
+++ b/indra/newview/scripts/lua/test_luafloater_gesture_list.lua
@@ -1,4 +1,4 @@
-XML_FILE_PATH = LL.source_dir() .. "/luafloater_gesture_list.xml"
+XML_FILE_PATH = LL.abspath("luafloater_gesture_list.xml")
 
 scriptparts = string.split(LL.source_path(), '/')
 scriptname = scriptparts[#scriptparts]

--- a/indra/newview/scripts/lua/util.lua
+++ b/indra/newview/scripts/lua/util.lua
@@ -2,9 +2,9 @@
 
 local util = {}
 
--- cheap test whether table t is empty
-function util.empty(t)
-    return not next(t)
+-- check if array-like table contains certain value
+function util.contains(t, v)
+    return table.find(t, v) ~= nil
 end
 
 -- reliable count of the number of entries in table t
@@ -15,6 +15,11 @@ function util.count(t)
         count += 1
     end
     return count
+end
+
+-- cheap test whether table t is empty
+function util.empty(t)
+    return not next(t)
 end
 
 -- recursive table equality
@@ -34,16 +39,6 @@ function util.equal(t1, t2)
     end
     -- All keys in t1 have equal values in t2; t2 == t1 if there are no extra keys in t2
     return util.empty(temp)
-end
-
--- check if array-like table contains certain value
-function util.contains(t, v)
-    for _, value in ipairs(t) do
-        if value == v then
-            return true
-        end
-    end
-    return false
 end
 
 return util


### PR DESCRIPTION
This lets a calling script verify that it's running at the right point in the
viewer's life cycle. A script that wants to interact with the SL agent
wouldn't work if run from the viewer's command line -- unless it calls
`startup.wait("STATE_STARTED")`, which pauses until login is complete.

Modify `test_luafloater_demo.lua` and `test_luafloater_gesture_list.lua` to find
their respective floater XUI files in the same directory as themselves.
Make them both capture the `reqid` returned by the `"showLuaFloater"`operation,
and filter for events bearing the same `reqid`. This paves the way for a given
script to display more than one floater concurrently.

Make `test_luafloater_demo.lua` (which does not require in-world resources) wait
until `'STATE_LOGIN_WAIT'`, the point at which the viewer has presented the
login screen.

Make `test_luafloater_gesture_list.lua` (which interacts with the agent) wait
until `'STATE_STARTED'`, the point at which the viewer is fully in world.

Either or both can now be launched from the viewer's command line.