### PR TITLE
viewer#1117 Use attacment info for declouding logic

### DIFF
--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -938,10 +938,16 @@ protected:
 	// Map of attachment points, by ID
 	//--------------------------------------------------------------------
 public:
-	S32 				getAttachmentCount(); // Warning: order(N) not order(1) // currently used only by -self
+	S32 				getAttachmentCount(); // Warning: order(N) not order(1)
 	typedef std::map<S32, LLViewerJointAttachment*> attachment_map_t;
 	attachment_map_t 								mAttachmentPoints;
 	std::vector<LLPointer<LLViewerObject> > 		mPendingAttachment;
+
+    // List of attachments' ids with attach points from simulator.
+    // we need this info to know when all attachments are present.
+    std::map<LLUUID, S32>                           mSimAttachments;
+    S32                                             mLastCloudAttachmentCount;
+    LLFrameTimer                                    mLastCloudAttachmentChangeTime;
 
 	//--------------------------------------------------------------------
 	// HUD functions


### PR DESCRIPTION
1. Use attachment count from simulator to determine cloud' state, but don't wait forever (wait 120s)
2. Reduce FIRST_APPEARANCE_CLOUD_MAX_DELAY since we no longer need to wait for potential attachments. If we got here, we know that we either waited long enough or that all attachments are already there.