### PR TITLE
Fix/re-enable MSVC compiler warnings

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1376,6 +1376,14 @@
       </map>
       <key>llphysicsextensions_source</key>
       <map>
+        <key>copyright</key>
+        <string>Copyright (c) 2010, Linden Research, Inc.</string>
+        <key>license</key>
+        <string>internal</string>
+        <key>license_file</key>
+        <string>LICENSES/llphysicsextensions.txt</string>
+        <key>name</key>
+        <string>llphysicsextensions_source</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1385,11 +1393,11 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>b037cc0b29ea70ee834cfae6dda5b7a25cd57174</string>
+              <string>24256fab0ccf6c0f70dcb536240e7e556f592ebe</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/144851460</string>
+              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/171617692</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -1401,14 +1409,30 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>bdea1fd5c4da9da5afde088d16188b45d0853e04</string>
+              <string>7d218e641c66a63bb6722b4605d6bcbf78c51c85</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/144851461</string>
+              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/171617691</string>
             </map>
             <key>name</key>
             <string>linux64</string>
+          </map>
+          <key>windows</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>creds</key>
+              <string>github</string>
+              <key>hash</key>
+              <string>9c06f431cbbf06e26cf5009527403a7e1e31a513</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/171617693</string>
+            </map>
+            <key>name</key>
+            <string>windows</string>
           </map>
           <key>windows64</key>
           <map>
@@ -1417,26 +1441,18 @@
               <key>creds</key>
               <string>github</string>
               <key>hash</key>
-              <string>f652ce0d6aef864689f0ed44255da4d9cd65a43f</string>
+              <string>56b94c0d0f0b2f221fd13648e99e9569b0490d76</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/144851463</string>
+              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/171617694</string>
             </map>
             <key>name</key>
             <string>windows64</string>
           </map>
         </map>
-        <key>license</key>
-        <string>internal</string>
-        <key>license_file</key>
-        <string>LICENSES/llphysicsextensions.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2010, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.0.479d20a</string>
-        <key>name</key>
-        <string>llphysicsextensions_source</string>
+        <string>1.0.b6dc588</string>
       </map>
       <key>llphysicsextensions_stub</key>
       <map>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1418,22 +1418,6 @@
             <key>name</key>
             <string>linux64</string>
           </map>
-          <key>windows</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>creds</key>
-              <string>github</string>
-              <key>hash</key>
-              <string>9c06f431cbbf06e26cf5009527403a7e1e31a513</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://api.github.com/repos/secondlife/llphysicsextensions_source/releases/assets/171617693</string>
-            </map>
-            <key>name</key>
-            <string>windows</string>
-          </map>
           <key>windows64</key>
           <map>
             <key>archive</key>

--- a/indra/llappearance/llavatarappearance.cpp
+++ b/indra/llappearance/llavatarappearance.cpp
@@ -164,19 +164,7 @@ LLAvatarAppearanceDefines::LLAvatarAppearanceDictionary* LLAvatarAppearance::sAv
 
 LLAvatarAppearance::LLAvatarAppearance(LLWearableData* wearable_data) :
     LLCharacter(),
-    mIsDummy(false),
-    mTexSkinColor( NULL ),
-    mTexHairColor( NULL ),
-    mTexEyeColor( NULL ),
-    mPelvisToFoot(0.f),
-    mHeadOffset(),
-    mRoot(NULL),
-    mWearableData(wearable_data),
-    mNumBones(0),
-    mNumCollisionVolumes(0),
-    mCollisionVolumes(NULL),
-    mIsBuilt(false),
-    mInitFlags(0)
+    mWearableData(wearable_data)
 {
     llassert_always(mWearableData);
     mBakedTextureDatas.resize(LLAvatarAppearanceDefines::BAKED_NUM_INDICES);

--- a/indra/llappearance/llavatarappearance.h
+++ b/indra/llappearance/llavatarappearance.h
@@ -70,7 +70,7 @@ public:
     static void         initClass();
     static void         cleanupClass(); // Cleanup data that's only init'd once per class.
     virtual void        initInstance(); // Called after construction to initialize the instance.
-    S32                 mInitFlags;
+    S32                 mInitFlags{ 0 };
     virtual bool        loadSkeletonNode();
     bool                loadMeshNodes();
     bool                loadLayersets();
@@ -135,8 +135,8 @@ public:
     F32                 getPelvisToFoot() const { return mPelvisToFoot; }
     /*virtual*/ LLJoint*    getRootJoint() { return mRoot; }
 
-    LLVector3           mHeadOffset; // current head position
-    LLAvatarJoint       *mRoot;
+    LLVector3           mHeadOffset{}; // current head position
+    LLAvatarJoint*      mRoot{ nullptr };
 
     typedef std::map<std::string, LLJoint*> joint_map_t;
     joint_map_t         mJointMap;
@@ -167,7 +167,7 @@ protected:
     bool                buildSkeleton(const LLAvatarSkeletonInfo *info);
 
     void                clearSkeleton();
-    bool                mIsBuilt; // state of deferred character building
+    bool                mIsBuilt{ false }; // state of deferred character building
     avatar_joint_list_t mSkeleton;
     LLVector3OverrideMap    mPelvisFixups;
     joint_alias_map_t   mJointAliasMap;
@@ -184,30 +184,30 @@ public:
     LLVector3           mBodySize;
     LLVector3           mAvatarOffset;
 protected:
-    F32                 mPelvisToFoot;
+    F32                 mPelvisToFoot{ 0.f };
 
     //--------------------------------------------------------------------
     // Cached pointers to well known joints
     //--------------------------------------------------------------------
 public:
-    LLJoint*        mPelvisp;
-    LLJoint*        mTorsop;
-    LLJoint*        mChestp;
-    LLJoint*        mNeckp;
-    LLJoint*        mHeadp;
-    LLJoint*        mSkullp;
-    LLJoint*        mEyeLeftp;
-    LLJoint*        mEyeRightp;
-    LLJoint*        mHipLeftp;
-    LLJoint*        mHipRightp;
-    LLJoint*        mKneeLeftp;
-    LLJoint*        mKneeRightp;
-    LLJoint*        mAnkleLeftp;
-    LLJoint*        mAnkleRightp;
-    LLJoint*        mFootLeftp;
-    LLJoint*        mFootRightp;
-    LLJoint*        mWristLeftp;
-    LLJoint*        mWristRightp;
+    LLJoint*        mPelvisp{nullptr};
+    LLJoint*        mTorsop{ nullptr };
+    LLJoint*        mChestp{ nullptr };
+    LLJoint*        mNeckp{ nullptr };
+    LLJoint*        mHeadp{ nullptr };
+    LLJoint*        mSkullp{ nullptr };
+    LLJoint*        mEyeLeftp{ nullptr };
+    LLJoint*        mEyeRightp{ nullptr };
+    LLJoint*        mHipLeftp{ nullptr };
+    LLJoint*        mHipRightp{ nullptr };
+    LLJoint*        mKneeLeftp{ nullptr };
+    LLJoint*        mKneeRightp{ nullptr };
+    LLJoint*        mAnkleLeftp{ nullptr };
+    LLJoint*        mAnkleRightp{ nullptr };
+    LLJoint*        mFootLeftp{ nullptr };
+    LLJoint*        mFootRightp{ nullptr };
+    LLJoint*        mWristLeftp{ nullptr };
+    LLJoint*        mWristRightp{ nullptr };
 
     //--------------------------------------------------------------------
     // XML parse tree
@@ -227,7 +227,7 @@ protected:
  **                    RENDERING
  **/
 public:
-    bool        mIsDummy; // for special views and animated object controllers; local to viewer
+    bool        mIsDummy{ false }; // for special views and animated object controllers; local to viewer
 
     //--------------------------------------------------------------------
     // Morph masks
@@ -290,9 +290,9 @@ public:
     LLColor4        getGlobalColor(const std::string& color_name ) const;
     virtual void    onGlobalColorChanged(const LLTexGlobalColor* global_color) = 0;
 protected:
-    LLTexGlobalColor* mTexSkinColor;
-    LLTexGlobalColor* mTexHairColor;
-    LLTexGlobalColor* mTexEyeColor;
+    LLTexGlobalColor* mTexSkinColor{ nullptr };
+    LLTexGlobalColor* mTexHairColor{ nullptr };
+    LLTexGlobalColor* mTexEyeColor{ nullptr };
 
     //--------------------------------------------------------------------
     // Visibility
@@ -315,7 +315,7 @@ public:
     virtual bool            isWearingWearableType(LLWearableType::EType type ) const;
 
 private:
-    LLWearableData* mWearableData;
+    LLWearableData* mWearableData{ nullptr };
 
 /********************************************************************************
  **                                                                            **
@@ -333,11 +333,11 @@ protected:
     struct BakedTextureData
     {
         LLUUID                              mLastTextureID;
-        LLTexLayerSet*                      mTexLayerSet; // Only exists for self
-        bool                                mIsLoaded;
-        bool                                mIsUsed;
-        LLAvatarAppearanceDefines::ETextureIndex    mTextureIndex;
-        U32                                 mMaskTexName;
+        LLTexLayerSet*                      mTexLayerSet{ nullptr }; // Only exists for self
+        bool                                mIsLoaded{ false };
+        bool                                mIsUsed{ false };
+        LLAvatarAppearanceDefines::ETextureIndex    mTextureIndex{ LLAvatarAppearanceDefines::ETextureIndex::TEX_INVALID };
+        U32                                 mMaskTexName{ 0 };
         // Stores pointers to the joint meshes that this baked texture deals with
         avatar_joint_mesh_list_t            mJointMeshes;
         morph_list_t                        mMaskedMorphs;
@@ -354,9 +354,9 @@ protected:
     // Collision volumes
     //--------------------------------------------------------------------
 public:
-    S32         mNumBones;
-    S32         mNumCollisionVolumes;
-    LLAvatarJointCollisionVolume* mCollisionVolumes;
+    S32         mNumBones{ 0 };
+    S32         mNumCollisionVolumes{ 0 };
+    LLAvatarJointCollisionVolume* mCollisionVolumes{ nullptr };
 protected:
     bool        allocateCollisionVolumes(U32 num);
 

--- a/indra/llappearance/lldriverparam.cpp
+++ b/indra/llappearance/lldriverparam.cpp
@@ -422,7 +422,7 @@ const LLVector4a*   LLDriverParam::getNextDistortion(U32 *index, LLPolyMesh **po
 
 S32 LLDriverParam::getDrivenParamsCount() const
 {
-    return mDriven.size();
+    return static_cast<S32>(mDriven.size());
 }
 
 const LLViewerVisualParam* LLDriverParam::getDrivenParam(S32 index) const

--- a/indra/llappearance/lldriverparam.h
+++ b/indra/llappearance/lldriverparam.h
@@ -130,10 +130,10 @@ protected:
 
     LL_ALIGN_16(LLVector4a  mDefaultVec); // temp holder
     entry_list_t mDriven;
-    LLViewerVisualParam* mCurrentDistortionParam;
+    LLViewerVisualParam* mCurrentDistortionParam{ nullptr };
     // Backlink only; don't make this an LLPointer.
-    LLAvatarAppearance* mAvatarAppearance;
-    LLWearable* mWearablep;
+    LLAvatarAppearance* mAvatarAppearance{ nullptr };
+    LLWearable* mWearablep{ nullptr };
 };
 
 #endif  // LL_LLDRIVERPARAM_H

--- a/indra/llappearance/lllocaltextureobject.cpp
+++ b/indra/llappearance/lllocaltextureobject.cpp
@@ -109,7 +109,7 @@ LLTexLayer* LLLocalTextureObject::getTexLayer(const std::string &name)
 
 U32 LLLocalTextureObject::getNumTexLayers() const
 {
-    return mTexLayers.size();
+    return static_cast<U32>(mTexLayers.size());
 }
 
 LLUUID LLLocalTextureObject::getID() const

--- a/indra/llappearance/llpolymorph.cpp
+++ b/indra/llappearance/llpolymorph.cpp
@@ -107,7 +107,7 @@ LLPolyMorphData::~LLPolyMorphData()
 bool LLPolyMorphData::loadBinary(LLFILE *fp, LLPolyMeshSharedData *mesh)
 {
     S32 numVertices;
-    S32 numRead;
+    size_t numRead;
 
     numRead = fread(&numVertices, sizeof(S32), 1, fp);
     llendianswizzle(&numVertices, sizeof(S32), 1);
@@ -384,7 +384,7 @@ bool LLPolyMorphTarget::setInfo(LLPolyMorphTargetInfo* info)
     if (!mMorphData)
     {
         const std::string driven_tag = "_Driven";
-        U32 pos = morph_param_name.find(driven_tag);
+        auto pos = morph_param_name.find(driven_tag);
         if (pos > 0)
         {
             morph_param_name = morph_param_name.substr(0,pos);

--- a/indra/llappearance/llwearable.cpp
+++ b/indra/llappearance/llwearable.cpp
@@ -744,7 +744,7 @@ void LLWearable::writeToAvatar(LLAvatarAppearance* avatarp)
 std::string terse_F32_to_string(F32 f)
 {
     std::string r = llformat("%.2f", f);
-    S32 len = r.length();
+    auto len = r.length();
 
     // "1.20"  -> "1.2"
     // "24.00" -> "24."

--- a/indra/llappearance/llwearabledata.cpp
+++ b/indra/llappearance/llwearabledata.cpp
@@ -334,7 +334,7 @@ U32 LLWearableData::getWearableCount(const LLWearableType::EType type) const
         return 0;
     }
     const wearableentry_vec_t& wearable_vec = wearable_iter->second;
-    return wearable_vec.size();
+    return static_cast<U32>(wearable_vec.size());
 }
 
 U32 LLWearableData::getWearableCount(const U32 tex_index) const

--- a/indra/llaudio/llaudiodecodemgr.cpp
+++ b/indra/llaudio/llaudiodecodemgr.cpp
@@ -422,7 +422,7 @@ bool LLVorbisDecodeState::finishDecode()
         ov_clear(&mVF);
 
         // write "data" chunk length, in little-endian format
-        S32 data_length = mWAVBuffer.size() - WAV_HEADER_SIZE;
+        S32 data_length = static_cast<S32>(mWAVBuffer.size()) - WAV_HEADER_SIZE;
         mWAVBuffer[40] = (data_length) & 0x000000FF;
         mWAVBuffer[41] = (data_length >> 8) & 0x000000FF;
         mWAVBuffer[42] = (data_length >> 16) & 0x000000FF;
@@ -463,7 +463,7 @@ bool LLVorbisDecodeState::finishDecode()
             {
                 memcpy(&mWAVBuffer[WAV_HEADER_SIZE], pcmout, (2 * fade_length));    /*Flawfinder: ignore*/
             }
-            S32 near_end = mWAVBuffer.size() - (2 * fade_length);
+            S32 near_end = static_cast<S32>(mWAVBuffer.size()) - (2 * fade_length);
             if ((S32)mWAVBuffer.size() >= ( near_end + 2* fade_length))
             {
                 memcpy(pcmout, &mWAVBuffer[near_end], (2 * fade_length));   /*Flawfinder: ignore*/
@@ -491,7 +491,7 @@ bool LLVorbisDecodeState::finishDecode()
             return true; // we've finished
         }
         mBytesRead = -1;
-        mFileHandle = LLLFSThread::sLocal->write(mOutFilename, &mWAVBuffer[0], 0, mWAVBuffer.size(),
+        mFileHandle = LLLFSThread::sLocal->write(mOutFilename, &mWAVBuffer[0], 0, static_cast<S32>(mWAVBuffer.size()),
                              new WriteResponder(this));
     }
 

--- a/indra/llcharacter/llcharacter.cpp
+++ b/indra/llcharacter/llcharacter.cpp
@@ -73,8 +73,8 @@ LLCharacter::~LLCharacter()
         delete param;
     }
 
-    U32 i ;
-    U32 size = sInstances.size() ;
+    size_t i ;
+    size_t size = sInstances.size() ;
     for(i = 0 ; i < size ; i++)
     {
         if(sInstances[i] == this)

--- a/indra/llcharacter/llgesture.cpp
+++ b/indra/llcharacter/llgesture.cpp
@@ -282,7 +282,7 @@ bool LLGestureList::trigger(KEY key, MASK mask)
 U8 *LLGestureList::serialize(U8 *buffer) const
 {
     // a single S32 serves as the header that tells us how many to read
-    U32 count = mList.size();
+    auto count = mList.size();
     htolememcpy(buffer, &count, MVT_S32, 4);
     buffer += sizeof(count);
 

--- a/indra/llcharacter/llgesture.h
+++ b/indra/llcharacter/llgesture.h
@@ -90,7 +90,7 @@ public:
     bool triggerAndReviseString(const std::string &string, std::string* revised_string);
 
     // Used for construction from UI
-    S32 count() const                       { return mList.size(); }
+    S32 count() const                       { return static_cast<S32>(mList.size()); }
     virtual LLGesture* get(S32 i) const     { return mList.at(i); }
     virtual void put(LLGesture* gesture)    { mList.push_back( gesture ); }
     void deleteAll();

--- a/indra/llcharacter/lljoint.cpp
+++ b/indra/llcharacter/lljoint.cpp
@@ -76,7 +76,7 @@ void LLVector3OverrideMap::showJointVector3Overrides( std::ostringstream& os ) c
 
 U32 LLVector3OverrideMap::count() const
 {
-    return m_map.size();
+    return static_cast<U32>(m_map.size());
 }
 
 void LLVector3OverrideMap::add(const LLUUID& mesh_id, const LLVector3& pos)
@@ -86,7 +86,7 @@ void LLVector3OverrideMap::add(const LLUUID& mesh_id, const LLVector3& pos)
 
 bool LLVector3OverrideMap::remove(const LLUUID& mesh_id)
 {
-    U32 remove_count = m_map.erase(mesh_id);
+    auto remove_count = m_map.erase(mesh_id);
     return (remove_count > 0);
 }
 

--- a/indra/llcharacter/llkeyframemotion.cpp
+++ b/indra/llcharacter/llkeyframemotion.cpp
@@ -430,8 +430,9 @@ void LLKeyframeMotion::JointMotion::update(LLJointState* joint_state, F32 time, 
 //-----------------------------------------------------------------------------
 LLKeyframeMotion::LLKeyframeMotion(const LLUUID &id)
     : LLMotion(id),
-        mJointMotionList(NULL),
-        mPelvisp(NULL),
+        mJointMotionList(nullptr),
+        mPelvisp(nullptr),
+        mCharacter(nullptr),
         mLastSkeletonSerialNum(0),
         mLastUpdateTime(0.f),
         mLastLoopedTime(0.f),
@@ -2079,7 +2080,7 @@ bool LLKeyframeMotion::serialize(LLDataPacker& dp) const
         JointMotion* joint_motionp = mJointMotionList->getJointMotion(i);
         success &= dp.packString(joint_motionp->mJointName, "joint_name");
         success &= dp.packS32(joint_motionp->mPriority, "joint_priority");
-        success &= dp.packS32(joint_motionp->mRotationCurve.mKeys.size(), "num_rot_keys");
+        success &= dp.packS32(static_cast<S32>(joint_motionp->mRotationCurve.mKeys.size()), "num_rot_keys");
 
         LL_DEBUGS("BVH") << "Joint " << i
             << " name: " << joint_motionp->mJointName
@@ -2105,7 +2106,7 @@ bool LLKeyframeMotion::serialize(LLDataPacker& dp) const
             LL_DEBUGS("BVH") << "  rot: t " << rot_key.mTime << " angles " << rot_angles.mV[VX] <<","<< rot_angles.mV[VY] <<","<< rot_angles.mV[VZ] << LL_ENDL;
         }
 
-        success &= dp.packS32(joint_motionp->mPositionCurve.mKeys.size(), "num_pos_keys");
+        success &= dp.packS32(static_cast<S32>(joint_motionp->mPositionCurve.mKeys.size()), "num_pos_keys");
         for (PositionCurve::key_map_t::value_type& pos_pair : joint_motionp->mPositionCurve.mKeys)
         {
             PositionKey& pos_key = pos_pair.second;
@@ -2125,7 +2126,7 @@ bool LLKeyframeMotion::serialize(LLDataPacker& dp) const
         }
     }
 
-    success &= dp.packS32(mJointMotionList->mConstraints.size(), "num_constraints");
+    success &= dp.packS32(static_cast<S32>(mJointMotionList->mConstraints.size()), "num_constraints");
     LL_DEBUGS("BVH") << "num_constraints " << mJointMotionList->mConstraints.size() << LL_ENDL;
     for (JointConstraintSharedData* shared_constraintp : mJointMotionList->mConstraints)
     {

--- a/indra/llcharacter/llkeyframemotion.h
+++ b/indra/llcharacter/llkeyframemotion.h
@@ -420,7 +420,7 @@ public:
         ~JointMotionList();
         U32 dumpDiagInfo();
         JointMotion* getJointMotion(U32 index) const { llassert(index < mJointMotionArray.size()); return mJointMotionArray[index]; }
-        U32 getNumJointMotions() const { return mJointMotionArray.size(); }
+        U32 getNumJointMotions() const { return static_cast<U32>(mJointMotionArray.size()); }
     };
 
 protected:

--- a/indra/llcharacter/llmotioncontroller.cpp
+++ b/indra/llcharacter/llmotioncontroller.cpp
@@ -156,11 +156,11 @@ LLMotionController::~LLMotionController()
 
 void LLMotionController::incMotionCounts(S32& num_motions, S32& num_loading_motions, S32& num_loaded_motions, S32& num_active_motions, S32& num_deprecated_motions)
 {
-    num_motions += mAllMotions.size();
-    num_loading_motions += mLoadingMotions.size();
-    num_loaded_motions += mLoadedMotions.size();
-    num_active_motions += mActiveMotions.size();
-    num_deprecated_motions += mDeprecatedMotions.size();
+    num_motions += static_cast<S32>(mAllMotions.size());
+    num_loading_motions += static_cast<S32>(mLoadingMotions.size());
+    num_loaded_motions += static_cast<S32>(mLoadedMotions.size());
+    num_active_motions += static_cast<S32>(mActiveMotions.size());
+    num_deprecated_motions += static_cast<S32>(mDeprecatedMotions.size());
 }
 
 //-----------------------------------------------------------------------------
@@ -222,7 +222,7 @@ void LLMotionController::purgeExcessMotions()
     }
 
     // clean up all inactive, loaded motions
-    for (LLUUID motion_id : motions_to_kill)
+    for (const LLUUID& motion_id : motions_to_kill)
     {
         // look up the motion again by ID to get canonical instance
         // and kill it only if that one is inactive
@@ -233,7 +233,7 @@ void LLMotionController::purgeExcessMotions()
         }
     }
 
-    U32 loaded_count = mLoadedMotions.size();
+    U32 loaded_count = static_cast<U32>(mLoadedMotions.size());
     if (loaded_count > (2 * MAX_MOTION_INSTANCES) && loaded_count > mLastCountAfterPurge)
     {
         LL_WARNS_ONCE("Animation") << loaded_count << " Loaded Motions. Amount of motions is over limit." << LL_ENDL;

--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -199,9 +199,9 @@ bool LLApp::parseCommandOptions(int argc, char** argv)
 
 #if LL_WINDOWS
         //Windows changed command line parsing.  Deal with it.
-        S32 slen = value.length() - 1;
-        S32 start = 0;
-        S32 end = slen;
+        size_t slen = value.length() - 1;
+        size_t start = 0;
+        size_t end = slen;
         if (argv[ii][start]=='"')start++;
         if (argv[ii][end]=='"')end--;
         if (start!=0 || end!=slen)
@@ -264,9 +264,9 @@ bool LLApp::parseCommandOptions(int argc, wchar_t** wargv)
 
 #if LL_WINDOWS
         //Windows changed command line parsing.  Deal with it.
-        S32 slen = value.length() - 1;
-        S32 start = 0;
-        S32 end = slen;
+        size_t slen = value.length() - 1;
+        size_t start = 0;
+        size_t end = slen;
         if (wargv[ii][start]=='"')start++;
         if (wargv[ii][end]=='"')end--;
         if (start!=0 || end!=slen)

--- a/indra/llcommon/llfasttimer.h
+++ b/indra/llcommon/llfasttimer.h
@@ -215,7 +215,7 @@ private:
 
 private:
     U64                     mStartTime;
-    BlockTimerStackRecord   mParentTimerData;
+    BlockTimerStackRecord   mParentTimerData{};
 
 public:
     // statics

--- a/indra/llcommon/llfile.cpp
+++ b/indra/llcommon/llfile.cpp
@@ -345,7 +345,7 @@ const char *LLFile::tmpdir()
         sep = '\\';
 
         std::vector<wchar_t> utf16path(MAX_PATH + 1);
-        GetTempPathW(utf16path.size(), &utf16path[0]);
+        GetTempPathW(static_cast<DWORD>(utf16path.size()), &utf16path[0]);
         utf8path = ll_convert_wide_to_string(&utf16path[0]);
 #else
         sep = '/';

--- a/indra/llcommon/llfile.h
+++ b/indra/llcommon/llfile.h
@@ -97,7 +97,7 @@ public:
     // no copy
     LLUniqueFile(const LLUniqueFile&) = delete;
     // move construction
-    LLUniqueFile(LLUniqueFile&& other)
+    LLUniqueFile(LLUniqueFile&& other) noexcept
     {
         mFileHandle = other.mFileHandle;
         other.mFileHandle = nullptr;
@@ -118,7 +118,7 @@ public:
     // copy assignment deleted
     LLUniqueFile& operator=(const LLUniqueFile&) = delete;
     // move assignment
-    LLUniqueFile& operator=(LLUniqueFile&& other)
+    LLUniqueFile& operator=(LLUniqueFile&& other) noexcept
     {
         close();
         std::swap(mFileHandle, other.mFileHandle);

--- a/indra/llcommon/llindexedvector.h
+++ b/indra/llcommon/llindexedvector.h
@@ -47,7 +47,7 @@ public:
     typedef typename std::vector<Type>::size_type size_type;
 protected:
     std::vector<Type> mVector;
-    std::map<Key, U32> mIndexMap;
+    std::map<Key, size_t> mIndexMap;
 
 public:
     LLIndexedVector() { mVector.reserve(BlockSize); }
@@ -68,10 +68,10 @@ public:
 
     Type& operator[](const Key& k)
     {
-        typename std::map<Key, U32>::const_iterator iter = mIndexMap.find(k);
+        typename std::map<Key, size_t>::const_iterator iter = mIndexMap.find(k);
         if (iter == mIndexMap.end())
         {
-            U32 n = mVector.size();
+            auto n = mVector.size();
             mIndexMap[k] = n;
             mVector.push_back(Type());
             llassert(mVector.size() == mIndexMap.size());
@@ -85,7 +85,7 @@ public:
 
     const_iterator find(const Key& k) const
     {
-        typename std::map<Key, U32>::const_iterator iter = mIndexMap.find(k);
+        typename std::map<Key, size_t>::const_iterator iter = mIndexMap.find(k);
         if(iter == mIndexMap.end())
         {
             return mVector.end();

--- a/indra/llcommon/llpreprocessor.h
+++ b/indra/llcommon/llpreprocessor.h
@@ -122,23 +122,6 @@
 
 // Deal with VC6 problems
 #if LL_MSVC
-#pragma warning( 3       : 4701 )   // "local variable used without being initialized"  Treat this as level 3, not level 4.
-#pragma warning( 3       : 4702 )   // "unreachable code"  Treat this as level 3, not level 4.
-#pragma warning( 3       : 4189 )   // "local variable initialized but not referenced"  Treat this as level 3, not level 4.
-//#pragma warning( 3    : 4018 )    // "signed/unsigned mismatch"  Treat this as level 3, not level 4.
-#pragma warning( 3      :  4263 )   // 'function' : member function does not override any base class virtual member function
-#pragma warning( 3      :  4264 )   // "'virtual_function' : no override available for virtual member function from base 'class'; function is hidden"
-#pragma warning( 3       : 4265 )   // "class has virtual functions, but destructor is not virtual"
-#pragma warning( 3      :  4266 )   // 'function' : no override available for virtual member function from base 'type'; function is hidden
-#pragma warning (disable : 4180)    // qualifier applied to function type has no meaning; ignored
-//#pragma warning( disable : 4284 ) // silly MS warning deep inside their <map> include file
-
-#if ADDRESS_SIZE == 64
-// That one is all over the place for x64 builds.
-#pragma warning( disable : 4267 )   // 'var' : conversion from 'size_t' to 'type', possible loss of data)
-#endif
-
-#pragma warning( disable : 4503 )   // 'decorated name length exceeded, name was truncated'. Does not seem to affect compilation.
 #pragma warning( disable : 4996 )   // warning: deprecated
 
 // Linker optimization with "extern template" generates these warnings

--- a/indra/llcommon/llpreprocessor.h
+++ b/indra/llcommon/llpreprocessor.h
@@ -139,7 +139,6 @@
 #endif
 
 #pragma warning( disable : 4503 )   // 'decorated name length exceeded, name was truncated'. Does not seem to affect compilation.
-#pragma warning( disable : 4800 )   // 'BOOL' : forcing value to bool 'true' or 'false' (performance warning)
 #pragma warning( disable : 4996 )   // warning: deprecated
 
 // Linker optimization with "extern template" generates these warnings

--- a/indra/llcommon/llqueuedthread.cpp
+++ b/indra/llcommon/llqueuedthread.cpp
@@ -210,7 +210,7 @@ void LLQueuedThread::waitOnPending()
 // MAIN thread
 void LLQueuedThread::printQueueStats()
 {
-    U32 size = mRequestQueue.size();
+    auto size = mRequestQueue.size();
     if (size > 0)
     {
         LL_INFOS() << llformat("Pending Requests:%d ", mRequestQueue.size()) << LL_ENDL;

--- a/indra/llcommon/llsdserialize.cpp
+++ b/indra/llcommon/llsdserialize.cpp
@@ -1546,7 +1546,7 @@ S32 LLSDBinaryFormatter::format_impl(const LLSD& data, std::ostream& ostr,
     case LLSD::TypeMap:
     {
         ostr.put('{');
-        U32 size_nbo = htonl(data.size());
+        U32 size_nbo = htonl(static_cast<u_long>(data.size()));
         ostr.write((const char*)(&size_nbo), sizeof(U32));
         LLSD::map_const_iterator iter = data.beginMap();
         LLSD::map_const_iterator end = data.endMap();
@@ -1563,7 +1563,7 @@ S32 LLSDBinaryFormatter::format_impl(const LLSD& data, std::ostream& ostr,
     case LLSD::TypeArray:
     {
         ostr.put('[');
-        U32 size_nbo = htonl(data.size());
+        U32 size_nbo = htonl(static_cast<u_long>(data.size()));
         ostr.write((const char*)(&size_nbo), sizeof(U32));
         LLSD::array_const_iterator iter = data.beginArray();
         LLSD::array_const_iterator end = data.endArray();
@@ -1630,7 +1630,7 @@ S32 LLSDBinaryFormatter::format_impl(const LLSD& data, std::ostream& ostr,
     {
         ostr.put('b');
         const std::vector<U8>& buffer = data.asBinary();
-        U32 size_nbo = htonl(buffer.size());
+        U32 size_nbo = htonl(static_cast<u_long>(buffer.size()));
         ostr.write((const char*)(&size_nbo), sizeof(U32));
         if(buffer.size()) ostr.write((const char*)&buffer[0], buffer.size());
         break;
@@ -1648,7 +1648,7 @@ void LLSDBinaryFormatter::formatString(
     const std::string& string,
     std::ostream& ostr) const
 {
-    U32 size_nbo = htonl(string.size());
+    U32 size_nbo = htonl(static_cast<u_long>(string.size()));
     ostr.write((const char*)(&size_nbo), sizeof(U32));
     ostr.write(string.c_str(), string.size());
 }

--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -528,6 +528,7 @@ public:
                          classname<DERIVED_TYPE>(),
                          " -- creating new instance"});
                 // fall through
+                [[fallthrough]];
             case UNINITIALIZED:
             case QUEUED:
                 // QUEUED means some secondary thread has already requested an

--- a/indra/llcommon/llstl.h
+++ b/indra/llcommon/llstl.h
@@ -326,7 +326,7 @@ inline bool vector_replace_with_last(std::vector<T>& invec, const T& val)
 template <typename T>
 inline T* vector_append(std::vector<T>& invec, S32 N)
 {
-    U32 sz = invec.size();
+    auto sz = invec.size();
     invec.resize(sz+N);
     return &(invec[sz]);
 }

--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -809,7 +809,7 @@ std::string ll_convert_wide_to_string(const wchar_t* in, size_t len_in, unsigned
             code_page,
             0,
             in,
-            len_in,
+            static_cast<int>(len_in),
             NULL,
             0,
             0,
@@ -824,7 +824,7 @@ std::string ll_convert_wide_to_string(const wchar_t* in, size_t len_in, unsigned
                 code_page,
                 0,
                 in,
-                len_in,
+                static_cast<int>(len_in),
                 pout,
                 len_out,
                 0,
@@ -851,8 +851,8 @@ std::wstring ll_convert_string_to_wide(const char* in, size_t len, unsigned int 
     std::vector<wchar_t> w_out(len + 1);
 
     memset(&w_out[0], 0, w_out.size());
-    int real_output_str_len = MultiByteToWideChar(code_page, 0, in, len,
-                                                  &w_out[0], w_out.size() - 1);
+    int real_output_str_len = MultiByteToWideChar(code_page, 0, in, static_cast<int>(len),
+                                                  &w_out[0], static_cast<int>(w_out.size() - 1));
 
     //looks like MultiByteToWideChar didn't add null terminator to converted string, see EXT-4858.
     w_out[real_output_str_len] = 0;
@@ -943,7 +943,7 @@ std::optional<std::wstring> llstring_getoptenv(const std::string& key)
     auto wkey = ll_convert_string_to_wide(key);
     // Take a wild guess as to how big the buffer should be.
     std::vector<wchar_t> buffer(1024);
-    auto n = GetEnvironmentVariableW(wkey.c_str(), &buffer[0], buffer.size());
+    auto n = GetEnvironmentVariableW(wkey.c_str(), &buffer[0], static_cast<DWORD>(buffer.size()));
     // If our initial guess was too short, n will indicate the size (in
     // wchar_t's) that buffer should have been, including the terminating nul.
     if (n > (buffer.size() - 1))
@@ -951,7 +951,7 @@ std::optional<std::wstring> llstring_getoptenv(const std::string& key)
         // make it big enough
         buffer.resize(n);
         // and try again
-        n = GetEnvironmentVariableW(wkey.c_str(), &buffer[0], buffer.size());
+        n = GetEnvironmentVariableW(wkey.c_str(), &buffer[0], static_cast<DWORD>(buffer.size()));
     }
     // did that (ultimately) succeed?
     if (n)

--- a/indra/llcommon/lltraceaccumulators.h
+++ b/indra/llcommon/lltraceaccumulators.h
@@ -522,9 +522,9 @@ namespace LLTrace
 
     struct BlockTimerStackRecord
     {
-        class BlockTimer*   mActiveTimer;
-        class BlockTimerStatHandle* mTimeBlock;
-        U64                 mChildTime;
+        class BlockTimer*   mActiveTimer{ nullptr };
+        class BlockTimerStatHandle* mTimeBlock{ nullptr };
+        U64                 mChildTime{ 0 };
     };
 
     struct AccumulatorBufferGroup : public LLRefCount

--- a/indra/llcommon/lluuid.h
+++ b/indra/llcommon/lluuid.h
@@ -82,8 +82,6 @@ public:
     // to integers, among other things.  Use isNull() or notNull().
     //      operator bool() const;
 
-    // JC: These must return real bool's (not BOOLs) or else use of the STL
-    // will generate bool-to-int performance warnings.
     bool    operator==(const LLUUID &rhs) const;
     bool    operator!=(const LLUUID &rhs) const;
     bool    operator<(const LLUUID &rhs) const;

--- a/indra/llcommon/tests/commonmisc_test.cpp
+++ b/indra/llcommon/tests/commonmisc_test.cpp
@@ -67,7 +67,7 @@ namespace tut
         std::ostringstream resp;
         resp << "{'connect':true,  'position':[r128,r128,r128], 'look_at':[r0,r1,r0], 'agent_access':'M', 'region_x':i8192, 'region_y':i8192}";
         std::string str = resp.str();
-        LLMemoryStream mstr((U8*)str.c_str(), str.size());
+        LLMemoryStream mstr((U8*)str.c_str(), static_cast<S32>(str.size()));
         LLSD response;
         S32 count = LLSDSerialize::fromNotation(response, mstr, str.size());
         ensure("stream parsed", response.isDefined());
@@ -252,7 +252,7 @@ namespace tut
         resp << "{'label':'short binary test', 'singlebinary':b(1)\"A\", 'singlerawstring':s(1)\"A\", 'endoftest':'end' }";
         std::string str = resp.str();
         LLSD sd;
-        LLMemoryStream mstr((U8*)str.c_str(), str.size());
+        LLMemoryStream mstr((U8*)str.c_str(), static_cast<S32>(str.size()));
         S32 count = LLSDSerialize::fromNotation(sd, mstr, str.size());
         ensure_equals("parse count", count, 5);
         ensure("sd created", sd.isDefined());
@@ -456,7 +456,7 @@ namespace tut
     void mem_object::test<1>()
     {
         const char HELLO_WORLD[] = "hello world";
-        LLMemoryStream mem((U8*)&HELLO_WORLD[0], strlen(HELLO_WORLD));      /* Flawfinder: ignore */
+        LLMemoryStream mem((U8*)&HELLO_WORLD[0], static_cast<S32>(strlen(HELLO_WORLD)));      /* Flawfinder: ignore */
         std::string hello;
         std::string world;
         mem >> hello >> world;

--- a/indra/llcommon/tests/lleventdispatcher_test.cpp
+++ b/indra/llcommon/tests/lleventdispatcher_test.cpp
@@ -491,7 +491,7 @@ namespace tut
             // Partial defaults arrays.
             for (LLSD::String a: ab)
             {
-                LLSD::Integer partition(std::min(partial_offset, dft_array_full[a].size()));
+                LLSD::Integer partition(static_cast<LLSD::Integer>(std::min(partial_offset, dft_array_full[a].size())));
                 dft_array_partial[a] =
                     llsd_copy_array(dft_array_full[a].beginArray() + partition,
                                     dft_array_full[a].endArray());
@@ -508,7 +508,7 @@ namespace tut
                 // (params, dft_array_full). Part of the point of using map-style
                 // defaults is to allow any subset of the target function's
                 // parameters to be optional, not just the rightmost.
-                for (LLSD::Integer ix = 0, ixend = params[a].size(); ix < ixend; ix += 2)
+                for (LLSD::Integer ix = 0, ixend = static_cast<LLSD::Integer>(params[a].size()); ix < ixend; ix += 2)
                 {
                     dft_map_partial[a][params[a][ix].asString()] = dft_array_full[a][ix];
                 }
@@ -696,7 +696,7 @@ namespace tut
         LLSD zipmap(const LLSD& keys, const LLSD& values)
         {
             LLSD map;
-            for (LLSD::Integer i = 0, iend = keys.size(); i < iend; ++i)
+            for (LLSD::Integer i = 0, iend = static_cast<LLSD::Integer>(keys.size()); i < iend; ++i)
             {
                 // Have to select asString() since you can index an LLSD
                 // object with either String or Integer.
@@ -955,7 +955,7 @@ namespace tut
             allreq[a] = zipmap(params[a], LLSD::emptyArray());
             // Same for leftreq, save that we use the subset of the params not
             // supplied by dft_array_partial[a].
-            LLSD::Integer partition(params[a].size() - dft_array_partial[a].size());
+            LLSD::Integer partition(static_cast<LLSD::Integer>(params[a].size() - dft_array_partial[a].size()));
             leftreq[a] = zipmap(llsd_copy_array(params[a].beginArray(),
                                                 params[a].beginArray() + partition),
                                 LLSD::emptyArray());

--- a/indra/llcommon/tests/llsdserialize_test.cpp
+++ b/indra/llcommon/tests/llsdserialize_test.cpp
@@ -701,7 +701,7 @@ namespace tut
                 "<key>cam</key><real>1.23</real>"
             "</map></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
     }
 
     template<> template<>
@@ -721,7 +721,7 @@ namespace tut
                 "<key>cam</key><real>1.23</real>"
             "</map></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
 
         v.clear();
         v["amy"] = 23;
@@ -734,7 +734,7 @@ namespace tut
                 "<key>cam</key><real>1.23</real>"
             "</map></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
 
         v.clear();
         v["amy"] = 23;
@@ -751,7 +751,7 @@ namespace tut
                 "<key>cam</key><real>1.23</real>"
             "</map></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
 
         v.clear();
         v[0] = 23;
@@ -766,7 +766,7 @@ namespace tut
                 "<real>1.23</real>"
             "</array></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
 
         v.clear();
         v[0] = 23;
@@ -782,7 +782,7 @@ namespace tut
                 "<real>1.23</real>"
             "</array></llsd>",
             v,
-            v.size() + 1);
+            static_cast<S32>(v.size()) + 1);
     }
 
     template<> template<>
@@ -1405,13 +1405,13 @@ namespace tut
         uint32_t size = htonl(1);
         memcpy(&vec[1], &size, sizeof(uint32_t));
         vec.push_back('k');
-        int key_size_loc = vec.size();
+        auto key_size_loc = vec.size();
         size = htonl(1); // 1 too short
         vec.resize(vec.size() + 4);
         memcpy(&vec[key_size_loc], &size, sizeof(uint32_t));
         vec.push_back('a'); vec.push_back('m'); vec.push_back('y');
         vec.push_back('i');
-        int integer_loc = vec.size();
+        auto integer_loc = vec.size();
         vec.resize(vec.size() + 4);
         uint32_t val_int = htonl(23);
         memcpy(&vec[integer_loc], &val_int, sizeof(uint32_t));
@@ -1473,7 +1473,7 @@ namespace tut
         memcpy(&vec[1], &size, sizeof(uint32_t));
         vec.push_back('"'); vec.push_back('a'); vec.push_back('m');
         vec.push_back('y'); vec.push_back('"'); vec.push_back('i');
-        int integer_loc = vec.size();
+        auto integer_loc = vec.size();
         vec.resize(vec.size() + 4);
         uint32_t val_int = htonl(23);
         memcpy(&vec[integer_loc], &val_int, sizeof(uint32_t));

--- a/indra/llcorehttp/_httplibcurl.cpp
+++ b/indra/llcorehttp/_httplibcurl.cpp
@@ -442,7 +442,7 @@ bool HttpLibcurl::completeRequest(CURLM * multi_handle, CURL * handle, CURLcode 
 
 int HttpLibcurl::getActiveCount() const
 {
-    return mActiveOps.size();
+    return static_cast<int>(mActiveOps.size());
 }
 
 

--- a/indra/llcorehttp/_httpoprequest.cpp
+++ b/indra/llcorehttp/_httpoprequest.cpp
@@ -267,7 +267,7 @@ void HttpOpRequest::visitNotifier(HttpRequest * request)
         if (mReplyOffset || mReplyLength)
         {
             // Got an explicit offset/length in response
-            response->setRange(mReplyOffset, mReplyLength, mReplyFullLength);
+            response->setRange(mReplyOffset, static_cast<unsigned int>(mReplyLength), static_cast<unsigned int>(mReplyFullLength));
         }
         response->setContentType(mReplyConType);
         response->setRetries(mPolicyRetries, mPolicy503Retries);
@@ -328,7 +328,7 @@ HttpStatus HttpOpRequest::setupGetByteRange(HttpRequest::policy_t policy_id,
     LL_PROFILE_ZONE_SCOPED_CATEGORY_NETWORK;
     setupCommon(policy_id, url, NULL, options, headers);
     mReqMethod = HOR_GET;
-    mReqOffset = offset;
+    mReqOffset = static_cast<off_t>(offset);
     mReqLength = len;
     if (offset || len)
     {
@@ -607,7 +607,7 @@ HttpStatus HttpOpRequest::prepareRequest(HttpService * service)
             long data_size(0);
             if (mReqBody)
             {
-                data_size = mReqBody->size();
+                data_size = static_cast<long>(mReqBody->size());
             }
             check_curl_easy_setopt(mCurlHandle, CURLOPT_POSTFIELDS, static_cast<void *>(NULL));
             check_curl_easy_setopt(mCurlHandle, CURLOPT_POSTFIELDSIZE, data_size);
@@ -618,13 +618,14 @@ HttpStatus HttpOpRequest::prepareRequest(HttpService * service)
     case HOR_PATCH:
         check_curl_easy_setopt(mCurlHandle, CURLOPT_CUSTOMREQUEST, "PATCH");
         // fall through.  The rest is the same as PUT
+        [[fallthrough]];
     case HOR_PUT:
         {
             check_curl_easy_setopt(mCurlHandle, CURLOPT_UPLOAD, 1);
             long data_size(0);
             if (mReqBody)
             {
-                data_size = mReqBody->size();
+                data_size = static_cast<long>(mReqBody->size());
             }
             check_curl_easy_setopt(mCurlHandle, CURLOPT_INFILESIZE, data_size);
             mCurlHeaders = curl_slist_append(mCurlHeaders, "Expect:");

--- a/indra/llcorehttp/_httppolicy.cpp
+++ b/indra/llcorehttp/_httppolicy.cpp
@@ -98,7 +98,7 @@ HttpPolicy::~HttpPolicy()
 
 HttpRequest::policy_t HttpPolicy::createPolicyClass()
 {
-    const HttpRequest::policy_t policy_class(mClasses.size());
+    const HttpRequest::policy_t policy_class(static_cast<HttpRequest::policy_t>(mClasses.size()));
     if (policy_class >= HTTP_POLICY_CLASS_LIMIT)
     {
         return HttpRequest::INVALID_POLICY_ID;
@@ -432,8 +432,8 @@ int HttpPolicy::getReadyCount(HttpRequest::policy_t policy_class) const
 {
     if (policy_class < mClasses.size())
     {
-        return (mClasses[policy_class]->mReadyQueue.size()
-                + mClasses[policy_class]->mRetryQueue.size());
+        return static_cast<int>((mClasses[policy_class]->mReadyQueue.size()
+            + mClasses[policy_class]->mRetryQueue.size()));
     }
     return 0;
 }

--- a/indra/llcorehttp/examples/http_texture_load.cpp
+++ b/indra/llcorehttp/examples/http_texture_load.cpp
@@ -519,7 +519,7 @@ void WorkingSet::onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * r
         {
             // More success
             LLCore::BufferArray * data(response->getBody());
-            mByteCount += data ? data->size() : 0;
+            mByteCount += data ? static_cast<long>(data->size()) : 0L;
             ++mSuccesses;
         }
         else
@@ -602,7 +602,7 @@ void WorkingSet::loadAssetUuids(FILE * in)
             mAssets.push_back(asset);
         }
     }
-    mRemaining = mLimit = mAssets.size();
+    mRemaining = mLimit = static_cast<int>(mAssets.size());
 }
 
 

--- a/indra/llcrashlogger/llcrashlogger.cpp
+++ b/indra/llcrashlogger/llcrashlogger.cpp
@@ -131,7 +131,7 @@ std::string getStartupStateFromLog(std::string& sllog)
     std::string startup_state = "STATE_FIRST";
     std::string startup_token = "Startup state changing from ";
 
-    int index = sllog.rfind(startup_token);
+    auto index = sllog.rfind(startup_token);
     if (index < 0 || index + startup_token.length() > sllog.length()) {
         return startup_state;
     }

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -638,7 +638,7 @@ std::string LLDir::getBaseFileName(const std::string& filepath, bool strip_exten
 std::string LLDir::getDirName(const std::string& filepath) const
 {
     std::size_t offset = filepath.find_last_of(getDirDelimiter());
-    S32 len = (offset == std::string::npos) ? 0 : offset;
+    auto len = (offset == std::string::npos) ? 0 : offset;
     std::string dirname = filepath.substr(0, len);
     return dirname;
 }
@@ -883,8 +883,8 @@ std::string LLDir::getScrubbedFileName(const std::string uncleanFileName)
     // replace any illegal file chars with and underscore '_'
     for( unsigned int i = 0; i < illegalChars.length(); i++ )
     {
-        int j = -1;
-        while((j = name.find(illegalChars[i])) > -1)
+        std::string::size_type j = -1;
+        while((j = name.find(illegalChars[i])) > std::string::npos)
         {
             name[j] = '_';
         }

--- a/indra/llfilesystem/lldir_win32.cpp
+++ b/indra/llfilesystem/lldir_win32.cpp
@@ -233,7 +233,7 @@ LLDir_Win32::LLDir_Win32()
     {
         w_str[size] = '\0';
         mExecutablePathAndName = utf16str_to_utf8str(llutf16string(w_str));
-        S32 path_end = mExecutablePathAndName.find_last_of('\\');
+        auto path_end = mExecutablePathAndName.find_last_of('\\');
         if (path_end != std::string::npos)
         {
             mExecutableDir = mExecutablePathAndName.substr(0, path_end);

--- a/indra/llfilesystem/lllfsthread.cpp
+++ b/indra/llfilesystem/lllfsthread.cpp
@@ -45,7 +45,7 @@ void LLLFSThread::initClass(bool local_is_threaded)
 //static
 S32 LLLFSThread::updateClass(U32 ms_elapsed)
 {
-    return sLocal->update((F32)ms_elapsed);
+    return static_cast<S32>(sLocal->update((F32)ms_elapsed));
 }
 
 //static

--- a/indra/llimage/llimagedxt.cpp
+++ b/indra/llimage/llimagedxt.cpp
@@ -476,7 +476,7 @@ bool LLImageDXT::convertToDXR()
 // virtual
 S32 LLImageDXT::calcHeaderSize()
 {
-    return llmax(sizeof(dxtfile_header_old_t), sizeof(dxtfile_header_t));
+    return static_cast<S32>(llmax(sizeof(dxtfile_header_old_t), sizeof(dxtfile_header_t)));
 }
 
 // virtual

--- a/indra/llimage/llimagetga.cpp
+++ b/indra/llimage/llimagetga.cpp
@@ -1179,7 +1179,7 @@ bool LLImageTGA::decodeAndProcess( LLImageRaw* raw_image, F32 domain, F32 weight
 // Reads a .tga file and creates an LLImageTGA with its data.
 bool LLImageTGA::loadFile( const std::string& path )
 {
-    S32 len = path.size();
+    auto len = path.size();
     if( len < 5 )
     {
         return false;
@@ -1206,7 +1206,7 @@ bool LLImageTGA::loadFile( const std::string& path )
     }
 
     U8* buffer = allocateData(file_size);
-    S32 bytes_read = fread(buffer, 1, file_size, file);
+    S32 bytes_read = static_cast<S32>(fread(buffer, 1, file_size, file));
     if( bytes_read != file_size )
     {
         deleteData();

--- a/indra/llimage/llpngwrapper.cpp
+++ b/indra/llimage/llpngwrapper.cpp
@@ -328,10 +328,10 @@ bool LLPngWrapper::writePng(const LLImageRaw* rawImage, U8* dest, size_t destSiz
         mWriteInfoPtr = png_create_info_struct(mWritePngPtr);
 
         // Setup write function
-        PngDataInfo dataPtr;
+        PngDataInfo dataPtr{};
         dataPtr.mData = dest;
         dataPtr.mOffset = 0;
-        dataPtr.mDataSize = destSize;
+        dataPtr.mDataSize = static_cast<S32>(destSize);
         png_set_write_fn(mWritePngPtr, &dataPtr, &writeDataCallback, &writeFlush);
 
         // Setup image params

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -462,7 +462,7 @@ namespace
         // Trim extra tracks.
         while (value.size() > LLSettingsDay::TRACK_MAX)
         {
-            value.erase(value.size() - 1);
+            value.erase(static_cast<LLSD::Integer>(value.size()) - 1);
         }
 
         S32 framecount(0);
@@ -511,7 +511,7 @@ namespace
 
         }
 
-        int waterTracks = value[0].size();
+        int waterTracks = static_cast<int>(value[0].size());
         int skyTracks   = framecount - waterTracks;
 
         if (waterTracks < 1)

--- a/indra/llmath/llsimdtypes.h
+++ b/indra/llmath/llsimdtypes.h
@@ -60,7 +60,7 @@ public:
     inline operator bool() const { return static_cast<const bool&>(m_bool); }
 
 private:
-    int m_bool;
+    int m_bool{ 0 };
 };
 
 #if LL_WINDOWS
@@ -118,7 +118,7 @@ public:
     }
 
 private:
-    LLQuad mQ;
+    LLQuad mQ{};
 };
 
 #endif //LL_SIMD_TYPES_H

--- a/indra/llmath/llsphere.cpp
+++ b/indra/llmath/llsphere.cpp
@@ -185,7 +185,7 @@ LLSphere LLSphere::getBoundingSphere(const std::vector<LLSphere>& sphere_list)
     // TODO -- improve the accuracy for small collections of spheres
 
     LLSphere bounding_sphere( LLVector3(0.f, 0.f, 0.f), 0.f );
-    S32 sphere_count = sphere_list.size();
+    auto sphere_count = sphere_list.size();
     if (1 == sphere_count)
     {
         // trivial case -- single sphere

--- a/indra/llmath/lltreenode.h
+++ b/indra/llmath/lltreenode.h
@@ -57,7 +57,7 @@ public:
     virtual bool remove(T* data);
     virtual void notifyRemoval(T* data);
     virtual U32 hasListeners() const { return !mListeners.empty(); }
-    virtual U32 getListenerCount() const { return mListeners.size(); }
+    virtual U32 getListenerCount() const { return static_cast<U32>(mListeners.size()); }
     virtual LLTreeListener<T>* getListener(U32 index) const
     {
         if (index < mListeners.size())

--- a/indra/llmath/llvector4a.h
+++ b/indra/llmath/llvector4a.h
@@ -322,7 +322,7 @@ public:
     inline operator LLQuad() const;
 
 private:
-    LLQuad mQ;
+    LLQuad mQ{};
 };
 
 inline void update_min_max(LLVector4a& min, LLVector4a& max, const LLVector4a& p)

--- a/indra/llmath/llvector4logical.h
+++ b/indra/llmath/llvector4logical.h
@@ -120,7 +120,7 @@ public:
 
 private:
 
-    LLQuad mQ;
+    LLQuad mQ{};
 };
 
 #endif //LL_VECTOR4ALOGICAL_H

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -2392,7 +2392,7 @@ bool LLVolume::unpackVolumeFaces(U8* in_data, S32 size)
 bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
 {
     {
-        U32 face_count = mdl.size();
+        auto face_count = mdl.size();
 
         if (face_count == 0)
         { //no faces unpacked, treat as failed decode
@@ -2424,7 +2424,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
             LLSD::Binary idx = mdl[i]["TriangleList"];
 
             //copy out indices
-            S32 num_indices = idx.size() / 2;
+            auto num_indices = idx.size() / 2;
             const S32 indices_to_discard = num_indices % 3;
             if (indices_to_discard > 0)
             {
@@ -2432,7 +2432,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
                 LL_WARNS() << "Incomplete triangle discarded from face! Indices count " << num_indices << " was not divisible by 3. face index: " << i << " Total: " << face_count << LL_ENDL;
                 num_indices -= indices_to_discard;
             }
-            face.resizeIndices(num_indices);
+            face.resizeIndices(static_cast<S32>(num_indices));
 
             if (num_indices > 2 && !face.mIndices)
             {
@@ -2453,7 +2453,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
             }
 
             //copy out vertices
-            U32 num_verts = pos.size()/(3*2);
+            U32 num_verts = static_cast<U32>(pos.size())/(3*2);
             face.resizeVertices(num_verts);
 
             if (num_verts > 0 && !face.mPositions)
@@ -5015,13 +5015,13 @@ void LLVolumeFace::remap()
 {
     // Generate a remap buffer
     std::vector<unsigned int> remap(mNumVertices);
-    S32 remap_vertices_count = LLMeshOptimizer::generateRemapMultiU16(&remap[0],
+    S32 remap_vertices_count = static_cast<S32>(LLMeshOptimizer::generateRemapMultiU16(&remap[0],
         mIndices,
         mNumIndices,
         mPositions,
         mNormals,
         mTexCoords,
-        mNumVertices);
+        mNumVertices));
 
     // Allocate new buffers
     S32 size = ((mNumIndices * sizeof(U16)) + 0xF) & ~0xF;
@@ -5565,7 +5565,7 @@ bool LLVolumeFace::cacheOptimize(bool gen_tangents)
 
         U32 stream_count = data.w.empty() ? 4 : 5;
 
-        size_t vert_count = meshopt_generateVertexRemapMulti(&remap[0], nullptr, data.p.size(), data.p.size(), mos, stream_count);
+        S32 vert_count = static_cast<S32>(meshopt_generateVertexRemapMulti(&remap[0], nullptr, data.p.size(), data.p.size(), mos, stream_count));
 
         if (vert_count < 65535 && vert_count != 0)
         {
@@ -6648,8 +6648,8 @@ void LLVolumeFace::pushIndex(const U16& idx)
 
 void LLVolumeFace::fillFromLegacyData(std::vector<LLVolumeFace::VertexData>& v, std::vector<U16>& idx)
 {
-    resizeVertices(v.size());
-    resizeIndices(idx.size());
+    resizeVertices(static_cast<S32>(v.size()));
+    resizeIndices(static_cast<S32>(idx.size()));
 
     for (U32 i = 0; i < v.size(); ++i)
     {

--- a/indra/llmath/llvolume.h
+++ b/indra/llmath/llvolume.h
@@ -1019,7 +1019,7 @@ public:
     U8 getProfileType() const                               { return mParams.getProfileParams().getCurveType(); }
     U8 getPathType() const                                  { return mParams.getPathParams().getCurveType(); }
     S32 getNumFaces() const;
-    S32 getNumVolumeFaces() const                           { return mVolumeFaces.size(); }
+    S32 getNumVolumeFaces() const                           { return static_cast<S32>(mVolumeFaces.size()); }
     F32 getDetail() const                                   { return mDetail; }
     F32 getSurfaceArea() const                              { return mSurfaceArea; }
     const LLVolumeParams& getParams() const                 { return mParams; }

--- a/indra/llmessage/llassetstorage.cpp
+++ b/indra/llmessage/llassetstorage.cpp
@@ -1125,7 +1125,7 @@ S32 LLAssetStorage::getNumPending(LLAssetStorage::ERequestType rt) const
     S32 num_pending = -1;
     if (requests)
     {
-        num_pending = requests->size();
+        num_pending = static_cast<S32>(requests->size());
     }
     return num_pending;
 }

--- a/indra/llmessage/llavatarnamecache.cpp
+++ b/indra/llmessage/llavatarnamecache.cpp
@@ -240,7 +240,7 @@ void LLAvatarNameCache::handleAvNameCacheSuccess(const LLSD &data, const LLSD &h
 
     // Same logic as error response case
     const LLSD& unresolved_agents = data["bad_ids"];
-    S32  num_unresolved = unresolved_agents.size();
+    auto num_unresolved = unresolved_agents.size();
     if (num_unresolved > 0)
     {
         LL_WARNS("AvNameCache") << "LLAvatarNameResponder::result " << num_unresolved << " unresolved ids; "

--- a/indra/llmessage/llcachename.cpp
+++ b/indra/llmessage/llcachename.cpp
@@ -562,13 +562,13 @@ std::string LLCacheName::buildLegacyName(const std::string& complete_name)
 {
     //boost::regexp was showing up in the crashreporter, so doing
     //painfully manual parsing using substr. LF
-    S32 open_paren = complete_name.rfind(" (");
-    S32 close_paren = complete_name.rfind(')');
+    auto open_paren = complete_name.rfind(" (");
+    auto close_paren = complete_name.rfind(')');
 
     if (open_paren != std::string::npos &&
         close_paren == complete_name.length()-1)
     {
-        S32 length = close_paren - open_paren - 2;
+        auto length = close_paren - open_paren - 2;
         std::string legacy_name = complete_name.substr(open_paren+2, length);
 
         if (legacy_name.length() > 0)
@@ -577,7 +577,7 @@ std::string LLCacheName::buildLegacyName(const std::string& complete_name)
             LLStringUtil::toUpper(cap_letter);
             legacy_name = cap_letter + legacy_name.substr(1);
 
-            S32 separator = legacy_name.find('.');
+            auto separator = legacy_name.find('.');
 
             if (separator != std::string::npos)
             {

--- a/indra/llmessage/llcircuit.cpp
+++ b/indra/llmessage/llcircuit.cpp
@@ -781,8 +781,8 @@ void LLCircuitData::checkPacketInID(TPACKETID id, bool receive_resent)
 void LLCircuit::updateWatchDogTimers(LLMessageSystem *msgsys)
 {
     F64Seconds cur_time = LLMessageSystem::getMessageTimeSeconds();
-    S32 count = mPingSet.size();
-    S32 cur = 0;
+    size_t count = mPingSet.size();
+    size_t cur = 0;
 
     // Only process each circuit once at most, stop processing if no circuits
     while((cur < count) && !mPingSet.empty())

--- a/indra/llmessage/llcoproceduremanager.cpp
+++ b/indra/llmessage/llcoproceduremanager.cpp
@@ -87,7 +87,7 @@ public:
     ///
     inline S32 count() const
     {
-        return countPending() + countActive();
+        return static_cast<S32>(countPending() + countActive());
     }
 
     void close();

--- a/indra/llmessage/lldatapacker.cpp
+++ b/indra/llmessage/lldatapacker.cpp
@@ -237,7 +237,7 @@ bool LLDataPacker::unpackUUIDs(LLUUID *values, S32 count, const char *name)
 
 bool LLDataPackerBinaryBuffer::packString(const std::string& value, const char *name)
 {
-    S32 length = value.length()+1;
+    S32 length = static_cast<S32>(value.length()) + 1;
 
     if (!verifyLength(length, name))
     {
@@ -740,7 +740,7 @@ bool LLDataPackerAsciiBuffer::packString(const std::string& value, const char *n
     }
     else
     {
-        numCopied = value.length() + 1; /*Flawfinder: ignore*/
+        numCopied = static_cast<S32>(value.length()) + 1; /*Flawfinder: ignore*/
     }
 
     // snprintf returns number of bytes that would have been written

--- a/indra/llmessage/llfiltersd2xmlrpc.cpp
+++ b/indra/llmessage/llfiltersd2xmlrpc.cpp
@@ -274,12 +274,12 @@ void LLFilterSD2XMLRPC::streamOut(std::ostream& ostr, const LLSD& sd)
         if(!buffer.empty())
         {
             // *TODO: convert to LLBase64
-            int b64_buffer_length = apr_base64_encode_len(buffer.size());
+            int b64_buffer_length = apr_base64_encode_len(static_cast<int>(buffer.size()));
             char* b64_buffer = new char[b64_buffer_length];
             b64_buffer_length = apr_base64_encode_binary(
                 b64_buffer,
                 &buffer[0],
-                buffer.size());
+                static_cast<int>(buffer.size()));
             ostr.write(b64_buffer, b64_buffer_length - 1);
             delete[] b64_buffer;
         }

--- a/indra/llmessage/lliohttpserver.cpp
+++ b/indra/llmessage/lliohttpserver.cpp
@@ -494,7 +494,7 @@ LLIOPipe::EStatus LLHTTPResponseHeader::process_impl(
         LLChangeChannel change(channels.in(), channels.out());
         std::for_each(buffer->beginSegment(), buffer->endSegment(), change);
         std::string header = ostr.str();
-        buffer->prepend(channels.out(), (U8*)header.c_str(), header.size());
+        buffer->prepend(channels.out(), (U8*)header.c_str(), static_cast<S32>(header.size()));
         PUMP_DEBUG;
         return STATUS_DONE;
     }

--- a/indra/llmessage/lliosocket.cpp
+++ b/indra/llmessage/lliosocket.cpp
@@ -346,7 +346,7 @@ LLIOPipe::EStatus LLIOSocketReader::process_impl(
         PUMP_DEBUG;
         len = READ_BUFFER_SIZE;
         status = apr_socket_recv(mSource->getSocket(), read_buf, &len);
-        buffer->append(channels.out(), (U8*)read_buf, len);
+        buffer->append(channels.out(), (U8*)read_buf, static_cast<S32>(len));
     } while((APR_SUCCESS == status) && (READ_BUFFER_SIZE == len));
     LL_DEBUGS() << "socket read status: " << status << LL_ENDL;
     LLIOPipe::EStatus rv = STATUS_OK;

--- a/indra/llmessage/llmail.cpp
+++ b/indra/llmessage/llmail.cpp
@@ -273,7 +273,7 @@ bool LLMail::send(
     std::string good_string = "\n..\n";
     while (1)
     {
-        int index = message.find(bad_string);
+        auto index = message.find(bad_string);
         if (index == std::string::npos) break;
         message.replace(index, bad_string.size(), good_string);
     }

--- a/indra/llmessage/llproxy.cpp
+++ b/indra/llmessage/llproxy.cpp
@@ -123,7 +123,7 @@ S32 LLProxy::proxyHandshake(LLHost proxy)
         // The server has requested a username/password combination
         std::string socks_username(getSocksUser());
         std::string socks_password(getSocksPwd());
-        U32 request_size = socks_username.size() + socks_password.size() + 3;
+        U32 request_size = static_cast<S32>(socks_username.size() + socks_password.size() + 3);
         char * password_auth = new char[request_size];
         password_auth[0] = 0x01;
         password_auth[1] = (char)(socks_username.size());

--- a/indra/llmessage/llpumpio.cpp
+++ b/indra/llmessage/llpumpio.cpp
@@ -818,7 +818,7 @@ void LLPumpIO::rebuildPollset()
     running_chains_t::iterator run_end = mRunningChains.end();
     for(; run_it != run_end; ++run_it)
     {
-        size += (*run_it).mDescriptors.size();
+        size += static_cast<U32>((*run_it).mDescriptors.size());
     }
     //LL_DEBUGS() << "found " << size << " descriptors." << LL_ENDL;
     if(size)

--- a/indra/llmessage/llregionflags.h
+++ b/indra/llmessage/llregionflags.h
@@ -28,83 +28,83 @@
 #define LL_LLREGIONFLAGS_H
 
 // Can you be hurt here? Should health be on?
-const U64 REGION_FLAGS_ALLOW_DAMAGE             = (1 << 0);
+constexpr U64 REGION_FLAGS_ALLOW_DAMAGE             = (1ULL << 0);
 
 // Can you make landmarks here?
-const U64 REGION_FLAGS_ALLOW_LANDMARK           = (1 << 1);
+constexpr U64 REGION_FLAGS_ALLOW_LANDMARK           = (1ULL << 1);
 
 // Do we reset the home position when someone teleports away from here?
-const U64 REGION_FLAGS_ALLOW_SET_HOME           = (1 << 2);
+constexpr U64 REGION_FLAGS_ALLOW_SET_HOME           = (1ULL << 2);
 
 // Do we reset the home position when someone teleports away from here?
-const U64 REGION_FLAGS_RESET_HOME_ON_TELEPORT   = (1 << 3);
+constexpr U64 REGION_FLAGS_RESET_HOME_ON_TELEPORT   = (1ULL << 3);
 
 // Does the sun move?
-const U64 REGION_FLAGS_SUN_FIXED                = (1 << 4);
+constexpr U64 REGION_FLAGS_SUN_FIXED                = (1ULL << 4);
 
 // Does the estate owner allow private parcels?
-const U64 REGION_FLAGS_ALLOW_ACCESS_OVERRIDE    = (1 << 5);
+constexpr U64 REGION_FLAGS_ALLOW_ACCESS_OVERRIDE    = (1ULL << 5);
 
 // Can't change the terrain heightfield, even on owned parcels,
 // but can plant trees and grass.
-const U64 REGION_FLAGS_BLOCK_TERRAFORM          = (1 << 6);
+constexpr U64 REGION_FLAGS_BLOCK_TERRAFORM          = (1ULL << 6);
 
 // Can't release, sell, or buy land.
-const U64 REGION_FLAGS_BLOCK_LAND_RESELL        = (1 << 7);
+constexpr U64 REGION_FLAGS_BLOCK_LAND_RESELL        = (1ULL << 7);
 
 // All content wiped once per night
-const U64 REGION_FLAGS_SANDBOX                  = (1 << 8);
+constexpr U64 REGION_FLAGS_SANDBOX                  = (1ULL << 8);
 
-const U64 REGION_FLAGS_ALLOW_ENVIRONMENT_OVERRIDE = (1 << 9);
+constexpr U64 REGION_FLAGS_ALLOW_ENVIRONMENT_OVERRIDE = (1ULL << 9);
 
-const U64 REGION_FLAGS_SKIP_COLLISIONS          = (1 << 12); // Pin all non agent rigid bodies
-const U64 REGION_FLAGS_SKIP_SCRIPTS             = (1 << 13);
-const U64 REGION_FLAGS_SKIP_PHYSICS             = (1 << 14); // Skip all physics
-const U64 REGION_FLAGS_EXTERNALLY_VISIBLE       = (1 << 15);
-const U64 REGION_FLAGS_ALLOW_RETURN_ENCROACHING_OBJECT = (1 << 16);
-const U64 REGION_FLAGS_ALLOW_RETURN_ENCROACHING_ESTATE_OBJECT = (1 << 17);
-const U64 REGION_FLAGS_BLOCK_DWELL              = (1 << 18);
+constexpr U64 REGION_FLAGS_SKIP_COLLISIONS          = (1ULL << 12); // Pin all non agent rigid bodies
+constexpr U64 REGION_FLAGS_SKIP_SCRIPTS             = (1ULL << 13);
+constexpr U64 REGION_FLAGS_SKIP_PHYSICS             = (1ULL << 14); // Skip all physics
+constexpr U64 REGION_FLAGS_EXTERNALLY_VISIBLE       = (1ULL << 15);
+constexpr U64 REGION_FLAGS_ALLOW_RETURN_ENCROACHING_OBJECT = (1ULL << 16);
+constexpr U64 REGION_FLAGS_ALLOW_RETURN_ENCROACHING_ESTATE_OBJECT = (1ULL << 17);
+constexpr U64 REGION_FLAGS_BLOCK_DWELL              = (1ULL << 18);
 
 // Is flight allowed?
-const U64 REGION_FLAGS_BLOCK_FLY                = (1 << 19);
+constexpr U64 REGION_FLAGS_BLOCK_FLY                = (1ULL << 19);
 
 // Is direct teleport (p2p) allowed?
-const U64 REGION_FLAGS_ALLOW_DIRECT_TELEPORT    = (1 << 20);
+constexpr U64 REGION_FLAGS_ALLOW_DIRECT_TELEPORT    = (1ULL << 20);
 
 // Is there an administrative override on scripts in the region at the
 // moment. This is the similar skip scripts, except this flag is
 // presisted in the database on an estate level.
-const U64 REGION_FLAGS_ESTATE_SKIP_SCRIPTS      = (1 << 21);
+constexpr U64 REGION_FLAGS_ESTATE_SKIP_SCRIPTS      = (1ULL << 21);
 
-const U64 REGION_FLAGS_RESTRICT_PUSHOBJECT      = (1 << 22);
+constexpr U64 REGION_FLAGS_RESTRICT_PUSHOBJECT      = (1ULL << 22);
 
-const U64 REGION_FLAGS_DENY_ANONYMOUS           = (1 << 23);
+constexpr U64 REGION_FLAGS_DENY_ANONYMOUS           = (1ULL << 23);
 
-const U64 REGION_FLAGS_ALLOW_PARCEL_CHANGES     = (1 << 26);
+constexpr U64 REGION_FLAGS_ALLOW_PARCEL_CHANGES     = (1ULL << 26);
 
-const U64 REGION_FLAGS_BLOCK_FLYOVER = (1 << 27);
+constexpr U64 REGION_FLAGS_BLOCK_FLYOVER = (1ULL << 27);
 
-const U64 REGION_FLAGS_ALLOW_VOICE = (1 << 28);
+constexpr U64 REGION_FLAGS_ALLOW_VOICE = (1ULL << 28);
 
-const U64 REGION_FLAGS_BLOCK_PARCEL_SEARCH = (1 << 29);
-const U64 REGION_FLAGS_DENY_AGEUNVERIFIED   = (1 << 30);
+constexpr U64 REGION_FLAGS_BLOCK_PARCEL_SEARCH = (1ULL << 29);
+constexpr U64 REGION_FLAGS_DENY_AGEUNVERIFIED   = (1ULL << 30);
 
-const U64 REGION_FLAGS_DENY_BOTS = (1 << 31);
+constexpr U64 REGION_FLAGS_DENY_BOTS = (1ULL << 31);
 
-const U64 REGION_FLAGS_DEFAULT = REGION_FLAGS_ALLOW_LANDMARK |
-                                 REGION_FLAGS_ALLOW_SET_HOME |
-                                 REGION_FLAGS_ALLOW_PARCEL_CHANGES |
-                                 REGION_FLAGS_ALLOW_VOICE;
+constexpr U64 REGION_FLAGS_DEFAULT = REGION_FLAGS_ALLOW_LANDMARK |
+                                     REGION_FLAGS_ALLOW_SET_HOME |
+                                     REGION_FLAGS_ALLOW_PARCEL_CHANGES |
+                                     REGION_FLAGS_ALLOW_VOICE;
 
 
-const U64 REGION_FLAGS_PRELUDE_SET = REGION_FLAGS_RESET_HOME_ON_TELEPORT;
-const U64 REGION_FLAGS_PRELUDE_UNSET = REGION_FLAGS_ALLOW_LANDMARK
-                                       | REGION_FLAGS_ALLOW_SET_HOME;
+constexpr U64 REGION_FLAGS_PRELUDE_SET = REGION_FLAGS_RESET_HOME_ON_TELEPORT;
+constexpr U64 REGION_FLAGS_PRELUDE_UNSET = REGION_FLAGS_ALLOW_LANDMARK |
+                                           REGION_FLAGS_ALLOW_SET_HOME;
 
-const U64 REGION_FLAGS_ESTATE_MASK = REGION_FLAGS_EXTERNALLY_VISIBLE
-                                     | REGION_FLAGS_SUN_FIXED
-                                     | REGION_FLAGS_DENY_ANONYMOUS
-                                     | REGION_FLAGS_DENY_AGEUNVERIFIED;
+constexpr U64 REGION_FLAGS_ESTATE_MASK = REGION_FLAGS_EXTERNALLY_VISIBLE |
+                                         REGION_FLAGS_SUN_FIXED |
+                                         REGION_FLAGS_DENY_ANONYMOUS |
+                                         REGION_FLAGS_DENY_AGEUNVERIFIED;
 
 inline bool is_flag_set(U64 flags, U64 flag)
 {
@@ -133,79 +133,75 @@ inline U64 unset_prelude_flags(U64 flags)
 }
 
 // Region protocols
-const U64 REGION_PROTOCOLS_AGENT_APPEARANCE_SERVICE = (1 << 0);
+constexpr U64 REGION_PROTOCOLS_AGENT_APPEARANCE_SERVICE = (1ULL << 0);
 
 // estate constants. Need to match first few etries in indra.estate table.
-const U32 ESTATE_ALL = 0; // will not match in db, reserved key for logic
-const U32 ESTATE_MAINLAND = 1;
-const U32 ESTATE_ORIENTATION = 2;
-const U32 ESTATE_INTERNAL = 3;
-const U32 ESTATE_SHOWCASE = 4;
-const U32 ESTATE_TEEN = 5;
-const U32 ESTATE_LAST_LINDEN = 5; // last linden owned/managed estate
+constexpr U32 ESTATE_ALL = 0; // will not match in db, reserved key for logic
+constexpr U32 ESTATE_MAINLAND = 1;
+constexpr U32 ESTATE_ORIENTATION = 2;
+constexpr U32 ESTATE_INTERNAL = 3;
+constexpr U32 ESTATE_SHOWCASE = 4;
+constexpr U32 ESTATE_TEEN = 5;
+constexpr U32 ESTATE_LAST_LINDEN = 5; // last linden owned/managed estate
 
 // for EstateOwnerRequest, setaccess message
-const U32 ESTATE_ACCESS_ALLOWED_AGENTS  = 1 << 0;
-const U32 ESTATE_ACCESS_ALLOWED_GROUPS  = 1 << 1;
-const U32 ESTATE_ACCESS_BANNED_AGENTS   = 1 << 2;
-const U32 ESTATE_ACCESS_MANAGERS        = 1 << 3;
+constexpr U32 ESTATE_ACCESS_ALLOWED_AGENTS  = 1 << 0;
+constexpr U32 ESTATE_ACCESS_ALLOWED_GROUPS  = 1 << 1;
+constexpr U32 ESTATE_ACCESS_BANNED_AGENTS   = 1 << 2;
+constexpr U32 ESTATE_ACCESS_MANAGERS        = 1 << 3;
 
 //maximum number of access list entries we can fit in one packet
-const S32 ESTATE_ACCESS_MAX_ENTRIES_PER_PACKET = 63;
+constexpr S32 ESTATE_ACCESS_MAX_ENTRIES_PER_PACKET = 63;
 
 // for reply to "getinfo", don't need to forward to all sims in estate
-const U32 ESTATE_ACCESS_SEND_TO_AGENT_ONLY = 1 << 4;
+constexpr U32 ESTATE_ACCESS_SEND_TO_AGENT_ONLY = 1 << 4;
 
-const U32 ESTATE_ACCESS_ALL = ESTATE_ACCESS_ALLOWED_AGENTS
-                              | ESTATE_ACCESS_ALLOWED_GROUPS
-                              | ESTATE_ACCESS_BANNED_AGENTS
-                              | ESTATE_ACCESS_MANAGERS;
+constexpr U32 ESTATE_ACCESS_ALL = ESTATE_ACCESS_ALLOWED_AGENTS
+                                  | ESTATE_ACCESS_ALLOWED_GROUPS
+                                  | ESTATE_ACCESS_BANNED_AGENTS
+                                  | ESTATE_ACCESS_MANAGERS;
 
 // for EstateOwnerRequest, estateaccessdelta, estateexperiencedelta messages
-const U32 ESTATE_ACCESS_APPLY_TO_ALL_ESTATES        = 1U << 0;
-const U32 ESTATE_ACCESS_APPLY_TO_MANAGED_ESTATES    = 1U << 1;
+constexpr U32 ESTATE_ACCESS_APPLY_TO_ALL_ESTATES        = 1U << 0;
+constexpr U32 ESTATE_ACCESS_APPLY_TO_MANAGED_ESTATES    = 1U << 1;
 
-const U32 ESTATE_ACCESS_ALLOWED_AGENT_ADD           = 1U << 2;
-const U32 ESTATE_ACCESS_ALLOWED_AGENT_REMOVE            = 1U << 3;
-const U32 ESTATE_ACCESS_ALLOWED_GROUP_ADD           = 1U << 4;
-const U32 ESTATE_ACCESS_ALLOWED_GROUP_REMOVE            = 1U << 5;
-const U32 ESTATE_ACCESS_BANNED_AGENT_ADD                = 1U << 6;
-const U32 ESTATE_ACCESS_BANNED_AGENT_REMOVE         = 1U << 7;
-const U32 ESTATE_ACCESS_MANAGER_ADD                 = 1U << 8;
-const U32 ESTATE_ACCESS_MANAGER_REMOVE              = 1U << 9;
-const U32 ESTATE_ACCESS_NO_REPLY                        = 1U << 10;
-const U32 ESTATE_ACCESS_FAILED_BAN_ESTATE_MANAGER   = 1U << 11;
+constexpr U32 ESTATE_ACCESS_ALLOWED_AGENT_ADD           = 1U << 2;
+constexpr U32 ESTATE_ACCESS_ALLOWED_AGENT_REMOVE        = 1U << 3;
+constexpr U32 ESTATE_ACCESS_ALLOWED_GROUP_ADD           = 1U << 4;
+constexpr U32 ESTATE_ACCESS_ALLOWED_GROUP_REMOVE        = 1U << 5;
+constexpr U32 ESTATE_ACCESS_BANNED_AGENT_ADD            = 1U << 6;
+constexpr U32 ESTATE_ACCESS_BANNED_AGENT_REMOVE         = 1U << 7;
+constexpr U32 ESTATE_ACCESS_MANAGER_ADD                 = 1U << 8;
+constexpr U32 ESTATE_ACCESS_MANAGER_REMOVE              = 1U << 9;
+constexpr U32 ESTATE_ACCESS_NO_REPLY                    = 1U << 10;
+constexpr U32 ESTATE_ACCESS_FAILED_BAN_ESTATE_MANAGER   = 1U << 11;
 
-const S32 ESTATE_MAX_MANAGERS = 20;
-const S32 ESTATE_MAX_ACCESS_IDS = 500;  // max for access
-const S32 ESTATE_MAX_BANNED_IDS = 750;  // max for banned
-const S32 ESTATE_MAX_GROUP_IDS = (S32) ESTATE_ACCESS_MAX_ENTRIES_PER_PACKET;
+constexpr S32 ESTATE_MAX_MANAGERS = 20;
+constexpr S32 ESTATE_MAX_ACCESS_IDS = 500;  // max for access
+constexpr S32 ESTATE_MAX_BANNED_IDS = 750;  // max for banned
+constexpr S32 ESTATE_MAX_GROUP_IDS = (S32) ESTATE_ACCESS_MAX_ENTRIES_PER_PACKET;
 
 // 'Sim Wide Delete' flags
-const U32 SWD_OTHERS_LAND_ONLY      = (1 << 0);
-const U32 SWD_ALWAYS_RETURN_OBJECTS = (1 << 1);
-const U32 SWD_SCRIPTED_ONLY         = (1 << 2);
+constexpr U32 SWD_OTHERS_LAND_ONLY      = (1 << 0);
+constexpr U32 SWD_ALWAYS_RETURN_OBJECTS = (1 << 1);
+constexpr U32 SWD_SCRIPTED_ONLY         = (1 << 2);
 
 // Controls experience key validity in the estate
-const U32 EXPERIENCE_KEY_TYPE_NONE      = 0;
-const U32 EXPERIENCE_KEY_TYPE_BLOCKED   = 1;
-const U32 EXPERIENCE_KEY_TYPE_ALLOWED   = 2;
-const U32 EXPERIENCE_KEY_TYPE_TRUSTED   = 3;
+constexpr U32 EXPERIENCE_KEY_TYPE_NONE      = 0;
+constexpr U32 EXPERIENCE_KEY_TYPE_BLOCKED   = 1;
+constexpr U32 EXPERIENCE_KEY_TYPE_ALLOWED   = 2;
+constexpr U32 EXPERIENCE_KEY_TYPE_TRUSTED   = 3;
 
-const U32 EXPERIENCE_KEY_TYPE_FIRST     = EXPERIENCE_KEY_TYPE_BLOCKED;
-const U32 EXPERIENCE_KEY_TYPE_LAST      = EXPERIENCE_KEY_TYPE_TRUSTED;
+constexpr U32 EXPERIENCE_KEY_TYPE_FIRST     = EXPERIENCE_KEY_TYPE_BLOCKED;
+constexpr U32 EXPERIENCE_KEY_TYPE_LAST      = EXPERIENCE_KEY_TYPE_TRUSTED;
 
 //
-const U32 ESTATE_EXPERIENCE_TRUSTED_ADD     = 1U << 2;
-const U32 ESTATE_EXPERIENCE_TRUSTED_REMOVE  = 1U << 3;
-const U32 ESTATE_EXPERIENCE_ALLOWED_ADD     = 1U << 4;
-const U32 ESTATE_EXPERIENCE_ALLOWED_REMOVE  = 1U << 5;
-const U32 ESTATE_EXPERIENCE_BLOCKED_ADD     = 1U << 6;
-const U32 ESTATE_EXPERIENCE_BLOCKED_REMOVE  = 1U << 7;
+constexpr U32 ESTATE_EXPERIENCE_TRUSTED_ADD     = 1U << 2;
+constexpr U32 ESTATE_EXPERIENCE_TRUSTED_REMOVE  = 1U << 3;
+constexpr U32 ESTATE_EXPERIENCE_ALLOWED_ADD     = 1U << 4;
+constexpr U32 ESTATE_EXPERIENCE_ALLOWED_REMOVE  = 1U << 5;
+constexpr U32 ESTATE_EXPERIENCE_BLOCKED_ADD     = 1U << 6;
+constexpr U32 ESTATE_EXPERIENCE_BLOCKED_REMOVE  = 1U << 7;
 
-const S32 ESTATE_MAX_EXPERIENCE_IDS = 8;
-
-
+constexpr S32 ESTATE_MAX_EXPERIENCE_IDS = 8;
 #endif
-
-

--- a/indra/llmessage/llsdmessagereader.cpp
+++ b/indra/llmessage/llsdmessagereader.cpp
@@ -242,7 +242,7 @@ void LLSDMessageReader::getString(const char *block, const char *var,
         return;
     }
     std::string data = getLLSD(mMessage, block, var, blocknum);
-    S32 data_size = data.size();
+    auto data_size = data.size();
     if (data_size >= buffer_size)
     {
         data_size = buffer_size - 1;
@@ -261,7 +261,7 @@ void LLSDMessageReader::getString(const char *block, const char *var,
 //virtual
 S32 LLSDMessageReader::getNumberOfBlocks(const char *blockname)
 {
-    return mMessage[blockname].size();
+    return static_cast<S32>(mMessage[blockname].size());
 }
 
 S32 getElementSize(const LLSD& llsd)
@@ -276,7 +276,7 @@ S32 getElementSize(const LLSD& llsd)
     case LLSD::TypeReal:
         return sizeof(F64);
     case LLSD::TypeString:
-        return llsd.size();
+        return static_cast<S32>(llsd.size());
     case LLSD::TypeUUID:
         return sizeof(LLUUID);
     case LLSD::TypeDate:
@@ -286,7 +286,7 @@ S32 getElementSize(const LLSD& llsd)
     case LLSD::TypeBinary:
     {
         std::vector<U8> data = llsd;
-        return data.size() * sizeof(U8);
+        return static_cast<S32>(data.size() * sizeof(U8));
     }
     case LLSD::TypeMap:
     case LLSD::TypeArray:

--- a/indra/llmessage/lltemplatemessagedispatcher.cpp
+++ b/indra/llmessage/lltemplatemessagedispatcher.cpp
@@ -44,7 +44,7 @@ void LLTemplateMessageDispatcher::dispatch(const std::string& msg_name,
                                            LLHTTPNode::ResponsePtr responsep)
 {
     std::vector<U8> data = message["body"]["binary-template-data"].asBinary();
-    U32 size = data.size();
+    auto size = data.size();
     if(size == 0)
     {
         return;
@@ -53,7 +53,7 @@ void LLTemplateMessageDispatcher::dispatch(const std::string& msg_name,
     LLHost host;
     host = gMessageSystem->getSender();
 
-    bool validate_message = mTemplateMessageReader.validateMessage(&(data[0]), data.size(), host, true);
+    bool validate_message = mTemplateMessageReader.validateMessage(&(data[0]), static_cast<S32>(size), host, true);
 
     if (validate_message)
     {

--- a/indra/llmessage/llxfer_file.cpp
+++ b/indra/llmessage/llxfer_file.cpp
@@ -317,7 +317,7 @@ S32 LLXfer_File::flush()
 
         if (mFp)
         {
-            S32 write_size = fwrite(mBuffer,1,mBufferLength,mFp);
+            S32 write_size = static_cast<S32>(fwrite(mBuffer,1,mBufferLength,mFp));
             if (write_size != mBufferLength)
             {
                 LL_WARNS("Xfer") << "Non-matching write size, requested " << mBufferLength

--- a/indra/llmessage/message.cpp
+++ b/indra/llmessage/message.cpp
@@ -2172,7 +2172,7 @@ S32 LLMessageSystem::sendError(
     if (LLMessageConfig::getMessageFlavor(ERROR_MESSAGE_NAME) ==
         LLMessageConfig::TEMPLATE_FLAVOR)
     {
-        S32 msg_size = temp.size() + mMessageBuilder->getMessageSize();
+        S32 msg_size = static_cast<S32>(temp.size()) + mMessageBuilder->getMessageSize();
         if(msg_size >= ETHERNET_MTU_BYTES)
         {
             pack_data = false;
@@ -2180,7 +2180,7 @@ S32 LLMessageSystem::sendError(
     }
     if(pack_data)
     {
-        addBinaryData("Data", (void*)temp.c_str(), temp.size());
+        addBinaryData("Data", (void*)temp.c_str(), static_cast<S32>(temp.size()));
     }
     else
     {

--- a/indra/llplugin/llpluginmessagepipe.cpp
+++ b/indra/llplugin/llpluginmessagepipe.cpp
@@ -371,7 +371,7 @@ bool LLPluginMessagePipe::pumpInput(F64 timeout)
 void LLPluginMessagePipe::processInput(void)
 {
     // Look for input delimiter(s) in the input buffer.
-    int delim;
+    size_t delim;
     mInputMutex.lock();
     while((delim = mInput.find(MESSAGE_DELIMITER)) != std::string::npos)
     {

--- a/indra/llplugin/llpluginsharedmemory.cpp
+++ b/indra/llplugin/llpluginsharedmemory.cpp
@@ -450,7 +450,7 @@ bool LLPluginSharedMemory::create(size_t size)
                  NULL,                      // default security
                  PAGE_READWRITE,            // read/write access
                  0,                         // max. object size
-                 mSize,                     // buffer size
+                 static_cast<DWORD>(mSize), // buffer size
                  mName.c_str());            // name of mapping object
 
     if(mImpl->mMapFile == NULL)

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -258,7 +258,7 @@ LLModel::EModelStatus load_face_from_dom_triangles(
 
                     // Don't share verts within the same tri, degenerate
                     //
-                    U32 indx_size = indices.size();
+                    U32 indx_size = static_cast<U32>(indices.size());
                     U32 verts_new_tri = indx_size % 3;
                     if ((verts_new_tri < 1 || indices[indx_size - 1] != shared_index)
                         && (verts_new_tri < 2 || indices[indx_size - 2] != shared_index))
@@ -732,7 +732,7 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
         { //for each vertex
             if (j > 2)
             {
-                U32 size = verts.size();
+                auto size = verts.size();
                 LLVolumeFace::VertexData v0 = verts[size-3];
                 LLVolumeFace::VertexData v1 = verts[size-1];
 
@@ -1098,7 +1098,7 @@ bool LLDAELoader::OpenFile(const std::string& filename)
     while (model_iter != mModelList.end())
     {
         LLModel* mdl = *model_iter;
-        U32 material_count = mdl->mMaterialList.size();
+        U32 material_count = static_cast<U32>(mdl->mMaterialList.size());
         LL_INFOS() << "Importing " << mdl->mLabel << " model with " << material_count << " material references" << LL_ENDL;
         std::vector<std::string>::iterator mat_iter = mdl->mMaterialList.begin();
         std::vector<std::string>::iterator end_iter = material_count > LIMIT_MATERIALS_OUTPUT
@@ -1287,11 +1287,11 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
             {
                 //Get the children at this level
                 daeTArray< daeSmartRef<daeElement> > children = pScene->getChildren();
-                S32 childCount = children.getCount();
+                auto childCount = children.getCount();
 
                 //Process any children that are joints
                 //Not all children are joints, some could be ambient lights, cameras, geometry etc..
-                for (S32 i = 0; i < childCount; ++i)
+                for (size_t i = 0; i < childCount; ++i)
                 {
                     domNode* pNode = daeSafeCast<domNode>(children[i]);
                     if (pNode)
@@ -1312,7 +1312,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                 if ( pSkeletonRootNode )
                 {
                     //Once we have the root node - start acccessing it's joint components
-                    const int jointCnt = mJointMap.size();
+                    const int jointCnt = static_cast<int>(mJointMap.size());
                     JointMap :: const_iterator jointIt = mJointMap.begin();
 
                     //Loop over all the possible joints within the .dae - using the allowed joint list in the ctor.
@@ -1453,9 +1453,9 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                     if (t)
                     {
                         domListOfFloats& transform = t->getValue();
-                        S32 count = transform.getCount()/16;
+                        auto count = transform.getCount()/16;
 
-                        for (S32 k = 0; k < count; ++k)
+                        for (size_t k = 0; k < count; ++k)
                         {
                             LLMatrix4 mat;
 
@@ -1531,7 +1531,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
         //with the skeleton are not stored in the same order as they are in the exported joint buffer.
         //This remaps the skeletal joints to be in the same order as the joints stored in the model.
         std::vector<std::string> :: const_iterator jointIt  = model->mSkinInfo.mJointNames.begin();
-        const int jointCnt = model->mSkinInfo.mJointNames.size();
+        const int jointCnt = static_cast<int>(model->mSkinInfo.mJointNames.size());
         for ( int i=0; i<jointCnt; ++i, ++jointIt )
         {
             std::string lookingForJoint = (*jointIt).c_str();
@@ -1550,7 +1550,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
             }
         }
 
-        U32 bind_count = model->mSkinInfo.mAlternateBindMatrix.size();
+        auto bind_count = model->mSkinInfo.mAlternateBindMatrix.size();
         if (bind_count > 0 && bind_count != jointCnt)
         {
             LL_WARNS("Mesh") << "Model " << model->mLabel << " has invalid joint bind matrix list." << LL_ENDL;
@@ -1699,8 +1699,8 @@ void LLDAELoader::buildJointToNodeMappingFromScene( daeElement* pRoot )
     if ( pScene )
     {
         daeTArray< daeSmartRef<daeElement> > children = pScene->getChildren();
-        S32 childCount = children.getCount();
-        for (S32 i = 0; i < childCount; ++i)
+        auto childCount = children.getCount();
+        for (size_t i = 0; i < childCount; ++i)
         {
             domNode* pNode = daeSafeCast<domNode>(children[i]);
             processJointToNodeMapping( pNode );
@@ -1745,8 +1745,8 @@ void LLDAELoader::processJointToNodeMapping( domNode* pNode )
 void LLDAELoader::processChildJoints( domNode* pParentNode )
 {
     daeTArray< daeSmartRef<daeElement> > childOfChild = pParentNode->getChildren();
-    S32 childOfChildCount = childOfChild.getCount();
-    for (S32 i = 0; i < childOfChildCount; ++i)
+    auto childOfChildCount = childOfChild.getCount();
+    for (size_t i = 0; i < childOfChildCount; ++i)
     {
         domNode* pChildNode = daeSafeCast<domNode>( childOfChild[i] );
         if ( pChildNode )
@@ -1847,7 +1847,7 @@ bool LLDAELoader::verifyController( domController* pController )
             {
                 sum += pVertexWeights->getVcount()->getValue()[i];
             }
-            result = verifyCount( sum * inputs.getCount(), (domInt) pVertexWeights->getV()->getValue().getCount() );
+            result = verifyCount( sum * static_cast<U32>(inputs.getCount()), (domInt) static_cast<int>(pVertexWeights->getV()->getValue().getCount()) );
         }
     }
 
@@ -1980,9 +1980,9 @@ void LLDAELoader::processJointNode( domNode* pNode, JointTransformMap& jointTran
 
     //Gather and handle the incoming nodes children
     daeTArray< daeSmartRef<daeElement> > childOfChild = pNode->getChildren();
-    S32 childOfChildCount = childOfChild.getCount();
+    auto childOfChildCount = childOfChild.getCount();
 
-    for (S32 i = 0; i < childOfChildCount; ++i)
+    for (size_t i = 0; i < childOfChildCount; ++i)
     {
         domNode* pChildNode = daeSafeCast<domNode>( childOfChild[i] );
         if ( pChildNode )
@@ -2192,8 +2192,8 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
 
     //process children
     daeTArray< daeSmartRef<daeElement> > children = element->getChildren();
-    int childCount = children.getCount();
-    for (S32 i = 0; i < childCount; i++)
+    auto childCount = children.getCount();
+    for (size_t i = 0; i < childCount; i++)
     {
         processElement(children[i],badElement, dae);
     }
@@ -2568,7 +2568,7 @@ bool LLDAELoader::loadModelsFromDomMesh(domMesh* mesh, std::vector<LLModel*>& mo
             ret->remapVolumeFaces();
         }
 
-        volume_faces = remainder.size();
+        volume_faces = static_cast<U32>(remainder.size());
 
         models_out.push_back(ret);
 

--- a/indra/llprimitive/llgltfloader.cpp
+++ b/indra/llprimitive/llgltfloader.cpp
@@ -231,7 +231,7 @@ bool LLGLTFLoader::parseMaterials()
         image.numChannels     = in_image.component;
         image.bytesPerChannel = in_image.bits >> 3;     // Convert bits to bytes
         image.pixelType       = in_image.pixel_type;    // Maps exactly, i.e. TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE == GL_UNSIGNED_BYTE, etc
-        image.size            = in_image.image.size();
+        image.size            = static_cast<U32>(in_image.image.size());
         image.height          = in_image.height;
         image.width           = in_image.width;
         image.data            = in_image.image.data();

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -180,7 +180,7 @@ bool LLGLTFMaterial::fromJSON(const std::string& json, std::string& warn_msg, st
 
     tinygltf::Model model_in;
 
-    if (gltf.LoadASCIIFromString(&model_in, &error_msg, &warn_msg, json.c_str(), json.length(), ""))
+    if (gltf.LoadASCIIFromString(&model_in, &error_msg, &warn_msg, json.c_str(), static_cast<unsigned int>(json.length()), ""))
     {
         setFromModel(model_in, 0);
 

--- a/indra/llprimitive/llgltfmaterial_templates.h
+++ b/indra/llprimitive/llgltfmaterial_templates.h
@@ -87,12 +87,12 @@ void LLGLTFMaterial::setFromTexture(const tinygltf::Model& model, const T& textu
 template<typename T>
 void LLGLTFMaterial::allocateTextureImage(tinygltf::Model& model, T& texture_info, const std::string& uri)
 {
-    const S32 image_idx = model.images.size();
+    const S32 image_idx = static_cast<S32>(model.images.size());
     model.images.emplace_back();
     model.images[image_idx].uri = uri;
 
     // The texture, not to be confused with the texture info
-    const S32 texture_idx = model.textures.size();
+    const S32 texture_idx = static_cast<S32>(model.textures.size());
     model.textures.emplace_back();
     tinygltf::Texture& texture = model.textures[texture_idx];
     texture.source = image_idx;

--- a/indra/llprimitive/llmediaentry.cpp
+++ b/indra/llprimitive/llmediaentry.cpp
@@ -353,7 +353,7 @@ U32 LLMediaEntry::setWhiteList( const std::vector<std::string> &whitelist )
 {
     // *NOTE: This code is VERY similar to the setWhitelist below.
     // IF YOU CHANGE THIS IMPLEMENTATION, BE SURE TO CHANGE THE OTHER!
-    U32 size = 0;
+    size_t size = 0;
     U32 count = 0;
     // First count to make sure the size constraint is not violated
     std::vector<std::string>::const_iterator iter = whitelist.begin();
@@ -394,7 +394,7 @@ U32 LLMediaEntry::setWhiteList( const LLSD &whitelist )
     {
         // *NOTE: This code is VERY similar to the setWhitelist above.
         // IF YOU CHANGE THIS IMPLEMENTATION, BE SURE TO CHANGE THE OTHER!
-        U32 size = 0;
+        size_t size = 0;
         U32 count = 0;
         // First check to make sure the size and count constraints are not violated
         LLSD::array_const_iterator iter = whitelist.beginArray();

--- a/indra/llprimitive/llmodel.cpp
+++ b/indra/llprimitive/llmodel.cpp
@@ -918,7 +918,7 @@ LLSD LLModel::writeModel(
                         //copy ostr to binary buffer
                         std::string data = ostr.str();
                         const U8* buff = (U8*)data.data();
-                        U32 bytes = data.size();
+                        U32 bytes = static_cast<U32>(data.size());
 
                         LLSD::Binary w(bytes);
                         for (U32 j = 0; j < bytes; ++j)
@@ -965,7 +965,7 @@ LLSD LLModel::writeModelToStream(std::ostream& ostr, LLSD& mdl, bool nowrite, bo
     { //write out skin block
         skin = zip_llsd(mdl["skin"]);
 
-        U32 size = skin.size();
+        U32 size = static_cast<U32>(skin.size());
         if (size > 0)
         {
             header["skin"]["offset"] = (LLSD::Integer) cur_offset;
@@ -980,7 +980,7 @@ LLSD LLModel::writeModelToStream(std::ostream& ostr, LLSD& mdl, bool nowrite, bo
     { //write out convex decomposition
         decomposition = zip_llsd(mdl["physics_convex"]);
 
-        U32 size = decomposition.size();
+        U32 size = static_cast<U32>(decomposition.size());
         if (size > 0)
         {
             header["physics_convex"]["offset"] = (LLSD::Integer) cur_offset;
@@ -1002,7 +1002,7 @@ LLSD LLModel::writeModelToStream(std::ostream& ostr, LLSD& mdl, bool nowrite, bo
         {
             out[i] = zip_llsd(mdl[model_names[i]]);
 
-            U32 size = out[i].size();
+            U32 size = static_cast<U32>(out[i].size());
 
             header[model_names[i]]["offset"] = (LLSD::Integer) cur_offset;
             header[model_names[i]]["size"] = (LLSD::Integer) size;
@@ -1159,7 +1159,7 @@ void LLModel::updateHullCenters()
         mCenterOfHullCenters += cur_center;
         cur_center *= 1.f/mPhysics.mHull[i].size();
         mHullCenter[i] = cur_center;
-        mHullPoints += mPhysics.mHull[i].size();
+        mHullPoints += static_cast<U32>(mPhysics.mHull[i].size());
     }
 
     if (mHullPoints > 0)
@@ -1280,14 +1280,14 @@ bool LLModel::loadModel(std::istream& is)
 
 bool LLModel::isMaterialListSubset( LLModel* ref )
 {
-    int refCnt = ref->mMaterialList.size();
-    int modelCnt = mMaterialList.size();
+    auto refCnt = ref->mMaterialList.size();
+    auto modelCnt = mMaterialList.size();
 
-    for (U32 src = 0; src < modelCnt; ++src)
+    for (size_t src = 0; src < modelCnt; ++src)
     {
         bool foundRef = false;
 
-        for (U32 dst = 0; dst < refCnt; ++dst)
+        for (size_t dst = 0; dst < refCnt; ++dst)
         {
             //LL_INFOS()<<mMaterialList[src]<<" "<<ref->mMaterialList[dst]<<LL_ENDL;
             foundRef = mMaterialList[src] == ref->mMaterialList[dst];
@@ -1630,15 +1630,15 @@ U32 LLMeshSkinInfo::sizeBytes() const
 {
     U32 res = sizeof(LLUUID); // mMeshID
 
-    res += sizeof(std::vector<std::string>) + sizeof(std::string) * mJointNames.size();
+    res += sizeof(std::vector<std::string>) + sizeof(std::string) * static_cast<U32>(mJointNames.size());
     for (U32 i = 0; i < mJointNames.size(); ++i)
     {
-        res += mJointNames[i].size(); // actual size, not capacity
+        res += static_cast<U32>(mJointNames[i].size()); // actual size, not capacity
     }
 
-    res += sizeof(std::vector<S32>) + sizeof(S32) * mJointNums.size();
-    res += sizeof(std::vector<LLMatrix4>) + 16 * sizeof(float) * mInvBindMatrix.size();
-    res += sizeof(std::vector<LLMatrix4>) + 16 * sizeof(float) * mAlternateBindMatrix.size();
+    res += sizeof(std::vector<S32>) + sizeof(S32) * static_cast<U32>(mJointNums.size());
+    res += sizeof(std::vector<LLMatrix4>) + 16 * sizeof(float) * static_cast<U32>(mInvBindMatrix.size());
+    res += sizeof(std::vector<LLMatrix4>) + 16 * sizeof(float) * static_cast<U32>(mAlternateBindMatrix.size());
     res += 16 * sizeof(float); //mBindShapeMatrix
     res += sizeof(float) + 3 * sizeof(bool);
 
@@ -1755,15 +1755,15 @@ U32 LLModel::Decomposition::sizeBytes() const
 {
     U32 res = sizeof(LLUUID); // mMeshID
 
-    res += sizeof(LLModel::convex_hull_decomposition) + sizeof(std::vector<LLVector3>) * mHull.size();
+    res += sizeof(LLModel::convex_hull_decomposition) + sizeof(std::vector<LLVector3>) * static_cast<U32>(mHull.size());
     for (U32 i = 0; i < mHull.size(); ++i)
     {
-        res += mHull[i].size() * sizeof(LLVector3);
+        res += static_cast<U32>(mHull[i].size()) * sizeof(LLVector3);
     }
 
-    res += sizeof(LLModel::hull) + sizeof(LLVector3) * mBaseHull.size();
+    res += sizeof(LLModel::hull) + sizeof(LLVector3) * static_cast<U32>(mBaseHull.size());
 
-    res += sizeof(std::vector<LLModel::PhysicsMesh>) + sizeof(std::vector<LLModel::PhysicsMesh>) * mMesh.size();
+    res += sizeof(std::vector<LLModel::PhysicsMesh>) + sizeof(std::vector<LLModel::PhysicsMesh>) * static_cast<U32>(mMesh.size());
     for (U32 i = 0; i < mMesh.size(); ++i)
     {
         res += mMesh[i].sizeBytes();
@@ -1814,7 +1814,7 @@ LLSD LLModel::Decomposition::asLLSD() const
 
     for (U32 i = 0; i < mHull.size(); ++i)
     {
-        U32 size = mHull[i].size();
+        U32 size = static_cast<U32>(mHull[i].size());
         total += size;
         hulls[i] = (U8) (size);
 

--- a/indra/llprimitive/llmodel.h
+++ b/indra/llprimitive/llmodel.h
@@ -122,8 +122,8 @@ public:
         U32 sizeBytes() const
         {
             U32 res = sizeof(std::vector<LLVector3>) * 2;
-            res += sizeof(LLVector3) * mPositions.size();
-            res += sizeof(LLVector3) * mNormals.size();
+            res += sizeof(LLVector3) * static_cast<U32>(mPositions.size());
+            res += sizeof(LLVector3) * static_cast<U32>(mNormals.size());
             return res;
         }
     };

--- a/indra/llprimitive/llmodel.h
+++ b/indra/llprimitive/llmodel.h
@@ -357,7 +357,7 @@ public:
 protected:
 
     LLUUID      mDiffuseMapID;
-    void*           mOpaqueData;    // allow refs to viewer/platform-specific structs for each material
+    void*       mOpaqueData{ nullptr };    // allow refs to viewer/platform-specific structs for each material
     // currently only stores an LLPointer< LLViewerFetchedTexture > > to
     // maintain refs to textures associated with each material for free
     // ref counting.

--- a/indra/llprimitive/llprimtexturelist.cpp
+++ b/indra/llprimitive/llprimtexturelist.cpp
@@ -83,13 +83,13 @@ void LLPrimTextureList::clear()
 void LLPrimTextureList::copy(const LLPrimTextureList& other_list)
 {
     // compare the sizes
-    S32 this_size = mEntryList.size();
-    S32 other_size = other_list.mEntryList.size();
+    auto this_size = mEntryList.size();
+    auto other_size = other_list.mEntryList.size();
 
     if (this_size > other_size)
     {
         // remove the extra entries
-        for (S32 index = this_size; index > other_size; --index)
+        for (size_t index = this_size; index > other_size; --index)
         {
             delete mEntryList[index-1];
         }
@@ -97,18 +97,18 @@ void LLPrimTextureList::copy(const LLPrimTextureList& other_list)
         this_size = other_size;
     }
 
-    S32 index = 0;
+    size_t index = 0;
     // copy for the entries that already exist
     for ( ; index < this_size; ++index)
     {
         delete mEntryList[index];
-        mEntryList[index] = other_list.getTexture(index)->newCopy();
+        mEntryList[index] = other_list.getTexture(static_cast<U8>(index))->newCopy();
     }
 
     // add new entires if needed
     for ( ; index < other_size; ++index)
     {
-        mEntryList.push_back( other_list.getTexture(index)->newCopy() );
+        mEntryList.push_back( other_list.getTexture(static_cast<U8>(index))->newCopy());
     }
 }
 
@@ -127,9 +127,9 @@ void LLPrimTextureList::take(LLPrimTextureList& other_list)
 // returns TEM_CHANGE_TEXTURE if successful, otherwise TEM_CHANGE_NONE
 S32 LLPrimTextureList::copyTexture(const U8 index, const LLTextureEntry& te)
 {
-    if (S32(index) >= mEntryList.size())
+    if (size_t(index) >= mEntryList.size())
     {
-        S32 current_size = mEntryList.size();
+        auto current_size = mEntryList.size();
         LL_WARNS() << "ignore copy of index = " << S32(index) << " into texture entry list of size = " << current_size << LL_ENDL;
         return TEM_CHANGE_NONE;
     }
@@ -389,7 +389,7 @@ LLMaterialPtr LLPrimTextureList::getMaterialParams(const U8 index)
 
 S32 LLPrimTextureList::size() const
 {
-    return mEntryList.size();
+    return static_cast<S32>(mEntryList.size());
 }
 
 // sets the size of the mEntryList container
@@ -400,12 +400,12 @@ void LLPrimTextureList::setSize(S32 new_size)
         new_size = 0;
     }
 
-    S32 current_size = mEntryList.size();
+    auto current_size = mEntryList.size();
 
     if (new_size > current_size)
     {
         mEntryList.resize(new_size);
-        for (S32 index = current_size; index < new_size; ++index)
+        for (size_t index = current_size; index < new_size; ++index)
         {
             if (current_size > 0
                 && mEntryList[current_size - 1])
@@ -423,7 +423,7 @@ void LLPrimTextureList::setSize(S32 new_size)
     }
     else if (new_size < current_size)
     {
-        for (S32 index = current_size-1; index >= new_size; --index)
+        for (size_t index = current_size-1; index >= new_size; --index)
         {
             delete mEntryList[index];
         }

--- a/indra/llprimitive/tests/llprimitive_test.cpp
+++ b/indra/llprimitive/tests/llprimitive_test.cpp
@@ -109,7 +109,7 @@ void LLPrimTextureList::take(LLPrimTextureList &other_list) { }
 void LLPrimTextureList::setSize(S32 new_size) { mEntryList.resize(new_size); }
 void LLPrimTextureList::setAllIDs(const LLUUID &id) { }
 LLTextureEntry * LLPrimTextureList::getTexture(const U8 index) const { return nullptr; }
-S32 LLPrimTextureList::size() const { return mEntryList.size(); }
+S32 LLPrimTextureList::size() const { return static_cast<S32>(mEntryList.size()); }
 
 class PRIMITIVE_TEST_SETUP
 {

--- a/indra/llrender/llfontbitmapcache.cpp
+++ b/indra/llrender/llfontbitmapcache.cpp
@@ -108,7 +108,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32& pos_x, S32& pos_y, EFontGlyp
 
             S32 num_components = getNumComponents(bitmap_type);
             mImageRawVec[bitmap_idx].push_back(new LLImageRaw(mBitmapWidth, mBitmapHeight, num_components));
-            bitmap_num = mImageRawVec[bitmap_idx].size() - 1;
+            bitmap_num = static_cast<U32>(mImageRawVec[bitmap_idx].size()) - 1;
 
             LLImageRaw* image_raw = getImageRaw(bitmap_type, bitmap_num);
             if (EFontGlyphType::Grayscale == bitmap_type)

--- a/indra/llrender/llfontbitmapcache.h
+++ b/indra/llrender/llfontbitmapcache.h
@@ -60,7 +60,7 @@ public:
     LLImageGL* getImageGL(EFontGlyphType bitmapType, U32 bitmapNum) const;
 
     S32 getMaxCharWidth() const { return mMaxCharWidth; }
-    U32 getNumBitmaps(EFontGlyphType bitmapType) const { return (bitmapType < EFontGlyphType::Count) ? mImageRawVec[static_cast<U32>(bitmapType)].size() : 0; }
+    U32 getNumBitmaps(EFontGlyphType bitmapType) const { return (bitmapType < EFontGlyphType::Count) ? static_cast<U32>(mImageRawVec[static_cast<U32>(bitmapType)].size()) : 0U; }
     S32 getBitmapWidth() const { return mBitmapWidth; }
     S32 getBitmapHeight() const { return mBitmapHeight; }
 

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -328,7 +328,7 @@ S32 LLFontFreetype::ftOpenFace(const std::string& filename, S32 face_n)
         pFtStream = new LLFT_Stream();
         pFtStream->base = 0;
         pFtStream->pos = 0;
-        pFtStream->size = file_size;
+        pFtStream->size = static_cast<unsigned long>(file_size);
         pFtStream->descriptor.pointer = pFileStream;
         pFtStream->read = ft_read_cb;
         pFtStream->close = ft_close_cb;

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -149,7 +149,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
     if(!sDisplayFont) //do not display texts
     {
-        return wstr.length() ;
+        return static_cast<S32>(wstr.length());
     }
 
     if (wstr.empty())

--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -621,7 +621,7 @@ bool LLGLSLShader::mapAttributes(const std::vector<LLStaticHashedString>* attrib
     }
 
     mAttribute.clear();
-    U32 numAttributes = (attributes == NULL) ? 0 : attributes->size();
+    U32 numAttributes = (attributes == NULL) ? 0U : static_cast<U32>(attributes->size());
 #if LL_RELEASE_WITH_DEBUG_INFO
     mAttribute.resize(LLShaderMgr::instance()->mReservedAttribs.size() + numAttributes, { -1, NULL });
 #else
@@ -843,7 +843,7 @@ bool LLGLSLShader::mapUniforms(const vector<LLStaticHashedString>* uniforms)
     mTexture.clear();
     mValue.clear();
     //initialize arrays
-    U32 numUniforms = (uniforms == NULL) ? 0 : uniforms->size();
+    U32 numUniforms = (uniforms == NULL) ? 0U : static_cast<U32>(uniforms->size());
     mUniform.resize(numUniforms + LLShaderMgr::instance()->mReservedUniforms.size(), -1);
     mTexture.resize(numUniforms + LLShaderMgr::instance()->mReservedUniforms.size(), -1);
 

--- a/indra/llrender/llglslshader.h
+++ b/indra/llrender/llglslshader.h
@@ -68,8 +68,8 @@ public:
     template<typename T>
     struct UniformSetting
     {
-        S32 mUniform;
-        T mValue;
+        S32 mUniform{ 0 };
+        T mValue{};
     };
 
     typedef UniformSetting<S32> IntSetting;

--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -208,7 +208,7 @@ bool LLRenderTarget::addColorAttachment(U32 color_fmt)
         return true;
     }
 
-    U32 offset = mTex.size();
+    U32 offset = static_cast<U32>(mTex.size());
 
     if( offset >= 4 )
     {
@@ -378,11 +378,11 @@ void LLRenderTarget::release()
     if (mFBO && (mTex.size() > 1))
     {
         glBindFramebuffer(GL_FRAMEBUFFER, mFBO);
-        S32 z;
+        size_t z;
         for (z = mTex.size() - 1; z >= 1; z--)
         {
             sBytesAllocated -= mResX*mResY*4;
-            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0+z, LLTexUnit::getInternalType(mUsage), 0, 0);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, static_cast<GLenum>(GL_COLOR_ATTACHMENT0+z), LLTexUnit::getInternalType(mUsage), 0, 0);
             LLImageGL::deleteTextures(1, &mTex[z]);
         }
         glBindFramebuffer(GL_FRAMEBUFFER, sCurFBO);
@@ -426,7 +426,7 @@ void LLRenderTarget::bindTarget()
                             GL_COLOR_ATTACHMENT1,
                             GL_COLOR_ATTACHMENT2,
                             GL_COLOR_ATTACHMENT3};
-    glDrawBuffers(mTex.size(), drawbuffers);
+    glDrawBuffers(static_cast<GLsizei>(mTex.size()), drawbuffers);
             
     if (mTex.empty())
     { //no color buffer to draw to
@@ -485,7 +485,7 @@ U32 LLRenderTarget::getTexture(U32 attachment) const
 
 U32 LLRenderTarget::getNumTextures() const
 {
-    return mTex.size();
+    return static_cast<U32>(mTex.size());
 }
 
 void LLRenderTarget::bindTexture(U32 index, S32 channel, LLTexUnit::eTextureFilterOptions filter_options)

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1096,7 +1096,7 @@ bool LLShaderMgr::saveCachedProgramBinary(LLGLSLShader* shader)
         program_binary.resize(binary_info.mBinaryLength);
 
         GLenum error = glGetError(); // Clear current error
-        glGetProgramBinary(shader->mProgramObject, program_binary.size() * sizeof(U8), nullptr, &binary_info.mBinaryFormat, program_binary.data());
+        glGetProgramBinary(shader->mProgramObject, static_cast<GLsizei>(program_binary.size() * sizeof(U8)), nullptr, &binary_info.mBinaryFormat, program_binary.data());
         error = glGetError();
         if (error == GL_NO_ERROR)
         {

--- a/indra/llui/llaccordionctrl.cpp
+++ b/indra/llui/llaccordionctrl.cpp
@@ -484,7 +484,7 @@ void LLAccordionCtrl::arrangeMultiple()
             if (mFitParent)
             {
                 // All expanded tabs will have equal height
-                panel_height = calcExpandedTabHeight(i, panel_top);
+                panel_height = calcExpandedTabHeight(static_cast<S32>(i), panel_top);
                 ctrlSetLeftTopAndSize(accordion_tab, panel_left, panel_top, panel_width, panel_height);
 
                 // Try to make accordion tab fit accordion view height.

--- a/indra/llui/llclipboard.cpp
+++ b/indra/llui/llclipboard.cpp
@@ -73,7 +73,7 @@ bool LLClipboard::addToClipboard(const LLUUID& src, const LLAssetType::EType typ
         if (LLAssetType::lookupIsAssetIDKnowable(type))
         {
             LLWString source = utf8str_to_wstring(src.asString());
-            res = addToClipboard(source, 0, source.size());
+            res = addToClipboard(source, 0, static_cast<S32>(source.size()));
         }
         if (res)
         {
@@ -87,13 +87,13 @@ bool LLClipboard::addToClipboard(const LLUUID& src, const LLAssetType::EType typ
 bool LLClipboard::pasteFromClipboard(std::vector<LLUUID>& inv_objects) const
 {
     bool res = false;
-    S32 count = mObjects.size();
+    auto count = mObjects.size();
     inv_objects.reserve(inv_objects.size() + count);
     if (count > 0)
     {
         res = true;
         inv_objects.clear();
-        for (S32 i = 0; i < count; i++)
+        for (size_t i = 0; i < count; i++)
         {
             inv_objects.push_back(mObjects[i]);
         }

--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -995,7 +995,7 @@ void LLComboBox::updateSelection()
         LLWString selected_item = utf8str_to_wstring(getSelectedItemLabel());
         LLWString wtext = left_wstring + selected_item.substr(left_wstring.size(), selected_item.size());
         mTextEntry->setText(wstring_to_utf8str(wtext));
-        mTextEntry->setSelection(left_wstring.size(), mTextEntry->getWText().size());
+        mTextEntry->setSelection(static_cast<S32>(left_wstring.size()), static_cast<S32>(mTextEntry->getWText().size()));
         mTextEntry->endSelection();
         mTextEntry->setTentative(false);
         mHasAutocompletedText = true;

--- a/indra/llui/llcommandmanager.cpp
+++ b/indra/llui/llcommandmanager.cpp
@@ -107,7 +107,7 @@ LLCommandManager::~LLCommandManager()
 
 U32 LLCommandManager::commandCount() const
 {
-    return mCommands.size();
+    return static_cast<U32>(mCommands.size());
 }
 
 LLCommand * LLCommandManager::getCommand(U32 commandIndex)

--- a/indra/llui/llcommandmanager.h
+++ b/indra/llui/llcommandmanager.h
@@ -198,7 +198,7 @@ protected:
     void addCommand(LLCommand * command);
 
 private:
-    typedef std::map<LLUUID, U32>       CommandIndexMap;
+    typedef std::map<LLUUID, size_t>    CommandIndexMap;
     typedef std::vector<LLCommand *>    CommandVector;
 
     CommandVector   mCommands;

--- a/indra/llui/llconsole.cpp
+++ b/indra/llui/llconsole.cpp
@@ -147,11 +147,11 @@ void LLConsole::draw()
         return;
     }
 
-    U32 num_lines=0;
+    size_t num_lines{ 0 };
 
     paragraph_t::reverse_iterator paragraph_it;
     paragraph_it = mParagraphs.rbegin();
-    U32 paragraph_num=mParagraphs.size();
+    auto paragraph_num=mParagraphs.size();
 
     while (!mParagraphs.empty() && paragraph_it != mParagraphs.rend())
     {
@@ -159,7 +159,7 @@ void LLConsole::draw()
         if(num_lines > mMaxLines
             || ( (mLinePersistTime > (F32)0.f) && ((*paragraph_it).mAddTime - skip_time)/(mLinePersistTime - mFadeTime) <= (F32)0.f))
         {                           //All lines above here are done.  Lose them.
-            for (U32 i=0;i<paragraph_num;i++)
+            for (size_t i = 0; i < paragraph_num; i++)
             {
                 if (!mParagraphs.empty())
                     mParagraphs.pop_front();
@@ -258,7 +258,7 @@ void LLConsole::Paragraph::makeParagraphColorSegments (const LLColor4 &color)
         ParagraphColorSegment color_segment;
 
         color_segment.mColor.setValue(color_llsd);
-        color_segment.mNumChars = color_str.length();
+        color_segment.mNumChars = static_cast<S32>(color_str.length());
 
         mParagraphColorSegments.push_back(color_segment);
     }
@@ -310,7 +310,7 @@ void LLConsole::Paragraph::updateLines(F32 screen_width, const LLFontGL* font, b
             skip_chars = 0;
         }
 
-        U32 drawable = font->maxDrawableChars(mParagraphText.c_str()+paragraph_offset, screen_width, line_end - paragraph_offset, LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+        U32 drawable = font->maxDrawableChars(mParagraphText.c_str()+paragraph_offset, screen_width, static_cast<S32>(line_end) - paragraph_offset, LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
 
         if (drawable != 0)
         {

--- a/indra/llui/llemojidictionary.cpp
+++ b/indra/llui/llemojidictionary.cpp
@@ -210,7 +210,7 @@ void LLEmojiDictionary::findByShortCode(
                 std::size_t begin, end;
                 if (searchInShortCode(begin, end, shortCode, needle))
                 {
-                    results[begin].emplace_back(d.Character, shortCode, begin, end);
+                    results[static_cast<llwchar>(begin)].emplace_back(d.Character, shortCode, begin, end);
                 }
             }
         }

--- a/indra/llui/llflatlistview.cpp
+++ b/indra/llui/llflatlistview.cpp
@@ -390,7 +390,7 @@ U32 LLFlatListView::size(const bool only_visible_items) const
     }
     else
     {
-        return mItemPairs.size();
+        return static_cast<U32>(mItemPairs.size());
     }
 }
 
@@ -563,7 +563,7 @@ void LLFlatListView::rearrangeItems()
     }
 
     // add paddings between items, excluding invisible ones
-    height += mItemPad * (mItemPairs.size() - invisible_children_count - 1);
+    height += mItemPad * (static_cast<S32>(mItemPairs.size()) - invisible_children_count - 1);
 
     LLRect rc = mItemsPanel->getRect();
     S32 width = mItemsNoScrollWidth;

--- a/indra/llui/llflatlistview.h
+++ b/indra/llui/llflatlistview.h
@@ -264,7 +264,7 @@ public:
     void setCommitOnSelectionChange(bool b)     { mCommitOnSelectionChange = b; }
 
     /** Get number of selected items in the list */
-    U32 numSelected() const {return mSelectedItemPairs.size(); }
+    U32 numSelected() const {return static_cast<U32>(mSelectedItemPairs.size()); }
 
     /** Get number of (visible) items in the list */
     U32 size(const bool only_visible_items = true) const;

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -758,7 +758,7 @@ void LLFolderView::removeSelectedItems()
         // items, since the removal will futz with internal data
         // structures.
         std::vector<LLFolderViewItem*> items;
-        S32 count = mSelectedItems.size();
+        auto count = mSelectedItems.size();
         if(count <= 0) return;
         LLFolderViewItem* item = NULL;
         selected_items_t::iterator item_it;
@@ -803,7 +803,7 @@ void LLFolderView::removeSelectedItems()
             setSelection(item_to_select, item_to_select ? item_to_select->isOpen() : false, mParentPanel.get()->hasFocus());
 
             listeners.reserve(count);
-            for(S32 i = 0; i < count; ++i)
+            for(size_t i = 0; i < count; ++i)
             {
                 listener = items[i]->getViewModelItem();
                 if(listener && (std::find(listeners.begin(), listeners.end(), listener) == listeners.end()))
@@ -922,7 +922,7 @@ void LLFolderView::copy()
 {
     // *NOTE: total hack to clear the inventory clipboard
     LLClipboard::instance().reset();
-    S32 count = mSelectedItems.size();
+    auto count = mSelectedItems.size();
     if(getVisible() && getEnabled() && (count > 0))
     {
         LLFolderViewModelItem* listener = NULL;
@@ -1059,7 +1059,7 @@ void LLFolderView::startRenamingSelectedItem( void )
     // make sure selection is visible
     scrollToShowSelection();
 
-    S32 count = mSelectedItems.size();
+    auto count = mSelectedItems.size();
     LLFolderViewItem* item = NULL;
     if(count > 0)
     {
@@ -1414,7 +1414,7 @@ bool LLFolderView::search(LLFolderViewItem* first_item, const std::string &searc
 
         std::string current_item_label(search_item->getViewModelItem()->getSearchableName());
         LLStringUtil::toUpper(current_item_label);
-        S32 search_string_length = llmin(upper_case_string.size(), current_item_label.size());
+        auto search_string_length = llmin(upper_case_string.size(), current_item_label.size());
         if (!current_item_label.compare(0, search_string_length, upper_case_string))
         {
             found = true;
@@ -1454,7 +1454,7 @@ bool LLFolderView::handleRightMouseDown( S32 x, S32 y, MASK mask )
     mParentPanel.get()->setFocus(true);
 
     bool handled = childrenHandleRightMouseDown(x, y, mask) != NULL;
-    S32 count = mSelectedItems.size();
+    auto count = mSelectedItems.size();
 
     LLMenuGL* menu = static_cast<LLMenuGL*>(mPopupMenuHandle.get());
     if (!menu)

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -940,22 +940,22 @@ void LLFolderViewItem::draw()
         return;
     }
 
-    std::string::size_type filter_string_length = mViewModelItem->hasFilterStringMatch() ? mViewModelItem->getFilterStringSize() : 0;
+    auto filter_string_length = mViewModelItem->hasFilterStringMatch() ? static_cast<S32>(mViewModelItem->getFilterStringSize()) : 0;
     F32 right_x  = 0;
     F32 y = (F32)getRect().getHeight() - font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
     F32 text_left = (F32)getLabelXPos();
     std::string combined_string = mLabel + mLabelSuffix;
 
     const LLFontGL* suffix_font = getLabelFontForStyle(LLFontGL::NORMAL);
-    S32 filter_offset = mViewModelItem->getFilterStringOffset();
+    S32 filter_offset = static_cast<S32>(mViewModelItem->getFilterStringOffset());
     if (filter_string_length > 0)
     {
         S32 bottom = llfloor(getRect().getHeight() - font->getLineHeight() - 3 - TOP_PAD);
         S32 top = getRect().getHeight() - TOP_PAD;
         if(mLabelSuffix.empty() || (font == suffix_font))
         {
-        S32 left = ll_round(text_left) + font->getWidth(combined_string, 0, mViewModelItem->getFilterStringOffset()) - 2;
-        S32 right = left + font->getWidth(combined_string, mViewModelItem->getFilterStringOffset(), filter_string_length) + 2;
+        S32 left = ll_round(text_left) + font->getWidth(combined_string, 0, static_cast<S32>(mViewModelItem->getFilterStringOffset())) - 2;
+        S32 right = left + font->getWidth(combined_string, static_cast<S32>(mViewModelItem->getFilterStringOffset()), filter_string_length) + 2;
 
         LLUIImage* box_image = default_params.selection_image;
         LLRect box_rect(left, top, right, bottom);
@@ -976,7 +976,7 @@ void LLFolderViewItem::draw()
             if(suffix_filter_length > 0)
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
-                S32 left = ll_round(text_left) + font->getWidthF32(mLabel, 0, mLabel.size()) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset) - 2;
+                S32 left = ll_round(text_left) + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset) - 2;
                 S32 right = left + suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length) + 2;
                 LLUIImage* box_image = default_params.selection_image;
                 LLRect box_rect(left, top, right, bottom);
@@ -1033,7 +1033,7 @@ void LLFolderViewItem::draw()
             if(suffix_filter_length > 0)
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
-                F32 match_string_left = text_left + font->getWidthF32(mLabel, 0, mLabel.size()) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset + suffix_filter_length) - suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length);
+                F32 match_string_left = text_left + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset + suffix_filter_length) - suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length);
                 F32 yy = (F32)getRect().getHeight() - suffix_font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
                 suffix_font->renderUTF8(mLabelSuffix, suffix_offset, match_string_left, yy, sFilterTextColor,
                     LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,

--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -39,7 +39,7 @@ inline bool LLKeywordToken::isHead(const llwchar* s) const
     // strncmp is much faster than string compare
     bool res = true;
     const llwchar* t = mToken.c_str();
-    S32 len = mToken.size();
+    auto len = mToken.size();
     for (S32 i=0; i<len; i++)
     {
         if (s[i] != t[i])
@@ -55,7 +55,7 @@ inline bool LLKeywordToken::isTail(const llwchar* s) const
 {
     bool res = true;
     const llwchar* t = mDelimiter.c_str();
-    S32 len = mDelimiter.size();
+    auto len = mDelimiter.size();
     for (S32 i=0; i<len; i++)
     {
         if (s[i] != t[i])
@@ -134,7 +134,7 @@ std::string LLKeywords::getArguments(LLSD& arguments)
 
     if (arguments.isArray())
     {
-        U32 argsCount = arguments.size();
+        auto argsCount = arguments.size();
         LLSD::array_iterator arrayIt = arguments.beginArray();
         for ( ; arrayIt != arguments.endArray(); ++arrayIt)
         {
@@ -489,7 +489,7 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
         return;
     }
 
-    S32 text_len = wtext.size() + 1;
+    S32 text_len = static_cast<S32>(wtext.size()) + 1;
 
     seg_list->push_back( new LLNormalTextSegment( style, 0, text_len, editor ) );
 
@@ -707,16 +707,16 @@ void LLKeywords::insertSegments(const LLWString& wtext, std::vector<LLTextSegmen
     {
         if (pos!=seg_start)
         {
-            LLTextSegmentPtr text_segment = new LLNormalTextSegment(cur_token_style, seg_start, pos, editor);
+            LLTextSegmentPtr text_segment = new LLNormalTextSegment(cur_token_style, seg_start, static_cast<S32>(pos), editor);
             text_segment->setToken( cur_token );
             insertSegment( seg_list, text_segment, text_len, style, editor);
         }
 
-        LLTextSegmentPtr text_segment = new LLLineBreakTextSegment(style, pos);
+        LLTextSegmentPtr text_segment = new LLLineBreakTextSegment(style, static_cast<S32>(pos));
         text_segment->setToken( cur_token );
         insertSegment( seg_list, text_segment, text_len, style, editor);
 
-        seg_start = pos+1;
+        seg_start = static_cast<S32>(pos) + 1;
         pos = wtext.find('\n',seg_start);
     }
 

--- a/indra/llui/llkeywords.h
+++ b/indra/llui/llkeywords.h
@@ -82,8 +82,8 @@ public:
     {
     }
 
-    S32                 getLengthHead() const   { return mToken.size(); }
-    S32                 getLengthTail() const   { return mDelimiter.size(); }
+    S32                 getLengthHead() const   { return static_cast<S32>(mToken.size()); }
+    S32                 getLengthTail() const   { return static_cast<S32>(mDelimiter.size()); }
     bool                isHead(const llwchar* s) const;
     bool                isTail(const llwchar* s) const;
     const LLWString&    getToken() const        { return mToken; }

--- a/indra/llui/lllayoutstack.h
+++ b/indra/llui/lllayoutstack.h
@@ -86,7 +86,7 @@ public:
 
     void addPanel(LLLayoutPanel* panel, EAnimate animate = NO_ANIMATE);
     void collapsePanel(LLPanel* panel, bool collapsed = true);
-    S32 getNumPanels() { return mPanels.size(); }
+    S32 getNumPanels() { return static_cast<S32>(mPanels.size()); }
 
     void updateLayout();
 

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -590,7 +590,7 @@ const std::string& LLLineEditor::getSuggestion(U32 index) const
 
 U32 LLLineEditor::getSuggestionCount() const
 {
-    return mSuggestionList.size();
+    return static_cast<U32>(mSuggestionList.size());
 }
 
 void LLLineEditor::replaceWithSuggestion(U32 index)
@@ -994,7 +994,7 @@ void LLLineEditor::addChar(const llwchar uni_char)
         mText.erase(getCursor(), 1);
     }
 
-    S32 cur_bytes = mText.getString().size();
+    S32 cur_bytes = static_cast<S32>(mText.getString().size());
 
     S32 new_bytes = wchar_utf8_length(new_c);
 
@@ -1007,7 +1007,7 @@ void LLLineEditor::addChar(const llwchar uni_char)
     }
     else if (mMaxLengthChars)
     {
-        S32 wide_chars = mText.getWString().size();
+        auto wide_chars = mText.getWString().size();
         if ((wide_chars + 1) > mMaxLengthChars)
         {
             allow_char = false;
@@ -1332,7 +1332,7 @@ void LLLineEditor::pasteHelper(bool is_primary)
 
             if (mMaxLengthChars)
             {
-                U32 available_chars = mMaxLengthChars - mText.getWString().size();
+                auto available_chars = mMaxLengthChars - mText.getWString().size();
 
                 if (available_chars < clean_string.size())
                 {
@@ -2300,10 +2300,10 @@ bool LLLineEditor::postvalidateFloat(const std::string &str)
 
     LLWString trimmed = utf8str_to_wstring(str);
     LLWStringUtil::trim(trimmed);
-    S32 len = trimmed.length();
+    auto len = trimmed.length();
     if( 0 < len )
     {
-        S32 i = 0;
+        size_t i = 0;
 
         // First character can be a negative sign
         if( '-' == trimmed[0] )
@@ -2360,7 +2360,7 @@ bool LLLineEditor::evaluateFloat()
     if (!success)
     {
         // Move the cursor to near the error on failure
-        setCursor(LLCalc::getInstance()->getLastErrorPos());
+        setCursor(static_cast<S32>(LLCalc::getInstance()->getLastErrorPos()));
         // *TODO: Translated error message indicating the type of error? Select error text?
     }
     else
@@ -2501,7 +2501,7 @@ void LLLineEditor::updatePreedit(const LLWString &preedit_string,
     if (LL_KIM_OVERWRITE == gKeyboard->getInsertMode())
     {
         mPreeditOverwrittenWString.assign( LLWString( mText, insert_preedit_at, mPreeditWString.length() ) );
-        mText.erase(insert_preedit_at, mPreeditWString.length());
+        mText.erase(insert_preedit_at, static_cast<S32>(mPreeditWString.length()));
     }
     else
     {

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -187,7 +187,7 @@ LLMenuItemGL::LLMenuItemGL(const LLMenuItemGL::Params& p)
     {
         mAcceleratorMask |= MASK_SHIFT;
     }
-    S32 pipe_pos = shortcut.rfind("|");
+    auto pipe_pos = shortcut.rfind("|");
     std::string key_str = shortcut.substr(pipe_pos+1);
 
     LLKeyboard::keyFromString(key_str, &mAcceleratorKey);
@@ -545,8 +545,8 @@ void LLMenuItemGL::draw( void )
         std::string::size_type offset = upper_case_label.find(mJumpKey);
         if (offset != std::string::npos)
         {
-            S32 x_begin = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, offset);
-            S32 x_end = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, offset + 1);
+            S32 x_begin = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, static_cast<S32>(offset));
+            S32 x_end = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, static_cast<S32>(offset) + 1);
             gl_line_2d(x_begin, (MENU_ITEM_PADDING / 2) + 1, x_end, (MENU_ITEM_PADDING / 2) + 1);
         }
     }
@@ -1649,8 +1649,8 @@ void LLMenuItemBranchDownGL::draw( void )
         if (offset != std::string::npos)
         {
             S32 x_offset = ll_round((F32)getRect().getWidth() / 2.f - getFont()->getWidthF32(mLabel.getString(), 0, S32_MAX) / 2.f);
-            S32 x_begin = x_offset + getFont()->getWidth(mLabel, 0, offset);
-            S32 x_end = x_offset + getFont()->getWidth(mLabel, 0, offset + 1);
+            S32 x_begin = x_offset + getFont()->getWidth(mLabel, 0, static_cast<S32>(offset));
+            S32 x_end = x_offset + getFont()->getWidth(mLabel, 0, static_cast<S32>(offset) + 1);
             gl_line_2d(x_begin, LABEL_BOTTOM_PAD_PIXELS, x_end, LABEL_BOTTOM_PAD_PIXELS);
         }
     }
@@ -2068,7 +2068,7 @@ bool LLMenuGL::scrollItems(EScrollingDirection direction)
         // Otherwise viewer will hang for a time needed to scroll U32_MAX
         // times in std::advance(). STORM-659.
         size_t nitems = mItems.size();
-        U32 scrollable_items = nitems < mMaxScrollableItems ? nitems : mMaxScrollableItems;
+        U32 scrollable_items = nitems < mMaxScrollableItems ? static_cast<U32>(nitems) : mMaxScrollableItems;
 
         // Advance by mMaxScrollableItems back from the end of the list
         // to make the last item visible.
@@ -2594,7 +2594,7 @@ void LLMenuGL::empty( void )
 // erase group of items from menu
 void LLMenuGL::erase( S32 begin, S32 end, bool arrange/* = true*/)
 {
-    S32 items = mItems.size();
+    auto items = mItems.size();
 
     if ( items == 0 || begin >= end || begin < 0 || end > items )
     {
@@ -2813,7 +2813,7 @@ void LLMenuGL::setTornOff(bool torn_off)
 
 U32 LLMenuGL::getItemCount()
 {
-    return mItems.size();
+    return static_cast<U32>(mItems.size());
 }
 
 LLMenuItemGL* LLMenuGL::getItem(S32 number)

--- a/indra/llui/llmodaldialog.h
+++ b/indra/llui/llmodaldialog.h
@@ -66,7 +66,7 @@ public:
     static void     onAppFocusLost();
     static void     onAppFocusGained();
 
-    static S32      activeCount() { return sModalStack.size(); }
+    static S32      activeCount() { return static_cast<S32>(sModalStack.size()); }
     static void     shutdownModals();
 
 protected:

--- a/indra/llui/llmultislider.h
+++ b/indra/llui/llmultislider.h
@@ -118,7 +118,7 @@ public:
     /*virtual*/ void    draw() override;
 
     S32             getMaxNumSliders() { return mMaxNumSliders; }
-    S32             getCurNumSliders() { return mValue.size(); }
+    S32             getCurNumSliders() { return static_cast<S32>(mValue.size()); }
     F32             getOverlapThreshold() { return mOverlapThreshold; }
     bool            canAddSliders() { return mValue.size() < mMaxNumSliders; }
 

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -1187,7 +1187,7 @@ bool LLNotificationChannel::isEmpty() const
 
 S32 LLNotificationChannel::size() const
 {
-    return mItems.size();
+    return static_cast<S32>(mItems.size());
 }
 
 size_t LLNotificationChannel::size()

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -249,7 +249,7 @@ public:
     void fromLLSD(const LLSD& sd);
     LLSD asLLSD() const;
 
-    S32 getNumElements() { return mFormData.size(); }
+    S32 getNumElements() { return static_cast<S32>(mFormData.size()); }
     LLSD getElement(S32 index) { return mFormData.get(index); }
     LLSD getElement(const std::string& element_name);
     void getElements(LLSD& elements, S32 offset = 0);

--- a/indra/llui/llradiogroup.h
+++ b/indra/llui/llradiogroup.h
@@ -87,7 +87,7 @@ public:
     LLCtrlSelectionInterface* getSelectionInterface()   { return (LLCtrlSelectionInterface*)this; };
 
     // LLCtrlSelectionInterface functions
-    /*virtual*/ S32     getItemCount() const                { return mRadioButtons.size(); }
+    /*virtual*/ S32     getItemCount() const                { return static_cast<S32>(mRadioButtons.size()); }
     /*virtual*/ bool    getCanSelect() const                { return true; }
     /*virtual*/ bool    selectFirstItem()                   { return setSelectedIndex(0); }
     /*virtual*/ bool    selectNthItem( S32 index )          { return setSelectedIndex(index); }

--- a/indra/llui/llresmgr.cpp
+++ b/indra/llui/llresmgr.cpp
@@ -140,7 +140,7 @@ std::string LLResMgr::getMonetaryString( S32 input ) const
     S32 output_pos = 0;
 
     cur_group = 0;
-    S32 pos = digits.size()-1;
+    auto pos = digits.size()-1;
     S32 count_within_group = 0;
     while( (pos >= 0) && (groupings[cur_group] >= 0) )
     {

--- a/indra/llui/llscrolllistctrl.cpp
+++ b/indra/llui/llscrolllistctrl.cpp
@@ -373,7 +373,7 @@ S32 LLScrollListCtrl::isEmpty() const
 
 S32 LLScrollListCtrl::getItemCount() const
 {
-    return mItemList.size();
+    return static_cast<S32>(mItemList.size());
 }
 
 bool LLScrollListCtrl::hasSelectedItem() const
@@ -1325,7 +1325,7 @@ bool LLScrollListCtrl::selectItemByPrefix(const LLWString& target, bool case_sen
     bool found = false;
 
     LLWString target_trimmed( target );
-    S32 target_len = target_trimmed.size();
+    auto target_len = target_trimmed.size();
 
     if( 0 == target_len )
     {
@@ -1377,8 +1377,8 @@ bool LLScrollListCtrl::selectItemByPrefix(const LLWString& target, bool case_sen
             if (select)
             {
                 // find offset of matching text (might have leading whitespace)
-                S32 offset = item_label.find(target_trimmed);
-                cellp->highlightText(offset, target_trimmed.size());
+                auto offset = item_label.find(target_trimmed);
+                cellp->highlightText(static_cast<S32>(offset), static_cast<S32>(target_trimmed.size()));
                 selectItem(item, -1);
                 found = true;
                 break;
@@ -1404,7 +1404,7 @@ U32 LLScrollListCtrl::searchItems(const LLWString& substring, bool case_sensitiv
     U32 found = 0;
 
     LLWString substring_trimmed(substring);
-    S32 len = substring_trimmed.size();
+    auto len = substring_trimmed.size();
 
     if (0 == len)
     {
@@ -1446,7 +1446,7 @@ U32 LLScrollListCtrl::searchItems(const LLWString& substring, bool case_sensitiv
             if (found_iter != std::string::npos)
             {
                 // find offset of matching text
-                cellp->highlightText(found_iter, substring_trimmed.size());
+                cellp->highlightText(static_cast<S32>(found_iter), static_cast<S32>(substring_trimmed.size()));
                 selectItem(item, -1, false);
 
                 found++;
@@ -2897,7 +2897,7 @@ void    LLScrollListCtrl::copy()
     {
         buffer += (*itor)->getContentsCSV() + "\n";
     }
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(buffer), 0, buffer.length());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(buffer), 0, static_cast<S32>(buffer.length()));
 }
 
 // virtual
@@ -2981,7 +2981,7 @@ void LLScrollListCtrl::addColumn(const LLScrollListColumn::Params& column_params
         // Add column
         mColumns[name] = new LLScrollListColumn(column_params, this);
         LLScrollListColumn* new_column = mColumns[name];
-        new_column->mIndex = mColumns.size()-1;
+        new_column->mIndex = static_cast<S32>(mColumns.size()) - 1;
 
         // Add button
         if (new_column->getWidth() > 0 || new_column->mRelWidth > 0 || new_column->mDynamicWidth)
@@ -3177,7 +3177,7 @@ LLScrollListItem* LLScrollListCtrl::addRow(LLScrollListItem *new_item, const LLS
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
     if (!item_p.validateBlock() || !new_item) return NULL;
-    new_item->setNumColumns(mColumns.size());
+    new_item->setNumColumns(static_cast<S32>(mColumns.size()));
 
     // Add any columns we don't already have
     S32 col_index = 0;
@@ -3212,7 +3212,7 @@ LLScrollListItem* LLScrollListCtrl::addRow(LLScrollListItem *new_item, const LLS
             }
             addColumn(new_column);
             columnp = mColumns[column];
-            new_item->setNumColumns(mColumns.size());
+            new_item->setNumColumns(static_cast<S32>(mColumns.size()));
         }
 
         S32 index = columnp->mIndex;
@@ -3245,7 +3245,7 @@ LLScrollListItem* LLScrollListCtrl::addRow(LLScrollListItem *new_item, const LLS
             new_column.name = "0";
 
             addColumn(new_column);
-            new_item->setNumColumns(mColumns.size());
+            new_item->setNumColumns(static_cast<S32>(mColumns.size()));
         }
 
         LLScrollListCell* cell = LLScrollListCell::create(LLScrollListCell::Params().value(item_p.value));

--- a/indra/llui/llscrolllistctrl.h
+++ b/indra/llui/llscrolllistctrl.h
@@ -178,7 +178,7 @@ public:
     virtual bool    preProcessChildNode(LLXMLNodePtr child);
     virtual LLScrollListColumn* getColumn(S32 index);
     virtual LLScrollListColumn* getColumn(const std::string& name);
-    virtual S32 getNumColumns() const { return mColumnsIndexed.size(); }
+    virtual S32 getNumColumns() const { return static_cast<S32>(mColumnsIndexed.size()); }
 
     // Adds a single element, from an array of:
     // "columns" => [ "column" => column name, "value" => value, "type" => type, "font" => font, "font-style" => style ], "id" => uuid

--- a/indra/llui/llscrolllistitem.cpp
+++ b/indra/llui/llscrolllistitem.cpp
@@ -85,7 +85,7 @@ void LLScrollListItem::addColumn(const LLScrollListCell::Params& p)
 
 void LLScrollListItem::setNumColumns(S32 columns)
 {
-    S32 prev_columns = mColumns.size();
+    auto prev_columns = mColumns.size();
     if (columns < prev_columns)
     {
         std::for_each(mColumns.begin()+columns, mColumns.end(), DeletePointer());
@@ -93,7 +93,7 @@ void LLScrollListItem::setNumColumns(S32 columns)
 
     mColumns.resize(columns);
 
-    for (S32 col = prev_columns; col < columns; ++col)
+    for (auto col = prev_columns; col < columns; ++col)
     {
         mColumns[col] = NULL;
     }
@@ -115,7 +115,7 @@ void LLScrollListItem::setColumn( S32 column, LLScrollListCell *cell )
 
 S32 LLScrollListItem::getNumColumns() const
 {
-    return mColumns.size();
+    return static_cast<S32>(mColumns.size());
 }
 
 LLScrollListCell* LLScrollListItem::getColumn(const S32 i) const

--- a/indra/llui/llspellcheck.cpp
+++ b/indra/llui/llspellcheck.cpp
@@ -94,7 +94,7 @@ S32 LLSpellChecker::getSuggestions(const std::string& word, std::vector<std::str
         }
         mHunspell->free_list(&suggestion_list, suggestion_cnt);
     }
-    return suggestions.size();
+    return static_cast<S32>(suggestions.size());
 }
 
 const LLSD LLSpellChecker::getDictionaryData(const std::string& dict_language)

--- a/indra/llui/llstatbar.cpp
+++ b/indra/llui/llstatbar.cpp
@@ -455,7 +455,7 @@ void LLStatBar::draw()
 
             if (mDisplayHistory && mStat.valid)
             {
-                const S32 num_values = frame_recording.getNumRecordedPeriods() - 1;
+                const S32 num_values = static_cast<S32>(frame_recording.getNumRecordedPeriods()) - 1;
                 F32 min_value = 0.f,
                     max_value = 0.f;
 

--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -1298,7 +1298,7 @@ void LLTabContainer::removeTabPanel(LLPanel* child)
 
     if (mCurrentTabIdx >= (S32)mTabList.size())
     {
-        mCurrentTabIdx = mTabList.size()-1;
+        mCurrentTabIdx = static_cast<S32>(mTabList.size()) - 1;
     }
     selectTab(mCurrentTabIdx);
     if (has_focus)
@@ -1377,7 +1377,7 @@ S32 LLTabContainer::getCurrentPanelIndex()
 
 S32 LLTabContainer::getTabCount()
 {
-    return mTabList.size();
+    return static_cast<S32>(mTabList.size());
 }
 
 LLPanel* LLTabContainer::getPanelByIndex(S32 index)
@@ -1444,7 +1444,7 @@ void LLTabContainer::selectFirstTab()
 
 void LLTabContainer::selectLastTab()
 {
-    selectTab( mTabList.size()-1 );
+    selectTab(static_cast<S32>(mTabList.size()) - 1);
 }
 
 void LLTabContainer::selectNextTab()
@@ -1482,12 +1482,12 @@ void LLTabContainer::selectPrevTab()
     }
     S32 idx = mCurrentTabIdx-1;
     if (idx < 0)
-        idx = mTabList.size()-1;
+        idx = static_cast<S32>(mTabList.size()) - 1;
     while (!selectTab(idx) && idx != mCurrentTabIdx)
     {
         idx = idx - 1;
         if (idx < 0)
-            idx = mTabList.size()-1;
+            idx = static_cast<S32>(mTabList.size()) - 1;
     }
     if (tab_has_focus)
     {

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -320,12 +320,12 @@ bool LLTextBase::truncate()
         if (value.type() == LLSD::TypeString)
         {
             // save a copy for strings.
-            utf8_byte_size = value.size();
+            utf8_byte_size = static_cast<S32>(value.size());
         }
         else
         {
             // non string LLSDs need explicit conversion to string
-            utf8_byte_size = value.asString().size();
+            utf8_byte_size = static_cast<S32>(value.asString().size());
         }
 
         if ( utf8_byte_size > mMaxTextByteLength )
@@ -335,7 +335,7 @@ bool LLTextBase::truncate()
             temp_utf8_text = utf8str_truncate( temp_utf8_text, mMaxTextByteLength );
             LLWString text = utf8str_to_wstring( temp_utf8_text );
             // remove extra bit of current string, to preserve formatting, etc.
-            removeStringNoUndo(text.size(), getWText().size() - text.size());
+            removeStringNoUndo(static_cast<S32>(text.size()), static_cast<S32>(getWText().size() - text.size()));
             did_truncate = true;
         }
     }
@@ -617,7 +617,7 @@ void LLTextBase::drawText()
     }
     else if (useLabel())
     {
-        text_len = mLabel.getWString().length();
+        text_len = static_cast<S32>(mLabel.getWString().length());
     }
 
     S32 selection_left = -1;
@@ -686,7 +686,7 @@ void LLTextBase::drawText()
 
                 // Find the start of the first word
                 U32 word_start = seg_start, word_end = -1;
-                U32 text_length = wstrText.length();
+                U32 text_length = static_cast<U32>(wstrText.length());
                 while ( (word_start < text_length) && (!LLStringOps::isAlpha(wstrText[word_start])) )
                 {
                     word_start++;
@@ -845,7 +845,7 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
     beforeValueChange();
 
     S32 old_len = getLength();      // length() returns character length
-    S32 insert_len = wstr.length();
+    S32 insert_len = static_cast<S32>(wstr.length());
 
     pos = getEditableIndex(pos, true);
     if (pos > old_len)
@@ -916,7 +916,7 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
     {
         LLStyleSP emoji_style;
         LLEmojiDictionary* ed = LLEmojiDictionary::instanceExists() ? LLEmojiDictionary::getInstance() : NULL;
-        for (S32 text_kitty = 0, text_len = wstr.size(); text_kitty < text_len; text_kitty++)
+        for (S32 text_kitty = 0, text_len = static_cast<S32>(wstr.size()); text_kitty < text_len; text_kitty++)
         {
             llwchar code = wstr[text_kitty];
             bool isEmoji = ed ? ed->isEmoji(code) : LLStringOps::isEmoji(code);
@@ -1469,7 +1469,7 @@ const std::string& LLTextBase::getSuggestion(U32 index) const
 
 U32 LLTextBase::getSuggestionCount() const
 {
-    return mSuggestionList.size();
+    return static_cast<U32>(mSuggestionList.size());
 }
 
 void LLTextBase::replaceWithSuggestion(U32 index)
@@ -2335,7 +2335,7 @@ void LLTextBase::resetLabel()
         style->setColor(mTentativeFgColor);
         LLStyleConstSP sp(style);
 
-        LLTextSegmentPtr label = new LLLabelTextSegment(sp, 0, mLabel.getWString().length() + 1, *this);
+        LLTextSegmentPtr label = new LLLabelTextSegment(sp, 0, static_cast<S32>(mLabel.getWString().length()) + 1, *this);
         insertSegment(label);
     }
 }
@@ -2395,7 +2395,7 @@ void LLTextBase::appendWidget(const LLInlineViewSegment::Params& params, const s
 {
     segment_vec_t segments;
     LLWString widget_wide_text = utf8str_to_wstring(text);
-    segments.push_back(new LLInlineViewSegment(params, getLength(), getLength() + widget_wide_text.size()));
+    segments.push_back(new LLInlineViewSegment(params, getLength(), getLength() + static_cast<S32>(widget_wide_text.size())));
 
     insertStringNoUndo(getLength(), widget_wide_text, &segments);
 }
@@ -2436,11 +2436,11 @@ void LLTextBase::appendAndHighlightTextImpl(const std::string &new_text, S32 hig
             {
                 highlight_params.font.style("NORMAL");
                 LLStyleConstSP normal_sp(new LLStyle(highlight_params));
-                segmentp = new LLOnHoverChangeableTextSegment(sp, normal_sp, cur_length, cur_length + wide_text.size(), *this);
+                segmentp = new LLOnHoverChangeableTextSegment(sp, normal_sp, cur_length, cur_length + static_cast<S32>(wide_text.size()), *this);
             }
             else
             {
-                segmentp = new LLNormalTextSegment(sp, cur_length, cur_length + wide_text.size(), *this);
+                segmentp = new LLNormalTextSegment(sp, cur_length, cur_length + static_cast<S32>(wide_text.size()), *this);
             }
             segment_vec_t segments;
             segments.push_back(segmentp);
@@ -2454,7 +2454,7 @@ void LLTextBase::appendAndHighlightTextImpl(const std::string &new_text, S32 hig
 
         segment_vec_t segments;
         S32 segment_start = old_length;
-        S32 segment_end = old_length + wide_text.size();
+        S32 segment_end = old_length + static_cast<S32>(wide_text.size());
         LLStyleConstSP sp(new LLStyle(style_params));
         if (underline_on_hover_only || mSkipLinkUnderline)
         {
@@ -2545,7 +2545,7 @@ void LLTextBase::replaceUrl(const std::string &url,
             S32 start = seg->getStart();
             S32 end = seg->getEnd();
             text = text.substr(0, start) + wlabel + text.substr(end, text.size() - end + 1);
-            seg->setEnd(start + wlabel.size());
+            seg->setEnd(start + static_cast<S32>(wlabel.size()));
             modified = true;
         }
 
@@ -2898,7 +2898,7 @@ bool LLTextBase::setCursor(S32 row, S32 column)
 {
     if (row < 0 || column < 0) return false;
 
-    S32 n_lines = mLineInfoList.size();
+    S32 n_lines = static_cast<S32>(mLineInfoList.size());
     for (S32 line = row; line < n_lines; ++line)
     {
         const line_info& li = mLineInfoList[line];
@@ -3537,7 +3537,7 @@ S32 LLNormalTextSegment::getNumChars(S32 num_pixels, S32 segment_offset, S32 lin
         : LLFontGL::ONLY_WORD_BOUNDARIES;
 
 
-    S32 offsetLength = text.length() - (segment_offset + mStart);
+    S32 offsetLength = static_cast<S32>(text.length()) - (segment_offset + mStart);
 
     if(getLength() < segment_offset + mStart)
     {
@@ -3617,7 +3617,7 @@ const LLWString& LLLabelTextSegment::getWText() const
 /*virtual*/
 const S32 LLLabelTextSegment::getLength() const
 {
-    return mEditor.getWlabel().length();
+    return static_cast<S32>(mEditor.getWlabel().length());
 }
 
 //

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -454,8 +454,8 @@ public:
     // force reflow of text
     void                    needsReflow(S32 index = 0);
 
-    S32                     getLength() const { return getWText().length(); }
-    S32                     getLineCount() const { return mLineInfoList.size(); }
+    S32                     getLength() const { return static_cast<S32>(getWText().length()); }
+    S32                     getLineCount() const { return static_cast<S32>(mLineInfoList.size()); }
     S32                     removeFirstLine(); // returns removed length
 
     void                    addDocumentChild(LLView* view);

--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -98,13 +98,13 @@ public:
     }
     virtual S32 undo( LLTextBase* editor )
     {
-        remove(editor, getPosition(), mWString.length() );
+        remove(editor, getPosition(), static_cast<S32>(mWString.length()));
         return getPosition();
     }
     virtual S32 redo( LLTextBase* editor )
     {
-        insert(editor, getPosition(), mWString );
-        return getPosition() + mWString.length();
+        insert(editor, getPosition(), mWString);
+        return getPosition() + static_cast<S32>(mWString.length());
     }
 
 private:
@@ -151,13 +151,13 @@ public:
     }
     virtual S32 undo( LLTextBase* editor )
     {
-        remove(editor, getPosition(), mWString.length() );
+        remove(editor, getPosition(), static_cast<S32>(mWString.length()));
         return getPosition();
     }
     virtual S32 redo( LLTextBase* editor )
     {
-        insert(editor, getPosition(), mWString );
-        return getPosition() + mWString.length();
+        insert(editor, getPosition(), mWString);
+        return getPosition() + static_cast<S32>(mWString.length());
     }
 
 private:
@@ -216,7 +216,7 @@ public:
     virtual S32 undo( LLTextBase* editor )
     {
         insert(editor, getPosition(), mWString);
-        return getPosition() + mWString.length();
+        return getPosition() + static_cast<S32>(mWString.length());
     }
     virtual S32 redo( LLTextBase* editor )
     {
@@ -365,16 +365,16 @@ void LLTextEditor::selectNext(const std::string& search_text_in, bool case_insen
         if (selected_text == search_text)
         {
             // We already have this word selected, we are searching for the next.
-            setCursorPos(mCursorPos + search_text.size());
+            setCursorPos(mCursorPos + static_cast<S32>(search_text.size()));
         }
     }
 
-    S32 loc = text.find(search_text,mCursorPos);
+    S32 loc = static_cast<S32>(text.find(search_text,mCursorPos));
 
     // If Maybe we wrapped, search again
     if (wrap && (-1 == loc))
     {
-        loc = text.find(search_text);
+        loc = static_cast<S32>(text.find(search_text));
     }
 
     // If still -1, then search_text just isn't found.
@@ -1578,8 +1578,8 @@ void LLTextEditor::cleanStringForPaste(LLWString & clean_string)
     if( mAllowEmbeddedItems )
     {
         const llwchar LF = 10;
-        S32 len = clean_string.length();
-        for( S32 i = 0; i < len; i++ )
+        auto len = clean_string.length();
+        for( size_t i = 0; i < len; i++ )
         {
             llwchar wc = clean_string[i];
             if( (wc < LLFontFreetype::FIRST_CHAR) && (wc != LF) )
@@ -2489,7 +2489,7 @@ void LLTextEditor::appendWidget(const LLInlineViewSegment::Params& params, const
 
     LLWString widget_wide_text = utf8str_to_wstring(text);
 
-    LLTextSegmentPtr segment = new LLInlineViewSegment(params, old_length, old_length + widget_wide_text.size());
+    LLTextSegmentPtr segment = new LLInlineViewSegment(params, old_length, old_length + static_cast<S32>(widget_wide_text.size()));
     insert(getLength(), widget_wide_text, false, segment);
 
     // Set the cursor and scroll position
@@ -2843,7 +2843,7 @@ void LLTextEditor::updatePreedit(const LLWString &preedit_string,
     if (LL_KIM_OVERWRITE == gKeyboard->getInsertMode())
     {
         mPreeditOverwrittenWString = getWText().substr(insert_preedit_at, mPreeditWString.length());
-        removeStringNoUndo(insert_preedit_at, mPreeditWString.length());
+        removeStringNoUndo(insert_preedit_at, static_cast<S32>(mPreeditWString.length()));
     }
     else
     {

--- a/indra/llui/lltextparser.cpp
+++ b/indra/llui/lltextparser.cpp
@@ -73,11 +73,11 @@ S32 LLTextParser::findPattern(const std::string &text, LLSD highlight)
             found = (! ltext.find(pattern) ? 0 : std::string::npos);
             break;
         case ENDS_WITH:
-            S32 pos = ltext.rfind(pattern);
+            auto pos = ltext.rfind(pattern);
             if (pos >= 0 && (ltext.length()-pattern.length()==pos)) found = pos;
             break;
     }
-    return found;
+    return static_cast<S32>(found);
 }
 
 LLSD LLTextParser::parsePartialLineHighlights(const std::string &text, const LLColor4 &color, EHighlightPosition part, S32 index)
@@ -99,8 +99,8 @@ LLSD LLTextParser::parsePartialLineHighlights(const std::string &text, const LLC
                 S32 start = findPattern(text,mHighlights[i]);
                 if (start >= 0 )
                 {
-                    S32 end =  std::string(mHighlights[i]["pattern"]).length();
-                    S32 len = text.length();
+                    auto end =  std::string(mHighlights[i]["pattern"]).length();
+                    auto len = text.length();
                     EHighlightPosition newpart;
                     if (start==0)
                     {

--- a/indra/llui/lltextvalidate.cpp
+++ b/indra/llui/lltextvalidate.cpp
@@ -73,7 +73,7 @@ class ValidatorFloat : public ValidatorImpl
 
         std::basic_string<CHAR> trimmed = str;
         LLStringUtilBase<CHAR>::trim(trimmed);
-        S32 len = trimmed.length();
+        auto len = trimmed.length();
         if (0 < len)
         {
             // May be a comma or period, depending on the locale
@@ -118,7 +118,7 @@ class ValidatorInt : public ValidatorImpl
 
         std::basic_string<CHAR> trimmed = str;
         LLStringUtilBase<CHAR>::trim(trimmed);
-        S32 len = trimmed.length();
+        auto len = trimmed.length();
         if (0 < len)
         {
             S32 i = 0;
@@ -157,7 +157,7 @@ class ValidatorPositiveS32 : public ValidatorImpl
 
         std::basic_string<CHAR> trimmed = str;
         LLStringUtilBase<CHAR>::trim(trimmed);
-        S32 len = trimmed.length();
+        auto len = trimmed.length();
         if (0 < len)
         {
             CHAR ch = trimmed.front();
@@ -167,7 +167,7 @@ class ValidatorPositiveS32 : public ValidatorImpl
                 return setError("Validator_ShouldNotBeMinusOrZero", LLSD().with("CH", llsd(ch)));
             }
 
-            for (S32 i = 0; i < len; ++i)
+            for (size_t i = 0; i < len; ++i)
             {
                 ch = trimmed[i];
                 if (!LLStringOps::isDigit(ch))
@@ -177,7 +177,7 @@ class ValidatorPositiveS32 : public ValidatorImpl
             }
         }
 
-        S32 val = strtol(trimmed);
+        auto val = strtol(trimmed);
         if (val <= 0)
         {
             return setError("Validator_InvalidNumericString", LLSD().with("STR", llsd(trimmed)));
@@ -201,7 +201,7 @@ class ValidatorNonNegativeS32 : public ValidatorImpl
 
         std::basic_string<CHAR> trimmed = str;
         LLStringUtilBase<CHAR>::trim(trimmed);
-        S32 len = trimmed.length();
+        auto len = trimmed.length();
         if (0 < len)
         {
             CHAR ch = trimmed.front();
@@ -211,7 +211,7 @@ class ValidatorNonNegativeS32 : public ValidatorImpl
                 return setError("Validator_ShouldNotBeMinus", LLSD().with("CH", llsd(ch)));
             }
 
-            for (S32 i = 0; i < len; ++i)
+            for (size_t i = 0; i < len; ++i)
             {
                 ch = trimmed[i];
                 if (!LLStringOps::isDigit(ch))
@@ -221,7 +221,7 @@ class ValidatorNonNegativeS32 : public ValidatorImpl
             }
         }
 
-        S32 val = strtol(trimmed);
+        auto val = strtol(trimmed);
         if (val < 0)
         {
             return setError("Validator_InvalidNumericString", LLSD().with("STR", llsd(trimmed)));
@@ -244,7 +244,7 @@ class ValidatorNonNegativeS32NoSpace : public ValidatorImpl
         LLLocale locale(LLLocale::USER_LOCALE);
 
         std::basic_string<CHAR> test_str = str;
-        S32 len = test_str.length();
+        auto len = test_str.length();
         if (0 < len)
         {
             CHAR ch = test_str.front();
@@ -254,7 +254,7 @@ class ValidatorNonNegativeS32NoSpace : public ValidatorImpl
                 return setError("Validator_ShouldNotBeMinus", LLSD().with("CH", llsd(ch)));
             }
 
-            for (S32 i = 0; i < len; ++i)
+            for (size_t i = 0; i < len; ++i)
             {
                 ch = test_str[i];
                 if (!LLStringOps::isDigit(ch) || LLStringOps::isSpace(ch))
@@ -264,7 +264,7 @@ class ValidatorNonNegativeS32NoSpace : public ValidatorImpl
             }
         }
 
-        S32 val = strtol(test_str);
+        auto val = strtol(test_str);
         if (val < 0)
         {
             return setError("Validator_InvalidNumericString", LLSD().with("STR", llsd(test_str)));
@@ -286,7 +286,7 @@ class ValidatorAlphaNum : public ValidatorImpl
     {
         LLLocale locale(LLLocale::USER_LOCALE);
 
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];
@@ -313,7 +313,7 @@ class ValidatorAlphaNumSpace : public ValidatorImpl
     {
         LLLocale locale(LLLocale::USER_LOCALE);
 
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];
@@ -341,7 +341,7 @@ class ValidatorASCIIPrintableNoPipe : public ValidatorImpl
     template <class CHAR>
     bool validate(const std::basic_string<CHAR>& str)
     {
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];
@@ -368,7 +368,7 @@ class ValidatorASCIIPrintableNoSpace : public ValidatorImpl
     template <class CHAR>
     bool validate(const std::basic_string<CHAR>& str)
     {
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];
@@ -395,7 +395,7 @@ protected:
     template <class CHAR>
     bool validate(const std::basic_string<CHAR>& str)
     {
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];
@@ -441,7 +441,7 @@ class ValidatorASCIIWithNewLine : public ValidatorImpl
     template <class CHAR>
     bool validate(const std::basic_string<CHAR>& str)
     {
-        S32 len = str.length();
+        auto len = str.length();
         while (len--)
         {
             CHAR ch = str[len];

--- a/indra/llui/lltimectrl.cpp
+++ b/indra/llui/lltimectrl.cpp
@@ -343,7 +343,7 @@ LLTimeCtrl::EEditingPart LLTimeCtrl::getEditingPart()
     S32 cur_pos = mEditor->getCursor();
     std::string time_str = mEditor->getText();
 
-    S32 colon_index = time_str.find_first_of(':');
+    auto colon_index = time_str.find_first_of(':');
 
     if (cur_pos <= colon_index)
     {
@@ -376,7 +376,7 @@ std::string LLTimeCtrl::getMinutesString(const std::string& str)
     size_t colon_index = str.find_first_of(':');
     ++colon_index;
 
-    int minutes_len = str.length() - colon_index - AMPM_LEN;
+    auto minutes_len = str.length() - colon_index - AMPM_LEN;
     std::string minutes_str = str.substr(colon_index, minutes_len);
 
     return minutes_str;
@@ -411,7 +411,7 @@ bool LLTimeCtrl::isMinutesStringValid(const std::string& str)
 // static
 bool LLTimeCtrl::isPMAMStringValid(const std::string& str)
 {
-    S32 len = str.length();
+    auto len = str.length();
 
     bool valid = (str[--len] == 'M') && (str[--len] == 'P' || str[len] == 'A');
 

--- a/indra/llui/lltoolbar.h
+++ b/indra/llui/lltoolbar.h
@@ -178,12 +178,12 @@ public:
 
     protected:
         friend class LLUICtrlFactory;
-        LLCenterLayoutPanel(const Params& params) : LLLayoutPanel(params), mButtonPanel(NULL) {}
+        LLCenterLayoutPanel(const Params& params) : LLLayoutPanel(params) {};
 
     private:
         reshape_callback_t                  mReshapeCallback;
-        LLToolBarEnums::EToolBarLocation    mLocationId;
-        LLPanel *                           mButtonPanel;
+        LLToolBarEnums::EToolBarLocation    mLocationId{ LLToolBarEnums::EToolBarLocation::TOOLBAR_NONE };
+        LLPanel *                           mButtonPanel{ nullptr };
     };
 
     struct Params : public LLInitParam::Block<Params, LLUICtrl::Params>

--- a/indra/llui/llui.h
+++ b/indra/llui/llui.h
@@ -234,7 +234,7 @@ public:
 
 
     private:
-        S32 mValue;
+        S32 mValue{ 0 };
     };
 
     //

--- a/indra/llui/lluistring.h
+++ b/indra/llui/lluistring.h
@@ -79,7 +79,7 @@ public:
     operator LLWString() const { return getUpdatedWResult(); }
 
     bool empty() const { return getUpdatedResult().empty(); }
-    S32 length() const { return getUpdatedWResult().size(); }
+    S32 length() const { return static_cast<S32>(getUpdatedWResult().size()); }
 
     void clear();
     void clearArgs() { if (mArgs) mArgs->clear(); }

--- a/indra/llui/llurlentry.cpp
+++ b/indra/llui/llurlentry.cpp
@@ -389,7 +389,7 @@ bool LLUrlEntryInvalidSLURL::isSLURLvalid(const std::string &url) const
 
     LLURI uri(url);
     LLSD path_array = uri.pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
     S32 x,y,z;
 
     if (path_parts == actual_parts)
@@ -454,7 +454,7 @@ std::string LLUrlEntrySLURL::getLabel(const std::string &url, const LLUrlLabelCa
 
     LLURI uri(url);
     LLSD path_array = uri.pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
     if (path_parts == 5)
     {
         // handle slurl with (X,Y,Z) coordinates
@@ -1074,7 +1074,7 @@ LLUrlEntryParcel::~LLUrlEntryParcel()
 std::string LLUrlEntryParcel::getLabel(const std::string &url, const LLUrlLabelCallback &cb)
 {
     LLSD path_array = LLURI(url).pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
 
     if (path_parts < 3) // no parcel id
     {
@@ -1165,7 +1165,7 @@ std::string LLUrlEntryPlace::getLabel(const std::string &url, const LLUrlLabelCa
     LLURI uri(url);
     std::string location = unescapeUrl(uri.hostName());
     LLSD path_array = uri.pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
     if (path_parts == 3)
     {
         // handle slurl with (X,Y,Z) coordinates
@@ -1214,7 +1214,7 @@ std::string LLUrlEntryRegion::getLabel(const std::string &url, const LLUrlLabelC
     //
 
     LLSD path_array = LLURI(url).pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
 
     if (path_parts < 3) // no region name
     {
@@ -1278,7 +1278,7 @@ std::string LLUrlEntryTeleport::getLabel(const std::string &url, const LLUrlLabe
     //
     LLURI uri(url);
     LLSD path_array = uri.pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
     std::string host = uri.hostName();
     std::string label = LLTrans::getString("SLurlLabelTeleport");
     if (!host.empty())
@@ -1413,7 +1413,7 @@ std::string LLUrlEntryWorldMap::getLabel(const std::string &url, const LLUrlLabe
     //
     LLURI uri(url);
     LLSD path_array = uri.pathArray();
-    S32 path_parts = path_array.size();
+    auto path_parts = path_array.size();
     if (path_parts < 3)
     {
         return url;
@@ -1505,7 +1505,7 @@ LLUrlEntryEmail::LLUrlEntryEmail()
 
 std::string LLUrlEntryEmail::getLabel(const std::string &url, const LLUrlLabelCallback &cb)
 {
-    int pos = url.find("mailto:");
+    auto pos = url.find("mailto:");
 
     if (pos == std::string::npos)
     {

--- a/indra/llui/llurlregistry.cpp
+++ b/indra/llui/llurlregistry.cpp
@@ -263,9 +263,9 @@ bool LLUrlRegistry::findUrl(const LLWString &text, LLUrlMatch &match, const LLUr
         {
             return false;
         }
-        S32 end = start + wurl.size() - 1;
+        auto end = start + wurl.size() - 1;
 
-        match.setValues(start, end, match.getUrl(),
+        match.setValues(static_cast<U32>(start), static_cast<U32>(end), match.getUrl(),
                         match.getLabel(),
                         match.getQuery(),
                         match.getTooltip(),

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -3634,13 +3634,13 @@ void LLSplashScreenWin32::updateImpl(const std::string& mesg)
 {
     if (!mWindow) return;
 
-    int output_str_len = MultiByteToWideChar(CP_UTF8, 0, mesg.c_str(), mesg.length(), NULL, 0);
+    int output_str_len = MultiByteToWideChar(CP_UTF8, 0, mesg.c_str(), static_cast<int>(mesg.length()), NULL, 0);
     if( output_str_len>1024 )
         return;
 
     WCHAR w_mesg[1025];//big enought to keep null terminatos
 
-    MultiByteToWideChar (CP_UTF8, 0, mesg.c_str(), mesg.length(), w_mesg, output_str_len);
+    MultiByteToWideChar (CP_UTF8, 0, mesg.c_str(), static_cast<int>(mesg.length()), w_mesg, output_str_len);
 
     //looks like MultiByteToWideChar didn't add null terminator to converted string, see EXT-4858
     w_mesg[output_str_len] = 0;
@@ -4034,14 +4034,14 @@ U32 LLWindowWin32::fillReconvertString(const LLWString &text,
     S32 focus, S32 focus_length, RECONVERTSTRING *reconvert_string)
 {
     const llutf16string text_utf16 = wstring_to_utf16str(text);
-    const DWORD required_size = sizeof(RECONVERTSTRING) + (text_utf16.length() + 1) * sizeof(WCHAR);
+    const DWORD required_size = sizeof(RECONVERTSTRING) + (static_cast<DWORD>(text_utf16.length()) + 1) * sizeof(WCHAR);
     if (reconvert_string && reconvert_string->dwSize >= required_size)
     {
         const DWORD focus_utf16_at = wstring_utf16_length(text, 0, focus);
         const DWORD focus_utf16_length = wstring_utf16_length(text, focus, focus_length);
 
         reconvert_string->dwVersion = 0;
-        reconvert_string->dwStrLen = text_utf16.length();
+        reconvert_string->dwStrLen = static_cast<DWORD>(text_utf16.length());
         reconvert_string->dwStrOffset = sizeof(RECONVERTSTRING);
         reconvert_string->dwCompStrLen = focus_utf16_length;
         reconvert_string->dwCompStrOffset = focus_utf16_at * sizeof(WCHAR);
@@ -4204,7 +4204,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
         }
     }
 
-    S32 caret_position = preedit_string.length();
+    S32 caret_position = static_cast<S32>(preedit_string.length());
     if (indexes & GCS_CURSORPOS)
     {
         const S32 caret_position_utf16 = LLWinImm::getCompositionString(himc, GCS_CURSORPOS, NULL, 0);
@@ -4250,7 +4250,7 @@ void LLWindowWin32::handleCompositionMessage(const U32 indexes)
         {
             if (preedit_segment_lengths.size() == 0)
             {
-                preedit_segment_lengths.assign(1, preedit_string.length());
+                preedit_segment_lengths.assign(1, static_cast<S32>(preedit_string.length()));
             }
             if (preedit_standouts.size() == 0)
             {

--- a/indra/llxml/llxmlnode.cpp
+++ b/indra/llxml/llxmlnode.cpp
@@ -670,7 +670,7 @@ bool LLXMLNode::parseFile(const std::string& filename, LLXMLNodePtr& node, LLXML
     buffer[nread] = 0;
     fclose(fp);
 
-    bool rv = parseBuffer(buffer, nread, node, defaults_tree);
+    bool rv = parseBuffer(buffer, static_cast<U32>(nread), node, defaults_tree);
     delete [] buffer;
     return rv;
 }
@@ -2681,7 +2681,7 @@ U32 LLXMLNode::getChildCount() const
 {
     if (mChildren.notNull())
     {
-        return mChildren->map.size();
+        return static_cast<U32>(mChildren->map.size());
     }
     return 0;
 }
@@ -2700,7 +2700,7 @@ LLXMLNode *get_rand_node(LLXMLNode *node)
 {
     if (node->mChildren.notNull())
     {
-        U32 num_children = node->mChildren->map.size();
+        U32 num_children = static_cast<U32>(node->mChildren->map.size());
         if (get_rand(2) == 0)
         {
             while (true)

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -1312,7 +1312,7 @@ boost::signals2::connection LLAgent::whenPositionChanged(position_signal_t::slot
 //-----------------------------------------------------------------------------
 S32 LLAgent::getRegionsVisited() const
 {
-    return mRegionsVisited.size();
+    return static_cast<S32>(mRegionsVisited.size());
 }
 
 //-----------------------------------------------------------------------------
@@ -3128,8 +3128,8 @@ bool LLAgent::isInGroup(const LLUUID& group_id, bool ignore_god_mode /* false */
     if (!ignore_god_mode && isGodlike())
         return true;
 
-    U32 count = mGroups.size();
-    for(U32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3148,8 +3148,8 @@ bool LLAgent::hasPowerInGroup(const LLUUID& group_id, U64 power) const
     // GP_NO_POWERS can also mean no power is enough to grant an ability.
     if (GP_NO_POWERS == power) return false;
 
-    U32 count = mGroups.size();
-    for(U32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3169,8 +3169,8 @@ U64 LLAgent::getPowerInGroup(const LLUUID& group_id) const
     if (isGodlike())
         return GP_ALL_POWERS;
 
-    U32 count = mGroups.size();
-    for(U32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3183,8 +3183,8 @@ U64 LLAgent::getPowerInGroup(const LLUUID& group_id) const
 
 bool LLAgent::getGroupData(const LLUUID& group_id, LLGroupData& data) const
 {
-    S32 count = mGroups.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3197,8 +3197,8 @@ bool LLAgent::getGroupData(const LLUUID& group_id, LLGroupData& data) const
 
 S32 LLAgent::getGroupContribution(const LLUUID& group_id) const
 {
-    S32 count = mGroups.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3211,8 +3211,8 @@ S32 LLAgent::getGroupContribution(const LLUUID& group_id) const
 
 bool LLAgent::setGroupContribution(const LLUUID& group_id, S32 contribution)
 {
-    S32 count = mGroups.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {
@@ -3234,8 +3234,8 @@ bool LLAgent::setGroupContribution(const LLUUID& group_id, S32 contribution)
 
 bool LLAgent::setUserGroupFlags(const LLUUID& group_id, bool accept_notices, bool list_in_profile)
 {
-    S32 count = mGroups.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         if(mGroups[i].mID == group_id)
         {

--- a/indra/newview/llagentpicksinfo.cpp
+++ b/indra/newview/llagentpicksinfo.cpp
@@ -123,5 +123,5 @@ void LLAgentPicksInfo::onServerRespond(LLAvatarData* picks)
         return;
     }
 
-    setNumberOfPicks(picks->picks_list.size());
+    setNumberOfPicks(static_cast<S32>(picks->picks_list.size()));
 }

--- a/indra/newview/llagentwearables.cpp
+++ b/indra/newview/llagentwearables.cpp
@@ -964,7 +964,7 @@ void LLAgentWearables::setWearableOutfit(const LLInventoryItem::item_array_t& it
 {
     LL_INFOS() << "setWearableOutfit() start" << LL_ENDL;
 
-    S32 count = wearables.size();
+    auto count = wearables.size();
     llassert(items.size() == count);
 
     // Check for whether outfit already matches the one requested
@@ -973,7 +973,7 @@ void LLAgentWearables::setWearableOutfit(const LLInventoryItem::item_array_t& it
     S32 type_counts[arr_size];
     bool update_inventory{ false };
     std::fill(type_counts,type_counts+arr_size,0);
-    for (S32 i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
     {
         LLViewerWearable* new_wearable = wearables[i];
         LLPointer<LLInventoryItem> new_item = items[i];
@@ -1407,7 +1407,7 @@ void LLAgentWearables::userRemoveMultipleAttachments(llvo_vec_t& objects_to_remo
 void LLAgentWearables::userAttachMultipleAttachments(LLInventoryModel::item_array_t& obj_item_array)
 {
     // Build a compound message to send all the objects that need to be rezzed.
-    S32 obj_count = obj_item_array.size();
+    auto obj_count = obj_item_array.size();
     if (obj_count > 0)
     {
         LL_DEBUGS("Avatar") << "ATT attaching multiple, total obj_count " << obj_count << LL_ENDL;

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -786,7 +786,7 @@ void AISAPI::FetchOrphans(completion_t callback)
 void AISAPI::EnqueueAISCommand(const std::string &procName, LLCoprocedureManager::CoProcedure_t proc)
 {
     LLCoprocedureManager &inst = LLCoprocedureManager::instance();
-    S32 pending_in_pool = inst.countPending("AIS");
+    auto pending_in_pool = inst.countPending("AIS");
     std::string procFullName = "AIS(" + procName + ")";
     if (pending_in_pool < MAX_SIMULTANEOUS_COROUTINES)
     {
@@ -815,7 +815,7 @@ void AISAPI::onIdle(void *userdata)
     if (!sPostponedQuery.empty())
     {
         LLCoprocedureManager &inst = LLCoprocedureManager::instance();
-        S32 pending_in_pool = inst.countPending("AIS");
+        auto pending_in_pool = inst.countPending("AIS");
         while (pending_in_pool < MAX_SIMULTANEOUS_COROUTINES && !sPostponedQuery.empty())
         {
             ais_query_item_t &item = sPostponedQuery.front();
@@ -1356,7 +1356,7 @@ void AISUpdate::parseCategory(const LLSD& category_map, S32 depth)
             uuid_int_map_t::const_iterator lookup_it = mCatDescendentsKnown.find(category_id);
             if (mCatDescendentsKnown.end() != lookup_it)
             {
-                S32 descendent_count = lookup_it->second;
+                S32 descendent_count = static_cast<S32>(lookup_it->second);
                 LL_DEBUGS("Inventory") << "Setting descendents count to " << descendent_count
                     << " for category " << category_id << LL_ENDL;
                 new_cat->setDescendentCount(descendent_count);
@@ -1409,7 +1409,7 @@ void AISUpdate::parseCategory(const LLSD& category_map, S32 depth)
             uuid_int_map_t::const_iterator lookup_it = mCatDescendentsKnown.find(category_id);
             if (mCatDescendentsKnown.end() != lookup_it)
             {
-                S32 descendent_count = lookup_it->second;
+                S32 descendent_count = static_cast<S32>(lookup_it->second);
                 LL_DEBUGS("Inventory") << "Setting descendents count to " << descendent_count
                     << " for new category " << category_id << LL_ENDL;
                 new_cat->setDescendentCount(descendent_count);
@@ -1585,7 +1585,7 @@ void AISUpdate::doUpdate()
     checkTimeout();
 
     // Do version/descendant accounting.
-    for (std::map<LLUUID,S32>::const_iterator catit = mCatDescendentDeltas.begin();
+    for (std::map<LLUUID,size_t>::const_iterator catit = mCatDescendentDeltas.begin();
          catit != mCatDescendentDeltas.end(); ++catit)
     {
         LL_DEBUGS("Inventory") << "descendant accounting for " << catit->first << LL_ENDL;
@@ -1609,7 +1609,7 @@ void AISUpdate::doUpdate()
         LLViewerInventoryCategory* cat = gInventory.getCategory(cat_id);
         if (cat)
         {
-            S32 descendent_delta = catit->second;
+            S32 descendent_delta = static_cast<S32>(catit->second);
             S32 old_count = cat->getDescendentCount();
             LL_DEBUGS("Inventory") << "Updating descendant count for "
                                    << cat->getName() << " " << cat_id
@@ -1733,7 +1733,7 @@ void AISUpdate::doUpdate()
          ucv_it != mCatVersionsUpdated.end(); ++ucv_it)
     {
         const LLUUID id = ucv_it->first;
-        S32 version = ucv_it->second;
+        S32 version = static_cast<S32>(ucv_it->second);
         LLViewerInventoryCategory *cat = gInventory.getCategory(id);
         LL_DEBUGS("Inventory") << "cat version update " << cat->getName() << " to version " << cat->getVersion() << LL_ENDL;
         if (cat->getVersion() != version)

--- a/indra/newview/llaisapi.h
+++ b/indra/newview/llaisapi.h
@@ -134,7 +134,7 @@ private:
     // Todo: make throttle work over all fetch requests isntead of per-request
     const F32 AIS_EXPIRY_SECONDS = 0.008f;
 
-    typedef std::map<LLUUID,S32> uuid_int_map_t;
+    typedef std::map<LLUUID,size_t> uuid_int_map_t;
     uuid_int_map_t mCatDescendentDeltas;
     uuid_int_map_t mCatDescendentsKnown;
     uuid_int_map_t mCatVersionsUpdated;

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -719,7 +719,7 @@ public:
     bool isMostRecent();
     void handleLateArrivals();
     void resetTime(F32 timeout);
-    static S32 countActive() { return sActiveHoldingPatterns.size(); }
+    static S32 countActive() { return static_cast<S32>(sActiveHoldingPatterns.size()); }
     S32 index() { return mIndex; }
 
 private:
@@ -1374,7 +1374,7 @@ static void removeDuplicateItems(LLInventoryModel::item_array_t& items)
     // encountered, so we actually keep the *last* of each duplicate
     // item.  This is needed to give the right priority when adding
     // duplicate items to an existing outfit.
-    for (S32 i=items.size()-1; i>=0; i--)
+    for (auto i=items.size()-1; i>=0; i--)
     {
         LLViewerInventoryItem *item = items.at(i);
         LLUUID item_id = item->getLinkedUUID();
@@ -2133,11 +2133,11 @@ void LLAppearanceMgr::filterWearableItems(
         items.clear();
         for (S32 i=0; i<LLWearableType::WT_COUNT; i++)
         {
-            S32 size = items_by_type[i].size();
+            auto size = items_by_type[i].size();
             if (size <= 0)
                 continue;
-            S32 start_index = llmax(0,size-max_per_type);
-            for (S32 j = start_index; j<size; j++)
+            auto start_index = llmax(0,size-max_per_type);
+            for (size_t j = start_index; j<size; j++)
             {
                 items.push_back(items_by_type[i][j]);
             }
@@ -3588,7 +3588,7 @@ struct WearablesOrderComparator
     LOG_CLASS(WearablesOrderComparator);
     WearablesOrderComparator(const LLWearableType::EType type)
     {
-        mControlSize = build_order_string(type, 0).size();
+        mControlSize = static_cast<U32>(build_order_string(type, 0).size());
     };
 
     bool operator()(const LLInventoryItem* item1, const LLInventoryItem* item2)
@@ -3623,7 +3623,7 @@ void LLAppearanceMgr::getWearableOrderingDescUpdates(LLInventoryModel::item_arra
 
     for (U32 type = LLWearableType::WT_SHIRT; type < LLWearableType::WT_COUNT; type++)
     {
-        U32 size = items_by_type[type].size();
+        U32 size = static_cast<U32>(items_by_type[type].size());
         if (!size) continue;
 
         //sinking down invalid items which need reordering
@@ -4577,7 +4577,7 @@ public:
         LLInventoryModel::item_array_t* items;
         gInventory.getDirectDescendentsOf(mComplete.front(), cats, items);
 
-        S32 count = items->size();
+        auto count = items->size();
         if(!count)
         {
             LL_WARNS() << "Nothing fetched in category " << mComplete.front()
@@ -4593,7 +4593,7 @@ public:
         S32 version = cat ? cat->getVersion() : -2;
         LL_INFOS() << "stage1, category " << mComplete.front() << " got " << count << " items, version " << version << " passing to stage2 " << LL_ENDL;
         uuid_vec_t ids;
-        for(S32 i = 0; i < count; ++i)
+        for(size_t i = 0; i < count; ++i)
         {
             ids.push_back(items->at(i)->getUUID());
         }

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1659,7 +1659,7 @@ bool LLAppViewer::doFrame()
 
 S32 LLAppViewer::updateTextureThreads(F32 max_time)
 {
-    S32 work_pending = 0;
+    size_t work_pending = 0;
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_APP("Texture Cache");
         work_pending += LLAppViewer::getTextureCache()->update(max_time); // unpauses the texture cache thread
@@ -1672,7 +1672,7 @@ S32 LLAppViewer::updateTextureThreads(F32 max_time)
         LL_PROFILE_ZONE_NAMED_CATEGORY_APP("Image Fetch");
         work_pending += LLAppViewer::getTextureFetch()->update(max_time); // unpauses the texture fetch thread
     }
-    return work_pending;
+    return static_cast<S32>(work_pending);
 }
 
 void LLAppViewer::flushLFSIO()
@@ -2019,9 +2019,9 @@ bool LLAppViewer::cleanup()
     while(1)
     {
         S32 pending = 0;
-        pending += LLAppViewer::getTextureCache()->update(1); // unpauses the worker thread
-        pending += LLAppViewer::getImageDecodeThread()->update(1); // unpauses the image thread
-        pending += LLAppViewer::getTextureFetch()->update(1); // unpauses the texture fetch thread
+        pending += static_cast<S32>(LLAppViewer::getTextureCache()->update(1)); // unpauses the worker thread
+        pending += static_cast<S32>(LLAppViewer::getImageDecodeThread()->update(1)); // unpauses the image thread
+        pending += static_cast<S32>(LLAppViewer::getTextureFetch()->update(1)); // unpauses the texture fetch thread
         pending += LLLFSThread::updateClass(0);
         F64 idle_time = idleTimer.getElapsedTimeF64();
         if(!pending)
@@ -3478,7 +3478,7 @@ std::string LLAppViewer::getViewerInfoString(bool default_string) const
         else
         {
             // array value: build KEY_0, KEY_1 etc. entries
-            for (LLSD::Integer n(0), size(ii->second.size()); n < size; ++n)
+            for (LLSD::Integer n(0), size(static_cast<LLSD::Integer>(ii->second.size())); n < size; ++n)
             {
                 args[STRINGIZE(ii->first << '_' << n)] = ii->second[n].asString();
             }
@@ -3721,7 +3721,7 @@ void LLAppViewer::recordMarkerVersion(LLAPRFile& marker_file)
     }
 
     // record the viewer version in the marker file
-    marker_file.write(marker_version.data(), marker_version.length());
+    marker_file.write(marker_version.data(), static_cast<S32>(marker_version.length()));
 }
 
 bool LLAppViewer::markerIsSameVersion(const std::string& marker_name) const
@@ -5164,7 +5164,7 @@ void LLAppViewer::updateNameLookupUrl(const LLViewerRegion * regionp)
     if (have_capability)
     {
         // we have support for display names, use it
-        U32 url_size = name_lookup_url.size();
+        auto url_size = name_lookup_url.size();
         // capabilities require URLs with slashes before query params:
         // https://<host>:<port>/cap/<uuid>/?ids=<blah>
         // but the caps are granted like:

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -964,7 +964,7 @@ bool LLAppViewerWin32::sendURLToOtherInstance(const std::string& url)
         COPYDATASTRUCT cds;
         const S32 SLURL_MESSAGE_TYPE = 0;
         cds.dwData = SLURL_MESSAGE_TYPE;
-        cds.cbData = url.length() + 1;
+        cds.cbData = static_cast<DWORD>(url.length()) + 1;
         cds.lpData = (void*)url.c_str();
 
         LRESULT msg_result = SendMessage(other_window, WM_COPYDATA, NULL, (LPARAM)&cds);

--- a/indra/newview/llattachmentsmgr.cpp
+++ b/indra/newview/llattachmentsmgr.cpp
@@ -296,7 +296,7 @@ void LLAttachmentsMgr::LLItemRequestTimes::addTime(const LLUUID& inv_item_id)
 void LLAttachmentsMgr::LLItemRequestTimes::removeTime(const LLUUID& inv_item_id)
 {
     LLInventoryItem *item = gInventory.getItem(inv_item_id);
-    S32 remove_count = (*this).erase(inv_item_id);
+    auto remove_count = (*this).erase(inv_item_id);
     if (remove_count)
     {
         LL_DEBUGS("Avatar") << "ATT " << mOpName << " removing request time "

--- a/indra/newview/llautoreplace.cpp
+++ b/indra/newview/llautoreplace.cpp
@@ -81,7 +81,7 @@ void LLAutoReplace::autoreplaceCallback(S32& replacement_start, S32& replacement
                         replacement_start = word_start;
                         replacement_length = word_end - word_start + 1;
                         replacement_string = utf8str_to_wstring(replacement_word);
-                        S32 size_change = replacement_string.size() - old_string.size();
+                        S32 size_change = static_cast<S32>(replacement_string.size() - old_string.size());
                         cursor_pos += size_change;
                     }
                 }

--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -653,8 +653,8 @@ void LLAvatarActions::csr(const LLUUID& id, std::string name)
     std::string url = "http://csr.lindenlab.com/agent/";
 
     // slow and stupid, but it's late
-    S32 len = name.length();
-    for (S32 i = 0; i < len; i++)
+    auto len = name.length();
+    for (size_t i = 0; i < len; i++)
     {
         if (name[i] == ' ')
         {
@@ -829,11 +829,11 @@ namespace action_give_inventory
             return;
         }
 
-        S32 count = LLShareInfo::instance().mAvatarNames.size();
+        auto count = LLShareInfo::instance().mAvatarNames.size();
         bool shared = count && !inventory_selected_uuids.empty();
 
         // iterate through avatars
-        for(S32 i = 0; i < count; ++i)
+        for(size_t i = 0; i < count; ++i)
         {
             const LLUUID& avatar_uuid = LLShareInfo::instance().mAvatarUuids[i];
 

--- a/indra/newview/llavatarrendernotifier.cpp
+++ b/indra/newview/llavatarrendernotifier.cpp
@@ -306,7 +306,7 @@ void LLHUDRenderNotifier::updateNotificationHUD(hud_complexity_list_t complexity
     }
 
     mHUDComplexityList = complexity;
-    mHUDsCount = mHUDComplexityList.size();
+    mHUDsCount = static_cast<S32>(mHUDComplexityList.size());
 
     static LLCachedControl<U32> show_my_complexity_changes(gSavedSettings, "ShowMyComplexityChanges", 20);
     if (!show_my_complexity_changes)

--- a/indra/newview/llblocklist.cpp
+++ b/indra/newview/llblocklist.cpp
@@ -47,7 +47,7 @@ LLBlockList::LLBlockList(const Params& p)
 {
 
     LLMuteList::getInstance()->addObserver(this);
-    mMuteListSize = LLMuteList::getInstance()->getMutes().size();
+    mMuteListSize = static_cast<U32>(LLMuteList::getInstance()->getMutes().size());
 
     // Set up context menu.
     LLUICtrl::CommitCallbackRegistry::ScopedRegistrar registrar;
@@ -92,7 +92,7 @@ void LLBlockList::createList()
 BlockListActionType LLBlockList::getCurrentMuteListActionType()
 {
     BlockListActionType type = NONE;
-    U32 curSize = LLMuteList::getInstance()->getMutes().size();
+    U32 curSize = static_cast<U32>(LLMuteList::getInstance()->getMutes().size());
     if( curSize > mMuteListSize)
         type = ADD;
     else if(curSize < mMuteListSize)
@@ -266,7 +266,7 @@ void LLBlockList::refresh()
             selectItemPair(getItemPair(next_selected), true);
         }
     }
-    mMuteListSize = LLMuteList::getInstance()->getMutes().size();
+    mMuteListSize = static_cast<U32>(LLMuteList::getInstance()->getMutes().size());
 
     // Sort the list.
     sort();

--- a/indra/newview/llcallingcard.cpp
+++ b/indra/newview/llcallingcard.cpp
@@ -26,16 +26,11 @@
 
 #include "llviewerprecompiledheaders.h"
 
-#if LL_WINDOWS
-#pragma warning( disable : 4800 ) // performance warning in <functional>
-#endif
-
 #include "llcallingcard.h"
 
 #include <algorithm>
 
 #include "indra_constants.h"
-//#include "llcachename.h"
 #include "llstl.h"
 #include "lltimer.h"
 #include "lluuid.h"

--- a/indra/newview/llchatbar.cpp
+++ b/indra/newview/llchatbar.cpp
@@ -470,7 +470,7 @@ void LLChatBar::onInputEditorKeystroke( LLLineEditor* caller, void* userdata )
     // to eat trailing spaces that might be part of a gesture.
     LLWStringUtil::trimHead(raw_text);
 
-    S32 length = raw_text.length();
+    auto length = raw_text.length();
 
     if( (length > 0) && (raw_text[0] != '/') )  // forward slash is used for escape (eg. emote) sequences
     {
@@ -518,7 +518,7 @@ void LLChatBar::onInputEditorKeystroke( LLLineEditor* caller, void* userdata )
 
                 // Select to end of line, starting from the character
                 // after the last one the user typed.
-                self->mInputEditor->setSelection(length, outlength);
+                self->mInputEditor->setSelection(static_cast<S32>(length), outlength);
             }
         }
 

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -725,8 +725,8 @@ public:
                  mSourceType == CHAT_SOURCE_AGENT)
         {
             //if it's an avatar name with a username add formatting
-            S32 username_start = chat.mFromName.rfind(" (");
-            S32 username_end = chat.mFromName.rfind(')');
+            auto username_start = chat.mFromName.rfind(" (");
+            auto username_end = chat.mFromName.rfind(')');
 
             if (username_start != std::string::npos &&
                 username_end == (chat.mFromName.length() - 1))

--- a/indra/newview/llchiclet.h
+++ b/indra/newview/llchiclet.h
@@ -628,7 +628,7 @@ public:
     /**
      * Returns number of hosted chiclets.
      */
-    S32 getChicletCount() {return mChicletList.size();};
+    S32 getChicletCount() { return static_cast<S32>(mChicletList.size()); }
 
     /**
      * Returns index of chiclet in list.
@@ -854,7 +854,7 @@ T* LLChicletPanel::createChiclet(const LLUUID& session_id, S32 index)
 template<class T>
 T* LLChicletPanel::createChiclet(const LLUUID& session_id)
 {
-    return createChiclet<T>(session_id, mChicletList.size());
+    return createChiclet<T>(session_id, static_cast<S32>(mChicletList.size()));
 }
 
 template<class T>

--- a/indra/newview/llcofwearables.cpp
+++ b/indra/newview/llcofwearables.cpp
@@ -618,13 +618,13 @@ void LLCOFWearables::populateClothingList(LLAppearanceMgr::wearables_by_type_t& 
 
     for (U32 type = LLWearableType::WT_SHIRT; type < LLWearableType::WT_COUNT; ++type)
     {
-        U32 size = clothing_by_type[type].size();
+        auto size = clothing_by_type[type].size();
         if (!size) continue;
 
         LLAppearanceMgr::sortItemsByActualDescription(clothing_by_type[type]);
 
         //clothing items are displayed in reverse order, from furthest ones to closest ones (relatively to the body)
-        for (U32 i = size; i != 0; --i)
+        for (size_t i = size; i != 0; --i)
         {
             LLViewerInventoryItem* item = clothing_by_type[type][i-1];
 
@@ -647,8 +647,8 @@ void LLCOFWearables::addClothingTypesDummies(const LLAppearanceMgr::wearables_by
 
     for (U32 type = LLWearableType::WT_SHIRT; type < LLWearableType::WT_COUNT; type++)
     {
-        U32 size = clothing_by_type[type].size();
-        if (size) continue;
+        if (clothing_by_type[type].empty())
+            continue;
 
         LLWearableType::EType w_type = static_cast<LLWearableType::EType>(type);
         LLPanelInventoryListItemBase* item_panel = LLPanelDummyClothingListItem::create(w_type);

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -378,8 +378,8 @@ bool LLCommandLineParser::parseCommandLineString(const std::string& str)
     if (!str.empty())
     {
         bool add_last_c = true;
-        S32 last_c_pos = str.size() - 1; //don't get out of bounds on pos+1, last char will be processed separately
-        for (S32 pos = 0; pos < last_c_pos; ++pos)
+        auto last_c_pos = str.size() - 1; //don't get out of bounds on pos+1, last char will be processed separately
+        for (size_t pos = 0; pos < last_c_pos; ++pos)
         {
             cmd_line_string.append(&str[pos], 1);
             if (str[pos] == '\\')

--- a/indra/newview/llcommunicationchannel.cpp
+++ b/indra/newview/llcommunicationchannel.cpp
@@ -54,7 +54,7 @@ bool LLCommunicationChannel::filterByDoNotDisturbStatus(LLNotificationPtr)
 
 S32 LLCommunicationChannel::getHistorySize() const
 {
-    return mHistory.size();
+    return static_cast<S32>(mHistory.size());
 }
 
 LLCommunicationChannel::history_list_t::const_iterator LLCommunicationChannel::beginHistory() const

--- a/indra/newview/llcontrolavatar.cpp
+++ b/indra/newview/llcontrolavatar.cpp
@@ -424,11 +424,11 @@ void LLControlAvatar::updateDebugText()
         S32 total_linkset_count = 0;
         if (mRootVolp)
         {
-            total_linkset_count = 1 + mRootVolp->getChildren().size();
+            total_linkset_count = 1 + static_cast<S32>(mRootVolp->getChildren().size());
         }
         std::vector<LLVOVolume*> volumes;
         getAnimatedVolumes(volumes);
-        S32 animated_volume_count = volumes.size();
+        S32 animated_volume_count = static_cast<S32>(volumes.size());
         std::string active_string;
         std::string type_string;
         std::string lod_string;

--- a/indra/newview/lldrawable.cpp
+++ b/indra/newview/lldrawable.cpp
@@ -339,7 +339,7 @@ LLFace* LLDrawable::addFace(const LLTextureEntry *te, LLViewerTexture *texturep)
 
     face = new LLFace(this, mVObjp);
 
-    face->setTEOffset(mFaces.size());
+    face->setTEOffset(static_cast<S32>(mFaces.size()));
     face->setTexture(texturep);
     face->setPoolType(gPipeline.getPoolTypeFromTE(te, texturep));
 
@@ -361,7 +361,7 @@ LLFace* LLDrawable::addFace(const LLTextureEntry *te, LLViewerTexture *texturep,
     LLFace *face;
     face = new LLFace(this, mVObjp);
 
-    face->setTEOffset(mFaces.size());
+    face->setTEOffset(static_cast<S32>(mFaces.size()));
     face->setTexture(texturep);
     face->setNormalMap(normalp);
     face->setPoolType(gPipeline.getPoolTypeFromTE(te, texturep));
@@ -384,7 +384,7 @@ LLFace* LLDrawable::addFace(const LLTextureEntry *te, LLViewerTexture *texturep,
     LLFace *face;
     face = new LLFace(this, mVObjp);
 
-    face->setTEOffset(mFaces.size());
+    face->setTEOffset(static_cast<S32>(mFaces.size()));
     face->setTexture(texturep);
     face->setNormalMap(normalp);
     face->setSpecularMap(specularp);
@@ -417,7 +417,7 @@ void LLDrawable::setNumFaces(const S32 newFaces, LLFacePool *poolp, LLViewerText
     else // (newFaces > mFaces.size())
     {
         mFaces.reserve(newFaces);
-        for (int i = mFaces.size(); i<newFaces; i++)
+        for (auto i = mFaces.size(); i<newFaces; i++)
         {
             addFace(poolp, texturep);
         }
@@ -442,7 +442,7 @@ void LLDrawable::setNumFacesFast(const S32 newFaces, LLFacePool *poolp, LLViewer
     else // (newFaces > mFaces.size())
     {
         mFaces.reserve(newFaces);
-        for (int i = mFaces.size(); i<newFaces; i++)
+        for (auto i = mFaces.size(); i<newFaces; i++)
         {
             addFace(poolp, texturep);
         }
@@ -455,10 +455,10 @@ void LLDrawable::mergeFaces(LLDrawable* src)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DRAWABLE
 
-    U32 face_count = mFaces.size() + src->mFaces.size();
+    auto face_count = mFaces.size() + src->mFaces.size();
 
     mFaces.reserve(face_count);
-    for (U32 i = 0; i < src->mFaces.size(); i++)
+    for (size_t i = 0; i < src->mFaces.size(); i++)
     {
         LLFace* facep = src->mFaces[i];
         facep->setDrawable(this);

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -315,7 +315,7 @@ void LLFacePool::addFaceReference(LLFace *facep)
 {
     if (-1 == facep->getReferenceIndex())
     {
-        facep->setReferenceIndex(mReferences.size());
+        facep->setReferenceIndex(static_cast<S32>(mReferences.size()));
         mReferences.push_back(facep);
     }
 }
@@ -667,7 +667,7 @@ bool LLRenderPass::uploadMatrixPalette(LLVOAvatar* avatar, LLMeshSkinInfo* skinI
         return false;
     }
     const LLVOAvatar::MatrixPaletteCache& mpc = avatar->updateSkinInfoMatrixPalette(skinInfo);
-    U32 count = mpc.mMatrixPalette.size();
+    U32 count = static_cast<U32>(mpc.mMatrixPalette.size());
 
     if (count == 0)
     {

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -918,7 +918,7 @@ bool LLDrawPoolAlpha::uploadMatrixPalette(const LLDrawInfo& params)
         return false;
     }
     const LLVOAvatar::MatrixPaletteCache& mpc = params.mAvatar.get()->updateSkinInfoMatrixPalette(params.mSkinInfo);
-    U32 count = mpc.mMatrixPalette.size();
+    U32 count = static_cast<U32>(mpc.mMatrixPalette.size());
 
     if (count == 0)
     {

--- a/indra/newview/lldrawpoolmaterials.cpp
+++ b/indra/newview/lldrawpoolmaterials.cpp
@@ -250,7 +250,7 @@ void LLDrawPoolMaterials::renderDeferred(S32 pass)
             if (params.mAvatar != lastAvatar)
             {
                 const LLVOAvatar::MatrixPaletteCache& mpc = params.mAvatar->updateSkinInfoMatrixPalette(params.mSkinInfo);
-                U32 count = mpc.mMatrixPalette.size();
+                U32 count = static_cast<U32>(mpc.mMatrixPalette.size());
 
                 if (count == 0)
                 {

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -757,7 +757,7 @@ namespace
         LLEnvironment::DayInstance::ptr_t   getBaseDayInstance() const  { return mBaseDayInstance; }
         void                                setBaseDayInstance(const LLEnvironment::DayInstance::ptr_t &baseday);
 
-        S32                                 countExperiencesActive() const { return mActiveExperiences.size(); }
+        S32                                 countExperiencesActive() const { return static_cast<S32>(mActiveExperiences.size()); }
 
         bool                                isOverriddenSky() const { return !mSkyExperience.isNull(); }
         bool                                isOverriddenWater() const { return !mWaterExperience.isNull(); }

--- a/indra/newview/llfasttimerview.cpp
+++ b/indra/newview/llfasttimerview.cpp
@@ -249,7 +249,7 @@ bool LLFastTimerView::handleHover(S32 x, S32 y, MASK mask)
 
         TimerBar* hover_bar = NULL;
         F32Seconds mouse_time_offset = ((F32)(x - mBarRect.mLeft) / (F32)mBarRect.getWidth()) * mTotalTimeDisplay;
-        for (int bar_index = 0, end_index = LLTrace::BlockTimerStatHandle::instance_tracker_t::instanceCount();
+        for (size_t bar_index = 0, end_index = LLTrace::BlockTimerStatHandle::instance_tracker_t::instanceCount();
             bar_index < end_index;
             ++bar_index)
         {
@@ -706,7 +706,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
 
         gGL.color3fv(base_col.mV);
         U32 count = 0;
-        U32 total_count = base_execution.size();
+        U32 total_count = static_cast<U32>(base_execution.size());
 
         last_p.clear();
 
@@ -728,7 +728,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
             LLGLEnable blend(GL_BLEND);
             gGL.color3fv(cur_col.mV);
             count = 0;
-            total_count = cur_execution.size();
+            total_count = static_cast<U32>(cur_execution.size());
 
             for (std::vector<LLSD::Real>::iterator iter = cur_execution.begin(); iter != cur_execution.end(); ++iter)
             {
@@ -1020,7 +1020,7 @@ void LLFastTimerView::drawLineGraph()
 
     //highlight visible range
     {
-        S32 first_frame = mRecording.getNumRecordedPeriods() - mScrollIndex;
+        S32 first_frame = static_cast<S32>(mRecording.getNumRecordedPeriods()) - mScrollIndex;
         S32 last_frame = first_frame - MAX_VISIBLE_HISTORY;
 
         F32 frame_delta = ((F32) (mGraphRect.getWidth()))/(mRecording.getNumRecordedPeriods()-1);
@@ -1083,7 +1083,7 @@ void LLFastTimerView::drawLineGraph()
         F32 time_scale_factor = (F32)mGraphRect.getHeight() / max_time.value();
         F32 hz_scale_factor = (F32) mGraphRect.getHeight() / (1.f / max_time.value());
 
-        for (U32 j = mRecording.getNumRecordedPeriods();
+        for (U32 j = static_cast<U32>(mRecording.getNumRecordedPeriods());
             j > 0;
             j--)
         {
@@ -1651,7 +1651,7 @@ S32 LLFastTimerView::drawBar(LLRect bar_rect, TimerBarRow& row, S32 image_width,
     bool children_visible = visible && !time_block->getTreeNode().mCollapsed;
 
     bar_index++;
-    const U32 num_bars = LLTrace::BlockTimerStatHandle::instance_tracker_t::instanceCount();
+    const auto num_bars = LLTrace::BlockTimerStatHandle::instance_tracker_t::instanceCount();
     if (bar_index < num_bars && row.mBars[bar_index].mFirstChild)
     {
         bool is_last = false;

--- a/indra/newview/llfavoritesbar.cpp
+++ b/indra/newview/llfavoritesbar.cpp
@@ -1250,7 +1250,7 @@ void LLFavoritesBarCtrl::fitLabelWidth(LLMenuItemCallGL* menu_item)
     // Check whether item name wider than menu
     if (menu_item->getNominalWidth() > max_width)
     {
-        S32 chars_total = item_name.length();
+        S32 chars_total = static_cast<S32>(item_name.length());
         S32 chars_fitted = 1;
         menu_item->setLabel(LLStringExplicit(""));
         S32 label_space = max_width - menu_item->getFont()->getWidth("...") -
@@ -1375,7 +1375,7 @@ bool LLFavoritesBarCtrl::handleRightMouseDown(S32 x, S32 y, MASK mask)
 }
 void copy_slurl_to_clipboard_cb(std::string& slurl)
 {
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(slurl),0,slurl.size());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(slurl), 0, static_cast<S32>(slurl.size()));
 
     LLSD args;
     args["SLURL"] = slurl;
@@ -1522,8 +1522,8 @@ bool LLFavoritesBarCtrl::isClipboardPasteable() const
 
     std::vector<LLUUID> objects;
     LLClipboard::instance().pasteFromClipboard(objects);
-    S32 count = objects.size();
-    for(S32 i = 0; i < count; i++)
+    auto count = objects.size();
+    for(size_t i = 0; i < count; i++)
     {
         const LLUUID &item_id = objects.at(i);
 
@@ -1551,9 +1551,9 @@ void LLFavoritesBarCtrl::pasteFromClipboard() const
         LLInventoryItem* item = NULL;
         std::vector<LLUUID> objects;
         LLClipboard::instance().pasteFromClipboard(objects);
-        S32 count = objects.size();
+        auto count = objects.size();
         LLUUID parent_id(mFavoriteFolderId);
-        for(S32 i = 0; i < count; i++)
+        for(size_t i = 0; i < count; i++)
         {
             item = model->getItem(objects.at(i));
             if (item)

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -196,7 +196,7 @@ static const std::vector<std::string> sGraphicsLevelNames = boost::assign::list_
 
 U32 LLFeatureManager::getMaxGraphicsLevel() const
 {
-    return sGraphicsLevelNames.size() - 1;
+    return static_cast<U32>(sGraphicsLevelNames.size()) - 1;
 }
 
 bool LLFeatureManager::isValidGraphicsLevel(U32 level) const

--- a/indra/newview/llflexibleobject.cpp
+++ b/indra/newview/llflexibleobject.cpp
@@ -72,13 +72,13 @@ LLVolumeImplFlexible::LLVolumeImplFlexible(LLViewerObject* vo, LLFlexibleObjectD
         mVO->mDrawable->makeActive() ;
     }
 
-    mInstanceIndex = sInstanceList.size();
+    mInstanceIndex = static_cast<S32>(sInstanceList.size());
     sInstanceList.push_back(this);
 }//-----------------------------------------------
 
 LLVolumeImplFlexible::~LLVolumeImplFlexible()
 {
-    S32 end_idx = sInstanceList.size()-1;
+    S32 end_idx = static_cast<S32>(sInstanceList.size()) - 1;
 
     if (end_idx != mInstanceIndex)
     {

--- a/indra/newview/llfloaterbulkpermission.cpp
+++ b/indra/newview/llfloaterbulkpermission.cpp
@@ -223,7 +223,7 @@ bool LLFloaterBulkPermission::start()
 // Go to the next object and start if found. Returns false if no objects left, true otherwise.
 bool LLFloaterBulkPermission::nextObject()
 {
-    S32 count;
+    size_t count;
     bool successful_start = false;
     do
     {
@@ -251,7 +251,7 @@ bool LLFloaterBulkPermission::popNext()
 {
     // get the head element from the container, and attempt to get its inventory.
     bool rv = false;
-    S32 count = mObjectIDs.size();
+    auto count = mObjectIDs.size();
     if(mCurrentObjectID.isNull() && (count > 0))
     {
         mCurrentObjectID = mObjectIDs.at(0);

--- a/indra/newview/llfloaterconversationpreview.cpp
+++ b/indra/newview/llfloaterconversationpreview.cpp
@@ -108,7 +108,7 @@ void LLFloaterConversationPreview::setPages(std::list<LLSD>* messages, const std
             delete mMessages; // Clean up temporary message list with "Loading..." text
         }
         mMessages = messages;
-        mCurrentPage = (mMessages->size() ? (mMessages->size() - 1) / mPageSize : 0);
+        mCurrentPage = (mMessages->size() ? (static_cast<int>(mMessages->size()) - 1) / mPageSize : 0);
 
         mPageSpinner->setEnabled(true);
         mPageSpinner->setMaxValue(mCurrentPage+1);

--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -103,16 +103,16 @@ public:
         F32 x = 4; // padding-left
         F32 y = getRect().getHeight() / 2;
         LLFontGL::getFontSansSerif()->render(
-            mText,                      // wstr
-            0,                          // begin_offset
-            x,                          // x
-            y,                          // y
-            LLColor4::white,            // color
-            LLFontGL::LEFT,             // halign
-            LLFontGL::VCENTER,          // valign
-            LLFontGL::NORMAL,           // style
-            LLFontGL::DROP_SHADOW_SOFT, // shadow
-            mText.size());              // max_chars
+            mText,                           // wstr
+            0,                               // begin_offset
+            x,                               // x
+            y,                               // y
+            LLColor4::white,                 // color
+            LLFontGL::LEFT,                  // halign
+            LLFontGL::VCENTER,               // valign
+            LLFontGL::NORMAL,                // style
+            LLFontGL::DROP_SHADOW_SOFT,      // shadow
+            static_cast<S32>(mText.size())); // max_chars
     }
 
     virtual void updatePanel(bool allow_modify) override {}
@@ -235,17 +235,17 @@ protected:
         {
             std::string text = mTitle.substr(0, mBegin);
             font->renderUTF8(
-                text,                       // text
-                0,                          // begin_offset
-                x0,                         // x
-                y,                          // y
-                color,                      // color
-                LLFontGL::LEFT,             // halign
-                LLFontGL::VCENTER,          // valign
-                LLFontGL::NORMAL,           // style
-                LLFontGL::DROP_SHADOW_SOFT, // shadow
-                text.size(),                // max_chars
-                x1);                        // max_pixels
+                text,                          // text
+                0,                             // begin_offset
+                x0,                            // x
+                y,                             // y
+                color,                         // color
+                LLFontGL::LEFT,                // halign
+                LLFontGL::VCENTER,             // valign
+                LLFontGL::NORMAL,              // style
+                LLFontGL::DROP_SHADOW_SOFT,    // shadow
+                static_cast<S32>(text.size()), // max_chars
+                x1);                           // max_pixels
             F32 dx = font->getWidthF32(text);
             x0 += dx;
             x1 -= dx;
@@ -254,17 +254,17 @@ protected:
         {
             std::string text = mTitle.substr(mBegin, mEnd - mBegin);
             font->renderUTF8(
-                text,                       // text
-                0,                          // begin_offset
-                x0,                         // x
-                y,                          // y
-                LLColor4::yellow6,          // color
-                LLFontGL::LEFT,             // halign
-                LLFontGL::VCENTER,          // valign
-                LLFontGL::NORMAL,           // style
-                LLFontGL::DROP_SHADOW_SOFT, // shadow
-                text.size(),                // max_chars
-                x1);                        // max_pixels
+                text,                          // text
+                0,                             // begin_offset
+                x0,                            // x
+                y,                             // y
+                LLColor4::yellow6,             // color
+                LLFontGL::LEFT,                // halign
+                LLFontGL::VCENTER,             // valign
+                LLFontGL::NORMAL,              // style
+                LLFontGL::DROP_SHADOW_SOFT,    // shadow
+                static_cast<S32>(text.size()), // max_chars
+                x1);                           // max_pixels
             F32 dx = font->getWidthF32(text);
             x0 += dx;
             x1 -= dx;
@@ -273,17 +273,17 @@ protected:
         {
             std::string text = mEnd ? mTitle.substr(mEnd) : mTitle;
             font->renderUTF8(
-                text,                       // text
-                0,                          // begin_offset
-                x0,                         // x
-                y,                          // y
-                color,                      // color
-                LLFontGL::LEFT,             // halign
-                LLFontGL::VCENTER,          // valign
-                LLFontGL::NORMAL,           // style
-                LLFontGL::DROP_SHADOW_SOFT, // shadow
-                text.size(),                // max_chars
-                x1);                        // max_pixels
+                text,                          // text
+                0,                             // begin_offset
+                x0,                            // x
+                y,                             // y
+                color,                         // color
+                LLFontGL::LEFT,                // halign
+                LLFontGL::VCENTER,             // valign
+                LLFontGL::NORMAL,              // style
+                LLFontGL::DROP_SHADOW_SOFT,    // shadow
+                static_cast<S32>(text.size()), // max_chars
+                x1);                           // max_pixels
         }
     }
 
@@ -413,9 +413,9 @@ void LLFloaterEmojiPicker::initialize()
     showPreview(true);
 
     mSelectedGroupIndex = groupIndex == ALL_EMOJIS_GROUP_INDEX ? 0 :
-        (1 + std::distance(mFilteredEmojiGroups.begin(),
+        static_cast<U32>((1 + std::distance(mFilteredEmojiGroups.begin(),
             std::find(mFilteredEmojiGroups.begin(), mFilteredEmojiGroups.end(), groupIndex))) %
-        (1 + mFilteredEmojiGroups.size());
+        (1 + mFilteredEmojiGroups.size()));
 
     mGroupButtons[mSelectedGroupIndex]->setToggleState(true);
     mGroupButtons[mSelectedGroupIndex]->setUseFontColor(true);
@@ -991,15 +991,15 @@ bool LLFloaterEmojiPicker::moveFocusedIconUp()
 
 bool LLFloaterEmojiPicker::moveFocusedIconDown()
 {
-    S32 rowCount = mEmojiGrid->getPanelList().size();
-    for (S32 i = mFocusedIconRow + 1; i < rowCount; ++i)
+    auto rowCount = mEmojiGrid->getPanelList().size();
+    for (size_t i = mFocusedIconRow + 1; i < rowCount; ++i)
     {
         LLScrollingPanel* panel = mEmojiGrid->getPanelList()[i];
         LLEmojiGridRow* row = dynamic_cast<LLEmojiGridRow*>(panel);
         if (row && row->mList->getPanelList().size() > mFocusedIconCol)
         {
             mEmojiScroll->scrollToShowRect(row->getBoundingRect());
-            mFocusedIconRow = i;
+            mFocusedIconRow = static_cast<S32>(i);
             selectFocusedIcon();
             return true;
         }
@@ -1027,7 +1027,7 @@ bool LLFloaterEmojiPicker::moveFocusedIconPrev()
         if (row && row->mList->getPanelList().size())
         {
             mEmojiScroll->scrollToShowRect(row->getBoundingRect());
-            mFocusedIconCol = row->mList->getPanelList().size() - 1;
+            mFocusedIconCol = static_cast<S32>(row->mList->getPanelList().size()) - 1;
             mFocusedIconRow = i;
             selectFocusedIcon();
             return true;
@@ -1044,7 +1044,7 @@ bool LLFloaterEmojiPicker::moveFocusedIconNext()
 
     LLScrollingPanel* panel = mEmojiGrid->getPanelList()[mFocusedIconRow];
     LLEmojiGridRow* row = dynamic_cast<LLEmojiGridRow*>(panel);
-    S32 colCount = row ? row->mList->getPanelList().size() : 0;
+    S32 colCount = row ? static_cast<S32>(row->mList->getPanelList().size()) : 0;
     if (mFocusedIconCol < colCount - 1)
     {
         mFocusedIconCol++;
@@ -1052,8 +1052,8 @@ bool LLFloaterEmojiPicker::moveFocusedIconNext()
         return true;
     }
 
-    S32 rowCount = mEmojiGrid->getPanelList().size();
-    for (S32 i = mFocusedIconRow + 1; i < rowCount; ++i)
+    auto rowCount = mEmojiGrid->getPanelList().size();
+    for (size_t i = mFocusedIconRow + 1; i < rowCount; ++i)
     {
         LLScrollingPanel* panel = mEmojiGrid->getPanelList()[i];
         LLEmojiGridRow* row = dynamic_cast<LLEmojiGridRow*>(panel);
@@ -1061,7 +1061,7 @@ bool LLFloaterEmojiPicker::moveFocusedIconNext()
         {
             mEmojiScroll->scrollToShowRect(row->getBoundingRect());
             mFocusedIconCol = 0;
-            mFocusedIconRow = i;
+            mFocusedIconRow = static_cast<S32>(i);
             selectFocusedIcon();
             return true;
         }
@@ -1112,10 +1112,10 @@ bool LLFloaterEmojiPicker::handleKey(KEY key, MASK mask, bool called_from_parent
         switch (key)
         {
         case KEY_LEFT:
-            selectEmojiGroup((mSelectedGroupIndex + mFilteredEmojis.size()) % mGroupButtons.size());
+            selectEmojiGroup(static_cast<U32>((mSelectedGroupIndex + mFilteredEmojis.size()) % mGroupButtons.size()));
             return true;
         case KEY_RIGHT:
-            selectEmojiGroup((mSelectedGroupIndex + 1) % mGroupButtons.size());
+            selectEmojiGroup(static_cast<U32>((mSelectedGroupIndex + 1) % mGroupButtons.size()));
             return true;
         }
     }

--- a/indra/newview/llfloatergroups.cpp
+++ b/indra/newview/llfloatergroups.cpp
@@ -342,13 +342,13 @@ void LLPanelGroups::onGroupList(LLUICtrl* ctrl, void* userdata)
 
 void init_group_list(LLScrollListCtrl* group_list, const LLUUID& highlight_id, U64 powers_mask)
 {
-    S32 count = gAgent.mGroups.size();
+    auto count = gAgent.mGroups.size();
     LLUUID id;
     if (!group_list) return;
 
     group_list->operateOnAll(LLCtrlListInterface::OP_DELETE);
 
-    for(S32 i = 0; i < count; ++i)
+    for(size_t i = 0; i < count; ++i)
     {
         id = gAgent.mGroups.at(i).mID;
         LLGroupData* group_datap = &gAgent.mGroups.at(i);

--- a/indra/newview/llfloaterimcontainer.cpp
+++ b/indra/newview/llfloaterimcontainer.cpp
@@ -1787,8 +1787,8 @@ void LLFloaterIMContainer::setNearbyDistances()
         // Get the position of the agent
         const LLVector3d& me_pos = gAgent.getPositionGlobal();
         // For each nearby avatar, compute and update the distance
-        int avatar_count = positions.size();
-        for (int i = 0; i < avatar_count; i++)
+        auto avatar_count = positions.size();
+        for (size_t i = 0; i < avatar_count; i++)
         {
             F64 dist = dist_vec_squared(positions[i], me_pos);
             item->setDistance(avatar_ids[i],dist);

--- a/indra/newview/llfloaterimcontainer.h
+++ b/indra/newview/llfloaterimcontainer.h
@@ -212,7 +212,7 @@ public:
     void highlightConversationItemWidget(const LLUUID& session_id, bool is_highlighted);
     bool isScrolledOutOfSight(LLConversationViewSession* conversation_item_widget);
     boost::signals2::connection mMicroChangedSignal;
-    S32 getConversationListItemSize() { return mConversationsWidgets.size(); }
+    S32 getConversationListItemSize() { return static_cast<S32>(mConversationsWidgets.size()); }
     typedef std::list<LLFloater*> floater_list_t;
     void getDetachedConversationFloaters(floater_list_t& floaters);
 

--- a/indra/newview/llfloaterimnearbychat.cpp
+++ b/indra/newview/llfloaterimnearbychat.cpp
@@ -431,7 +431,7 @@ bool LLFloaterIMNearbyChat::handleKeyHere( KEY key, MASK mask )
 
 bool LLFloaterIMNearbyChat::matchChatTypeTrigger(const std::string& in_str, std::string* out_str)
 {
-    U32 in_len = in_str.length();
+    auto in_len = in_str.length();
     S32 cnt = sizeof(sChatTypeTriggers) / sizeof(*sChatTypeTriggers);
 
     bool string_was_found = false;
@@ -470,7 +470,7 @@ void LLFloaterIMNearbyChat::onChatBoxKeystroke()
     // to eat trailing spaces that might be part of a gesture.
     LLWStringUtil::trimHead(raw_text);
 
-    S32 length = raw_text.length();
+    auto length = raw_text.length();
 
     if( (length > 0) && (raw_text[0] != '/') )  // forward slash is used for escape (eg. emote) sequences
     {
@@ -517,7 +517,7 @@ void LLFloaterIMNearbyChat::onChatBoxKeystroke()
                 mInputEditor->setText(utf8_trigger + rest_of_match); // keep original capitalization for user-entered part
                 // Select to end of line, starting from the character
                 // after the last one the user typed.
-                mInputEditor->selectByCursorPosition(utf8_out_str.size()-rest_of_match.size(),utf8_out_str.size());
+                mInputEditor->selectByCursorPosition(static_cast<S32>(utf8_out_str.size() - rest_of_match.size()), static_cast<S32>(utf8_out_str.size()));
             }
 
         }
@@ -549,7 +549,7 @@ void LLFloaterIMNearbyChat::onChatBoxFocusReceived()
 
 EChatType LLFloaterIMNearbyChat::processChatTypeTriggers(EChatType type, std::string &str)
 {
-    U32 length = str.length();
+    auto length = str.length();
     S32 cnt = sizeof(sChatTypeTriggers) / sizeof(*sChatTypeTriggers);
 
     for (S32 n = 0; n < cnt; n++)
@@ -560,7 +560,7 @@ EChatType LLFloaterIMNearbyChat::processChatTypeTriggers(EChatType type, std::st
 
             if (!LLStringUtil::compareInsensitive(trigger, sChatTypeTriggers[n].name))
             {
-                U32 trigger_length = sChatTypeTriggers[n].name.length();
+                auto trigger_length = sChatTypeTriggers[n].name.length();
 
                 // It's to remove space after trigger name
                 if (length > trigger_length && str[trigger_length] == ' ')
@@ -754,8 +754,8 @@ void LLFloaterIMNearbyChat::sendChatFromViewer(const LLWString &wtext, EChatType
 bool LLFloaterIMNearbyChat::isWordsName(const std::string& name)
 {
     // checking to see if it's display name plus username in parentheses
-    S32 open_paren = name.find(" (", 0);
-    S32 close_paren = name.find(')', 0);
+    auto open_paren = name.find(" (", 0);
+    auto close_paren = name.find(')', 0);
 
     if (open_paren != std::string::npos &&
         close_paren == name.length()-1)
@@ -765,7 +765,7 @@ bool LLFloaterIMNearbyChat::isWordsName(const std::string& name)
     else
     {
         //checking for a single space
-        S32 pos = name.find(' ', 0);
+        auto pos = name.find(' ', 0);
         return std::string::npos != pos && name.rfind(' ', name.length()) == pos && 0 != pos && name.length()-1 != pos;
     }
 }

--- a/indra/newview/llfloaterimnearbychat.h
+++ b/indra/newview/llfloaterimnearbychat.h
@@ -70,7 +70,7 @@ public:
     LLChatEntry* getChatBox() { return mInputEditor; }
 
     std::string getCurrentChat();
-    S32 getMessageArchiveLength() {return mMessageArchive.size();}
+    S32 getMessageArchiveLength() { return static_cast<S32>(mMessageArchive.size()); }
 
     virtual bool handleKeyHere( KEY key, MASK mask );
 

--- a/indra/newview/llfloaterimsession.cpp
+++ b/indra/newview/llfloaterimsession.cpp
@@ -1190,7 +1190,7 @@ bool LLFloaterIMSession::inviteToSession(const uuid_vec_t& ids)
 
     if (is_region_exist)
     {
-        S32 count = ids.size();
+        auto count = ids.size();
 
         if( isInviteAllowed() && (count > 0) )
         {
@@ -1200,7 +1200,7 @@ bool LLFloaterIMSession::inviteToSession(const uuid_vec_t& ids)
 
             LLSD data;
             data["params"] = LLSD::emptyArray();
-            for (int i = 0; i < count; i++)
+            for (size_t i = 0; i < count; i++)
             {
                 data["params"].append(ids[i]);
             }

--- a/indra/newview/llfloaterland.cpp
+++ b/indra/newview/llfloaterland.cpp
@@ -2512,7 +2512,7 @@ void LLPanelLandAccess::refresh()
             // Clear the sort order so we don't re-sort on every add.
             mListAccess->clearSortOrder();
             mListAccess->deleteAllItems();
-            S32 count = parcel->mAccessList.size();
+            auto count = parcel->mAccessList.size();
             getChild<LLUICtrl>("AllowedText")->setTextArg("[COUNT]", llformat("%d",count));
             getChild<LLUICtrl>("AllowedText")->setTextArg("[MAX]", llformat("%d",PARCEL_MAX_ACCESS_LIST));
 
@@ -2560,7 +2560,7 @@ void LLPanelLandAccess::refresh()
             // Clear the sort order so we don't re-sort on every add.
             mListBanned->clearSortOrder();
             mListBanned->deleteAllItems();
-            S32 count = parcel->mBanList.size();
+            auto count = parcel->mBanList.size();
             getChild<LLUICtrl>("BanCheck")->setTextArg("[COUNT]", llformat("%d",count));
             getChild<LLUICtrl>("BanCheck")->setTextArg("[MAX]", llformat("%d",PARCEL_MAX_ACCESS_LIST));
 
@@ -2760,13 +2760,13 @@ void LLPanelLandAccess::refresh_ui()
             getChildView("GroupCheck")->setEnabled(can_manage_allowed && can_allow_groups);
         }
         getChildView("AccessList")->setEnabled(can_manage_allowed);
-        S32 allowed_list_count = parcel->mAccessList.size();
+        auto allowed_list_count = parcel->mAccessList.size();
         getChildView("add_allowed")->setEnabled(can_manage_allowed && allowed_list_count < PARCEL_MAX_ACCESS_LIST);
         bool has_selected = (mListAccess && mListAccess->getSelectionInterface()->getFirstSelectedIndex() >= 0);
         getChildView("remove_allowed")->setEnabled(can_manage_allowed && has_selected);
 
         getChildView("BannedList")->setEnabled(can_manage_banned);
-        S32 banned_list_count = parcel->mBanList.size();
+        auto banned_list_count = parcel->mBanList.size();
         getChildView("add_banned")->setEnabled(can_manage_banned && banned_list_count < PARCEL_MAX_ACCESS_LIST);
         has_selected = (mListBanned && mListBanned->getSelectionInterface()->getFirstSelectedIndex() >= 0);
         getChildView("remove_banned")->setEnabled(can_manage_banned && has_selected);

--- a/indra/newview/llfloaterlandholdings.cpp
+++ b/indra/newview/llfloaterlandholdings.cpp
@@ -76,8 +76,8 @@ bool LLFloaterLandHoldings::postBuild()
     grant_list->sortByColumnIndex(0, true);
     grant_list->setDoubleClickCallback(onGrantList, this);
 
-    S32 count = gAgent.mGroups.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = gAgent.mGroups.size();
+    for(size_t i = 0; i < count; ++i)
     {
         LLUUID id(gAgent.mGroups.at(i).mID);
         LLUIString areastr = getString("area_string");

--- a/indra/newview/llfloatermarketplacelistings.cpp
+++ b/indra/newview/llfloatermarketplacelistings.cpp
@@ -577,7 +577,7 @@ S32 LLFloaterMarketplaceListings::getFolderCount()
         LLInventoryModel::item_array_t * items;
         gInventory.getDirectDescendentsOf(mRootFolderId, cats, items);
 
-        return (cats->size() + items->size());
+        return static_cast<S32>(cats->size() + items->size());
     }
     else
     {

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -1420,7 +1420,7 @@ void LLFloaterModelPreview::updateAvatarTab(bool highlight_overrides)
                 LLModel* model = instance.mModel;
                 const LLMeshSkinInfo *skin = &model->mSkinInfo;
                 U32 joint_count = LLSkinningUtil::getMeshJointCount(skin);
-                U32 bind_count = highlight_overrides ? skin->mAlternateBindMatrix.size() : 0; // simply do not include overrides if data is not needed
+                U32 bind_count = highlight_overrides ? static_cast<U32>(skin->mAlternateBindMatrix.size()) : 0; // simply do not include overrides if data is not needed
                 if (bind_count > 0 && bind_count != joint_count)
                 {
                     std::ostringstream out;
@@ -1544,7 +1544,7 @@ void LLFloaterModelPreview::addStringToLogTab(const std::string& str, bool flash
     }
 
     LLWString text = utf8str_to_wstring(str);
-    S32 add_text_len = text.length() + 1; // newline
+    S32 add_text_len = static_cast<S32>(text.length()) + 1; // newline
     S32 editor_max_len = mUploadLogText->getMaxTextLength();
     if (add_text_len > editor_max_len)
         {

--- a/indra/newview/llfloatermyscripts.cpp
+++ b/indra/newview/llfloatermyscripts.cpp
@@ -137,7 +137,7 @@ void LLFloaterMyScripts::setAttachmentDetails(LLSD content)
         return;
     }
 
-    S32 number_attachments = content["attachments"].size();
+    S32 number_attachments = static_cast<S32>(content["attachments"].size());
 
     for(int i = 0; i < number_attachments; i++)
     {
@@ -148,7 +148,7 @@ void LLFloaterMyScripts::setAttachmentDetails(LLSD content)
             humanReadableLocation = LLTrans::getString(actualLocation.c_str());
         }
 
-        S32 number_objects = content["attachments"][i]["objects"].size();
+        S32 number_objects = static_cast<S32>(content["attachments"][i]["objects"].size());
         for(int j = 0; j < number_objects; j++)
         {
             LLUUID task_id = content["attachments"][i]["objects"][j]["id"].asUUID();

--- a/indra/newview/llfloaterpathfindingcharacters.cpp
+++ b/indra/newview/llfloaterpathfindingcharacters.cpp
@@ -284,7 +284,7 @@ void LLFloaterPathfindingCharacters::showCapsule() const
             if (LLPathingLib::getInstance() != NULL)
             {
                 LLPathingLib::getInstance()->createPhysicsCapsuleRep(character->getLength(), character->getRadius(),
-                    character->isHorizontal(), character->getUUID());
+                    (BOOL)character->isHorizontal(), character->getUUID());
             }
         }
 

--- a/indra/newview/llfloaterpathfindingconsole.cpp
+++ b/indra/newview/llfloaterpathfindingconsole.cpp
@@ -30,10 +30,6 @@
 
 #include "llfloaterpathfindingconsole.h"
 
-#include <vector>
-
-#include <boost/signals2.hpp>
-
 #include "llagent.h"
 #include "llbutton.h"
 #include "llcheckboxctrl.h"
@@ -46,7 +42,6 @@
 #include "llpanel.h"
 #include "llpathfindingnavmeshzone.h"
 #include "llpathfindingpathtool.h"
-#include "llpathinglib.h"
 #include "llsliderctrl.h"
 #include "llsd.h"
 #include "lltabcontainer.h"

--- a/indra/newview/llfloaterpathfindingobjects.cpp
+++ b/indra/newview/llfloaterpathfindingobjects.cpp
@@ -135,7 +135,7 @@ void LLFloaterPathfindingObjects::draw()
         std::vector<LLScrollListItem *> selectedItems = mObjectsScrollList->getAllSelected();
         if (!selectedItems.empty())
         {
-            int numSelectedItems = selectedItems.size();
+            auto numSelectedItems = selectedItems.size();
             S32 nameColumnIndex = getNameColumnIndex();
             const LLColor4 &beaconColor = getBeaconColor();
             const LLColor4 &beaconTextColor = getBeaconTextColor();
@@ -334,7 +334,7 @@ void LLFloaterPathfindingObjects::rebuildObjectsScrollList(bool update_if_needed
     if (!mHasObjectsToBeSelected)
     {
         std::vector<LLScrollListItem*> selectedItems = mObjectsScrollList->getAllSelected();
-        int numSelectedItems = selectedItems.size();
+        auto numSelectedItems = selectedItems.size();
         if (numSelectedItems > 0)
         {
             mObjectsToBeSelected.reserve(selectedItems.size());
@@ -835,7 +835,7 @@ void LLFloaterPathfindingObjects::selectScrollListItemsInWorld()
     std::vector<LLScrollListItem *> selectedItems = mObjectsScrollList->getAllSelected();
     if (!selectedItems.empty())
     {
-        int numSelectedItems = selectedItems.size();
+        auto numSelectedItems = selectedItems.size();
 
         std::vector<LLViewerObject *>viewerObjects;
         viewerObjects.reserve(numSelectedItems);

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -3726,7 +3726,7 @@ void LLPanelEstateAccess::copyListToClipboard(std::string list_name)
         }
     }
 
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(list_to_copy), 0, list_to_copy.length());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(list_to_copy), 0, static_cast<S32>(list_to_copy.length()));
 }
 
 bool LLPanelEstateAccess::refreshFromRegion(LLViewerRegion* region)

--- a/indra/newview/llfloaterscriptlimits.cpp
+++ b/indra/newview/llfloaterscriptlimits.cpp
@@ -403,7 +403,7 @@ void LLPanelScriptLimitsRegionMemory::setRegionDetails(LLSD content)
         return;
     }
 
-    S32 number_parcels = content["parcels"].size();
+    auto number_parcels = content["parcels"].size();
 
     LLStringUtil::format_map_t args_parcels;
     args_parcels["[PARCELS]"] = llformat ("%d", number_parcels);
@@ -418,10 +418,10 @@ void LLPanelScriptLimitsRegionMemory::setRegionDetails(LLSD content)
     bool has_locations = false;
     bool has_local_ids = false;
 
-    for(S32 i = 0; i < number_parcels; i++)
+    for(size_t i = 0; i < number_parcels; i++)
     {
         std::string parcel_name = content["parcels"][i]["name"].asString();
-        S32 number_objects = content["parcels"][i]["objects"].size();
+        auto number_objects = content["parcels"][i]["objects"].size();
 
         S32 local_id = 0;
         if(content["parcels"][i].has("local_id"))
@@ -431,7 +431,7 @@ void LLPanelScriptLimitsRegionMemory::setRegionDetails(LLSD content)
             local_id = content["parcels"][i]["local_id"].asInteger();
         }
 
-        for(S32 j = 0; j < number_objects; j++)
+        for(size_t j = 0; j < number_objects; j++)
         {
             S32 size = content["parcels"][i]["objects"][j]["resources"]["memory"].asInteger() / SIZE_OF_ONE_KB;
 
@@ -898,10 +898,10 @@ void LLPanelScriptLimitsRegionMemory::returnObjects()
         return;
     }
 
-    S32 number_parcels = mContent["parcels"].size();
+    auto number_parcels = mContent["parcels"].size();
 
     // a message per parcel containing all objects to be returned from that parcel
-    for(S32 i = 0; i < number_parcels; i++)
+    for(size_t i = 0; i < number_parcels; i++)
     {
         S32 local_id = 0;
         if(mContent["parcels"][i].has("local_id"))

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -966,8 +966,8 @@ void LLFloaterWorldMap::buildLandmarkIDLists()
     mLandmarkAssetIDList.reserve(mLandmarkAssetIDList.size() + items.size());
     mLandmarkItemIDList.reserve(mLandmarkItemIDList.size() + items.size());
 
-    S32 count = items.size();
-    for(S32 i = 0; i < count; ++i)
+    auto count = items.size();
+    for(size_t i = 0; i < count; ++i)
     {
         LLInventoryItem* item = items.at(i);
 
@@ -1552,7 +1552,7 @@ void LLFloaterWorldMap::updateSims(bool found_null_sim)
     LLScrollListCtrl *list = getChild<LLScrollListCtrl>("search_results");
     list->operateOnAll(LLCtrlListInterface::OP_DELETE);
 
-    S32 name_length = mCompletingRegionName.length();
+    auto name_length = mCompletingRegionName.length();
 
     LLSD match;
 

--- a/indra/newview/llfriendcard.cpp
+++ b/indra/newview/llfriendcard.cpp
@@ -83,7 +83,7 @@ const LLUUID& get_folder_uuid(const LLUUID& parentFolderUUID, LLInventoryCollect
     gInventory.collectDescendentsIf(parentFolderUUID, cats, items,
         LLInventoryModel::EXCLUDE_TRASH, matchFunctor);
 
-    S32 cats_count = cats.size();
+    auto cats_count = cats.size();
 
     if (cats_count > 1)
     {
@@ -244,7 +244,7 @@ bool LLFriendCardsManager::isObjDirectDescendentOfCategory(const LLInventoryObje
             {
                 LLUUID creator_id = item->getCreatorUUID();
                 LLViewerInventoryItem* cur_item = NULL;
-                for ( S32 i = items->size() - 1; i >= 0; --i )
+                for ( auto i = items->size() - 1; i >= 0; --i )
                 {
                     cur_item = items->at(i);
                     if ( creator_id == cur_item->getCreatorUUID() )
@@ -261,7 +261,7 @@ bool LLFriendCardsManager::isObjDirectDescendentOfCategory(const LLInventoryObje
             // Note: UUID's of compared items also may be not equal.
             std::string obj_name = obj->getName();
             LLViewerInventoryItem* cur_item = NULL;
-            for ( S32 i = items->size() - 1; i >= 0; --i )
+            for ( auto i = items->size() - 1; i >= 0; --i )
             {
                 cur_item = items->at(i);
                 if ( obj->getType() != cur_item->getType() )
@@ -281,7 +281,7 @@ bool LLFriendCardsManager::isObjDirectDescendentOfCategory(const LLInventoryObje
         // then return true. Note: UUID's of compared items also may be not equal.
         std::string obj_name = obj->getName();
         LLViewerInventoryCategory* cur_cat = NULL;
-        for ( S32 i = cats->size() - 1; i >= 0; --i )
+        for ( auto i = cats->size() - 1; i >= 0; --i )
         {
             cur_cat = cats->at(i);
             if ( obj->getType() != cur_cat->getType() )

--- a/indra/newview/llgesturemgr.cpp
+++ b/indra/newview/llgesturemgr.cpp
@@ -671,7 +671,7 @@ bool LLGestureMgr::triggerAndReviseString(const std::string &utf8str, std::strin
             {
                 // choose one at random
                 {
-                    S32 random = ll_rand(matching.size());
+                    S32 random = ll_rand(static_cast<S32>(matching.size()));
 
                     gesture = matching[random];
 
@@ -745,7 +745,7 @@ bool LLGestureMgr::triggerGesture(KEY key, MASK mask)
     // choose one and play it
     if (matching.size() > 0)
     {
-        U32 random = ll_rand(matching.size());
+        U32 random = ll_rand(static_cast<S32>(matching.size()));
 
         LLMultiGesture* gesture = matching[random];
 
@@ -783,7 +783,7 @@ bool LLGestureMgr::triggerGestureRelease(KEY key, MASK mask)
 
 S32 LLGestureMgr::getPlayingCount() const
 {
-    return mPlaying.size();
+    return static_cast<S32>(mPlaying.size());
 }
 
 
@@ -1462,7 +1462,7 @@ void LLGestureMgr::notifyObservers()
 
 bool LLGestureMgr::matchPrefix(const std::string& in_str, std::string* out_str)
 {
-    S32 in_len = in_str.length();
+    auto in_len = in_str.length();
 
     //return whole trigger, if received text equals to it
     item_map_t::iterator it;
@@ -1490,7 +1490,7 @@ bool LLGestureMgr::matchPrefix(const std::string& in_str, std::string* out_str)
         {
             const std::string& trigger = gesture->getTrigger();
 
-            if (in_len > (S32)trigger.length())
+            if (in_len > trigger.length())
             {
                 // too short, bail out
                 continue;

--- a/indra/newview/llgiveinventory.cpp
+++ b/indra/newview/llgiveinventory.cpp
@@ -242,9 +242,9 @@ bool LLGiveInventory::doGiveInventoryCategory(const LLUUID& to_agent,
         items,
         LLInventoryModel::EXCLUDE_TRASH,
         giveable);
-    S32 count = cats.size();
+    auto count = cats.size();
     bool complete = true;
-    for(S32 i = 0; i < count; ++i)
+    for(size_t i = 0; i < count; ++i)
     {
         if (!gInventory.isCategoryComplete(cats.at(i)->getUUID()))
         {
@@ -446,8 +446,8 @@ bool LLGiveInventory::handleCopyProtectedCategory(const LLSD& notification, cons
                 items,
                 LLInventoryModel::EXCLUDE_TRASH,
                 remove);
-            S32 count = items.size();
-            for(S32 i = 0; i < count; ++i)
+            auto count = items.size();
+            for(size_t i = 0; i < count; ++i)
             {
                 gInventory.deleteObject(items.at(i)->getUUID());
             }
@@ -503,7 +503,7 @@ bool LLGiveInventory::commitGiveInventoryCategory(const LLUUID& to_agent,
     // MAX ITEMS is based on (sizeof(uuid)+2) * count must be <
     // MTUBYTES or 18 * count < 1200 => count < 1200/18 =>
     // 66. I've cut it down a bit from there to give some pad.
-    S32 count = items.size() + cats.size();
+    auto count = items.size() + cats.size();
     if (count > MAX_ITEMS)
     {
         LLNotificationsUtil::add("TooManyItems");
@@ -520,7 +520,7 @@ bool LLGiveInventory::commitGiveInventoryCategory(const LLUUID& to_agent,
         LLAgentUI::buildFullname(name);
         LLUUID transaction_id;
         transaction_id.generate();
-        S32 bucket_size = (sizeof(U8) + UUID_BYTES) * (count + 1);
+        S32 bucket_size = (sizeof(U8) + UUID_BYTES) * (static_cast<S32>(count) + 1);
         U8* bucket = new U8[bucket_size];
         U8* pos = bucket;
         U8 type = (U8)cat->getType();

--- a/indra/newview/llglsandbox.cpp
+++ b/indra/newview/llglsandbox.cpp
@@ -939,7 +939,7 @@ public:
     {
         // takes (count, pointer)
         // &vector[0] gets pointer to contiguous array
-        LLImageGL::generateTextures(source.size(), &source[0]);
+        LLImageGL::generateTextures(static_cast<S32>(source.size()), &source[0]);
     }
 
     ~TextureHolder()
@@ -950,7 +950,7 @@ public:
                 texUnit->unbind(LLTexUnit::TT_TEXTURE);
         }
         // ensure that we delete these textures regardless of how we exit
-        LLImageGL::deleteTextures(source.size(), &source[0]);
+        LLImageGL::deleteTextures(static_cast<S32>(source.size()), &source[0]);
     }
 
     bool bind(U32 index)

--- a/indra/newview/llgltfmateriallist.cpp
+++ b/indra/newview/llgltfmateriallist.cpp
@@ -207,8 +207,8 @@ void LLGLTFMaterialList::applyOverrideMessage(LLMessageSystem* msg, const std::s
             cache.mObjectId = id;
             cache.mRegionHandle = region->getHandle();
 
-            U32 count = llmin(tes.size(), MAX_TES);
-            for (U32 i = 0; i < count; ++i)
+            auto count = llmin(tes.size(), MAX_TES);
+            for (size_t i = 0; i < count; ++i)
             {
                 LLGLTFMaterial* mat = new LLGLTFMaterial(); // setTEGLTFMaterialOverride and cache will take ownership
                 mat->applyOverrideLLSD(od[i]);
@@ -381,7 +381,7 @@ void LLGLTFMaterialList::flushUpdates(void(*done_callback)(bool))
 {
     LLSD& data = sUpdates;
 
-    S32 i = data.size();
+    auto i = data.size();
 
     for (ModifyMaterialData& e : sModifyQueue)
     {
@@ -492,7 +492,7 @@ void LLGLTFMaterialList::onAssetLoadComplete(const LLUUID& id, LLAssetType::ETyp
                 }
 
                 buffer.resize(size);
-                file.read((U8*)&buffer[0], buffer.size());
+                file.read((U8*)&buffer[0], static_cast<S32>(buffer.size()));
             }
 
             {
@@ -501,7 +501,7 @@ void LLGLTFMaterialList::onAssetLoadComplete(const LLUUID& id, LLAssetType::ETyp
                 LLSD asset;
 
                 // read file into buffer
-                std::istrstream str(&buffer[0], buffer.size());
+                std::istrstream str(&buffer[0], static_cast<S32>(buffer.size()));
 
                 if (LLSDSerialize::deserialize(asset, str, buffer.size()))
                 {
@@ -518,7 +518,7 @@ void LLGLTFMaterialList::onAssetLoadComplete(const LLUUID& id, LLAssetType::ETyp
                                 LL_PROFILE_ZONE_SCOPED;
                                 tinygltf::TinyGLTF gltf;
 
-                                if (!gltf.LoadASCIIFromString(&asset_data->mModelIn, &error_msg, &warn_msg, data.c_str(), data.length(), ""))
+                                if (!gltf.LoadASCIIFromString(&asset_data->mModelIn, &error_msg, &warn_msg, data.c_str(), static_cast<U32>(data.length()), ""))
                                 {
                                     LL_WARNS("GLTF") << "Failed to decode material asset: "
                                         << LL_NEWLINE

--- a/indra/newview/llgrouplist.cpp
+++ b/indra/newview/llgrouplist.cpp
@@ -223,7 +223,7 @@ void LLGroupList::refresh()
     if (mForAgent)
     {
         const LLUUID&       highlight_id    = gAgent.getGroupID();
-        S32                 count           = gAgent.mGroups.size();
+        S32                 count           = static_cast<S32>(gAgent.mGroups.size());
         LLUUID              id;
         bool                have_filter     = !mNameFilter.empty();
 

--- a/indra/newview/llgroupmgr.cpp
+++ b/indra/newview/llgroupmgr.cpp
@@ -168,7 +168,7 @@ S32 LLGroupRoleData::getMembersInRole(uuid_vec_t members,
     {
         // This is the everyone role, just return the size of members,
         // because everyone is in the everyone role.
-        return members.size();
+        return static_cast<S32>(members.size());
     }
 
     // Sort the members list, if needed.
@@ -184,7 +184,7 @@ S32 LLGroupRoleData::getMembersInRole(uuid_vec_t members,
     }
 
     // Return the number of members in the intersection.
-    S32 max_size = llmin( members.size(), mMemberIDs.size() );
+    auto max_size = llmin( members.size(), mMemberIDs.size() );
     uuid_vec_t in_role( max_size );
     uuid_vec_t::iterator in_role_end;
     in_role_end = std::set_intersection(mMemberIDs.begin(), mMemberIDs.end(),

--- a/indra/newview/llgroupmgr.h
+++ b/indra/newview/llgroupmgr.h
@@ -151,7 +151,7 @@ public:
 
     const uuid_vec_t& getRoleMembers() const { return mMemberIDs; }
     S32 getMembersInRole(uuid_vec_t members, bool needs_sort = true);
-    S32 getTotalMembersInRole() { return mMemberCount ? mMemberCount : mMemberIDs.size(); } //FIXME: Returns 0 for Everyone role when Member list isn't yet loaded, see MAINT-5225
+    S32 getTotalMembersInRole() { return mMemberCount ? mMemberCount : static_cast<S32>(mMemberIDs.size()); } //FIXME: Returns 0 for Everyone role when Member list isn't yet loaded, see MAINT-5225
 
     LLRoleData getRoleData() const { return mRoleData; }
     void setRoleData(LLRoleData data) { mRoleData = data; }

--- a/indra/newview/llhudnametag.cpp
+++ b/indra/newview/llhudnametag.cpp
@@ -443,7 +443,7 @@ void LLHUDNameTag::addLine(const std::string &text_utf8,
                 // "QualityAssurance AssuresQuality1" will end up as "QualityAssurance AssuresQua..." because we are enforcing single line
                 do
                 {
-                    S32 segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, wline.length(), LLFontGL::ANYWHERE);
+                    auto segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
                     if (segment_length + line_length < wline.length()) // since we only draw one string, line_length should be 0
                     {
                         // token does does not fit into signle line, need to draw "...".
@@ -451,7 +451,7 @@ void LLHUDNameTag::addLine(const std::string &text_utf8,
                         const LLWString dots_pad(utf8str_to_wstring(std::string("....")));
                         S32 elipses_width = font->getWidthF32(dots_pad.c_str());
                         // truncated string length
-                        segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels - elipses_width, wline.length(), LLFontGL::ANYWHERE);
+                        segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels - elipses_width, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
                         const LLWString dots(utf8str_to_wstring(std::string("...")));
                         LLHUDTextSegment segment(iter->substr(line_length, segment_length) + dots, style, color, font);
                         mTextSegments.push_back(segment);
@@ -472,7 +472,7 @@ void LLHUDNameTag::addLine(const std::string &text_utf8,
                 // "QualityAssurance AssuresQuality 1" will be split into two lines "QualityAssurance" and "AssuresQuality"
                 do
                 {
-                    S32 segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, wline.length(), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+                    S32 segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
                     LLHUDTextSegment segment(iter->substr(line_length, segment_length), style, color, font);
                     mTextSegments.push_back(segment);
                     line_length += segment_length;
@@ -511,7 +511,7 @@ void LLHUDNameTag::addLabel(const std::string& label_utf8, F32 max_pixels)
             do
             {
                 S32 segment_length = mFontp->maxDrawableChars(iter->substr(line_length).c_str(),
-                    max_pixels, wstr.length(), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+                    max_pixels, static_cast<S32>(wstr.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
                 LLHUDTextSegment segment(iter->substr(line_length, segment_length), LLFontGL::NORMAL, mColor, mFontp);
                 mLabelSegments.push_back(segment);
                 line_length += segment_length;

--- a/indra/newview/llhudrender.cpp
+++ b/indra/newview/llhudrender.cpp
@@ -138,7 +138,7 @@ void hud_render_text(const LLWString &wstr, const LLVector3 &pos_agent,
     LLUI::translate((F32) winX*1.0f/LLFontGL::sScaleX, (F32) winY*1.0f/(LLFontGL::sScaleY), -(((F32) winZ*2.f)-1.f));
     F32 right_x;
 
-    font.render(wstr, 0, 0, 1, color, LLFontGL::LEFT, LLFontGL::BASELINE, style, shadow, wstr.length(), 1000, &right_x, /*use_ellipses*/false, /*use_color*/true);
+    font.render(wstr, 0, 0, 1, color, LLFontGL::LEFT, LLFontGL::BASELINE, style, shadow, static_cast<S32>(wstr.length()), 1000, &right_x, /*use_ellipses*/false, /*use_color*/true);
 
     LLUI::popMatrix();
     gGL.popMatrix();

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -274,7 +274,7 @@ void LLHUDText::addLine(const std::string &text_utf8,
             do
             {
                 F32 max_pixels = HUD_TEXT_MAX_WIDTH_NO_BUBBLE;
-                S32 segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, wline.length(), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+                S32 segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
                 LLHUDTextSegment segment(iter->substr(line_length, segment_length), style, color, font);
                 mTextSegments.push_back(segment);
                 line_length += segment_length;

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -203,7 +203,7 @@ void inventory_offer_handler(LLOfferInfo* info)
 
     // Strip any SLURL from the message display. (DEV-2754)
     std::string msg = info->mDesc;
-    int indx = msg.find(" ( http://slurl.com/secondlife/");
+    auto indx = msg.find(" ( http://slurl.com/secondlife/");
     if (indx == std::string::npos)
     {
         // try to find new slurl host
@@ -701,7 +701,7 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
             }
             else
             {
-                S32 index = original_name.find(" Resident");
+                auto index = original_name.find(" Resident");
                 if (index != std::string::npos)
                 {
                     original_name = original_name.substr(0, index);
@@ -1651,7 +1651,7 @@ void LLIMProcessing::requestOfflineMessagesCoro(std::string url)
             message_data["region_id"].asUUID(),
             position,
             bin_bucket.data(),
-            bin_bucket.size(),
+            static_cast<S32>(bin_bucket.size()),
             sender,
             message_data["asset_id"].asUUID());
 

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -741,7 +741,7 @@ void LLIMModel::LLIMSession::onAdHocNameCache(const LLAvatarName& av_name)
 
     if (!av_name.isValidName())
     {
-        S32 separator_index = mName.rfind(" ");
+        auto separator_index = mName.rfind(" ");
         std::string name = mName.substr(0, separator_index);
         ++separator_index;
         std::string conference_word = mName.substr(separator_index, mName.length());
@@ -1188,7 +1188,7 @@ void LLIMModel::LLIMSession::addMessagesFromServerHistory(const LLSD& history,  
         }
     }
 
-    S32 shifted_size = shift_msgs.size();
+    auto shifted_size = shift_msgs.size();
     while (shift_msgs.size() > 0)
     {   // Finally add back any new messages, and tweak the index value to be correct.
         LLSD newer_message = shift_msgs.front();
@@ -1250,7 +1250,7 @@ LLIMModel::LLIMSession* LLIMModel::findIMSession(const LLUUID& session_id) const
 //*TODO consider switching to using std::set instead of std::list for holding LLUUIDs across the whole code
 LLIMModel::LLIMSession* LLIMModel::findAdHocIMSession(const uuid_vec_t& ids)
 {
-    S32 num = ids.size();
+    auto num = ids.size();
     if (!num) return NULL;
 
     if (mId2SessionMap.empty()) return NULL;
@@ -1504,7 +1504,7 @@ void LLIMModel::getMessagesSilently(const LLUUID& session_id, chat_message_list_
         return;
     }
 
-    int i = session->mMsgs.size() - start_index;
+    auto i = session->mMsgs.size() - start_index;
 
     for (chat_message_list_t::iterator iter = session->mMsgs.begin();
         iter != session->mMsgs.end() && i > 0;
@@ -1985,12 +1985,12 @@ void start_deprecated_conference_chat(
 {
     U8* bucket;
     U8* pos;
-    S32 count;
+    size_t count;
     S32 bucket_size;
 
     // *FIX: this could suffer from endian issues
     count = agents_to_invite.size();
-    bucket_size = UUID_BYTES * count;
+    bucket_size = UUID_BYTES * static_cast<S32>(count);
     bucket = new U8[bucket_size];
     pos = bucket;
 
@@ -3830,7 +3830,7 @@ void LLIMMgr::noteOfflineUsers(
     const LLUUID& session_id,
     const std::vector<LLUUID>& ids)
 {
-    S32 count = ids.size();
+    auto count = ids.size();
     if(count == 0)
     {
         const std::string& only_user = LLTrans::getString("only_user_message");
@@ -3868,7 +3868,7 @@ void LLIMMgr::noteMutedUsers(const LLUUID& session_id,
         return;
     }
 
-    S32 count = ids.size();
+    auto count = ids.size();
     if(count > 0)
     {
         LLIMModel* im_model = LLIMModel::getInstance();

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -454,8 +454,8 @@ void LLInvFVBridge::removeBatch(std::vector<LLFolderViewModelItem*>& batch)
     LLViewerInventoryCategory* cat = NULL;
     LLInventoryModel::cat_array_t   descendent_categories;
     LLInventoryModel::item_array_t  descendent_items;
-    S32 count = batch.size();
-    S32 i,j;
+    size_t count = batch.size();
+    size_t i,j;
     for(i = 0; i < count; ++i)
     {
         bridge = (LLInvFVBridge*)(batch[i]);
@@ -506,8 +506,8 @@ void  LLInvFVBridge::removeBatchNoCheck(std::vector<LLFolderViewModelItem*>&  ba
     uuid_vec_t move_ids;
     LLInventoryModel::update_map_t update;
     bool start_new_message = true;
-    S32 count = batch.size();
-    S32 i;
+    size_t count = batch.size();
+    size_t i;
 
     // first, hide any 'preview' floaters that correspond to the items
     // being deleted.
@@ -642,11 +642,8 @@ bool LLInvFVBridge::isClipboardPasteable() const
     // In normal mode, we need to check each element of the clipboard to know if we can paste or not
     std::vector<LLUUID> objects;
     LLClipboard::instance().pasteFromClipboard(objects);
-    S32 count = objects.size();
-    for(S32 i = 0; i < count; i++)
+    for (const auto& item_id : objects)
     {
-        const LLUUID &item_id = objects.at(i);
-
         // Folders are pastable if all items in there are copyable
         const LLInventoryCategory *cat = model->getCategory(item_id);
         if (cat)
@@ -682,10 +679,9 @@ bool LLInvFVBridge::isClipboardPasteableAsLink() const
 
     std::vector<LLUUID> objects;
     LLClipboard::instance().pasteFromClipboard(objects);
-    S32 count = objects.size();
-    for(S32 i = 0; i < count; i++)
+    for (const auto& item_id : objects)
     {
-        const LLInventoryItem *item = model->getItem(objects.at(i));
+        const LLInventoryItem *item = model->getItem(item_id);
         if (item)
         {
             if (!LLAssetType::lookupCanLink(item->getActualType()))
@@ -698,7 +694,7 @@ bool LLInvFVBridge::isClipboardPasteableAsLink() const
                 return false;
             }
         }
-        const LLViewerInventoryCategory *cat = model->getCategory(objects.at(i));
+        const LLViewerInventoryCategory *cat = model->getCategory(item_id);
         if (cat && LLFolderType::lookupIsProtectedType(cat->getPreferredType()))
         {
             return false;
@@ -2175,8 +2171,7 @@ bool LLItemBridge::removeItem()
         if (!item->getIsLinkType())
         {
             LLInventoryModel::item_array_t item_array = gInventory.collectLinksTo(mUUID);
-            const U32 num_links = item_array.size();
-            if (num_links > 0)
+            if (!item_array.empty())
             {
                 // Warn if the user is will break any links when deleting this item.
                 LLNotifications::instance().add(params);
@@ -2375,8 +2370,8 @@ std::string LLFolderBridge::getLabelSuffix() const
         LLInventoryModel::cat_array_t cat_array;
         LLInventoryModel::item_array_t item_array;
         gInventory.collectDescendents(getUUID(), cat_array, item_array, true);
-        S32 count = item_array.size();
-        if(count > 0)
+        auto count = item_array.size();
+        if (count > 0)
         {
             std::ostringstream oss;
             oss << count;
@@ -2514,7 +2509,7 @@ bool LLFolderBridge::isClipboardPasteable() const
 
         // Search for the direct descendent of current Friends subfolder among all pasted items,
         // and return false if is found.
-        for(S32 i = objects.size() - 1; i >= 0; --i)
+        for(auto i = objects.size() - 1; i >= 0; --i)
         {
             const LLUUID &obj_id = objects.at(i);
             if ( LLFriendCardsManager::instance().isObjDirectDescendentOfCategory(model->getObject(obj_id), current_cat) )
@@ -2548,10 +2543,8 @@ bool LLFolderBridge::isClipboardPasteableAsLink() const
         const LLUUID &current_cat_id = current_cat->getUUID();
         std::vector<LLUUID> objects;
         LLClipboard::instance().pasteFromClipboard(objects);
-        S32 count = objects.size();
-        for(S32 i = 0; i < count; i++)
+        for (const auto& obj_id : objects)
         {
-            const LLUUID &obj_id = objects.at(i);
             const LLInventoryCategory *cat = model->getCategory(obj_id);
             if (cat)
             {
@@ -3193,13 +3186,13 @@ void LLRightClickInventoryFetchDescendentsObserver::execute(bool clear_observer)
         LLInventoryModel::item_array_t* item_array;
         gInventory.getDirectDescendentsOf(*current_folder, cat_array, item_array);
 
-        S32 item_count(0);
+        size_t item_count(0);
         if( item_array )
         {
             item_count = item_array->size();
         }
 
-        S32 cat_count(0);
+        size_t cat_count(0);
         if( cat_array )
         {
             cat_count = cat_array->size();
@@ -3218,18 +3211,18 @@ void LLRightClickInventoryFetchDescendentsObserver::execute(bool clear_observer)
         // Fetch the items
         if (item_count)
         {
-            for (S32 i = 0; i < item_count; ++i)
+            for (size_t i = 0; i < item_count; ++i)
             {
-                ids.push_back(item_array->at(i)->getUUID());
+                ids.emplace_back(item_array->at(i)->getUUID());
             }
             outfit = new LLRightClickInventoryFetchObserver(ids);
         }
         // Fetch the subfolders
         if (cat_count)
         {
-            for (S32 i = 0; i < cat_count; ++i)
+            for (size_t i = 0; i < cat_count; ++i)
             {
-                ids.push_back(cat_array->at(i)->getUUID());
+                ids.emplace_back(cat_array->at(i)->getUUID());
             }
             categories = new LLRightClickInventoryFetchDescendentsObserver(ids);
         }
@@ -3614,7 +3607,7 @@ void LLFolderBridge::copyOutfitToClipboard()
     LLInventoryModel::item_array_t* item_array;
     gInventory.getDirectDescendentsOf(mUUID, cat_array, item_array);
 
-    S32 item_count(0);
+    size_t item_count(0);
     if( item_array )
     {
         item_count = item_array->size();
@@ -3622,7 +3615,7 @@ void LLFolderBridge::copyOutfitToClipboard()
 
     if (item_count)
     {
-        for (S32 i = 0; i < item_count;)
+        for (size_t i = 0; i < item_count;)
         {
             LLSD uuid =item_array->at(i)->getUUID();
             LLViewerInventoryItem* item = gInventory.getItem(uuid);
@@ -3636,7 +3629,7 @@ void LLFolderBridge::copyOutfitToClipboard()
         }
     }
 
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(text),0,text.size());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(text), 0, static_cast<S32>(text.size()));
 }
 
 void LLFolderBridge::openItem()
@@ -3929,11 +3922,11 @@ void LLFolderBridge::perform_pasteFromClipboard()
                 LLInventoryItem *item = model->getItem(item_id);
                 LLInventoryCategory *cat = model->getCategory(item_id);
 
-                if (item && !can_move_item_to_marketplace(master_folder, dest_folder, item, error_msg, objects.size() - index, true))
+                if (item && !can_move_item_to_marketplace(master_folder, dest_folder, item, error_msg, static_cast<S32>(objects.size()) - index, true))
                 {
                     break;
                 }
-                if (cat && !can_move_folder_to_marketplace(master_folder, dest_folder, cat, error_msg, objects.size() - index, true, true))
+                if (cat && !can_move_folder_to_marketplace(master_folder, dest_folder, cat, error_msg, static_cast<S32>(objects.size()) - index, true, true))
                 {
                     break;
                 }
@@ -5193,7 +5186,7 @@ bool move_task_inventory_callback(const LLSD& notification, const LLSD& response
         {
             LLInventoryObject::object_list_t inventory_objects;
             object->getInventoryContents(inventory_objects);
-            int contents_count = inventory_objects.size();
+            int contents_count = static_cast<int>(inventory_objects.size());
             LLInventoryCopyAndWearObserver* inventoryObserver = new LLInventoryCopyAndWearObserver(cat_and_wear->mCatID, contents_count, cat_and_wear->mFolderResponded,
                                                                                                     cat_and_wear->mReplace);
 
@@ -5822,8 +5815,8 @@ bool check_category(LLInventoryModel* model,
     LLInventoryModel::item_array_t descendent_items;
     model->collectDescendents(cat_id, descendent_categories, descendent_items, true);
 
-    S32 num_descendent_categories = descendent_categories.size();
-    S32 num_descendent_items = descendent_items.size();
+    auto num_descendent_categories = descendent_categories.size();
+    auto num_descendent_items = descendent_items.size();
 
     if (num_descendent_categories + num_descendent_items == 0)
     {
@@ -5833,7 +5826,7 @@ bool check_category(LLInventoryModel* model,
         return check_item(cat_id, active_panel, filter);
     }
 
-    for (S32 i = 0; i < num_descendent_categories; ++i)
+    for (size_t i = 0; i < num_descendent_categories; ++i)
     {
         LLInventoryCategory* category = descendent_categories[i];
         if(!check_category(model, category->getUUID(), active_panel, filter))
@@ -5842,7 +5835,7 @@ bool check_category(LLInventoryModel* model,
         }
     }
 
-    for (S32 i = 0; i < num_descendent_items; ++i)
+    for (size_t i = 0; i < num_descendent_items; ++i)
     {
         LLViewerInventoryItem* item = descendent_items[i];
         if(!check_item(item->getUUID(), active_panel, filter))
@@ -6256,8 +6249,8 @@ void LLCallingCardBridge::checkSearchBySuffixChanges()
         // changes in mDisplayName are processed by rename function and here it will be always same
         // suffixes are also of fixed length, and we are processing change of one at a time,
         // so it should be safe to use length (note: mSearchableName is capitalized)
-        S32 old_length = mSearchableName.length();
-        S32 new_length = mDisplayName.length() + getLabelSuffix().length();
+        auto old_length = mSearchableName.length();
+        auto new_length = mDisplayName.length() + getLabelSuffix().length();
         if (old_length == new_length)
         {
             return;

--- a/indra/newview/llinventoryfilter.cpp
+++ b/indra/newview/llinventoryfilter.cpp
@@ -434,7 +434,7 @@ bool LLInventoryFilter::checkAgainstFilterType(const LLFolderViewModelItemInvent
                 LLInventoryModel::cat_array_t* cat_array = NULL;
                 LLInventoryModel::item_array_t* item_array = NULL;
                 gInventory.getDirectDescendentsOf(object_id,cat_array,item_array);
-                S32 descendents_actual = 0;
+                size_t descendents_actual = 0;
                 if(cat_array && item_array)
                 {
                     descendents_actual = cat_array->size() + item_array->size();

--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -156,7 +156,7 @@ S32 count_descendants_items(const LLUUID& cat_id)
     LLInventoryModel::item_array_t* item_array;
     gInventory.getDirectDescendentsOf(cat_id,cat_array,item_array);
 
-    S32 count = item_array->size();
+    S32 count = static_cast<S32>(item_array->size());
 
     LLInventoryModel::cat_array_t cat_array_copy = *cat_array;
     for (LLInventoryModel::cat_array_t::iterator iter = cat_array_copy.begin(); iter != cat_array_copy.end(); iter++)
@@ -1104,7 +1104,7 @@ S32 compute_stock_count(LLUUID cat_uuid, bool force_count /* false */)
         LLInventoryModel::cat_array_t* cat_array;
         LLInventoryModel::item_array_t* item_array;
         gInventory.getDirectDescendentsOf(cat_uuid,cat_array,item_array);
-        return item_array->size();
+        return static_cast<S32>(item_array->size());
     }
 
     // When force_count is true, we do not do any verification of the marketplace status and simply compute
@@ -1358,7 +1358,7 @@ bool can_move_item_to_marketplace(const LLInventoryCategory* root_folder, LLInve
 
             existing_item_count += count_copyable_items(existing_items) + count_stock_folders(existing_categories);
             existing_stock_count += count_stock_items(existing_items);
-            existing_folder_count += existing_categories.size();
+            existing_folder_count += static_cast<S32>(existing_categories.size());
 
             // If the incoming item is a nocopy (stock) item, we need to consider that it will create a stock folder
             if (!inv_item->getPermissions().allowOperationBy(PERM_COPY, gAgent.getID(), gAgent.getGroupID()) && !move_in_stock)
@@ -1430,7 +1430,7 @@ bool can_move_folder_to_marketplace(const LLInventoryCategory* root_folder, LLIn
         LLInventoryModel::item_array_t descendent_items;
         gInventory.collectDescendents(inv_cat->getUUID(), descendent_categories, descendent_items, false);
 
-        int dragged_folder_count = descendent_categories.size() + bundle_size;  // Note: We assume that we're moving a bunch of folders in. That might be wrong...
+        int dragged_folder_count = static_cast<int>(descendent_categories.size()) + bundle_size;  // Note: We assume that we're moving a bunch of folders in. That might be wrong...
         int dragged_item_count = count_copyable_items(descendent_items) + count_stock_folders(descendent_categories);
         int dragged_stock_count = count_stock_items(descendent_items);
         int existing_item_count = 0;
@@ -1452,7 +1452,7 @@ bool can_move_folder_to_marketplace(const LLInventoryCategory* root_folder, LLIn
             LLInventoryModel::item_array_t existing_items;
             gInventory.collectDescendents(version_folder->getUUID(), existing_categories, existing_items, false);
 
-            existing_folder_count += existing_categories.size();
+            existing_folder_count += static_cast<int>(existing_categories.size());
             existing_item_count += count_copyable_items(existing_items) + count_stock_folders(existing_categories);
             existing_stock_count += count_stock_items(existing_items);
         }
@@ -1882,7 +1882,7 @@ void validate_marketplacelistings(
     }
 
     // How many types of items? Which type is it if only one?
-    S32 count = items_vector.size();
+    auto count = items_vector.size();
     U32 default_key = (U32)(LLInventoryType::IT_COUNT) << 24; // This is the key for any normal copyable item
     U32 unique_key = (count == 1 ? items_vector.begin()->first : default_key); // The key in the case of one item type only
 

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -257,8 +257,8 @@ void LLInventoryGallery::updateRootFolder()
         {
             updateRemovedItem(mItems[i]->getUUID());
         }
-        S32 hidden_count = mHiddenItems.size();
-        for (S32 i = hidden_count - 1; i >= 0; i--)
+        auto hidden_count = mHiddenItems.size();
+        for (size_t i = hidden_count - 1; i >= 0; i--)
         {
             updateRemovedItem(mHiddenItems[i]->getUUID());
         }
@@ -343,7 +343,7 @@ void LLInventoryGallery::initGallery()
     {
         uuid_vec_t cats;
         getCurrentCategories(cats);
-        int n = cats.size();
+        int n = static_cast<int>(cats.size());
         buildGalleryPanel(n);
         mScrollPanel->addChild(mGalleryPanel);
         for (int i = 0; i < n; i++)
@@ -619,8 +619,8 @@ void LLInventoryGallery::removeFromGalleryMiddle(LLInventoryGalleryItem* item)
         removeFromGalleryLast(mItems[i]);
     }
     removeFromGalleryLast(mItems[n]);
-    int saved_count = saved.size();
-    for (int i = 0; i < saved_count; i++)
+    size_t saved_count = saved.size();
+    for (size_t i = 0; i < saved_count; i++)
     {
         addToGallery(saved.back());
         saved.pop_back();
@@ -1882,13 +1882,10 @@ bool LLInventoryGallery::canPaste() const
     }
 
     // In normal mode, we need to check each element of the clipboard to know if we can paste or not
-    std::vector<LLUUID> objects;
+    uuid_vec_t objects;
     LLClipboard::instance().pasteFromClipboard(objects);
-    S32 count = objects.size();
-    for (S32 i = 0; i < count; i++)
+    for (const auto& item_id : objects)
     {
-        const LLUUID& item_id = objects.at(i);
-
         // Each item must be copyable to be pastable
         if (!isItemCopyable(item_id))
         {

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -1290,7 +1290,6 @@ void LLInventoryModel::collectDescendentsIf(const LLUUID& id,
         }
     }
 
-    LLViewerInventoryItem* item = NULL;
     item_array_t* item_array = get_ptr_in_map(mParentChildItemTree, id);
 
     // Move onto items

--- a/indra/newview/llinventorymodelbackgroundfetch.cpp
+++ b/indra/newview/llinventorymodelbackgroundfetch.cpp
@@ -1496,7 +1496,7 @@ void BGFolderHttpHandler::processFailure(LLCore::HttpStatus status, LLCore::Http
             return;
         }
 
-        S32 size = mRequestSD["folders"].size();
+        auto size = mRequestSD["folders"].size();
 
         if (size > 1)
         {
@@ -1513,7 +1513,7 @@ void BGFolderHttpHandler::processFailure(LLCore::HttpStatus status, LLCore::Http
                 {
                     recursive_cats.push_back(folder_id);
                 }
-                if (folders.size() == (S32)(size / 2))
+                if (folders.size() == (size / 2))
                 {
                     LLSD request_body;
                     request_body["folders"] = folders;

--- a/indra/newview/llinventoryobserver.cpp
+++ b/indra/newview/llinventoryobserver.cpp
@@ -477,7 +477,7 @@ bool LLInventoryFetchDescendentsObserver::isCategoryComplete(const LLViewerInven
         // from memory.
         return true;
     }
-    const S32 current_num_known_descendents = cats->size() + items->size();
+    const S32 current_num_known_descendents = static_cast<S32>(cats->size() + items->size());
 
     // Got the number of descendents that we were expecting, so we're done.
     if (current_num_known_descendents == expected_num_descendents)
@@ -715,7 +715,7 @@ void LLInventoryCategoriesObserver::changed(U32 mask)
             continue;
         }
 
-        const S32 current_num_known_descendents = cats->size() + items->size();
+        const S32 current_num_known_descendents = static_cast<S32>(cats->size() + items->size());
 
         bool cat_changed = false;
 
@@ -795,7 +795,7 @@ bool LLInventoryCategoriesObserver::addCategory(const LLUUID& cat_id, callback_t
         }
         else
         {
-            current_num_known_descendents = cats->size() + items->size();
+            current_num_known_descendents = static_cast<S32>(cats->size() + items->size());
         }
     }
 

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -1220,7 +1220,7 @@ LLFolderViewItem* LLInventoryPanel::buildViewsTree(const LLUUID& id,
         // Make sure panel won't lock in a loop over existing items if
         // folder is enormous and at least some work gets done
         const S32 MIN_ITEMS_PER_CALL = 500;
-        const S32 starting_item_count = mItemMap.size();
+        const S32 starting_item_count = static_cast<S32>(mItemMap.size());
 
         LLFolderViewFolder *parentp = dynamic_cast<LLFolderViewFolder*>(folder_view_item);
         bool done = true;
@@ -1251,7 +1251,7 @@ LLFolderViewItem* LLInventoryPanel::buildViewsTree(const LLUUID& id,
 
                 if (!mBuildChildrenViews
                     && mode == BUILD_TIMELIMIT
-                    && MIN_ITEMS_PER_CALL + starting_item_count < mItemMap.size())
+                    && MIN_ITEMS_PER_CALL + starting_item_count < static_cast<S32>(mItemMap.size()))
                 {
                     // Single folder view, check if we still have time
                     //
@@ -1665,7 +1665,7 @@ bool LLInventoryPanel::beginIMSession()
                                                 item_array,
                                                 LLInventoryModel::EXCLUDE_TRASH,
                                                 is_buddy);
-                S32 count = item_array.size();
+                auto count = item_array.size();
                 if(count > 0)
                 {
                     //*TODO by what to replace that?
@@ -1674,7 +1674,7 @@ bool LLInventoryPanel::beginIMSession()
                     // create the session
                     LLAvatarTracker& at = LLAvatarTracker::instance();
                     LLUUID id;
-                    for(S32 i = 0; i < count; ++i)
+                    for(size_t i = 0; i < count; ++i)
                     {
                         id = item_array.at(i)->getCreatorUUID();
                         if(at.isBuddyOnline(id))
@@ -1761,7 +1761,7 @@ void LLInventoryPanel::purgeSelectedItems()
     const std::set<LLFolderViewItem*> inventory_selected = mFolderRoot.get()->getSelectionList();
     if (inventory_selected.empty()) return;
     LLSD args;
-    S32 count = inventory_selected.size();
+    auto count = inventory_selected.size();
     std::vector<LLUUID> selected_items;
     for (std::set<LLFolderViewItem*>::const_iterator it = inventory_selected.begin(), end_it = inventory_selected.end();
         it != end_it;
@@ -1774,7 +1774,7 @@ void LLInventoryPanel::purgeSelectedItems()
         count += items.size() + cats.size();
         selected_items.push_back(item_id);
     }
-    args["COUNT"] = count;
+    args["COUNT"] = static_cast<S32>(count);
     LLNotificationsUtil::add("PurgeSelectedItems", args, LLSD(), boost::bind(callbackPurgeSelectedItems, _1, _2, selected_items));
 }
 

--- a/indra/newview/llkeyconflict.cpp
+++ b/indra/newview/llkeyconflict.cpp
@@ -476,8 +476,8 @@ void LLKeyConflictHandler::saveToSettings(bool temporary)
                 // so make sure to cleanup.
                 // Also this helps in keeping file small.
                 iter->second.mKeyBind.trimEmpty();
-                U32 size = iter->second.mKeyBind.getDataCount();
-                for (U32 i = 0; i < size; ++i)
+                auto size = iter->second.mKeyBind.getDataCount();
+                for (size_t i = 0; i < size; ++i)
                 {
                     if (iter->first.empty())
                     {
@@ -491,7 +491,7 @@ void LLKeyConflictHandler::saveToSettings(bool temporary)
                         continue;
                     }
 
-                    LLKeyData data = key.mKeyBind.getKeyData(i);
+                    LLKeyData data = key.mKeyBind.getKeyData(static_cast<U32>(i));
                     // Still write empty LLKeyData to make sure we will maintain UI position
                     if (data.mKey == KEY_NONE)
                     {

--- a/indra/newview/lllandmarklist.cpp
+++ b/indra/newview/lllandmarklist.cpp
@@ -118,7 +118,7 @@ void LLLandmarkList::processGetAssetReply(
             file.read((U8*)&buffer[0], file_length);
             buffer[file_length] = 0;
 
-            LLLandmark* landmark = LLLandmark::constructFromString(&buffer[0], buffer.size());
+            LLLandmark* landmark = LLLandmark::constructFromString(&buffer[0], static_cast<S32>(buffer.size()));
             if (landmark)
             {
                 gLandmarkList.mList[uuid] = landmark;

--- a/indra/newview/lllocalgltfmaterials.cpp
+++ b/indra/newview/lllocalgltfmaterials.cpp
@@ -340,19 +340,19 @@ S32 LLLocalGLTFMaterialMgr::addUnit(const std::string& filename)
     tinygltf::Model model;
     LLTinyGLTFHelper::loadModel(filename, model);
 
-    S32 materials_in_file = model.materials.size();
+    auto materials_in_file = model.materials.size();
     if (materials_in_file <= 0)
     {
         return 0;
     }
 
     S32 loaded_materials = 0;
-    for (S32 i = 0; i < materials_in_file; i++)
+    for (size_t i = 0; i < materials_in_file; i++)
     {
         // Todo: this is rather inefficient, files will be spammed with
         // separate loads and date checks, find a way to improve this.
         // May be doUpdates() should be checking individual files.
-        LLPointer<LLLocalGLTFMaterial> unit = new LLLocalGLTFMaterial(filename, i);
+        LLPointer<LLLocalGLTFMaterial> unit = new LLLocalGLTFMaterial(filename, static_cast<S32>(i));
 
         // load material from file
         if (unit->updateSelf())

--- a/indra/newview/lllogchat.cpp
+++ b/indra/newview/lllogchat.cpp
@@ -452,11 +452,11 @@ void LLLogChat::loadChatHistory(const std::string& file_name, std::list<LLSD>& m
         return;
     }
 
-    S32 save_num_messages = messages.size();
+    auto save_num_messages = messages.size();
 
     char buffer[LOG_RECALL_SIZE];       /*Flawfinder: ignore*/
     char *bptr;
-    S32 len;
+    size_t len;
     bool firstline = true;
 
     if (load_all_history || fseek(fptr, (LOG_RECALL_SIZE - 1) * -1  , SEEK_END))
@@ -1142,7 +1142,7 @@ void LLLoadHistoryThread::run()
     if(mNewLoad)
     {
         loadHistory(mFileName, mMessages, mLoadParams);
-        int count = mMessages->size();
+        auto count = mMessages->size();
         LL_INFOS() << "mMessages->size(): " << count << LL_ENDL;
         setFinished();
     }
@@ -1189,7 +1189,7 @@ void LLLoadHistoryThread::loadHistory(const std::string& file_name, std::list<LL
     char buffer[LOG_RECALL_SIZE];       /*Flawfinder: ignore*/
 
     char *bptr;
-    S32 len;
+    size_t len;
     bool firstline = true;
 
     if (load_all_history || fseek(fptr, (LOG_RECALL_SIZE - 1) * -1  , SEEK_END))

--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -1247,7 +1247,7 @@ bool LLMaterialEditor::decodeAsset(const std::vector<char>& buffer)
 
                     tinygltf::Model model_in;
 
-                    if (loader.LoadASCIIFromString(&model_in, &error_msg, &warn_msg, data.c_str(), data.length(), ""))
+                    if (loader.LoadASCIIFromString(&model_in, &error_msg, &warn_msg, data.c_str(), static_cast<unsigned int>(data.length()), ""))
                     {
                         // assets are only supposed to have one item
                         // *NOTE: This duplicates some functionality from

--- a/indra/newview/llmaterialmgr.cpp
+++ b/indra/newview/llmaterialmgr.cpp
@@ -431,7 +431,7 @@ void LLMaterialMgr::onGetResponse(bool success, const LLSD& content, const LLUUI
     const LLSD::Binary& content_binary = content[MATERIALS_CAP_ZIP_FIELD].asBinary();
 
     LLSD response_data;
-    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), content_binary.size());
+    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), static_cast<S32>(content_binary.size()));
     if (uzip_result != LLUZipHelper::ZR_OK)
     {
         LL_WARNS("Materials") << "Cannot unzip LLSD binary content: " << uzip_result << LL_ENDL;
@@ -472,7 +472,7 @@ void LLMaterialMgr::onGetAllResponse(bool success, const LLSD& content, const LL
     const LLSD::Binary& content_binary = content[MATERIALS_CAP_ZIP_FIELD].asBinary();
 
     LLSD response_data;
-    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), content_binary.size());
+    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), static_cast<S32>(content_binary.size()));
     if (uzip_result != LLUZipHelper::ZR_OK)
     {
         LL_WARNS("Materials") << "Cannot unzip LLSD binary content: " << uzip_result << LL_ENDL;
@@ -539,7 +539,7 @@ void LLMaterialMgr::onPutResponse(bool success, const LLSD& content)
     const LLSD::Binary& content_binary = content[MATERIALS_CAP_ZIP_FIELD].asBinary();
 
     LLSD response_data;
-    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), content_binary.size());
+    U32 uzip_result = LLUZipHelper::unzip_llsd(response_data, content_binary.data(), static_cast<S32>(content_binary.size()));
     if (uzip_result != LLUZipHelper::ZR_OK)
     {
         LL_WARNS("Materials") << "Cannot unzip LLSD binary content: " << uzip_result << LL_ENDL;
@@ -670,7 +670,7 @@ void LLMaterialMgr::processGetQueue()
 
         std::string materialString = zip_llsd(materialsData);
 
-        S32 materialSize = materialString.size();
+        auto materialSize = materialString.size();
         if (materialSize <= 0)
         {
             LL_ERRS("Materials") << "cannot zip LLSD binary content" << LL_ENDL;
@@ -960,7 +960,7 @@ void LLMaterialMgr::processPutQueue()
 
         std::string materialString = zip_llsd(materialsData);
 
-        S32 materialSize = materialString.size();
+        auto materialSize = materialString.size();
 
         if (materialSize > 0)
         {

--- a/indra/newview/llmediadataclient.cpp
+++ b/indra/newview/llmediadataclient.cpp
@@ -692,7 +692,7 @@ void LLObjectMediaDataClient::sortQueue()
         mQueue.sort(compareRequestScores);
 
         // ...then cull items over the max
-        U32 size = mQueue.size();
+        U32 size = static_cast<U32>(mQueue.size());
         if (size > mMaxSortedQueueSize)
         {
             U32 num_to_cull = (size - mMaxSortedQueueSize);

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -916,7 +916,7 @@ void LLMeshRepoThread::run()
             // Dispatch all HttpHandler notifications
             mHttpRequest->update(0L);
         }
-        sRequestWaterLevel = mHttpRequestSet.size();            // Stats data update
+        sRequestWaterLevel = static_cast<S32>(mHttpRequestSet.size());            // Stats data update
 
         // NOTE: order of queue processing intentionally favors LOD requests over header requests
         // Todo: we are processing mLODReqQ, mHeaderReqQ, mSkinRequests, mDecompositionRequests and mPhysicsShapeRequests
@@ -3082,7 +3082,7 @@ void LLMeshHandlerBase::onCompleted(LLCore::HttpHandle handle, LLCore::HttpRespo
         LLCore::BufferArray * body(response->getBody());
         S32 body_offset(0);
         U8 * data(NULL);
-        S32 data_size(body ? body->size() : 0);
+        auto data_size(body ? body->size() : 0);
 
         if (data_size > 0)
         {
@@ -3143,7 +3143,7 @@ void LLMeshHandlerBase::onCompleted(LLCore::HttpHandle handle, LLCore::HttpRespo
             if (data)
             {
                 body->read(body_offset, (char *) data, data_size - body_offset);
-                LLMeshRepository::sBytesReceived += data_size;
+                LLMeshRepository::sBytesReceived += static_cast<U32>(data_size);
             }
             else
             {
@@ -3152,7 +3152,7 @@ void LLMeshHandlerBase::onCompleted(LLCore::HttpHandle handle, LLCore::HttpRespo
             }
         }
 
-        processData(body, body_offset, data, data_size - body_offset);
+        processData(body, body_offset, data, static_cast<S32>(data_size) - body_offset);
 
         delete [] data;
     }
@@ -3624,8 +3624,8 @@ S32 LLMeshRepository::update()
         return 0 ;
     }
 
-    S32 size = mUploadWaitList.size() ;
-    for (S32 i = 0; i < size; ++i)
+    auto size = mUploadWaitList.size() ;
+    for (size_t i = 0; i < size; ++i)
     {
         mUploads.push_back(mUploadWaitList[i]);
         mUploadWaitList[i]->preStart() ;
@@ -3633,7 +3633,7 @@ S32 LLMeshRepository::update()
     }
     mUploadWaitList.clear() ;
 
-    return size ;
+    return static_cast<S32>(size);
 }
 
 void LLMeshRepository::unregisterMesh(LLVOVolume* vobj)
@@ -4864,7 +4864,7 @@ void LLPhysicsDecomp::setMeshData(LLCDMeshData& mesh, bool vertex_based)
 {
     mesh.mVertexBase = mCurRequest->mPositions[0].mV;
     mesh.mVertexStrideBytes = 12;
-    mesh.mNumVertices = mCurRequest->mPositions.size();
+    mesh.mNumVertices = static_cast<int>(mCurRequest->mPositions.size());
 
     if(!vertex_based)
     {
@@ -4872,7 +4872,7 @@ void LLPhysicsDecomp::setMeshData(LLCDMeshData& mesh, bool vertex_based)
         mesh.mIndexBase = &(mCurRequest->mIndices[0]);
         mesh.mIndexStrideBytes = 6;
 
-        mesh.mNumTriangles = mCurRequest->mIndices.size()/3;
+        mesh.mNumTriangles = static_cast<int>(mCurRequest->mIndices.size())/3;
     }
 
     if ((vertex_based || mesh.mNumTriangles > 0) && mesh.mNumVertices > 2)
@@ -5283,10 +5283,10 @@ void LLMeshRepository::buildPhysicsMesh(LLModel::Decomposition& decomp)
 {
     decomp.mMesh.resize(decomp.mHull.size());
 
-    for (U32 i = 0; i < decomp.mHull.size(); ++i)
+    for (size_t i = 0; i < decomp.mHull.size(); ++i)
     {
         LLCDHull hull;
-        hull.mNumVertices = decomp.mHull[i].size();
+        hull.mNumVertices = static_cast<int>(decomp.mHull[i].size());
         hull.mVertexBase = decomp.mHull[i][0].mV;
         hull.mVertexStrideBytes = 12;
 
@@ -5305,7 +5305,7 @@ void LLMeshRepository::buildPhysicsMesh(LLModel::Decomposition& decomp)
     if (!decomp.mBaseHull.empty() && decomp.mBaseHullMesh.empty())
     { //get mesh for base hull
         LLCDHull hull;
-        hull.mNumVertices = decomp.mBaseHull.size();
+        hull.mNumVertices = static_cast<int>(decomp.mBaseHull.size());
         hull.mVertexBase = decomp.mBaseHull[0].mV;
         hull.mVertexStrideBytes = 12;
 

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -2283,7 +2283,7 @@ void LLModelPreview::updateStatusMessages()
     mModelNoErrors = true;
 
     const U32 lod_high = LLModel::LOD_HIGH;
-    U32 high_submodel_count = mModel[lod_high].size() - countRootModels(mModel[lod_high]);
+    U32 high_submodel_count = static_cast<U32>(mModel[lod_high].size()) - countRootModels(mModel[lod_high]);
 
     for (S32 lod = 0; lod <= lod_high; ++lod)
     {
@@ -2482,10 +2482,10 @@ void LLModelPreview::updateStatusMessages()
 
                 if (!decomp.empty())
                 {
-                    phys_hulls += decomp.size();
+                    phys_hulls += static_cast<S32>(decomp.size());
                     for (U32 i = 0; i < decomp.size(); ++i)
                     {
-                        phys_points += decomp[i].size();
+                        phys_points += static_cast<S32>(decomp[i].size());
                     }
                 }
                 else
@@ -3437,8 +3437,8 @@ bool LLModelPreview::render()
 
                 gGL.multMatrix((GLfloat*)mat.mMatrix);
 
-                U32 num_models = mVertexBuffer[mPreviewLOD][model].size();
-                for (U32 i = 0; i < num_models; ++i)
+                auto num_models = mVertexBuffer[mPreviewLOD][model].size();
+                for (size_t i = 0; i < num_models; ++i)
                 {
                     LLVertexBuffer* buffer = mVertexBuffer[mPreviewLOD][model][i];
 
@@ -3446,7 +3446,7 @@ bool LLModelPreview::render()
 
                     if (textures)
                     {
-                        int materialCnt = instance.mModel->mMaterialList.size();
+                        auto materialCnt = instance.mModel->mMaterialList.size();
                         if (i < materialCnt)
                         {
                             const std::string& binding = instance.mModel->mMaterialList[i];
@@ -3584,9 +3584,9 @@ bool LLModelPreview::render()
 
                         if (render_mesh)
                         {
-                            U32 num_models = mVertexBuffer[LLModel::LOD_PHYSICS][model].size();
+                            auto num_models = mVertexBuffer[LLModel::LOD_PHYSICS][model].size();
                             if (pass > 0){
-                                for (U32 i = 0; i < num_models; ++i)
+                                for (size_t i = 0; i < num_models; ++i)
                                 {
                                     LLVertexBuffer* buffer = mVertexBuffer[LLModel::LOD_PHYSICS][model][i];
 
@@ -3649,8 +3649,8 @@ bool LLModelPreview::render()
 
                                 if (physics.mHull.empty())
                                 {
-                                    U32 num_models = mVertexBuffer[LLModel::LOD_PHYSICS][model].size();
-                                    for (U32 v = 0; v < num_models; ++v)
+                                    auto num_models = mVertexBuffer[LLModel::LOD_PHYSICS][model].size();
+                                    for (size_t v = 0; v < num_models; ++v)
                                     {
                                         LLVertexBuffer* buffer = mVertexBuffer[LLModel::LOD_PHYSICS][model][v];
 
@@ -3717,7 +3717,7 @@ bool LLModelPreview::render()
                         const LLMeshSkinInfo *skin = &model->mSkinInfo;
                         LLSkinningUtil::initJointNums(&model->mSkinInfo, getPreviewAvatar());// inits skin->mJointNums if nessesary
                         U32 joint_count = LLSkinningUtil::getMeshJointCount(skin);
-                        U32 bind_count = skin->mAlternateBindMatrix.size();
+                        auto bind_count = skin->mAlternateBindMatrix.size();
 
                         if (joint_overrides
                             && bind_count > 0
@@ -3762,7 +3762,7 @@ bool LLModelPreview::render()
                             }
                         }
 
-                        for (U32 i = 0, e = mVertexBuffer[mPreviewLOD][model].size(); i < e; ++i)
+                        for (U32 i = 0, e = static_cast<U32>(mVertexBuffer[mPreviewLOD][model].size()); i < e; ++i)
                         {
                             LLVertexBuffer* buffer = mVertexBuffer[mPreviewLOD][model][i];
 
@@ -3773,7 +3773,7 @@ bool LLModelPreview::render()
 
                             if (textures)
                             {
-                                int materialCnt = instance.mModel->mMaterialList.size();
+                                auto materialCnt = instance.mModel->mMaterialList.size();
                                 if (i < materialCnt)
                                 {
                                     const std::string& binding = instance.mModel->mMaterialList[i];

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -123,7 +123,7 @@ void LLOutfitGallery::onOpen(const LLSD& info)
     {
         uuid_vec_t cats;
         getCurrentCategories(cats);
-        int n = cats.size();
+        int n = static_cast<int>(cats.size());
         buildGalleryPanel(n);
         mScrollPanel->addChild(mGalleryPanel);
         for (int i = 0; i < n; i++)
@@ -601,8 +601,8 @@ void LLOutfitGallery::removeFromGalleryMiddle(LLOutfitGalleryItem* item)
         removeFromGalleryLast(mItems[i]);
     }
     removeFromGalleryLast(mItems[n]);
-    int saved_count = saved.size();
-    for (int i = 0; i < saved_count; i++)
+    auto saved_count = saved.size();
+    for (size_t i = 0; i < saved_count; i++)
     {
         addToGallery(saved.back());
         saved.pop_back();

--- a/indra/newview/lloutfitslist.cpp
+++ b/indra/newview/lloutfitslist.cpp
@@ -376,7 +376,7 @@ void LLOutfitsList::getSelectedItemsUUIDs(uuid_vec_t& selected_uuids) const
         uuid_vec_t uuids;
         (*iter).second->getSelectedUUIDs(uuids);
 
-        S32 prev_size = selected_uuids.size();
+        auto prev_size = selected_uuids.size();
         selected_uuids.resize(prev_size + uuids.size());
         std::copy(uuids.begin(), uuids.end(), selected_uuids.begin() + prev_size);
     }

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -94,13 +94,13 @@ void LLPanelEmojiComplete::draw()
         if (mVertical)
         {
             x = mRenderRect.mLeft;
-            y = mRenderRect.mTop - (mCurSelected - firstVisibleIdx + 1) * mEmojiHeight;
+            y = mRenderRect.mTop - static_cast<S32>(mCurSelected - firstVisibleIdx + 1) * mEmojiHeight;
             width = mRenderRect.getWidth();
             height = mEmojiHeight;
         }
         else
         {
-            x = mRenderRect.mLeft + (mCurSelected - firstVisibleIdx) * mEmojiWidth;
+            x = mRenderRect.mLeft + static_cast<S32>(mCurSelected - firstVisibleIdx) * mEmojiWidth;
             y = mRenderRect.mBottom;
             width = mEmojiWidth;
             height = mRenderRect.getHeight();
@@ -113,7 +113,7 @@ void LLPanelEmojiComplete::draw()
     F32 textLeft = mVertical ? mRenderRect.mLeft + mEmojiWidth + mPadding : 0;
     F32 textWidth = mVertical ? getRect().getWidth() - textLeft - mPadding : 0;
 
-    for (U32 curIdx = firstVisibleIdx; curIdx < lastVisibleIdx; curIdx++)
+    for (size_t curIdx = firstVisibleIdx; curIdx < lastVisibleIdx; curIdx++)
     {
         LLWString text(1, mEmojis[curIdx].Character);
         mIconFont->render(text, 0, iconCenterX, iconCenterY,
@@ -129,7 +129,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(0, mEmojis[curIdx].Begin);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::white,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    text.size(), x1);
+                    static_cast<S32>(text.size()), x1);
                 x0 += mTextFont->getWidthF32(text);
                 x1 = textLeft + textWidth - x0;
             }
@@ -138,7 +138,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(mEmojis[curIdx].Begin, mEmojis[curIdx].End - mEmojis[curIdx].Begin);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::yellow6,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    text.size(), x1);
+                    static_cast<S32>(text.size()), x1);
                 x0 += mTextFont->getWidthF32(text);
                 x1 = textLeft + textWidth - x0;
             }
@@ -147,7 +147,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(mEmojis[curIdx].End);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::white,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    text.size(), x1);
+                    static_cast<S32>(text.size()), x1);
             }
             iconCenterY -= mEmojiHeight;
         }
@@ -373,11 +373,11 @@ void LLPanelEmojiComplete::onEmojisChanged()
             {
                 width += mScrollbar->getThickness();
             }
-            height = mVisibleEmojis * mEmojiHeight;
+            height = static_cast<S32>(mVisibleEmojis) * mEmojiHeight;
         }
         else
         {
-            width = mVisibleEmojis * mEmojiWidth;
+            width = static_cast<S32>(mVisibleEmojis) * mEmojiWidth;
             height = getRect().getHeight();
         }
         LLUICtrl::reshape(width, height, false);
@@ -445,8 +445,8 @@ void LLPanelEmojiComplete::updateConstraints()
         if (!mNoScroll && mVisibleEmojis < mTotalEmojis)
         {
             mRenderRect.mRight -= mScrollbar->getThickness();
-            mScrollbar->setDocSize(mTotalEmojis);
-            mScrollbar->setPageSize(mVisibleEmojis);
+            mScrollbar->setDocSize(static_cast<S32>(mTotalEmojis));
+            mScrollbar->setPageSize(static_cast<S32>(mVisibleEmojis));
             mScrollbar->setOrigin(mRenderRect.mRight, 0);
             mScrollbar->reshape(mScrollbar->getThickness(), mRenderRect.mTop, true);
             mScrollbar->setVisible(true);
@@ -459,7 +459,7 @@ void LLPanelEmojiComplete::updateConstraints()
     else
     {
         mEmojiHeight = mRenderRect.getHeight();
-        mRenderRect.stretch((mRenderRect.getWidth() - mVisibleEmojis * mEmojiWidth) / -2, 0);
+        mRenderRect.stretch((mRenderRect.getWidth() - static_cast<S32>(mVisibleEmojis) * mEmojiWidth) / -2, 0);
     }
 
     updateScrollPos();
@@ -486,7 +486,7 @@ void LLPanelEmojiComplete::updateScrollPos()
 
     if (mScrollbar && mScrollbar->getVisible())
     {
-        mScrollbar->setDocPos(mScrollPos);
+        mScrollbar->setDocPos(static_cast<S32>(mScrollPos));
     }
 }
 

--- a/indra/newview/llpanelexperiencelog.cpp
+++ b/indra/newview/llpanelexperiencelog.cpp
@@ -126,7 +126,7 @@ void LLPanelExperienceLog::refresh()
                 events_to_save.erase(day->first);
                 continue;
             }
-            int size = dayArray.size();
+            int size = static_cast<int>(dayArray.size());
             if(itemsToSkip > size)
             {
                 itemsToSkip -= size;
@@ -137,7 +137,7 @@ void LLPanelExperienceLog::refresh()
                 moreItems = true;
                 break;
             }
-            for(int i = dayArray.size() - itemsToSkip - 1; i >= 0; i--)
+            for(int i = static_cast<int>(dayArray.size()) - itemsToSkip - 1; i >= 0; i--)
             {
                 if(items >= mPageSize)
                 {

--- a/indra/newview/llpanelgroupcreate.cpp
+++ b/indra/newview/llpanelgroupcreate.cpp
@@ -194,7 +194,7 @@ void LLPanelGroupCreate::onBtnCreate()
     // Validate the group name length.
     std::string gr_name = mGroupNameEditor->getText();
     LLStringUtil::trim(gr_name);
-    S32 group_name_len = gr_name.size();
+    S32 group_name_len = static_cast<S32>(gr_name.size());
     if (group_name_len < DB_GROUP_NAME_MIN_LEN
         || group_name_len > DB_GROUP_NAME_STR_LEN)
     {

--- a/indra/newview/llpanelgrouproles.cpp
+++ b/indra/newview/llpanelgrouproles.cpp
@@ -1173,7 +1173,7 @@ void LLPanelGroupMembersSubTab::confirmEjectMembers()
     std::vector<LLScrollListItem*> selection = mMembersList->getAllSelected();
     if (selection.empty()) return;
 
-    S32 selection_count = selection.size();
+    auto selection_count = selection.size();
     if (selection_count == 1)
     {
         LLSD args;
@@ -1868,7 +1868,7 @@ void LLPanelGroupMembersSubTab::confirmBanMembers()
     std::vector<LLScrollListItem*> selection = mMembersList->getAllSelected();
     if (selection.empty()) return;
 
-    S32 selection_count = selection.size();
+    auto selection_count = selection.size();
     if (selection_count == 1)
     {
         LLSD args;
@@ -2197,7 +2197,7 @@ void LLPanelGroupRolesSubTab::update(LLGroupChange gc)
                 if (matchesSearchFilter(rd.mRoleName, rd.mRoleTitle))
                 {
                     // If this is the everyone role, then EVERYONE is in it.
-                    S32 members_in_role = (*rit).first.isNull() ? gdatap->mMembers.size() : (*rit).second->getTotalMembersInRole();
+                    S32 members_in_role = (*rit).first.isNull() ? static_cast<S32>(gdatap->mMembers.size()) : (*rit).second->getTotalMembersInRole();
                     LLSD row = createRoleItem((*rit).first,rd.mRoleName, rd.mRoleTitle, members_in_role);
                     item = mRolesList->addElement(row, ((*rit).first.isNull()) ? ADD_TOP : ADD_BOTTOM, this);
                     if (had_selection && ((*rit).first == last_selected))
@@ -3109,7 +3109,7 @@ void LLPanelGroupBanListSubTab::activate()
     {
         mCreateBanButton->setEnabled(gAgent.hasPowerInGroup(mGroupID, GP_GROUP_BAN_ACCESS) &&
                                      group_datap->mBanList.size() < GB_MAX_BANNED_AGENTS);
-        setBanCount(group_datap->mBanList.size());
+        setBanCount(static_cast<U32>(group_datap->mBanList.size()));
     }
     else
     {
@@ -3236,7 +3236,7 @@ void LLPanelGroupBanListSubTab::handleDeleteBanEntry()
 
     // update ban-count related elements
     mCreateBanButton->setEnabled(true);
-    setBanCount(gdatap->mBanList.size());
+    setBanCount(static_cast<U32>(gdatap->mBanList.size()));
 
     LLGroupMgr::getInstance()->sendGroupBanRequest(LLGroupMgr::REQUEST_POST, mGroupID, LLGroupMgr::BAN_DELETE, ban_ids);
 }
@@ -3314,7 +3314,7 @@ void LLPanelGroupBanListSubTab::populateBanList()
     mRefreshBanListButton->setEnabled(true);
     mCreateBanButton->setEnabled(gAgent.hasPowerInGroup(mGroupID, GP_GROUP_BAN_ACCESS) &&
                                  gdatap->mBanList.size() < GB_MAX_BANNED_AGENTS);
-    setBanCount(gdatap->mBanList.size());
+    setBanCount(static_cast<U32>(gdatap->mBanList.size()));
 }
 
 void LLPanelGroupBanListSubTab::setGroupID(const LLUUID& id)

--- a/indra/newview/llpanellogin.cpp
+++ b/indra/newview/llpanellogin.cpp
@@ -335,7 +335,7 @@ void LLPanelLogin::addFavoritesToStartLocation()
     {
         // first login panel has no favorites, just update name length and buttons
         std::string user_defined_name = getChild<LLComboBox>("username_combo")->getSimple();
-        mUsernameLength = user_defined_name.length();
+        mUsernameLength = static_cast<unsigned int>(user_defined_name.length());
         updateLoginButtons();
         return;
     }
@@ -355,7 +355,7 @@ void LLPanelLogin::addFavoritesToStartLocation()
     LLStringUtil::toLower(user_defined_name);
     std::string filename = gDirUtilp->getExpandedFilename(LL_PATH_USER_SETTINGS, "stored_favorites_" + LLGridManager::getInstance()->getGrid() + ".xml");
     std::string old_filename = gDirUtilp->getExpandedFilename(LL_PATH_USER_SETTINGS, "stored_favorites.xml");
-    mUsernameLength = user_defined_name.length();
+    mUsernameLength = static_cast<unsigned int>(user_defined_name.length());
     updateLoginButtons();
 
     std::string::size_type index = user_defined_name.find_first_of(" ._");
@@ -597,13 +597,13 @@ void LLPanelLogin::setFields(LLPointer<LLCredential> credential)
             login_id += lastname;
         }
         sInstance->getChild<LLComboBox>("username_combo")->setLabel(login_id);
-        sInstance->mUsernameLength = login_id.length();
+        sInstance->mUsernameLength = static_cast<unsigned int>(login_id.length());
     }
     else if(identifier.has("type") && (std::string)identifier["type"] == "account")
     {
         std::string login_id = identifier["account_name"].asString();
         sInstance->getChild<LLComboBox>("username_combo")->setLabel(login_id);
-        sInstance->mUsernameLength = login_id.length();
+        sInstance->mUsernameLength = static_cast<unsigned int>(login_id.length());
     }
     else
     {
@@ -627,7 +627,7 @@ void LLPanelLogin::setFields(LLPointer<LLCredential> credential)
         // nice row of asterisks.
         const std::string filler("123456789!123456");
         sInstance->getChild<LLUICtrl>("password_edit")->setValue(filler);
-        sInstance->mPasswordLength = filler.length();
+        sInstance->mPasswordLength = static_cast<unsigned int>(filler.length());
         sInstance->updateLoginButtons();
     }
     else
@@ -793,7 +793,7 @@ void LLPanelLogin::onUpdateStartSLURL(const LLSLURL& new_start_slurl)
             {
 
                 location_combo->setLabel(new_start_slurl.getLocationString());
-                sInstance->mLocationLength = new_start_slurl.getLocationString().length();
+                sInstance->mLocationLength = static_cast<unsigned int>(new_start_slurl.getLocationString().length());
                 sInstance->updateLoginButtons();
             }
         }
@@ -1124,7 +1124,7 @@ void LLPanelLogin::onPassKey(LLLineEditor* caller, void* user_data)
     }
 
     LLLineEditor* password_edit(self->getChild<LLLineEditor>("password_edit"));
-    self->mPasswordLength = password_edit->getText().length();
+    self->mPasswordLength = static_cast<unsigned int>(password_edit->getText().length());
     self->updateLoginButtons();
 }
 
@@ -1158,8 +1158,8 @@ void LLPanelLogin::updateServer()
                 // restore creds
                 user_combo->setTextEntry(username);
                 pswd_edit->setValue(password);
-                sInstance->mUsernameLength = username.length();
-                sInstance->mPasswordLength = password.length();
+                sInstance->mUsernameLength = static_cast<unsigned int>(username.length());
+                sInstance->mPasswordLength = static_cast<unsigned int>(password.length());
             }
             else
             {

--- a/indra/newview/llpanelmarketplaceinbox.cpp
+++ b/indra/newview/llpanelmarketplaceinbox.cpp
@@ -179,7 +179,7 @@ U32 LLPanelMarketplaceInbox::getFreshItemCount() const
 
 U32 LLPanelMarketplaceInbox::getTotalItemCount() const
 {
-    U32 item_count = 0;
+    size_t item_count = 0;
 
     if (mInventoryPanel)
     {
@@ -192,7 +192,7 @@ U32 LLPanelMarketplaceInbox::getTotalItemCount() const
         }
     }
 
-    return item_count;
+    return static_cast<U32>(item_count);
 }
 
 void LLPanelMarketplaceInbox::onClearSearch()

--- a/indra/newview/llpanelnearbymedia.cpp
+++ b/indra/newview/llpanelnearbymedia.cpp
@@ -1241,7 +1241,7 @@ void LLPanelNearByMedia::onMenuAction(const LLSD& userdata)
 
         if (!url.empty())
         {
-            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(url), 0, url.size());
+            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(url), 0, static_cast<S32>(url.size()));
         }
     }
     else if ("copy_data" == command_name)
@@ -1254,12 +1254,12 @@ void LLPanelNearByMedia::onMenuAction(const LLSD& userdata)
         {
             pos += encoding_specifier.size();
             std::string res = LLBase64::decodeAsString(url.substr(pos));
-            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(res), 0, res.size());
+            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(res), 0, static_cast<S32>(res.size()));
         }
         else
         {
             url = LLURI::unescape(url);
-            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(url), 0, url.size());
+            LLClipboard::instance().copyToClipboard(utf8str_to_wstring(url), 0, static_cast<S32>(url.size()));
         }
     }
 }

--- a/indra/newview/llpanelpeople.cpp
+++ b/indra/newview/llpanelpeople.cpp
@@ -871,7 +871,7 @@ void LLPanelPeople::updateButtons()
         LLPanel* groups_panel = mTabContainer->getCurrentPanel();
         groups_panel->getChildView("minus_btn")->setEnabled(item_selected && selected_id.notNull()); // a real group selected
 
-        U32 groups_count = gAgent.mGroups.size();
+        U32 groups_count = static_cast<U32>(gAgent.mGroups.size());
         S32 max_groups = LLAgentBenefitsMgr::current().getGroupMembershipLimit();
         U32 groups_remaining = max_groups > groups_count ? max_groups - groups_count : 0;
         groups_panel->getChild<LLUICtrl>("groupcount")->setTextArg("[COUNT]", llformat("%d", groups_count));

--- a/indra/newview/llpanelpermissions.cpp
+++ b/indra/newview/llpanelpermissions.cpp
@@ -986,7 +986,7 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
 
     LLWString wline = utf8str_to_wstring(name);
     // panel supports two lines long names
-    S32 segment_length = font->maxDrawableChars(wline.c_str(), max_pixels, wline.length(), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+    S32 segment_length = font->maxDrawableChars(wline.c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
     if (segment_length == wline.length())
     {
         // no work needed
@@ -994,7 +994,7 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
     }
 
     S32 first_line_length = segment_length;
-    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels, wline.length(), LLFontGL::ANYWHERE);
+    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
     if (segment_length + first_line_length == wline.length())
     {
         // no work needed
@@ -1004,7 +1004,7 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
     // name does not fit, cut it, add ...
     const LLWString dots_pad(utf8str_to_wstring(std::string("....")));
     S32 elipses_width = font->getWidthF32(dots_pad.c_str());
-    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels - elipses_width, wline.length(), LLFontGL::ANYWHERE);
+    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels - elipses_width, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
 
     name = name.substr(0, segment_length + first_line_length) + std::string("...");
 }

--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -1430,7 +1430,7 @@ void LLPanelProfileSecondLife::onCommitMenu(const LLSD& userdata)
     else if (item_name == "copy_user_id")
     {
         LLWString wstr = utf8str_to_wstring(getAvatarId().asString());
-        LLClipboard::instance().copyToClipboard(wstr, 0, wstr.size());
+        LLClipboard::instance().copyToClipboard(wstr, 0, static_cast<S32>(wstr.size()));
     }
     else if (item_name == "agent_permissions")
     {
@@ -1455,7 +1455,7 @@ void LLPanelProfileSecondLife::onCommitMenu(const LLSD& userdata)
         {
             wstr = utf8str_to_wstring(av_name.getUserName());
         }
-        LLClipboard::instance().copyToClipboard(wstr, 0, wstr.size());
+        LLClipboard::instance().copyToClipboard(wstr, 0, static_cast<S32>(wstr.size()));
     }
     else if (item_name == "edit_display_name")
     {

--- a/indra/newview/llpanelteleporthistory.cpp
+++ b/indra/newview/llpanelteleporthistory.cpp
@@ -598,7 +598,7 @@ void LLTeleportHistoryPanel::getNextTab(const LLDate& item_date, S32& tab_idx, L
 {
     const U32 seconds_in_day = 24 * 60 * 60;
 
-    S32 tabs_cnt = mItemContainers.size();
+    S32 tabs_cnt = static_cast<S32>(mItemContainers.size());
     S32 curr_year = 0, curr_month = 0, curr_day = 0;
 
     tab_date = LLDate::now();
@@ -695,7 +695,7 @@ void LLTeleportHistoryPanel::refresh()
             // tab_boundary_date would be earliest possible date for this tab
             S32 tab_idx = 0;
             getNextTab(date, tab_idx, tab_boundary_date);
-            tab_idx = mItemContainers.size() - 1 - tab_idx;
+            tab_idx = static_cast<S32>(mItemContainers.size()) - 1 - tab_idx;
             if (tab_idx >= 0)
             {
                 LLAccordionCtrlTab* tab = mItemContainers.at(tab_idx);
@@ -743,7 +743,7 @@ void LLTeleportHistoryPanel::refresh()
             break;
     }
 
-    for (S32 n = mItemContainers.size() - 1; n >= 0; --n)
+    for (size_t n = mItemContainers.size() - 1; n >= 0; --n)
     {
         LLAccordionCtrlTab* tab = mItemContainers.at(n);
         LLFlatListView* fv = getFlatListViewFromTab(tab);
@@ -798,14 +798,14 @@ void LLTeleportHistoryPanel::replaceItem(S32 removed_index)
     LLTeleportHistoryFlatItem* item = LLTeleportHistoryFlatItemStorage::instance()
         .getFlatItemForPersistentItem(mGearItemMenu,
                                       history_items[history_items.size() - 1], // Most recent item, it was added instead of removed
-                                      history_items.size(), // index will be decremented inside loop below
+                                      static_cast<S32>(history_items.size()), // index will be decremented inside loop below
                                       sFilterSubString);
 
     fv->addItem(item, LLUUID::null, ADD_TOP);
 
     // Index of each item, from last to removed item should be decremented
     // to point to the right item in LLTeleportHistoryStorage
-    for (S32 tab_idx = mItemContainers.size() - 1; tab_idx >= 0; --tab_idx)
+    for (auto tab_idx = mItemContainers.size() - 1; tab_idx >= 0; --tab_idx)
     {
         LLAccordionCtrlTab* tab = mItemContainers.at(tab_idx);
         if (!tab->getVisible())
@@ -821,8 +821,8 @@ void LLTeleportHistoryPanel::replaceItem(S32 removed_index)
         std::vector<LLPanel*> items;
         fv->getItems(items);
 
-        S32 items_cnt = items.size();
-        for (S32 n = 0; n < items_cnt; ++n)
+        auto items_cnt = items.size();
+        for (size_t n = 0; n < items_cnt; ++n)
         {
             LLTeleportHistoryFlatItem *item = (LLTeleportHistoryFlatItem*) items[n];
 
@@ -857,9 +857,9 @@ void LLTeleportHistoryPanel::showTeleportHistory()
         mTeleportHistory = LLTeleportHistoryStorage::getInstance();
     }
 
-    mCurrentItem = mTeleportHistory->getItems().size() - 1;
+    mCurrentItem = static_cast<S32>(mTeleportHistory->getItems().size()) - 1;
 
-    for (S32 n = mItemContainers.size() - 1; n >= 0; --n)
+    for (auto n = mItemContainers.size() - 1; n >= 0; --n)
     {
         LLAccordionCtrlTab* tab = mItemContainers.at(n);
         if (tab)
@@ -884,9 +884,9 @@ void LLTeleportHistoryPanel::handleItemSelect(LLFlatListView* selected)
     if (item)
         mLastSelectedItemIndex = item->getIndex();
 
-    S32 tabs_cnt = mItemContainers.size();
+    auto tabs_cnt = mItemContainers.size();
 
-    for (S32 n = 0; n < tabs_cnt; n++)
+    for (size_t n = 0; n < tabs_cnt; n++)
     {
         LLAccordionCtrlTab* tab = mItemContainers.at(n);
 
@@ -1001,7 +1001,7 @@ LLFlatListView* LLTeleportHistoryPanel::getFlatListViewFromTab(LLAccordionCtrlTa
 
 void LLTeleportHistoryPanel::gotSLURLCallback(const std::string& slurl)
 {
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(slurl), 0, slurl.size());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(slurl), 0, static_cast<S32>(slurl.size()));
 
     LLSD args;
     args["SLURL"] = slurl;
@@ -1015,9 +1015,9 @@ void LLTeleportHistoryPanel::onGearMenuAction(const LLSD& userdata)
 
     if ("expand_all" == command_name)
     {
-        S32 tabs_cnt = mItemContainers.size();
+        auto tabs_cnt = mItemContainers.size();
 
-        for (S32 n = 0; n < tabs_cnt; n++)
+        for (size_t n = 0; n < tabs_cnt; n++)
         {
             mItemContainers.at(n)->setDisplayChildren(true);
         }
@@ -1025,9 +1025,9 @@ void LLTeleportHistoryPanel::onGearMenuAction(const LLSD& userdata)
     }
     else if ("collapse_all" == command_name)
     {
-        S32 tabs_cnt = mItemContainers.size();
+        auto tabs_cnt = mItemContainers.size();
 
-        for (S32 n = 0; n < tabs_cnt; n++)
+        for (size_t n = 0; n < tabs_cnt; n++)
         {
             mItemContainers.at(n)->setDisplayChildren(false);
         }
@@ -1082,12 +1082,12 @@ bool LLTeleportHistoryPanel::isActionEnabled(const LLSD& userdata) const
     if (command_name == "collapse_all"
         || command_name == "expand_all")
     {
-        S32 tabs_cnt = mItemContainers.size();
+        auto tabs_cnt = mItemContainers.size();
 
         bool has_expanded_tabs = false;
         bool has_collapsed_tabs = false;
 
-        for (S32 n = 0; n < tabs_cnt; n++)
+        for (size_t n = 0; n < tabs_cnt; n++)
         {
             LLAccordionCtrlTab* tab = mItemContainers.at(n);
             if (!tab->getVisible())

--- a/indra/newview/llpanelwearing.cpp
+++ b/indra/newview/llpanelwearing.cpp
@@ -478,11 +478,11 @@ void LLPanelWearing::getAttachmentLimitsCoro(std::string url)
 void LLPanelWearing::setAttachmentDetails(LLSD content)
 {
     mObjectNames.clear();
-    S32 number_attachments = content["attachments"].size();
-    for(int i = 0; i < number_attachments; i++)
+    auto number_attachments = content["attachments"].size();
+    for(size_t i = 0; i < number_attachments; i++)
     {
-        S32 number_objects = content["attachments"][i]["objects"].size();
-        for(int j = 0; j < number_objects; j++)
+        auto number_objects = content["attachments"][i]["objects"].size();
+        for(size_t j = 0; j < number_objects; j++)
         {
             LLUUID task_id = content["attachments"][i]["objects"][j]["id"].asUUID();
             std::string name = content["attachments"][i]["objects"][j]["name"].asString();
@@ -594,6 +594,6 @@ void LLPanelWearing::copyToClipboard()
         }
     }
 
-    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(text),0,text.size());
+    LLClipboard::instance().copyToClipboard(utf8str_to_wstring(text), 0, static_cast<S32>(text.size()));
 }
 // EOF

--- a/indra/newview/llpathfindingnavmesh.cpp
+++ b/indra/newview/llpathfindingnavmesh.cpp
@@ -140,12 +140,12 @@ void LLPathfindingNavMesh::handleNavMeshResult(const LLSD &pContent, U32 pNavMes
         if ( pContent.has(NAVMESH_DATA_FIELD) )
         {
             const LLSD::Binary &value = pContent.get(NAVMESH_DATA_FIELD).asBinary();
-            unsigned int binSize = value.size();
+            auto binSize = value.size();
             std::string newStr(reinterpret_cast<const char *>(&value[0]), binSize);
             std::istringstream streamdecomp( newStr );
             size_t decompBinSize = 0;
             bool valid = false;
-            U8* pUncompressedNavMeshContainer = unzip_llsdNavMesh( valid, decompBinSize, streamdecomp, binSize ) ;
+            U8* pUncompressedNavMeshContainer = unzip_llsdNavMesh(valid, decompBinSize, streamdecomp, static_cast<S32>(binSize));
             if ( !valid )
             {
                 LL_WARNS() << "Unable to decompress the navmesh llsd." << LL_ENDL;

--- a/indra/newview/llpathfindingpathtool.cpp
+++ b/indra/newview/llpathfindingpathtool.cpp
@@ -35,9 +35,6 @@
 
 #include "llagent.h"
 #include "llpathfindingmanager.h"
-#include "llpathinglib.h"
-#include "llsingleton.h"
-#include "lltool.h"
 #include "llviewercamera.h"
 #include "llviewerregion.h"
 #include "llviewerwindow.h"

--- a/indra/newview/llperfstats.cpp
+++ b/indra/newview/llperfstats.cpp
@@ -302,7 +302,7 @@ namespace LLPerfStats
         std::vector<LLVector3d> positions;
         uuid_vec_t avatar_ids;
         LLWorld::getInstance()->getAvatars(&avatar_ids, &positions, our_pos, distance);
-        return positions.size();
+        return static_cast<int>(positions.size());
     }
 
     const U32 NUM_PERIODS = 50;

--- a/indra/newview/llpreviewgesture.cpp
+++ b/indra/newview/llpreviewgesture.cpp
@@ -549,11 +549,9 @@ void LLPreviewGesture::addAnimations()
 
     // Copy into something we can sort
     std::vector<LLInventoryItem*> animations;
-
-    S32 count = items.size();
-    for(i = 0; i < count; ++i)
+    for (auto& item : items)
     {
-        animations.push_back( items.at(i) );
+        animations.emplace_back(item);
     }
 
     // Do the sort
@@ -594,12 +592,9 @@ void LLPreviewGesture::addSounds()
 
     // Copy sounds into something we can sort
     std::vector<LLInventoryItem*> sounds;
-
-    S32 i;
-    S32 count = items.size();
-    for(i = 0; i < count; ++i)
+    for (auto& item : items)
     {
-        sounds.push_back( items.at(i) );
+        sounds.emplace_back(item);
     }
 
     // Do the sort
@@ -951,8 +946,8 @@ void LLPreviewGesture::loadUIFromGesture(LLMultiGesture* gesture)
     mKeyCombo->setEnabledByValue(LLKeyboard::stringFromKey(KEY_F10), gesture->mMask != MASK_CONTROL);
 
     // Make UI steps for each gesture step
-    S32 i;
-    S32 count = gesture->mSteps.size();
+    size_t i;
+    size_t count = gesture->mSteps.size();
     for (i = 0; i < count; ++i)
     {
         LLGestureStep* step = gesture->mSteps[i];

--- a/indra/newview/llpreviewnotecard.cpp
+++ b/indra/newview/llpreviewnotecard.cpp
@@ -593,7 +593,7 @@ bool LLPreviewNotecard::saveIfNeeded(LLInventoryItem* copyitem, bool sync)
                 LLSaveNotecardInfo* info = new LLSaveNotecardInfo(this, mItemUUID, mObjectUUID,
                                                                 tid, copyitem);
 
-                S32 size = buffer.length() + 1;
+                S32 size = static_cast<S32>(buffer.length()) + 1;
                 file.write((U8*)buffer.c_str(), size);
 
                 gAssetStorage->storeAssetData(tid, LLAssetType::AT_NOTECARD,

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -1203,9 +1203,9 @@ struct LLEntryAndEdCore
 
 void LLScriptEdCore::deleteBridges()
 {
-    S32 count = mBridges.size();
+    auto count = mBridges.size();
     LLEntryAndEdCore* eandc;
-    for(S32 i = 0; i < count; i++)
+    for(size_t i = 0; i < count; i++)
     {
         eandc = mBridges.at(i);
         delete eandc;

--- a/indra/newview/llpreviewtexture.cpp
+++ b/indra/newview/llpreviewtexture.cpp
@@ -673,7 +673,7 @@ void LLPreviewTexture::adjustAspectRatio()
                 std::string ratio = std::to_string(num)+":" + std::to_string(denom);
                 mRatiosList.push_back(ratio);
                 combo->add(ratio);
-                combo->setCurrentByIndex(mRatiosList.size()- 1);
+                combo->setCurrentByIndex(static_cast<S32>(mRatiosList.size()) - 1);
             }
             else
             {

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -699,7 +699,7 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
             
             res /= 2;
 
-            S32 mip = i - (mMipChain.size() - mips);
+            GLint mip = static_cast<GLint>(i - (mMipChain.size() - mips));
 
             if (mip >= 0)
             {

--- a/indra/newview/llscenemonitor.cpp
+++ b/indra/newview/llscenemonitor.cpp
@@ -527,7 +527,7 @@ void LLSceneMonitor::dumpToFile(const std::string &file_name)
         os << std::setprecision(10);
 
         LLTrace::PeriodicRecording& scene_load_recording = mSceneLoadRecording.getResults();
-        const U32 frame_count = scene_load_recording.getNumRecordedPeriods();
+        const auto frame_count = scene_load_recording.getNumRecordedPeriods();
 
         F64Seconds frame_time;
 

--- a/indra/newview/llsceneview.cpp
+++ b/indra/newview/llsceneview.cpp
@@ -194,13 +194,13 @@ void LLSceneView::draw()
 
             F32 size_range = size_domain[1]-size_domain[0];
 
-            U32 count = size[idx].size();
+            auto count = size[idx].size();
 
             F32 total = 0.f;
 
             gGL.begin(LLRender::LINE_STRIP);
 
-            for (U32 i = 0; i < count; ++i)
+            for (size_t i = 0; i < count; ++i)
             {
                 F32 rad = size[idx][i];
                 total += rad;
@@ -260,11 +260,11 @@ void LLSceneView::draw()
 
             U32 triangle_range = tri_domain[1]-tri_domain[0];
 
-            U32 count = triangles[idx].size();
+            auto count = triangles[idx].size();
 
             gGL.begin(LLRender::LINE_STRIP);
             //plot triangles
-            for (U32 i = 0; i < count; ++i)
+            for (size_t i = 0; i < count; ++i)
             {
                 U32 tri_count = triangles[idx][i];
                 F32 y = (F32) (tri_count-tri_domain[0])/triangle_range*tri_rect.getHeight()+tri_rect.mBottom;
@@ -325,13 +325,13 @@ void LLSceneView::draw()
 
             F32 cost_range = streaming_domain[1]-streaming_domain[0];
 
-            U32 count = streaming_cost[idx].size();
+            auto count = streaming_cost[idx].size();
 
             F32 total = 0;
 
             gGL.begin(LLRender::LINE_STRIP);
             //plot triangles
-            for (U32 i = 0; i < count; ++i)
+            for (size_t i = 0; i < count; ++i)
             {
                 F32 sc = streaming_cost[idx][i];
                 total += sc;
@@ -391,13 +391,13 @@ void LLSceneView::draw()
 
             F32 cost_range = physics_domain[1]-physics_domain[0];
 
-            U32 count = physics_cost[idx].size();
+            auto count = physics_cost[idx].size();
 
             F32 total = 0;
 
             gGL.begin(LLRender::LINE_STRIP);
             //plot triangles
-            for (U32 i = 0; i < count; ++i)
+            for (size_t i = 0; i < count; ++i)
             {
                 F32 pc = physics_cost[idx][i];
                 total += pc;

--- a/indra/newview/llsechandler_basic.cpp
+++ b/indra/newview/llsechandler_basic.cpp
@@ -75,7 +75,7 @@ LLBasicCertificate::LLBasicCertificate(const std::string& pem_cert,
 {
     // BIO_new_mem_buf returns a read only bio, but takes a void* which isn't const
     // so we need to cast it.
-    BIO * pem_bio = BIO_new_mem_buf((void*)pem_cert.c_str(), pem_cert.length());
+    BIO * pem_bio = BIO_new_mem_buf((void*)pem_cert.c_str(), static_cast<int>(pem_cert.length()));
     if(pem_bio == NULL)
     {
         LL_WARNS("SECAPI") << "Could not allocate an openssl memory BIO." << LL_ENDL;
@@ -747,7 +747,7 @@ bool _cert_subdomain_wildcard_match(const std::string& subdomain,
 {
     // split wildcard into the portion before the *, and the portion after
 
-    int wildcard_pos = wildcard.find_first_of('*');
+    auto wildcard_pos = wildcard.find_first_of('*');
     // check the case where there is no wildcard.
     if(wildcard_pos == wildcard.npos)
     {
@@ -779,7 +779,7 @@ bool _cert_subdomain_wildcard_match(const std::string& subdomain,
     std::string new_subdomain = subdomain.substr(wildcard_pos, subdomain.npos);
 
     // iterate through the current subdomain, finding instances of the match string.
-    int sub_pos = new_subdomain.find_first_of(new_wildcard_match_string);
+    auto sub_pos = new_subdomain.find_first_of(new_wildcard_match_string);
     while(sub_pos != std::string::npos)
     {
         new_subdomain = new_subdomain.substr(sub_pos, std::string::npos);
@@ -811,8 +811,8 @@ bool _cert_hostname_wildcard_match(const std::string& hostname, const std::strin
     std::string new_cn = common_name;
 
     // find the last '.' in the hostname and the match name.
-    int subdomain_pos = new_hostname.find_last_of('.');
-    int subcn_pos = new_cn.find_last_of('.');
+    auto subdomain_pos = new_hostname.find_last_of('.');
+    auto subcn_pos = new_cn.find_last_of('.');
 
     // if the last char is a '.', strip it
     if(subdomain_pos == (new_hostname.length()-1))
@@ -1860,7 +1860,7 @@ std::string LLSecAPIBasicHandler::_legacyLoadPassword()
     unsigned char unique_id[MAC_ADDRESS_BYTES];
     LLMachineID::getUniqueID(unique_id, sizeof(unique_id));
     LLXORCipher cipher(unique_id, sizeof(unique_id));
-    cipher.decrypt(&buffer[0], buffer.size());
+    cipher.decrypt(&buffer[0], static_cast<U32>(buffer.size()));
 
     return std::string((const char*)&buffer[0], buffer.size());
 }

--- a/indra/newview/llsechandler_basic.h
+++ b/indra/newview/llsechandler_basic.h
@@ -138,7 +138,7 @@ public:
     virtual iterator find(const LLSD& params);
 
     // return the number of certs in the store
-    virtual int size() const { return mCerts.size(); }
+    virtual int size() const { return static_cast<int>(mCerts.size()); }
 
     // insert the cert to the store.  if a copy of the cert already exists in the store, it is removed first
     virtual void  add(LLPointer<LLCertificate> cert) { insert(end(), cert); }

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -7648,7 +7648,7 @@ void LLObjectSelection::updateEffects()
 
 S32 LLObjectSelection::getNumNodes()
 {
-    return mList.size();
+    return static_cast<S32>(mList.size());
 }
 
 void LLObjectSelection::addNode(LLSelectNode *nodep)
@@ -7715,7 +7715,7 @@ bool LLObjectSelection::isEmpty() const
 S32 LLObjectSelection::getObjectCount()
 {
     cleanupNodes();
-    S32 count = mList.size();
+    S32 count = static_cast<S32>(mList.size());
 
     return count;
 }
@@ -8454,7 +8454,7 @@ bool LLSelectMgr::selectionMove(const LLVector3& displ,
 
             if (enable_rot)
             {
-                int children_count = obj->getChildren().size();
+                auto children_count = obj->getChildren().size();
                 if (obj_count > 1 && children_count > 0)
                 {
                     // for linked sets, rotate around the group center

--- a/indra/newview/llsidepanelinventory.cpp
+++ b/indra/newview/llsidepanelinventory.cpp
@@ -505,7 +505,7 @@ LLInventoryItem *LLSidepanelInventory::getSelectedItem()
 
 U32 LLSidepanelInventory::getSelectedCount()
 {
-    int count = 0;
+    size_t count = 0;
 
     std::set<LLFolderViewItem*> selection_list = mPanelMainInventory->getActivePanel()->getRootFolder()->getSelectionList();
     count += selection_list.size();
@@ -517,7 +517,7 @@ U32 LLSidepanelInventory::getSelectedCount()
         count += selection_list.size();
     }
 
-    return count;
+    return static_cast<U32>(count);
 }
 
 LLInventoryPanel *LLSidepanelInventory::getActivePanel()

--- a/indra/newview/llskinningutil.cpp
+++ b/indra/newview/llskinningutil.cpp
@@ -194,7 +194,7 @@ void LLSkinningUtil::checkSkinWeights(LLVector4a* weights, U32 num_vertices, con
 
 void LLSkinningUtil::scrubSkinWeights(LLVector4a* weights, U32 num_vertices, const LLMeshSkinInfo* skin)
 {
-    const S32 max_joints = skin->mJointNames.size();
+    const S32 max_joints = static_cast<S32>(skin->mJointNames.size());
     for (U32 j=0; j<num_vertices; j++)
     {
         F32 *w = weights[j].getF32ptr();
@@ -318,7 +318,7 @@ void LLSkinningUtil::updateRiggingInfo(const LLMeshSkinInfo* skin, LLVOAvatar *a
     if (vol_face.mJointRiggingInfoTab.needsUpdate())
     {
         S32 num_verts = vol_face.mNumVertices;
-        S32 num_joints = skin->mJointNames.size();
+        S32 num_joints = static_cast<S32>(skin->mJointNames.size());
         if (num_verts > 0 && vol_face.mWeights && num_joints > 0)
         {
             initJointNums(const_cast<LLMeshSkinInfo*>(skin), avatar);

--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -2289,12 +2289,12 @@ void renderPhysicsShape(LLDrawable* drawable, LLVOVolume* volume, bool wireframe
                     LLCDMeshData mesh;
                     mesh.mIndexBase = &index[0];
                     mesh.mVertexBase = pos[0].mV;
-                    mesh.mNumVertices = pos.size();
+                    mesh.mNumVertices = static_cast<int>(pos.size());
                     mesh.mVertexStrideBytes = 12;
                     mesh.mIndexStrideBytes = 6;
                     mesh.mIndexType = LLCDMeshData::INT_16;
 
-                    mesh.mNumTriangles = index.size()/3;
+                    mesh.mNumTriangles = static_cast<int>(index.size())/3;
 
                     LLCDMeshData res;
 

--- a/indra/newview/llsplitbutton.cpp
+++ b/indra/newview/llsplitbutton.cpp
@@ -216,7 +216,7 @@ LLSplitButton::LLSplitButton(const LLSplitButton::Params& p)
 
     //a panel for hidden item buttons
     LLPanel::Params panel_params = p.items_panel;
-    mItemsPanel= prepareItemsPanel(panel_params, p.items.numValidElements());
+    mItemsPanel= prepareItemsPanel(panel_params, static_cast<S32>(p.items.numValidElements()));
     addChild(mItemsPanel);
 
 

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -378,7 +378,7 @@ bool idle_startup()
 
     const std::string delims (" ");
     std::string system;
-    int begIdx, endIdx;
+    size_t begIdx, endIdx;
     std::string osString = LLOSInfo::instance().getOSStringSimple();
 
     begIdx = osString.find_first_not_of (delims);
@@ -3642,7 +3642,7 @@ bool process_login_success_response()
     if (!look_at_str.empty())
     {
         size_t len = look_at_str.size();
-        LLMemoryStream mstr((U8*)look_at_str.c_str(), len);
+        LLMemoryStream mstr((U8*)look_at_str.c_str(), static_cast<S32>(len));
         LLSD sd = LLSDSerialize::fromNotation(mstr, len);
         gAgentStartLookAt = ll_vector3_from_sd(sd);
     }
@@ -3680,7 +3680,7 @@ bool process_login_success_response()
     if(!home_location.empty())
     {
         size_t len = home_location.size();
-        LLMemoryStream mstr((U8*)home_location.c_str(), len);
+        LLMemoryStream mstr((U8*)home_location.c_str(), static_cast<S32>(len));
         LLSD sd = LLSDSerialize::fromNotation(mstr, len);
         S32 region_x = sd["region_handle"][0].asInteger();
         S32 region_y = sd["region_handle"][1].asInteger();

--- a/indra/newview/lltexturecache.cpp
+++ b/indra/newview/lltexturecache.cpp
@@ -1375,13 +1375,13 @@ U32 LLTextureCache::openAndReadEntries(std::vector<Entry>& entries)
 
 void LLTextureCache::writeEntriesAndClose(const std::vector<Entry>& entries)
 {
-    S32 num_entries = entries.size();
+    auto num_entries = entries.size();
     llassert_always(num_entries == mHeaderEntriesInfo.mEntries);
 
     if (!mReadOnly)
     {
         LLAPRFile* aprfile = openHeaderEntriesFile(false, (S32)sizeof(EntriesInfo));
-        for (S32 idx=0; idx<num_entries; idx++)
+        for (size_t idx=0; idx<num_entries; idx++)
         {
             S32 bytes_written = aprfile->write((void*)(&entries[idx]), (S32)sizeof(Entry));
             if(bytes_written != sizeof(Entry))

--- a/indra/newview/lltexturecache.h
+++ b/indra/newview/lltexturecache.h
@@ -140,8 +140,8 @@ public:
     void unlockWorkers() { mWorkersMutex.unlock(); }
 
     // debug
-    S32 getNumReads() { return mReaders.size(); }
-    S32 getNumWrites() { return mWriters.size(); }
+    S32 getNumReads() { return static_cast<S32>(mReaders.size()); }
+    S32 getNumWrites() { return static_cast<S32>(mWriters.size()); }
     S64Bytes getUsage() { return S64Bytes(mTexturesSizeTotal); }
     S64Bytes getMaxUsage() { return S64Bytes(sCacheMaxTexturesSize); }
     U32 getEntries() { return mHeaderEntriesInfo.mEntries; }

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -1655,7 +1655,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
                 return true;
             }
 
-            S32 append_size(mHttpBufferArray->size());
+            S32 append_size(static_cast<S32>(mHttpBufferArray->size()));
             S32 total_size(cur_size + append_size);
             S32 src_offset(0);
             llassert_always(append_size == mRequestedSize);
@@ -2193,7 +2193,7 @@ S32 LLTextureFetchWorker::callbackHttpGet(LLCore::HttpResponse * response,
     {
         // get length of stream:
         LLCore::BufferArray * body(response->getBody());
-        data_size = body ? body->size() : 0;
+        data_size = body ? static_cast<S32>(body->size()) : 0;
 
         LL_DEBUGS(LOG_TXT) << "HTTP RECEIVED: " << mID.asString() << " Bytes: " << data_size << LL_ENDL;
         if (data_size > 0)
@@ -3405,7 +3405,7 @@ void LLTextureFetch::cancelHttpWaiters()
 int LLTextureFetch::getHttpWaitersCount()
 {
     mNetworkQueueMutex.lock();                                          // +Mfnq
-    int ret(mHttpWaitResource.size());
+    int ret(static_cast<int>(mHttpWaitResource.size()));
     mNetworkQueueMutex.unlock();                                        // -Mfnq
     return ret;
 }

--- a/indra/newview/lltextureinfo.cpp
+++ b/indra/newview/lltextureinfo.cpp
@@ -80,7 +80,7 @@ void LLTextureInfo::addRequest(const LLUUID& id)
 
 U32 LLTextureInfo::getTextureInfoMapSize()
 {
-    return mTextures.size();
+    return static_cast<U32>(mTextures.size());
 }
 
 bool LLTextureInfo::has(const LLUUID& id)

--- a/indra/newview/lltoastalertpanel.cpp
+++ b/indra/newview/lltoastalertpanel.cpp
@@ -161,14 +161,14 @@ LLToastAlertPanel::LLToastAlertPanel( LLNotificationPtr notification, bool modal
         options = supplied_options;
     }
 
-    S32 num_options = options.size();
+    auto num_options = options.size();
 
     // Calc total width of buttons
     S32 button_width = 0;
     S32 sp = font->getWidth(std::string("OO"));
     S32 btn_total_width = 0;
     S32 default_size_btns = 0;
-    for( S32 i = 0; i < num_options; i++ )
+    for (size_t i = 0; i < num_options; i++)
     {
         S32 w = S32(font->getWidth( options[i].second ) + 0.99f) + sp + 2 * LLBUTTON_H_PAD;
         if (mButtonData[i].mWidth > w)
@@ -184,7 +184,7 @@ LLToastAlertPanel::LLToastAlertPanel( LLNotificationPtr notification, bool modal
 
     if( num_options > 1 )
     {
-        btn_total_width = btn_total_width + (button_width * default_size_btns) + ((num_options - 1) * BTN_HPAD);
+        btn_total_width = btn_total_width + (button_width * default_size_btns) + ((static_cast<S32>(num_options) - 1) * BTN_HPAD);
     }
     else
     {

--- a/indra/newview/lltoastpanel.cpp
+++ b/indra/newview/lltoastpanel.cpp
@@ -216,7 +216,7 @@ bool LLCheckBoxToastPanel::setCheckBox(const std::string& check_title,
     S32 dialog_width = max_msg_width + 2 * h_pad;
 
     S32 dialog_height = LLToastPanel::getRect().getHeight();
-    dialog_height += LINE_HEIGHT * lines.size();
+    dialog_height += LINE_HEIGHT * static_cast<S32>(lines.size());
     dialog_height += LINE_HEIGHT / 2;
 
     LLToastPanel::reshape(dialog_width, dialog_height, false);
@@ -227,7 +227,7 @@ bool LLCheckBoxToastPanel::setCheckBox(const std::string& check_title,
     LLRect check_rect;
     // if we are part of the toast, we need to leave space for buttons
     S32 msg_y = v_pad + (parent_view ? 0 : (BTN_HEIGHT + LINE_HEIGHT / 2));
-    mCheck->setRect(check_rect.setOriginAndSize(msg_x, msg_y, max_msg_width, LINE_HEIGHT*lines.size()));
+    mCheck->setRect(check_rect.setOriginAndSize(msg_x, msg_y, max_msg_width, LINE_HEIGHT * static_cast<S32>(lines.size())));
     mCheck->setLabel(check_title);
     mCheck->setCommitCallback(cb);
 

--- a/indra/newview/lltooldraganddrop.cpp
+++ b/indra/newview/lltooldraganddrop.cpp
@@ -363,16 +363,13 @@ void LLToolDragAndDrop::beginDrag(EDragAndDropType type,
                 items,
                 LLInventoryModel::EXCLUDE_TRASH,
                 is_not_preferred);
-            S32 count = cats.size();
-            S32 i;
-            for(i = 0; i < count; ++i)
+            for (auto& cat : cats)
             {
-                folder_ids.push_back(cats.at(i)->getUUID());
+                folder_ids.emplace_back(cat->getUUID());
             }
-            count = items.size();
-            for(i = 0; i < count; ++i)
+            for (auto& item : items)
             {
-                item_ids.push_back(items.at(i)->getUUID());
+                item_ids.emplace_back(item->getUUID());
             }
             if (!folder_ids.empty() || !item_ids.empty())
             {
@@ -414,9 +411,9 @@ void LLToolDragAndDrop::beginMultiDrag(
     {
         // find categories (i.e. inventory folders) in the cargo.
         LLInventoryCategory* cat = NULL;
-        S32 count = llmin(cargo_ids.size(), types.size());
-        std::set<LLUUID> cat_ids;
-        for(S32 i = 0; i < count; ++i)
+        auto count = llmin(cargo_ids.size(), types.size());
+        uuid_set_t cat_ids;
+        for (size_t i = 0; i < count; ++i)
         {
             cat = gInventory.getCategory(cargo_ids[i]);
             if (cat)
@@ -434,10 +431,9 @@ void LLToolDragAndDrop::beginMultiDrag(
                     items,
                     LLInventoryModel::EXCLUDE_TRASH,
                     is_not_preferred);
-                S32 cat_count = cats.size();
-                for(S32 i = 0; i < cat_count; ++i)
+                for (auto& cat : cats)
                 {
-                    cat_ids.insert(cat->getUUID());
+                    cat_ids.emplace(cat->getUUID());
                 }
             }
         }

--- a/indra/newview/lltooldraganddrop.h
+++ b/indra/newview/lltooldraganddrop.h
@@ -87,7 +87,7 @@ public:
 
     void setCargoCount(U32 count) { mCargoCount = count; }
     void resetCargoCount() { mCargoCount = 0; }
-    U32 getCargoCount() const { return (mCargoCount > 0) ? mCargoCount : mCargoIDs.size(); }
+    U32 getCargoCount() const { return (mCargoCount > 0) ? mCargoCount : static_cast<S32>(mCargoIDs.size()); }
     S32 getCargoIndex() const { return mCurItemIndex; }
 
     static S32 getOperationId() { return sOperationId; }

--- a/indra/newview/lltranslate.cpp
+++ b/indra/newview/lltranslate.cpp
@@ -1148,7 +1148,7 @@ std::string LLTranslate::addNoTranslateTags(std::string mesg)
             upd_msg.insert(dif + match.getStart(), AZURE_NOTRANSLATE_OPENING_TAG);
             upd_msg.insert(dif + AZURE_NOTRANSLATE_OPENING_TAG.size() + match.getEnd() + 1, AZURE_NOTRANSLATE_CLOSING_TAG);
             mesg.erase(match.getStart(), match.getEnd() - match.getStart());
-            dif += match.getEnd() - match.getStart() + AZURE_NOTRANSLATE_OPENING_TAG.size() + AZURE_NOTRANSLATE_CLOSING_TAG.size();
+            dif += match.getEnd() - match.getStart() + static_cast<S32>(AZURE_NOTRANSLATE_OPENING_TAG.size() + AZURE_NOTRANSLATE_CLOSING_TAG.size());
         }
         return upd_msg;
     }
@@ -1170,9 +1170,9 @@ std::string LLTranslate::removeNoTranslateTags(std::string mesg)
     {
         std::string upd_msg(mesg);
         LLUrlMatch match;
-        S32 opening_tag_size = AZURE_NOTRANSLATE_OPENING_TAG.size();
-        S32 closing_tag_size = AZURE_NOTRANSLATE_CLOSING_TAG.size();
-        S32 dif = 0;
+        auto opening_tag_size = AZURE_NOTRANSLATE_OPENING_TAG.size();
+        auto closing_tag_size = AZURE_NOTRANSLATE_CLOSING_TAG.size();
+        size_t dif = 0;
         //remove 'no-translate' tags we added to the links before
         while (LLUrlRegistry::instance().findUrl(mesg, match))
         {

--- a/indra/newview/lluploaddialog.cpp
+++ b/indra/newview/lluploaddialog.cpp
@@ -102,7 +102,7 @@ void LLUploadDialog::setMessage( const std::string& msg)
     S32 max_msg_width = 0;
     std::list<std::string> msg_lines;
 
-    S32 size = msg.size() + 1;
+    auto size = msg.size() + 1;
     std::vector<char> temp_msg(size); // non-const copy to make strtok happy
     strcpy( &temp_msg[0], msg.c_str());
     char* token = strtok( &temp_msg[0], "\n" );
@@ -117,7 +117,7 @@ void LLUploadDialog::setMessage( const std::string& msg)
 
     S32 line_height = font->getLineHeight();
     S32 dialog_width = max_msg_width + 2 * HPAD;
-    S32 dialog_height = line_height * msg_lines.size() + 2 * VPAD;
+    S32 dialog_height = line_height * static_cast<S32>(msg_lines.size()) + 2 * VPAD;
 
     reshape( dialog_width, dialog_height, false );
 

--- a/indra/newview/llurl.cpp
+++ b/indra/newview/llurl.cpp
@@ -71,7 +71,7 @@ void LLURL::init(const char * url)
 
     char *parse;
     char *leftover_url = url_copy;
-    S32 span = 0;
+    size_t span = 0;
 
     // copy and lop off tag
     if ((parse = strchr(url_copy,'#')))

--- a/indra/newview/llurllineeditorctrl.cpp
+++ b/indra/newview/llurllineeditorctrl.cpp
@@ -89,5 +89,5 @@ void LLURLLineEditor::copyEscapedURLToClipboard()
     else // human-readable location
         text_to_copy = utf8str_to_wstring(unescaped_text);
 
-    LLClipboard::instance().copyToClipboard(text_to_copy, 0, text_to_copy.size());
+    LLClipboard::instance().copyToClipboard(text_to_copy, 0, static_cast<S32>(text_to_copy.size()));
 }

--- a/indra/newview/llurlwhitelist.cpp
+++ b/indra/newview/llurlwhitelist.cpp
@@ -128,8 +128,8 @@ bool LLUrlWhiteList::clear ()
 std::string url_cleanup(std::string pattern)
 {
     LLStringUtil::trim(pattern);
-    S32 length = pattern.length();
-    S32 position = 0;
+    size_t length = pattern.length();
+    size_t position = 0;
     std::string::reverse_iterator it = pattern.rbegin();
     ++it;   // skip last char, might be '/'
     ++position;
@@ -139,7 +139,7 @@ std::string url_cleanup(std::string pattern)
         if (c == '/')
         {
             // found second to last '/'
-            S32 desired_length = length - position;
+            auto desired_length = length - position;
             LLStringUtil::truncate(pattern, desired_length);
             break;
         }

--- a/indra/newview/llviewerassetstorage.cpp
+++ b/indra/newview/llviewerassetstorage.cpp
@@ -542,7 +542,7 @@ void LLViewerAssetStorage::assetRequestCoro(
 
         const LLSD::Binary &raw = result[LLCoreHttpUtil::HttpCoroutineAdapter::HTTP_RESULTS_RAW].asBinary();
 
-        S32 size = raw.size();
+        S32 size = static_cast<S32>(raw.size());
         if (size > 0)
         {
             mTotalBytesFetched += size;

--- a/indra/newview/llviewerassetupload.cpp
+++ b/indra/newview/llviewerassetupload.cpp
@@ -598,7 +598,7 @@ LLSD LLNewBufferedResourceUploadInfo::exportTempFile()
 
     // copy buffer to the cache for upload
     LLFileSystem file(getAssetId(), getAssetType(), LLFileSystem::APPEND);
-    file.write((U8*) mBuffer.c_str(), mBuffer.size());
+    file.write((U8*) mBuffer.c_str(), static_cast<S32>(mBuffer.size()));
 
     return LLSD();
 }
@@ -700,7 +700,7 @@ LLSD LLBufferedAssetUploadInfo::prepareUpload()
 
     LLFileSystem file(getAssetId(), getAssetType(), LLFileSystem::APPEND);
 
-    S32 size = mContents.length() + 1;
+    S32 size = static_cast<S32>(mContents.length()) + 1;
     file.write((U8*)mContents.c_str(), size);
 
     mStoredToCache = true;

--- a/indra/newview/llviewergesture.cpp
+++ b/indra/newview/llviewergesture.cpp
@@ -156,7 +156,7 @@ LLGesture *LLViewerGestureList::create_gesture(U8 **buffer, S32 max_size)
 // output_str
 bool LLViewerGestureList::matchPrefix(const std::string& in_str, std::string* out_str)
 {
-    S32 in_len = in_str.length();
+    S32 in_len = static_cast<S32>(in_str.length());
 
     std::string in_str_lc = in_str;
     LLStringUtil::toLower(in_str_lc);

--- a/indra/newview/llviewerinput.cpp
+++ b/indra/newview/llviewerinput.cpp
@@ -1124,7 +1124,7 @@ bool LLViewerInput::handleGlobalBindsKeyDown(KEY key, MASK mask)
         return false;
     }
     S32 mode = getMode();
-    return scanKey(mGlobalKeyBindings[mode], mGlobalKeyBindings[mode].size(), key, mask, true, false, false, false);
+    return scanKey(mGlobalKeyBindings[mode], static_cast<S32>(mGlobalKeyBindings[mode].size()), key, mask, true, false, false, false);
 }
 
 bool LLViewerInput::handleGlobalBindsKeyUp(KEY key, MASK mask)
@@ -1137,7 +1137,7 @@ bool LLViewerInput::handleGlobalBindsKeyUp(KEY key, MASK mask)
     }
 
     S32 mode = getMode();
-    return scanKey(mGlobalKeyBindings[mode], mGlobalKeyBindings[mode].size(), key, mask, false, true, false, false);
+    return scanKey(mGlobalKeyBindings[mode], static_cast<S32>(mGlobalKeyBindings[mode].size()), key, mask, false, true, false, false);
 }
 
 bool LLViewerInput::handleGlobalBindsMouse(EMouseClickType clicktype, MASK mask, bool down)
@@ -1153,18 +1153,18 @@ bool LLViewerInput::handleGlobalBindsMouse(EMouseClickType clicktype, MASK mask,
     S32 mode = getMode();
     if (down)
     {
-        res = scanMouse(mGlobalMouseBindings[mode], mGlobalMouseBindings[mode].size(), clicktype, mask, MOUSE_STATE_DOWN, true);
+        res = scanMouse(mGlobalMouseBindings[mode], static_cast<S32>(mGlobalMouseBindings[mode].size()), clicktype, mask, MOUSE_STATE_DOWN, true);
     }
     else
     {
-        res = scanMouse(mGlobalMouseBindings[mode], mGlobalMouseBindings[mode].size(), clicktype, mask, MOUSE_STATE_UP, true);
+        res = scanMouse(mGlobalMouseBindings[mode], static_cast<S32>(mGlobalMouseBindings[mode].size()), clicktype, mask, MOUSE_STATE_UP, true);
     }
     return res;
 }
 
 bool LLViewerInput::bindKey(const S32 mode, const KEY key, const MASK mask, const std::string& function_name)
 {
-    S32 index;
+    size_t index;
     typedef boost::function<bool(EKeystate)> function_t;
     function_t function = NULL;
     std::string name;
@@ -1211,7 +1211,7 @@ bool LLViewerInput::bindKey(const S32 mode, const KEY key, const MASK mask, cons
     // check for duplicate first and overwrite
     if (result->mIsGlobal)
     {
-        S32 size = mGlobalKeyBindings[mode].size();
+        auto size = mGlobalKeyBindings[mode].size();
         for (index = 0; index < size; index++)
         {
             if (key == mGlobalKeyBindings[mode][index].mKey && mask == mGlobalKeyBindings[mode][index].mMask)
@@ -1223,7 +1223,7 @@ bool LLViewerInput::bindKey(const S32 mode, const KEY key, const MASK mask, cons
     }
     else
     {
-        S32 size = mKeyBindings[mode].size();
+        auto size = mKeyBindings[mode].size();
         for (index = 0; index < size; index++)
         {
             if (key == mKeyBindings[mode][index].mKey && mask == mKeyBindings[mode][index].mMask)
@@ -1254,7 +1254,7 @@ bool LLViewerInput::bindKey(const S32 mode, const KEY key, const MASK mask, cons
 
 bool LLViewerInput::bindMouse(const S32 mode, const EMouseClickType mouse, const MASK mask, const std::string& function_name)
 {
-    S32 index;
+    size_t index;
     typedef boost::function<bool(EKeystate)> function_t;
     function_t function = NULL;
 
@@ -1293,7 +1293,7 @@ bool LLViewerInput::bindMouse(const S32 mode, const EMouseClickType mouse, const
     // check for duplicate first and overwrite
     if (result->mIsGlobal)
     {
-        S32 size = mGlobalMouseBindings[mode].size();
+        auto size = mGlobalMouseBindings[mode].size();
         for (index = 0; index < size; index++)
         {
             if (mouse == mGlobalMouseBindings[mode][index].mMouse && mask == mGlobalMouseBindings[mode][index].mMask)
@@ -1305,7 +1305,7 @@ bool LLViewerInput::bindMouse(const S32 mode, const EMouseClickType mouse, const
     }
     else
     {
-        S32 size = mMouseBindings[mode].size();
+        auto size = mMouseBindings[mode].size();
         for (index = 0; index < size; index++)
         {
             if (mouse == mMouseBindings[mode][index].mMouse && mask == mMouseBindings[mode][index].mMask)
@@ -1608,7 +1608,7 @@ bool LLViewerInput::scanKey(KEY key, bool key_down, bool key_up, bool key_level)
     // don't process key down on repeated keys
     bool repeat = gKeyboard->getKeyRepeated(key);
 
-    bool res = scanKey(mKeyBindings[mode], mKeyBindings[mode].size(), key, mask, key_down, key_up, key_level, repeat);
+    bool res = scanKey(mKeyBindings[mode], static_cast<S32>(mKeyBindings[mode].size()), key, mask, key_down, key_up, key_level, repeat);
 
     return res;
 }
@@ -1744,7 +1744,7 @@ bool LLViewerInput::scanMouse(EMouseClickType click, EMouseState state) const
     bool res = false;
     S32 mode = getMode();
     MASK mask = gKeyboard->currentMask(true);
-    res = scanMouse(mMouseBindings[mode], mMouseBindings[mode].size(), click, mask, state, false);
+    res = scanMouse(mMouseBindings[mode], static_cast<S32>(mMouseBindings[mode].size()), click, mask, state, false);
 
     // No user defined actions found or those actions can't handle the key/button,
     // so handle CONTROL_LBUTTON if nessesary.
@@ -1805,14 +1805,14 @@ void LLViewerInput::scanMouse()
 
 bool LLViewerInput::isMouseBindUsed(const EMouseClickType mouse, const MASK mask, const S32 mode) const
 {
-    S32 size = mMouseBindings[mode].size();
-    for (S32 index = 0; index < size; index++)
+    auto size = mMouseBindings[mode].size();
+    for (size_t index = 0; index < size; index++)
     {
         if (mouse == mMouseBindings[mode][index].mMouse && mask == mMouseBindings[mode][index].mMask)
             return true;
     }
     size = mGlobalMouseBindings[mode].size();
-    for (S32 index = 0; index < size; index++)
+    for (size_t index = 0; index < size; index++)
     {
         if (mouse == mGlobalMouseBindings[mode][index].mMouse && mask == mGlobalMouseBindings[mode][index].mMask)
             return true;

--- a/indra/newview/llviewerinventory.cpp
+++ b/indra/newview/llviewerinventory.cpp
@@ -746,7 +746,7 @@ S32 LLViewerInventoryCategory::getViewerDescendentCount() const
     S32 descendents_actual = 0;
     if(cats && items)
     {
-        descendents_actual = cats->size() + items->size();
+        descendents_actual = static_cast<S32>(cats->size() + items->size());
     }
     return descendents_actual;
 }

--- a/indra/newview/llviewerjointattachment.h
+++ b/indra/newview/llviewerjointattachment.h
@@ -74,7 +74,7 @@ public:
 
     S32 getGroup() const { return mGroup; }
     S32 getPieSlice() const { return mPieSlice; }
-    S32 getNumObjects() const { return mAttachedObjects.size(); }
+    S32 getNumObjects() const { return static_cast<S32>(mAttachedObjects.size()); }
     S32 getNumAnimatedObjects() const;
 
     void clampObjectPosition();

--- a/indra/newview/llviewermenufile.cpp
+++ b/indra/newview/llviewermenufile.cpp
@@ -569,7 +569,7 @@ void do_bulk_upload(std::vector<std::string> filenames, const LLSD& notification
             tinygltf::Model model;
             if (LLTinyGLTFHelper::loadModel(filename, model))
             {
-                S32 materials_in_file = model.materials.size();
+                S32 materials_in_file = static_cast<S32>(model.materials.size());
 
                 for (S32 i = 0; i < materials_in_file; i++)
                 {
@@ -617,7 +617,7 @@ bool get_bulk_upload_expected_cost(const std::vector<std::string>& filenames, S3
 
             if (LLTinyGLTFHelper::loadModel(filename, model))
             {
-                S32 materials_in_file = model.materials.size();
+                S32 materials_in_file = static_cast<S32>(model.materials.size());
 
                 for (S32 i = 0; i < materials_in_file; i++)
                 {

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -6286,8 +6286,8 @@ void send_group_notice(const LLUUID& group_id,
         item_def["owner_id"] = item->getPermissions().getOwner();
         std::ostringstream ostr;
         LLSDSerialize::serialize(item_def, ostr, LLSDSerialize::LLSD_XML);
-        bin_bucket_size = ostr.str().copy(
-            (char*)bin_bucket, ostr.str().size());
+        bin_bucket_size = static_cast<S32>(ostr.str().copy(
+            (char*)bin_bucket, ostr.str().size()));
         bin_bucket[bin_bucket_size] = '\0';
     }
     else

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -7335,7 +7335,7 @@ public:
         const LLSD& input) const
     {
         LLSD object_data = input["body"]["ObjectData"];
-        S32 num_entries = object_data.size();
+        S32 num_entries = static_cast<S32>(object_data.size());
 
         for ( S32 i = 0; i < num_entries; i++ )
         {

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -285,7 +285,7 @@ public:
     virtual void addChild(LLViewerObject *childp);
     virtual void removeChild(LLViewerObject *childp);
     const_child_list_t& getChildren() const {   return mChildList; }
-    S32 numChildren() const { return mChildList.size(); }
+    S32 numChildren() const { return static_cast<S32>(mChildList.size()); }
     void addThisAndAllChildren(std::vector<LLViewerObject*>& objects);
     void addThisAndNonJointChildren(std::vector<LLViewerObject*>& objects);
     bool isChild(LLViewerObject *childp) const;

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -1480,7 +1480,7 @@ void LLViewerObjectList::removeFromActiveList(LLViewerObject* objectp)
 
         objectp->setListIndex(-1);
 
-        S32 last_index = mActiveObjects.size()-1;
+        S32 last_index = static_cast<S32>(mActiveObjects.size()) - 1;
 
         if (idx != last_index)
         {
@@ -1511,7 +1511,7 @@ void LLViewerObjectList::updateActive(LLViewerObject *objectp)
             if (idx <= -1)
             {
                 mActiveObjects.push_back(objectp);
-                objectp->setListIndex(mActiveObjects.size()-1);
+                objectp->setListIndex(static_cast<S32>(mActiveObjects.size()) - 1);
             objectp->setOnActiveList(true);
         }
         else

--- a/indra/newview/llviewerparcelmgr.cpp
+++ b/indra/newview/llviewerparcelmgr.cpp
@@ -615,15 +615,13 @@ void LLViewerParcelMgr::removeObserver(LLParcelObserver* observer)
 void LLViewerParcelMgr::notifyObservers()
 {
     std::vector<LLParcelObserver*> observers;
-    S32 count = mObservers.size();
-    S32 i;
-    for(i = 0; i < count; ++i)
+    for (auto observer : mObservers)
     {
-        observers.push_back(mObservers.at(i));
+        observers.emplace_back(observer);
     }
-    for(i = 0; i < count; ++i)
+    for (auto observer : observers)
     {
-        observers.at(i)->changed();
+        observer->changed();
     }
 }
 
@@ -2149,7 +2147,7 @@ void LLViewerParcelMgr::sendParcelAccessListUpdate(U32 which)
 
 void LLViewerParcelMgr::sendParcelAccessListUpdate(U32 flags, const LLAccessEntry::map& entries, LLViewerRegion* region, S32 parcel_local_id)
 {
-    S32 count = entries.size();
+    S32 count = static_cast<S32>(entries.size());
     S32 num_sections = (S32) ceil(count/PARCEL_MAX_ENTRIES_PER_PACKET);
     S32 sequence_id = 1;
     bool start_message = true;

--- a/indra/newview/llviewerpartsim.cpp
+++ b/indra/newview/llviewerpartsim.cpp
@@ -279,7 +279,7 @@ void LLViewerPartGroup::updateParticles(const F32 lastdt)
 
     LLVector3 gravity(0.f, 0.f, GRAVITY);
 
-    LLViewerPartSim::checkParticleCount(mParticles.size());
+    LLViewerPartSim::checkParticleCount(static_cast<U32>(mParticles.size()));
 
     LLViewerCamera* camera = LLViewerCamera::getInstance();
     LLViewerRegion *regionp = getRegion();

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -136,7 +136,7 @@ public:
     bool handle(const LLSD& params, const LLSD& query_map, const std::string& grid, LLMediaCtrl* web)
     {
         // make sure that we at least have a region name
-        int num_params = params.size();
+        auto num_params = params.size();
         if (num_params < 1)
         {
             return false;
@@ -150,7 +150,7 @@ public:
         }
         boost::regex name_rx("[A-Za-z0-9()_%]+");
         boost::regex coord_rx("[0-9]+");
-        for (int i = 0; i < num_params; i++)
+        for (size_t i = 0; i < num_params; i++)
         {
             if (i > 0)
             {
@@ -922,7 +922,7 @@ const LLUUID& LLViewerRegion::getOwner() const
 void LLViewerRegion::setRegionNameAndZone   (const std::string& name_zone)
 {
     std::string::size_type pipe_pos = name_zone.find('|');
-    S32 length   = name_zone.size();
+    auto length   = name_zone.size();
     if (pipe_pos != std::string::npos)
     {
         mName   = name_zone.substr(0, pipe_pos);
@@ -1172,7 +1172,7 @@ void LLViewerRegion::killCacheEntry(U32 local_id)
 
 U32 LLViewerRegion::getNumOfActiveCachedObjects() const
 {
-    return  mImpl->mActiveSet.size();
+    return static_cast<U32>(mImpl->mActiveSet.size());
 }
 
 void LLViewerRegion::addActiveCacheEntry(LLVOCacheEntry* entry)
@@ -1259,7 +1259,7 @@ bool LLViewerRegion::addVisibleGroup(LLViewerOctreeGroup* group)
 
 U32 LLViewerRegion::getNumOfVisibleGroups() const
 {
-    return mImpl ? mImpl->mVisibleGroups.size() : 0;
+    return mImpl ? static_cast<U32>(mImpl->mVisibleGroups.size()) : 0;
 }
 
 void LLViewerRegion::updateReflectionProbes()
@@ -1735,7 +1735,7 @@ void LLViewerRegion::killInvisibleObjects(F32 max_time)
     }
 
     std::vector<LLDrawable*> delete_list;
-    S32 update_counter = llmin(max_update, mImpl->mActiveSet.size());
+    auto update_counter = llmin(max_update, mImpl->mActiveSet.size());
     LLVOCacheEntry::vocache_entry_set_t::iterator iter = mImpl->mActiveSet.upper_bound(mLastVisitedEntry);
 
     for(; update_counter > 0; --update_counter, ++iter)
@@ -1774,10 +1774,9 @@ void LLViewerRegion::killInvisibleObjects(F32 max_time)
     if(!delete_list.empty())
     {
         mInvisibilityCheckHistory |= 1;
-        S32 count = delete_list.size();
-        for(S32 i = 0; i < count; i++)
+        for (auto drawable : delete_list)
         {
-            gObjectList.killObject(delete_list[i]->getVObj());
+            gObjectList.killObject(drawable->getVObj());
         }
         delete_list.clear();
     }
@@ -2576,10 +2575,9 @@ void LLViewerRegion::decodeBoundingInfo(LLVOCacheEntry* entry)
         if(iter != mOrphanMap.end())
         {
             std::vector<U32>* orphans = &mOrphanMap[entry->getLocalID()];
-            S32 size = orphans->size();
-            for(S32 i = 0; i < size; i++)
+            for (U32 orphan : *orphans)
             {
-                LLVOCacheEntry* child = getCacheEntry((*orphans)[i]);
+                LLVOCacheEntry* child = getCacheEntry(orphan);
                 if(child)
                 {
                     entry->addChild(child);
@@ -2837,7 +2835,7 @@ void LLViewerRegion::requestCacheMisses()
 
     mCacheDirty = true ;
     // LL_INFOS() << "KILLDEBUG Sent cache miss full " << full_count << " crc " << crc_count << LL_ENDL;
-    LLViewerStatsRecorder::instance().requestCacheMissesEvent(mCacheMissList.size());
+    LLViewerStatsRecorder::instance().requestCacheMissesEvent(static_cast<S32>(mCacheMissList.size()));
 
     mCacheMissList.clear();
 }

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -233,7 +233,7 @@ public:
         }
 
         F32 right_x;
-        mStyle->getFont()->render(mLabel, 0, image_rect.mRight + EMBEDDED_ITEM_LABEL_PADDING, draw_rect.mTop, color, LLFontGL::LEFT, LLFontGL::TOP, LLFontGL::UNDERLINE, LLFontGL::NO_SHADOW, mLabel.length(), S32_MAX, &right_x);
+        mStyle->getFont()->render(mLabel, 0, image_rect.mRight + EMBEDDED_ITEM_LABEL_PADDING, draw_rect.mTop, color, LLFontGL::LEFT, LLFontGL::TOP, LLFontGL::UNDERLINE, LLFontGL::NO_SHADOW, static_cast<S32>(mLabel.length()), S32_MAX, &right_x);
         return right_x;
     }
 

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -3516,12 +3516,12 @@ void LLViewerMediaTexture::removeFace(U32 ch, LLFace* facep)
                 return;
             }
 
-            S32 end = te_list.size();
+            auto end = te_list.size();
 
             for(std::list< LLPointer<LLViewerTexture> >::iterator iter = mTextureList.begin();
                 iter != mTextureList.end(); ++iter)
             {
-                S32 i = 0;
+                size_t i = 0;
 
                 for(i = 0; i < end; i++)
                 {

--- a/indra/newview/llviewertextureanim.cpp
+++ b/indra/newview/llviewertextureanim.cpp
@@ -43,13 +43,13 @@ LLViewerTextureAnim::LLViewerTextureAnim(LLVOVolume* vobj) : LLTextureAnim()
     mScaleS = mScaleT = 1;
     mRot = 0;
 
-    mInstanceIndex = sInstanceList.size();
+    mInstanceIndex = static_cast<S32>(sInstanceList.size());
     sInstanceList.push_back(this);
 }
 
 LLViewerTextureAnim::~LLViewerTextureAnim()
 {
-    S32 end_idx = sInstanceList.size()-1;
+    S32 end_idx = static_cast<S32>(sInstanceList.size()) - 1;
 
     if (end_idx != mInstanceIndex)
     {

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -690,7 +690,7 @@ void LLViewerTextureList::removeImageFromList(LLViewerFetchedTexture *image)
     llassert_always(mInitialized) ;
     llassert(image);
 
-    S32 count = 0;
+    size_t count = 0;
     if (image->isInImageList())
     {
         count = mImageList.erase(image) ;
@@ -1223,7 +1223,7 @@ void LLViewerTextureList::decodeAllImages(F32 max_time)
     }
     std::shared_ptr<LL::WorkQueue> main_queue = LLImageGLThread::sEnabledTextures ? LL::WorkQueue::getInstance("mainloop") : NULL;
     // Run threads
-    S32 fetch_pending = 0;
+    size_t fetch_pending = 0;
     while (1)
     {
         LLAppViewer::instance()->getTextureCache()->update(1); // unpauses the texture cache thread

--- a/indra/newview/llviewertexturelist.h
+++ b/indra/newview/llviewertexturelist.h
@@ -134,7 +134,7 @@ public:
 
     void handleIRCallback(void **data, const S32 number);
 
-    S32 getNumImages()                  { return mImageList.size(); }
+    S32 getNumImages()                  { return static_cast<S32>(mImageList.size()); }
 
     // Local UI images
     // Local UI images

--- a/indra/newview/llviewerthrottle.cpp
+++ b/indra/newview/llviewerthrottle.cpp
@@ -246,9 +246,9 @@ LLViewerThrottleGroup LLViewerThrottle::getThrottleGroup(const F32 bandwidth_kbp
     //Clamp the bandwidth users can set.
     F32 set_bandwidth = llclamp(bandwidth_kbps, MIN_BANDWIDTH, MAX_BANDWIDTH);
 
-    S32 count = mPresets.size();
+    auto count = mPresets.size();
 
-    S32 i;
+    size_t i;
     for (i = 0; i < count; i++)
     {
         if (mPresets[i].getTotal() > set_bandwidth)

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1664,13 +1664,13 @@ bool LLViewerWindow::handlePaint(LLWindow *window,  S32 x,  S32 y, S32 width,  S
                 recording.getPerSec(LLStatViewer::FPS), //mFPSStat.getMeanPerSec(),
                 recording.getLastValue(LLStatViewer::SIM_PHYSICS_FPS),
                 recording.getLastValue(LLStatViewer::SIM_TIME_DILATION));
-        S32 len = temp_str.length();
+        int len = static_cast<int>(temp_str.length());
         TextOutA(hdc, 0, 0, temp_str.c_str(), len);
 
 
         LLVector3d pos_global = gAgent.getPositionGlobal();
         temp_str = llformat( "Avatar pos %6.1lf %6.1lf %6.1lf", pos_global.mdV[0], pos_global.mdV[1], pos_global.mdV[2]);
-        len = temp_str.length();
+        len = static_cast<S32>(temp_str.length());
         TextOutA(hdc, 0, 25, temp_str.c_str(), len);
 
         TextOutA(hdc, 0, 50, "Set \"HeadlessClient FALSE\" in settings.ini file to reenable", 61);

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2327,7 +2327,7 @@ void LLVOAvatar::updateMeshData()
 
         S32 f_num = 0 ;
         const U32 VERTEX_NUMBER_THRESHOLD = 128 ;//small number of this means each part of an avatar has its own vertex buffer.
-        const S32 num_parts = mMeshLOD.size();
+        const auto num_parts = mMeshLOD.size();
 
         // this order is determined by number of LODS
         // if a mesh earlier in this list changed LODs while a later mesh doesn't,
@@ -5718,7 +5718,7 @@ void LLVOAvatar::checkTextureLoading()
         return ; //have not been invisible for enough time.
     }
 
-    mLoadedCallbackTextures = pause ? mCallbackTextureList.size() : 0;
+    mLoadedCallbackTextures = pause ? static_cast<S32>(mCallbackTextureList.size()) : 0;
 
     for(LLLoadedCallbackEntry::source_callback_list_t::iterator iter = mCallbackTextureList.begin();
         iter != mCallbackTextureList.end(); ++iter)
@@ -6597,8 +6597,8 @@ void LLVOAvatar::addAttachmentOverridesForObject(LLViewerObject *vo, std::set<LL
 
     if ( vobj && vobj->isMesh() && pSkinData )
     {
-        const int bindCnt = pSkinData->mAlternateBindMatrix.size();
-        const int jointCnt = pSkinData->mJointNames.size();
+        const int bindCnt = static_cast<int>(pSkinData->mAlternateBindMatrix.size());
+        const int jointCnt = static_cast<int>(pSkinData->mJointNames.size());
         if ((bindCnt > 0) && (bindCnt != jointCnt))
         {
             LL_WARNS_ONCE() << "invalid mesh, bindCnt " << bindCnt << "!= jointCnt " << jointCnt << ", joint overrides will be ignored." << LL_ENDL;
@@ -7945,7 +7945,7 @@ LLVOAvatar* LLVOAvatar::findAvatarFromAttachment( LLViewerObject* obj )
 
 S32 LLVOAvatar::getAttachmentCount() const
 {
-    S32 count = 0;
+    size_t count = 0;
 
     for (attachment_map_t::const_iterator iter = mAttachmentPoints.begin(); iter != mAttachmentPoints.end(); ++iter)
     {
@@ -7953,7 +7953,7 @@ S32 LLVOAvatar::getAttachmentCount() const
         count += pAttachment->mAttachedObjects.size();
     }
 
-    return count;
+    return static_cast<S32>(count);
 }
 
 bool LLVOAvatar::isWearingWearableType(LLWearableType::EType type) const
@@ -8982,7 +8982,7 @@ void LLVOAvatar::addChat(const LLChat& chat)
 
     mChats.push_back(chat);
 
-    S32 chat_length = 0;
+    size_t chat_length = 0;
     for( chat_iter = mChats.begin(); chat_iter != mChats.end(); ++chat_iter)
     {
         chat_length += chat_iter->mText.size();
@@ -9594,7 +9594,7 @@ void LLVOAvatar::processAvatarAppearance( LLMessageSystem* mesgsys )
     }
 
     // SUNSHINE CLEANUP - is this case OK now?
-    S32 num_params = contents->mParamWeights.size();
+    auto num_params = contents->mParamWeights.size();
     if (num_params <= 1)
     {
         // In this case, we have no reliable basis for knowing
@@ -9638,7 +9638,7 @@ void LLVOAvatar::processAvatarAppearance( LLMessageSystem* mesgsys )
 
 void LLVOAvatar::applyParsedAppearanceMessage(LLAppearanceMessageContents& contents, bool slam_params)
 {
-    S32 num_params = contents.mParamWeights.size();
+    auto num_params = contents.mParamWeights.size();
     ESex old_sex = getSex();
 
     if (applyParsedTEMessage(contents.mTEContents) > 0 && isChanged(TEXTURE))
@@ -9689,7 +9689,7 @@ void LLVOAvatar::applyParsedAppearanceMessage(LLAppearanceMessageContents& conte
         bool interp_params = false;
         S32 params_changed_count = 0;
 
-        for( S32 i = 0; i < num_params; i++ )
+        for( size_t i = 0; i < num_params; i++ )
         {
             LLVisualParam* param = contents.mParams[i];
             F32 newWeight = contents.mParamWeights[i];
@@ -11138,7 +11138,7 @@ void LLVOAvatar::accountRenderComplexityForObject(
                 attached_object->mRiggedAttachedWarned = true;
             }
 
-            hud_object_complexity.texturesCount += textures.size();
+            hud_object_complexity.texturesCount += static_cast<U32>(textures.size());
 
             for (LLVOVolume::texture_cost_t::iterator volume_texture = textures.begin();
                 volume_texture != textures.end();

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -1270,7 +1270,7 @@ void LLVOCache::removeEntry(HeaderEntryInfo* entry)
         removeFromCache(entry);
         delete entry;
 
-        mNumEntries = mHandleEntryMap.size() ;
+        mNumEntries = static_cast<U32>(mHandleEntryMap.size());
     }
 }
 
@@ -1447,7 +1447,7 @@ void LLVOCache::writeCacheHeader()
             success = check_write(&apr_file, (void*)*iter, sizeof(HeaderEntryInfo));
         }
 
-        mNumEntries = mHeaderEntryQueue.size() ;
+        mNumEntries = static_cast<U32>(mHeaderEntryQueue.size());
         if(success && mNumEntries < MAX_NUM_OBJECT_ENTRIES)
         {
             HeaderEntryInfo* entry = new HeaderEntryInfo() ;
@@ -1633,7 +1633,7 @@ void LLVOCache::purgeEntries(U32 size)
         delete entry;
         // TODO also delete extras
     }
-    mNumEntries = mHandleEntryMap.size() ;
+    mNumEntries = static_cast<U32>(mHandleEntryMap.size());
 }
 
 void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry::vocache_entry_map_t& cache_entry_map, bool dirty_cache, bool removal_enabled)
@@ -1703,7 +1703,7 @@ void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry:
 
         if(success)
         {
-            S32 num_entries = cache_entry_map.size(); // if removal is enabled num_entries might be wrong
+            S32 num_entries = static_cast<S32>(cache_entry_map.size()); // if removal is enabled num_entries might be wrong
             success = check_write(&apr_file, &num_entries, sizeof(S32));
             if (success)
             {
@@ -1791,7 +1791,7 @@ void LLVOCache::writeGenericExtrasToCache(U64 handle, const LLUUID& id, const LL
         // TODO - clean up broken cache file
     }
 
-    U32 num_entries = cache_extras_entry_map.size();
+    auto num_entries = cache_extras_entry_map.size();
     out << num_entries << '\n';
     if(!out.good())
     {

--- a/indra/newview/llvocache.h
+++ b/indra/newview/llvocache.h
@@ -144,7 +144,7 @@ public:
     void removeChild(LLVOCacheEntry* entry);
     void removeAllChildren();
     LLVOCacheEntry* getChild(); //remove the first child, and return it.
-    S32  getNumOfChildren() const  {return mChildrenList.size();}
+    S32  getNumOfChildren() const { return static_cast<S32>(mChildrenList.size()); }
 
     void setBoundingInfo(const LLVector3& pos, const LLVector3& scale); //called from processing object update message
     void updateParentBoundingInfo();

--- a/indra/newview/llvograss.cpp
+++ b/indra/newview/llvograss.cpp
@@ -696,7 +696,7 @@ void LLGrassPartition::getGeometry(LLSpatialGroup* group)
         vertex_count += facep->getGeomCount();
         index_count += facep->getIndicesCount();
 
-        S32 idx = draw_vec.size()-1;
+        auto idx = draw_vec.size()-1;
 
         bool fullbright = facep->isState(LLFace::FULLBRIGHT);
 

--- a/indra/newview/llvoicevisualizer.cpp
+++ b/indra/newview/llvoicevisualizer.cpp
@@ -248,7 +248,7 @@ void LLVoiceVisualizer::lipStringToF32s ( std::string& in_string, F32*& out_F32s
 {
     delete[] out_F32s;  // get rid of the current array
 
-    count_F32s = in_string.length();
+    count_F32s = static_cast<U32>(in_string.length());
     if (count_F32s == 0)
     {
         // we don't like zero length arrays

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -7389,8 +7389,8 @@ LLIOPipe::EStatus LLVivoxProtocolParser::process_impl(
     }
 
     // Look for input delimiter(s) in the input buffer.  If one is found, send the message to the xml parser.
-    int start = 0;
-    int delim;
+    size_t start = 0;
+    size_t delim;
     while((delim = mInput.find("\n\n\n", start)) != std::string::npos)
     {
 
@@ -7401,7 +7401,7 @@ LLIOPipe::EStatus LLVivoxProtocolParser::process_impl(
         XML_SetElementHandler(parser, ExpatStartTag, ExpatEndTag);
         XML_SetCharacterDataHandler(parser, ExpatCharHandler);
         XML_SetUserData(parser, this);
-        XML_Parse(parser, mInput.data() + start, delim - start, false);
+        XML_Parse(parser, mInput.data() + start, static_cast<int>(delim - start), false);
 
         LL_DEBUGS("VivoxProtocolParser") << "parsing: " << mInput.substr(start, delim - start) << LL_ENDL;
         start = delim + 3;

--- a/indra/newview/llvopartgroup.cpp
+++ b/indra/newview/llvopartgroup.cpp
@@ -317,7 +317,7 @@ bool LLVOPartGroup::updateGeometry(LLDrawable *drawable)
     F32 pixel_meter_ratio = LLViewerCamera::getInstance()->getPixelMeterRatio();
     pixel_meter_ratio *= pixel_meter_ratio;
 
-    LLViewerPartSim::checkParticleCount(mViewerPartGroupp->mParticles.size()) ;
+    LLViewerPartSim::checkParticleCount(static_cast<U32>(mViewerPartGroupp->mParticles.size()));
 
     S32 count=0;
     mDepth = 0.f;
@@ -899,7 +899,7 @@ void LLParticlePartition::getGeometry(LLSpatialGroup* group)
         llassert(facep->getGeomCount() == 4);
         llassert(facep->getIndicesCount() == 6);
 
-        S32 idx = draw_vec.size()-1;
+        auto idx = draw_vec.size()-1;
 
         bool fullbright = facep->isState(LLFace::FULLBRIGHT);
 

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5199,7 +5199,7 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
     //add face to drawmap
     LLSpatialGroup::drawmap_elem_t& draw_vec = group->mDrawMap[passType];
 
-    S32 idx = draw_vec.size()-1;
+    auto idx = draw_vec.size()-1;
 
     bool fullbright = (type == LLRenderPass::PASS_FULLBRIGHT) ||
         (type == LLRenderPass::PASS_INVISIBLE) ||

--- a/indra/newview/llwearableitemslist.cpp
+++ b/indra/newview/llwearableitemslist.cpp
@@ -959,14 +959,14 @@ void LLWearableItemsList::ContextMenu::updateItemsVisibility(LLContextMenu* menu
         return;
     }
 
-    const uuid_vec_t& ids = mUUIDs; // selected items IDs
-    U32 mask = 0;                   // mask of selected items' types
-    U32 n_items = ids.size();       // number of selected items
-    U32 n_worn = 0;                 // number of worn items among the selected ones
-    U32 n_already_worn = 0;         // number of items worn of same type as selected items
-    U32 n_links = 0;                // number of links among the selected items
-    U32 n_editable = 0;             // number of editable items among the selected ones
-    U32 n_touchable = 0;            // number of touchable items among the selected ones
+    const uuid_vec_t& ids = mUUIDs;             // selected items IDs
+    U32 mask = 0;                               // mask of selected items' types
+    U32 n_items = static_cast<U32>(ids.size()); // number of selected items
+    U32 n_worn = 0;                             // number of worn items among the selected ones
+    U32 n_already_worn = 0;                     // number of items worn of same type as selected items
+    U32 n_links = 0;                            // number of links among the selected items
+    U32 n_editable = 0;                         // number of editable items among the selected ones
+    U32 n_touchable = 0;                        // number of touchable items among the selected ones
 
     bool can_be_worn = true;
 

--- a/indra/newview/llwearablelist.h
+++ b/indra/newview/llwearablelist.h
@@ -46,7 +46,7 @@ class LLWearableList : public LLSingleton<LLWearableList>
 public:
     void cleanup() ;
 
-    S32                 getLength() const { return mList.size(); }
+    S32                 getLength() const { return static_cast<S32>(mList.size()); }
 
     void                getAsset(const LLAssetID& assetID,
                                  const std::string& wearable_name,

--- a/indra/newview/llweb.cpp
+++ b/indra/newview/llweb.cpp
@@ -131,8 +131,8 @@ std::string LLWeb::escapeURL(const std::string& url)
     // The CURL curl_escape() function escapes colons, slashes,
     // and all characters but A-Z and 0-9.  Do a cheesy mini-escape.
     std::string escaped_url;
-    S32 len = url.length();
-    for (S32 i = 0; i < len; i++)
+    auto len = url.length();
+    for (size_t i = 0; i < len; i++)
     {
         char c = url[i];
         if (c == ' ')

--- a/indra/newview/llworld.cpp
+++ b/indra/newview/llworld.cpp
@@ -1352,8 +1352,8 @@ void LLWorld::getAvatars(uuid_vec_t* avatar_ids, std::vector<LLVector3d>* positi
     {
         LLViewerRegion* regionp = *iter;
         const LLVector3d& origin_global = regionp->getOriginGlobal();
-        S32 count = regionp->mMapAvatars.size();
-        for (S32 i = 0; i < count; i++)
+        auto count = regionp->mMapAvatars.size();
+        for (size_t i = 0; i < count; i++)
         {
             LLVector3d pos_global = unpackLocalToGlobalPosition(regionp->mMapAvatars.at(i), origin_global);
             if(dist_vec_squared(pos_global, relative_to) <= radius_squared)

--- a/indra/newview/llxmlrpctransaction.cpp
+++ b/indra/newview/llxmlrpctransaction.cpp
@@ -282,7 +282,7 @@ void LLXMLRPCTransaction::Handler::onCompleted(LLCore::HttpHandle handle,
 
     body->read(0, bodydata, body->size());
 
-    mImpl->mResponse = XMLRPC_REQUEST_FromXML(bodydata, body->size(), 0);
+    mImpl->mResponse = XMLRPC_REQUEST_FromXML(bodydata, static_cast<int>(body->size()), 0);
 
     delete[] bodydata;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -3618,10 +3618,8 @@ void LLPipeline::renderHighlights()
         // Make sure the selection image gets downloaded and decoded
         mFaceSelectImagep->addTextureStats((F32)MAX_IMAGE_AREA);
 
-        U32 count = mSelectedFaces.size();
-        for (U32 i = 0; i < count; i++)
+        for (auto facep : mSelectedFaces)
         {
-            LLFace *facep = mSelectedFaces[i];
             if (!facep || facep->getDrawable()->isDead())
             {
                 LL_ERRS() << "Bad face on selection" << LL_ENDL;
@@ -3637,10 +3635,8 @@ void LLPipeline::renderHighlights()
         // Paint 'em red!
         color.setVec(1.f, 0.f, 0.f, 0.5f);
 
-        int count = mHighlightFaces.size();
-        for (S32 i = 0; i < count; i++)
+        for (auto facep : mHighlightFaces)
         {
-            LLFace* facep = mHighlightFaces[i];
             facep->renderSelected(LLViewerTexture::sNullImagep, color);
         }
     }
@@ -3666,10 +3662,8 @@ void LLPipeline::renderHighlights()
 
         mFaceSelectImagep->addTextureStats((F32)MAX_IMAGE_AREA);
 
-        U32 count = mSelectedFaces.size();
-        for (U32 i = 0; i < count; i++)
+        for (auto facep : mSelectedFaces)
         {
-            LLFace *facep = mSelectedFaces[i];
             if (!facep || facep->getDrawable()->isDead())
             {
                 LL_ERRS() << "Bad face on selection" << LL_ENDL;
@@ -3696,10 +3690,8 @@ void LLPipeline::renderHighlights()
 
         mFaceSelectImagep->addTextureStats((F32)MAX_IMAGE_AREA);
 
-        U32 count = mSelectedFaces.size();
-        for (U32 i = 0; i < count; i++)
+        for (auto facep : mSelectedFaces)
         {
-            LLFace *facep = mSelectedFaces[i];
             if (!facep || facep->getDrawable()->isDead())
             {
                 LL_ERRS() << "Bad face on selection" << LL_ENDL;
@@ -4737,7 +4729,7 @@ void LLPipeline::rebuildPools()
 
     assertInitialized();
 
-    S32 max_count = mPools.size();
+    auto max_count = mPools.size();
     pool_set_t::iterator iter1 = mPools.upper_bound(mLastRebuildPool);
     while(max_count > 0 && mPools.size() > 0) // && num_rebuilds < MAX_REBUILDS)
     {

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -346,7 +346,7 @@ public:
     void findReferences(LLDrawable *drawablep); // Find the lists which have references to this object
     bool verify();                      // Verify that all data in the pipeline is "correct"
 
-    S32  getLightCount() const { return mLights.size(); }
+    S32  getLightCount() const { return static_cast<S32>(mLights.size()); }
 
     void calcNearbyLights(LLCamera& camera);
     void setupHWLights();

--- a/indra/newview/tests/llsechandler_basic_test.cpp
+++ b/indra/newview/tests/llsechandler_basic_test.cpp
@@ -634,19 +634,19 @@ namespace tut
 
             // Read each of the 4 Pem certs and store in mX509*Cert pointers
             BIO * validation_bio;
-            validation_bio = BIO_new_mem_buf((void*)mPemTestCert.c_str(), mPemTestCert.length());
+            validation_bio = BIO_new_mem_buf((void*)mPemTestCert.c_str(), static_cast<S32>(mPemTestCert.length()));
             PEM_read_bio_X509(validation_bio, &mX509TestCert, 0, NULL);
             BIO_free(validation_bio);
 
-            validation_bio = BIO_new_mem_buf((void*)mPemRootCert.c_str(), mPemRootCert.length());
+            validation_bio = BIO_new_mem_buf((void*)mPemRootCert.c_str(), static_cast<S32>(mPemRootCert.length()));
             PEM_read_bio_X509(validation_bio, &mX509RootCert, 0, NULL);
             BIO_free(validation_bio);
 
-            validation_bio = BIO_new_mem_buf((void*)mPemIntermediateCert.c_str(), mPemIntermediateCert.length());
+            validation_bio = BIO_new_mem_buf((void*)mPemIntermediateCert.c_str(), static_cast<S32>(mPemIntermediateCert.length()));
             PEM_read_bio_X509(validation_bio, &mX509IntermediateCert, 0, NULL);
             BIO_free(validation_bio);
 
-            validation_bio = BIO_new_mem_buf((void*)mPemChildCert.c_str(), mPemChildCert.length());
+            validation_bio = BIO_new_mem_buf((void*)mPemChildCert.c_str(), static_cast<S32>(mPemChildCert.length()));
             PEM_read_bio_X509(validation_bio, &mX509ChildCert, 0, NULL);
             BIO_free(validation_bio);
         }

--- a/indra/test/io.cpp
+++ b/indra/test/io.cpp
@@ -155,7 +155,7 @@ namespace tut
     void buffer_object::test<1>()
     {
         const char HELLO_WORLD[] = "hello world";
-        const S32 str_len = strlen(HELLO_WORLD);
+        const S32 str_len = static_cast<S32>(strlen(HELLO_WORLD));
         LLChannelDescriptors ch = mBuffer.nextChannel();
         mBuffer.append(ch.in(), (U8*)HELLO_WORLD, str_len);
         S32 count = mBuffer.countAfter(ch.in(), NULL);
@@ -170,7 +170,7 @@ namespace tut
     void buffer_object::test<2>()
     {
         const char HELLO_WORLD[] = "hello world";
-        const S32 str_len = strlen(HELLO_WORLD);        /* Flawfinder: ignore */
+        const S32 str_len = static_cast<S32>(strlen(HELLO_WORLD));        /* Flawfinder: ignore */
         LLChannelDescriptors ch = mBuffer.nextChannel();
         mBuffer.append(ch.in(), (U8*)HELLO_WORLD, str_len);
         mBuffer.append(ch.in(), (U8*)HELLO_WORLD, str_len);
@@ -249,15 +249,15 @@ namespace tut
         expected << "ContentLength: " << response.length() << "\r\n\r\n"
                  << response;
         LLChannelDescriptors ch = mBuffer.nextChannel();
-        mBuffer.append(ch.in(), (U8*)request.c_str(), request.length());
-        mBuffer.append(ch.out(), (U8*)response.c_str(), response.length());
+        mBuffer.append(ch.in(), (U8*)request.c_str(), static_cast<S32>(request.length()));
+        mBuffer.append(ch.out(), (U8*)response.c_str(), static_cast<S32>(response.length()));
         S32 count = mBuffer.countAfter(ch.out(), NULL);
         std::ostringstream header;
         header << "ContentLength: " << count << "\r\n\r\n";
         std::string head(header.str());
-        mBuffer.prepend(ch.out(), (U8*)head.c_str(), head.length());
+        mBuffer.prepend(ch.out(), (U8*)head.c_str(), static_cast<S32>(head.length()));
         char buffer[1024];  /* Flawfinder: ignore */
-        S32 len = response.size() + head.length();
+        S32 len = static_cast<S32>(response.size() + head.length());
         ensure_equals("same length", len, (S32)expected.str().length());
         mBuffer.readAfter(ch.out(), NULL, (U8*)buffer, len);
         buffer[len] = '\0';
@@ -282,7 +282,7 @@ namespace tut
             text.append(lines[i]);
         }
         LLChannelDescriptors ch = mBuffer.nextChannel();
-        mBuffer.append(ch.in(), (U8*)text.c_str(), text.length());
+        mBuffer.append(ch.in(), (U8*)text.c_str(), static_cast<S32>(text.length()));
         const S32 BUFFER_LEN = 1024;
         char buf[BUFFER_LEN];
         S32 len;
@@ -411,7 +411,7 @@ namespace tut
     void bas_object::test<1>()
     {
         const char HELLO_WORLD[] = "hello world";
-        const S32 str_len = strlen(HELLO_WORLD);    /* Flawfinder: ignore */
+        const S32 str_len = static_cast<S32>(strlen(HELLO_WORLD));    /* Flawfinder: ignore */
         LLChannelDescriptors ch = mBuffer.nextChannel();
         LLBufferStream str(ch, &mBuffer);
         mBuffer.append(ch.in(), (U8*)HELLO_WORLD, str_len);
@@ -431,10 +431,10 @@ namespace tut
         std::string ignore("ignore me");
         LLChannelDescriptors ch = mBuffer.nextChannel();
         LLBufferStream str(ch, &mBuffer);
-        mBuffer.append(ch.in(), (U8*)part1.c_str(), part1.length());
-        mBuffer.append(ch.in(), (U8*)part2.c_str(), part2.length());
-        mBuffer.append(ch.out(), (U8*)ignore.c_str(), ignore.length());
-        mBuffer.append(ch.in(), (U8*)part3.c_str(), part3.length());
+        mBuffer.append(ch.in(), (U8*)part1.c_str(), static_cast<S32>(part1.length()));
+        mBuffer.append(ch.in(), (U8*)part2.c_str(), static_cast<S32>(part2.length()));
+        mBuffer.append(ch.out(), (U8*)ignore.c_str(), static_cast<S32>(ignore.length()));
+        mBuffer.append(ch.in(), (U8*)part3.c_str(), static_cast<S32>(part3.length()));
         std::string eat;
         std::string my;
         std::string shorts;
@@ -452,8 +452,8 @@ namespace tut
         std::string part1("junk in ");
         std::string part2("the trunk");
         const S32 CHANNEL = 0;
-        mBuffer.append(CHANNEL, (U8*)part1.c_str(), part1.length());
-        mBuffer.append(CHANNEL, (U8*)part2.c_str(), part2.length());
+        mBuffer.append(CHANNEL, (U8*)part1.c_str(), static_cast<S32>(part1.length()));
+        mBuffer.append(CHANNEL, (U8*)part2.c_str(), static_cast<S32>(part2.length()));
         U8* last = 0;
         const S32 BUF_LEN = 128;
         char buf[BUF_LEN];
@@ -475,7 +475,7 @@ namespace tut
     {
         std::string phrase("zippity do da!");
         const S32 CHANNEL = 0;
-        mBuffer.append(CHANNEL, (U8*)phrase.c_str(), phrase.length());
+        mBuffer.append(CHANNEL, (U8*)phrase.c_str(), static_cast<S32>(phrase.length()));
         const S32 BUF_LEN = 128;
         char buf[BUF_LEN];
         S32 len = 7;
@@ -506,7 +506,7 @@ namespace tut
         const S32 BUF_LEN = 128;
         char buf[BUF_LEN];
         S32 actual_len = BUF_LEN;
-        S32 expected_len = h1.size() + h2.size();
+        S32 expected_len = static_cast<S32>(h1.size() + h2.size());
         (void) mBuffer.readAfter(ch.out(), NULL, (U8*)buf, actual_len);
         ensure_equals("streamed size", actual_len, expected_len);
         buf[actual_len] = '\0';
@@ -728,7 +728,7 @@ namespace tut
                                         "'circuit_code': i124,'group_id': '8615c885-9cf0-bf0a-6e40-0c11462aa652','limited_to_estate': i1,'look_at': [ i0, i0, i0],"
                                         "'agent_id': '0e346d8b-4433-4d66-a6b0-fd37083abc4c','first_name': 'Kelly','start': 'url'}]}";
         LLChannelDescriptors ch = mBuffer.nextChannel();
-        mBuffer.append(ch.out(), (U8*)LOGIN_STREAM, strlen(LOGIN_STREAM));      /* Flawfinder: ignore */
+        mBuffer.append(ch.out(), (U8*)LOGIN_STREAM, static_cast<S32>(strlen(LOGIN_STREAM)));      /* Flawfinder: ignore */
         ch = mBuffer.nextChannel();
         LLBufferStream istr(ch, &mBuffer);
         LLSD data;
@@ -1130,7 +1130,7 @@ namespace tut
         mPump->addChain(chain, NEVER_CHAIN_EXPIRY_SECS);
         // We need to tickle the pump a little to set up the listen()
         pump_loop(mPump, 0.1f);
-        U32 count = mPump->runningChains();
+        auto count = mPump->runningChains();
         ensure_equals("server chain onboard", count, 1);
         LL_DEBUGS() << "** Server is up." << LL_ENDL;
 

--- a/indra/test/llbuffer_tut.cpp
+++ b/indra/test/llbuffer_tut.cpp
@@ -128,7 +128,7 @@ namespace tut
     {
         LLBufferArray bufferArray;
         const char array[] = "SecondLife";
-        S32 len = strlen(array);
+        S32 len = static_cast<S32>(strlen(array));
         LLChannelDescriptors channelDescriptors = bufferArray.nextChannel();
         bufferArray.append(channelDescriptors.in(), (U8*)array, len);
         S32 count = bufferArray.countAfter(channelDescriptors.in(), NULL);
@@ -141,9 +141,9 @@ namespace tut
     {
         LLBufferArray bufferArray;
         const char array[] = "SecondLife";
-        S32 len = strlen(array);
+        S32 len = static_cast<S32>(strlen(array));
         const char array1[] = "LindenLabs";
-        S32 len1 = strlen(array1);
+        S32 len1 = static_cast<S32>(strlen(array1));
 
         std::string str(array1);
         str.append(array);
@@ -166,9 +166,9 @@ namespace tut
     {
         LLBufferArray bufferArray;
         const char array[] = "SecondLife";
-        S32 len = strlen(array);
+        S32 len = static_cast<S32>(strlen(array));
         const char array1[] = "LindenLabs";
-        S32 len1 = strlen(array1);
+        S32 len1 = static_cast<S32>(strlen(array1));
 
         std::string str(array);
         str.append(array1);
@@ -190,7 +190,7 @@ namespace tut
     {
         LLBufferArray bufferArray;
         const char array[] = "SecondLife";
-        S32 len = strlen(array) + 1;
+        S32 len = static_cast<S32>(strlen(array)) + 1;
         std::string str(array);
         LLChannelDescriptors channelDescriptors = bufferArray.nextChannel();
         bufferArray.append(channelDescriptors.in(), (U8*)array, len);
@@ -208,7 +208,7 @@ namespace tut
     void buffer_object_t::test<10>()
     {
         const char array[] = "SecondLife is a Virtual World";
-        S32 len = strlen(array);
+        S32 len = static_cast<S32>(strlen(array));
         LLBufferArray bufferArray;
         bufferArray.append(0, (U8*)array, len);
 
@@ -229,7 +229,7 @@ namespace tut
     void buffer_object_t::test<11>()
     {
         const char array[] = "SecondLife is a Virtual World";
-        S32 len = strlen(array);
+        S32 len = static_cast<S32>(strlen(array));
         LLBufferArray bufferArray;
         bufferArray.append(0, (U8*)array, len);
 

--- a/indra/test/llpipeutil.cpp
+++ b/indra/test/llpipeutil.cpp
@@ -60,7 +60,7 @@ LLIOPipe::EStatus LLPipeStringInjector::process_impl(
         LLSD& context,
         LLPumpIO* pump)
 {
-    buffer->append(channels.out(), (U8*) mString.data(), mString.size());
+    buffer->append(channels.out(), (U8*) mString.data(), static_cast<S32>(mString.size()));
     eos = true;
     return STATUS_DONE;
 }

--- a/indra/test/llsdmessagereader_tut.cpp
+++ b/indra/test/llsdmessagereader_tut.cpp
@@ -318,7 +318,7 @@ namespace tut
         inValue[1] = 1;
 
         LLSDMessageReader msg = testType(inValue);
-        msg.getBinaryData("block", "var", &(outValue[0]), inValue.size());
+        msg.getBinaryData("block", "var", &(outValue[0]), static_cast<S32>(inValue.size()));
         ensure_equals("Ensure Binary", outValue, inValue);
     }
 }

--- a/indra/test/llstreamtools_tut.cpp
+++ b/indra/test/llstreamtools_tut.cpp
@@ -846,7 +846,7 @@ namespace tut
         char buf[255] = {0};
 
         fullread(is, buf, 255);
-        ensure_memory_matches("fullread: read with newlines", (void*) buf,  str.size()-1, (void*) str.c_str(), str.size()-1);
+        ensure_memory_matches("fullread: read with newlines", (void*) buf, static_cast<U32>(str.size())-1, (void*) str.c_str(), static_cast<U32>(str.size())-1);
 
         is.clear();
         is.str(str = "First Line.\nSecond Line\n");


### PR DESCRIPTION
@marchcat Instead of some pointless whitespace changes 😆 here's something that actually might help code quality: Re-enabled a bunch of compiler warnings that do not occur anymore and also address the "possible loss of data" warnings by using the correct type or adding explicit casts.