### PR TITLE
[WebRTC-Voice] Fix server reconnect issue (and other issues)

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -652,6 +652,13 @@ LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
 {
 }
 
+LLWebRTCPeerConnectionImpl::~LLWebRTCPeerConnectionImpl()
+{
+    terminate();
+    mSignalingObserverList.clear();
+    mDataObserverList.clear();
+}
+
 //
 // LLWebRTCPeerConnection interface
 //
@@ -669,9 +676,6 @@ void LLWebRTCPeerConnectionImpl::terminate()
     mDataChannel.swap(dataChannel);
     rtc::scoped_refptr<webrtc::MediaStreamInterface> localStream;
     mLocalStream.swap(localStream);
-
-    mSignalingObserverList.clear();
-    mDataObserverList.clear();
 
     mWebRTCImpl->PostSignalingTask(
         [=]()

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -766,7 +766,7 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection(const LLWebRTCPeerConnecti
 
             rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track(
                 mPeerConnectionFactory->CreateAudioTrack("SLAudio", mPeerConnectionFactory->CreateAudioSource(audioOptions).get()));
-            audio_track->set_enabled(true);
+            audio_track->set_enabled(false);
             mLocalStream->AddTrack(audio_track);
 
             mPeerConnection->AddTrack(audio_track, {"SLStream"});
@@ -999,8 +999,6 @@ void LLWebRTCPeerConnectionImpl::OnConnectionChange(webrtc::PeerConnectionInterf
     {
         case webrtc::PeerConnectionInterface::PeerConnectionState::kConnected:
         {
-            mWebRTCImpl->setRecording(true);
-
             mWebRTCImpl->PostWorkerTask([this]() {
                 for (auto &observer : mSignalingObserverList)
                 {

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -276,7 +276,7 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 {
   public:
     LLWebRTCPeerConnectionImpl();
-    ~LLWebRTCPeerConnectionImpl() {}
+    ~LLWebRTCPeerConnectionImpl();
 
     void init(LLWebRTCImpl * webrtc_impl);
     void terminate();

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -724,13 +724,13 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 	mOtherParticipantID(other_participant_id),
 	mInitialTargetIDs(ids),
 	mVoiceChannel(NULL),
-    mP2PAsAdhocCall(false),
+	mP2PAsAdhocCall(false),
 	mSpeakers(NULL),
 	mSessionInitialized(false),
 	mCallBackEnabled(true),
 	mTextIMPossible(true),
 	mStartCallOnInitialize(false),
-    mStartedAsIMCall(!voice_channel_info.isUndefined()),
+	mStartedAsIMCall(!voice_channel_info.isUndefined()),
 	mIsDNDsend(false),
 	mAvatarNameCacheConnection()
 {
@@ -738,16 +738,16 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
     mSessionType        = P2P_SESSION;
 
 	if (IM_NOTHING_SPECIAL == mType || IM_SESSION_P2P_INVITE == mType)
-    {
-        mP2PAsAdhocCall = (LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info) == NULL);
+	{
+		mP2PAsAdhocCall = (LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info) == NULL);
 	}
-    else
-    {
-        // determine whether it is group or conference session
-        mSessionType = gAgent.isInGroup(mSessionID) ? GROUP_SESSION : ADHOC_SESSION;
-    }
+	else
+	{
+		// determine whether it is group or conference session
+		mSessionType = gAgent.isInGroup(mSessionID) ? GROUP_SESSION : ADHOC_SESSION;
+	}
 
-    initVoiceChannel(voice_channel_info);
+	initVoiceChannel(voice_channel_info);
 
 	// All participants will be added to the list of people we've recently interacted with.
 
@@ -789,64 +789,64 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 
 void LLIMModel::LLIMSession::initVoiceChannel(const LLSD& voiceChannelInfo)
 {
-    mVoiceChannelStateChangeConnection.disconnect();
+	mVoiceChannelStateChangeConnection.disconnect();
 
 	if (mVoiceChannel)
-    {
-        mVoiceChannel->deactivate();
+	{
+		mVoiceChannel->deactivate();
 
-        delete mVoiceChannel;
-        mVoiceChannel = NULL;
-    }
-    mP2PAsAdhocCall = false;
-    if (IM_NOTHING_SPECIAL == mType || IM_SESSION_P2P_INVITE == mType)
-    {
-        LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voiceChannelInfo);
+		delete mVoiceChannel;
+		mVoiceChannel = NULL;
+	}
+	mP2PAsAdhocCall = false;
+	if (IM_NOTHING_SPECIAL == mType || IM_SESSION_P2P_INVITE == mType)
+	{
+		LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voiceChannelInfo);
 
-        if (outgoingInterface)
-        {
-            // only use LLVoiceChannelP2P if the provider can handle the special P2P interface,
-            // which uses the voice server to relay calls and invites.  Otherwise,
-            // we use the group voice provider.
-            mVoiceChannel = new LLVoiceChannelP2P(mSessionID, mName, mOtherParticipantID, outgoingInterface);
-        }
-        else
-        {
-            mP2PAsAdhocCall = true;
-            mVoiceChannel  = new LLVoiceChannelGroup(mSessionID, mName, true);
-        }
-    }
-    else
-    {
-        // determine whether it is group or conference session
-        if (mSessionType == GROUP_SESSION)
-        {
-            mSessionType  = GROUP_SESSION;
-            mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
-        }
-        else if (mSessionType == ADHOC_SESSION)
-        {
-            mSessionType  = ADHOC_SESSION;
-            mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
-        }
+		if (outgoingInterface)
+		{
+			// only use LLVoiceChannelP2P if the provider can handle the special P2P interface,
+			// which uses the voice server to relay calls and invites.  Otherwise,
+			// we use the group voice provider.
+			mVoiceChannel = new LLVoiceChannelP2P(mSessionID, mName, mOtherParticipantID, outgoingInterface);
+		}
 		else
 		{
-            LL_WARNS("Voice") << "Invalid Session Type when initializing voice channel: " << mSessionType << LL_ENDL;
-            return;
+			mP2PAsAdhocCall = true;
+			mVoiceChannel  = new LLVoiceChannelGroup(mSessionID, mName, true);
 		}
-    }
+	}
+	else
+	{
+		// determine whether it is group or conference session
+		if (mSessionType == GROUP_SESSION)
+		{
+			mSessionType  = GROUP_SESSION;
+			mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
+		}
+		else if (mSessionType == ADHOC_SESSION)
+		{
+			mSessionType  = ADHOC_SESSION;
+			mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
+		}
+		else
+		{
+			LL_WARNS("Voice") << "Invalid Session Type when initializing voice channel: " << mSessionType << LL_ENDL;
+			return;
+		}
+	}
 
-    mVoiceChannelStateChangeConnection =
-        mVoiceChannel->setStateChangedCallback(boost::bind(&LLIMSession::onVoiceChannelStateChanged, this, _1, _2, _3));
+	mVoiceChannelStateChangeConnection =
+		mVoiceChannel->setStateChangedCallback(boost::bind(&LLIMSession::onVoiceChannelStateChanged, this, _1, _2, _3));
 
 	if (!mSpeakers)
 	{
-        mSpeakers = new LLIMSpeakerMgr(mVoiceChannel);
+		mSpeakers = new LLIMSpeakerMgr(mVoiceChannel);
 	}
-    else
-    {
-        mSpeakers->setVoiceChannel(mVoiceChannel);
-    }
+	else
+	{
+		mSpeakers->setVoiceChannel(mVoiceChannel);
+	}
 }
 
 void LLIMModel::LLIMSession::onAdHocNameCache(const LLAvatarName& av_name)
@@ -984,10 +984,10 @@ void LLIMModel::LLIMSession::sessionInitReplyReceived(const LLUUID& new_session_
 	if (new_session_id != mSessionID)
 	{
 		mSessionID = new_session_id;
-        if (mVoiceChannel)
-        {
-            mVoiceChannel->updateSessionID(new_session_id);
-        }
+		if (mVoiceChannel)
+		{
+			mVoiceChannel->updateSessionID(new_session_id);
+		}
 	}
 }
 
@@ -1831,14 +1831,14 @@ LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id, const LLSD
 		LL_WARNS() << "session " << session_id << "does not exist " << LL_ENDL;
 		return NULL;
 	}
-    if (IM_NOTHING_SPECIAL == session->mType || IM_SESSION_P2P_INVITE == session->mType)
-    {
-        LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info);
-        if ((outgoingInterface != NULL) != (dynamic_cast<LLVoiceChannelP2P *>(session->mVoiceChannel) != NULL))
-        {
-            session->initVoiceChannel(voice_channel_info);
-        }
-    }
+	if (IM_NOTHING_SPECIAL == session->mType || IM_SESSION_P2P_INVITE == session->mType)
+	{
+		LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info);
+		if ((outgoingInterface != NULL) != (dynamic_cast<LLVoiceChannelP2P *>(session->mVoiceChannel) != NULL))
+		{
+			session->initVoiceChannel(voice_channel_info);
+		}
+	}
 
 	return session->mVoiceChannel;
 }
@@ -2180,7 +2180,7 @@ bool LLIMModel::sendStartSession(
 		//we also need to wait for reply from the server in case of ad-hoc chat (we'll get new session id)
 		return true;
 	}
-    else if (p2p_as_adhoc_call && ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL)))
+	else if (p2p_as_adhoc_call && ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL)))
 	{
 		LLViewerRegion *region = gAgent.getRegion();
 		if (region)
@@ -2801,7 +2801,7 @@ void LLIncomingCallDialog::onLifetimeExpired()
 		LLUUID session_id = mPayload["session_id"].asUUID();
 		gIMMgr->clearPendingAgentListUpdates(session_id);
 		gIMMgr->clearPendingInvitation(session_id);
-        LLIncomingCallDialog::onReject(this);
+		LLIncomingCallDialog::onReject(this);
 	}
 }
 
