### PR TITLE
jira-archive-internal#67837 Windows' bulk export of snapshots and textures #2

### DIFF
--- a/indra/newview/llpreviewtexture.h
+++ b/indra/newview/llpreviewtexture.h
@@ -86,6 +86,7 @@ private:
 	S32                 mImageOldBoostLevel;
 	std::string			mSaveFileName;
 	LLFrameTimer		mSavedFileTimer;
+    bool				mSavingMultiple;
 	bool				mLoadingFullImage;
 	bool                mShowKeepDiscard;
 	bool                mCopyToInv;


### PR DESCRIPTION
Properly sanitize names (getScrubbedFileName)
Better duplicate avoidance (check file before creating it, not before scheduling creation of a bunch of potentially identical files)