### PR TITLE
viewer-private#226 Unhandled PngError throws application into a loop

### DIFF
--- a/indra/llimage/llpngwrapper.cpp
+++ b/indra/llimage/llpngwrapper.cpp
@@ -216,6 +216,13 @@ BOOL LLPngWrapper::readPng(U8* src, S32 dataSize, LLImageRaw* rawImage, ImageInf
 		releaseResources();
 		return (FALSE);
 	}
+    catch (...)
+    {
+        mErrorMessage = "LLPngWrapper";
+        releaseResources();
+        LOG_UNHANDLED_EXCEPTION("");
+        return (FALSE);
+    }
 
 	// Clean up and return
 	releaseResources();

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -332,54 +332,62 @@ void LLFloaterImagePreview::draw()
 //-----------------------------------------------------------------------------
 bool LLFloaterImagePreview::loadImage(const std::string& src_filename)
 {
-	std::string exten = gDirUtilp->getExtension(src_filename);
-	U32 codec = LLImageBase::getCodecFromExtension(exten);
+    try
+    {
+        std::string exten = gDirUtilp->getExtension(src_filename);
+        U32 codec = LLImageBase::getCodecFromExtension(exten);
 
-	LLImageDimensionsInfo image_info;
-	if (!image_info.load(src_filename,codec))
-	{
-		mImageLoadError = image_info.getLastError();
-		return false;
-	}
+        LLImageDimensionsInfo image_info;
+        if (!image_info.load(src_filename, codec))
+        {
+            mImageLoadError = image_info.getLastError();
+            return false;
+        }
 
-	S32 max_width = gSavedSettings.getS32("max_texture_dimension_X");
-	S32 max_height = gSavedSettings.getS32("max_texture_dimension_Y");
+        S32 max_width = gSavedSettings.getS32("max_texture_dimension_X");
+        S32 max_height = gSavedSettings.getS32("max_texture_dimension_Y");
 
-	if ((image_info.getWidth() > max_width) || (image_info.getHeight() > max_height))
-	{
-		LLStringUtil::format_map_t args;
-		args["WIDTH"] = llformat("%d", max_width);
-		args["HEIGHT"] = llformat("%d", max_height);
+        if ((image_info.getWidth() > max_width) || (image_info.getHeight() > max_height))
+        {
+            LLStringUtil::format_map_t args;
+            args["WIDTH"] = llformat("%d", max_width);
+            args["HEIGHT"] = llformat("%d", max_height);
 
-		mImageLoadError = LLTrans::getString("texture_load_dimensions_error", args);
-		return false;
-	}
-	
-	// Load the image
-	LLPointer<LLImageFormatted> image = LLImageFormatted::createFromType(codec);
-	if (image.isNull())
-	{
-		return false;
-	}
-	if (!image->load(src_filename))
-	{
-		return false;
-	}
-	// Decompress or expand it in a raw image structure
-	LLPointer<LLImageRaw> raw_image = new LLImageRaw;
-	if (!image->decode(raw_image, 0.0f))
-	{
-		return false;
-	}
-	// Check the image constraints
-	if ((image->getComponents() != 3) && (image->getComponents() != 4))
-	{
-		image->setLastError("Image files with less than 3 or more than 4 components are not supported.");
-		return false;
-	}
-	
-	raw_image->biasedScaleToPowerOfTwo(1024);
-	mRawImagep = raw_image;
+            mImageLoadError = LLTrans::getString("texture_load_dimensions_error", args);
+            return false;
+        }
+
+        // Load the image
+        LLPointer<LLImageFormatted> image = LLImageFormatted::createFromType(codec);
+        if (image.isNull())
+        {
+            return false;
+        }
+        if (!image->load(src_filename))
+        {
+            return false;
+        }
+        // Decompress or expand it in a raw image structure
+        LLPointer<LLImageRaw> raw_image = new LLImageRaw;
+        if (!image->decode(raw_image, 0.0f))
+        {
+            return false;
+        }
+        // Check the image constraints
+        if ((image->getComponents() != 3) && (image->getComponents() != 4))
+        {
+            image->setLastError("Image files with less than 3 or more than 4 components are not supported.");
+            return false;
+        }
+
+        raw_image->biasedScaleToPowerOfTwo(1024);
+        mRawImagep = raw_image;
+    }
+    catch (...)
+    {
+        LOG_UNHANDLED_EXCEPTION("");
+        return false;
+    }
 	
 	return true;
 }

--- a/indra/newview/llviewertexturelist.h
+++ b/indra/newview/llviewertexturelist.h
@@ -96,7 +96,7 @@ public:
                                  const std::string& out_filename,
                                  const S32 max_image_dimentions = LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT,
                                  const S32 min_image_dimentions = 0);
-    static BOOL createUploadFile(const std::string& filename,
+    static bool createUploadFile(const std::string& filename,
                                  const std::string& out_filename,
                                  const U8 codec,
                                  const S32 max_image_dimentions = LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT,


### PR DESCRIPTION
png_read_info triggered a PngError, LLAppViewer::frame() handled it instead of LLPngWrapper::readPng, and since status didn't change viewer tried to decode image again and again and again.

I clearly lack some understanding about exceptions, because I don't know how it is possible for PngError to bypass 'catch (const PngError& msg)' in readPng yet be caught in LLFloaterImagePreview::loadImage() or LLAppViewer::frame(). Ether way fix catches the issue and aborts load instead of looping viewer.