### PR TITLE
#1116 HDRI preview enhancements

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9384,6 +9384,17 @@
     <key>Value</key>
     <real>1.0</real>
   </map>
+  <key>RenderHDRIIrradianceOnly</key>
+  <map>
+    <key>Comment</key>
+    <string>Only use HDRI sky for irradiance map when RenderHDRISplitScreen is 0</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
   <key>RenderMaxOpenGLVersion</key>
   <map>
     <key>Comment</key>


### PR DESCRIPTION
Don't split sky in radiance and irradiance maps
Allow for applying HDRI sky to only irradiance map Allow for showing entire EEP sky (clouds and all) when split is set to zero