### PR TITLE
#1651 Include translated text in chat log

### DIFF
--- a/indra/newview/llfloaterimnearbychat.cpp
+++ b/indra/newview/llfloaterimnearbychat.cpp
@@ -238,6 +238,7 @@ void LLFloaterIMNearbyChat::loadHistory()
         chat.mFromName = from;
         chat.mFromID = from_id;
         chat.mText = msg[LL_IM_TEXT].asString();
+        chat.mTrans = msg[LL_IM_TRANS].asString();
         chat.mTimeStr = msg[LL_IM_TIME].asString();
         chat.mChatStyle = CHAT_STYLE_HISTORY;
 
@@ -578,7 +579,7 @@ EChatType LLFloaterIMNearbyChat::processChatTypeTriggers(EChatType type, std::st
     return type;
 }
 
-void LLFloaterIMNearbyChat::sendChat( EChatType type )
+void LLFloaterIMNearbyChat::sendChat(EChatType type)
 {
     if (mInputEditor)
     {
@@ -633,7 +634,7 @@ void LLFloaterIMNearbyChat::sendChat( EChatType type )
     }
 }
 
-void LLFloaterIMNearbyChat::addMessage(const LLChat& chat,bool archive,const LLSD &args)
+void LLFloaterIMNearbyChat::addMessage(const LLChat& chat, bool archive, const LLSD &args)
 {
     appendMessage(chat, args);
 
@@ -663,7 +664,7 @@ void LLFloaterIMNearbyChat::addMessage(const LLChat& chat,bool archive,const LLS
             }
         }
 
-        LLLogChat::saveHistory("chat", from_name, chat.mFromID, chat.mText);
+        LLLogChat::saveHistory("chat", from_name, chat.mFromID, chat.mText, chat.mTrans);
     }
 }
 

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -1554,7 +1554,7 @@ bool LLIMModel::addToHistory(const LLUUID& session_id,
     return true;
 }
 
-bool LLIMModel::logToFile(const std::string& file_name, const std::string& from, const LLUUID& from_id, const std::string& utf8_text)
+bool LLIMModel::logToFile(const std::string& file_name, const std::string& from, const LLUUID& from_id, const std::string& utf8_text, const std::string& utf8_trans)
 {
     if (gSavedPerAccountSettings.getS32("KeepConversationLogTranscripts") > 1)
     {
@@ -1568,7 +1568,7 @@ bool LLIMModel::logToFile(const std::string& file_name, const std::string& from,
             from_name = av_name.getCompleteName();
         }
 
-        LLLogChat::saveHistory(file_name, from_name, from_id, utf8_text);
+        LLLogChat::saveHistory(file_name, from_name, from_id, utf8_text, utf8_trans);
         LLConversationLog::instance().cache(); // update the conversation log too
         return true;
     }
@@ -1662,7 +1662,7 @@ LLIMModel::LLIMSession* LLIMModel::addMessageSilently(const LLUUID& session_id, 
     addToHistory(session_id, from_name, from_id, utf8_text, utf8_trans, utf8_error, is_region_msg, timestamp);
     if (log2file)
     {
-        logToFile(getHistoryFileName(session_id), from_name, from_id, utf8_text);
+        logToFile(getHistoryFileName(session_id), from_name, from_id, utf8_text, utf8_trans);
     }
 
     session->mNumUnread++;

--- a/indra/newview/llimview.h
+++ b/indra/newview/llimview.h
@@ -314,7 +314,7 @@ public:
     /**
      * Saves an IM message into a file
      */
-    bool logToFile(const std::string& file_name, const std::string& from, const LLUUID& from_id, const std::string& utf8_text);
+    bool logToFile(const std::string& file_name, const std::string& from, const LLUUID& from_id, const std::string& utf8_text, const std::string& utf8_trans = LLStringUtil::null);
 
 private:
 

--- a/indra/newview/lllogchat.h
+++ b/indra/newview/lllogchat.h
@@ -102,7 +102,8 @@ public:
     static void saveHistory(const std::string& filename,
                 const std::string& from,
                 const LLUUID& from_id,
-                const std::string& line);
+                const std::string& line,
+                const std::string& trans);
     static bool transcriptFilesExist();
     static void findTranscriptFiles(std::string pattern, std::vector<std::string>& list_of_transcriptions);
     static void getListOfTranscriptFiles(std::vector<std::string>& list);


### PR DESCRIPTION
Original message is displayed with an arrow icon and in italics
![image](https://github.com/secondlife/viewer/assets/124201357/d8fe5e02-53e7-47d4-9aac-69365c92c5f4)

It is saved to the log with a special marker
```
[2024/06/07 10:46]  AlexandrG ProductEngine: Hello everyone!
 -► Bonjour à tous !
```

After loading from the chat it is displayed with an arrow icon and in italics again
![image](https://github.com/secondlife/viewer/assets/124201357/a06bbbf6-9090-457e-a7f1-f6f2c62f3ff6)

After loading this chat history in the viewer with no SST support it is displayed as follows
![image](https://github.com/secondlife/viewer/assets/124201357/9a7b5d10-4928-43a2-a3cc-07a820d4d2f1)
(no italics and no arrow icon, but the translation marker looks very similar to the arrow icon)