### PR TITLE
Fix issue where groups/adhoc chats were named with the initiators display name.

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -280,9 +280,15 @@ void LLWebRTCImpl::terminate()
     {
         connection->terminate();
     }
-    mPeerConnections.clear();
+
+    // connection->terminate() above spawns a number of Signaling thread calls to
+    // shut down the connection.  The following Blocking Call will wait
+    // until they're done before it's executed, allowing time to clean up.
 
     mSignalingThread->BlockingCall([this]() { mPeerConnectionFactory = nullptr; });
+
+    mPeerConnections.clear();
+
     mWorkerThread->BlockingCall(
         [this]()
         {
@@ -652,7 +658,6 @@ LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
 
 LLWebRTCPeerConnectionImpl::~LLWebRTCPeerConnectionImpl()
 {
-    terminate();
     mSignalingObserverList.clear();
     mDataObserverList.clear();
 }

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -212,6 +212,9 @@ class LLWebRTCSignalingObserver
     // Called when a connection enters a failure state and renegotiation is needed.
     virtual void OnRenegotiationNeeded() = 0;
 
+    // Called when a peer connection has shut down
+    virtual void OnPeerConnectionClosed() = 0;
+
     // Called when the audio channel has been established and audio
     // can begin.
     virtual void OnAudioEstablished(LLWebRTCAudioInterface *audio_interface) = 0;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -355,8 +355,6 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 
     LLWebRTCImpl * mWebRTCImpl;
 
-    bool mClosing;
-
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
 
     bool mMute;

--- a/indra/newview/llfloaterimsession.cpp
+++ b/indra/newview/llfloaterimsession.cpp
@@ -94,6 +94,7 @@ LLFloaterIMSession::LLFloaterIMSession(const LLUUID& session_id)
     mEnableCallbackRegistrar.add("Avatar.EnableGearItem", boost::bind(&LLFloaterIMSession::enableGearMenuItem, this, _2));
     mCommitCallbackRegistrar.add("Avatar.GearDoToSelected", boost::bind(&LLFloaterIMSession::GearDoToSelected, this, _2));
     mEnableCallbackRegistrar.add("Avatar.CheckGearItem", boost::bind(&LLFloaterIMSession::checkGearMenuItem, this, _2));
+    mVoiceChannelChanged = LLVoiceChannel::setCurrentVoiceChannelChangedCallback(boost::bind(&LLFloaterIMSession::onVoiceChannelChanged, this, _1));
 
     setDocked(true);
 }
@@ -292,6 +293,8 @@ LLFloaterIMSession::~LLFloaterIMSession()
 	}
 
 	LLTransientFloaterMgr::getInstance()->removeControlView(LLTransientFloaterMgr::IM, this);
+
+	mVoiceChannelChanged.disconnect();
 }
 
 
@@ -519,6 +522,14 @@ void LLFloaterIMSession::sendParticipantsAddedNotification(const uuid_vec_t& uui
 	args["[NAME]"] = names_string;
 
 	sendMsg(getString(uuids.size() > 1 ? "multiple_participants_added" : "participant_added", args));
+}
+
+void LLFloaterIMSession::onVoiceChannelChanged(const LLUUID &session_id)
+{
+	if (session_id == mSessionID)
+	{
+		boundVoiceChannel();
+	}
 }
 
 void LLFloaterIMSession::boundVoiceChannel()

--- a/indra/newview/llfloaterimsession.h
+++ b/indra/newview/llfloaterimsession.h
@@ -161,6 +161,8 @@ private:
 
 	void onCallButtonClicked();
 
+	void onVoiceChannelChanged(const LLUUID &session_id);
+
 	void boundVoiceChannel();
 
 	// Add the "User is typing..." indicator.
@@ -194,6 +196,9 @@ private:
 
 	uuid_vec_t mInvitedParticipants;
 	uuid_vec_t mPendingParticipants;
+
+	// notification when the voice channel is swapped out from beneath us.
+	boost::signals2::connection mVoiceChannelChanged;
 
 	// connection to voice channel state change signal
 	boost::signals2::connection mVoiceChannelStateChangeConnection;

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -1823,21 +1823,13 @@ EInstantMessage LLIMModel::getType(const LLUUID& session_id) const
 	return session->mType;
 }
 
-LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id, const LLSD& voice_channel_info ) const
+LLVoiceChannel* LLIMModel::getVoiceChannel( const LLUUID& session_id) const
 {
 	LLIMSession* session = findIMSession(session_id);
 	if (!session)
 	{
 		LL_WARNS() << "session " << session_id << "does not exist " << LL_ENDL;
 		return NULL;
-	}
-	if (IM_NOTHING_SPECIAL == session->mType || IM_SESSION_P2P_INVITE == session->mType)
-	{
-		LLVoiceP2POutgoingCallInterface *outgoingInterface = LLVoiceClient::getInstance()->getOutgoingCallInterface(voice_channel_info);
-		if ((outgoingInterface != NULL) != (dynamic_cast<LLVoiceChannelP2P *>(session->mVoiceChannel) != NULL))
-		{
-			session->initVoiceChannel(voice_channel_info);
-		}
 	}
 
 	return session->mVoiceChannel;
@@ -3846,8 +3838,12 @@ void LLIMMgr::removeSessionObserver(LLIMSessionObserver *observer)
 
 bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection direction, const LLSD& voice_channel_info)
 {
-	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id, voice_channel_info);
+	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id);
 	if (!voice_channel) return false;
+	if (!voice_channel_info.isUndefined())
+	{
+		voice_channel->setChannelInfo(voice_channel_info);
+	}
 	voice_channel->setCallDirection(direction);
 	voice_channel->activate();
 	return true;
