### PR TITLE
viewer#1260 Fix thumbnail preview being blury and not loading

### DIFF
--- a/indra/newview/llinspecttexture.cpp
+++ b/indra/newview/llinspecttexture.cpp
@@ -112,7 +112,6 @@ public:
 
 protected:
 	LLPointer<LLViewerFetchedTexture> m_Image;
-	S32         mImageBoostLevel = LLGLTexture::BOOST_NONE;
 	std::string mLoadingText;
 };
 
@@ -125,11 +124,7 @@ LLTexturePreviewView::LLTexturePreviewView(const LLView::Params& p)
 
 LLTexturePreviewView::~LLTexturePreviewView()
 {
-	if (m_Image)
-	{
-		m_Image->setBoostLevel(mImageBoostLevel);
-		m_Image = nullptr;
-	}
+    m_Image = nullptr;
 }
 
 void LLTexturePreviewView::draw()
@@ -150,33 +145,33 @@ void LLTexturePreviewView::draw()
 		bool isLoading = (!m_Image->isFullyLoaded()) && (m_Image->getDiscardLevel() > 0);
 		if (isLoading)
 			LLFontGL::getFontSansSerif()->renderUTF8(mLoadingText, 0, llfloor(rctClient.mLeft + 3),  llfloor(rctClient.mTop - 25), LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
-		m_Image->addTextureStats((isLoading) ? MAX_IMAGE_AREA : (F32)(rctClient.getWidth() * rctClient.getHeight()));
+
+        m_Image->setKnownDrawSize(MAX_IMAGE_SIZE, MAX_IMAGE_SIZE);
 	}
 }
 
 void LLTexturePreviewView::setImageFromAssetId(const LLUUID& idAsset)
 {
-	m_Image = LLViewerTextureManager::getFetchedTexture(idAsset, FTT_DEFAULT, MIPMAP_TRUE, LLGLTexture::BOOST_NONE, LLViewerTexture::LOD_TEXTURE);
-	if (m_Image)
-	{
-		mImageBoostLevel = m_Image->getBoostLevel();
-		m_Image->setBoostLevel(LLGLTexture::BOOST_PREVIEW);
-		m_Image->forceToSaveRawImage(0);
-		if ( (!m_Image->isFullyLoaded()) && (!m_Image->hasFetcher()) )
-		{
-			if (m_Image->isInFastCacheList())
-			{
-				m_Image->loadFromFastCache();
-			}
-			gTextureList.forceImmediateUpdate(m_Image);
-		}
-	}
+    m_Image = LLViewerTextureManager::getFetchedTexture(idAsset, FTT_DEFAULT, MIPMAP_TRUE, LLGLTexture::BOOST_THUMBNAIL);
+    if (m_Image)
+    {
+        m_Image->forceToSaveRawImage(0);
+        m_Image->setKnownDrawSize(MAX_IMAGE_SIZE, MAX_IMAGE_SIZE);
+        if ((!m_Image->isFullyLoaded()) && (!m_Image->hasFetcher()))
+        {
+            if (m_Image->isInFastCacheList())
+            {
+                m_Image->loadFromFastCache();
+            }
+            gTextureList.forceImmediateUpdate(m_Image);
+        }
+    }
 }
 
 void LLTexturePreviewView::setImageFromItemId(const LLUUID& idItem)
 {
 	const LLViewerInventoryItem* pItem = gInventory.getItem(idItem);
-	setImageFromAssetId( (pItem) ? pItem->getAssetUUID() : LLUUID::null );
+	setImageFromAssetId( (pItem) ? pItem->getAssetUUID() : LLUUID::null);
 }
 
 // ============================================================================

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -2509,12 +2509,13 @@ LLTextureFetch::~LLTextureFetch()
 }
 
 S32 LLTextureFetch::createRequest(FTType f_type, const std::string& url, const LLUUID& id, const LLHost& host, F32 priority,
-								   S32 w, S32 h, S32 c, S32 desired_discard, bool needs_aux, bool can_use_http)
+								   S32 w, S32 h, S32 c, S32 desired_discard, bool needs_aux, bool can_use_http, S32& worker_discard)
 {
     LL_PROFILE_ZONE_SCOPED;
+    worker_discard = -1;
 	if (mDebugPause)
 	{
-		return -1;
+		return FETCH_REQUEST_CREATION_FAILED;
 	}
 
 	if (f_type == FTT_SERVER_BAKE)
@@ -2530,7 +2531,7 @@ S32 LLTextureFetch::createRequest(FTType f_type, const std::string& url, const L
 							  << host << " != " << worker->mHost << LL_ENDL;
 			removeRequest(worker, true);
 			worker = NULL;
-			return -1;
+			return FETCH_REQUEST_ABORTED;
 		}
 	}
 
