### PR TITLE
Fix merge error introduced in eb526fec0aadcaf30363fdfb1e253a609bf83acc

### DIFF
--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -5463,17 +5463,6 @@ struct MikktData
             n[i].normalize();
             tc[i].set(face->mTexCoords[idx]);
 
-            if (idx >= (U32)face->mNumVertices)
-            {
-                // invalid index
-                // replace with a valid index to avoid crashes
-                idx = face->mNumVertices - 1;
-                face->mIndices[i] = idx;
-
-                // Needs better logging
-                LL_DEBUGS_ONCE("LLVOLUME") << "Invalid index, substituting" << LL_ENDL;
-            }
-
             if (face->mWeights)
             {
                 w[i].set(face->mWeights[idx].getF32ptr());


### PR DESCRIPTION
@marchcat  This code resulted from code prior the use of Mikktspace (f4e6ccc2c4a79e77dc338f8caec6510751c3ee83) and made it into the Mikktspace code during eb526fec0aadcaf30363fdfb1e253a609bf83acc