@@ -2990,7 +2990,7 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 
 			if (voice)
 			{
-                gIMMgr->startCall(session_id, LLVoiceChannel::INCOMING_CALL, payload["voice_channel_info"]);
+				gIMMgr->startCall(session_id, LLVoiceChannel::INCOMING_CALL, payload["voice_channel_info"]);
 			}
 			else
 			{
@@ -3597,7 +3597,7 @@ void LLIMMgr::inviteToSession(
 	{
 		// we're throwing up a dialogue, so we're using the voice channel passed to us,
 		// save it in the payload.
-        payload["voice_channel_info"] = voice_channel_info;
+		payload["voice_channel_info"] = voice_channel_info;
 		if (caller_name.empty())
 		{
 			LLAvatarNameCache::get(caller_id,
@@ -4149,12 +4149,12 @@ public:
 		}
 		if (input["body"]["info"].has("voice_channel_info"))
 		{
-            LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
-            if (session)
-            {
-                session->initVoiceChannel(input["body"]["info"]["voice_channel_info"]);
-                session->mVoiceChannel->activate();
-            }
+			LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
+			if (session)
+			{
+				session->initVoiceChannel(input["body"]["info"]["voice_channel_info"]);
+				session->mVoiceChannel->activate();
+			}
 		}
 	}
 };

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -104,7 +104,7 @@ void startConferenceCoro(std::string url, LLUUID tempSessionId, LLUUID creatorId
 
 void startP2PVoiceCoro(std::string url, LLUUID tempSessionId, LLUUID creatorId, LLUUID otherParticipantId);
 
-void chatterBoxInvitationCoro(std::string url, LLUUID sessionId, LLIMMgr::EInvitationType invitationType);
+void chatterBoxInvitationCoro(std::string url, LLUUID sessionId, LLIMMgr::EInvitationType invitationType, const LLSD& voiceChannelInfo);
 void chatterBoxHistoryCoro(std::string url, LLUUID sessionId, std::string from, std::string message, U32 timestamp);
 void start_deprecated_conference_chat(const LLUUID& temp_session_id, const LLUUID& creator_id, const LLUUID& other_participant_id, const LLSD& agents_to_invite);
 
@@ -424,6 +424,17 @@ void startConferenceCoro(std::string url,
     postData["method"] = "start conference";
     postData["session-id"] = tempSessionId;
     postData["params"] = agents;
+    LLSD altParams;
+    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
+    if (voice_server_type.empty())
+    {
+        // default to the server type associated with the region we're on.
+        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+        voice_server_type              = versionInfo.internalVoiceServerType;
+    }
+    altParams["voice_server_type"] = voice_server_type;
+    postData["alt_params"]         = altParams;
+
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);
 
     LLSD httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -462,6 +473,17 @@ void startP2PVoiceCoro(std::string url, LLUUID sessionID, LLUUID creatorId, LLUU
     postData["method"]     = "start p2p voice";
     postData["session-id"] = sessionID;
     postData["params"]     = otherParticipantId;
+    LLSD altParams;
+    std::string voice_server_type = gSavedSettings.getString("VoiceServerType");
+    if (voice_server_type.empty())
+    {
+        // default to the server type associated with the region we're on.
+        LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
+        voice_server_type              = versionInfo.internalVoiceServerType;
+    }
+    altParams["voice_server_type"] = voice_server_type;
+    postData["alt_params"]         = altParams;
+
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, postData);
 
     LLSD               httpResults = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS];
@@ -480,7 +502,7 @@ void startP2PVoiceCoro(std::string url, LLUUID sessionID, LLUUID creatorId, LLUU
     }
 }
 
-void chatterBoxInvitationCoro(std::string url, LLUUID sessionId, LLIMMgr::EInvitationType invitationType)
+void chatterBoxInvitationCoro(std::string url, LLUUID sessionId, LLIMMgr::EInvitationType invitationType, const LLSD& voiceChannelInfo)
 {
     LLCore::HttpRequest::policy_t httpPolicy(LLCore::HttpRequest::DEFAULT_POLICY_ID);
     LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t
@@ -546,7 +568,7 @@ void chatterBoxInvitationCoro(std::string url, LLUUID sessionId, LLIMMgr::EInvit
 
     if (LLIMMgr::INVITATION_TYPE_VOICE == invitationType)
     {
-        gIMMgr->startCall(sessionId, LLVoiceChannel::INCOMING_CALL);
+        gIMMgr->startCall(sessionId, LLVoiceChannel::INCOMING_CALL, voiceChannelInfo);
     }
 
     if ((invitationType == LLIMMgr::INVITATION_TYPE_VOICE
@@ -690,8 +712,8 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 									const std::string& name,
 									const EInstantMessage& type,
 									const LLUUID& other_participant_id,
+	                                const LLSD& voice_channel_info,
 									const uuid_vec_t& ids,
-									const LLSD& voiceChannelInfo,
 									bool has_offline_msg)
 :	mSessionID(session_id),
 	mName(name),
@@ -702,56 +724,30 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 	mOtherParticipantID(other_participant_id),
 	mInitialTargetIDs(ids),
 	mVoiceChannel(NULL),
+    mP2PAsAdhocCall(false),
 	mSpeakers(NULL),
 	mSessionInitialized(false),
 	mCallBackEnabled(true),
 	mTextIMPossible(true),
 	mStartCallOnInitialize(false),
-	mStartedAsIMCall(!voiceChannelInfo.isUndefined()),
+    mStartedAsIMCall(!voice_channel_info.isUndefined()),
 	mIsDNDsend(false),
 	mAvatarNameCacheConnection()
 {
 	// set P2P type by default
     mSessionType        = P2P_SESSION;
-    bool p2pAsAdhocCall = false;
 
 	if (IM_NOTHING_SPECIAL == mType || IM_SESSION_P2P_INVITE == mType)
     {
-		LLVoiceP2POutgoingCallInterface *outgoingInterface =
-			LLVoiceClient::getInstance()->getOutgoingCallInterface(voiceChannelInfo);
-
-		if (outgoingInterface)
-		{
-			// only use LLVoiceChannelP2P if the provider can handle the special P2P interface,
-			// which uses the voice server to relay calls and invites.  Otherwise,
-			// we use the group voice provider.
-			mVoiceChannel = new LLVoiceChannelP2P(session_id, name, other_participant_id, outgoingInterface);
-		}
-		else
-		{
-			p2pAsAdhocCall = true;
-			mVoiceChannel  = new LLVoiceChannelGroup(session_id, name, true);
-		}
+        mP2PAsAdhocCall = (LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info) == NULL);
 	}
-	else
-	{
-		// determine whether it is group or conference session
-		if (gAgent.isInGroup(mSessionID))
-		{
-			mSessionType = GROUP_SESSION;
-			mVoiceChannel = new LLVoiceChannelGroup(session_id, name, false);
-		}
-        else
-		{
-			mSessionType = ADHOC_SESSION;
-			mVoiceChannel = new LLVoiceChannelGroup(session_id, name, false);
-		}
-	}
+    else
+    {
+        // determine whether it is group or conference session
+        mSessionType = gAgent.isInGroup(mSessionID) ? GROUP_SESSION : ADHOC_SESSION;
+    }
 
-	mVoiceChannelStateChangeConnection = mVoiceChannel->setStateChangedCallback(boost::bind(&LLIMSession::onVoiceChannelStateChanged, this, _1, _2, _3));
-	mVoiceChannel->setChannelInfo(voiceChannelInfo);
-
-	mSpeakers = new LLIMSpeakerMgr(mVoiceChannel);
+    initVoiceChannel(voice_channel_info);
 
 	// All participants will be added to the list of people we've recently interacted with.
 
@@ -761,7 +757,7 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 
 	//we need to wait for session initialization for outgoing ad-hoc and group chat session
 	//correct session id for initiated ad-hoc chat will be received from the server
-	if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, p2pAsAdhocCall))
+	if (!LLIMModel::getInstance()->sendStartSession(mSessionID, mOtherParticipantID, mInitialTargetIDs, mType, mP2PAsAdhocCall))
 	{
 		//we don't need to wait for any responses
 		//so we're already initialized
@@ -789,6 +785,68 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 	{
 		mAvatarNameCacheConnection = LLAvatarNameCache::get(mOtherParticipantID,boost::bind(&LLIMModel::LLIMSession::onAdHocNameCache,this, _2));
 	}
+}
+
+void LLIMModel::LLIMSession::initVoiceChannel(const LLSD& voiceChannelInfo)
+{
+    mVoiceChannelStateChangeConnection.disconnect();
+
+	if (mVoiceChannel)
+    {
+        mVoiceChannel->deactivate();
+
+        delete mVoiceChannel;
+        mVoiceChannel = NULL;
+    }
+    mP2PAsAdhocCall = false;
+    if (IM_NOTHING_SPECIAL == mType || IM_SESSION_P2P_INVITE == mType)
+    {
+        LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voiceChannelInfo);
+
+        if (outgoingInterface)
+        {
+            // only use LLVoiceChannelP2P if the provider can handle the special P2P interface,
+            // which uses the voice server to relay calls and invites.  Otherwise,
+            // we use the group voice provider.
+            mVoiceChannel = new LLVoiceChannelP2P(mSessionID, mName, mOtherParticipantID, outgoingInterface);
+        }
+        else
+        {
+            mP2PAsAdhocCall = true;
+            mVoiceChannel  = new LLVoiceChannelGroup(mSessionID, mName, true);
+        }
+    }
+    else
+    {
+        // determine whether it is group or conference session
+        if (mSessionType == GROUP_SESSION)
+        {
+            mSessionType  = GROUP_SESSION;
+            mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
+        }
+        else if (mSessionType == ADHOC_SESSION)
+        {
+            mSessionType  = ADHOC_SESSION;
+            mVoiceChannel = new LLVoiceChannelGroup(mSessionID, mName, false);
+        }
+		else
+		{
+            LL_WARNS("Voice") << "Invalid Session Type when initializing voice channel: " << mSessionType << LL_ENDL;
+            return;
+		}
+    }
+
+    mVoiceChannelStateChangeConnection =
+        mVoiceChannel->setStateChangedCallback(boost::bind(&LLIMSession::onVoiceChannelStateChanged, this, _1, _2, _3));
+
+	if (!mSpeakers)
+	{
+        mSpeakers = new LLIMSpeakerMgr(mVoiceChannel);
+	}
+    else
+    {
+        mSpeakers->setVoiceChannel(mVoiceChannel);
+    }
 }
 
 void LLIMModel::LLIMSession::onAdHocNameCache(const LLAvatarName& av_name)
@@ -894,7 +952,7 @@ void LLIMModel::LLIMSession::onVoiceChannelStateChanged(const LLVoiceChannel::ES
 		break;
 	}
 	// Update speakers list when connected
-	if (LLVoiceChannel::STATE_CONNECTED == new_state)
+	if (mSpeakers && LLVoiceChannel::STATE_CONNECTED == new_state)
 	{
 		mSpeakers->update(true);
 	}
@@ -926,7 +984,10 @@ void LLIMModel::LLIMSession::sessionInitReplyReceived(const LLUUID& new_session_
 	if (new_session_id != mSessionID)
 	{
 		mSessionID = new_session_id;
-		mVoiceChannel->updateSessionID(new_session_id);
+        if (mVoiceChannel)
+        {
+            mVoiceChannel->updateSessionID(new_session_id);
+        }
 	}
 }
 
@@ -1498,7 +1559,7 @@ bool LLIMModel::newSession(const LLUUID& session_id, const std::string& name, co
 		return false;
 	}
 
-	LLIMSession* session = new LLIMSession(session_id, name, type, other_participant_id, ids, voiceChannelInfo, has_offline_msg);
+	LLIMSession *session       = new LLIMSession(session_id, name, type, other_participant_id, voiceChannelInfo, ids, has_offline_msg);
 	mId2SessionMap[session_id] = session;
 
 	// When notifying observer, name of session is used instead of "name", because they may not be the
@@ -1762,7 +1823,7 @@ EInstantMessage LLIMModel::getType(const LLUUID& session_id) const
 	return session->mType;
 }
 
-LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id ) const
+LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id, const LLSD& voice_channel_info ) const
 {
 	LLIMSession* session = findIMSession(session_id);
 	if (!session)
@@ -1770,6 +1831,14 @@ LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id ) const
 		LL_WARNS() << "session " << session_id << "does not exist " << LL_ENDL;
 		return NULL;
 	}
+    if (IM_NOTHING_SPECIAL == session->mType || IM_SESSION_P2P_INVITE == session->mType)
+    {
+        LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info);
+        if ((outgoingInterface != NULL) != (dynamic_cast<LLVoiceChannelP2P *>(session->mVoiceChannel) != NULL))
+        {
+            session->initVoiceChannel(voice_channel_info);
+        }
+    }
 
 	return session->mVoiceChannel;
 }
@@ -2111,7 +2180,7 @@ bool LLIMModel::sendStartSession(
 		//we also need to wait for reply from the server in case of ad-hoc chat (we'll get new session id)
 		return true;
 	}
-	else if (p2p_as_adhoc_call && ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL)))
+    else if (p2p_as_adhoc_call && ((dialog == IM_SESSION_P2P_INVITE) || (dialog == IM_NOTHING_SPECIAL)))
 	{
 		LLViewerRegion *region = gAgent.getRegion();
 		if (region)
@@ -2732,7 +2801,7 @@ void LLIncomingCallDialog::onLifetimeExpired()
 		LLUUID session_id = mPayload["session_id"].asUUID();
 		gIMMgr->clearPendingAgentListUpdates(session_id);
 		gIMMgr->clearPendingInvitation(session_id);
-		closeFloater();
+        LLIncomingCallDialog::onReject(this);
 	}
 }
 
