### PR TITLE
Make it so that reset skeleton is a networked ViewerEffect

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -325,6 +325,7 @@ set(viewer_SOURCE_FILES
     llhudeffectpointat.cpp
     llhudeffecttrail.cpp
     llhudeffectblob.cpp
+    llhudeffectresetskeleton.cpp
     llhudicon.cpp
     llhudmanager.cpp
     llhudnametag.cpp
@@ -980,6 +981,7 @@ set(viewer_HEADER_FILES
     llhudeffectpointat.h
     llhudeffecttrail.h
     llhudeffectblob.h
+    llhudeffectresetskeleton.h
     llhudicon.h
     llhudmanager.h
     llhudnametag.h

--- a/indra/newview/llhudeffectresetskeleton.cpp
+++ b/indra/newview/llhudeffectresetskeleton.cpp
@@ -1,0 +1,207 @@
+/** 
+ * @file llhudeffectresetskeleton.cpp
+ * @brief LLHUDEffectResetSkeleton class implementation
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "llviewerprecompiledheaders.h"
+
+#include "llhudeffectresetskeleton.h"
+
+#include "llagent.h"
+#include "llviewerobjectlist.h"
+#include "llvoavatar.h"
+#include "message.h"
+
+// packet layout
+const S32 TARGET_OBJECT = 0; // This is to allow for targetting owned animesh
+const S32 RESET_ANIMATIONS = 16; //This can also be a flags if needed
+const S32 PKT_SIZE = 17;
+
+//-----------------------------------------------------------------------------
+// LLHUDEffectResetSkeleton()
+//-----------------------------------------------------------------------------
+LLHUDEffectResetSkeleton::LLHUDEffectResetSkeleton(const U8 type) : 
+	LLHUDEffect(type)
+{
+}
+
+//-----------------------------------------------------------------------------
+// ~LLHUDEffectResetSkeleton()
+//-----------------------------------------------------------------------------
+LLHUDEffectResetSkeleton::~LLHUDEffectResetSkeleton()
+{
+}
+
+//-----------------------------------------------------------------------------
+// packData()
+//-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::packData(LLMessageSystem *mesgsys)
+{
+	// Pack the default data
+	LLHUDEffect::packData(mesgsys);
+
+	// Pack the type-specific data.  Uses a fun packed binary format.  Whee!
+	U8 packed_data[PKT_SIZE];
+	memset(packed_data, 0, PKT_SIZE);
+
+	// pack both target object and position
+	// position interpreted as offset if target object is non-null
+	if (mTargetObject)
+	{
+		htolememcpy(&(packed_data[TARGET_OBJECT]), mTargetObject->mID.mData, MVT_LLUUID, 16);
+	}
+	else
+	{
+		htolememcpy(&(packed_data[TARGET_OBJECT]), LLUUID::null.mData, MVT_LLUUID, 16);
+	}
+	
+	U8 resetAnimations = (U8)mResetAnimations;
+	htolememcpy(&(packed_data[RESET_ANIMATIONS]), &resetAnimations, MVT_U8, 1);
+
+	mesgsys->addBinaryDataFast(_PREHASH_TypeData, packed_data, PKT_SIZE);
+}
+
+//-----------------------------------------------------------------------------
+// unpackData()
+//-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::unpackData(LLMessageSystem *mesgsys, S32 blocknum)
+{
+	LLVector3d new_target;
+	U8 packed_data[PKT_SIZE];
+
+	
+	LLHUDEffect::unpackData(mesgsys, blocknum);
+	
+	LLUUID source_id;
+	mesgsys->getUUIDFast(_PREHASH_Effect, _PREHASH_AgentID, source_id, blocknum);
+	
+	LLViewerObject *objp = gObjectList.findObject(source_id);
+	if (objp && objp->isAvatar())
+	{
+		setSourceObject(objp);
+	}
+	else
+	{
+		//LL_WARNS() << "Could not find source avatar for ResetSkeleton effect" << LL_ENDL;
+		return;
+	}
+	
+	S32 size = mesgsys->getSizeFast(_PREHASH_Effect, blocknum, _PREHASH_TypeData);
+	if (size != PKT_SIZE)
+	{
+		LL_WARNS() << "ResetSkeleton effect with bad size " << size << LL_ENDL;
+		return;
+	}
+	
+	mesgsys->getBinaryDataFast(_PREHASH_Effect, _PREHASH_TypeData, packed_data, PKT_SIZE, blocknum);
+	
+	LLUUID target_id;
+	htolememcpy(target_id.mData, &(packed_data[TARGET_OBJECT]), MVT_LLUUID, 16);
+
+	if (target_id.isNull())
+	{
+		target_id = source_id;
+	}
+	
+	objp = gObjectList.findObject(target_id);
+
+	if (objp)
+	{
+		setTargetObject(objp);
+	}
+	
+	U8 resetAnimations = 0;
+	htolememcpy(&resetAnimations, &(packed_data[RESET_ANIMATIONS]), MVT_U8, 1);
+	
+	// Pre-emptively assume this is going to be flags in the future.
+	// It isn't needed now, but this will assure that only bit 1 is set
+	mResetAnimations = resetAnimations & 1;
+	
+	update();
+}
+
+//-----------------------------------------------------------------------------
+// setTargetObjectAndOffset()
+//-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::setTargetObject(LLViewerObject *objp)
+{
+	mTargetObject = objp;
+}
+
+
+//-----------------------------------------------------------------------------
+// markDead()
+//-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::markDead()
+{
+	LLHUDEffect::markDead();
+}
+
+void LLHUDEffectResetSkeleton::setSourceObject(LLViewerObject* objectp)
+{
+	// restrict source objects to avatars
+	if (objectp && objectp->isAvatar())
+	{
+		LLHUDEffect::setSourceObject(objectp);
+	}
+}
+
+//-----------------------------------------------------------------------------
+// update()
+//-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::update()
+{
+	// If the target object is dead, set the target object to NULL
+	if (mTargetObject.isNull() || mTargetObject->isDead())
+	{
+		markDead();
+		return;
+	}
+
+	if (mSourceObject.isNull() || mSourceObject->isDead())
+	{
+		markDead();
+		return;
+	}
+	
+	bool owned = false;
+	if(mTargetObject->isAnimatedObject())
+	{
+		owned = mTargetObject->mOwnerID == mSourceObject->getID();
+	}
+	else
+	{
+		owned = mTargetObject->getID() == mSourceObject->getID();
+	}
+
+	if (owned)
+	{
+		if (mTargetObject->isAvatar() || mTargetObject->isAnimatedObject())
+		{
+			((LLVOAvatar*)(LLViewerObject*)mTargetObject)->resetSkeleton(mResetAnimations);
+		}
+	}
+	
+	markDead();
+}

--- a/indra/newview/llhudeffectresetskeleton.cpp
+++ b/indra/newview/llhudeffectresetskeleton.cpp
@@ -196,7 +196,7 @@ void LLHUDEffectResetSkeleton::update()
 		// Only the owner of a avatar can reset their skeleton like this
 		if (mSourceObject->getID() == mTargetObject->getID())
 		{
-			LLVOAvatar* avatar = (LLVOAvatar*)(LLViewerObject*)mTargetObject;
+			LLVOAvatar* avatar = mTargetObject->asAvatar();
 			avatar->resetSkeleton(mResetAnimations);
 		}
 	}

--- a/indra/newview/llhudeffectresetskeleton.h
+++ b/indra/newview/llhudeffectresetskeleton.h
@@ -1,0 +1,59 @@
+/** 
+ * @file llhudeffectresetskeleton.h
+ * @brief LLHUDEffectResetSkeleton class definition
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Linden Research, Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef LL_LLHUDEFFECTRESETSKELETON_H
+#define LL_LLHUDEFFECTRESETSKELETON_H
+
+#include "llhudeffect.h"
+
+class LLViewerObject;
+class LLVOAvatar;
+
+
+class LLHUDEffectResetSkeleton final : public LLHUDEffect
+{
+public:
+	friend class LLHUDObject;
+
+	/*virtual*/ void markDead();
+	/*virtual*/ void setSourceObject(LLViewerObject* objectp);
+
+	void setTargetObject(LLViewerObject *objp);
+	void setResetAnimations(bool enable){ mResetAnimations = enable; };
+
+protected:
+	LLHUDEffectResetSkeleton(const U8 type);
+	~LLHUDEffectResetSkeleton();
+
+	/*virtual*/ void packData(LLMessageSystem *mesgsys);
+	/*virtual*/ void unpackData(LLMessageSystem *mesgsys, S32 blocknum);
+
+	void update();
+private:
+	bool						mResetAnimations;
+};
+
+#endif // LL_LLHUDEFFECTRESETSKELETON_H

--- a/indra/newview/llhudobject.cpp
+++ b/indra/newview/llhudobject.cpp
@@ -36,6 +36,7 @@
 #include "llhudeffecttrail.h"
 #include "llhudeffectlookat.h"
 #include "llhudeffectpointat.h"
+#include "llhudeffectresetskeleton.h"
 #include "llhudnametag.h"
 #include "llvoicevisualizer.h"
 
@@ -240,6 +241,9 @@ LLHUDEffect *LLHUDObject::addHUDEffect(const U8 type)
 		break;
 	case LL_HUD_EFFECT_BLOB:
 		hud_objectp = new LLHUDEffectBlob(type);
+		break;
+	case LL_HUD_EFFECT_RESET_SKELETON:
+		hud_objectp = new LLHUDEffectResetSkeleton(type);
 		break;
 	default:
 		LL_WARNS() << "Unknown type of hud effect:" << (U32) type << LL_ENDL;

--- a/indra/newview/llhudobject.h
+++ b/indra/newview/llhudobject.h
@@ -96,7 +96,8 @@ public:
 		LL_HUD_EFFECT_POINTAT,
 		LL_HUD_EFFECT_VOICE_VISUALIZER,	// Ventrella
 		LL_HUD_NAME_TAG,
-		LL_HUD_EFFECT_BLOB
+		LL_HUD_EFFECT_BLOB,
+		LL_HUD_EFFECT_RESET_SKELETON
 	};
 protected:
 	static void sortObjects();

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -6506,16 +6506,16 @@ class LLAvatarResetSkeleton: public view_listener_t
         }
 		if(avatar)
         {
-			if(avatar->getID() == gAgent.getID())
+			if(avatar->getID() == gAgentID)
 			{
-				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
+				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
 				effectp->setSourceObject(gAgentAvatarp);
 				effectp->setTargetObject((LLViewerObject*)avatar);
 				effectp->setResetAnimations(false);
 			}
 			else
 			{
-				effectp->setResetAnimations(false);
+				avatar->setResetAnimations(false);
 			}
         }
         return true;
