### PR TITLE
[WebRTC] Explicit decline message for webrtc p2p sessions.

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -515,16 +515,6 @@ void LLWebRTCImpl::updateDevices()
         char name[webrtc::kAdmMaxDeviceNameSize];
         char guid[webrtc::kAdmMaxGuidSize];
         mTuningDeviceModule->PlayoutDeviceName(index, name, guid);
-
-#if WEBRTC_LINUX
-        // Linux audio implementation (pulse and alsa)
-        // return empty strings for the guid, so 
-        // use the name for the guid
-        if (!strcmp(guid, ""))
-        {
-            strcpy(guid, name);
-        }
-#endif // WEBRTC_LINUX
         mPlayoutDeviceList.emplace_back(name, guid);
     }
 
@@ -543,15 +533,6 @@ void LLWebRTCImpl::updateDevices()
         char name[webrtc::kAdmMaxDeviceNameSize];
         char guid[webrtc::kAdmMaxGuidSize];
         mTuningDeviceModule->RecordingDeviceName(index, name, guid);
-#if WEBRTC_LINUX
-        // Linux audio implementation (pulse and alsa)
-        // return empty strings for the guid, so
-        // use the name for the guid
-        if (!strcmp(guid, ""))
-        {
-            strcpy(guid, name);
-        }
-#endif  // WEBRTC_LINUX
         mRecordingDeviceList.emplace_back(name, guid);
     }
 

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -401,7 +401,7 @@ void ll_set_device_module_capture_device(rtc::scoped_refptr<webrtc::AudioDeviceM
 #else
     // passed in default is -1, but the device list
     // has it at 0
-    device_module->SetPlayoutDevice(device + 1);
+    device_module->SetRecordingDevice(device + 1);
 #endif
     device_module->InitMicrophone();
     device_module->InitRecording();

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -78,7 +78,12 @@ class LLWebRTCVoiceDevice
     LLWebRTCVoiceDevice(const std::string &display_name, const std::string &id) :
         mDisplayName(display_name),
         mID(id)
-    {};
+    {
+        if (mID.empty())
+        {
+            mID = display_name;
+        }
+    };
 };
 
 typedef std::vector<LLWebRTCVoiceDevice> LLWebRTCVoiceDeviceList;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -35,6 +35,7 @@
 #define WEBRTC_POSIX 1
 #elif __linux__
 #define WEBRTC_LINUX 1
