### PR TITLE
Make sure inventory does not end with dead objects in it's maps

### DIFF
--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -2050,8 +2050,8 @@ void LLInventoryModel::deleteObject(const LLUUID& id, bool fix_broken_links, boo
 		{
 			LL_WARNS(LOG_INV) << "Deleting cat " << id << " while it still has child cats" << LL_ENDL;
 		}
+        mParentChildCategoryTree.erase(id);
 		delete cat_list;
-		mParentChildCategoryTree.erase(id);
 	}
 	addChangedMask(LLInventoryObserver::REMOVE, id);
 
@@ -5040,4 +5040,3 @@ void LLInventoryModel::FetchItemHttpHandler::processFailure(const char * const r
 					  << LLCoreHttpUtil::responseToString(response) << "]" << LL_ENDL;
 	gInventory.notifyObservers();
 }
-

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -578,8 +578,8 @@ void LLInventoryPanel::itemChanged(const LLUUID& item_id, U32 mask, const LLInve
 		if (model_item && view_item && viewmodel_item)
 		{
 			const LLUUID& idp = viewmodel_item->getUUID();
+            removeItemID(idp);
 			view_item->destroyView();
-			removeItemID(idp);
 		}
 
         LLInventoryObject const* objectp = mInventory->getObject(item_id);


### PR DESCRIPTION
Found by running with -fsanitize=address. The viewer does access dead objects, because in at least two places the object gets destroyed before it gets removed from the internal maps.

If the object is destroyed first, removed second then it will lead to map iteration visiting those dead objects and asking for it's ID

```
void LLInventoryPanel::removeItemID(const LLUUID& id)
{
	LLInventoryModel::cat_array_t categories;
	LLInventoryModel::item_array_t items;
	gInventory.collectDescendents(id, categories, items, TRUE);
...
```

then
```
void LLInventoryModel::collectDescendentsIf(const LLUUID& id,
   cat_array_t& cats,   item_array_t& items,  BOOL include_trash, LLInventoryCollectFunctor& add)
{
	// Start with categories
	if(!include_trash)
	{
		const LLUUID trash_id = findCategoryUUIDForType(LLFolderType::FT_TRASH);
		if(trash_id.notNull() && (trash_id == id))
			return;
	}
	cat_array_t* cat_array = get_ptr_in_map(mParentChildCategoryTree, id);
	if(cat_array)
	{
		S32 count = cat_array->size();
...
```

here cat_array can be dead, yet it would be used.