### PR TITLE
Reintroduce `LLCoros::killreq()` to request killing a named coroutine.

### DIFF
--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -428,7 +428,6 @@ void LLApp::setStatus(EAppStatus status)
             statsd = LLSD::Integer(status);
         }
         LLEventPumps::instance().obtain("LLApp").post(llsd::map("status", statsd));
-        LLEventPumps::instance().obtain("LLLua").post(llsd::map("status", "close_all"));
     }
 }
 

--- a/indra/llcommon/llcoros.h
+++ b/indra/llcommon/llcoros.h
@@ -29,17 +29,18 @@
 #if ! defined(LL_LLCOROS_H)
 #define LL_LLCOROS_H
 
+#include "llevents.h"
 #include "llexception.h"
+#include "llinstancetracker.h"
+#include "llsingleton.h"
+#include "mutex.h"
 #include <boost/fiber/fss.hpp>
 #include <boost/fiber/future/promise.hpp>
 #include <boost/fiber/future/future.hpp>
-#include "mutex.h"
-#include "llsingleton.h"
-#include "llinstancetracker.h"
-#include <boost/function.hpp>
-#include <string>
 #include <exception>
+#include <functional>
 #include <queue>
+#include <string>
 
 // e.g. #include LLCOROS_MUTEX_HEADER
 #define LLCOROS_MUTEX_HEADER   <boost/fiber/mutex.hpp>
@@ -101,7 +102,7 @@ public:
     /// stuck with the term "coroutine."
     typedef boost::fibers::fiber coro;
     /// Canonical callable type
-    typedef boost::function<void()> callable_t;
+    typedef std::function<void()> callable_t;
 
     /**
      * Create and start running a new coroutine with specified name. The name
@@ -143,13 +144,13 @@ public:
     std::string launch(const std::string& prefix, const callable_t& callable);
 
     /**
-     * Abort a running coroutine by name. Normally, when a coroutine either
+     * Ask the named coroutine to abort. Normally, when a coroutine either
      * runs to completion or terminates with an exception, LLCoros quietly
      * cleans it up. This is for use only when you must explicitly interrupt
      * one prematurely. Returns @c true if the specified name was found and
      * still running at the time.
      */