@@ -2583,13 +2584,14 @@ S32 LLTextureFetch::createRequest(FTType f_type, const std::string& url, const L
 	{
 		if (worker->wasAborted())
 		{
-			return -1; // need to wait for previous aborted request to complete
+			return FETCH_REQUEST_ABORTED; // need to wait for previous aborted request to complete
 		}
+        worker_discard = desired_discard;
 		worker->lockWorkMutex();										// +Mw
         if (worker->mState == LLTextureFetchWorker::DONE && worker->mDesiredSize == llmax(desired_size, TEXTURE_CACHE_ENTRY_SIZE) && worker->mDesiredDiscard == desired_discard) {
 			worker->unlockWorkMutex();									// -Mw
 
-            return -1; // similar request has failed or is in a transitional state
+            return FETCH_REQUEST_EXISTS; // similar request has failed or is in a transitional state
         }
 		worker->mActiveCount++;
 		worker->mNeedsAux = needs_aux;
@@ -2623,11 +2625,12 @@ S32 LLTextureFetch::createRequest(FTType f_type, const std::string& url, const L
 		worker->mNeedsAux = needs_aux;
 		worker->setCanUseHTTP(can_use_http) ;
 		worker->unlockWorkMutex();										// -Mw
+        worker_discard = desired_discard;
 	}
 
  	LL_DEBUGS(LOG_TXT) << "REQUESTED: " << id << " f_type " << fttype_to_string(f_type)
 					   << " Discard: " << desired_discard << " size " << desired_size << LL_ENDL;
-	return desired_discard;
+	return FETCH_REQUEST_OK;
 }
 // Threads:  T*
 //

--- a/indra/newview/lltexturefetch.h
+++ b/indra/newview/lltexturefetch.h
@@ -76,9 +76,14 @@ public:
     // Threads:  Tmain
 	void shutDownImageDecodeThread();
 
-	// Threads:  T* (but Tmain mostly)
-	S32 createRequest(FTType f_type, const std::string& url, const LLUUID& id, const LLHost& host, F32 priority,
-					   S32 w, S32 h, S32 c, S32 discard, bool needs_aux, bool can_use_http);
+    static constexpr S32 FETCH_REQUEST_OK = 0;
+    static constexpr S32 FETCH_REQUEST_CREATION_FAILED = -1;
+    static constexpr S32 FETCH_REQUEST_ABORTED = -2;
+    static constexpr S32 FETCH_REQUEST_EXISTS = -3;
+    // Threads:  T* (but Tmain mostly)
+    // returns discard on success, fail code otherwise
+    S32 createRequest(FTType f_type, const std::string& url, const LLUUID& id, const LLHost& host, F32 priority,
+                      S32 w, S32 h, S32 c, S32 discard, bool needs_aux, bool can_use_http, S32& worker_disacrd);
 
 	// Requests that a fetch operation be deleted from the queue.
 	// If @cancel is true, also stops any I/O operations pending.

--- a/indra/newview/llthumbnailctrl.cpp
+++ b/indra/newview/llthumbnailctrl.cpp
@@ -110,8 +110,10 @@ void LLThumbnailCtrl::draw()
         }
         
         gl_draw_scaled_image( draw_rect.mLeft, draw_rect.mBottom, draw_rect.getWidth(), draw_rect.getHeight(), mTexturep, UI_VERTEX_COLOR % alpha);
-        
-        mTexturep->setKnownDrawSize(draw_rect.getWidth(), draw_rect.getHeight());
+
+        // Thumbnails are usually 256x256 or smaller, either report that or
+        // some high value to get image with higher priority
+        mTexturep->setKnownDrawSize(MAX_IMAGE_SIZE, MAX_IMAGE_SIZE);
     }
     else if( mImagep.notNull() )
     {
@@ -238,12 +240,8 @@ void LLThumbnailCtrl::initImage()
         {
             // Should it support baked textures?
             mTexturep = LLViewerTextureManager::getFetchedTexture(mImageAssetID, FTT_DEFAULT, MIPMAP_YES, LLGLTexture::BOOST_THUMBNAIL);
-
             mTexturep->forceToSaveRawImage(0);
-
-            S32 desired_draw_width = MAX_IMAGE_SIZE;
-            S32 desired_draw_height = MAX_IMAGE_SIZE;
-            mTexturep->setKnownDrawSize(desired_draw_width, desired_draw_height);
+            mTexturep->setKnownDrawSize(MAX_IMAGE_SIZE, MAX_IMAGE_SIZE);
         }
     }
     else if (tvalue.isString())

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1193,12 +1193,11 @@ void LLViewerFetchedTexture::loadFromFastCache()
 
             if (mBoostLevel == LLGLTexture::BOOST_THUMBNAIL)
             {
-                S32 expected_width = mKnownDrawWidth > 0 ? mKnownDrawWidth : DEFAULT_THUMBNAIL_DIMENSIONS;
-                S32 expected_height = mKnownDrawHeight > 0 ? mKnownDrawHeight : DEFAULT_THUMBNAIL_DIMENSIONS;
-                if (mRawImage && (mRawImage->getWidth() > expected_width || mRawImage->getHeight() > expected_height))
+                if (mRawImage && (mRawImage->getWidth() > DEFAULT_THUMBNAIL_DIMENSIONS || mRawImage->getHeight() > DEFAULT_THUMBNAIL_DIMENSIONS))
                 {
-                    // scale oversized icon, no need to give more work to gl
-                    mRawImage->scale(expected_width, expected_height);
+                    // Scale oversized thumbnail
+                    // thumbnails aren't supposed to go over DEFAULT_THUMBNAIL_DIMENSIONS
+                    mRawImage->scale(DEFAULT_THUMBNAIL_DIMENSIONS, DEFAULT_THUMBNAIL_DIMENSIONS);
                 }
             }
 
