### PR TITLE
viewer-private#236 Don't block removal of marketplace folders

### DIFF
--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -843,12 +843,6 @@ bool get_is_category_and_children_removable(LLInventoryModel* model, const LLUUI
         return false;
     }
 
-    const LLUUID mp_id = gInventory.findCategoryUUIDForType(LLFolderType::FT_MARKETPLACE_LISTINGS);
-    if (mp_id.notNull() && gInventory.isObjectDescendentOf(folder_id, mp_id))
-    {
-        return false;
-    }
-
     LLInventoryModel::cat_array_t cat_array;
     LLInventoryModel::item_array_t item_array;
     model->collectDescendents(


### PR DESCRIPTION
Marketplace is not visible outside of own floater and that floater will do an extra warning when deleting listings that have additional data.

Should either go into maint-x, where issue was introduced or whatever comes next.