### PR TITLE
triage#170 Fix 'Clear log' button having incorrect state

### DIFF
--- a/indra/newview/llconversationlog.cpp
+++ b/indra/newview/llconversationlog.cpp
@@ -648,7 +648,7 @@ void LLConversationLog::onClearLogResponse(const LLSD& notification, const LLSD&
 	{
 		mConversations.clear();
 		notifyObservers();
-		cache();
+        saveToFile(getFileName());
 		deleteBackupLogs();
 	}
 }

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1917,7 +1917,21 @@ void LLFloaterPreference::selectChatPanel()
 
 void LLFloaterPreference::changed()
 {
-	getChild<LLButton>("clear_log")->setEnabled(LLConversationLog::instance().getConversations().size() > 0);
+    if (LLConversationLog::instance().getIsLoggingEnabled())
+    {
+        getChild<LLButton>("clear_log")->setEnabled(LLConversationLog::instance().getConversations().size() > 0);
+    }
+    else
+    {
+        // onClearLog clears list, then notifies changed() and only then clears file,
+        // so check presence of conversations before checking file, file will cleared later.
+        llstat st;
+        bool has_logs = LLConversationLog::instance().getConversations().size() > 0
+                        && LLFile::stat(LLConversationLog::instance().getFileName(), &st) == 0
+                        && S_ISREG(st.st_mode)
+                        && st.st_size > 0;
+        getChild<LLButton>("clear_log")->setEnabled(has_logs);
+    }
 
 	// set 'enable' property for 'Delete transcripts...' button
 	updateDeleteTranscriptsButton();


### PR DESCRIPTION
1. onClear should clear file even if in 'don't log' state.
2. When chat isn't logging, check presence of old log by checking file.