### PR TITLE
viewer#1143 Crash at LLReflectionMap::autoAdjustOrigin #2

### DIFF
--- a/indra/newview/llreflectionmap.cpp
+++ b/indra/newview/llreflectionmap.cpp
@@ -70,7 +70,8 @@ void LLReflectionMap::autoAdjustOrigin()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;
 
-    if (mGroup && !mComplete)
+
+    if (mGroup && !mComplete && !mGroup->hasState(LLViewerOctreeGroup::DEAD))
     {
         const LLVector4a* bounds = mGroup->getBounds();
         auto* node = mGroup->getOctreeNode();


### PR DESCRIPTION
Run into this crash on a materials region on shutdown, wasn't able to repeat, but group's state contained DEAD(8) flag.