### PR TITLE
Add LINK_WITH_MOLD option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,8 +98,19 @@ jobs:
             ${{ runner.os }}-64-
 
       - name: Install Linux dependencies
-        if: runner.os == 'linux'
-        run: sudo apt update && sudo apt install -y libsndio-dev libpulse-dev libfltk1.3-dev libunwind-dev libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxrender-dev libxfixes-dev libxxf86vm-dev libxss-dev libdbus-1-dev libudev-dev libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libfreetype6-dev ninja-build libxft-dev
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            libsndio-dev libpulse-dev libfltk1.3-dev \
+            libunwind-dev libgl1-mesa-dev libglu1-mesa-dev \
+            libx11-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxi-dev libxext-dev \
+            libxrender-dev libxfixes-dev libxxf86vm-dev \
+            libxss-dev libdbus-1-dev libudev-dev \
+            libssl-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libfreetype6-dev ninja-build libxft-dev \
+            llvm mold
 
       - name: Install windows dependencies
         if: runner.os == 'Windows'
@@ -207,6 +218,13 @@ jobs:
             export PYTHON_COMMAND="python3"
           fi
           export PYTHON_COMMAND_NATIVE="$(native_path "$PYTHON_COMMAND")"
+
+          # Compile with clang, link with mold on linux.
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            export CC=clang
+            export CXX=clang++
+            export CMAKE_OPTIONS='-DLINK_WITH_MOLD=ON'
+          fi 
 
           ./build.sh
 

--- a/build.sh
+++ b/build.sh
@@ -205,6 +205,7 @@ pre_build()
      -DVIEWER_CHANNEL:STRING="${viewer_channel}" \
      -DGRID:STRING="\"$viewer_grid\"" \
      -DTEMPLATE_VERIFIER_OPTIONS:STRING="$template_verifier_options" $template_verifier_master_url \
+     $CMAKE_OPTIONS \
      "${SIGNING[@]}" \
     || fatal "$variant configuration failed"
 

--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -15,6 +15,7 @@
 include_guard()
 
 include(Variables)
+include(Linker)
 
 # We go to some trouble to set LL_BUILD to the set of relevant compiler flags.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $ENV{LL_BUILD}")
@@ -127,23 +128,37 @@ if (LINUX)
           APPID=secondlife
           LL_IGNORE_SIGCHLD
   )
+
   add_compile_options(
-          -fexceptions
-          -fno-math-errno
-          -fno-strict-aliasing
-          -fsigned-char
-          -msse2
-          -mfpmath=sse
-          -pthread
-          -Wno-parentheses
-          -Wno-deprecated
-          -Wno-c++20-compat
-          -Wno-pessimizing-move
-          -Wno-stringop-overflow
-          -Wno-stringop-truncation
-          -Wno-dangling-pointer
-          -fvisibility=hidden
+      -fexceptions
+      -fno-math-errno
+      -fno-strict-aliasing
+      -fsigned-char
+      -msse2
+      -mfpmath=sse
+      -pthread
+      -fvisibility=hidden
   )
+
+  set(GCC_CLANG_COMPATIBLE_WARNINGS
+      -Wno-parentheses
+      -Wno-deprecated
+      -Wno-c++20-compat
+      -Wno-pessimizing-move
+  )
+
+  set(CLANG_WARNINGS
+      ${GCC_CLANG_COMPATIBLE_WARNINGS}
+      # Put clang specific warning configuration here
+  )
+
+  set(GCC_WARNINGS
+      ${GCC_CLANG_COMPATIBLE_WARNINGS}
+      -Wno-stringop-overflow
+      -Wno-stringop-truncation
+      -Wno-dangling-pointer
+  )
+
   add_link_options(
           -Wl,--no-keep-memory
           -Wl,--build-id
@@ -156,12 +171,15 @@ if (LINUX)
   # this stops us requiring a really recent glibc at runtime
   add_compile_options(-fno-stack-protector)
 
-  # ND: clang is a bit more picky than GCC, the latter seems to auto include -lstdc++ and -lm. The former not so and thus fails to link
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # ND: clang is a bit more picky than GCC, the latter seems to auto include -lstdc++ and -lm. The former not so and thus fails to link
     add_link_options(
             -lstdc++
             -lm
     )
+    add_compile_options(${CLANG_WARNINGS})
+  else()
+    add_compile_options(${GCC_WARNINGS})
   endif()
 endif (LINUX)
 
@@ -190,10 +208,6 @@ if (DARWIN)
   set(GCC_WARNINGS -Wall -Wno-sign-compare -Wno-trigraphs)
 
   list(APPEND GCC_WARNINGS -Wno-reorder -Wno-non-virtual-dtor )
-
-  if(LINUX)
-    list(APPEND GCC_WARNINGS -Wno-maybe-uninitialized -Wno-dangling-pointer )
-  endif()
 
   add_compile_options(${GCC_WARNINGS})
   add_compile_options(-m${ADDRESS_SIZE})

--- a/indra/cmake/Linker.cmake
+++ b/indra/cmake/Linker.cmake
@@ -1,0 +1,11 @@
+include_guard(GLOBAL)
+
+if (${LINK_WITH_MOLD})
+  find_program(MOLD_BIN mold REQUIRED)
+  if(MOLD_BIN)
+    message(STATUS "Mold linker found: ${MOLD_BIN}. Enabling mold as active linker.")
+    add_link_options("-fuse-ld=${MOLD_BIN}")
+  else()
+    message(STATUS "Mold linker not found. Using default linker.")
+  endif()
+endif()


### PR DESCRIPTION
Allow developers to link the linux build with mold by supplying `-DLINK_WITH_MOLD=ON` to cmake. This is a more convenient alternative to supplying `-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"` explicitly, and provides some friendly cmake feedback if the linker is not found.

This shaves ~3 minutes off the linux build in GHA, and 30% (6 minutes) off my local machine's build.

This changeset also switches the default linux compiler in out CI/CD to clang, and breaks apart compiler warnings into GCC and CLANG specific sections so that they can be independently configured.