### PR TITLE
viewer-private#244 Reconnect to voice after 'tuning'

### DIFF
--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -383,6 +383,12 @@ void LLVoiceChannel::resume()
         {
             if (sSuspendedVoiceChannel)
             {
+                if (sSuspendedVoiceChannel->callStarted())
+                {
+                    // should have channel data already, restart
+                    sSuspendedVoiceChannel->setState(STATE_READY);
+                }
+                // won't do anything if call is already started
                 sSuspendedVoiceChannel->activate();
             }
             else


### PR DESCRIPTION
activate() does nothing if call already started so either suspending should mark call as suspended or resuming should mark it as ready