-//  bool kill(const std::string& name);
+    bool killreq(const std::string& name);
 
     /**
      * From within a coroutine, look up the (tweaked) name string by which
@@ -251,15 +252,21 @@ public:
     /// thrown by checkStop()
     // It may sound ironic that Stop is derived from LLContinueError, but the
     // point is that LLContinueError is the category of exception that should
-    // not immediately crash the viewer. Stop and its subclasses are to notify
-    // coroutines that the viewer intends to shut down. The expected response
-    // is to terminate the coroutine, rather than abort the viewer.
+    // not immediately crash the viewer. Stop and its subclasses are to tell
+    // coroutines to terminate, e.g. because the viewer is shutting down. We
+    // do not want any such exception to crash the viewer.
     struct Stop: public LLContinueError
     {
         Stop(const std::string& what): LLContinueError(what) {}
     };
 
-    /// early stages
+    /// someone wants to kill this specific coroutine
+    struct Killed: public Stop
+    {
+        Killed(const std::string& what): Stop(what) {}
+    };
+
+    /// early shutdown stages
     struct Stopping: public Stop
     {
         Stopping(const std::string& what): Stop(what) {}
@@ -278,9 +285,31 @@ public:
     };
 
     /// Call this intermittently if there's a chance your coroutine might
-    /// continue running into application shutdown. Throws Stop if LLCoros has
-    /// been cleaned up.
-    static void checkStop();
+    /// still be running at application shutdown. Throws one of the Stop
+    /// subclasses if the caller needs to terminate. Pass a cleanup function
+    /// if you need to execute that cleanup before terminating.
+    /// Of course, if your cleanup function throws, that will be the exception
+    /// propagated by checkStop().
+    static void checkStop(callable_t cleanup={});
+
+    /// Call getStopListener() at the source end of a queue, promise or other
+    /// resource on which coroutines will wait, so that shutdown can wake up
+    /// consuming coroutines. @a caller should distinguish who's calling. The
+    /// passed @a cleanup function must close the queue, break the promise or
+    /// otherwise cause waiting consumers to wake up in an abnormal way. It's
+    /// advisable to store the returned LLBoundListener in an
+    /// LLTempBoundListener, or otherwise arrange to disconnect it.
+    static LLBoundListener getStopListener(const std::string& caller, LLVoidListener cleanup);
+
+    /// This getStopListener() overload is like the two-argument one, for use
+    /// when we know the name of the only coroutine that will wait on the
+    /// resource in question. Pass @a consumer as the empty string if the
+    /// consumer coroutine is the same as the calling coroutine. Unlike the
+    /// two-argument getStopListener(), this one also responds to
+    /// killreq(target).
+    static LLBoundListener getStopListener(const std::string& caller,
+                                           const std::string& consumer,
+                                           LLVoidListener cleanup);
 
     /**
      * Aliases for promise and future. An older underlying future implementation
@@ -312,6 +341,8 @@ private:
     static CoroData& get_CoroData(const std::string& caller);
     void saveException(const std::string& name, std::exception_ptr exc);
 
+    LLTempBoundListener mConn;
+
     struct ExceptionData
     {
         ExceptionData(const std::string& nm, std::exception_ptr exc):
@@ -335,8 +366,10 @@ private:
 
         // tweaked name of the current coroutine
         const std::string mName;
-        // set_consuming() state
-        bool mConsuming;
+        // set_consuming() state -- don't consume events unless specifically directed
+        bool mConsuming{ false };
+        // killed by which coroutine
+        std::string mKilledBy;
         // setStatus() state
         std::string mStatus;
         F64 mCreationTime; // since epoch

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -52,6 +52,9 @@ namespace lluau
     int loadstring(lua_State* L, const std::string& desc, const std::string& text);
 
     fsyspath source_path(lua_State* L);
+
+    void set_interrupts_counter(lua_State *L, S32 counter);
+    void check_interrupts_counter(lua_State* L);
 } // namespace lluau
 
 std::string lua_tostdstring(lua_State* L, int index);

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -41,7 +41,7 @@ LuaListener::LuaListener(lua_State* L):
     // Listen for shutdown events.
     mShutdownConnection(
         LLCoros::getStopListener(
-            LLEventPump::inventName("LuaState"),
+            "LuaState",
             mCoroName,
             [this](const LLSD&)
             {

--- a/indra/llcommon/lualistener.h
+++ b/indra/llcommon/lualistener.h
@@ -73,10 +73,9 @@ private:
 
     LLThreadSafeQueue<PumpData> mQueue;
 
+    std::string mCoroName;
     std::unique_ptr<LLLeapListener> mListener;
     LLTempBoundListener mShutdownConnection;
-
-    std::string mCoroName;
 };
 
 #endif /* ! defined(LL_LUALISTENER_H) */

--- a/indra/llcommon/threadpool.h
+++ b/indra/llcommon/threadpool.h
@@ -13,6 +13,7 @@
 #if ! defined(LL_THREADPOOL_H)
 #define LL_THREADPOOL_H
 
+#include "llcoros.h"
 #include "threadpool_fwd.h"
 #include "workqueue.h"
 #include <memory>                   // std::unique_ptr
@@ -52,8 +53,8 @@ namespace LL
         void start();
 
         /**
-         * ThreadPool listens for application shutdown messages on the "LLApp"
-         * LLEventPump. Call close() to shut down this ThreadPool early.
+         * ThreadPool listens for application shutdown events. Call close() to
+         * shut down this ThreadPool early.
          */
         virtual void close();
 
@@ -95,6 +96,7 @@ namespace LL
 
         std::string mName;
         size_t mThreadCount;
