### PR TITLE
Remove orphaned code apparently left over from testing

### DIFF
--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -1805,7 +1805,6 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
                     getChild<LLUICtrl>("shinyOffsetV")->setValue(offset_y);
                     getChild<LLUICtrl>("glossiness")->setValue(material->getSpecularLightExponent());
                     getChild<LLUICtrl>("environment")->setValue(material->getEnvironmentIntensity());
-                    getChild<LLUICtrl>("mirror")->setValue(material->getEnvironmentIntensity());
 
                     updateShinyControls(!material->getSpecularID().isNull(), true);
                 }


### PR DESCRIPTION
@RunitaiLinden @brad-linden This seems to be a left-over from when Geenz added mirrors. There is no such a control in the corresponding XUI file.