### PR TITLE
secondlife/viewer#1331 The animation with null id is attempted to fetch

### DIFF
--- a/indra/llcharacter/llkeyframemotion.h
+++ b/indra/llcharacter/llkeyframemotion.h
@@ -412,7 +412,9 @@ public:
 		// mEmoteName is a facial motion, but it's necessary to appear here so that it's cached.
 		// TODO: LLKeyframeDataCache::getKeyframeData should probably return a class containing 
 		// JointMotionList and mEmoteName, see LLKeyframeMotion::onInitialize.
-		std::string				mEmoteName; 
+		std::string				mEmoteName;
+		LLUUID					mEmoteID;
+
 	public:
 		JointMotionList();
 		~JointMotionList();


### PR DESCRIPTION
For https://github.com/secondlife/viewer/issues/1331

Many motions in many avatars refer "Closed_Mouth" but it isn't known in the viewer library and can't be started
We may silently ignore this emote_name to prevent spamming the log but warn for other unknown motion names