@@ -2921,7 +2990,7 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 
 			if (voice)
 			{
-				gIMMgr->startCall(session_id, LLVoiceChannel::INCOMING_CALL);
+                gIMMgr->startCall(session_id, LLVoiceChannel::INCOMING_CALL, payload["voice_channel_info"]);
 			}
 			else
 			{
@@ -2975,8 +3044,7 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 			if (voice)
 			{
                 LLCoros::instance().launch("chatterBoxInvitationCoro",
-                    boost::bind(&chatterBoxInvitationCoro, url,
-                    session_id, inv_type));
+                                           boost::bind(&chatterBoxInvitationCoro, url, session_id, inv_type, payload["voice_channel_info"]));
 
 				// send notification message to the corresponding chat
 				if (payload["notify_box_type"].asString() == "VoiceInviteGroup" || payload["notify_box_type"].asString() == "VoiceInviteAdHoc")
@@ -3460,7 +3528,6 @@ void LLIMMgr::inviteToSession(
 	payload["caller_name"] = caller_name;
 	payload["type"] = type;
 	payload["inv_type"] = inv_type;
-	payload["voice_channel_info"] = voice_channel_info;
 	payload["notify_box_type"] = notify_box_type;
 	payload["question_type"] = question_type;
 
@@ -3490,7 +3557,6 @@ void LLIMMgr::inviteToSession(
 		LLIncomingCallDialog::processCallResponse(0, payload);
 		return;
 	}
-
 	if (voice_invite)
 	{
 		bool isRejectGroupCall = (gSavedSettings.getBOOL("VoiceCallsRejectGroup") && (notify_box_type == "VoiceInviteGroup"));
@@ -3529,6 +3595,9 @@ void LLIMMgr::inviteToSession(
 
 	if ( !mPendingInvitations.has(session_id.asString()) )
 	{
+		// we're throwing up a dialogue, so we're using the voice channel passed to us,
+		// save it in the payload.
+        payload["voice_channel_info"] = voice_channel_info;
 		if (caller_name.empty())
 		{
 			LLAvatarNameCache::get(caller_id,
@@ -3773,9 +3842,9 @@ void LLIMMgr::removeSessionObserver(LLIMSessionObserver *observer)
 	mSessionObservers.remove(observer);
 }
 
-bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection direction)
+bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection direction, const LLSD& voice_channel_info)
 {
-	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id);
+	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id, voice_channel_info);
 	if (!voice_channel) return false;
 	voice_channel->setCallDirection(direction);
 	voice_channel->activate();
@@ -3784,7 +3853,7 @@ bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection dir
 
 bool LLIMMgr::endCall(const LLUUID& session_id)
 {
-	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id);
+	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id, LLSD());
 	if (!voice_channel) return false;
 
 	voice_channel->deactivate();
@@ -4078,6 +4147,15 @@ public:
 		{
 			im_mgr->processSessionUpdate(input["body"]["info"]);
 		}
+		if (input["body"]["info"].has("voice_channel_info"))
+		{
+            LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
+            if (session)
+            {
+                session->initVoiceChannel(input["body"]["info"]["voice_channel_info"]);
+                session->mVoiceChannel->activate();
+            }
+		}
 	}
 };
 
