### PR TITLE
Enable IME on XWayland desktop environment

### DIFF
--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -654,11 +654,6 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
         SDL_SetHint( std::get<0>(hint), std::get<1>(hint));
     }
 
-#if LL_LINUX
-    // Enable IME on XWayland
-    setenv("XMODIFIERS", std::string("@im=fcitx;ibus").c_str(), 1);
-#endif
-
     std::initializer_list<std::tuple<uint32_t, char const*, bool>> initList=
             { {SDL_INIT_VIDEO,"SDL_INIT_VIDEO", true},
               {SDL_INIT_AUDIO,"SDL_INIT_AUDIO", false},

--- a/indra/llwindow/llwindowsdl.cpp
+++ b/indra/llwindow/llwindowsdl.cpp
@@ -654,6 +654,11 @@ BOOL LLWindowSDL::createContext(int x, int y, int width, int height, int bits, B
         SDL_SetHint( std::get<0>(hint), std::get<1>(hint));
     }
 
+#if LL_LINUX
+    // Enable IME on XWayland
+    setenv("XMODIFIERS", std::string("@im=fcitx;ibus").c_str(), 1);
+#endif
+
     std::initializer_list<std::tuple<uint32_t, char const*, bool>> initList=
             { {SDL_INIT_VIDEO,"SDL_INIT_VIDEO", true},
               {SDL_INIT_AUDIO,"SDL_INIT_AUDIO", false},

--- a/indra/newview/linux_tools/wrapper.sh
+++ b/indra/newview/linux_tools/wrapper.sh
@@ -62,6 +62,10 @@ export SDL_VIDEO_X11_DGAMOUSE=0
 if [ "$GTK_IM_MODULE" = "scim" ]; then
     export GTK_IM_MODULE=xim
 fi
+if [ "$XMODIFIERS" = "" ]; then
+    ## IME is valid only for fcitx, not when using ibus
+    export XMODIFIERS="@im=fcitx"
+fi
 
 ## - Automatically work around the ATI mouse cursor crash bug:
 ## (this workaround is disabled as most fglrx users do not see the bug)


### PR DESCRIPTION
This change fixes the IME to work even if the desktop environment is running on Wayland.