### PR TITLE
triage#163 'Create folder from selected' misbehaves in marketplace

### DIFF
--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -852,7 +852,7 @@ void LLInvFVBridge::getClipboardEntries(bool show_asset_id,
 			disabled_items.push_back(std::string("Copy"));
 		}
 
-        if (isAgentInventory() && !single_folder_root)
+        if (isAgentInventory() && !single_folder_root && !isMarketplaceListingsFolder())
         {
             items.push_back(std::string("New folder from selected"));
             items.push_back(std::string("Subfolder Separator"));


### PR DESCRIPTION
Marketplace deliberately doesn't allow creating folders and the "New folder from selected" is a way of creating a new folder then moving selected items inside, therefore shouldn't be allowed.