### PR TITLE
viewer#1117 optimize one getIsCloud() call away

### DIFF
--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -8270,7 +8270,7 @@ void LLVOAvatar::logMetricsTimerRecord(const std::string& phase_name, F32 elapse
 bool LLVOAvatar::updateIsFullyLoaded()
 {
 	S32 rez_status = getRezzedStatus();
-	bool loading = getIsCloud();
+	bool loading = rez_status == 0;
 	if (mFirstFullyVisible && !mIsControlAvatar)
 	{
         loading = ((rez_status < 2)


### PR DESCRIPTION
getIsCloud() is relatively expensive, especially for 'self', yet getRezzedStatus() already checks it and return 0, no need to repeat.