@@ -3855,7 +3851,7 @@ bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection dir
 
 bool LLIMMgr::endCall(const LLUUID& session_id)
 {
-	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id, LLSD());
+	LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(session_id);
 	if (!voice_channel) return false;
 
 	voice_channel->deactivate();

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -789,10 +789,15 @@ LLIMModel::LLIMSession::LLIMSession(const LLUUID& session_id,
 
 void LLIMModel::LLIMSession::initVoiceChannel(const LLSD& voiceChannelInfo)
 {
-	mVoiceChannelStateChangeConnection.disconnect();
 
 	if (mVoiceChannel)
 	{
+		if (mVoiceChannel->isThisVoiceChannel(voiceChannelInfo))
+		{
+			return;
+		}
+		mVoiceChannelStateChangeConnection.disconnect();
+
 		mVoiceChannel->deactivate();
 
 		delete mVoiceChannel;

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -2966,10 +2966,6 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 	LLUUID session_id = payload["session_id"].asUUID();
 	LLUUID caller_id = payload["caller_id"].asUUID();
 	std::string session_name = payload["session_name"].asString();
-	if (session_name.empty())
-	{
-		session_name = payload["caller_name"].asString();
-	}
 	EInstantMessage type = (EInstantMessage)payload["type"].asInteger();
 	LLIMMgr::EInvitationType inv_type = (LLIMMgr::EInvitationType)payload["inv_type"].asInteger();
 	bool voice = true;

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3393,8 +3393,9 @@ LLUUID LLIMMgr::addSession(
             im_floater->reloadMessages();
 		}
 	}
+    LLIMModel::LLIMSession *session = LLIMModel::getInstance()->findIMSession(session_id);
 
-	bool new_session = (LLIMModel::getInstance()->findIMSession(session_id) == NULL);
+	bool new_session = (session == NULL);
 
 	//works only for outgoing ad-hoc sessions
 	if (new_session &&
@@ -3417,6 +3418,7 @@ LLUUID LLIMMgr::addSession(
     //Notifies observers that the session was already added
     else
     {
+        session->initVoiceChannel(voiceChannelInfo);
         std::string session_name = LLIMModel::getInstance()->getName(session_id);
         LLIMMgr::getInstance()->notifyObserverSessionActivated(session_id, session_name, other_participant_id);
     }

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -2980,6 +2980,10 @@ void LLIncomingCallDialog::processCallResponse(S32 response, const LLSD &payload
 	{
 		if (type == IM_SESSION_P2P_INVITE)
 		{
+            if (session_name.empty())
+            {
+                session_name = payload["caller_name"].asString();
+            }
 			// create a normal IM session
 			session_id = gIMMgr->addP2PSession(
 				session_name, caller_id, payload["voice_channel_info"]);

--- a/indra/newview/llimview.h
+++ b/indra/newview/llimview.h
@@ -287,7 +287,7 @@ public:
 	 * Get voice channel for the session specified by session_id
 	 * Returns NULL if the session does not exist
 	 */
-	LLVoiceChannel* getVoiceChannel(const LLUUID& session_id, const LLSD& voice_channel_info = LLSD()) const;
+	LLVoiceChannel* getVoiceChannel(const LLUUID& session_id) const;
 
 	/**
 	* Get im speaker manager for the session specified by session_id

--- a/indra/newview/llvoicechannel.h
+++ b/indra/newview/llvoicechannel.h
@@ -93,6 +93,8 @@ public:
 	void setCallDirection(EDirection direction) {mCallDirection = direction;}
 	EDirection getCallDirection() {return mCallDirection;}
 
+	bool isThisVoiceChannel(const LLSD &voiceChannelInfo) { return LLVoiceClient::getInstance()->compareChannels(mChannelInfo, voiceChannelInfo); }
+
 	static LLVoiceChannel* getChannelByID(const LLUUID& session_id);
 	static LLVoiceChannel* getCurrentVoiceChannel();
 
@@ -115,7 +117,7 @@ public:
 	EState		mState;
 	std::string	mSessionName;
 	LLSD        mNotifyArgs;
-	LLSD        mChannelInfo; 
+	LLSD        mChannelInfo;
 	// true if call was ended by agent
 	bool mCallEndedByAgent;
 	bool mIgnoreNextSessionLeave;

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -157,7 +157,6 @@ LLVoiceClient::LLVoiceClient(LLPumpIO *pump)
 
 LLVoiceClient::~LLVoiceClient()
 {
-    llassert(!mSpatialVoiceModule);
 }
 
 void LLVoiceClient::init(LLPumpIO *pump)

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -540,9 +540,11 @@ LLVoiceP2POutgoingCallInterface *LLVoiceClient::getOutgoingCallInterface(const L
         LLVoiceVersionInfo versionInfo = LLVoiceClient::getInstance()->getVersion();
         voice_server_type = versionInfo.internalVoiceServerType;
     }
-    if (voiceChannelInfo.has("voice_server_type"))
+    if (voiceChannelInfo.has("voice_server_type") && voiceChannelInfo["voice_server_type"] != voice_server_type)
     {
-        voice_server_type = voiceChannelInfo["voice_server_type"].asString();
+        // there's a mismatch between what the peer is offering and what our server
+        // can handle, so downgrade to vivox
+        voice_server_type = VIVOX_VOICE_SERVER_TYPE;
     }
     LLVoiceModuleInterface *module = getVoiceModule(voice_server_type);
     return dynamic_cast<LLVoiceP2POutgoingCallInterface *>(module);

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -6363,7 +6363,8 @@ void LLVivoxVoiceClient::predAvatarNameResolution(const LLVivoxVoiceClient::sess
                 session->mCallerID,
                 session->mName,
                 IM_SESSION_P2P_INVITE,
-                LLIMMgr::INVITATION_TYPE_VOICE);
+                LLIMMgr::INVITATION_TYPE_VOICE,
+                session->getVoiceChannelInfo());
         }
     }
 }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2471,7 +2471,6 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
     httpOpts->setWantHeaders(true);
 
     mOutstandingRequests++;
-    setVoiceConnectionState(VOICE_STATE_WAIT_FOR_EXIT);
 
     // tell the server to shut down the connection as a courtesy.
     // shutdownConnection will drop the WebRTC connection which will
@@ -2479,10 +2478,7 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, body, httpOpts);
 
     mOutstandingRequests--;
-    if (!LLWebRTCVoiceClient::isShuttingDown())
-    {
-        setVoiceConnectionState(VOICE_STATE_SESSION_EXIT);
-    }
+    setVoiceConnectionState(VOICE_STATE_SESSION_EXIT);
 }
 
 // Tell the simulator to tell the Secondlife WebRTC server that we want a voice
@@ -2745,6 +2741,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
             break;
 
         case VOICE_STATE_DISCONNECT:
+            setVoiceConnectionState(VOICE_STATE_WAIT_FOR_EXIT);
             LLCoros::instance().launch("LLVoiceWebRTCConnection::breakVoiceConnectionCoro",
                                        boost::bind(&LLVoiceWebRTCConnection::breakVoiceConnectionCoro, this));
             break;

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -585,6 +585,7 @@ class LLVoiceWebRTCConnection :
     void OnIceCandidate(const llwebrtc::LLWebRTCIceCandidate &candidate) override;
     void OnOfferAvailable(const std::string &sdp) override;
     void OnRenegotiationNeeded() override;
+    void OnPeerConnectionClosed() override;
     void OnAudioEstablished(llwebrtc::LLWebRTCAudioInterface *audio_interface) override;
     //@}
 
@@ -640,13 +641,15 @@ class LLVoiceWebRTCConnection :
         VOICE_STATE_DISCONNECT             = 0x100,
         VOICE_STATE_WAIT_FOR_EXIT          = 0x200,
         VOICE_STATE_SESSION_EXIT           = 0x400,
-        VOICE_STATE_SESSION_STOPPING       = 0x780
+        VOICE_STATE_WAIT_FOR_CLOSE         = 0x800,
+        VOICE_STATE_CLOSED                 = 0x1000,
+        VOICE_STATE_SESSION_STOPPING       = 0x1F80
     } EVoiceConnectionState;
 
     EVoiceConnectionState mVoiceConnectionState;
     LL::WorkQueue::weak_t mMainQueue;
 
-    void                  setVoiceConnectionState(EVoiceConnectionState new_voice_connection_state)
+    void setVoiceConnectionState(EVoiceConnectionState new_voice_connection_state)
     {
         if (new_voice_connection_state & VOICE_STATE_SESSION_STOPPING)
         {


### PR DESCRIPTION
https://github.com/secondlife/server/issues/908

When user A creates a group call with B, the name of the call as seen in the IM floater is user A's username, instead of the group name.