@@ -6543,7 +6543,7 @@ class LLAvatarResetSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			if(avatar->getID() == gAgent.getID())
+			if(avatar->getID() == gAgentID)
 			{
 				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
 				effectp->setSourceObject(gAgentAvatarp);
@@ -6552,7 +6552,7 @@ class LLAvatarResetSkeletonAndAnimations : public view_listener_t
 			}
 			else
 			{
-				effectp->setResetAnimations(true);
+				avatar->setResetAnimations(true);
 			}
 		}
 		return true;
@@ -6566,7 +6566,7 @@ class LLAvatarResetSelfSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			if(avatar->getID() == gAgent.getID())
+			if(avatar->getID() == gAgentID)
 			{
 				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
 				effectp->setSourceObject(gAgentAvatarp);
@@ -6575,7 +6575,7 @@ class LLAvatarResetSelfSkeletonAndAnimations : public view_listener_t
 			}
 			else
 			{
-				effectp->setResetAnimations(true);
+				avatar->setResetAnimations(true);
 			}
 		}
 		else

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -6515,7 +6515,7 @@ class LLAvatarResetSkeleton: public view_listener_t
 			}
 			else
 			{
-				avatar->setResetAnimations(false);
+				avatar->resetSkeleton(false);
 			}
         }
         return true;
