### PR TITLE
Revert "viewer#819 Avoid reading the same XML file multiple times"

### DIFF
--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -70,7 +70,6 @@ LLDir *gDirUtilp = (LLDir *)&gDirUtil;
 /// Values for findSkinnedFilenames(subdir) parameter
 const char
 	*LLDir::XUI      = "xui",
-	*LLDir::HTML     = "html",
 	*LLDir::TEXTURES = "textures",
 	*LLDir::SKINBASE = "";
 
@@ -761,13 +760,14 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 		else
 		{
 			// We do not recognize this subdir. Investigate.
-			if (skinExists(subdir, "en"))
+			std::string subdir_path(add(getDefaultSkinDir(), subdir));
+			if (fileExists(add(subdir_path, "en")))
 			{
 				// defaultSkinDir/subdir contains subdir "en". That's our
 				// default language; this subdir is localized.
 				found = sLocalized.insert(StringMap::value_type(subdir, "en")).first;
 			}
-			else if (skinExists(subdir, "en-us"))
+			else if (fileExists(add(subdir_path, "en-us")))
 			{
 				// defaultSkinDir/subdir contains subdir "en-us" but not "en".
 				// Set as default language; this subdir is localized.
@@ -862,33 +862,6 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
 	LL_CONT << LL_ENDL;
 
 	return results;
-}
-
-// virtual
-bool LLDir::skinExists(const std::string& subdir, const std::string& skin) const
-{
-    std::string skin_path(add(getDefaultSkinDir(), subdir, skin));
-    return fileExists(skin_path);
-}
-
-// virtual
-std::string LLDir::getFileContents(const std::string& filename) const
-{
-    LLFILE* fp = LLFile::fopen(filename, "rb"); /* Flawfinder: ignore */
-    if (fp)
-    {
-        fseek(fp, 0, SEEK_END);
-        U32 length = ftell(fp);
-        fseek(fp, 0, SEEK_SET);
-
-        std::vector<char> buffer(length);
-        size_t nread = fread(buffer.data(), 1, length, fp);
-        fclose(fp);
-
-        return std::string(buffer.data(), nread);
-    }
-
-    return LLStringUtil::null;
 }
 
 std::string LLDir::getTempFilename() const

--- a/indra/llfilesystem/lldir.h
+++ b/indra/llfilesystem/lldir.h
@@ -72,8 +72,6 @@ class LLDir
 // pure virtual functions
 	virtual std::string getCurPath() = 0;
 	virtual bool fileExists(const std::string &filename) const = 0;
-	virtual bool skinExists(const std::string& subdir, const std::string &skin) const;
-	virtual std::string getFileContents(const std::string& filename) const;
 
 	const std::string findFile(const std::string& filename, const std::vector<std::string> filenames) const; 
 	const std::string findFile(const std::string& filename, const std::string& searchPath1 = "", const std::string& searchPath2 = "", const std::string& searchPath3 = "") const;
@@ -152,7 +150,7 @@ class LLDir
 												  const std::string& filename,
 												  ESkinConstraint constraint=CURRENT_SKIN) const;
 	/// Values for findSkinnedFilenames(subdir) parameter
