### PR TITLE
triage#59 Render Friends Only option

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10910,6 +10910,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>RenderAvatarFriendsOnly</key>
+    <map>
+        <key>Comment</key>
+        <string>When enabled hides all avatars that aren't friends. Does not affect inworld control avatars (animeshes), nor self.</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <real>0</real>
+    </map>
     <key>RenderAvatarComplexityMode</key>
     <map>
         <key>Comment</key>

--- a/indra/newview/llcontrolavatar.h
+++ b/indra/newview/llcontrolavatar.h
@@ -85,6 +85,7 @@ public:
     virtual bool shouldRenderRigged() const;
 
 	virtual bool isImpostor(); 
+    virtual bool isBuddy() const { return false; }
     
     bool mPlaying;
 

--- a/indra/newview/lldrawpoolavatar.cpp
+++ b/indra/newview/lldrawpoolavatar.cpp
@@ -370,6 +370,15 @@ void LLDrawPoolAvatar::renderShadow(S32 pass)
 		return;
 	}
 
+    LLCachedControl<bool> debug_invisible(gSavedSettings, "RenderAvatarFriendsOnly", false);
+    if (debug_invisible()
+        && !avatarp->isControlAvatar()
+        && !avatarp->isSelf()
+        && !avatarp->isBuddy())
+    {
+        return;
+    }
+
     LLVOAvatar::AvatarOverallAppearance oa = avatarp->getOverallAppearance();
 	bool impostor = !LLPipeline::sImpostorRender && avatarp->isImpostor();
     // no shadows if the shadows are causing this avatar to breach the limit.
@@ -722,6 +731,17 @@ void LLDrawPoolAvatar::renderAvatars(LLVOAvatar* single_avatar, S32 pass)
 		// don't render please
 		return;
 	}
+
+    LLCachedControl<bool> friends_only(gSavedSettings, "RenderAvatarFriendsOnly", false);
+    if (!single_avatar
+        && friends_only()
+        && !avatarp->isUIAvatar()
+        && !avatarp->isControlAvatar()
+        && !avatarp->isSelf()
+        && !avatarp->isBuddy())
+    {
+        return;
+    }
 
 	bool impostor = !LLPipeline::sImpostorRender && avatarp->isImpostor() && !single_avatar;
 

--- a/indra/newview/lluiavatar.h
+++ b/indra/newview/lluiavatar.h
@@ -39,6 +39,7 @@ public:
     LLUIAvatar(const LLUUID &id, const LLPCode pcode, LLViewerRegion *regionp);
 	virtual void 			initInstance(); // Called after construction to initialize the class.
 	virtual	~LLUIAvatar();
+    virtual bool isBuddy() const { return false; }
 };
 
 #endif //LL_CONTROLAVATAR_H

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2586,6 +2586,27 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
 		LL_INFOS() << "Warning!  Idle on dead avatar" << LL_ENDL;
 		return;
 	}
+
+    LLCachedControl<bool> friends_only(gSavedSettings, "RenderAvatarFriendsOnly", false);
+    if (friends_only()
+        && !isUIAvatar()
+        && !isControlAvatar()
+        && !isSelf()
+        && !isBuddy())
+    {
+        if (mNameText)
+        {
+            mNameIsSet = false;
+            mNameText->markDead();
+            mNameText = NULL;
+            sNumVisibleChatBubbles--;
+        }
+        deleteParticleSource();
+        mVoiceVisualizer->setVoiceEnabled(false);
+
+        return;
+    }
+
     // record time and refresh "tooSlow" status
     updateTooSlow();
 
@@ -11722,4 +11743,8 @@ F32 LLVOAvatar::getAverageGPURenderTime()
 
     return ret;
 }
+bool LLVOAvatar::isBuddy() const
+{
+    return LLAvatarTracker::instance().isBuddy(getID());
+} 
 

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -253,6 +253,7 @@ public:
 
 	virtual bool 	isControlAvatar() const { return mIsControlAvatar; } // True if this avatar is a control av (no associated user)
 	virtual bool 	isUIAvatar() const { return mIsUIAvatar; } // True if this avatar is a supplemental av used in some UI views (no associated user)
+    virtual bool 	isBuddy() const;
 
 	// If this is an attachment, return the avatar it is attached to. Otherwise NULL.
 	virtual const LLVOAvatar *getAttachedAvatar() const { return NULL; }

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -110,6 +110,7 @@ private:
 
 public:
 	/*virtual*/ bool 	isSelf() const { return true; }
+        virtual bool 	isBuddy() const { return false; }
 	/*virtual*/ bool	isValid() const;
 
 	//--------------------------------------------------------------------

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3843,6 +3843,16 @@ function="World.EnvPreset"
                      function="ToggleControl"
                      parameter="AllowSelectAvatar" />
                 </menu_item_check>
+                <menu_item_check
+                 label="Render Only Friends"
+                 name="Render Only Friends">
+                    <menu_item_check.on_check
+                     function="CheckControl"
+                     parameter="RenderAvatarFriendsOnly" />
+                    <menu_item_check.on_click
+                     function="ToggleControl"
+                     parameter="RenderAvatarFriendsOnly" />
+                </menu_item_check>
             </menu>
             <menu
              create_jump_keys="true"


### PR DESCRIPTION
An option for performance testing, video recording or taking photos, so that unexpected people won't appear in your photos or tests.

P.S. Another commit is already in maint-a, so made this one for maint-a as well.