@@ -6552,7 +6552,7 @@ class LLAvatarResetSkeletonAndAnimations : public view_listener_t
 			}
 			else
 			{
-				avatar->setResetAnimations(true);
+				avatar->resetSkeleton(true);
 			}
 		}
 		return true;
@@ -6575,7 +6575,7 @@ class LLAvatarResetSelfSkeletonAndAnimations : public view_listener_t
 			}
 			else
 			{
-				avatar->setResetAnimations(true);
+				avatar->resetSkeleton(true);
 			}
 		}
 		else

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -6506,19 +6506,17 @@ class LLAvatarResetSkeleton: public view_listener_t
         }
 		if(avatar)
         {
-			bool owned = false;
-			if(avatar->isAnimatedObject())
+			if(avatar->getID() == gAgent.getID())
 			{
-				owned = avatar->mOwnerID == gAgent.getID();
+				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
+				effectp->setSourceObject(gAgentAvatarp);
+				effectp->setTargetObject((LLViewerObject*)avatar);
+				effectp->setResetAnimations(false);
 			}
 			else
 			{
-				owned = avatar->getID() == gAgent.getID();
+				effectp->setResetAnimations(false);
 			}
-			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
-			effectp->setSourceObject(gAgentAvatarp);
-			effectp->setTargetObject((LLViewerObject*)avatar);
-			effectp->setResetAnimations(false);
         }
         return true;
     }
