### PR TITLE
viewer#1117 Use attachment info to prevent accidental nudity #2

### DIFF
--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -207,7 +207,7 @@ const U32 LLVOAvatar::VISUAL_COMPLEXITY_UNKNOWN = 0;
 const F64 HUD_OVERSIZED_TEXTURE_DATA_SIZE = 1024 * 1024;
 
 const F32 MAX_TEXTURE_WAIT_TIME_SEC = 60;
-const F32 MAX_ATTACHMENT_WAIT_TIME_SEC = 120;
+const F32 MAX_ATTACHMENT_WAIT_TIME_SEC = 60;
 
 const S32 MIN_NONTUNED_AVS = 5;
 
@@ -680,7 +680,6 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
 	mMutedAVColor(LLColor4::white /* used for "uninitialize" */),
 	mFirstFullyVisible(true),
     mFirstDecloudTime(-1.f),
-	mFirstUseDelaySeconds(FIRST_APPEARANCE_CLOUD_MIN_DELAY),
 	mFullyLoaded(false),
 	mPreviousFullyLoaded(false),
 	mFullyLoadedInitialized(false),
@@ -8290,7 +8289,7 @@ bool LLVOAvatar::updateIsFullyLoaded()
                   );
 
         // compare amount of attachments to one reported by simulator
-        if (!loading && !isSelf() && rez_status < 4 && mLastCloudAttachmentCount != mSimAttachments.size())
+        if (!loading && !isSelf() && rez_status < 4 && mLastCloudAttachmentCount < mSimAttachments.size())
         {
             S32 attachment_count = getAttachmentCount();
             if (mLastCloudAttachmentCount != attachment_count)
@@ -8358,11 +8357,12 @@ bool LLVOAvatar::processFullyLoadedChange(bool loading)
 
 	if (mFirstFullyVisible)
 	{
+        F32 first_use_delay = FIRST_APPEARANCE_CLOUD_MIN_DELAY;
         if (!isSelf() && loading)
         {
                 // Note that textures can causes 60s delay on thier own
                 // so this delay might end up on top of textures' delay
-                mFirstUseDelaySeconds = llclamp(
+                first_use_delay = llclamp(
                     mFirstAppearanceMessageTimer.getElapsedTimeF32(),
                     FIRST_APPEARANCE_CLOUD_MIN_DELAY,
                     FIRST_APPEARANCE_CLOUD_MAX_DELAY);
@@ -8371,10 +8371,10 @@ bool LLVOAvatar::processFullyLoadedChange(bool loading)
                 {
                     // Impostors are less of a priority,
                     // let them stay cloud longer
-                    mFirstUseDelaySeconds *= FIRST_APPEARANCE_CLOUD_IMPOSTOR_MODIFIER;
+                    first_use_delay *= FIRST_APPEARANCE_CLOUD_IMPOSTOR_MODIFIER;
                 }
         }
-		mFullyLoaded = (mFullyLoadedTimer.getElapsedTimeF32() > mFirstUseDelaySeconds);
+		mFullyLoaded = (mFullyLoadedTimer.getElapsedTimeF32() > first_use_delay);
 	}
 	else
 	{
@@ -9385,7 +9385,17 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
             << (attachment_id.isNull() ? "pending" : attachment_id.asString())
             << " on point " << (S32)attach_point << LL_ENDL;
 
-        mSimAttachments[attachment_id] = attach_point;
+        if (attachment_id.notNull())
+        {
+            mSimAttachments[attachment_id] = attach_point;
+        }
+        else
+        {
+            // at the moment viewer is only interested in non-null attachments
+            LL_DEBUGS("AVAppearanceAttachments") << "AV " << getID()
+                << " has null attachment on point " << (S32)attach_point
+                << ", discarding" << LL_ENDL;
+        }
     }
 
     // todo? Doesn't detect if attachments were switched

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -424,7 +424,6 @@ protected:
 private:
 	bool			mFirstFullyVisible;
     F32				mFirstDecloudTime;
-	F32				mFirstUseDelaySeconds;
 	LLFrameTimer	mFirstAppearanceMessageTimer;
 
 	bool			mFullyLoaded;


### PR DESCRIPTION
Discard null id attachments.

I'm not sure why server reports null attachments (just in case it is some 'can't expose this id' case asked about that), but since viewer compares this info to loaded attachments (existing LLViewerObject) viewer only needs non-null ids.