### PR TITLE
viewer#1672 Crash at setDefaultFOV

### DIFF
--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -94,7 +94,13 @@ LLViewerCamera::LLViewerCamera() : LLCamera()
     mZoomSubregion = 1;
     mAverageSpeed = 0.f;
     mAverageAngularSpeed = 0.f;
-    gSavedSettings.getControl("CameraAngle")->getCommitSignal()->connect(boost::bind(&LLViewerCamera::updateCameraAngle, this, _2));
+
+    mCameraAngleChangedSignal = gSavedSettings.getControl("CameraAngle")->getCommitSignal()->connect(boost::bind(&LLViewerCamera::updateCameraAngle, this, _2));
+}
+
+LLViewerCamera::~LLViewerCamera()
+{
+    mCameraAngleChangedSignal.disconnect();
 }
 
 void LLViewerCamera::updateCameraLocation(const LLVector3 &center, const LLVector3 &up_direction, const LLVector3 &point_of_interest)
@@ -896,9 +902,8 @@ BOOL LLViewerCamera::isDefaultFOVChanged()
 }
 
 // static
-void LLViewerCamera::updateCameraAngle( void* user_data, const LLSD& value)
+void LLViewerCamera::updateCameraAngle(const LLSD& value)
 {
-    LLViewerCamera* self=(LLViewerCamera*)user_data;
-    self->setDefaultFOV(value.asReal());
+    setDefaultFOV(value.asReal());
 }
 

--- a/indra/newview/llviewercamera.h
+++ b/indra/newview/llviewercamera.h
@@ -43,6 +43,7 @@ class alignas(16) LLViewerCamera : public LLCamera, public LLSimpleton<LLViewerC
     LL_ALIGN_NEW
 public:
     LLViewerCamera();
+    ~LLViewerCamera();
 
     typedef enum
     {
@@ -65,7 +66,7 @@ public:
                                 const LLVector3 &point_of_interest);
 
     static void updateFrustumPlanes(LLCamera& camera, BOOL ortho = FALSE, BOOL zflip = FALSE, BOOL no_hacks = FALSE);
-    static void updateCameraAngle(void* user_data, const LLSD& value);
+    void updateCameraAngle(const LLSD& value);
     void setPerspective(BOOL for_selection, S32 x, S32 y_from_bot, S32 width, S32 height, BOOL limit_select_distance, F32 z_near = 0, F32 z_far = 0);
 
     const LLMatrix4 &getProjection() const;
@@ -124,6 +125,8 @@ protected:
     S32                 mScreenPixelArea; // Pixel area of entire window
     F32                 mZoomFactor;
     S16                 mZoomSubregion;
+
+    boost::signals2::connection mCameraAngleChangedSignal;
 
 public:
 };


### PR DESCRIPTION
Some things can make a copy of camera, like LLViewerWindow::cubeSnapshot so need to store and clean up the connection