@@ -6545,19 +6543,17 @@ class LLAvatarResetSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			bool owned = false;
-			if(avatar->isAnimatedObject())
+			if(avatar->getID() == gAgent.getID())
 			{
-				owned = avatar->mOwnerID == gAgent.getID();
+				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
+				effectp->setSourceObject(gAgentAvatarp);
+				effectp->setTargetObject((LLViewerObject*)avatar);
+				effectp->setResetAnimations(true);
 			}
 			else
 			{
-				owned = avatar->getID() == gAgent.getID();
+				effectp->setResetAnimations(true);
 			}
-			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
-			effectp->setSourceObject(gAgentAvatarp);
-			effectp->setTargetObject((LLViewerObject*)avatar);
-			effectp->setResetAnimations(true);
 		}
 		return true;
 	}
@@ -6570,19 +6566,17 @@ class LLAvatarResetSelfSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			bool owned = false;
-			if(avatar->isAnimatedObject())
+			if(avatar->getID() == gAgent.getID())
 			{
-				owned = avatar->mOwnerID == gAgent.getID();
+				LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
+				effectp->setSourceObject(gAgentAvatarp);
+				effectp->setTargetObject((LLViewerObject*)avatar);
+				effectp->setResetAnimations(true);
 			}
 			else
 			{
-				owned = avatar->getID() == gAgent.getID();
+				effectp->setResetAnimations(true);
 			}
-			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
-			effectp->setSourceObject(gAgentAvatarp);
-			effectp->setTargetObject((LLViewerObject*)avatar);
-			effectp->setResetAnimations(true);
 		}
 		else
 		{

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -84,6 +84,7 @@
 #include "lltoolface.h"
 #include "llhints.h"
 #include "llhudeffecttrail.h"
+#include "llhudeffectresetskeleton.h"
 #include "llhudmanager.h"
 #include "llimview.h"
 #include "llinventorybridge.h"
@@ -6505,7 +6506,19 @@ class LLAvatarResetSkeleton: public view_listener_t
         }
 		if(avatar)
         {
-            avatar->resetSkeleton(false);
+			bool owned = false;
+			if(avatar->isAnimatedObject())
+			{
+				owned = avatar->mOwnerID == gAgent.getID();
+			}
+			else
+			{
+				owned = avatar->getID() == gAgent.getID();
+			}
+			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
+			effectp->setSourceObject(gAgentAvatarp);
+			effectp->setTargetObject((LLViewerObject*)avatar);
+			effectp->setResetAnimations(false);
         }
         return true;
     }
