### PR TITLE
Pull in crash fixes from maint c

### DIFF
--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -1094,7 +1094,8 @@ S32 LLGLSLShader::bindTexture(S32 uniform, LLTexture* texture, LLTexUnit::eTextu
 
     if (uniform < 0 || uniform >= (S32)mTexture.size())
     {
-        LL_SHADER_UNIFORM_ERRS() << "Uniform out of range: " << uniform << LL_ENDL;
+        LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << uniform << LL_ENDL;
+        llassert(false);
         return -1;
     }
 
@@ -1115,6 +1116,8 @@ S32 LLGLSLShader::bindTexture(S32 uniform, LLRenderTarget* texture, bool depth, 
 
     if (uniform < 0 || uniform >= (S32)mTexture.size())
     {
+        LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << uniform << LL_ENDL;
+        llassert(false);
         return -1;
     }
 
@@ -1162,7 +1165,8 @@ S32 LLGLSLShader::unbindTexture(S32 uniform, LLTexUnit::eTextureType mode)
 
     if (uniform < 0 || uniform >= (S32)mTexture.size())
     {
-        LL_SHADER_UNIFORM_ERRS() << "Uniform out of range: " << uniform << LL_ENDL;
+        LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << uniform << LL_ENDL;
+        llassert(false);
         return -1;
     }
 
@@ -1187,7 +1191,8 @@ S32 LLGLSLShader::enableTexture(S32 uniform, LLTexUnit::eTextureType mode, LLTex
 
     if (uniform < 0 || uniform >= (S32)mTexture.size())
     {
-        LL_SHADER_UNIFORM_ERRS() << "Uniform out of range: " << uniform << LL_ENDL;
+        LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << uniform << LL_ENDL;
+        llassert(false);
         return -1;
     }
 
@@ -1208,7 +1213,8 @@ S32 LLGLSLShader::disableTexture(S32 uniform, LLTexUnit::eTextureType mode, LLTe
 
     if (uniform < 0 || uniform >= (S32)mTexture.size())
     {
-        LL_SHADER_UNIFORM_ERRS() << "Uniform out of range: " << uniform << LL_ENDL;
+        LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << uniform << LL_ENDL;
+        llassert(false);
         return -1;
     }
     S32 index = mTexture[uniform];
@@ -1239,7 +1245,8 @@ void LLGLSLShader::uniform1i(U32 index, GLint x)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1264,7 +1271,8 @@ void LLGLSLShader::uniform1f(U32 index, GLfloat x)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1299,7 +1307,8 @@ void LLGLSLShader::uniform2f(U32 index, GLfloat x, GLfloat y)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1325,7 +1334,8 @@ void LLGLSLShader::uniform3f(U32 index, GLfloat x, GLfloat y, GLfloat z)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1351,7 +1361,8 @@ void LLGLSLShader::uniform4f(U32 index, GLfloat x, GLfloat y, GLfloat z, GLfloat
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1377,7 +1388,8 @@ void LLGLSLShader::uniform1iv(U32 index, U32 count, const GLint* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1403,7 +1415,8 @@ void LLGLSLShader::uniform4iv(U32 index, U32 count, const GLint* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1430,7 +1443,8 @@ void LLGLSLShader::uniform1fv(U32 index, U32 count, const GLfloat* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1456,7 +1470,8 @@ void LLGLSLShader::uniform2fv(U32 index, U32 count, const GLfloat* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1482,7 +1497,8 @@ void LLGLSLShader::uniform3fv(U32 index, U32 count, const GLfloat* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1508,7 +1524,8 @@ void LLGLSLShader::uniform4fv(U32 index, U32 count, const GLfloat* v)
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1535,7 +1552,8 @@ void LLGLSLShader::uniformMatrix2fv(U32 index, U32 count, GLboolean transpose, c
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1555,7 +1573,8 @@ void LLGLSLShader::uniformMatrix3fv(U32 index, U32 count, GLboolean transpose, c
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1575,7 +1594,8 @@ void LLGLSLShader::uniformMatrix3x4fv(U32 index, U32 count, GLboolean transpose,
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 
@@ -1595,7 +1615,8 @@ void LLGLSLShader::uniformMatrix4fv(U32 index, U32 count, GLboolean transpose, c
     {
         if (mUniform.size() <= index)
         {
-            LL_SHADER_UNIFORM_ERRS() << "Uniform index out of bounds." << LL_ENDL;
+            LL_WARNS_ONCE("Shader") << "Uniform index out of bounds. Size: " << (S32)mUniform.size() << " index: " << index << LL_ENDL;
+            llassert(false);
             return;
         }
 

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -548,6 +548,5 @@ glh::matrix4f gl_perspective(GLfloat fovy, GLfloat aspect, GLfloat zNear, GLfloa
 glh::matrix4f gl_lookat(LLVector3 eye, LLVector3 center, LLVector3 up);
 
 #define LL_SHADER_LOADING_WARNS(...) LL_WARNS()
-#define LL_SHADER_UNIFORM_ERRS(...)  LL_ERRS("Shader")
 
 #endif

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -756,9 +756,12 @@ void LLRenderPass::pushGLTFBatch(LLDrawInfo& params)
 {
     auto& mat = params.mGLTFMaterial;
 
-    mat->bind(params.mTexture);
+    if (mat.notNull())
+    {
+        mat->bind(params.mTexture);
+    }
 
-    LLGLDisable cull_face(mat->mDoubleSided ? GL_CULL_FACE : 0);
+    LLGLDisable cull_face(mat.notNull() && mat->mDoubleSided ? GL_CULL_FACE : 0);
 
     setup_texture_matrix(params);
 

--- a/indra/newview/llreflectionmap.cpp
+++ b/indra/newview/llreflectionmap.cpp
@@ -251,32 +251,27 @@ bool LLReflectionMap::getBox(LLMatrix4& box)
     if (mViewerObject)
     {
         LLVolume* volume = mViewerObject->getVolume();
-        if (volume)
+        if (volume && mViewerObject->getReflectionProbeIsBox())
         {
-            LLVOVolume* vobjp = (LLVOVolume*)mViewerObject;
-
-            if (vobjp->getReflectionProbeIsBox())
+            glh::matrix4f mv(gGLModelView);
+            glh::matrix4f scale;
+            LLVector3 s = mViewerObject->getScale().scaledVec(LLVector3(0.5f, 0.5f, 0.5f));
+            mRadius = s.magVec();
+            scale.set_scale(glh::vec3f(s.mV));
+            if (mViewerObject->mDrawable != nullptr)
             {
-                glh::matrix4f mv(gGLModelView);
-                glh::matrix4f scale;
-                LLVector3 s = vobjp->getScale().scaledVec(LLVector3(0.5f, 0.5f, 0.5f));
-                mRadius = s.magVec();
-                scale.set_scale(glh::vec3f(s.mV));
-                if (vobjp->mDrawable != nullptr)
-                {
-                    // object to agent space (no scale)
-                    glh::matrix4f rm((F32*)vobjp->mDrawable->getWorldMatrix().mMatrix);
+                // object to agent space (no scale)
+                glh::matrix4f rm((F32*)mViewerObject->mDrawable->getWorldMatrix().mMatrix);
 
-                    // construct object to camera space (with scale)
-                    mv = mv * rm * scale;
+                // construct object to camera space (with scale)
+                mv = mv * rm * scale;
 
-                    // inverse is camera space to object unit cube
-                    mv = mv.inverse();
+                // inverse is camera space to object unit cube
+                mv = mv.inverse();
 
-                    box = LLMatrix4(mv.m);
+                box = LLMatrix4(mv.m);
 
-                    return true;
-                }
+                return true;
             }
         }
     }

--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -94,7 +94,13 @@ LLViewerCamera::LLViewerCamera() : LLCamera()
     mZoomSubregion = 1;
     mAverageSpeed = 0.f;
     mAverageAngularSpeed = 0.f;
-    gSavedSettings.getControl("CameraAngle")->getCommitSignal()->connect(boost::bind(&LLViewerCamera::updateCameraAngle, this, _2));
+
+    mCameraAngleChangedSignal = gSavedSettings.getControl("CameraAngle")->getCommitSignal()->connect(boost::bind(&LLViewerCamera::updateCameraAngle, this, _2));
+}
+
+LLViewerCamera::~LLViewerCamera()
+{
+    mCameraAngleChangedSignal.disconnect();
 }
 
 void LLViewerCamera::updateCameraLocation(const LLVector3 &center, const LLVector3 &up_direction, const LLVector3 &point_of_interest)
@@ -895,10 +901,8 @@ bool LLViewerCamera::isDefaultFOVChanged()
     return false;
 }
 
-// static
-void LLViewerCamera::updateCameraAngle( void* user_data, const LLSD& value)
+void LLViewerCamera::updateCameraAngle(const LLSD& value)
 {
-    LLViewerCamera* self=(LLViewerCamera*)user_data;
-    self->setDefaultFOV(value.asReal());
+    setDefaultFOV(value.asReal());
 }
 

--- a/indra/newview/llviewercamera.h
+++ b/indra/newview/llviewercamera.h
@@ -43,6 +43,7 @@ class alignas(16) LLViewerCamera : public LLCamera, public LLSimpleton<LLViewerC
     LL_ALIGN_NEW
 public:
     LLViewerCamera();
+    ~LLViewerCamera();
 
     typedef enum
     {
@@ -65,7 +66,7 @@ public:
                                 const LLVector3 &point_of_interest);
 
     static void updateFrustumPlanes(LLCamera& camera, bool ortho = false, bool zflip = false, bool no_hacks = false);
-    static void updateCameraAngle(void* user_data, const LLSD& value);
+    void updateCameraAngle(const LLSD& value);
     void setPerspective(bool for_selection, S32 x, S32 y_from_bot, S32 width, S32 height, bool limit_select_distance, F32 z_near = 0, F32 z_far = 0);
 
     const LLMatrix4 &getProjection() const;
@@ -124,6 +125,8 @@ protected:
     S32                 mScreenPixelArea; // Pixel area of entire window
     F32                 mZoomFactor;
     S16                 mZoomSubregion;
+
+    boost::signals2::connection mCameraAngleChangedSignal;
 
 public:
 };

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -258,6 +258,7 @@ public:
     virtual bool isRiggedMesh() const               { return false; }
     virtual bool hasLightTexture() const            { return false; }
     virtual bool isReflectionProbe() const          { return false; }
+    virtual bool getReflectionProbeIsBox() const    { return false; }
 
     // This method returns true if the object is over land owned by
     // the agent, one of its groups, or it encroaches and

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2836,7 +2836,11 @@ bool LLViewerRegion::probeCache(U32 local_id, U32 crc, U32 flags, U8 &cache_miss
 
             if(entry->isState(LLVOCacheEntry::ACTIVE))
             {
-                ((LLDrawable*)entry->getEntry()->getDrawable())->getVObj()->loadFlags(flags);
+                LLDrawable* drawable = (LLDrawable*)entry->getEntry()->getDrawable();
+                if (drawable && drawable->getVObj())
+                {
+                    drawable->getVObj()->loadFlags(flags);
+                }
                 return true;
             }
 

--- a/indra/newview/llvovolume.h
+++ b/indra/newview/llvovolume.h
@@ -306,7 +306,7 @@ public:
     bool isReflectionProbe() const override;
     F32 getReflectionProbeAmbiance() const;
     F32 getReflectionProbeNearClip() const;
-    bool getReflectionProbeIsBox() const;
+    bool getReflectionProbeIsBox() const override;
     bool getReflectionProbeIsDynamic() const;
     bool getReflectionProbeIsMirror() const;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -10224,7 +10224,7 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
     result.clear();
     grabReferences(result);
 
-    if (!avatar || !avatar->mDrawable)
+    if (!avatar || avatar->isDead() || !avatar->mDrawable)
     {
         LL_WARNS_ONCE("AvatarRenderPipeline") << "Avatar is " << (avatar ? "not drawable" : "null") << LL_ENDL;
         return;


### PR DESCRIPTION
Just puling in recent crashfixes to maint-a. partially because they are graphical in nature and mant-a will be pulled into gltf, partially to get them out sooner and a bit because they touch nearby bools, to pre-resolve conflicts.