### PR TITLE
[WebRTC] Outgoing calls now use the voice server type corresponding to the region the agent is on. 

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -735,6 +735,10 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection(const LLWebRTCPeerConnecti
             else
             {
                 RTC_LOG(LS_ERROR) << __FUNCTION__ << "Error creating peer connection: " << error_or_peer_connection.error().message();
+                for (auto &observer : mSignalingObserverList)
+                {
+                    observer->OnRenegotiationNeeded();
+                }
                 return;
             }
 

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -15155,13 +15155,13 @@
     <key>VoiceServerType</key>
     <map>
       <key>Comment</key>
-      <string>The type of voice server to connect to.</string>
+      <string>The type of voice server to use for group, conference, and p2p calls.</string>
       <key>Persist</key>
       <integer>0</integer>
       <key>Type</key>
       <string>String</string>
       <key>Value</key>
-      <string>webrtc</string>
+      <string/>
     </map>
     <key>WLSkyDetail</key>
     <map>

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -425,7 +425,14 @@ void startConferenceCoro(std::string url,
     postData["session-id"] = tempSessionId;
     postData["params"] = agents;
     LLSD altParams;
-    altParams["voice_server_type"] = gSavedSettings.getString("VoiceServerType");
+    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
+    if (voice_server_type.empty())
+    {
+        // default to the server type associated with the region we're on.
+        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+        voice_server_type              = versionInfo.internalVoiceServerType;
+    }
+    altParams["voice_server_type"] = voice_server_type;
     postData["alt_params"]         = altParams;
 
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);
@@ -467,7 +474,14 @@ void startP2PVoiceCoro(std::string url, LLUUID sessionID, LLUUID creatorId, LLUU
     postData["session-id"] = sessionID;
     postData["params"]     = otherParticipantId;
     LLSD altParams;
-    altParams["voice_server_type"] = gSavedSettings.getString("VoiceServerType");
+    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
+    if (voice_server_type.empty())
+    {
+        // default to the server type associated with the region we're on.
+        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+        voice_server_type              = versionInfo.internalVoiceServerType;
+    }
+    altParams["voice_server_type"] = voice_server_type;
     postData["alt_params"]         = altParams;
 
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -424,17 +424,6 @@ void startConferenceCoro(std::string url,
     postData["method"] = "start conference";
     postData["session-id"] = tempSessionId;
     postData["params"] = agents;
-    LLSD altParams;
-    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
-    if (voice_server_type.empty())
-    {
-        // default to the server type associated with the region we're on.
-        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
-        voice_server_type              = versionInfo.internalVoiceServerType;
-    }
-    altParams["voice_server_type"] = voice_server_type;
-    postData["alt_params"]         = altParams;
-
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);
 
     LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -473,17 +462,6 @@ void startP2PVoiceCoro(std::string url, LLUUID sessionID, LLUUID creatorId, LLUU
     postData["method"]     = "start p2p voice";
     postData["session-id"] = sessionID;
     postData["params"]     = otherParticipantId;
-    LLSD altParams;
-    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
-    if (voice_server_type.empty())
-    {
-        // default to the server type associated with the region we're on.
-        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
-        voice_server_type              = versionInfo.internalVoiceServerType;
-    }
-    altParams["voice_server_type"] = voice_server_type;
-    postData["alt_params"]         = altParams;
-
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);
 
     LLSD               httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -2133,7 +2111,7 @@ bool LLIMModel::sendStartSession(
 		//we also need to wait for reply from the server in case of ad-hoc chat (we'll get new session id)
 		return true;
 	}
-	else if ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL))
+	else if (p2p_as_adhoc_call && ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL)))
 	{
 		LLViewerRegion *region = gAgent.getRegion();
 		if (region)

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -594,7 +594,14 @@ void LLVoiceChannelGroup::voiceCallCapCoro(std::string url)
 	postData["method"] = "call";
 	postData["session-id"] = mSessionID;
 	LLSD altParams;
-	altParams["preferred_voice_server_type"] = gSavedSettings.getString("VoiceServerType");
+	std::string  preferred_voice_server_type = gSavedSettings.getString("VoiceServerType");
+	if (preferred_voice_server_type.empty())
+	{
+		// default to the server type associated with the region we're on.
+		LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+		preferred_voice_server_type = versionInfo.internalVoiceServerType;
+	}
+	altParams["preferred_voice_server_type"] = preferred_voice_server_type;
 	postData["alt_params"] = altParams;
 
 	LL_INFOS("Voice", "voiceCallCapCoro") << "Generic POST for " << url << LL_ENDL;

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -538,12 +538,18 @@ LLVoiceP2PIncomingCallInterfacePtr LLVoiceClient::getIncomingCallInterface(const
 // outgoing calls
 LLVoiceP2POutgoingCallInterface *LLVoiceClient::getOutgoingCallInterface(const LLSD& voiceChannelInfo)
 {
-    std::string voiceServerType = gSavedSettings.getString("VoiceServerType");
+    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
+    if (voice_server_type.empty())
+    {
+        // default to the server type associated with the region we're on.
+        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+        voice_server_type = versionInfo.internalVoiceServerType;
+    }
     if (voiceChannelInfo.has("voice_server_type"))
     {
-        voiceServerType = voiceChannelInfo["voice_server_type"].asString();
+        voice_server_type = voiceChannelInfo["voice_server_type"].asString();
     }
-    LLVoiceModuleInterface *module = getVoiceModule(voiceServerType);
+    LLVoiceModuleInterface *module = getVoiceModule(voice_server_type);
     return dynamic_cast<LLVoiceP2POutgoingCallInterface *>(module);
 }
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -4952,6 +4952,7 @@ bool LLVivoxVoiceClient::setSpatialChannel(const LLSD& channelInfo)
 void LLVivoxVoiceClient::callUser(const LLUUID &uuid)
 {
 	std::string userURI = sipURIFromID(uuid);
+	mProcessChannels = true;
 
 	switchChannel(userURI, false, true, true);
 }
@@ -4974,7 +4975,7 @@ bool LLVivoxVoiceClient::answerInvite(const std::string &sessionHandle)
         session->mIsSpatial = false;
         session->mReconnect = false;
         session->mIsP2P     = true;
-
+        mProcessChannels    = true;
         joinSession(session);
         return true;
     }
@@ -5078,7 +5079,9 @@ void LLVivoxVoiceClient::leaveNonSpatialChannel()
 
 void LLVivoxVoiceClient::processChannels(bool process)
 {
-	mProcessChannels = process;
+    mCurrentParcelLocalID = -1;
+    mCurrentRegionName.clear();
+    mProcessChannels = process;
 }
 
 bool LLVivoxVoiceClient::isCurrentChannel(const LLSD &channelInfo)

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5456,6 +5456,8 @@ void LLVivoxVoiceClient::setVoiceEnabled(bool enabled)
 			LLVoiceChannel::getCurrentVoiceChannel()->deactivate();
 			gAgent.setVoiceConnected(false);
 			status = LLVoiceClientStatusObserver::STATUS_VOICE_DISABLED;
+			mCurrentParcelLocalID = -1;
+			mCurrentRegionName.clear();
 		}
 
 		notifyStatusObservers(status);

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -144,12 +144,7 @@ public:
         startAdHocSession(channelInfo, notify_on_first_join, hangup_on_last_leave);
     }
 
-    bool setSpatialChannel(const LLSD &channelInfo) override
-    {
-        // we don't really have credentials for a spatial channel in webrtc,
-        // it's all handled by the sim.
-        return true;
-    }
+    bool setSpatialChannel(const LLSD &channelInfo) override;
 
     void leaveNonSpatialChannel() override;
 


### PR DESCRIPTION
Outgoing p2p/adhoc/group calls that initiate a session will use the voice server type corresponding to the voice server the region currently uses (vivox or webrtc.)  This allows the viewer to initiate calls to non-webrtc viewers if the call originates from a vivox region.

Also.

Changing enable/disable and region/parcel voice on a parcel now results in voice renegotiation.  i.e. disabling voice on a parcel now kicks the agent off the parcel.  This is also enforced on the server.