### PR TITLE
GCC compatibility

### DIFF
--- a/indra/llfilesystem/tests/lldir_test.cpp
+++ b/indra/llfilesystem/tests/lldir_test.cpp
@@ -434,7 +434,7 @@ namespace tut
       
       for (counter=0, foundUnused=false; !foundUnused; counter++ )
       {
-         char counterStr[3];
+         char counterStr[12] = {};
          sprintf(counterStr, "%02d", counter);
          uniqueDir = dirbase + counterStr;
          foundUnused = ! ( LLFile::isdir(uniqueDir) || LLFile::isfile(uniqueDir) );


### PR DESCRIPTION
GCC will rightfully complain that counterStr is too small. So increase it accordingly.

This function though is peculiar in more than this way, it could run away like a diesel engine on fire. As the for loop possible can never exit. Which granted is very unlikely but could happen none the less