### PR TITLE
Inject XZ_DEFAULTS=-T0 into the environment. This will speed up archive generation.

### DIFF
--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -65,6 +65,8 @@ class ViewerManifest(LLManifest):
         self.path(src="../../scripts/messages/message_template.msg", dst="app_settings/message_template.msg")
         self.path(src="../../etc/message.xml", dst="app_settings/message.xml")
 
+        os.environ["XZ_DEFAULTS"] = "-T0"
+
         if self.is_packaging_viewer():
             with self.prefix(src_dst="app_settings"):
                 self.exclude("logcontrol.xml")


### PR DESCRIPTION
This will make sure xz archive compression will use all available threads.

@bennettgoble this might be of interest to you, as it can shave off a good amount of time from builds