### PR TITLE
viewer#1218 Moon beacon can't be toggled when setting is no-mod

### DIFF
--- a/indra/newview/llfloatereditenvironmentbase.h
+++ b/indra/newview/llfloatereditenvironmentbase.h
@@ -133,7 +133,8 @@ protected:
     LLSettingsEditPanel() :
         LLPanel(),
         mIsDirty(false),
-        mOnDirtyChanged()
+        mOnDirtyChanged(),
+        mCanEdit(false)
     {}
 
 private:

--- a/indra/newview/skins/default/xui/en/panel_settings_sky_sunmoon.xml
+++ b/indra/newview/skins/default/xui/en/panel_settings_sky_sunmoon.xml
@@ -248,29 +248,13 @@
                     
         </layout_panel>
         <layout_panel
-                name="moon_layout"
-                border="false"
+                border="true"
                 bevel_style="in"
+                name="moon_layout"
                 auto_resize="true"
                 user_resize="false"
                 visible="true"
                 height="400">
-            <layout_stack 
-                    name="moon_stack"
-                    left="5"
-                    top="5"
-                    right="-5"
-                    bottom="-5"
-                    follows="left|top|right|bottom"
-                    orientation="vertical">
-                <layout_panel
-                        border="true"
-                        bevel_style="in"
-                        auto_resize="true"
-                        user_resize="false"
-                        visible="true"
-                        name="moon_layout"
-                        height="220">
                     <text
                             name="moon_label"
                             follows="left|top"
@@ -423,9 +407,7 @@
                         name="moonbeacon" 
                         top_pad="5"
                         left_delta="-8"/>
-                            
-                </layout_panel>
-            </layout_stack>
+
         </layout_panel>
     </layout_stack>
 </panel>                

--- a/indra/newview/skins/default/xui/ja/panel_settings_sky_sunmoon.xml
+++ b/indra/newview/skins/default/xui/ja/panel_settings_sky_sunmoon.xml
@@ -44,8 +44,6 @@
 			<check_box label="ビーコンを表示" name="sunbeacon"/>
 		</layout_panel>
 		<layout_panel name="moon_layout">
-			<layout_stack name="moon_stack">
-				<layout_panel name="moon_layout">
 					<text name="moon_label">
 						月
 					</text>
@@ -74,8 +72,6 @@
 					</text>
 					<slider name="moon_brightness"/>
 					<check_box label="ビーコンを表示" name="moonbeacon"/>
-				</layout_panel>
-			</layout_stack>
 		</layout_panel>
 	</layout_stack>
 </panel>

--- a/indra/newview/skins/default/xui/pl/panel_settings_sky_sunmoon.xml
+++ b/indra/newview/skins/default/xui/pl/panel_settings_sky_sunmoon.xml
@@ -35,8 +35,6 @@
 			<check_box label="Pokaż emiter" name="sunbeacon" />
 		</layout_panel>
 		<layout_panel name="moon_layout">
-			<layout_stack name="moon_stack">
-				<layout_panel name="moon_layout">
 					<text name="moon_label">
 						Księżyc
 					</text>
@@ -59,8 +57,6 @@
 						Jasność:
 					</text>
 					<check_box label="Pokaż emiter" name="moonbeacon" />
-				</layout_panel>
-			</layout_stack>
 		</layout_panel>
 	</layout_stack>
 </panel>                


### PR DESCRIPTION
Two moon_layout stacks, disabling content of external disabled whole internal stack, not just specific elements. Removed extra stack.