@@ -4162,7 +4240,7 @@ public:
 			{
                 LLCoros::instance().launch("chatterBoxInvitationCoro",
                     boost::bind(&chatterBoxInvitationCoro, url,
-                    session_id, LLIMMgr::INVITATION_TYPE_INSTANT_MESSAGE));
+                    session_id, LLIMMgr::INVITATION_TYPE_INSTANT_MESSAGE, LLSD()));
 			}
 		} //end if invitation has instant message
 		else if ( input["body"].has("voice") )
@@ -4174,7 +4252,7 @@ public:
 			}
 
             BOOL session_type_p2p = input["body"]["voice"].get("invitation_type").asInteger() == EMultiAgentChatSessionType::P2P_CHAT_SESSION;
-            LL_DEBUGS("Voice") << "Received P2P voice information from the server: " << input["body"]<< LL_ENDL;
+            LL_DEBUGS("Voice") << "Received voice information from the server: " << input["body"]<< LL_ENDL;
 			gIMMgr->inviteToSession(
 				input["body"]["session_id"].asUUID(),
 				input["body"]["session_name"].asString(),

--- a/indra/newview/llimview.h
+++ b/indra/newview/llimview.h
@@ -80,8 +80,10 @@ public:
 		} SType;
 
 		LLIMSession(const LLUUID& session_id, const std::string& name,
-			const EInstantMessage& type, const LLUUID& other_participant_id, const uuid_vec_t& ids, const LLSD& voiceChannelInfo, bool has_offline_msg);
+			const EInstantMessage& type, const LLUUID& other_participant_id, const LLSD& voiceChannelInfo, const uuid_vec_t& ids, bool has_offline_msg);
 		virtual ~LLIMSession();
