### PR TITLE
Mark script messages in compact mode too; code clean up

### DIFF
--- a/indra/llui/llchat.h
+++ b/indra/llui/llchat.h
@@ -113,4 +113,16 @@ public:
 };
 static const std::string LUA_PREFIX("[LUA]");
 
+inline std::string remove_LUA_PREFIX(const std::string &string, bool is_lua)
+{
+    if (is_lua)
+    {
+        return string.substr(LUA_PREFIX.size());
+    }
+    else
+    {
+        return string;
+    }
+}
+
 #endif

--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -613,7 +613,7 @@ void LLFloaterIMNearbyChatHandler::processChat(const LLChat& chat_msg,
         }
         else
         {
-            toast_msg = chat_msg.mIsScript ? chat_msg.mText.substr(LUA_PREFIX.size()) : chat_msg.mText;
+            toast_msg = remove_LUA_PREFIX(chat_msg.mText, chat_msg.mIsScript);
         }
 
         bool chat_overlaps = false;

--- a/indra/newview/llfloaterimnearbychatlistener.cpp
+++ b/indra/newview/llfloaterimnearbychatlistener.cpp
@@ -39,7 +39,8 @@ static const F32 CHAT_THROTTLE_PERIOD = 1.f;
 
 LLFloaterIMNearbyChatListener::LLFloaterIMNearbyChatListener()
   : LLEventAPI("LLChatBar",
-               "LLChatBar listener to (e.g.) sendChat, etc.")
+               "LLChatBar listener to (e.g.) sendChat, etc."),
+    mLastThrottleTime(0)
 {
     add("sendChat",
         "Send chat to the simulator:\n"
@@ -51,17 +52,16 @@ LLFloaterIMNearbyChatListener::LLFloaterIMNearbyChatListener()
 
 
 // "sendChat" command
-void LLFloaterIMNearbyChatListener::sendChat(LLSD const & chat_data) const
+void LLFloaterIMNearbyChatListener::sendChat(LLSD const & chat_data)
 {
-    static F64 last_throttle_time = 0.0;
     F64 cur_time = LLTimer::getElapsedSeconds();
 
-    if (cur_time < last_throttle_time + CHAT_THROTTLE_PERIOD)
+    if (cur_time < mLastThrottleTime + CHAT_THROTTLE_PERIOD)
     {
         LL_DEBUGS("LLFloaterIMNearbyChatListener") << "'sendChat' was  throttled" << LL_ENDL;
         return;
     }
-    last_throttle_time = cur_time;
+    mLastThrottleTime = cur_time;
 
     // Extract the data
     std::string chat_text = LUA_PREFIX + chat_data["message"].asString();
@@ -105,6 +105,6 @@ void LLFloaterIMNearbyChatListener::sendChat(LLSD const & chat_data) const
     }
 
     // Send it as if it was typed in
-    LLFloaterIMNearbyChat::sendChatFromViewer(chat_to_send, type_o_chat, ((BOOL) (channel == 0)) && gSavedSettings.getBOOL("PlayChatAnim"));
+    LLFloaterIMNearbyChat::sendChatFromViewer(chat_to_send, type_o_chat, ((channel == 0)) && gSavedSettings.getBOOL("PlayChatAnim"));
 }
 

--- a/indra/newview/llfloaterimnearbychatlistener.h
+++ b/indra/newview/llfloaterimnearbychatlistener.h
@@ -41,7 +41,9 @@ public:
     LLFloaterIMNearbyChatListener();
 
 private:
-    void sendChat(LLSD const & chat_data) const;
+    void sendChat(LLSD const & chat_data);
+
+    F64 mLastThrottleTime;
 };
 
 #endif // LL_LLFLOATERIMNEARBYCHATLISTENER_H

--- a/indra/newview/llviewerchat.cpp
+++ b/indra/newview/llviewerchat.cpp
@@ -217,7 +217,7 @@ S32 LLViewerChat::getChatFontSize()
 //static
 void LLViewerChat::formatChatMsg(const LLChat& chat, std::string& formated_msg)
 {
-    std::string tmpmsg = chat.mIsScript ? chat.mText.substr(LUA_PREFIX.size()) : chat.mText;
+    std::string tmpmsg = remove_LUA_PREFIX(chat.mText, chat.mIsScript);
     if(chat.mChatStyle == CHAT_STYLE_IRC)
     {
         formated_msg = chat.mFromName + tmpmsg.substr(3);

--- a/indra/newview/scripts/lua/test_LLChat.lua
+++ b/indra/newview/scripts/lua/test_LLChat.lua
@@ -2,15 +2,15 @@ LLChat = require 'LLChat'
 
 function generateRandomWord(length)
     local alphabet = "abcdefghijklmnopqrstuvwxyz"
-    local word = ""
+    local wordTable = {}
     for i = 1, length do
         local randomIndex = math.random(1, #alphabet)
-        word = word .. alphabet:sub(randomIndex, randomIndex)
+        table.insert(wordTable, alphabet:sub(randomIndex, randomIndex))
     end
-    return word
+    return table.concat(wordTable)
 end
 
-local msg = ""
+local msg = "AI says:"
 math.randomseed(os.time())
 for i = 1, math.random(1, 10) do
     msg = msg .. " ".. generateRandomWord(math.random(1, 8))


### PR DESCRIPTION
Show "Script by" prefix in chat history for compact mode, as Ansariel pointed out.
Some clean up according to previous PR.