-	static const char *XUI, *HTML, *TEXTURES, *SKINBASE;
+	static const char *XUI, *TEXTURES, *SKINBASE;
 	/**
 	 * Return the base-language pathname from findSkinnedFilenames(), or
 	 * the empty string if no such file exists. Parameters are identical to

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -3522,16 +3522,12 @@ bool LLFloater::isVisible(const LLFloater* floater)
     return floater && floater->getVisible();
 }
 
-bool LLFloater::buildFromFile(const std::string& filename, bool cacheable)
+bool LLFloater::buildFromFile(const std::string& filename)
 {
     LL_PROFILE_ZONE_SCOPED;
-
-    llassert_msg(!cacheable || !mSingleInstance || !mReuseInstance,
-        "No needs to cache XML for floater with mSingleInstance AND mReuseInstance flags set");
-
 	LLXMLNodePtr root;
 
-	if (!LLUICtrlFactory::getLayeredXMLNode(filename, root, LLDir::CURRENT_SKIN, cacheable))
+	if (!LLUICtrlFactory::getLayeredXMLNode(filename, root))
 	{
 		LL_WARNS() << "Couldn't find (or parse) floater from: " << filename << LL_ENDL;
 		return false;

--- a/indra/llui/llfloater.h
+++ b/indra/llui/llfloater.h
@@ -208,7 +208,7 @@ public:
 
 	// Don't export top/left for rect, only height/width
 	static void setupParamsForExport(Params& p, LLView* parent);
-	bool buildFromFile(const std::string &filename, bool cacheable = false);
+	bool buildFromFile(const std::string &filename);
 
 	boost::signals2::connection setMinimizeCallback( const commit_signal_t::slot_type& cb );
 	boost::signals2::connection setOpenCallback( const commit_signal_t::slot_type& cb );

--- a/indra/llui/llmenubutton.cpp
+++ b/indra/llui/llmenubutton.cpp
@@ -95,7 +95,7 @@ void LLMenuButton::setMenu(const std::string& menu_filename, EMenuPosition posit
 	}
 
 	llassert(LLMenuGL::sMenuContainer != NULL);
-	LLToggleableMenu* menu = LLUICtrlFactory::getInstance()->createFromFile<LLToggleableMenu>(menu_filename, LLMenuGL::sMenuContainer, LLMenuHolderGL::child_registry_t::instance(), true);
+	LLToggleableMenu* menu = LLUICtrlFactory::getInstance()->createFromFile<LLToggleableMenu>(menu_filename, LLMenuGL::sMenuContainer, LLMenuHolderGL::child_registry_t::instance());
 	if (!menu)
 	{
 		LL_WARNS() << "Error loading menu_button menu" << LL_ENDL;

--- a/indra/llui/llpanel.cpp
+++ b/indra/llui/llpanel.cpp
@@ -803,13 +803,13 @@ boost::signals2::connection LLPanel::setVisibleCallback( const commit_signal_t::
 //-----------------------------------------------------------------------------
 // buildPanel()
 //-----------------------------------------------------------------------------
-bool LLPanel::buildFromFile(const std::string& filename, const LLPanel::Params& default_params, bool cacheable)
+bool LLPanel::buildFromFile(const std::string& filename, const LLPanel::Params& default_params)
 {
     LL_PROFILE_ZONE_SCOPED;
 	bool didPost = false;
 	LLXMLNodePtr root;
 
-	if (!LLUICtrlFactory::getLayeredXMLNode(filename, root, LLDir::CURRENT_SKIN, cacheable))
+	if (!LLUICtrlFactory::getLayeredXMLNode(filename, root))
 	{
 		LL_WARNS() << "Couldn't parse panel from: " << filename << LL_ENDL;
 		return didPost;

--- a/indra/llui/llpanel.h
+++ b/indra/llui/llpanel.h
@@ -107,8 +107,7 @@ protected:
 public:
 	typedef std::vector<class LLUICtrl *>				ctrl_list_t;
 
-	bool buildFromFile(const std::string &filename, const LLPanel::Params& default_params, bool cacheable = false);
-	bool buildFromFile(const std::string &filename, bool cacheable = false) { return buildFromFile(filename, getDefaultParams(), cacheable); }
+	bool buildFromFile(const std::string &filename, const LLPanel::Params& default_params = getDefaultParams());
 
 	static LLPanel* createFactoryPanel(const std::string& name);
 

--- a/indra/llui/lluictrlfactory.cpp
+++ b/indra/llui/lluictrlfactory.cpp
@@ -157,7 +157,7 @@ void LLUICtrlFactory::createChildren(LLView* viewp, LLXMLNodePtr node, const wid
 // getLayeredXMLNode()
 //-----------------------------------------------------------------------------
 bool LLUICtrlFactory::getLayeredXMLNode(const std::string &xui_filename, LLXMLNodePtr& root,
-                                        LLDir::ESkinConstraint constraint, bool cacheable)
+                                        LLDir::ESkinConstraint constraint)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 	std::vector<std::string> paths =
@@ -169,7 +169,7 @@ bool LLUICtrlFactory::getLayeredXMLNode(const std::string &xui_filename, LLXMLNo
 		paths.push_back(xui_filename);
 	}
 
-	return LLXMLNode::getLayeredXMLNode(root, paths, cacheable);
+	return LLXMLNode::getLayeredXMLNode(root, paths);
 }
 
 

--- a/indra/llui/lluictrlfactory.h
+++ b/indra/llui/lluictrlfactory.h
@@ -148,7 +148,7 @@ public:
 	LLView* createFromXML(LLXMLNodePtr node, LLView* parent, const std::string& filename, const widget_registry_t&, LLXMLNodePtr output_node );
 
 	template<typename T>
-	static T* createFromFile(const std::string &filename, LLView *parent, const widget_registry_t& registry, bool cacheable = false)
+	static T* createFromFile(const std::string &filename, LLView *parent, const widget_registry_t& registry)
 	{
 		T* widget = NULL;
 
@@ -156,7 +156,7 @@ public:
 		{
 			LLXMLNodePtr root_node;
 
-			if (!LLUICtrlFactory::getLayeredXMLNode(filename, root_node, LLDir::CURRENT_SKIN, cacheable))
+			if (!LLUICtrlFactory::getLayeredXMLNode(filename, root_node))
 			{
                 LL_WARNS() << "Couldn't parse XUI from path: " << instance().getCurFileName() << ", from filename: " << filename << LL_ENDL;
 				goto fail;
@@ -192,7 +192,7 @@ fail:
 	static void createChildren(LLView* viewp, LLXMLNodePtr node, const widget_registry_t&, LLXMLNodePtr output_node = NULL);
 
 	static bool getLayeredXMLNode(const std::string &filename, LLXMLNodePtr& root,
-								  LLDir::ESkinConstraint constraint = LLDir::CURRENT_SKIN, bool cacheable = false);
+								  LLDir::ESkinConstraint constraint=LLDir::CURRENT_SKIN);
 
 private:
 	//NOTE: both friend declarations are necessary to keep both gcc and msvc happy

--- a/indra/llui/llxuiparser.cpp
+++ b/indra/llui/llxuiparser.cpp
@@ -28,7 +28,6 @@
 
 #include "llxuiparser.h"
 
-#include "lldir.h"
 #include "llxmlnode.h"
 #include "llfasttimer.h"
 #ifdef LL_USESYSTEMLIBS
@@ -45,7 +44,6 @@
 
 #include "lluicolor.h"
 #include "v3math.h"
-
 using namespace BOOST_SPIRIT_CLASSIC_NS;
 
 const S32 MAX_STRING_ATTRIBUTE_SIZE = 40;
@@ -1399,17 +1397,36 @@ bool LLSimpleXUIParser::readXUI(const std::string& filename, LLInitParam::BaseBl
 	mCurReadDepth = 0;
 	setParseSilently(silent);
 
-	std::string xml = gDirUtilp->getFileContents(filename);
-	if (xml.empty())
+	ScopedFile file(filename, "rb");
+	if( !file.isOpen() )
 	{
 		LL_WARNS("ReadXUI") << "Unable to open file " << filename << LL_ENDL;
 		XML_ParserFree( mParser );
 		return false;
 	}
 
+	S32 bytes_read = 0;
+	
+	S32 buffer_size = file.getRemainingBytes();
+	void* buffer = XML_GetBuffer(mParser, buffer_size);
+	if( !buffer ) 
+	{
+		LL_WARNS("ReadXUI") << "Unable to allocate XML buffer while reading file " << filename << LL_ENDL;
+		XML_ParserFree( mParser );
+		return false;
+	}
+
+	bytes_read = (S32)fread(buffer, 1, buffer_size, file.mFile);
+	if( bytes_read <= 0 )
+	{
+		LL_WARNS("ReadXUI") << "Error while reading file  " << filename << LL_ENDL;
+		XML_ParserFree( mParser );
+		return false;
+	}
+	
 	mEmptyLeafNode.push_back(false);
 
-	if (!XML_Parse(mParser, xml.data(), (int)xml.size(), true))
+	if( !XML_ParseBuffer(mParser, bytes_read, true ) )
 	{
 		LL_WARNS("ReadXUI") << "Error while parsing file  " << filename << LL_ENDL;
 		XML_ParserFree( mParser );

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -753,13 +753,13 @@ void LLControlGroup::setUntypedValue(std::string_view name, const LLSD& val)
 //---------------------------------------------------------------
 
 // Returns number of controls loaded, so 0 if failure
-U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, const std::string& xml, bool require_declaration, eControlType declare_as)
+U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, bool require_declaration, eControlType declare_as)
 {
 	std::string name;
 
 	LLXmlTree xml_controls;
 
-	if (!xml_controls.parseString(xml))
+	if (!xml_controls.parseFile(filename))
 	{
 		LL_WARNS("Settings") << "Unable to open control file " << filename << LL_ENDL;
 		return 0;
@@ -772,7 +772,7 @@ U32 LLControlGroup::loadFromFileLegacy(const std::string& filename, const std::s
 		return 0;
 	}
 
-	U32 validitems = 0;
+	U32		validitems = 0;
 	S32 version;
 	
 	rootp->getAttributeS32("version", version);
@@ -990,24 +990,24 @@ U32 LLControlGroup::saveToFile(const std::string& filename, bool nondefault_only
 U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_values, bool save_values)
 {
 	LLSD settings;
-
-	std::string xml = gDirUtilp->getFileContents(filename);
-	if (xml.empty())
+	llifstream infile;
+	infile.open(filename.c_str());
+	if(!infile.is_open())
 	{
 		LL_WARNS("Settings") << "Cannot find file " << filename << " to load." << LL_ENDL;
 		return 0;
 	}
 
-	std::stringstream stream(xml);
-	if (LLSDParser::PARSE_FAILURE == LLSDSerialize::fromXML(settings, stream))
+	if (LLSDParser::PARSE_FAILURE == LLSDSerialize::fromXML(settings, infile))
 	{
+		infile.close();
 		LL_WARNS("Settings") << "Unable to parse LLSD control file " << filename << ". Trying Legacy Method." << LL_ENDL;
-		return loadFromFileLegacy(filename, xml, true, TYPE_STRING);
+		return loadFromFileLegacy(filename, true, TYPE_STRING);
 	}
 
 	U32	validitems = 0;
 	bool hidefromsettingseditor = false;
-
+	
 	for(LLSD::map_const_iterator itr = settings.beginMap(); itr != settings.endMap(); ++itr)
 	{
 		LLControlVariable::ePersist persist = LLControlVariable::PERSIST_NONDFT;
@@ -1019,7 +1019,7 @@ U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_v
 			persist = control_map["Persist"].asInteger()?
 					  LLControlVariable::PERSIST_NONDFT : LLControlVariable::PERSIST_NO;
 		}
-
+		
 		// Sometimes we want to use the settings system to provide cheap persistence, but we
 		// don't want the settings themselves to be easily manipulated in the UI because 
 		// doing so can cause support problems. So we have this option:
@@ -1031,7 +1031,7 @@ U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_v
 		{
 			hidefromsettingseditor = false;
 		}
-
+		
 		// If the control exists just set the value from the input file.
 		LLControlVariable* existing_control = getControl(name);
 		if(existing_control)

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -300,7 +300,7 @@ public:
 	// Returns number of controls loaded, 0 if failed
 	// If require_declaration is false, will auto-declare controls it finds
 	// as the given type.
-	U32	loadFromFileLegacy(const std::string& filename, const std::string& xml, bool require_declaration = true, eControlType declare_as = TYPE_STRING);
+	U32	loadFromFileLegacy(const std::string& filename, bool require_declaration = true, eControlType declare_as = TYPE_STRING);
  	U32 saveToFile(const std::string& filename, bool nondefault_only);
  	U32	loadFromFile(const std::string& filename, bool default_values = false, bool save_values = true);
 	void	resetToDefaults();

--- a/indra/llxml/llxmlnode.h
+++ b/indra/llxml/llxmlnode.h
@@ -121,39 +121,39 @@ public:
 	LLXMLNode(const char* name, bool is_attribute);
 	LLXMLNode(LLStringTableEntry* name, bool is_attribute);
 	LLXMLNode(const LLXMLNode& rhs);
-	LLXMLNodePtr deepCopy() const;
+	LLXMLNodePtr deepCopy();
 
 	bool isNull();
 
 	bool deleteChild(LLXMLNode* child);
-    void addChild(LLXMLNodePtr& new_child);
+    void addChild(LLXMLNodePtr& new_child); 
     void setParent(LLXMLNodePtr& new_parent); // reparent if necessary
 
-    // Deserialization
+    // Serialization
 	static bool parseFile(
 		const std::string& filename,
-		LLXMLNodePtr& node,
-		LLXMLNode* defaults_tree,
-		bool cacheable = false);
-    static bool parseBuffer(
-        const char* buffer,
-        U32 length,
-        LLXMLNodePtr& node,
-        LLXMLNode* defaults);
+		LLXMLNodePtr& node, 
+		LLXMLNode* defaults_tree);
+	static bool parseBuffer(
+		U8* buffer,
+		U32 length,
+		LLXMLNodePtr& node, 
+		LLXMLNode* defaults);
 	static bool parseStream(
 		std::istream& str,
-		LLXMLNodePtr& node,
+		LLXMLNodePtr& node, 
 		LLXMLNode* defaults);
 	static bool updateNode(
 		LLXMLNodePtr& node,
 		LLXMLNodePtr& update_node);
-
-	static bool getLayeredXMLNode(LLXMLNodePtr& root, const std::vector<std::string>& paths, bool cacheable = false);
-
+	
+	static bool getLayeredXMLNode(LLXMLNodePtr& root, const std::vector<std::string>& paths);
+	
+	
 	// Write standard XML file header:
 	// <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 	static void writeHeaderToFile(LLFILE *out_file);
-
+	
 	// Write XML to file with one attribute per line.
 	// XML escapes values as they are written.
     void writeToFile(LLFILE *out_file, const std::string& indent = std::string(), bool use_type_decorations=true);
@@ -237,7 +237,7 @@ public:
 	// Setters
 
 	bool setAttributeString(const char* attr, const std::string& value);
-
+	
 	void setBoolValue(const bool value)	{ setBoolValue(1, &value); }
 	void setByteValue(const U8 value, Encoding encoding = ENCODING_DEFAULT) { setByteValue(1, &value, encoding); }
 	void setIntValue(const S32 value, Encoding encoding = ENCODING_DEFAULT) { setIntValue(1, &value, encoding); }
@@ -290,10 +290,6 @@ public:
 
 protected:
 	bool removeChild(LLXMLNode* child);
-    static bool parseBuffer(
-        const char* buffer,
-        U32 length,
-        LLXMLNodePtr& node);
 
 public:
 	std::string mID;				// The ID attribute of this node

--- a/indra/llxml/llxmltree.cpp
+++ b/indra/llxml/llxmltree.cpp
@@ -35,7 +35,6 @@
 #include "v4math.h"
 #include "llquaternion.h"
 #include "lluuid.h"
-#include "lldir.h"
 
 //////////////////////////////////////////////////////////////
 // LLXmlTree
@@ -61,37 +60,20 @@ void LLXmlTree::cleanup()
 	mNodeNames.cleanup();
 }
 
-bool LLXmlTree::parseFile(const std::string & filename, bool keep_contents)
-{
-	delete mRoot;
-	mRoot = NULL;
 
-	std::string xml = gDirUtilp->getFileContents(filename);
-	if (xml.empty())
-	{
-		LL_WARNS() << "LLXmlTree parse failed. No XML file: " << filename << LL_ENDL;
-		return false;
-	}
-
-	bool success = parseString(xml, keep_contents);
-
-	return success;
-}
-
-bool LLXmlTree::parseString(const std::string &xml, bool keep_contents)
+bool LLXmlTree::parseFile(const std::string &path, bool keep_contents)
 {
 	delete mRoot;
 	mRoot = NULL;
 
 	LLXmlTreeParser parser(this);
-	bool success = parser.parseString(xml, &mRoot, keep_contents);
-	if (!success)
+	bool success = parser.parseFile( path, &mRoot, keep_contents );
+	if( !success )
 	{
 		S32 line_number = parser.getCurrentLineNumber();
 		const char* error =  parser.getErrorString();
 		LL_WARNS() << "LLXmlTree parse failed.  Line " << line_number << ": " << error << LL_ENDL;
 	}
-
 	return success;
 }
 
@@ -554,27 +536,6 @@ bool LLXmlTreeParser::parseFile(const std::string &path, LLXmlTreeNode** root, b
 	return success;
 }
 
-bool LLXmlTreeParser::parseString(const std::string& xml, LLXmlTreeNode** root, bool keep_contents)
-{
-	llassert( !mRoot );
-	llassert( !mCurrent );
-
-	mKeepContents = keep_contents;
-
-	bool success = LLXmlParser::parse(xml.data(), (int)xml.size(), true);
-
-	*root = mRoot;
-	mRoot = NULL;
-
-	if (success)
-	{
-		llassert(!mCurrent);
-	}
-
-	mCurrent = NULL;
-	
-	return success;
-}
 
 const std::string& LLXmlTreeParser::tabs()
 {

--- a/indra/llxml/llxmltree.h
+++ b/indra/llxml/llxmltree.h
@@ -56,7 +56,6 @@ public:
 	void cleanup();
 
 	virtual bool	parseFile(const std::string &path, bool keep_contents = true);
-	virtual bool	parseString(const std::string &xml, bool keep_contents = true);
 
 	LLXmlTreeNode*	getRoot() { return mRoot; }
 
@@ -200,8 +199,7 @@ public:
 	LLXmlTreeParser(LLXmlTree* tree);
 	virtual ~LLXmlTreeParser();
 
-	bool parseFile(const std::string &path, LLXmlTreeNode** root, bool keep_contents);
-	bool parseString(const std::string &xml, LLXmlTreeNode** root, bool keep_contents);
+	bool parseFile(const std::string &path, LLXmlTreeNode** root, bool keep_contents );
 
 protected:
 	const std::string& tabs();

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2995,7 +2995,7 @@ void LLAppViewer::initStrings()
 {
 	std::string strings_file = "strings.xml";
 	std::string strings_path_full = gDirUtilp->findSkinnedFilenameBaseLang(LLDir::XUI, strings_file);
-	if (strings_path_full.empty() || !gDirUtilp->fileExists(strings_path_full))
+	if (strings_path_full.empty() || !LLFile::isfile(strings_path_full))
 	{
 		if (strings_path_full.empty())
 		{

--- a/indra/newview/llblocklist.cpp
+++ b/indra/newview/llblocklist.cpp
@@ -61,9 +61,8 @@ LLBlockList::LLBlockList(const Params& p)
 	LLToggleableMenu* context_menu = LLUICtrlFactory::getInstance()->createFromFile<LLToggleableMenu>(
 									"menu_people_blocked_gear.xml",
 									gMenuHolder,
-									LLViewerMenuHolderGL::child_registry_t::instance(),
-									true);
-	if (context_menu)
+									LLViewerMenuHolderGL::child_registry_t::instance());
+	if(context_menu)
 	{
 		mContextMenu = context_menu->getHandle();
 	}

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -131,7 +131,7 @@ public:
 	static LLChatHistoryHeader* createInstance(const std::string& file_name)
 	{
 		LLChatHistoryHeader* pInstance = new LLChatHistoryHeader;
-		pInstance->buildFromFile(file_name, true);
+		pInstance->buildFromFile(file_name);	
 		return pInstance;
 	}
 
@@ -587,7 +587,7 @@ public:
 		mUserNameTextBox = getChild<LLTextBox>("user_name");
 		mTimeBoxTextBox = getChild<LLTextBox>("time_box");
 
-		mInfoCtrl = LLUICtrlFactory::getInstance()->createFromFile<LLUICtrl>("inspector_info_ctrl.xml", this, LLPanel::child_registry_t::instance(), true);
+		mInfoCtrl = LLUICtrlFactory::getInstance()->createFromFile<LLUICtrl>("inspector_info_ctrl.xml", this, LLPanel::child_registry_t::instance());
         if (mInfoCtrl)
         {
             mInfoCtrl->setCommitCallback(boost::bind(&LLChatHistoryHeader::onClickInfoCtrl, mInfoCtrl));
@@ -1181,7 +1181,7 @@ void LLChatHistory::initFromParams(const LLChatHistory::Params& p)
 
 LLView* LLChatHistory::getSeparator()
 {
-	LLPanel* separator = LLUICtrlFactory::getInstance()->createFromFile<LLPanel>(mMessageSeparatorFilename, NULL, LLPanel::child_registry_t::instance(), true);
+	LLPanel* separator = LLUICtrlFactory::getInstance()->createFromFile<LLPanel>(mMessageSeparatorFilename, NULL, LLPanel::child_registry_t::instance());
 	return separator;
 }
 

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -657,11 +657,12 @@ void LLControlGroupCLP::configure(const std::string& config_filename, LLControlG
     // This method reads the llsd based config file, and uses it to set 
     // members of a control group.
     LLSD clpConfigLLSD;
+    
+    llifstream input_stream;
+    input_stream.open(config_filename.c_str(), std::ios::in | std::ios::binary);
 
-    std::string xml = gDirUtilp->getFileContents(config_filename);
-    if (!xml.empty())
+    if(input_stream.is_open())
     {
-        std::stringstream input_stream(xml);
         LLSDSerialize::fromXML(clpConfigLLSD, input_stream);
         for(LLSD::map_iterator option_itr = clpConfigLLSD.beginMap(); 
             option_itr != clpConfigLLSD.endMap(); 

--- a/indra/newview/llfavoritesbar.cpp
+++ b/indra/newview/llfavoritesbar.cpp
@@ -886,11 +886,10 @@ const LLButton::Params& LLFavoritesBarCtrl::getButtonParams()
 	if (!params_initialized)
 	{
 		LLXMLNodePtr button_xml_node;
-		static const std::string filename("favorites_bar_button.xml");
-		if (LLUICtrlFactory::getLayeredXMLNode(filename, button_xml_node, LLDir::CURRENT_SKIN, true))
+		if(LLUICtrlFactory::getLayeredXMLNode("favorites_bar_button.xml", button_xml_node))
 		{
 			LLXUIParser parser;
-			parser.readXUI(button_xml_node, button_params, filename);
+			parser.readXUI(button_xml_node, button_params, "favorites_bar_button.xml");
 		}
 		params_initialized = true;
 	}

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -633,7 +633,7 @@ void LLMediaCtrl::navigateTo( std::string url_in, std::string mime_type, bool cl
 void LLMediaCtrl::navigateToLocalPage( const std::string& subdir, const std::string& filename_in )
 {
 	std::string filename(gDirUtilp->add(subdir, filename_in));
-	std::string expanded_filename = gDirUtilp->findSkinnedFilename(LLDir::HTML, filename);
+	std::string expanded_filename = gDirUtilp->findSkinnedFilename("html", filename);
 
 	if (expanded_filename.empty())
 	{

--- a/indra/newview/llnotificationlistitem.cpp
+++ b/indra/newview/llnotificationlistitem.cpp
@@ -594,7 +594,7 @@ LLSystemNotificationListItem::LLSystemNotificationListItem(const Params& p)
     mSystemNotificationIcon(NULL),
     mIsCaution(false)
 {
-    buildFromFile("panel_notification_list_item.xml", true);
+    buildFromFile("panel_notification_list_item.xml");
     mIsCaution = p.notification_priority >= NOTIFICATION_PRIORITY_HIGH;
     if (mIsCaution)
     {

--- a/indra/newview/lltoast.cpp
+++ b/indra/newview/lltoast.cpp
@@ -119,7 +119,7 @@ LLToast::LLToast(const LLToast::Params& p)
 {
 	mTimer.reset(new LLToastLifeTimer(this, p.lifetime_secs));
 
-	buildFromFile("panel_toast.xml", true);
+	buildFromFile("panel_toast.xml");
 
 	setCanDrag(false);
 

--- a/indra/newview/lltoastnotifypanel.cpp
+++ b/indra/newview/lltoastnotifypanel.cpp
@@ -266,9 +266,9 @@ void LLToastNotifyPanel::init( LLRect rect, bool show_images )
 	LLRect current_rect = getRect();
 
 	setXMLFilename("");
-	buildFromFile("panel_notification.xml", true);
+	buildFromFile("panel_notification.xml");
 
-    if (rect != LLRect::null)
+    if(rect != LLRect::null)
     {
         this->setShape(rect);
     }

--- a/indra/newview/lltoastscriptquestion.cpp
+++ b/indra/newview/lltoastscriptquestion.cpp
@@ -37,7 +37,7 @@ LLToastScriptQuestion::LLToastScriptQuestion(const LLNotificationPtr& notificati
 :
 LLToastPanel(notification)
 {
-	buildFromFile("panel_script_question_toast.xml", true);
+	buildFromFile("panel_script_question_toast.xml");
 }
 
 bool LLToastScriptQuestion::postBuild()

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -416,7 +416,7 @@ LLViewerFetchedTexture* LLViewerTextureList::getImageFromFile(const std::string&
 		return NULL ;
 	}
 
-	std::string full_path = gDirUtilp->findSkinnedFilename(LLDir::TEXTURES, filename);
+	std::string full_path = gDirUtilp->findSkinnedFilename("textures", filename);
 	if (full_path.empty())
 	{
 		LL_WARNS() << "Failed to find local image file: " << filename << LL_ENDL;


### PR DESCRIPTION
This reverts commit a865d423974ea06dffa47798c81e98e7570b02ec.

Reason for revert: viewer#1420 (chat UI's agent names were shifted out of view), reverting to not hold maint-A (is deepCopy not full?)