### PR TITLE
Re-enable compiler warnings C4018, C4100, C4231 and C4506

### DIFF
--- a/indra/llappearance/llpolymesh.cpp
+++ b/indra/llappearance/llpolymesh.cpp
@@ -983,7 +983,7 @@ void LLPolyMesh::initializeForMorph()
     LLVector4a::memcpyNonAliased16((F32*) mScaledBinormals, (F32*) mSharedData->mBaseNormals, sizeof(LLVector4a) * mSharedData->mNumVertices);
     LLVector4a::memcpyNonAliased16((F32*) mTexCoords, (F32*) mSharedData->mTexCoords, sizeof(LLVector2) * (mSharedData->mNumVertices + mSharedData->mNumVertices%2));
 
-    for (U32 i = 0; i < mSharedData->mNumVertices; ++i)
+    for (S32 i = 0; i < mSharedData->mNumVertices; ++i)
     {
         mClothingWeights[i].clear();
     }

--- a/indra/llcommon/llalignedarray.h
+++ b/indra/llcommon/llalignedarray.h
@@ -116,7 +116,7 @@ void LLAlignedArray<T, alignment>::resize(U32 size)
 template <class T, U32 alignment>
 T& LLAlignedArray<T, alignment>::operator[](int idx)
 {
-    if(idx >= mElementCount || idx < 0)
+    if (idx < 0 || unsigned(idx) >= mElementCount)
     {
         LL_ERRS() << "Out of bounds LLAlignedArray, requested: " << (S32)idx << " size: " << mElementCount << LL_ENDL;
     }
@@ -126,7 +126,7 @@ T& LLAlignedArray<T, alignment>::operator[](int idx)
 template <class T, U32 alignment>
 const T& LLAlignedArray<T, alignment>::operator[](int idx) const
 {
-    if (idx >= mElementCount || idx < 0)
+    if (idx < 0 || unsigned(idx) >= mElementCount)
     {
         LL_ERRS() << "Out of bounds LLAlignedArray, requested: " << (S32)idx << " size: " << mElementCount << LL_ENDL;
     }

--- a/indra/llcommon/llleap.cpp
+++ b/indra/llcommon/llleap.cpp
@@ -233,7 +233,7 @@ public:
 
         LL_DEBUGS("EventHost") << "Sending: "
                                << static_cast<U64>(buffer.tellp()) << ':';
-        std::string::size_type truncate(80);
+        llssize truncate(80);
         if (buffer.tellp() <= truncate)
         {
             LL_CONT << buffer.str();

--- a/indra/llcommon/llpreprocessor.h
+++ b/indra/llcommon/llpreprocessor.h
@@ -124,12 +124,7 @@
 #if LL_MSVC
 #pragma warning( disable : 4996 )   // warning: deprecated
 
-// Linker optimization with "extern template" generates these warnings
-#pragma warning( disable : 4231 )   // nonstandard extension used : 'extern' before template explicit instantiation
-#pragma warning( disable : 4506 )   // no definition for inline function
-
 // level 4 warnings that we need to disable:
-#pragma warning (disable : 4100) // unreferenced formal parameter
 #pragma warning (disable : 4127) // conditional expression is constant (e.g. while(1) )
 #pragma warning (disable : 4244) // possible loss of data on conversions
 #pragma warning (disable : 4396) // the inline specifier cannot be used when a friend declaration refers to a specialization of a function template
@@ -138,7 +133,6 @@
 
 #pragma warning (disable : 4251) // member needs to have dll-interface to be used by clients of class
 #pragma warning (disable : 4275) // non dll-interface class used as base for dll-interface class
-#pragma warning (disable : 4018) // '<' : signed/unsigned mismatch
 
 #endif  //  LL_MSVC
 

--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -36,6 +36,10 @@
 #include "llthread.h"               // on_main_thread()
 #include "llmainthreadtask.h"
 
+#ifdef LL_WINDOWS
+#pragma warning( disable : 4506 )   // no definition for inline function
+#endif
+
 class LLSingletonBase: private boost::noncopyable
 {
 public:

--- a/indra/llcommon/llstreamqueue.h
+++ b/indra/llcommon/llstreamqueue.h
@@ -216,7 +216,7 @@ std::streamsize LLGenericStreamQueue<Ch>::skip(std::streamsize n)
 {
     typename BufferList::iterator bli(mBuffer.begin()), blend(mBuffer.end());
     std::streamsize toskip(n), skipped(0);
-    while (bli != blend && toskip >= bli->length())
+    while (bli != blend && (size_t)toskip >= bli->length())
     {
         std::streamsize chunk(bli->length());
         typename BufferList::iterator zap(bli++);

--- a/indra/llcorehttp/_httplibcurl.cpp
+++ b/indra/llcorehttp/_httplibcurl.cpp
@@ -88,7 +88,7 @@ void HttpLibcurl::shutdown()
 
     if (mMultiHandles)
     {
-        for (int policy_class(0); policy_class < mPolicyCount; ++policy_class)
+        for (unsigned int policy_class(0); policy_class < mPolicyCount; ++policy_class)
         {
             if (mMultiHandles[policy_class])
             {
@@ -122,7 +122,7 @@ void HttpLibcurl::start(int policy_count)
     mActiveHandles = new int [mPolicyCount];
     mDirtyPolicy = new bool [mPolicyCount];
 
-    for (int policy_class(0); policy_class < mPolicyCount; ++policy_class)
+    for (unsigned int policy_class(0); policy_class < mPolicyCount; ++policy_class)
     {
         if (NULL == (mMultiHandles[policy_class] = curl_multi_init()))
         {
@@ -148,7 +148,7 @@ HttpService::ELoopSpeed HttpLibcurl::processTransport()
     HttpService::ELoopSpeed ret(HttpService::REQUEST_SLEEP);
 
     // Give libcurl some cycles to do I/O & callbacks
-    for (int policy_class(0); policy_class < mPolicyCount; ++policy_class)
+    for (unsigned int policy_class(0); policy_class < mPolicyCount; ++policy_class)
     {
         if (! mMultiHandles[policy_class])
         {
@@ -446,14 +446,14 @@ int HttpLibcurl::getActiveCount() const
 }
 
 
-int HttpLibcurl::getActiveCountInClass(int policy_class) const
+int HttpLibcurl::getActiveCountInClass(unsigned int policy_class) const
 {
     llassert_always(policy_class < mPolicyCount);
 
     return mActiveHandles ? mActiveHandles[policy_class] : 0;
 }
 
-void HttpLibcurl::policyUpdated(int policy_class)
+void HttpLibcurl::policyUpdated(unsigned int policy_class)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_NETWORK;
     if (policy_class < 0 || policy_class >= mPolicyCount || ! mMultiHandles)

--- a/indra/llcorehttp/_httplibcurl.h
+++ b/indra/llcorehttp/_httplibcurl.h
@@ -107,7 +107,7 @@ public:
     ///
     /// Threading:  called by worker thread.
     int getActiveCount() const;
-    int getActiveCountInClass(int policy_class) const;
+    int getActiveCountInClass(unsigned int policy_class) const;
 
     /// Attempt to cancel a request identified by handle.
     ///
@@ -124,7 +124,7 @@ public:
     /// initialization and dynamic option setting.
     ///
     /// Threading:  called by worker thread.
-    void policyUpdated(int policy_class);
+    void policyUpdated(unsigned int policy_class);
 
     /// Allocate a curl handle for caller.  May be freed using
     /// either the freeHandle() method or calling curl_easy_cleanup()
@@ -211,7 +211,7 @@ protected:
     HttpService *       mService;           // Simple reference, not owner
     HandleCache         mHandleCache;       // Handle allocator, owner
     active_set_t        mActiveOps;
-    int                 mPolicyCount;
+    unsigned int        mPolicyCount;
     CURLM **            mMultiHandles;      // One handle per policy class
     int *               mActiveHandles;     // Active count per policy class
     bool *              mDirtyPolicy;       // Dirty policy update waiting for stall (per pc)

--- a/indra/llimage/llimagefilter.cpp
+++ b/indra/llimage/llimagefilter.cpp
@@ -781,9 +781,9 @@ void LLImageFilter::filterLinearize(F32 tail, const LLColor3& alpha)
 
     // Compute min and max counts minus tail
     tail = llclampf(tail);
-    S32 total = cumulated_histo[255];
-    S32 min_c = (S32)((F32)(total) * tail);
-    S32 max_c = (S32)((F32)(total) * (1.0 - tail));
+    U32 total = cumulated_histo[255];
+    U32 min_c = (U32)((F32)(total) * tail);
+    U32 max_c = (U32)((F32)(total) * (1.0 - tail));
 
     // Find min and max values
     S32 min_v = 0;
@@ -798,9 +798,9 @@ void LLImageFilter::filterLinearize(F32 tail, const LLColor3& alpha)
     }
 
     // Compute linear lookup table
-    U8 linear_red_lut[256];
-    U8 linear_green_lut[256];
-    U8 linear_blue_lut[256];
+    U8 linear_red_lut[256]{};
+    U8 linear_green_lut[256]{};
+    U8 linear_blue_lut[256]{};
     if (max_v == min_v)
     {
         // Degenerated binary split case
@@ -850,16 +850,16 @@ void LLImageFilter::filterEqualize(S32 nb_classes, const LLColor3& alpha)
     }
 
     // Compute deltas
-    S32 total = cumulated_histo[255];
-    S32 delta_count = total / nb_classes;
-    S32 current_count = delta_count;
-    S32 delta_value = 256 / (nb_classes - 1);
-    S32 current_value = 0;
+    U32 total = cumulated_histo[255];
+    U32 delta_count = total / nb_classes;
+    U32 current_count = delta_count;
+    U32 delta_value = 256 / (nb_classes - 1);
+    U32 current_value = 0;
 
     // Compute equalized lookup table
-    U8 equalize_red_lut[256];
-    U8 equalize_green_lut[256];
-    U8 equalize_blue_lut[256];
+    U8 equalize_red_lut[256]{};
+    U8 equalize_green_lut[256]{};
+    U8 equalize_blue_lut[256]{};
     for (S32 i = 0; i < 256; i++)
     {
         // Blend in current_value with alpha values

--- a/indra/llimage/llimagetga.cpp
+++ b/indra/llimage/llimagetga.cpp
@@ -467,7 +467,7 @@ bool LLImageTGA::decodeTruecolorNonRle( LLImageRaw* raw_image, bool &alpha_opaqu
 
     S32 pixels = getWidth() * getHeight();
 
-    if (pixels * (mIs15Bit ? 2 : getComponents()) > getDataSize() - mDataOffset)
+    if (pixels * (mIs15Bit ? 2 : getComponents()) > getDataSize() - (S32)mDataOffset)
     { //here we have situation when data size in src less than actually needed
         return false;
     }

--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -172,7 +172,7 @@ static OPJ_OFF_T opj_skip(OPJ_OFF_T bytes, void* user_data)
     JPEG2KBase* jpeg_codec = static_cast<JPEG2KBase*>(user_data);
     jpeg_codec->offset += bytes;
 
-    if (jpeg_codec->offset > jpeg_codec->size)
+    if (jpeg_codec->offset > (OPJ_OFF_T)jpeg_codec->size)
     {
         jpeg_codec->offset = jpeg_codec->size;
         // Indicate end of stream
@@ -793,7 +793,7 @@ bool LLImageJ2COJ::decodeImpl(LLImageJ2C &base, LLImageRaw &raw_image, F32 decod
             S32 offset = dest;
             for (S32 y = (height - 1); y >= 0; y--)
             {
-                for (S32 x = 0; x < width; x++)
+                for (U32 x = 0; x < width; x++)
                 {
                     rawp[offset] = image->comps[comp].data[y*comp_width + x];
                     offset += channels;

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -111,10 +111,10 @@ const LLSettingsDay::Seconds LLSettingsDay::MINIMUM_DAYOFFSET(0);
 const LLSettingsDay::Seconds LLSettingsDay::DEFAULT_DAYOFFSET(57600);  // +16 hours == -8 hours (SLT time offset)
 const LLSettingsDay::Seconds LLSettingsDay::MAXIMUM_DAYOFFSET(86400);  // 24 hours
 
-const S32 LLSettingsDay::TRACK_WATER(0);   // water track is 0
-const S32 LLSettingsDay::TRACK_GROUND_LEVEL(1);
-const S32 LLSettingsDay::TRACK_MAX(5);     // 5 tracks, 4 skys, 1 water
-const S32 LLSettingsDay::FRAME_MAX(56);
+const U32 LLSettingsDay::TRACK_WATER(0);   // water track is 0
+const U32 LLSettingsDay::TRACK_GROUND_LEVEL(1);
+const U32 LLSettingsDay::TRACK_MAX(5);     // 5 tracks, 4 skys, 1 water
+const U32 LLSettingsDay::FRAME_MAX(56);
 
 const F32 LLSettingsDay::DEFAULT_FRAME_SLOP_FACTOR(0.02501f);
 

--- a/indra/llinventory/llsettingsdaycycle.h
+++ b/indra/llinventory/llsettingsdaycycle.h
@@ -59,10 +59,10 @@ public:
     static const Seconds DEFAULT_DAYOFFSET;
     static const Seconds MAXIMUM_DAYOFFSET;
 
-    static const S32     TRACK_WATER;
-    static const S32     TRACK_GROUND_LEVEL;
-    static const S32     TRACK_MAX;
-    static const S32     FRAME_MAX;
+    static const U32     TRACK_WATER;
+    static const U32     TRACK_GROUND_LEVEL;
+    static const U32     TRACK_MAX;
+    static const U32     FRAME_MAX;
 
     static const F32     DEFAULT_FRAME_SLOP_FACTOR;
 

--- a/indra/llmath/lloctree.h
+++ b/indra/llmath/lloctree.h
@@ -453,7 +453,7 @@ public:
 
         S32 i = data->getBinIndex();
 
-        if (i >= 0 && i < getElementCount())
+        if (i >= 0 && i < (S32)getElementCount())
         {
             if (mData[i] == data)
             { //found it

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -410,7 +410,7 @@ public:
             llassert(!branch->isLeaf()); // Empty leaf
         }
 
-        for (S32 i = 0; i < branch->getChildCount(); ++i)
+        for (U32 i = 0; i < branch->getChildCount(); ++i)
         {  //stretch by child extents
             LLVolumeOctreeListener* child = (LLVolumeOctreeListener*) branch->getChild(i)->getListener(0);
             min.setMin(min, child->mExtents[0]);
@@ -2717,7 +2717,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
 
             if (do_reverse_triangles)
             {
-                for (U32 j = 0; j < face.mNumIndices; j += 3)
+                for (S32 j = 0; j < face.mNumIndices; j += 3)
                 {
                     // swap the 2nd and 3rd index
                     S32 swap = face.mIndices[j+1];
@@ -2754,7 +2754,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
                     min_tc = face.mTexCoords[0];
                     max_tc = face.mTexCoords[0];
 
-                    for (U32 j = 1; j < face.mNumVertices; ++j)
+                    for (S32 j = 1; j < face.mNumVertices; ++j)
                     {
                         update_min_max(min_tc, max_tc, face.mTexCoords[j]);
                     }
@@ -3850,7 +3850,7 @@ void LLVolume::generateSilhouetteVertices(std::vector<LLVector3> &vertices,
             LLVector4a* v = (LLVector4a*)face.mPositions;
             LLVector4a* n = (LLVector4a*)face.mNormals;
 
-            for (U32 j = 0; j < face.mNumIndices / 3; j++)
+            for (S32 j = 0; j < face.mNumIndices / 3; j++)
             {
                 for (S32 k = 0; k < 3; k++)
                 {
@@ -3976,7 +3976,7 @@ void LLVolume::generateSilhouetteVertices(std::vector<LLVector3> &vertices,
             LLVector4a* v = (LLVector4a*) face.mPositions;
             LLVector4a* n = (LLVector4a*) face.mNormals;
 
-            for (U32 j = 0; j < face.mNumIndices/3; j++)
+            for (S32 j = 0; j < face.mNumIndices/3; j++)
             {
                 //approximate normal
                 S32 v1 = face.mIndices[j*3+0];
@@ -4013,7 +4013,7 @@ void LLVolume::generateSilhouetteVertices(std::vector<LLVector3> &vertices,
             }
 
             //for each triangle
-            for (U32 j = 0; j < face.mNumIndices/3; j++)
+            for (S32 j = 0; j < face.mNumIndices/3; j++)
             {
                 if (fFacing[j] == (AWAY | TOWARDS))
                 { //this is a degenerate triangle
@@ -5066,7 +5066,7 @@ void LLVolumeFace::optimize(F32 angle_cutoff)
     range.setSub(mExtents[1],mExtents[0]);
 
     //remove redundant vertices
-    for (U32 i = 0; i < mNumIndices; ++i)
+    for (S32 i = 0; i < mNumIndices; ++i)
     {
         U16 index = mIndices[i];
 
@@ -5452,7 +5452,7 @@ struct MikktData
         LLVector3 inv_scale(1.f / face->mNormalizedScale.mV[0], 1.f / face->mNormalizedScale.mV[1], 1.f / face->mNormalizedScale.mV[2]);
 
 
-        for (int i = 0; i < face->mNumIndices; ++i)
+        for (S32 i = 0; i < face->mNumIndices; ++i)
         {
             U32 idx = face->mIndices[i];
 
@@ -5463,7 +5463,7 @@ struct MikktData
             n[i].normalize();
             tc[i].set(face->mTexCoords[idx]);
 
-            if (idx >= face->mNumVertices)
+            if (idx >= (U32)face->mNumVertices)
             {
                 // invalid index
                 // replace with a valid index to avoid crashes
@@ -5582,11 +5582,11 @@ bool LLVolumeFace::cacheOptimize(bool gen_tangents)
 
             allocateTangents(mNumVertices);
 
-            for (int i = 0; i < mNumIndices; ++i)
+            for (S32 i = 0; i < mNumIndices; ++i)
             {
                 U32 src_idx = i;
                 U32 dst_idx = remap[i];
-                if (dst_idx >= mNumVertices)
+                if (dst_idx >= (U32)mNumVertices)
                 {
                     dst_idx = mNumVertices - 1;
                     // Shouldn't happen, figure out what gets returned in remap and why.
@@ -5613,7 +5613,7 @@ bool LLVolumeFace::cacheOptimize(bool gen_tangents)
             scale.load3(mNormalizedScale.mV);
             scale.getF32ptr()[3] = 1.f;
 
-            for (int i = 0; i < mNumVertices; ++i)
+            for (S32 i = 0; i < mNumVertices; ++i)
             {
                 mPositions[i].mul(inv_scale);
                 mNormals[i].mul(scale);
@@ -6472,7 +6472,7 @@ void LLVolumeFace::createTangents()
         CalculateTangentArray(mNumVertices, mPositions, mNormals, mTexCoords, mNumIndices / 3, mIndices, mTangents);
 
         //normalize normals
-        for (U32 i = 0; i < mNumVertices; i++)
+        for (S32 i = 0; i < mNumVertices; i++)
         {
             //bump map/planar projection code requires normals to be normalized
             mNormals[i].normalize3fast();
@@ -6744,7 +6744,7 @@ bool LLVolumeFace::createSide(LLVolume* volume, bool partial_build)
             {
                 // Get s value for tex-coord.
                 S32 index = mBeginS + s;
-                if (index >= profile.size())
+                if (index >= (S32)profile.size())
                 {
                     // edge?
                     ss = flat ? 1.f - begin_stex : 1.f;

--- a/indra/llmath/llvolumeoctree.cpp
+++ b/indra/llmath/llvolumeoctree.cpp
@@ -113,7 +113,7 @@ void LLOctreeTriangleRayIntersect::traverse(const LLOctreeNode<LLVolumeTriangle,
     if (LLLineSegmentBoxIntersect(mStart, mEnd, vl->mBounds[0], vl->mBounds[1]))
     {
         node->accept(this);
-        for (S32 i = 0; i < node->getChildCount(); ++i)
+        for (U32 i = 0; i < node->getChildCount(); ++i)
         {
             traverse(node->getChild(i));
         }

--- a/indra/llmessage/llpartdata.cpp
+++ b/indra/llmessage/llpartdata.cpp
@@ -289,14 +289,14 @@ bool LLPartSysData::unpack(LLDataPacker &dp)
         //skip to LLPartData block
         U8 feh = 0;
 
-        for (U32 i = 0; i < size; ++i)
+        for (S32 i = 0; i < size; ++i)
         {
             dp.unpackU8(feh, "whippang");
         }
 
         dp.unpackS32(size, "partsize");
         //skip LLPartData block
-        for (U32 i = 0; i < size; ++i)
+        for (S32 i = 0; i < size; ++i)
         {
             dp.unpackU8(feh, "whippang");
         }

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -1000,9 +1000,9 @@ bool LLDAELoader::OpenFile(const std::string& filename)
 
     //Verify some basic properties of the dae
     //1. Basic validity check on controller
-    U32 controllerCount = (int) db->getElementCount( NULL, "controller" );
+    U32 controllerCount = db->getElementCount(NULL, "controller");
     bool result = false;
-    for ( int i=0; i<controllerCount; ++i )
+    for (U32 i = 0; i < controllerCount; ++i)
     {
         domController* pController = NULL;
         db->getElement( (daeElement**) &pController, i , NULL, "controller" );
@@ -1255,7 +1255,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
         //Some collada setup for accessing the skeleton
         U32 skeleton_count = dae->getDatabase()->getElementCount( NULL, "skeleton" );
         std::vector<domInstance_controller::domSkeleton*> skeletons;
-        for (S32 i=0; i<skeleton_count; i++)
+        for (U32 i = 0; i < skeleton_count; i++)
         {
             daeElement* pElement = 0;
             dae->getDatabase()->getElement( &pElement, i, 0, "skeleton" );

--- a/indra/llprimitive/llmodel.cpp
+++ b/indra/llprimitive/llmodel.cpp
@@ -101,7 +101,7 @@ void LLModel::offsetMesh( const LLVector3& pivotPoint )
         LLVolumeFace& face = *currentFaceIt;
         LLVector4a *pos = (LLVector4a*) face.mPositions;
 
-        for (U32 i=0; i<face.mNumVertices; ++i )
+        for (S32 i=0; i<face.mNumVertices; ++i )
         {
             pos[i].add( pivot );
         }
@@ -110,7 +110,7 @@ void LLModel::offsetMesh( const LLVector3& pivotPoint )
 
 void LLModel::remapVolumeFaces()
 {
-    for (U32 i = 0; i < getNumVolumeFaces(); ++i)
+    for (S32 i = 0; i < getNumVolumeFaces(); ++i)
     {
         mVolumeFaces[i].remap();
     }
@@ -118,7 +118,7 @@ void LLModel::remapVolumeFaces()
 
 void LLModel::optimizeVolumeFaces()
 {
-    for (U32 i = 0; i < getNumVolumeFaces(); ++i)
+    for (S32 i = 0; i < getNumVolumeFaces(); ++i)
     {
         mVolumeFaces[i].optimize();
     }
@@ -173,7 +173,7 @@ void LLModel::trimVolumeFacesToSize(U32 new_count, LLVolume::face_list_t* remain
 {
     llassert(new_count <= LL_SCULPT_MESH_MAX_FACES);
 
-    if (new_count && (getNumVolumeFaces() > new_count))
+    if (new_count > 0 && ((U32)getNumVolumeFaces() > new_count))
     {
         // Copy out remaining volume faces for alternative handling, if provided
         //
@@ -224,7 +224,7 @@ void LLModel::normalizeVolumeFaces()
                 min_tc = face.mTexCoords[0];
                 max_tc = face.mTexCoords[0];
 
-                for (U32 j = 1; j < face.mNumVertices; ++j)
+                for (S32 j = 1; j < face.mNumVertices; ++j)
                 {
                     update_min_max(min_tc, max_tc, face.mTexCoords[j]);
                 }
@@ -299,7 +299,7 @@ void LLModel::normalizeVolumeFaces()
             LLVector4a* norm = (LLVector4a*) face.mNormals;
             LLVector4a* t = (LLVector4a*)face.mTangents;
 
-            for (U32 j = 0; j < face.mNumVertices; ++j)
+            for (S32 j = 0; j < face.mNumVertices; ++j)
             {
                 pos[j].add(trans);
                 pos[j].mul(scale);
@@ -363,7 +363,7 @@ LLVector3 LLModel::getTransformedCenter(const LLMatrix4& mat)
         {
             LLVolumeFace& face = mVolumeFaces[i];
 
-            for (U32 j = 0; j < face.mNumVertices; ++j)
+            for (S32 j = 0; j < face.mNumVertices; ++j)
             {
                 m.affineTransform(face.mPositions[j],t);
                 update_min_max(minv, maxv, t);
@@ -475,7 +475,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         faceted.resizeVertices(vol_face.mNumIndices);
         faceted.resizeIndices(vol_face.mNumIndices);
         //bake out triangles into temporary face, clearing texture coordinates
-        for (U32 i = 0; i < vol_face.mNumIndices; ++i)
+        for (S32 i = 0; i < vol_face.mNumIndices; ++i)
         {
             U32 idx = vol_face.mIndices[i];
 
@@ -485,7 +485,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         }
 
         //generate normals for temporary face
-        for (U32 i = 0; i < faceted.mNumIndices; i += 3)
+        for (S32 i = 0; i < faceted.mNumIndices; i += 3)
         { //for each triangle
             U16 i0 = faceted.mIndices[i+0];
             U16 i1 = faceted.mIndices[i+1];
@@ -514,12 +514,12 @@ void LLModel::generateNormals(F32 angle_cutoff)
 
         //generate normals for welded face based on new topology (step 3)
 
-        for (U32 i = 0; i < faceted.mNumVertices; i++)
+        for (S32 i = 0; i < faceted.mNumVertices; i++)
         {
             faceted.mNormals[i].clear();
         }
 
-        for (U32 i = 0; i < faceted.mNumIndices; i += 3)
+        for (S32 i = 0; i < faceted.mNumIndices; i += 3)
         { //for each triangle
             U16 i0 = faceted.mIndices[i+0];
             U16 i1 = faceted.mIndices[i+1];
@@ -548,7 +548,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         //normalize normals and build point map
         LLVolumeFace::VertexMapData::PointMap point_map;
 
-        for (U32 i = 0; i < faceted.mNumVertices; ++i)
+        for (S32 i = 0; i < faceted.mNumVertices; ++i)
         {
             faceted.mNormals[i].normalize3();
 
@@ -566,7 +566,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         new_face.resizeIndices(vol_face.mNumIndices);
         new_face.resizeVertices(vol_face.mNumIndices);
 
-        for (U32 i = 0; i < vol_face.mNumIndices; ++i)
+        for (S32 i = 0; i < vol_face.mNumIndices; ++i)
         {
             U32 idx = vol_face.mIndices[i];
             LLVolumeFace::VertexData v;
@@ -577,7 +577,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
 
         if (vol_face.mTexCoords)
         {
-            for (U32 i = 0; i < vol_face.mNumIndices; i++)
+            for (S32 i = 0; i < vol_face.mNumIndices; i++)
             {
                 U32 idx = vol_face.mIndices[i];
                 new_face.mTexCoords[i] = vol_face.mTexCoords[idx];
@@ -590,7 +590,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         }
 
         //generate normals for new face
-        for (U32 i = 0; i < new_face.mNumIndices; i += 3)
+        for (S32 i = 0; i < new_face.mNumIndices; i += 3)
         { //for each triangle
             U16 i0 = new_face.mIndices[i+0];
             U16 i1 = new_face.mIndices[i+1];
@@ -615,7 +615,7 @@ void LLModel::generateNormals(F32 angle_cutoff)
         }
 
         //swap out normals in new_face with best match from point map (step 5)
-        for (U32 i = 0; i < new_face.mNumVertices; ++i)
+        for (S32 i = 0; i < new_face.mNumVertices; ++i)
         {
             //LLVolumeFace::VertexData v = new_face.mVertices[i];
 
@@ -725,7 +725,7 @@ LLSD LLModel::writeModel(
             for (S32 i = 0; i < model[idx]->getNumVolumeFaces(); ++i)
             { //for each face
                 const LLVolumeFace& face = model[idx]->getVolumeFace(i);
-                for (U32 j = 0; j < face.mNumVertices; ++j)
+                for (S32 j = 0; j < face.mNumVertices; ++j)
                 {
                     update_min_max(min_pos, max_pos, face.mPositions[j].getF32ptr());
                 }
@@ -762,7 +762,7 @@ LLSD LLModel::writeModel(
                     max_tc = min_tc;
 
                     //get texture coordinate domain
-                    for (U32 j = 0; j < face.mNumVertices; ++j)
+                    for (S32 j = 0; j < face.mNumVertices; ++j)
                     {
                         update_min_max(min_tc, max_tc, ftc[j]);
                     }
@@ -770,7 +770,7 @@ LLSD LLModel::writeModel(
 
                 LLVector2 tc_range = max_tc - min_tc;
 
-                for (U32 j = 0; j < face.mNumVertices; ++j)
+                for (S32 j = 0; j < face.mNumVertices; ++j)
                 { //for each vert
 
                     F32* pos = face.mPositions[j].getF32ptr();
@@ -840,7 +840,7 @@ LLSD LLModel::writeModel(
                 }
 
                 U32 idx_idx = 0;
-                for (U32 j = 0; j < face.mNumIndices; ++j)
+                for (S32 j = 0; j < face.mNumIndices; ++j)
                 {
                     U8* buff = (U8*) &(face.mIndices[j]);
                     indices[idx_idx++] = buff[0];
@@ -887,7 +887,7 @@ LLSD LLModel::writeModel(
                         // a bone index of 0xFF signifies no more influences for this vertex
 
                         std::stringstream ostr;
-                        for (U32 j = 0; j < face.mNumVertices; ++j)
+                        for (S32 j = 0; j < face.mNumVertices; ++j)
                         {
                             LLVector3 pos(face.mPositions[j].getF32ptr());
 
@@ -2015,7 +2015,7 @@ bool ll_is_degenerate(const LLVector4a& a, const LLVector4a& b, const LLVector4a
 
 bool validate_face(const LLVolumeFace& face)
 {
-    for (U32 i = 0; i < face.mNumIndices; ++i)
+    for (S32 i = 0; i < face.mNumIndices; ++i)
     {
         if (face.mIndices[i] >= face.mNumVertices)
         {

--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -1173,7 +1173,7 @@ bool LLGLManager::initGL()
     // This is called here because it depends on the setting of mIsGF2or4MX, and sets up mHasMultitexture.
     initExtensions();
 
-    S32 old_vram = mVRAM;
+    U32 old_vram = mVRAM;
     mVRAM = 0;
 
 #if LL_WINDOWS
@@ -1215,7 +1215,7 @@ bool LLGLManager::initGL()
         // Function will check all GPUs WMI knows of and will pick up the one with most
         // memory. We need to check all GPUs because system can switch active GPU to
         // weaker one, to preserve power when not under load.
-        S32 mem = LLDXHardware::getMBVideoMemoryViaWMI();
+        U32 mem = LLDXHardware::getMBVideoMemoryViaWMI();
         if (mem != 0)
         {
             mVRAM = mem;
@@ -1345,7 +1345,7 @@ void LLGLManager::asLLSD(LLSD& info)
     info["gpu_version"] = mDriverVersionVendorString;
     info["opengl_version"] = mGLVersionString;
 
-    info["vram"] = mVRAM;
+    info["vram"] = LLSD::Integer(mVRAM);
 
     // OpenGL limits
     info["max_samples"] = mMaxSamples;

--- a/indra/llrender/llgl.h
+++ b/indra/llrender/llgl.h
@@ -118,9 +118,7 @@ public:
     std::string mDriverVersionVendorString;
     std::string mGLVersionString;
 
-    S32 mVRAM; // VRAM in MB
-
-    void getPixelFormat(); // Get the best pixel format
+    U32 mVRAM; // VRAM in MB
 
     std::string getGLInfoString();
     void printGLInfoString();
@@ -138,7 +136,6 @@ public:
 private:
     void initExtensions();
     void initGLStates();
-    void initGLImages();
 };
 
 extern LLGLManager gGLManager;

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -100,7 +100,7 @@ void LLImageGLMemory::free_tex_image(U32 texName)
 // track texture free on given texNames
 void LLImageGLMemory::free_tex_images(U32 count, const U32* texNames)
 {
-    for (int i = 0; i < count; ++i)
+    for (U32 i = 0; i < count; ++i)
     {
         free_tex_image(texNames[i]);
     }
@@ -1318,7 +1318,7 @@ void LLImageGL::generateTextures(S32 numTextures, U32 *textures)
         name_count = pool_size;
     }
 
-    if (numTextures <= name_count)
+    if ((U32)numTextures <= name_count)
     {
         //copy teture names off the end of the pool
         memcpy(textures, name_pool + name_count - numTextures, sizeof(U32) * numTextures);

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -665,7 +665,7 @@ GLuint LLShaderMgr::loadShaderFile(const std::string& filename, S32 & shader_lev
         {  //switches are supported in GLSL 1.30 and later
             if (gGLManager.mIsNVIDIA)
             { //switches are unreliable on some NVIDIA drivers
-                for (U32 i = 0; i < texture_index_channels; ++i)
+                for (S32 i = 0; i < texture_index_channels; ++i)
                 {
                     std::string if_string = llformat("\t%sif (vary_texture_index == %d) { return texture(tex%d, texcoord); }\n", i > 0 ? "else " : "", i, i);
                     extra_code_text[extra_code_count++] = strdup(if_string.c_str());

--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -643,7 +643,7 @@ void LLVertexBuffer::drawElements(U32 mode, const LLVector4a* pos, const LLVecto
 
     if (tc != nullptr)
     {
-        for (int i = 0; i < num_indices; ++i)
+        for (U32 i = 0; i < num_indices; ++i)
         {
             U16 idx = indicesp[i];
             gGL.texCoord2fv(tc[idx].mV);
@@ -652,7 +652,7 @@ void LLVertexBuffer::drawElements(U32 mode, const LLVector4a* pos, const LLVecto
     }
     else
     {
-        for (int i = 0; i < num_indices; ++i)
+        for (U32 i = 0; i < num_indices; ++i)
         {
             U16 idx = indicesp[i];
             gGL.vertex3fv(pos[idx].getF32ptr());
@@ -669,19 +669,17 @@ bool LLVertexBuffer::validateRange(U32 start, U32 end, U32 count, U32 indices_of
         return true;
     }
 
-    llassert(start < (U32)mNumVerts);
-    llassert(end < (U32)mNumVerts);
+    llassert(start < mNumVerts);
+    llassert(end < mNumVerts);
 
-    if (start >= (U32) mNumVerts ||
-        end >= (U32) mNumVerts)
+    if (start >= mNumVerts ||
+        end >= mNumVerts)
     {
         LL_ERRS() << "Bad vertex buffer draw range: [" << start << ", " << end << "] vs " << mNumVerts << LL_ENDL;
     }
 
-    llassert(mNumIndices >= 0);
-
-    if (indices_offset >= (U32) mNumIndices ||
-        indices_offset + count > (U32) mNumIndices)
+    if (indices_offset >= mNumIndices ||
+        indices_offset + count > mNumIndices)
     {
         LL_ERRS() << "Bad index buffer draw range: [" << indices_offset << ", " << indices_offset+count << "]" << LL_ENDL;
     }
@@ -718,7 +716,7 @@ bool LLVertexBuffer::validateRange(U32 start, U32 end, U32 count, U32 indices_of
             for (U32 i = start; i < end; i++)
             {
                 U32 idx = (U32) (v[i][3]+0.25f);
-                if (idx >= shader->mFeatures.mIndexedTextureChannels)
+                if (idx >= (U32)shader->mFeatures.mIndexedTextureChannels)
                 {
                     LL_ERRS() << "Bad texture index found in vertex data stream." << LL_ENDL;
                 }

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -789,7 +789,7 @@ void LLTextBase::drawText()
             }
 
             // Draw squiggly lines under any visible misspelled words
-            while ( (mMisspellRanges.end() != misspell_it) && (misspell_it->first < seg_end) && (misspell_it->second > seg_start) )
+            while ( (mMisspellRanges.end() != misspell_it) && (misspell_it->first < (U32)seg_end) && (misspell_it->second > (U32)seg_start) )
             {
                 // Skip the current word if the user is still busy editing it
                 if ( (!mSpellCheckTimer.hasExpired()) && (misspell_it->first <= (U32)mCursorPos) && (misspell_it->second >= (U32)mCursorPos) )
@@ -798,7 +798,7 @@ void LLTextBase::drawText()
                     continue;
                 }
 
-                U32 misspell_start = llmax<U32>(misspell_it->first, seg_start), misspell_end = llmin<U32>(misspell_it->second, seg_end);
+                U32 misspell_start = llmax<U32>(misspell_it->first, (U32)seg_start), misspell_end = llmin<U32>(misspell_it->second, (U32)seg_end);
                 S32 squiggle_start = 0, squiggle_end = 0, pony = 0;
                 cur_segment->getDimensions(seg_start - cur_segment->getStart(), misspell_start - seg_start, squiggle_start, pony);
                 cur_segment->getDimensions(misspell_start - cur_segment->getStart(), misspell_end - misspell_start, squiggle_end, pony);
@@ -821,7 +821,7 @@ void LLTextBase::drawText()
                     squiggle_start += 4;
                 }
 
-                if (misspell_it->second > seg_end)
+                if (misspell_it->second > (U32)seg_end)
                 {
                     break;
                 }

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -216,7 +216,7 @@ HRESULT GetVideoMemoryViaWMI(WCHAR* strInputDeviceID, DWORD* pdwAdapterRam)
 }
 
 //static
-S32 LLDXHardware::getMBVideoMemoryViaWMI()
+U32 LLDXHardware::getMBVideoMemoryViaWMI()
 {
     DWORD vram = 0;
     if (SUCCEEDED(GetVideoMemoryViaWMI(NULL, &vram)))

--- a/indra/llwindow/lldxhardware.h
+++ b/indra/llwindow/lldxhardware.h
@@ -104,7 +104,7 @@ public:
 
     // Will get memory of best GPU in MB, return memory on sucsess, 0 on failure
     // Note: WMI is not accurate in some cases
-    static S32 getMBVideoMemoryViaWMI();
+    static U32 getMBVideoMemoryViaWMI();
 
     // Find a particular device that matches the following specs.
     // Empty strings indicate that you don't care.

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -446,7 +446,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
         mMaxCores = llmin(mMaxCores, (U32) 64);
         DWORD_PTR mask = 0;
 
-        for (int i = 0; i < mMaxCores; ++i)
+        for (U32 i = 0; i < mMaxCores; ++i)
         {
             mask |= ((DWORD_PTR) 1) << i;
         }

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -12456,7 +12456,7 @@
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
-    <string>S32</string>
+    <string>U32</string>
     <key>Value</key>
     <integer>8</integer>
   </map>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3339,7 +3339,7 @@ LLSD LLAppViewer::getViewerInfo() const
     info["NET_BANDWITH"] = gSavedSettings.getF32("ThrottleBandwidthKBPS");
     info["LOD_FACTOR"] = gSavedSettings.getF32("RenderVolumeLODFactor");
     info["RENDER_QUALITY"] = (F32)gSavedSettings.getU32("RenderQualityPerformance");
-    info["TEXTURE_MEMORY"] = gGLManager.mVRAM;
+    info["TEXTURE_MEMORY"] = LLSD::Integer(gGLManager.mVRAM);
 
 #if LL_DARWIN
     info["HIDPI"] = gHiDPISupport;

--- a/indra/newview/llcylinder.cpp
+++ b/indra/newview/llcylinder.cpp
@@ -48,7 +48,7 @@ void LLCone::render(S32 sides)
     gGL.begin(LLRender::TRIANGLE_FAN);
     gGL.vertex3f(0,0,0);
 
-    for (U32 i = 0; i < sides; i++)
+    for (S32 i = 0; i < sides; i++)
     {
         F32 a = (F32) i/sides * F_PI*2.f;
         F32 x = cosf(a)*0.5f;
@@ -61,7 +61,7 @@ void LLCone::render(S32 sides)
 
     gGL.begin(LLRender::TRIANGLE_FAN);
     gGL.vertex3f(0.f, 0.f, 0.5f);
-    for (U32 i = 0; i < sides; i++)
+    for (S32 i = 0; i < sides; i++)
     {
         F32 a = (F32) i/sides * F_PI*2.f;
         F32 x = cosf(a)*0.5f;

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -2508,7 +2508,7 @@ LLSettingsDay::ptr_t LLEnvironment::createDayCycleFromEnvironment(EnvSelection_t
 
     if (type == "sky")
     {
-        for (S32 idx = 1; idx < LLSettingsDay::TRACK_MAX; ++idx)
+        for (U32 idx = 1; idx < LLSettingsDay::TRACK_MAX; ++idx)
             day->clearCycleTrack(idx);
         day->setSettingsAtKeyframe(settings, 0.0f, 1);
     }

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -1180,7 +1180,7 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
 
     if (mVertexBuffer.notNull())
     {
-        if (num_indices + (S32) mIndicesIndex > mVertexBuffer->getNumIndices())
+        if (num_indices + mIndicesIndex > mVertexBuffer->getNumIndices())
         {
             if (gDebugGL)
             {
@@ -1196,7 +1196,7 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
             return false;
         }
 
-        if (num_vertices + mGeomIndex > mVertexBuffer->getNumVerts())
+        if (num_vertices + (U32)mGeomIndex > mVertexBuffer->getNumVerts())
         {
             if (gDebugGL)
             {
@@ -1595,7 +1595,7 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
                             mask.setElement<2>();
                             mask.setElement<3>();
 
-                            U32 count = num_vertices/2 + num_vertices%2;
+                            S32 count = num_vertices/2 + num_vertices%2;
 
                             for (S32 i = 0; i < count; i++)
                             {
@@ -2292,7 +2292,7 @@ bool LLFace::verify(const U32* indices_array) const
     }
 
     // First, check whether the face data fits within the pool's range.
-    if ((mGeomIndex + mGeomCount) > mVertexBuffer->getNumVerts())
+    if ((U32)(mGeomIndex + mGeomCount) > mVertexBuffer->getNumVerts())
     {
         ok = false;
         LL_INFOS() << "Face references invalid vertices!" << LL_ENDL;

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -419,9 +419,9 @@ void LLFloater360Capture::mockSnapShot(LLImageRaw* raw)
     unsigned int depth = raw->getComponents();
     unsigned char* pixels = raw->getData();
 
-    for (int y = 0; y < height; y++)
+    for (unsigned int y = 0; y < height; y++)
     {
-        for (int x = 0; x < width; x++)
+        for (unsigned int x = 0; x < width; x++)
         {
             unsigned long offset = y * width * depth + x * depth;
             unsigned char red = x * 256 / width;

--- a/indra/newview/llfloatereditextdaycycle.cpp
+++ b/indra/newview/llfloatereditextdaycycle.cpp
@@ -1195,7 +1195,7 @@ void LLFloaterEditExtDayCycle::updateButtons()
         }
         else
         {
-            for (S32 track = 1; track < LLSettingsDay::TRACK_MAX; ++track)
+            for (U32 track = 1; track < LLSettingsDay::TRACK_MAX; ++track)
             {
                 if (track == mCurrentTrack)
                     continue;
@@ -1220,7 +1220,7 @@ void LLFloaterEditExtDayCycle::updateButtons()
 
     // update track buttons
     bool extended_env = LLEnvironment::instance().isExtendedEnvironmentEnabled();
-    for (S32 track = 0; track < LLSettingsDay::TRACK_MAX; ++track)
+    for (U32 track = 0; track < LLSettingsDay::TRACK_MAX; ++track)
     {
         LLButton* button = getChild<LLButton>(track_tabs[track], true);
         button->setEnabled(extended_env);

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -1186,8 +1186,8 @@ void LLInvFVBridge::addMarketplaceContextMenuOptions(U32 flags,
         gInventory.collectDescendents(local_version_folder_id, categories, items, false);
         static LLCachedControl<U32> max_depth(gSavedSettings, "InventoryOutboxMaxFolderDepth", 4);
         static LLCachedControl<U32> max_count(gSavedSettings, "InventoryOutboxMaxFolderCount", 20);
-        if (categories.size() >= max_count
-            || depth > (max_depth + 1))
+        if (categories.size() >= (size_t)max_count
+            || (U32)depth > (max_depth + 1))
         {
             disabled_items.push_back(std::string("New Folder"));
         }

--- a/indra/newview/llinventoryfunctions.cpp
+++ b/indra/newview/llinventoryfunctions.cpp
@@ -1333,12 +1333,12 @@ bool can_move_item_to_marketplace(const LLInventoryCategory* root_folder, LLInve
     if (accept)
     {
         // If the dest folder is a stock folder, we do not count the incoming items toward the total (stock items are seen as one)
-        int existing_item_count = (move_in_stock ? 0 : bundle_size);
+        unsigned int existing_item_count = (move_in_stock ? 0 : bundle_size);
 
         // If the dest folder is a stock folder, we do assume that the incoming items are also stock items (they should anyway)
-        int existing_stock_count = (move_in_stock ? bundle_size : 0);
+        unsigned int existing_stock_count = (move_in_stock ? bundle_size : 0);
 
-        int existing_folder_count = 0;
+        unsigned int existing_folder_count = 0;
 
         // Get the version folder: that's where the counts start from
         const LLViewerInventoryCategory * version_folder = ((root_folder && (root_folder != dest_folder)) ? gInventory.getFirstDescendantOf(root_folder->getUUID(), dest_folder->getUUID()) : NULL);
@@ -1457,9 +1457,9 @@ bool can_move_folder_to_marketplace(const LLInventoryCategory* root_folder, LLIn
             existing_stock_count += count_stock_items(existing_items);
         }
 
-        const int total_folder_count = existing_folder_count + dragged_folder_count;
-        const int total_item_count = existing_item_count + dragged_item_count;
-        const int total_stock_count = existing_stock_count + dragged_stock_count;
+        const unsigned int total_folder_count = existing_folder_count + dragged_folder_count;
+        const unsigned int total_item_count = existing_item_count + dragged_item_count;
+        const unsigned int total_stock_count = existing_stock_count + dragged_stock_count;
 
         if (total_folder_count > gSavedSettings.getU32("InventoryOutboxMaxFolderCount"))
         {

--- a/indra/newview/llinventorymodelbackgroundfetch.cpp
+++ b/indra/newview/llinventorymodelbackgroundfetch.cpp
@@ -734,7 +734,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis()
     // Reserve one request for actions outside of fetch (like renames)
     const U32 max_concurrent_fetches = llclamp(ais_pool - 1, 1, 50);
 
-    if (mFetchCount >= max_concurrent_fetches)
+    if ((U32)mFetchCount >= max_concurrent_fetches)
     {
         return;
     }
@@ -747,7 +747,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis()
     const F64 end_time = curent_time + max_time;
     S32 last_fetch_count = mFetchCount;
 
-    while (!mFetchFolderQueue.empty() && mFetchCount < max_concurrent_fetches && curent_time < end_time)
+    while (!mFetchFolderQueue.empty() && (U32)mFetchCount < max_concurrent_fetches && curent_time < end_time)
     {
         const FetchQueueInfo & fetch_info(mFetchFolderQueue.front());
         bulkFetchViaAis(fetch_info);
@@ -758,7 +758,7 @@ void LLInventoryModelBackgroundFetch::bulkFetchViaAis()
     // Ideally we shouldn't fetch items if recursive fetch isn't done,
     // but there is a chance some request will start timeouting and recursive
     // fetch will get stuck on a signle folder, don't block item fetch in such case
-    while (!mFetchItemQueue.empty() && mFetchCount < max_concurrent_fetches && curent_time < end_time)
+    while (!mFetchItemQueue.empty() && (U32)mFetchCount < max_concurrent_fetches && curent_time < end_time)
     {
         const FetchQueueInfo& fetch_info(mFetchItemQueue.front());
         bulkFetchViaAis(fetch_info);

--- a/indra/newview/lllocalbitmaps.cpp
+++ b/indra/newview/lllocalbitmaps.cpp
@@ -438,7 +438,7 @@ std::vector<LLViewerObject*> LLLocalBitmap::prepUpdateObjects(LLUUID old_id, U32
     std::vector<LLViewerObject*> obj_list;
     LLViewerFetchedTexture* old_texture = gTextureList.findImage(old_id, TEX_LIST_STANDARD);
 
-    for(U32 face_iterator = 0; face_iterator < old_texture->getNumFaces(channel); face_iterator++)
+    for (S32 face_iterator = 0; face_iterator < old_texture->getNumFaces(channel); face_iterator++)
     {
         // getting an object from a face
         LLFace* face_to_object = (*old_texture->getFaceList(channel))[face_iterator];
@@ -554,7 +554,7 @@ void LLLocalBitmap::updateUserPrims(LLUUID old_id, LLUUID new_id, U32 channel)
 void LLLocalBitmap::updateUserVolumes(LLUUID old_id, LLUUID new_id, U32 channel)
 {
     LLViewerFetchedTexture* old_texture = gTextureList.findImage(old_id, TEX_LIST_STANDARD);
-    for (U32 volume_iter = 0; volume_iter < old_texture->getNumVolumes(channel); volume_iter++)
+    for (S32 volume_iter = 0; volume_iter < old_texture->getNumVolumes(channel); volume_iter++)
     {
         LLVOVolume* volobjp = (*old_texture->getVolumeList(channel))[volume_iter];
         switch (channel)

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -448,7 +448,7 @@ U32 get_volume_memory_size(const LLVolume* volume)
     U32 indices = 0;
     U32 vertices = 0;
 
-    for (U32 i = 0; i < volume->getNumVolumeFaces(); ++i)
+    for (S32 i = 0; i < volume->getNumVolumeFaces(); ++i)
     {
         const LLVolumeFace& face = volume->getVolumeFace(i);
         indices += face.mNumIndices;
@@ -5203,16 +5203,16 @@ void LLPhysicsDecomp::Request::assignData(LLModel* mdl)
 {
     if (!mdl)
     {
-        return ;
+        return;
     }
 
     U16 index_offset = 0;
-    U16 tri[3] ;
+    U16 tri[3]{};
 
     mPositions.clear();
     mIndices.clear();
-    mBBox[1] = LLVector3(F32_MIN, F32_MIN, F32_MIN) ;
-    mBBox[0] = LLVector3(F32_MAX, F32_MAX, F32_MAX) ;
+    mBBox[1] = LLVector3(F32_MIN, F32_MIN, F32_MIN);
+    mBBox[0] = LLVector3(F32_MAX, F32_MAX, F32_MAX);
 
     //queue up vertex positions and indices
     for (S32 i = 0; i < mdl->getNumVolumeFaces(); ++i)
@@ -5223,36 +5223,34 @@ void LLPhysicsDecomp::Request::assignData(LLModel* mdl)
             continue;
         }
 
-        for (U32 j = 0; j < face.mNumVertices; ++j)
+        for (S32 j = 0; j < face.mNumVertices; ++j)
         {
             mPositions.push_back(LLVector3(face.mPositions[j].getF32ptr()));
-            for(U32 k = 0 ; k < 3 ; k++)
+            for (U32 k = 0 ; k < 3 ; k++)
             {
-                mBBox[0].mV[k] = llmin(mBBox[0].mV[k], mPositions[j].mV[k]) ;
-                mBBox[1].mV[k] = llmax(mBBox[1].mV[k], mPositions[j].mV[k]) ;
+                mBBox[0].mV[k] = llmin(mBBox[0].mV[k], mPositions[j].mV[k]);
+                mBBox[1].mV[k] = llmax(mBBox[1].mV[k], mPositions[j].mV[k]);
             }
         }
 
-        updateTriangleAreaThreshold() ;
+        updateTriangleAreaThreshold();
 
-        for (U32 j = 0; j+2 < face.mNumIndices; j += 3)
+        for (S32 j = 0; j+2 < face.mNumIndices; j += 3)
         {
             tri[0] = face.mIndices[j] + index_offset ;
-            tri[1] = face.mIndices[j + 1] + index_offset ;
-            tri[2] = face.mIndices[j + 2] + index_offset ;
+            tri[1] = face.mIndices[j + 1] + index_offset;
+            tri[2] = face.mIndices[j + 2] + index_offset;
 
-            if(isValidTriangle(tri[0], tri[1], tri[2]))
+            if (isValidTriangle(tri[0], tri[1], tri[2]))
             {
-                mIndices.push_back(tri[0]);
-                mIndices.push_back(tri[1]);
-                mIndices.push_back(tri[2]);
+                mIndices.emplace_back(tri[0]);
+                mIndices.emplace_back(tri[1]);
+                mIndices.emplace_back(tri[2]);
             }
         }
 
         index_offset += face.mNumVertices;
     }
-
-    return ;
 }
 
 void LLPhysicsDecomp::Request::updateTriangleAreaThreshold()

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -1362,7 +1362,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
     S32 size_indices = 0;
     S32 size_vertices = 0;
 
-    for (U32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
+    for (S32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
     {
         const LLVolumeFace &face = base_model->getVolumeFace(face_idx);
         size_indices += face.mNumIndices;
@@ -1388,7 +1388,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
     S32 combined_positions_shift = 0;
     S32 indices_idx_shift = 0;
     S32 combined_indices_shift = 0;
-    for (U32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
+    for (S32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
     {
         const LLVolumeFace &face = base_model->getVolumeFace(face_idx);
 
@@ -1513,7 +1513,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
     S32 valid_faces = 0;
 
     // Crude method to copy indices back into face
-    for (U32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
+    for (S32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
     {
         const LLVolumeFace &face = base_model->getVolumeFace(face_idx);
 
@@ -1531,7 +1531,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
         // Copy relevant indices and vertices
         for (S32 i = 0; i < size_new_indices; ++i)
         {
-            U32 idx = output_indices[i];
+            S32 idx = (S32)output_indices[i];
 
             if ((i % 3) == 0)
             {
@@ -1560,7 +1560,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
                         // U16 vertices overflow shouldn't happen, but just in case
                         size_new_indices = 0;
                         valid_faces = 0;
-                        for (U32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
+                        for (S32 face_idx = 0; face_idx < base_model->getNumVolumeFaces(); ++face_idx)
                         {
                             genMeshOptimizerPerFace(base_model, target_model, face_idx, indices_decimator, error_threshold, simplification_mode);
                             const LLVolumeFace &face = target_model->getVolumeFace(face_idx);
@@ -1906,7 +1906,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
             LLModel* target_model = mModel[lod][mdl_idx];
 
             // carry over normalized transform into simplified model
-            for (int i = 0; i < base->getNumVolumeFaces(); ++i)
+            for (S32 i = 0; i < base->getNumVolumeFaces(); ++i)
             {
                 LLVolumeFace& src = base->getVolumeFace(i);
                 LLVolumeFace& dst = target_model->getVolumeFace(i);
@@ -1920,7 +1920,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
             if (model_meshopt_mode == MESH_OPTIMIZER_PRECISE)
             {
                 // Run meshoptimizer for each face
-                for (U32 face_idx = 0; face_idx < base->getNumVolumeFaces(); ++face_idx)
+                for (S32 face_idx = 0; face_idx < base->getNumVolumeFaces(); ++face_idx)
                 {
                     F32 res = genMeshOptimizerPerFace(base, target_model, face_idx, indices_decimator, lod_error_threshold, MESH_OPTIMIZER_FULL);
                     if (res < 0)
@@ -1936,7 +1936,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
             if (model_meshopt_mode == MESH_OPTIMIZER_SLOPPY)
             {
                 // Run meshoptimizer for each face
-                for (U32 face_idx = 0; face_idx < base->getNumVolumeFaces(); ++face_idx)
+                for (S32 face_idx = 0; face_idx < base->getNumVolumeFaces(); ++face_idx)
                 {
                     if (genMeshOptimizerPerFace(base, target_model, face_idx, indices_decimator, lod_error_threshold, MESH_OPTIMIZER_NO_TOPOLOGY) < 0)
                     {

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -349,7 +349,7 @@ U32 LLPanelEmojiComplete::getMaxShortCodeWidth() const
     U32 max_width = 0;
     for (const LLEmojiSearchResult& result : mEmojis)
     {
-        S32 width = mTextFont->getWidth(result.String);
+        U32 width = mTextFont->getWidth(result.String);
         if (width > max_width)
         {
             max_width = width;

--- a/indra/newview/llpanelenvironment.cpp
+++ b/indra/newview/llpanelenvironment.cpp
@@ -339,7 +339,7 @@ void LLPanelEnvironmentInfo::refreshFromEstate()
         refresh();
 }
 
-std::string LLPanelEnvironmentInfo::getNameForTrackIndex(S32 index)
+std::string LLPanelEnvironmentInfo::getNameForTrackIndex(U32 index)
 {
     std::string invname;
     if (!mCurrentEnvironment || index < LLSettingsDay::TRACK_WATER || index >= LLSettingsDay::TRACK_MAX)

--- a/indra/newview/llpanelenvironment.h
+++ b/indra/newview/llpanelenvironment.h
@@ -136,7 +136,7 @@ protected:
     virtual bool                isLargeEnough() = 0;
     virtual void                refreshFromSource() = 0;
 
-    std::string                 getNameForTrackIndex(S32 index);
+    std::string                 getNameForTrackIndex(U32 index);
 
     LLFloaterSettingsPicker *   getSettingsPicker(bool create = true);
     LLFloaterEditExtDayCycle *  getEditFloater(bool create = true);

--- a/indra/newview/llpanelexperiencelog.cpp
+++ b/indra/newview/llpanelexperiencelog.cpp
@@ -108,8 +108,8 @@ void LLPanelExperienceLog::refresh()
     bool waiting = false;
     LLUUID waiting_id;
 
-    int itemsToSkip = mPageSize*mCurrentPage;
-    int items = 0;
+    unsigned int itemsToSkip = mPageSize*mCurrentPage;
+    unsigned int items = 0;
     bool moreItems = false;
     LLSD events_to_save = events;
     if (events.isMap() && events.size() != 0)
@@ -126,7 +126,7 @@ void LLPanelExperienceLog::refresh()
                 events_to_save.erase(day->first);
                 continue;
             }
-            int size = static_cast<int>(dayArray.size());
+            unsigned int size = static_cast<unsigned int>(dayArray.size());
             if(itemsToSkip > size)
             {
                 itemsToSkip -= size;

--- a/indra/newview/llpanelpeople.cpp
+++ b/indra/newview/llpanelpeople.cpp
@@ -872,7 +872,7 @@ void LLPanelPeople::updateButtons()
         groups_panel->getChildView("minus_btn")->setEnabled(item_selected && selected_id.notNull()); // a real group selected
 
         U32 groups_count = static_cast<U32>(gAgent.mGroups.size());
-        S32 max_groups = LLAgentBenefitsMgr::current().getGroupMembershipLimit();
+        U32 max_groups = LLAgentBenefitsMgr::current().getGroupMembershipLimit();
         U32 groups_remaining = max_groups > groups_count ? max_groups - groups_count : 0;
         groups_panel->getChild<LLUICtrl>("groupcount")->setTextArg("[COUNT]", llformat("%d", groups_count));
         groups_panel->getChild<LLUICtrl>("groupcount")->setTextArg("[REMAINING]", llformat("%d", groups_remaining));

--- a/indra/newview/llperfstats.cpp
+++ b/indra/newview/llperfstats.cpp
@@ -378,7 +378,7 @@ namespace LLPerfStats
             auto count = countNearbyAvatars(std::min(LLPipeline::RenderFarClip, tunables.userImpostorDistance));
             if( count != tunables.nonImpostors )
             {
-                tunables.updateNonImposters( (count < LLVOAvatar::NON_IMPOSTORS_MAX_SLIDER)?count : 0 );
+                tunables.updateNonImposters(((U32)count < LLVOAvatar::NON_IMPOSTORS_MAX_SLIDER) ? count : 0);
                 LL_DEBUGS("AutoTune") << "There are " << count << "avatars within " << std::min(LLPipeline::RenderFarClip, tunables.userImpostorDistance) << "m of the camera" << LL_ENDL;
             }
         }

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -145,7 +145,7 @@ void LLReflectionMapManager::update()
         U32 count = log2((F32)res) + 0.5f;
         
         mMipChain.resize(count);
-        for (int i = 0; i < count; ++i)
+        for (U32 i = 0; i < count; ++i)
         {
             mMipChain[i].allocate(res, res, GL_RGB16F);
             res /= 2;
@@ -228,7 +228,7 @@ void LLReflectionMapManager::update()
     // next distribute the free indices
     U32 count = llmin(mReflectionProbeCount, (U32)mProbes.size());
 
-    for (S32 i = 1; i < count && !mCubeFree.empty(); ++i)
+    for (U32 i = 1; i < count && !mCubeFree.empty(); ++i)
     {
         // find the closest probe that needs a cube index
         LLReflectionMap* probe = mProbes[i];
@@ -242,7 +242,7 @@ void LLReflectionMapManager::update()
         }
     }
 
-    for (int i = 0; i < mProbes.size(); ++i)
+    for (unsigned int i = 0; i < mProbes.size(); ++i)
     {
         LLReflectionMap* probe = mProbes[i];
         if (probe->getNumRefs() == 1)
@@ -984,8 +984,8 @@ void LLReflectionMapManager::updateUniforms()
             //      4. For each bucket, store the index of the nearest probe that might influence pixels in that bucket
             //      5. In the shader, lookup the bucket for the pixel depth to get the index of the first probe that could possibly influence
             //          the current pixel.
-            int depth_min = llclamp(llfloor(refmap->mMinDepth), 0, 255);
-            int depth_max = llclamp(llfloor(refmap->mMaxDepth), 0, 255);
+            unsigned int depth_min = llclamp(llfloor(refmap->mMinDepth), 0, 255);
+            unsigned int depth_max = llclamp(llfloor(refmap->mMaxDepth), 0, 255);
             for (U32 i = depth_min; i <= depth_max; ++i)
             {
                 if (refmap->mMinDepth < minDepth[i])

--- a/indra/newview/llsceneview.cpp
+++ b/indra/newview/llsceneview.cpp
@@ -102,7 +102,7 @@ void LLSceneView::draw()
     LLViewerRegion* region = gAgent.getRegion();
     if (region)
     {
-        for (U32 i = 0; i < gObjectList.getNumObjects(); ++i)
+        for (S32 i = 0; i < gObjectList.getNumObjects(); ++i)
         {
             LLViewerObject* object = gObjectList.getObject(i);
 

--- a/indra/newview/llsettingspicker.cpp
+++ b/indra/newview/llsettingspicker.cpp
@@ -326,7 +326,7 @@ void LLFloaterSettingsPicker::onAssetLoaded(LLUUID asset_id, LLSettingsBase::ptr
         // track 1 always present
         track_selection->add(getString(STR_TRACK_GROUND), LLSD::Integer(LLSettingsDay::TRACK_GROUND_LEVEL), ADD_TOP, true);
         LLUIString formatted_label = getString(STR_TRACK_SKY);
-        for (int i = 2; i < LLSettingsDay::TRACK_MAX; i++)
+        for (U32 i = 2; i < LLSettingsDay::TRACK_MAX; i++)
         {
             if (!pday->isTrackEmpty(i))
             {

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -1387,7 +1387,7 @@ LLSettingsDay::ptr_t LLSettingsVODay::buildDeepCloneAndUncompress() const
     U32 flags = getFlags();
     LLSettingsDay::ptr_t day_clone = std::make_shared<LLSettingsVODay>(settings);
 
-    for (S32 i = 0; i < LLSettingsDay::TRACK_MAX; ++i)
+    for (U32 i = 0; i < LLSettingsDay::TRACK_MAX; ++i)
     {
         const LLSettingsDay::CycleTrack_t& track = getCycleTrackConst(i);
         LLSettingsDay::CycleTrack_t::const_iterator iter = track.begin();

--- a/indra/newview/llskinningutil.cpp
+++ b/indra/newview/llskinningutil.cpp
@@ -131,7 +131,7 @@ void LLSkinningUtil::initSkinningMatrixPalette(
 
     LLMatrix4a world[LL_CHARACTER_MAX_ANIMATED_JOINTS];
 
-    for (U32 j = 0; j < count; ++j)
+    for (S32 j = 0; j < count; ++j)
     {
         S32 joint_num = skin->mJointNums[j];
         LLJoint *joint = avatar->getJoint(joint_num);

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -1664,7 +1664,7 @@ bool LLTextureFetchWorker::doWork(S32 param)
                 // In case of a partial response, our offset may
                 // not be trivially contiguous with the data we have.
                 // Get back into alignment.
-                if ( (mHttpReplyOffset > cur_size) || (cur_size > mHttpReplyOffset + append_size))
+                if ( ((S32)mHttpReplyOffset > cur_size) || (cur_size > (S32)mHttpReplyOffset + append_size))
                 {
                     LL_WARNS(LOG_TXT) << "Partial HTTP response produces break in image data for texture "
                                       << mID << ".  Aborting load."  << LL_ENDL;

--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -810,7 +810,7 @@ bool LLViewerCamera::areVertsVisible(LLViewerObject* volumep, bool all_verts)
     {
         const LLVolumeFace& face = volume->getVolumeFace(i);
 
-        for (U32 v = 0; v < face.mNumVertices; v++)
+        for (S32 v = 0; v < face.mNumVertices; v++)
         {
             const LLVector4a& src_vec = face.mPositions[v];
             LLVector4a vec;

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -962,7 +962,7 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
 
         {
             LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("Texture Unbind");
-            for (U32 i = 0; i < gGLManager.mNumTextureImageUnits; i++)
+            for (S32 i = 0; i < gGLManager.mNumTextureImageUnits; i++)
             { //dummy cleanup of any currently bound textures
                 if (gGL.getTexUnit(i)->getCurrType() != LLTexUnit::TT_NONE)
                 {

--- a/indra/newview/llviewerjointmesh.cpp
+++ b/indra/newview/llviewerjointmesh.cpp
@@ -423,7 +423,7 @@ void LLViewerJointMesh::updateFaceData(LLFace *face, F32 pixel_area, bool damp_w
 
             const S32 offset = (S32) mMesh->mFaceVertexOffset;
 
-            for (S32 i = 0; i < idx_count; ++i)
+            for (U32 i = 0; i < idx_count; ++i)
             {
                 *(idx++) = *(src_idx++)+offset;
             }

--- a/indra/newview/llvieweroctree.cpp
+++ b/indra/newview/llvieweroctree.cpp
@@ -1135,7 +1135,7 @@ void LLOcclusionCullingGroup::checkOcclusion()
                 mOcclusionCheckCount[LLViewerCamera::sCurCameraID]++;
             }
 
-            static LLCachedControl<S32> occlusion_timeout(gSavedSettings, "RenderOcclusionTimeout", 4);
+            static LLCachedControl<U32> occlusion_timeout(gSavedSettings, "RenderOcclusionTimeout", 4);
 
             if (available || mOcclusionCheckCount[LLViewerCamera::sCurCameraID] > occlusion_timeout)
             {

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -765,8 +765,8 @@ void LLViewerTexture::removeFace(U32 ch, LLFace* facep)
     if(mNumFaces[ch] > 1)
     {
         S32 index = facep->getIndexInTex(ch);
-        llassert(index < mFaceList[ch].size());
-        llassert(index < mNumFaces[ch]);
+        llassert(index < (S32)mFaceList[ch].size());
+        llassert(index < (S32)mNumFaces[ch]);
         mFaceList[ch][index] = mFaceList[ch][--mNumFaces[ch]];
         mFaceList[ch][index]->setIndexInTex(ch, index);
     }
@@ -818,8 +818,8 @@ void LLViewerTexture::removeVolume(U32 ch, LLVOVolume* volumep)
     if (mNumVolumes[ch] > 1)
     {
         S32 index = volumep->getIndexInTex(ch);
-        llassert(index < mVolumeList[ch].size());
-        llassert(index < mNumVolumes[ch]);
+        llassert(index < (S32)mVolumeList[ch].size());
+        llassert(index < (S32)mNumVolumes[ch]);
         mVolumeList[ch][index] = mVolumeList[ch][--mNumVolumes[ch]];
         mVolumeList[ch][index]->setIndexInTex(ch, index);
     }

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1326,8 +1326,8 @@ void LLViewerFetchedTexture::addToCreateTexture()
         //
         if(mRequestedDiscardLevel <= mDesiredDiscardLevel && !mForceToSaveRawImage)
         {
-            S32 w = mFullWidth >> mRawDiscardLevel;
-            S32 h = mFullHeight >> mRawDiscardLevel;
+            U32 w = mFullWidth >> mRawDiscardLevel;
+            U32 h = mFullHeight >> mRawDiscardLevel;
 
             //if big image, do not load extra data
             //scale it down to size >= LLViewerTexture::sMinLargeImageSize
@@ -1672,7 +1672,7 @@ void LLViewerFetchedTexture::processTextureStats()
         else
         {
             U32 desired_size = MAX_IMAGE_SIZE_DEFAULT; // MAX_IMAGE_SIZE_DEFAULT = 1024 and max size ever is 2048
-            if(!mKnownDrawWidth || !mKnownDrawHeight || mFullWidth <= mKnownDrawWidth || mFullHeight <= mKnownDrawHeight)
+            if(!mKnownDrawWidth || !mKnownDrawHeight || (S32)mFullWidth <= mKnownDrawWidth || (S32)mFullHeight <= mKnownDrawHeight)
             {
                 if (mFullWidth > desired_size || mFullHeight > desired_size)
                 {

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -898,7 +898,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     {
         for (U32 i = 0; i < LLRender::NUM_TEXTURE_CHANNELS; ++i)
         {
-            for (U32 fi = 0; fi < imagep->getNumFaces(i); ++fi)
+            for (S32 fi = 0; fi < imagep->getNumFaces(i); ++fi)
             {
                 LLFace* face = (*(imagep->getFaceList(i)))[fi];
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -616,7 +616,7 @@ public:
                     LLViewerRegion* region = gAgent.getRegion();
                     if (region)
                     {
-                        for (U32 i = 0; i < gObjectList.getNumObjects(); ++i)
+                        for (S32 i = 0; i < gObjectList.getNumObjects(); ++i)
                         {
                             LLViewerObject* object = gObjectList.getObject(i);
                             if (object &&

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -6597,8 +6597,8 @@ void LLVOAvatar::addAttachmentOverridesForObject(LLViewerObject *vo, std::set<LL
 
     if ( vobj && vobj->isMesh() && pSkinData )
     {
-        const int bindCnt = static_cast<int>(pSkinData->mAlternateBindMatrix.size());
-        const int jointCnt = static_cast<int>(pSkinData->mJointNames.size());
+        const unsigned int bindCnt = static_cast<unsigned int>(pSkinData->mAlternateBindMatrix.size());
+        const unsigned int jointCnt = static_cast<unsigned int>(pSkinData->mJointNames.size());
         if ((bindCnt > 0) && (bindCnt != jointCnt))
         {
             LL_WARNS_ONCE() << "invalid mesh, bindCnt " << bindCnt << "!= jointCnt " << jointCnt << ", joint overrides will be ignored." << LL_ENDL;
@@ -6625,10 +6625,10 @@ void LLVOAvatar::addAttachmentOverridesForObject(LLViewerObject *vo, std::set<LL
                 LL_DEBUGS("AnimatedObjects") << "adding attachment overrides for " << mesh_id
                                              << " to root object " << root_object->getID() << LL_ENDL;
             }
-            bool fullRig = jointCnt>=JOINT_COUNT_REQUIRED_FOR_FULLRIG;
+            bool fullRig = jointCnt >= JOINT_COUNT_REQUIRED_FOR_FULLRIG;
             if ( fullRig && !mesh_overrides_loaded )
             {
-                for ( int i=0; i<jointCnt; ++i )
+                for (unsigned int i = 0; i < jointCnt; ++i)
                 {
                     std::string lookingForJoint = pSkinData->mJointNames[i].c_str();
                     LLJoint* pJoint = getJoint( lookingForJoint );
@@ -7499,7 +7499,7 @@ S32 LLVOAvatar::getMaxAttachments() const
 //-----------------------------------------------------------------------------
 bool LLVOAvatar::canAttachMoreObjects(U32 n) const
 {
-    return (getNumAttachments() + n) <= getMaxAttachments();
+    return (getNumAttachments() + n) <= (U32)getMaxAttachments();
 }
 
 //-----------------------------------------------------------------------------
@@ -7533,7 +7533,7 @@ S32 LLVOAvatar::getMaxAnimatedObjectAttachments() const
 //-----------------------------------------------------------------------------
 bool LLVOAvatar::canAttachMoreAnimatedObjects(U32 n) const
 {
-    return (getNumAnimatedObjectAttachments() + n) <= getMaxAnimatedObjectAttachments();
+    return (getNumAnimatedObjectAttachments() + n) <= (U32)getMaxAnimatedObjectAttachments();
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -333,7 +333,7 @@ void LLVOCacheEntry::setState(U32 state)
 
     if(getState() == ACTIVE)
     {
-        const S32 MIN_INTERVAL = 64 + sMinFrameRange;
+        const U32 MIN_INTERVAL = 64U + sMinFrameRange;
         U32 last_visible = getVisible();
 
         setVisible();
@@ -536,7 +536,7 @@ bool LLVOCacheEntry::isAnyVisible(const LLVector4a& camera_origin, const LLVecto
     if(!vis)
     {
         S32 cur_vis = llmax(group->getAnyVisible(), (S32)getVisible());
-        vis = (cur_vis + sMinFrameRange > LLViewerOctreeEntryData::getCurrentFrame());
+        vis = (cur_vis + (S32)sMinFrameRange > LLViewerOctreeEntryData::getCurrentFrame());
     }
 
     //within the back sphere

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -3984,7 +3984,7 @@ U32 LLVOVolume::getRenderCost(texture_cost_t &textures) const
     U32 media_faces = 0;
 
     const LLDrawable* drawablep = mDrawable;
-    U32 num_faces = drawablep->getNumFaces();
+    S32 num_faces = drawablep->getNumFaces();
 
     const LLVolumeParams& volume_params = getVolume()->getParams();
 
@@ -4953,7 +4953,7 @@ void LLRiggedVolume::update(
                 else
             #endif
                 {
-                    for (U32 j = 0; j < dst_face.mNumVertices; ++j)
+                    for (S32 j = 0; j < dst_face.mNumVertices; ++j)
                     {
                         LLMatrix4a final_mat;
                         LLSkinningUtil::getPerVertexSkinMatrix(weight[j].getF32ptr(), mat, false, final_mat, max_joints);
@@ -4980,7 +4980,7 @@ void LLRiggedVolume::update(
                     box_max = max;
                 }
 
-                for (U32 j = 1; j < dst_face.mNumVertices; ++j)
+                for (S32 j = 1; j < dst_face.mNumVertices; ++j)
                 {
                     min.setMin(min, pos[j]);
                     max.setMax(max, pos[j]);


### PR DESCRIPTION
@marchcat Some more compiler warnings re-enabled on global level. Most of the changes resulting from fixes for C4018 (signed/unsigned mismatch). It could be there is some more mismatch in llkdu, which I wasn't able to test in the OS build.