### PR TITLE
viewer#1568 Revert "SL-17597 AV height in Shape dialog IS WRONG"

### DIFF
--- a/indra/llappearance/llavatarappearance.h
+++ b/indra/llappearance/llavatarappearance.h
@@ -147,8 +147,6 @@ public:
     void compareJointStateMaps(joint_state_map_t& last_state,
                                joint_state_map_t& curr_state);
     void computeBodySize();
-    F32 computeBodyHeight();
-    F32 computePelvisToFoot();
 
 public:
     typedef std::vector<LLAvatarJoint*> avatar_joint_list_t;


### PR DESCRIPTION
This reverts commit f5a7c22cea16b51db12360436ce64c2433a5aa5f to fix viewer#1568.