@@ -1941,13 +1940,10 @@ bool LLViewerFetchedTexture::updateFetch()
 
                 if (mBoostLevel == LLGLTexture::BOOST_THUMBNAIL)
                 {
-                    S32 expected_width = mKnownDrawWidth > 0 ? mKnownDrawWidth : DEFAULT_THUMBNAIL_DIMENSIONS;
-                    S32 expected_height = mKnownDrawHeight > 0 ? mKnownDrawHeight : DEFAULT_THUMBNAIL_DIMENSIONS;
-                    if (mRawImage && (mRawImage->getWidth() > expected_width || mRawImage->getHeight() > expected_height))
+                    if (mRawImage && (mRawImage->getWidth() > DEFAULT_THUMBNAIL_DIMENSIONS || mRawImage->getHeight() > DEFAULT_THUMBNAIL_DIMENSIONS))
                     {
-                        // scale oversized icon, no need to give more work to gl
-                        // since we got mRawImage from thread worker and image may be in use (ex: writing cache), make a copy
-                        mRawImage = mRawImage->scaled(expected_width, expected_height);
+                        // Scale oversized thumbnail
+                        mRawImage = mRawImage->scaled(DEFAULT_THUMBNAIL_DIMENSIONS, DEFAULT_THUMBNAIL_DIMENSIONS);
                     }
                 }
 
@@ -2797,11 +2793,9 @@ void LLViewerFetchedTexture::setCachedRawImage(S32 discard_level, LLImageRaw* im
         }
         else if (mBoostLevel == LLGLTexture::BOOST_THUMBNAIL)
         {
-            S32 expected_width = mKnownDrawWidth > 0 ? mKnownDrawWidth : DEFAULT_THUMBNAIL_DIMENSIONS;
-            S32 expected_height = mKnownDrawHeight > 0 ? mKnownDrawHeight : DEFAULT_THUMBNAIL_DIMENSIONS;
-            if (mRawImage->getWidth() > expected_width || mRawImage->getHeight() > expected_height)
+            if (mRawImage->getWidth() > DEFAULT_THUMBNAIL_DIMENSIONS || mRawImage->getHeight() > DEFAULT_THUMBNAIL_DIMENSIONS)
             {
-                mCachedRawImage = new LLImageRaw(expected_width, expected_height, imageraw->getComponents());
+                mCachedRawImage = new LLImageRaw(DEFAULT_THUMBNAIL_DIMENSIONS, DEFAULT_THUMBNAIL_DIMENSIONS, imageraw->getComponents());
                 mCachedRawImage->copyScaled(imageraw);
             }
             else
@@ -2919,11 +2913,9 @@ void LLViewerFetchedTexture::saveRawImage()
     }
     else if (mBoostLevel == LLGLTexture::BOOST_THUMBNAIL)
     {
-        S32 expected_width = mKnownDrawWidth > 0 ? mKnownDrawWidth : DEFAULT_THUMBNAIL_DIMENSIONS;
-        S32 expected_height = mKnownDrawHeight > 0 ? mKnownDrawHeight : DEFAULT_THUMBNAIL_DIMENSIONS;
-        if (mRawImage->getWidth() > expected_width || mRawImage->getHeight() > expected_height)
+        if (mRawImage->getWidth() > DEFAULT_THUMBNAIL_DIMENSIONS || mRawImage->getHeight() > DEFAULT_THUMBNAIL_DIMENSIONS)
         {
-            mSavedRawImage = new LLImageRaw(expected_width, expected_height, mRawImage->getComponents());
+            mSavedRawImage = new LLImageRaw(DEFAULT_THUMBNAIL_DIMENSIONS, DEFAULT_THUMBNAIL_DIMENSIONS, mRawImage->getComponents());
             mSavedRawImage->copyScaled(mRawImage);
         }
         else

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -452,7 +452,8 @@ protected:
 	S32	mKnownDrawHeight;
 	BOOL mKnownDrawSizeChanged ;
 	std::string mUrl;
-	
+
+    S32 mLastWorkerDiscardLevel;
 	S32 mRequestedDiscardLevel;
 	F32 mRequestedDownloadPriority;
 	S32 mFetchState;


### PR DESCRIPTION
1. Switched 'inspect' to thumbnails to minimalize differences
2. Reporting larger area to bump priority
3. Change scaling behavior. Old mechanics worked fine for icons that were scaled down from large images to ~32, but for thumbnails it can result in 256 image scaling down to ~200 before being scaled up to UI's scale (scale factor), causing extra loss of quality.

This might be not a straight fix (somehow preview image was leaking into thumbnail and back?), but by showing thumbnails as thumbnails and enforcing separation it bypasses the issue (still tracking how that happens).