### PR TITLE
viewer#676 Use attacment info for rez state reporting

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10313,6 +10313,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>NameTagDebugAVRezState</key>
+    <map>
+        <key>Comment</key>
+        <string>Show Avatar Rez state in name tag</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>RenderInitError</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -381,7 +381,8 @@ public:
 	// Loading state
 	//--------------------------------------------------------------------
 public:
-	bool			isFullyLoaded() const;
+    bool			isFullyLoaded() const;
+    F32				getFirstDecloudTime() const {return mFirstDecloudTime;}
 
     // check and return current state relative to limits
     // default will test only the geometry (combined=false).
@@ -421,6 +422,7 @@ protected:
 
 private:
 	bool			mFirstFullyVisible;
+    F32				mFirstDecloudTime;
 	F32				mFirstUseDelaySeconds;
 	LLFrameTimer	mFirstAppearanceMessageTimer;
 
@@ -714,7 +716,7 @@ public:
 
 	bool			isFullyBaked();
 	static bool		areAllNearbyInstancesBaked(S32& grey_avatars);
-	static void		getNearbyRezzedStats(std::vector<S32>& counts);
+	static void		getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_time, S32& cloud_avatars);
 	static std::string rezStatusToString(S32 status);
 
 	//--------------------------------------------------------------------
@@ -938,7 +940,7 @@ protected:
 	// Map of attachment points, by ID
 	//--------------------------------------------------------------------
 public:
-	S32 				getAttachmentCount(); // Warning: order(N) not order(1)
+	S32 				getAttachmentCount() const; // Warning: order(N) not order(1)
 	typedef std::map<S32, LLViewerJointAttachment*> attachment_map_t;
 	attachment_map_t 								mAttachmentPoints;
 	std::vector<LLPointer<LLViewerObject> > 		mPendingAttachment;

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -2226,16 +2226,21 @@ void LLVOAvatarSelf::appearanceChangeMetricsCoro(std::string url)
 
     // Status of our own rezzing.
     msg["rez_status"] = LLVOAvatar::rezStatusToString(getRezzedStatus());
+    msg["first_decloud_time"] = getFirstDecloudTime();
 
     // Status of all nearby avs including ourself.
     msg["nearby"] = LLSD::emptyArray();
     std::vector<S32> rez_counts;
-    LLVOAvatar::getNearbyRezzedStats(rez_counts);
+    F32 avg_time;
+    S32 total_cloud_avatars;
+    LLVOAvatar::getNearbyRezzedStats(rez_counts, avg_time, total_cloud_avatars);
     for (S32 rez_stat = 0; rez_stat < rez_counts.size(); ++rez_stat)
     {
         std::string rez_status_name = LLVOAvatar::rezStatusToString(rez_stat);
         msg["nearby"][rez_status_name] = rez_counts[rez_stat];
     }
+    msg["nearby"]["avg_decloud_time"] = avg_time;
+    msg["nearby"]["cloud_total"] = total_cloud_avatars;
 
     //	std::vector<std::string> bucket_fields("timer_name","is_self","grid_x","grid_y","is_using_server_bake");
     std::vector<std::string> by_fields;

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3901,6 +3901,16 @@ function="World.EnvPreset"
                  function="Advanced.ToggleDebugCharacterVis" />
             </menu_item_check>
             <menu_item_check
+             label="Debug Character Rez State"
+             name="Debug Character Rez State">
+                <menu_item_check.on_check
+                 function="CheckControl"
+                 parameter="NameTagDebugAVRezState" />
+                <menu_item_check.on_click
+                 function="ToggleControl"
+                 parameter="NameTagDebugAVRezState" />
+            </menu_item_check>
+            <menu_item_check
              label="Show Collision Skeleton"
              name="Show Collision Skeleton">
                 <menu_item_check.on_check


### PR DESCRIPTION
1. Updated 'rez' status with attachment count
2. Updated "ViewerMetrics" and other parts to include new rez status
3. Added average initial decloud and total current cloud count to ViewerMetrics (since rez status doesn't cover all cases)
4. Added a developer setting to show rez status in a name tag (because following logs is a pain)

P.S. Did couple tests and half the time agents are cloud because agents are waiting for meshes. This isn't refleted in rez state yet because check for meshes is somewhat expensive