### PR TITLE
brad/maint a eol style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,6 @@ FILES_ARE_UNICODE_UTF-16LE.txt text eol=crlf
 
 # Windows Manifest files
 *.manifest text eol=crlf
+
+# Windows Installer Script files (normalization disabled)
+*.nsi -text


### PR DESCRIPTION
The .nsi files we have in the repo already have CRLF EOLs embedded in them, this protects them from translation