### PR TITLE
Add script termination option to 'Lua Scripts' floater

### DIFF
--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -429,6 +429,7 @@ void LLApp::setStatus(EAppStatus status)
             statsd = LLSD::Integer(status);
         }
         LLEventPumps::instance().obtain("LLApp").post(llsd::map("status", statsd));
+        LLEventPumps::instance().obtain("LLLua").post(llsd::map("status", "close_all"));
     }
 }
 

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -44,8 +44,8 @@ LuaListener::LuaListener(lua_State* L):
             LLEventPump::inventName("LuaState"),
             [this](const LLSD& status)
             {
-                const auto& coro_name = status["coro"].asString();
-                const auto& statsd = status["status"].asString();
+                auto coro_name = status["coro"].asString();
+                auto statsd = status["status"].asString();
                 if ((statsd == "close_all") || ((statsd == "close") && (coro_name == mCoroName)))
                 {
                     // If a Lua script is still blocked in getNext() during

--- a/indra/llcommon/lualistener.h
+++ b/indra/llcommon/lualistener.h
@@ -75,6 +75,8 @@ private:
 
     std::unique_ptr<LLLeapListener> mListener;
     LLTempBoundListener mShutdownConnection;
+
+    std::string mCoroName;
 };
 
 #endif /* ! defined(LL_LUALISTENER_H) */

--- a/indra/newview/llfloaterluascripts.cpp
+++ b/indra/newview/llfloaterluascripts.cpp
@@ -45,6 +45,11 @@ LLFloaterLUAScripts::LLFloaterLUAScripts(const LLSD &key)
     { 
         gViewerWindow->getWindow()->openFolder(mTargetFolderPath);
     });
+    mCommitCallbackRegistrar.add("Script.Terminate", [this](LLUICtrl*, const LLSD &userdata) 
+    { 
+        LLEventPumps::instance().obtain("LLLua").post(llsd::map("status", "close", "coro", mCoroName));
+        LLLUAmanager::terminateScript(mCoroName);
+    });
 }
 
 
@@ -113,6 +118,7 @@ void LLFloaterLUAScripts::onScrollListRightClicked(LLUICtrl *ctrl, S32 x, S32 y)
         if (menu)
         {
             mTargetFolderPath = std::filesystem::path((item->getColumn(1)->getValue().asString())).parent_path().string();
+            mCoroName = item->getValue().asString();
             menu->show(x, y);
             LLMenuGL::showPopup(this, menu, x, y);
         }

--- a/indra/newview/llfloaterluascripts.h
+++ b/indra/newview/llfloaterluascripts.h
@@ -46,8 +46,6 @@ private:
 
     std::unique_ptr<LLTimer> mUpdateTimer;
     LLScrollListCtrl* mScriptList;
-    std::string mTargetFolderPath;
-    std::string mCoroName;
 
     LLHandle<LLContextMenu> mContextMenuHandle;
 };

--- a/indra/newview/llfloaterluascripts.h
+++ b/indra/newview/llfloaterluascripts.h
@@ -47,6 +47,7 @@ private:
     std::unique_ptr<LLTimer> mUpdateTimer;
     LLScrollListCtrl* mScriptList;
     std::string mTargetFolderPath;
+    std::string mCoroName;
 
     LLHandle<LLContextMenu> mContextMenuHandle;
 };

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -190,7 +190,6 @@ void LLLUAmanager::runScriptFile(const std::string &filename, script_result_fn r
             // It will be called when the LuaState is destroyed.
             LuaState L(finished_cb);
 
-            static int index = 0;
             lua_callbacks(L)->interrupt = [](lua_State *L, int gc)
             {
                 if (gc >= 0)

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -192,14 +192,14 @@ void LLLUAmanager::runScriptFile(const std::string &filename, script_result_fn r
 
             lua_callbacks(L)->interrupt = [](lua_State *L, int gc)
             {
+                // skip if we're interrupting only for garbage collection
                 if (gc >= 0)
                     return;
                
-                std::set<std::string> scripts = LLLUAmanager::getTerminationList();
-                std::string coro = LLCoros::getName();
-                if (scripts.find(coro) != scripts.end()) 
+                auto it = sTerminationList.find(LLCoros::getName());
+                if (it != sTerminationList.end()) 
                 {
-                    sTerminationList.erase(coro);
+                    sTerminationList.erase(it);
                     lluau::error(L, "Script was terminated");
                 }
             };

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -85,9 +85,12 @@ public:
     static void runScriptOnLogin();
 
     static const std::map<std::string, std::string> getScriptNames() { return sScriptNames; }
+    static std::set<std::string> getTerminationList() { return sTerminationList; }
+    static void terminateScript(std::string& coro_name) { sTerminationList.insert(coro_name); }
 
  private:
-    static std::map<std::string, std::string> sScriptNames;
+   static std::map<std::string, std::string> sScriptNames;
+   static std::set<std::string> sTerminationList;
 };
 
 class LLRequireResolver

--- a/indra/newview/skins/default/xui/en/menu_lua_scripts.xml
+++ b/indra/newview/skins/default/xui/en/menu_lua_scripts.xml
@@ -8,4 +8,12 @@
     <menu_item_call.on_click
      function="Script.OpenFolder" />
   </menu_item_call>
+  <menu_item_separator/>
+  <menu_item_call
+   label="Terminate script"
+   layout="topleft"
+   name="terminate">
+    <menu_item_call.on_click
+     function="Script.Terminate" />
+   </menu_item_call>
 </context_menu>


### PR DESCRIPTION
Add the way to terminate selected script in 'Lua Scripts' floater: call `lluau::error` when it's needed (but if the script is blocked in `getNext()`, close the queue first).