### PR TITLE
SL-18721 Window shutdown adjustments

### DIFF
--- a/indra/llcommon/threadpool.h
+++ b/indra/llcommon/threadpool.h
@@ -55,7 +55,7 @@ namespace LL
          * ThreadPool listens for application shutdown messages on the "LLApp"
          * LLEventPump. Call close() to shut down this ThreadPool early.
          */
-        virtual void close();
+        void close();
 
         std::string getName() const { return mName; }
         size_t getWidth() const { return mThreads.size(); }


### PR DESCRIPTION
On viewer shutdown
1. Instead of handling potential WM_* messages viewer is no longer equiped to handle drop window's pointer and expect only WM_DESTROY
2. Detach thread and let it do its own thing, thread will delete itself
3. Reverts commit 1161262029f9619fb02d81575382b64d82d9cd09

Reason for the change: window was closing too early (as son as "LLApp" status changes) without proper cleanup.

Previously we couldn't make the window last properly because it resulted in significant amount of 'logout freezes' we couldn't repro. I have particularly high hopes for the '1', since no message processing means whatever was causing freezes is less likely to trigger (if it was a WM_*) and deadlock viewer (can happen if viewer was waiting on join and thread was for some reason waiting for viewer). But in case thread still somehow freezes or takes longer than it should, added '2'.