+        LLTempBoundListener mStopListener;
     };
 
     /**

--- a/indra/llcommon/workqueue.cpp
+++ b/indra/llcommon/workqueue.cpp
@@ -32,8 +32,11 @@ using Lock  = LLCoros::LockType;
 LL::WorkQueueBase::WorkQueueBase(const std::string& name):
     super(makeName(name))
 {
-    // TODO: register for "LLApp" events so we can implicitly close() on
-    // viewer shutdown.
+    // Register for status change events so we'll implicitly close() on viewer
+    // shutdown.
+    mStopListener = LLCoros::getStopListener(
+        "WorkQueue:" + getKey(),
+        [this](const LLSD&){ close(); });
 }
 
 void LL::WorkQueueBase::runUntilClose()

--- a/indra/llcommon/workqueue.h
+++ b/indra/llcommon/workqueue.h
@@ -13,6 +13,7 @@
 #define LL_WORKQUEUE_H
 
 #include "llcoros.h"
+#include "llevents.h"
 #include "llexception.h"
 #include "llinstancetracker.h"
 #include "llinstancetrackersubclass.h"
@@ -193,6 +194,8 @@ namespace LL
         static void error(const std::string& msg);
         static std::string makeName(const std::string& name);
         void callWork(const Work& work);
+
+        LLTempBoundListener mStopListener;
 
     private:
         virtual Work pop_() = 0;

--- a/indra/llimage/tests/llimageworker_test.cpp
+++ b/indra/llimage/tests/llimageworker_test.cpp
@@ -98,7 +98,7 @@ namespace tut
 				done = res;
 				*done = false;
 			}
-			virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux)
+			virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux, U32)
 			{
 				*done = true;
 			}

--- a/indra/newview/llfloaterluascripts.cpp
+++ b/indra/newview/llfloaterluascripts.cpp
@@ -54,8 +54,7 @@ LLFloaterLUAScripts::LLFloaterLUAScripts(const LLSD &key)
         if (mScriptList->hasSelectedItem())
         {
             std::string coro_name = mScriptList->getSelectedValue();
-            LLEventPumps::instance().obtain("LLLua").post(llsd::map("status", "close", "coro", coro_name));
-            LLLUAmanager::terminateScript(coro_name);
+            LLCoros::instance().killreq(coro_name);
         }
     });
 }

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -85,12 +85,9 @@ public:
     static void runScriptOnLogin();
 
     static const std::map<std::string, std::string> getScriptNames() { return sScriptNames; }
-    static std::set<std::string> getTerminationList() { return sTerminationList; }
-    static void terminateScript(std::string& coro_name) { sTerminationList.insert(coro_name); }
 
  private:
    static std::map<std::string, std::string> sScriptNames;
-   static std::set<std::string> sTerminationList;
 };
 
 class LLRequireResolver


### PR DESCRIPTION
Make `LLCoros` constructor echo "LLApp" status-change events on new "LLCoros"
event pump.

Rename `LLCoros::kill()` to `killreq()` because this operation only registers a
request for the named coroutine to terminate next time it calls `checkStop()`.
Add a new `CoroData` member to record the name of the coroutine requesting
termination. `killreq()` sets that and also posts "killreq" to "LLCoros".

Add an optional final-cleanup callback to `LLCoros::checkStop()`. Make
`checkStop()` check for a pending `killreq()` request as well as viewer
termination. Introduce new `LLCoros::Killed` exception for that case.

Introduce `LLCoros::getStopListener()`, with two overloads, to encapsulate some
of the messy logic to listen (perhaps temporarily) for viewer shutdown. Both
overloads are for use by code at the source end of a queue or promise or other
resource for which coroutines might still be waiting at viewer shutdown time.
One overload is specifically for when the caller knows the name of the one and
only coroutine that will wait on the resource (e.g. because the caller _is_ that
coroutine). That overload honors `killreq()`.

Use `getStopListener()` to simplify the four existing places where we set up
such a listener. Add a fifth: also make `WorkQueue` listen for viewer shutdown
(resolving a TODO comment).

Remove `LLLUAmanager::terminateScript()`, `getTerminationList()` and the static
`sTerminationList`. In the Lua interrupt callback, instead of checking
`sTerminationList`, call `LLCoros::checkStop()`.

Change `LLFloaterLUAScripts` terminate-script logic to call `LLCoros::killreq()`
instead of posting on "LLLua" and calling `LLLUAmanager::terminateScript()`.

Drop `LLApp::setStatus()` posting to "LLLua" `LLEventPump`: the above makes that
moot.