### PR TITLE
viewer#1195 Real Life photo can be set to a bake texture

### DIFF
--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -2317,7 +2317,8 @@ void LLPanelProfileFirstLife::onChangePhoto()
                     onCommitPhoto(asset_id);
                 }
             });
-            texture_floaterp->setLocalTextureEnabled(FALSE);
+            texture_floaterp->setLocalTextureEnabled(false);
+            texture_floaterp->setBakeTextureEnabled(false);
             texture_floaterp->setCanApply(false, true, false);
 
             parent_floater->addDependentFloater(mFloaterTexturePickerHandle);


### PR DESCRIPTION
Maxim might have fixed this one in other maints, but I don't see it and we got an ticket so decided to cover all bases.
Since BOOL converion comes eralier, used 'false'.