@@ -6532,7 +6545,19 @@ class LLAvatarResetSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			avatar->resetSkeleton(true);
+			bool owned = false;
+			if(avatar->isAnimatedObject())
+			{
+				owned = avatar->mOwnerID == gAgent.getID();
+			}
+			else
+			{
+				owned = avatar->getID() == gAgent.getID();
+			}
+			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
+			effectp->setSourceObject(gAgentAvatarp);
+			effectp->setTargetObject((LLViewerObject*)avatar);
+			effectp->setResetAnimations(true);
 		}
 		return true;
 	}
@@ -6545,11 +6570,26 @@ class LLAvatarResetSelfSkeletonAndAnimations : public view_listener_t
 		LLVOAvatar* avatar = find_avatar_from_object(LLSelectMgr::getInstance()->getSelection()->getPrimaryObject());
 		if (avatar)
 		{
-			avatar->resetSkeleton(true);
+			bool owned = false;
+			if(avatar->isAnimatedObject())
+			{
+				owned = avatar->mOwnerID == gAgent.getID();
+			}
+			else
+			{
+				owned = avatar->getID() == gAgent.getID();
+			}
+			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, owned);
+			effectp->setSourceObject(gAgentAvatarp);
+			effectp->setTargetObject((LLViewerObject*)avatar);
+			effectp->setResetAnimations(true);
 		}
 		else
 		{
-			gAgentAvatarp->resetSkeleton(true);
+			LLHUDEffectResetSkeleton* effectp = (LLHUDEffectResetSkeleton*)LLHUDManager::getInstance()->createViewerEffect(LLHUDObject::LL_HUD_EFFECT_RESET_SKELETON, true);
+			effectp->setSourceObject(gAgentAvatarp);
+			effectp->setTargetObject(gAgentAvatarp);
+			effectp->setResetAnimations(true);
 		}
 		return true;
 	}


### PR DESCRIPTION
This fixes https://github.com/secondlife/jira-archive/issues/4306

This change does the following:
* Create the `LLHUDEffectResetSkeleton(LLHUDEffect)` class
* Create the `LL_HUD_EFFECT_RESET_SKELETON` viewer effect type
* Move handling of `resetSkeleton(bool resetAnimations)` from floater callbacks to the `LLHUDEffectResetSkeleton::update` function
* Change the "Reset Skeleton" floater callbacks to create the `LLHUDEffectResetSkeleton` viewer effect
* Allow networked resetting of skeleton of own avatar
* Allow networked resetting of skeleton of owned animesh
* Allow local resetting of skeleton of any avatar (Existing behavior)
* Allow local resetting of skeleton of any animesh (Existing behavior)

This creates a new viewer effect message with the ID of 17. The following format is used in the `ViewerEffect.Effect[].TypeData` section:
```cpp
struct LLHUDEffectResetSkeleton_data {
    LLUUID TargetObject; // It is "valid" for this to be NULL_KEY, in which it will default to the sender's ID
    uint8_t ResetAnimations;
};
```
The `ResetAnimations` field is prepared in a way that only the first bit is checked, allowing this to be moved to a flags in the future if need be.

Ownership of a effect is determined by the `ViewerEffect.Effect[].AgentID` field, which I am suspecting is verified by the simulator based off the `ViewerEffect.AgentData.AgentID` field. My testings show that you cannot spoof a ViewerEffect's AgentID, but this should be double checked.