### PR TITLE
First pass of Linux compile testing

### DIFF
--- a/indra/cmake/WebRTC.cmake
+++ b/indra/cmake/WebRTC.cmake
@@ -26,7 +26,7 @@ elseif (DARWIN)
         ${COCOA_LIBRARY}
     )
 elseif (LINUX)
-    target_link_libraries( ll::webrtc INTERFACE libwebrtc )
+    target_link_libraries( ll::webrtc INTERFACE libwebrtc.a X11 )
 endif (WINDOWS)
 
 

--- a/indra/llwebrtc/CMakeLists.txt
+++ b/indra/llwebrtc/CMakeLists.txt
@@ -10,8 +10,9 @@ include(WebRTC)
 
 project(llwebrtc)
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
-
+if(LINUX)
+    add_compile_options(-Wno-deprecated-declarations) # webrtc::CreateAudioDeviceWithDataObserver is deprecated
+endif()
 
 set(llwebrtc_SOURCE_FILES
     llwebrtc.cpp
@@ -26,7 +27,6 @@ set(llwebrtc_HEADER_FILES
 list(APPEND llwebrtc_SOURCE_FILES ${llwebrtc_HEADER_FILES})
 
 add_library (llwebrtc SHARED ${llwebrtc_SOURCE_FILES})
-    
 set_target_properties(llwebrtc PROPERTIES PUBLIC_HEADER llwebrtc.h)
 
 if (WINDOWS)
@@ -44,7 +44,7 @@ elseif (LINUX)
     target_link_libraries(llwebrtc PRIVATE ll::webrtc)
 endif (WINDOWS)
     
-target_include_directories( llwebrtc  INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories( llwebrtc INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 if (WINDOWS)
     set_property(TARGET llwebrtc PROPERTY


### PR DESCRIPTION
Unable to link though
```
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `llwebrtc::LLWebRTCImpl::init()':
llwebrtc/llwebrtc.cpp:181: undefined reference to `rtc::Thread::SetName(std::basic_string_view<char, std::char_traits<char> >, void const*)'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:184: undefined reference to `rtc::Thread::SetName(std::basic_string_view<char, std::char_traits<char> >, void const*)'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:187: undefined reference to `rtc::Thread::SetName(std::basic_string_view<char, std::char_traits<char> >, void const*)'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:268: undefined reference to `webrtc::CreatePeerConnectionFactory(rtc::Thread*, rtc::Thread*, rtc::Thread*, rtc::scoped_refptr<webrtc::AudioDeviceModule>, rtc::scoped_refptr<webrtc::AudioEncoderFactory>, rtc::scoped_refptr<webrtc::AudioDecoderFactory>, std::unique_ptr<webrtc::VideoEncoderFactory, std::default_delete<webrtc::VideoEncoderFactory> >, std::unique_ptr<webrtc::VideoDecoderFactory, std::default_delete<webrtc::VideoDecoderFactory> >, rtc::scoped_refptr<webrtc::AudioMixer>, rtc::scoped_refptr<webrtc::AudioProcessing>, webrtc::AudioFrameProcessor*, std::unique_ptr<webrtc::FieldTrialsView, std::default_delete<webrtc::FieldTrialsView> >)'
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `void absl::internal_any_invocable::RemoteInvoker<false, void, llwebrtc::LLWebRTCPeerConnectionImpl::AnswerAvailable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1}&&>(absl::internal_any_invocable::TypeErasedState*)':
llwebrtc/llwebrtc.cpp:853: undefined reference to `webrtc::CreateSessionDescription(webrtc::SdpType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `void absl::internal_any_invocable::LocalInvoker<false, void, llwebrtc::LLWebRTCImpl::init()::{lambda()#1}&&>(absl::internal_any_invocable::TypeErasedState*)':
llwebrtc/llwebrtc.cpp:196: undefined reference to `webrtc::CreateAudioDeviceWithDataObserver(webrtc::AudioDeviceModule::AudioLayer, webrtc::TaskQueueFactory*, std::unique_ptr<webrtc::AudioDeviceDataObserver, std::default_delete<webrtc::AudioDeviceDataObserver> >)'
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `llwebrtc::LLWebRTCPeerConnectionImpl::OnSuccess(webrtc::SessionDescriptionInterface*)':
llwebrtc/llwebrtc.cpp:1149: undefined reference to `webrtc::CreateSessionDescription(webrtc::SdpType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `llwebrtc::iceCandidateToTrickleString(webrtc::IceCandidateInterface const*)':
llwebrtc/llwebrtc.cpp:1037: undefined reference to `rtc::IPAddress::ToString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1038: undefined reference to `rtc::SocketAddress::PortAsString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1059: undefined reference to `rtc::IPAddress::ToString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1060: undefined reference to `rtc::SocketAddress::PortAsString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1047: undefined reference to `rtc::IPAddress::ToString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1048: undefined reference to `rtc::SocketAddress::PortAsString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1053: undefined reference to `rtc::IPAddress::ToString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/llwebrtc.cpp:1054: undefined reference to `rtc::SocketAddress::PortAsString[abi:cxx11]() const'
/usr/bin/ld: llwebrtc/CMakeFiles/llwebrtc.dir/llwebrtc.cpp.o: in function `llwebrtc::LLWebRTCPeerConnectionImpl::OnIceCandidate(webrtc::IceCandidateInterface const*)':
llwebrtc/llwebrtc.cpp:1100: undefined reference to `webrtc::CreateIceCandidate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, cricket::Candidate const&)'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.

```