### PR TITLE
Fix for the laggy tracker beacon on Mac Apple Silicon

### DIFF
--- a/indra/newview/lltracker.cpp
+++ b/indra/newview/lltracker.cpp
@@ -489,10 +489,21 @@ void draw_shockwave(F32 center_z, F32 t, S32 steps, LLColor4 color)
     gGL.end();
 }
 
+
 void LLTracker::drawBeacon(LLVector3 pos_agent, std::string direction, LLColor4 fogged_color, F32 dist)
 {
+#if LL_DARWIN
+    const U32 BEACON_VERTS = 16;
+#else
     const U32 BEACON_VERTS = 256;
+#endif
+
     F32 step;
+
+    LLColor4 c_col         = LLColor4(1, 1, 1, 1);
+    LLColor4 col_next      = LLColor4(1, 1, 1, 1);
+    LLColor4 col_edge      = LLColor4(1, 1, 1, 0);
+    LLColor4 col_edge_next = LLColor4(1, 1, 1, 0);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -509,51 +520,62 @@ void LLTracker::drawBeacon(LLVector3 pos_agent, std::string direction, LLColor4 
         step = pos_agent.mV[2] / BEACON_VERTS;
     }
 
-        gGL.color4fv(fogged_color.mV);
+    gGL.color4fv(fogged_color.mV);
 
-        LLVector3 x_axis = LLViewerCamera::getInstance()->getLeftAxis();
-        F32 t = gRenderStartTime.getElapsedTimeF32();
+    LLVector3 x_axis = LLViewerCamera::getInstance()->getLeftAxis();
+    F32 t = gRenderStartTime.getElapsedTimeF32();
 
-        for (U32 i = 0; i < BEACON_VERTS; i++)
-        {
-            F32 x = x_axis.mV[0];
-            F32 y = x_axis.mV[1];
+    F32 x = x_axis.mV[0];
+    F32 y = x_axis.mV[1];
+    F32 z = 0.0f;
+    F32 z_next;
 
-            F32 z = i * step;
-            F32 z_next = (i+1)*step;
+    F32 a,an;
+    F32 xa,ya;
+    F32 xan,yan;
 
-        bool tracking_avatar = getTrackingStatus() == TRACKING_AVATAR;
-        F32 a = pulse_func(t, z, tracking_avatar, direction);
-        F32 an = pulse_func(t, z_next, tracking_avatar, direction);
+    bool tracking_avatar = getTrackingStatus() == TRACKING_AVATAR;
 
-            LLColor4 c_col = fogged_color + LLColor4(a,a,a,a);
-            LLColor4 col_next = fogged_color + LLColor4(an,an,an,an);
-            LLColor4 col_edge = fogged_color * LLColor4(a,a,a,0.0f);
-            LLColor4 col_edge_next = fogged_color * LLColor4(an,an,an,0.0f);
+    gGL.begin(LLRender::TRIANGLE_STRIP);
 
-            a *= 2.f;
-        a += 1.0f;
+    for (U32 i = 0; i < BEACON_VERTS; i++)
+    {
+        z = i * step;
+        z_next = z + step;
 
-            an *= 2.f;
-        an += 1.0f;
+        a = pulse_func(t, z, tracking_avatar, direction);
+        an = pulse_func(t, z_next, tracking_avatar, direction);
 
-            gGL.begin(LLRender::TRIANGLE_STRIP);
-            gGL.color4fv(col_edge.mV);
-            gGL.vertex3f(-x*a, -y*a, z);
-            gGL.color4fv(col_edge_next.mV);
-            gGL.vertex3f(-x*an, -y*an, z_next);
+        c_col = fogged_color + LLColor4(a, a, a, a);
+        col_next = fogged_color + LLColor4(an, an, an, an);
+        col_edge = fogged_color * LLColor4(a, a, a, 0.0f);
+        col_edge_next = fogged_color * LLColor4(an, an, an, 0.0f);
 
-            gGL.color4fv(c_col.mV);
-            gGL.vertex3f(0, 0, z);
-            gGL.color4fv(col_next.mV);
-            gGL.vertex3f(0, 0, z_next);
+        a = a + a + 1.f;
+        an = an + an + 1.0f;
 
-            gGL.color4fv(col_edge.mV);
-            gGL.vertex3f(x*a,y*a,z);
-            gGL.color4fv(col_edge_next.mV);
-            gGL.vertex3f(x*an,y*an,z_next);
-        gGL.end();
+        xa = x*a;
+        ya = y*a;
+        xan = x*an;
+        yan = y*an;
+
+        gGL.color4fv(col_edge.mV);
+        gGL.vertex3f(-xa, -ya, z);
+        gGL.color4fv(col_edge_next.mV);
+        gGL.vertex3f(-xan, -yan, z_next);
+
+        gGL.color4fv(c_col.mV);
+        gGL.vertex3f(0, 0, z);
+        gGL.color4fv(col_next.mV);
+        gGL.vertex3f(0, 0, z_next);
+
+        gGL.color4fv(col_edge.mV);
+        gGL.vertex3f(xa, ya, z);
+        gGL.color4fv(col_edge_next.mV);
+        gGL.vertex3f(xan, yan, z_next);
     }
+
+    gGL.end();
     gGL.popMatrix();
 }
 


### PR DESCRIPTION
This fix comes in 2 commits : 

commit 1: 
I first pushed out of the loop the gl.begin() and gl.end() to avoid multiple draw calls.
I also changed the BEACON_VERTS value for DARWIN, but since only one draw call was made it wasn't so much needed anymore.

commit 2:
I switched to using TRIANGLES instead of TRIANGLES_STRIP because the beacon is basically some sort of grid and to draw a grid using a triangles strip properly, in 1 call, i would have needed to use degenerate triangles, and indices. 
The way llrender deals with those formal immediate calls (and buffering them) also made me choose this method.
I also adjusted the subdivisions according to the actual height of the DOWN and UP beacons, with a constant defining the maximum of subdivisions.
The code remains compatible with the debug setting : CheesyBeacon which adds an animated effect.

the issue : https://github.com/secondlife/viewer/issues/999