+#define WEBRTC_POSIX 1
 #endif
 
 #include "llwebrtc.h"

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3595,17 +3595,21 @@ void LLIMMgr::processAgentListUpdates(const LLUUID& session_id, const LLSD& body
         LLSD::map_const_iterator update_it;
         for (update_it = body["agent_updates"].beginMap(); update_it != body["agent_updates"].endMap(); ++update_it)
         {
-            LLUUID agent_id(update_it->first);
             LLSD   agent_data = update_it->second;
 
-            if (agent_data.isMap())
+            if (agent_data.isMap() && agent_data.has("info") && agent_data["info"].isMap())
             {
                 // Is one of the participants leaving a P2P Chat?
-                if (agent_data.has("transition") && agent_data["transition"].asString() == "LEAVE")
+                if (agent_data["info"].has("can_voice_chat") && !agent_data["info"]["can_voice_chat"].asBoolean())
                 {
                     LLVoiceChannelGroup *channelp = dynamic_cast < LLVoiceChannelGroup*>(LLVoiceChannel::getChannelByID(session_id));
                     if (channelp && channelp->isP2P())
                     {
+						// it's an adhoc-style P2P channel, and voice is disabled / declined.  notify the user
+						// and shut down the voice channel.
+                        LLSD notifyArgs = LLSD::emptyMap();
+                        notifyArgs["VOICE_CHANNEL_NAME"]  = channelp->getSessionName();
+                        LLNotificationsUtil::add("P2PCallDeclined", notifyArgs);
                         endCall(session_id);
                         break;
                     }

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3005,42 +3005,42 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 	{
 		if (type == IM_SESSION_P2P_INVITE)
 		{
-            // decline p2p voice, either via the vivox-style call mechanism
+			// decline p2p voice, either via the vivox-style call mechanism
 			// or via the webrtc-style "decline p2p" mechanism.
-            LLVoiceP2PIncomingCallInterfacePtr call = LLVoiceClient::getInstance()->getIncomingCallInterface(payload["voice_channel_info"]);
-            if (call)
-            {
-                call->declineInvite();
-            }
+			LLVoiceP2PIncomingCallInterfacePtr call = LLVoiceClient::getInstance()->getIncomingCallInterface(payload["voice_channel_info"]);
+			if (call)
+			{
+				call->declineInvite();
+			}
 			else
 			{
 				// webrtc-style decline.
-                LLViewerRegion *region = gAgent.getRegion();
-                if (region)
-                {
-                    std::string url = region->getCapability("ChatSessionRequest");
+				LLViewerRegion *region = gAgent.getRegion();
+				if (region)
+				{
+					std::string url = region->getCapability("ChatSessionRequest");
 
-                    LLSD data;
-                    data["method"]     = "decline p2p voice";
-                    data["session-id"] = session_id;
+					LLSD data;
+					data["method"]     = "decline p2p voice";
+					data["session-id"] = session_id;
 
-                    LLCoreHttpUtil::HttpCoroutineAdapter::messageHttpPost(url, data, "P2P declined", "P2P decline failed.");
-                }
+					LLCoreHttpUtil::HttpCoroutineAdapter::messageHttpPost(url, data, "P2P declined", "P2P decline failed.");
+				}
 			}
 		}
 		else
 		{
-            LLViewerRegion *region = gAgent.getRegion();
-            if (region)
-            {
-                std::string url = region->getCapability("ChatSessionRequest");
+			LLViewerRegion *region = gAgent.getRegion();
+			if (region)
+			{
+				std::string url = region->getCapability("ChatSessionRequest");
 
-                LLSD data;
-                data["method"]     = "decline invitation";
-                data["session-id"] = session_id;
+				LLSD data;
+				data["method"]     = "decline invitation";
+				data["session-id"] = session_id;
 
-                LLCoreHttpUtil::HttpCoroutineAdapter::messageHttpPost(url, data, "Invitation declined", "Invitation decline failed.");
-            }
+				LLCoreHttpUtil::HttpCoroutineAdapter::messageHttpPost(url, data, "Invitation declined", "Invitation decline failed.");
+			}
 		}
 	}
 

--- a/indra/newview/llvoicechannel.h
+++ b/indra/newview/llvoicechannel.h
@@ -147,6 +147,8 @@ public:
 	void setChannelInfo(const LLSD &channelInfo) override;
 	void requestChannelInfo() override;
 
+	bool isP2P() { return mIsP2P; }
+
 protected:
 	void setState(EState state) override;
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5089,7 +5089,7 @@ bool LLVivoxVoiceClient::isCurrentChannel(const LLSD &channelInfo)
     }
     if (mAudioSession)
     {
-        if (!channelInfo["sessionHandle"].asString().empty())
+        if (!channelInfo["session_handle"].asString().empty())
         {
             return mAudioSession->mHandle == channelInfo["session_handle"].asString();
         }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2368,12 +2368,14 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
     if (!regionp || !regionp->capabilitiesReceived())
     {
         LL_DEBUGS("Voice") << "no capabilities for voice provisioning; waiting " << LL_ENDL;
+        setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
         return;
     }
 
     std::string url = regionp->getCapability("ProvisionVoiceAccountRequest");
     if (url.empty())
     {
+        setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
         return;
     }
 

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -1360,7 +1360,7 @@ bool LLWebRTCVoiceClient::isCurrentChannel(const LLSD &channelInfo)
 
     if (mSession)
     {
-        if (!channelInfo["sessionHandle"].asString().empty())
+        if (!channelInfo["session_handle"].asString().empty())
         {
             return mSession->mHandle == channelInfo["session_handle"].asString();
         }


### PR DESCRIPTION
WebRTC P2P uses a different mechanism for managing p2p voice calls than Vivox, as WebRTC uses the existing messaging infrastructure to handle calls, declines, accepts, etc.  Vivox uses a vivox-supplied mechanism for p2p calls.

This required us to add explicit p2p call and p2p decline messaging.

Also, in this PR, are some linux-related code fixes and some renaming of items to be more clear.