### PR TITLE
Re-enable compiler warnings C4127, C4512 & C4706

### DIFF
--- a/indra/llcommon/llfile.cpp
+++ b/indra/llcommon/llfile.cpp
@@ -27,6 +27,12 @@
  * $/LicenseInfo$
  */
 
+#include "linden_common.h"
+#include "llfile.h"
+#include "llstring.h"
+#include "llerror.h"
+#include "stringize.h"
+
 #if LL_WINDOWS
 #include "llwin32headerslean.h"
 #include <stdlib.h>                 // Windows errno
@@ -34,12 +40,6 @@
 #else
 #include <errno.h>
 #endif
-
-#include "linden_common.h"
-#include "llfile.h"
-#include "llstring.h"
-#include "llerror.h"
-#include "stringize.h"
 
 using namespace std;
 

--- a/indra/llcommon/llfindlocale.cpp
+++ b/indra/llcommon/llfindlocale.cpp
@@ -157,14 +157,22 @@ canonise_fl(FL_Locale *l) {
   if (l->lang && 0 == strcmp(l->lang, "en")) {
     if (l->country && 0 == strcmp(l->country, "UK")) {
       free((void*)l->country);
+#ifdef LL_WINDOWS
+      l->country = _strdup("GB");
+#else
       l->country = strdup("GB");
+#endif
     }
   }
   /* ja_JA -> ja_JP */
   if (l->lang && 0 == strcmp(l->lang, "ja")) {
     if (l->country && 0 == strcmp(l->country, "JA")) {
       free((void*)l->country);
+#ifdef LL_WINDOWS
+      l->country = _strdup("JP");
+#else
       l->country = strdup("JP");
+#endif
     }
   }
 }

--- a/indra/llcommon/llpreprocessor.h
+++ b/indra/llcommon/llpreprocessor.h
@@ -120,20 +120,20 @@
 #endif  //  LL_WINDOWS
 
 
-// Deal with VC6 problems
+// Deal with VC++ problems
 #if LL_MSVC
-#pragma warning( disable : 4996 )   // warning: deprecated
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS // disable warnings for methods considered unsafe
+#endif
+#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS
+#define _WINSOCK_DEPRECATED_NO_WARNINGS // disable deprecated WinSock API warnings
+#endif
 
 // level 4 warnings that we need to disable:
-#pragma warning (disable : 4127) // conditional expression is constant (e.g. while(1) )
 #pragma warning (disable : 4244) // possible loss of data on conversions
 #pragma warning (disable : 4396) // the inline specifier cannot be used when a friend declaration refers to a specialization of a function template
-#pragma warning (disable : 4512) // assignment operator could not be generated
-#pragma warning (disable : 4706) // assignment within conditional (even if((x = y)) )
-
 #pragma warning (disable : 4251) // member needs to have dll-interface to be used by clients of class
 #pragma warning (disable : 4275) // non dll-interface class used as base for dll-interface class
-
 #endif  //  LL_MSVC
 
 #if LL_WINDOWS

--- a/indra/llcorehttp/examples/http_texture_load.cpp
+++ b/indra/llcorehttp/examples/http_texture_load.cpp
@@ -24,6 +24,8 @@
  * $/LicenseInfo$
  */
 
+#include "linden_common.h"
+
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
@@ -32,8 +34,6 @@
 #if !defined(WIN32)
 #include <pthread.h>
 #endif
-
-#include "linden_common.h"
 
 #include "httpcommon.h"
 #include "httprequest.h"

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -454,10 +454,10 @@ void get_wstring(IDxDiagContainer* containerp, WCHAR* wszPropName, WCHAR* wszPro
         switch( var.vt )
         {
             case VT_UI4:
-                swprintf( wszPropValue, L"%d", var.ulVal ); /* Flawfinder: ignore */
+                swprintf( wszPropValue, outputSize, L"%d", var.ulVal ); /* Flawfinder: ignore */
                 break;
             case VT_I4:
-                swprintf( wszPropValue, L"%d", var.lVal );  /* Flawfinder: ignore */
+                swprintf( wszPropValue, outputSize, L"%d", var.lVal );  /* Flawfinder: ignore */
                 break;
             case VT_BOOL:
                 wcscpy( wszPropValue, (var.boolVal) ? L"true" : L"false" ); /* Flawfinder: ignore */


### PR DESCRIPTION
Disable particular CRT and WinSock API warnings for functions Microsoft considers unsafe/deprecated

@marchcat And some more changes... 😄 