+
+		void initVoiceChannel(const LLSD &voiceChannelInfo = LLSD());
 
 		void sessionInitReplyReceived(const LLUUID& new_session_id);
 		void addMessagesFromHistoryCache(const std::list<LLSD>& history);        // From local file
@@ -141,6 +143,7 @@ public:
 
 		LLVoiceChannel* mVoiceChannel;
 		LLIMSpeakerMgr* mSpeakers;
+        bool            mP2PAsAdhocCall;
 
 		bool mSessionInitialized;
 
@@ -284,7 +287,7 @@ public:
 	 * Get voice channel for the session specified by session_id
 	 * Returns NULL if the session does not exist
 	 */
-	LLVoiceChannel* getVoiceChannel(const LLUUID& session_id) const;
+	LLVoiceChannel* getVoiceChannel(const LLUUID& session_id, const LLSD& voice_channel_info = LLSD()) const;
 
 	/**
 	* Get im speaker manager for the session specified by session_id
@@ -464,7 +467,7 @@ public:
 	 * Start call in a session
 	 * @return false if voice channel doesn't exist
 	 **/
-	bool startCall(const LLUUID& session_id, LLVoiceChannel::EDirection direction = LLVoiceChannel::OUTGOING_CALL);
+	bool startCall(const LLUUID& session_id, LLVoiceChannel::EDirection direction = LLVoiceChannel::OUTGOING_CALL, const LLSD& voice_channel_info = LLSD());
 
 	/**
 	 * End call in a session

--- a/indra/newview/llspeakers.cpp
+++ b/indra/newview/llspeakers.cpp
@@ -618,7 +618,7 @@ void LLSpeakerMgr::getSpeakerList(speaker_list_t* speaker_list, BOOL include_tex
 
 const LLUUID LLSpeakerMgr::getSessionID() 
 { 
-	return mVoiceChannel->getSessionID(); 
+	return mVoiceChannel ? mVoiceChannel->getSessionID() : LLUUID(); 
 }
 
 bool LLSpeakerMgr::isSpeakerToBeRemoved(const LLUUID& speaker_id)

--- a/indra/newview/llspeakers.h
+++ b/indra/newview/llspeakers.h
@@ -241,6 +241,7 @@ public:
 	typedef std::vector<LLPointer<LLSpeaker> > speaker_list_t;
 	void getSpeakerList(speaker_list_t* speaker_list, BOOL include_text);
 	LLVoiceChannel* getVoiceChannel() { return mVoiceChannel; }
+    void setVoiceChannel(LLVoiceChannel *voiceChannel) { mVoiceChannel = voiceChannel;  }
 	const LLUUID getSessionID();
 	bool isSpeakerToBeRemoved(const LLUUID& speaker_id);
 

--- a/indra/newview/llspeakers.h
+++ b/indra/newview/llspeakers.h
@@ -241,7 +241,7 @@ public:
 	typedef std::vector<LLPointer<LLSpeaker> > speaker_list_t;
 	void getSpeakerList(speaker_list_t* speaker_list, BOOL include_text);
 	LLVoiceChannel* getVoiceChannel() { return mVoiceChannel; }
-    void setVoiceChannel(LLVoiceChannel *voiceChannel) { mVoiceChannel = voiceChannel;  }
+	void setVoiceChannel(LLVoiceChannel *voiceChannel) { mVoiceChannel = voiceChannel;  }
 	const LLUUID getSessionID();
 	bool isSpeakerToBeRemoved(const LLUUID& speaker_id);
 

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -473,8 +473,7 @@ void LLVoiceChannelGroup::requestChannelInfo()
 
 void LLVoiceChannelGroup::setChannelInfo(const LLSD& channelInfo)
 {
-	mChannelInfo     = channelInfo;
-    LL_INFOS("Voice") << "setChannelInfo: " << channelInfo << LL_ENDL;
+	mChannelInfo = channelInfo;
 
 	if (mState == STATE_NO_CHANNEL_INFO)
 	{

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -152,13 +152,16 @@ void LLVoiceChannel::handleStatusChange(EStatusType type)
 	case STATUS_LOGGED_IN:
 		break;
 	case STATUS_LEFT_CHANNEL:
-		if (callStarted() && !mIgnoreNextSessionLeave && !sSuspended)
+		if (callStarted() && !sSuspended)
 		{
 			// if forceably removed from channel
 			// update the UI and revert to default channel
+			// deactivate will set the State to STATE_HUNG_UP
+			// so when handleStatusChange is called again during
+			// shutdown callStarted will return false and deactivate
+			// won't be called again.
 			deactivate();
 		}
-		mIgnoreNextSessionLeave = FALSE;
 		break;
 	case STATUS_JOINING:
 		if (callStarted())
@@ -433,7 +436,7 @@ void LLVoiceChannelGroup::activate()
 				// Adding ad-hoc call participants to Recent People List.
 				// If it's an outgoing ad-hoc, we can use mInitialTargetIDs that holds IDs of people we
 				// called(both online and offline) as source to get people for recent (STORM-210).
-				if (session->isOutgoingAdHoc())
+				if (session && session->isOutgoingAdHoc())
 				{
 					for (uuid_vec_t::iterator it = session->mInitialTargetIDs.begin(); it != session->mInitialTargetIDs.end(); ++it)
 					{
@@ -471,6 +474,7 @@ void LLVoiceChannelGroup::requestChannelInfo()
 void LLVoiceChannelGroup::setChannelInfo(const LLSD& channelInfo)
 {
 	mChannelInfo     = channelInfo;
+    LL_INFOS("Voice") << "setChannelInfo: " << channelInfo << LL_ENDL;
 
 	if (mState == STATE_NO_CHANNEL_INFO)
 	{

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -421,7 +421,7 @@ public:
 
 	// initiate a call with a peer using the P2P interface, which only applies to some
 	// voice server types.  Otherwise, a group call should be used for P2P
-    LLVoiceP2POutgoingCallInterface* getOutgoingCallInterface(const LLSD& voiceChannelInfo = LLSD());
+	LLVoiceP2POutgoingCallInterface* getOutgoingCallInterface(const LLSD& voiceChannelInfo = LLSD());
 
 	LLVoiceP2PIncomingCallInterfacePtr getIncomingCallInterface(const LLSD &voiceCallInfo);
 

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -421,7 +421,7 @@ public:
 
 	// initiate a call with a peer using the P2P interface, which only applies to some
 	// voice server types.  Otherwise, a group call should be used for P2P
-    LLVoiceP2POutgoingCallInterface* getOutgoingCallInterface(const LLSD& voiceChannelInfo);
+    LLVoiceP2POutgoingCallInterface* getOutgoingCallInterface(const LLSD& voiceChannelInfo = LLSD());
 
 	LLVoiceP2PIncomingCallInterfacePtr getIncomingCallInterface(const LLSD &voiceCallInfo);
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -1200,7 +1200,7 @@ bool LLVivoxVoiceClient::provisionVoiceAccount()
         LL_WARNS("Voice") << "Could not access voice provision cap after " << retryCount << " attempts." << LL_ENDL;
         return false;
     }
-    LL_WARNS("Voice") << "Voice Provision Result." << result << LL_ENDL;
+    LL_DEBUGS("Voice") << "Voice Provision Result." << result << LL_ENDL;
     std::string voiceSipUriHostname;
     std::string voiceAccountServerUri;
     std::string voiceUserName = result["username"].asString();
@@ -1749,7 +1749,7 @@ bool LLVivoxVoiceClient::addAndJoinSession(const sessionStatePtr_t &nextSession)
             }
             else if ((message == "failed") || (message == "removed") || (message == "timeout"))
             {   // we will get a removed message if a voice call is declined.
-
+                LL_INFOS("Voice") << "Result:" << result << LL_ENDL;
                 if (message == "failed")
                 {
                     int reason = result["reason"].asInteger();
@@ -6344,8 +6344,7 @@ void LLVivoxVoiceClient::predAvatarNameResolution(const LLVivoxVoiceClient::sess
                 session->mCallerID,
                 session->mName,
                 IM_SESSION_P2P_INVITE,
-                LLIMMgr::INVITATION_TYPE_VOICE,
-                session->getVoiceChannelInfo());
+                LLIMMgr::INVITATION_TYPE_VOICE);
         }
     }
 }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -87,7 +87,7 @@ namespace {
     const F32 VOLUME_SCALE_WEBRTC = 0.01f;
     const F32 LEVEL_SCALE_WEBRTC  = 0.008f;
 
-    const F32 SPEAKING_AUDIO_LEVEL = 0.40;
+    const F32 SPEAKING_AUDIO_LEVEL = 0.35;
 
     static const std::string REPORTED_VOICE_SERVER_TYPE = "Secondlife WebRTC Gateway";
 

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -1119,10 +1119,6 @@ void LLWebRTCVoiceClient::removeParticipantByID(const std::string &channelID, co
         if (participant)
         {
             session->removeParticipant(participant);
-            if (session->mHangupOnLastLeave && (id != gAgentID) && (session->mParticipantsByUUID.size() <= 1))
-            {
-                notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
-            }
         }
     }
 }
@@ -1213,6 +1209,10 @@ void LLWebRTCVoiceClient::sessionState::removeParticipant(const LLWebRTCVoiceCli
             {
                 LLWebRTCVoiceClient::getInstance()->notifyParticipantObservers();
             }
+        }
+        if (mHangupOnLastLeave && (participant->mAvatarID != gAgentID) && (mParticipantsByUUID.size() <= 1))
+        {
+            LLWebRTCVoiceClient::getInstance()->notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
         }
     }
 }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -1194,13 +1194,14 @@ void LLWebRTCVoiceClient::sessionState::removeParticipant(const LLWebRTCVoiceCli
 
     if (participant)
     {
+        LLUUID participantID = participant->mAvatarID;
         participantUUIDMap::iterator iter = mParticipantsByUUID.find(participant->mAvatarID);
 
-        LL_DEBUGS("Voice") << "participant \"" << participant->mURI << "\" (" << participant->mAvatarID << ") removed." << LL_ENDL;
+        LL_DEBUGS("Voice") << "participant \"" << participant->mURI << "\" (" << participantID << ") removed." << LL_ENDL;
 
         if (iter == mParticipantsByUUID.end())
         {
-            LL_WARNS("Voice") << "Internal error: participant ID " << participant->mAvatarID << " not in UUID map" << LL_ENDL;
+            LL_WARNS("Voice") << "Internal error: participant ID " << participantID << " not in UUID map" << LL_ENDL;
         }
         else
         {
@@ -1210,7 +1211,7 @@ void LLWebRTCVoiceClient::sessionState::removeParticipant(const LLWebRTCVoiceCli
                 LLWebRTCVoiceClient::getInstance()->notifyParticipantObservers();
             }
         }
-        if (mHangupOnLastLeave && (participant->mAvatarID != gAgentID) && (mParticipantsByUUID.size() <= 1))
+        if (mHangupOnLastLeave && (participantID != gAgentID) && (mParticipantsByUUID.size() <= 1))
         {
             LLWebRTCVoiceClient::getInstance()->notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
         }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -254,6 +254,7 @@ void LLWebRTCVoiceClient::init(LLPumpIO* pump)
 
     mWebRTCDeviceInterface = llwebrtc::getDeviceInterface();
     mWebRTCDeviceInterface->setDevicesObserver(this);
+    mMainQueue = LL::WorkQueue::getInstance("mainloop");
 }
 
 void LLWebRTCVoiceClient::terminate()
@@ -1486,7 +1487,6 @@ void LLWebRTCVoiceClient::setVoiceEnabled(bool enabled)
             updatePosition();
             if (!mIsCoroutineActive)
             {
-                mMainQueue = LL::WorkQueue::getInstance("mainloop");
                 LLCoros::instance().launch("LLWebRTCVoiceClient::voiceConnectionCoro",
                     boost::bind(&LLWebRTCVoiceClient::voiceConnectionCoro, LLWebRTCVoiceClient::getInstance()));
             }

--- a/indra/newview/skins/default/xui/en/floater_incoming_call.xml
+++ b/indra/newview/skins/default/xui/en/floater_incoming_call.xml
@@ -12,7 +12,7 @@
  width="550">
     <floater.string
      name="lifetime">
-        5
+        30
     </floater.string>
     <floater.string
      name="localchat">


### PR DESCRIPTION
* Populate voice devices on viewer startup, not after login, so that the pre-login preferences work.
* Renegotiate voice if the voice server type has changed in adhoc/group/p2p calls.
* Fix issue where deleting observers was preventing voice reconnects from happening.
* Don't default the tracks to enabled.
* Tweak the speaking audio level detection.
* Increase invite dialog timeout to 30 seconds.