### PR TITLE
#1386 Remove Buttons from mapping options

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -4760,13 +4760,9 @@ void LLAppViewer::idle()
         bool should_send_game_control = LLGameControl::computeFinalStateAndCheckForChanges();
         if (LLPanelPreferenceGameControl::isWaitingForInputChannel())
         {
-            LLGameControl::InputChannel channel = LLGameControl::getActiveInputChannel();
-            if (channel.mType != LLGameControl::InputChannel::TYPE_NONE)
-            {
-                LLPanelPreferenceGameControl::applyGameControlInput(channel);
-                // skip this send because input is being used to set preferences
-                should_send_game_control = false;
-            }
+            LLPanelPreferenceGameControl::applyGameControlInput();
+            // skip this send because input is being used to set preferences
+            should_send_game_control = false;
         }
         if (should_send_game_control)
         {

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -3070,7 +3070,8 @@ void LLPanelPreferenceControls::onCancelKeyBind()
 //------------------------LLPanelPreferenceGameControl--------------------------------
 
 // LLPanelPreferenceGameControl is effectively a singleton, so we track its instance
-static LLPanelPreferenceGameControl* gGameControlPanel;
+static LLPanelPreferenceGameControl* gGameControlPanel { nullptr };
+static LLScrollListCell* gSelectedCell { nullptr };
 
 LLPanelPreferenceGameControl::LLPanelPreferenceGameControl()
 {
@@ -3126,8 +3127,6 @@ void LLPanelPreferenceGameControl::saveSettings()
         mSavedValues[flycamMappings] = flycamMappings->getValue();
     }
 }
-
-static LLScrollListCell* gSelectedCell { nullptr };
 
 void LLPanelPreferenceGameControl::onActionSelect()
 {
@@ -3220,9 +3219,20 @@ bool LLPanelPreferenceGameControl::isWaitingForInputChannel()
 }
 
 // static
-void LLPanelPreferenceGameControl::applyGameControlInput(const LLGameControl::InputChannel& channel)
+void LLPanelPreferenceGameControl::applyGameControlInput()
 {
-    if (gGameControlPanel && gSelectedCell && !channel.isNone())
+    if (!gGameControlPanel || !gSelectedCell)
+        return;
+
+    LLGameControl::InputChannel::Type expectedType =
+        gGameControlPanel->mAnalogChannelSelector->getVisible() ? LLGameControl::InputChannel::TYPE_AXIS :
+        gGameControlPanel->mBinaryChannelSelector->getVisible() ? LLGameControl::InputChannel::TYPE_BUTTON :
+        LLGameControl::InputChannel::TYPE_NONE;
+    if (expectedType == LLGameControl::InputChannel::TYPE_NONE)
+        return;
+
+    LLGameControl::InputChannel channel = LLGameControl::getActiveInputChannel();
+    if (channel.mType == expectedType)
     {
         gSelectedCell->setValue(channel.getLocalName());
         gGameControlPanel->mActionTable->deselectAllItems();

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -390,7 +390,7 @@ public:
     void onCommitInputChannel(LLUICtrl* ctrl);
 
     static bool isWaitingForInputChannel();
-    static void applyGameControlInput(const LLGameControl::InputChannel& channel);
+    static void applyGameControlInput();
 
 protected:
     BOOL postBuild() override;


### PR DESCRIPTION
Additional change to ignore input from inappropriate channels
when entering a new channel mapping using the game controller