### PR TITLE
viewer-private#240 Restore missing marketplace notification

### DIFF
--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -31,11 +31,12 @@
 #include "llfolderviewitem.h"
 #include "llfolderview.h"
 #include "llfolderviewmodel.h"
-#include "llpanel.h"
 #include "llcallbacklist.h"
 #include "llcriticaldamp.h"
 #include "llclipboard.h"
 #include "llfocusmgr.h"     // gFocusMgr
+#include "llnotificationsutil.h"
+#include "llpanel.h"
 #include "lltrans.h"
 #include "llwindow.h"
 
@@ -105,7 +106,7 @@ LLFolderViewItem::Params::Params()
     item_height("item_height"),
     item_top_pad("item_top_pad"),
     creation_date(),
-    allow_wear("allow_wear", true),
+    marketplace_item("marketplace_item", false),
     allow_drop("allow_drop", true),
     font_color("font_color"),
     font_highlight_color("font_highlight_color"),
@@ -144,7 +145,7 @@ LLFolderViewItem::LLFolderViewItem(const LLFolderViewItem::Params& p)
     mRoot(p.root),
     mViewModelItem(p.listener),
     mIsMouseOverTitle(false),
-    mAllowWear(p.allow_wear),
+    mMarketplaceItem(p.marketplace_item),
     mAllowDrop(p.allow_drop),
     mFontColor(p.font_color),
     mFontHighlightColor(p.font_highlight_color),
@@ -533,9 +534,14 @@ void LLFolderViewItem::buildContextMenu(LLMenuGL& menu, U32 flags)
 
 void LLFolderViewItem::openItem( void )
 {
-    if (mAllowWear || !getViewModelItem()->isItemWearable())
+    if (!mMarketplaceItem || !getViewModelItem()->isItemWearable())
     {
         getViewModelItem()->openItem();
+    }
+    else if (mMarketplaceItem)
+    {
+        // Wearing an object from any listing, active or not, is verbotten
+        LLNotificationsUtil::add("AlertMerchantListingCannotWear");
     }
 }
 

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -59,7 +59,7 @@ public:
                                                     item_top_pad;
 
         Optional<time_t>                            creation_date;
-        Optional<bool>                              allow_wear;
+        Optional<bool>                              marketplace_item;
         Optional<bool>                              allow_drop;
 
         Optional<LLUIColor>                         font_color;
@@ -121,7 +121,7 @@ protected:
                                 mIsCurSelection,
                                 mDragAndDropTarget,
                                 mIsMouseOverTitle,
-                                mAllowWear,
+                                mMarketplaceItem,
                                 mAllowDrop,
                                 mSingleFolderMode,
                                 mDoubleClickOverride,

--- a/indra/newview/skins/default/xui/en/panel_marketplace_listings_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_marketplace_listings_inventory.xml
@@ -21,5 +21,5 @@
     border="false"
     bevel_style="none"
     show_item_link_overlays="true">
-    <item allow_wear="false"/>
+    <item marketplace_item="true"/> 
 </inventory_panel>

--- a/indra/newview/skins/default/xui/en/panel_marketplace_listings_listed.xml
+++ b/indra/newview/skins/default/xui/en/panel_marketplace_listings_listed.xml
@@ -20,5 +20,5 @@
     border="false"
     bevel_style="none"
     show_item_link_overlays="true">
-    <item allow_wear="false"/>
+    <item marketplace_item="true"/>
 </inventory_panel>

--- a/indra/newview/skins/default/xui/en/panel_marketplace_listings_unassociated.xml
+++ b/indra/newview/skins/default/xui/en/panel_marketplace_listings_unassociated.xml
@@ -19,5 +19,5 @@
     border="false"
     bevel_style="none"
     show_item_link_overlays="true">
-    <item allow_wear="false"/>
+    <item marketplace_item="true"/>
 </inventory_panel>

--- a/indra/newview/skins/default/xui/en/panel_marketplace_listings_unlisted.xml
+++ b/indra/newview/skins/default/xui/en/panel_marketplace_listings_unlisted.xml
@@ -20,5 +20,5 @@
     border="false"
     bevel_style="none"
     show_item_link_overlays="true">
-    <item allow_wear="false"/>
+    <item marketplace_item="true"/>
 </inventory_panel>


### PR DESCRIPTION
allow_wear was only used in marketplacec, so converted to mMarketplaceItem and user to show a marketplace specific notification (removing allow_wear and doing checks from a bridge might have been a better option).