### PR TITLE
Add timestamp to snapshot file names

### DIFF
--- a/indra/llcommon/lldate.cpp
+++ b/indra/llcommon/lldate.cpp
@@ -86,6 +86,15 @@ std::string LLDate::asRFC1123() const
 	return toHTTPDateString (std::string ("%A, %d %b %Y %H:%M:%S GMT"));
 }
 
+std::string LLDate::toLocalDateString (std::string fmt) const
+{
+    LL_PROFILE_ZONE_SCOPED;
+
+    time_t locSeconds = (time_t) mSecondsSinceEpoch;
+    struct tm * lt = localtime (&locSeconds);
+    return toHTTPDateString(lt, fmt);
+}
+
 std::string LLDate::toHTTPDateString (std::string fmt) const
 {
     LL_PROFILE_ZONE_SCOPED;

--- a/indra/llcommon/lldate.h
+++ b/indra/llcommon/lldate.h
@@ -80,6 +80,7 @@ public:
 	std::string asRFC1123() const;
 	void toStream(std::ostream&) const;
 	bool split(S32 *year, S32 *month = NULL, S32 *day = NULL, S32 *hour = NULL, S32 *min = NULL, S32 *sec = NULL) const;
+	std::string toLocalDateString (std::string fmt) const;
 	std::string toHTTPDateString (std::string fmt) const;
 	static std::string toHTTPDateString (tm * gmt, std::string fmt);
 	/** 

--- a/indra/llimage/tests/llimageworker_test.cpp
+++ b/indra/llimage/tests/llimageworker_test.cpp
@@ -98,7 +98,7 @@ namespace tut
 				done = res;
 				*done = false;
 			}
-			virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux)
+			virtual void completed(bool success, LLImageRaw* raw, LLImageRaw* aux, U32)
 			{
 				*done = true;
 			}

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -33,6 +33,7 @@
 #include "llagentui.h"
 #include "llbase64.h"
 #include "llcallbacklist.h"
+#include "lldate.h"
 #include "llenvironment.h"
 #include "llimagejpeg.h"
 #include "llmediactrl.h"
@@ -862,15 +863,7 @@ const std::string LLFloater360Capture::generate_proposed_filename()
     filename << "_";
 
     // add in the current HH-MM-SS (with leading 0's) so users can easily save many shots in same folder
-    std::time_t cur_epoch = std::time(nullptr);
-    std::tm* tm_time = std::localtime(&cur_epoch);
-    filename << std::setfill('0') << std::setw(4) << (tm_time->tm_year + 1900);
-    filename << std::setfill('0') << std::setw(2) << (tm_time->tm_mon + 1);
-    filename << std::setfill('0') << std::setw(2) << tm_time->tm_mday;
-    filename << "_";
-    filename << std::setfill('0') << std::setw(2) << tm_time->tm_hour;
-    filename << std::setfill('0') << std::setw(2) << tm_time->tm_min;
-    filename << std::setfill('0') << std::setw(2) << tm_time->tm_sec;
+    filename << LLDate::now().toLocalDateString("%Y%m%d_%H%M%S");
 
     // the unusual way we save the output image (originates in the
     // embedded browser and not the C++ code) means that the system

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -66,6 +66,7 @@
 #include "llchatentry.h"
 #include "indra_constants.h"
 #include "llassetstorage.h"
+#include "lldate.h"
 #include "llerrorcontrol.h"
 #include "llfontgl.h"
 #include "llmousehandler.h"
@@ -4761,29 +4762,26 @@ void LLViewerWindow::saveImageLocal(LLImageFormatted *image, const snapshot_save
 		failure_cb();
 	}
 	
-	// Look for an unused file name
-	BOOL is_snapshot_name_loc_set = isSnapshotLocSet();
-	std::string filepath;
-	S32 i = 1;
-	S32 err = 0;
-	std::string extension("." + image->getExtension());
-	do
-	{
-		filepath = sSnapshotDir;
-		filepath += gDirUtilp->getDirDelimiter();
-		filepath += sSnapshotBaseName;
+    // Look for an unused file name
+    auto is_snapshot_name_loc_set = isSnapshotLocSet();
+    std::string filepath;
+    auto i = 1;
+    auto err = 0;
+    auto extension("." + image->getExtension());
+    auto now = LLDate::now();
+    do
+    {
+        filepath = sSnapshotDir;
+        filepath += gDirUtilp->getDirDelimiter();
+        filepath += sSnapshotBaseName;
+        filepath += now.toLocalDateString("_%Y-%m-%d_%H%M%S");
+        filepath += llformat("%.2d", i);
+        filepath += extension;
 
-		if (is_snapshot_name_loc_set)
-		{
-			filepath += llformat("_%.3d",i);
-		}		
-
-		filepath += extension;
-
-		llstat stat_info;
-		err = LLFile::stat( filepath, &stat_info );
-		i++;
-	}
+        llstat stat_info;
+        err = LLFile::stat( filepath, &stat_info );
+        i++;
+    }
 	while( -1 != err  // Search until the file is not found (i.e., stat() gives an error).
 			&& is_snapshot_name_loc_set); // Or stop if we are rewriting.
 


### PR DESCRIPTION
This changeset adds a timestamp in the format of "YYYY-MM-DD_HMS" to snapshot filenames. This is useful for understanding when a snapshot was taken, chronologically ordering files, and is less confusing than the current method of adding a number to the snapshot name, as it does not result in interleaving of old and new snapshots inside a directory.

Closes #1343

<img width="300" src="https://github.com/secondlife/viewer/assets/151138/e81516a7-dac8-4f90-9349-e156e0c9a5b7">
