### PR TITLE
brad/mac shader fix

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/pbrterrainF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbrterrainF.glsl
@@ -242,14 +242,13 @@ void main()
     {
     case MIX_Y:
 #if TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 3
-        TerrainCoord terrain_texcoord;
         terrain_texcoord[0].xy = vary_coords[2].zw;
         terrain_texcoord[0].zw = vary_coords[3].xy;
         terrain_texcoord[1].xy = vary_coords[3].zw;
         terrain_texcoord[1].zw = vary_coords[4].xy;
         terrain_texcoord[2].xy = vary_coords[4].zw;
 #elif TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 1
-        TerrainCoord terrain_texcoord = vary_coords[0].zw;
+        terrain_texcoord = vary_coords[0].zw;
 #endif
         mix2 = terrain_sample_and_multiply_pbr(
             terrain_texcoord
@@ -285,14 +284,13 @@ void main()
     {
     case MIX_Z:
 #if TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 3
-        TerrainCoord terrain_texcoord;
         terrain_texcoord[0].xy = vary_coords[5].xy;
         terrain_texcoord[0].zw = vary_coords[5].zw;
         terrain_texcoord[1].xy = vary_coords[6].xy;
         terrain_texcoord[1].zw = vary_coords[6].zw;
         terrain_texcoord[2].xy = vary_coords[7].xy;
 #elif TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 1
-        TerrainCoord terrain_texcoord = vary_coords[1].xy;
+        terrain_texcoord = vary_coords[1].xy;
 #endif
         mix2 = terrain_sample_and_multiply_pbr(
             terrain_texcoord
@@ -328,14 +326,13 @@ void main()
     {
     case MIX_W:
 #if TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 3
-        TerrainCoord terrain_texcoord;
         terrain_texcoord[0].xy = vary_coords[7].zw;
         terrain_texcoord[0].zw = vary_coords[8].xy;
         terrain_texcoord[1].xy = vary_coords[8].zw;
         terrain_texcoord[1].zw = vary_coords[9].xy;
         terrain_texcoord[2].xy = vary_coords[9].zw;
 #elif TERRAIN_PLANAR_TEXTURE_SAMPLE_COUNT == 1
-        TerrainCoord terrain_texcoord = vary_coords[1].zw;
+        terrain_texcoord = vary_coords[1].zw;
 #endif
         mix2 = terrain_sample_and_multiply_pbr(
             terrain_texcoord


### PR DESCRIPTION
fix error: 'Redeclaration of sized array 'terrain_texcoord' not allowed'