### PR TITLE
secondlife/viewer#1475: Fix Terrain tab controls no longer disabled when insufficient permissions

### DIFF
--- a/doc/contributions.txt
+++ b/doc/contributions.txt
@@ -606,6 +606,7 @@ Henri Beauchamp
 	SL-19110
 	SL-19159
 	[NO JIRA] (fullbright HUD alpha fix)
+    secondlife/viewer#1744
 herina Bode
 Hikkoshi Sakai
 	VWR-429

--- a/indra/llmath/llmath.h
+++ b/indra/llmath/llmath.h
@@ -517,7 +517,7 @@ inline void ll_remove_outliers(std::vector<VEC_TYPE>& data, F32 k)
         i++;
     }
 
-    S32 j = data.size()-1;
+    size_t j = data.size()-1;
     while (j > 0 && data[j] > max)
     {
         j--;

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -591,11 +591,19 @@ void LLView::deleteAllChildren()
     updateBoundingRect();
 }
 
-void LLView::setAllChildrenEnabled(bool b)
+void LLView::setAllChildrenEnabled(bool b, bool recursive /*= false*/)
 {
     for (LLView* viewp : mChildList)
     {
         viewp->setEnabled(b);
+    }
+
+    if (recursive)
+    {
+        for (LLView* viewp : mChildList)
+        {
+            viewp->setAllChildrenEnabled(b, recursive);
+        }
     }
 }
 

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -287,7 +287,7 @@ public:
     // children, etc.
     virtual void deleteAllChildren();
 
-    void    setAllChildrenEnabled(bool b);
+    void    setAllChildrenEnabled(bool b, bool recursive = false);
 
     virtual void    setVisible(bool visible);
     void            setVisibleDirect(bool visible) { mVisible = visible; }

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -1945,6 +1945,15 @@
             <key>tooltip</key>
             <string/>
          </map>
+         <key>INVENTORY_SETTING</key>
+         <map>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <integer>56</integer>
+            <key>tooltip</key>
+            <string/>
+         </map>
          <key>INVENTORY_SOUND</key>
          <map>
             <key>type</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9253,17 +9253,6 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-    <key>RenderTerrainPBRForce</key>
-    <map>
-      <key>Comment</key>
-      <string>Force-load PBR terrain if enabled</string>
-      <key>Persist</key>
-      <integer>0</integer>
-      <key>Type</key>
-      <string>Boolean</string>
-      <key>Value</key>
-      <integer>0</integer>
-    </map>
     <key>RenderTerrainPBRDetail</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/textureUtilV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/textureUtilV.glsl
@@ -135,8 +135,7 @@ vec3 tangent_space_transform(vec4 vertex_tangent, vec3 vertex_normal, vec4[2] kh
     return (weights.x * vertex_binormal.xyz) + (weights.y * vertex_tangent.xyz);
 }
 
-// Similar to tangent_space_transform but no offset during coordinate system
-// conversion, and no texture animation support.
+// Similar to tangent_space_transform but no texture animation support.
 vec3 terrain_tangent_space_transform(vec4 vertex_tangent, vec3 vertex_normal, vec4[2] khr_gltf_transform)
 {
     // Immediately convert to left-handed coordinate system ((0,1) -> (0, -1))

--- a/indra/newview/lldrawpoolterrain.cpp
+++ b/indra/newview/lldrawpoolterrain.cpp
@@ -202,7 +202,7 @@ void LLDrawPoolTerrain::drawLoop()
 
 void LLDrawPoolTerrain::renderFullShader()
 {
-    const bool use_local_materials = gLocalTerrainMaterials.materialsReady(true, false);
+    const bool use_local_materials = gLocalTerrainMaterials.makeMaterialsReady(true, false);
     // Hack! Get the region that this draw pool is rendering from!
     LLViewerRegion *regionp = mDrawFace[0]->getDrawable()->getVObj()->getRegion();
     LLVLComposition *compp = regionp->getComposition();

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -1669,8 +1669,8 @@ bool LLPanelRegionTerrainInfo::refreshFromRegion(LLViewerRegion* region)
 
         static LLCachedControl<bool> feature_pbr_terrain_enabled(gSavedSettings, "RenderTerrainPBREnabled", false);
 
-        const bool textures_ready = compp->texturesReady(false, false);
-        const bool materials_ready = feature_pbr_terrain_enabled && compp->materialsReady(false, false);
+        const bool textures_ready = compp->makeTexturesReady(false, false);
+        const bool materials_ready = feature_pbr_terrain_enabled && compp->makeMaterialsReady(false, false);
 
         bool set_texture_swatches;
         bool set_material_swatches;

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -356,7 +356,7 @@ void LLFloaterRegionInfo::requestRegionInfo()
     {
         tab->getChild<LLPanel>("General")->setCtrlsEnabled(false);
         tab->getChild<LLPanel>("Debug")->setCtrlsEnabled(false);
-        tab->getChild<LLPanel>("Terrain")->setCtrlsEnabled(false);
+        tab->getChild<LLPanel>("Terrain")->setAllChildrenEnabled(false, true);
         tab->getChild<LLPanel>("Estate")->setCtrlsEnabled(false);
         tab->getChild<LLPanel>("Access")->setCtrlsEnabled(false);
     }
@@ -553,7 +553,7 @@ void LLFloaterRegionInfo::processRegionInfo(LLMessageSystem* msg)
     panel->getChild<LLUICtrl>("terrain_raise_spin")->setValue(region_info.mTerrainRaiseLimit);
     panel->getChild<LLUICtrl>("terrain_lower_spin")->setValue(region_info.mTerrainLowerLimit);
 
-    panel->setCtrlsEnabled(allow_modify);
+    panel->setAllChildrenEnabled(allow_modify, true);
 
     if (floater->getVisible())
     {
@@ -668,7 +668,7 @@ void LLFloaterRegionInfo::disableTabCtrls()
 
     tab->getChild<LLPanel>("General")->setCtrlsEnabled(false);
     tab->getChild<LLPanel>("Debug")->setCtrlsEnabled(false);
-    tab->getChild<LLPanel>("Terrain")->setCtrlsEnabled(false);
+    tab->getChild<LLPanel>("Terrain")->setAllChildrenEnabled(false, true);
     tab->getChild<LLPanel>("panel_env_info")->setCtrlsEnabled(false);
     tab->getChild<LLPanel>("Estate")->setCtrlsEnabled(false);
     tab->getChild<LLPanel>("Access")->setCtrlsEnabled(false);
@@ -1657,7 +1657,7 @@ bool LLPanelRegionTerrainInfo::refreshFromRegion(LLViewerRegion* region)
                         || (region && (region->getOwner() == gAgent.getID()));
     bool owner_or_god_or_manager = owner_or_god
                         || (region && region->isEstateManager());
-    setCtrlsEnabled(owner_or_god_or_manager);
+    setAllChildrenEnabled(owner_or_god_or_manager, true);
 
     getChildView("apply_btn")->setEnabled(false);
 

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2495,11 +2495,11 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
             if (features.has("PBRTerrainTransformsEnabled"))
             {
                 bool enabled = features["PBRTerrainTransformsEnabled"];
-                gSavedSettings.setBOOL("RenderTerrainTransformsPBREnabled", enabled);
+                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", enabled);
             }
             else
             {
-                gSavedSettings.setBOOL("RenderTerrainTransformsPBREnabled", false);
+                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", false);
             }
         };
 

--- a/indra/newview/llvlcomposition.cpp
+++ b/indra/newview/llvlcomposition.cpp
@@ -127,12 +127,12 @@ void LLTerrainMaterials::apply(const LLModifyRegion& other)
 
 bool LLTerrainMaterials::generateMaterials()
 {
-    if (texturesReady(true, true))
+    if (makeTexturesReady(true, true))
     {
         return true;
     }
 
-    if (materialsReady(true, true))
+    if (makeMaterialsReady(true, true))
     {
         return true;
     }
@@ -220,17 +220,17 @@ LLTerrainMaterials::Type LLTerrainMaterials::getMaterialType()
 {
     LL_PROFILE_ZONE_SCOPED;
 
-    const bool use_textures = texturesReady(false, false) || !materialsReady(false, false);
+    const bool use_textures = makeTexturesReady(false, false) || !makeMaterialsReady(false, false);
     return use_textures ? Type::TEXTURE : Type::PBR;
 }
 
-bool LLTerrainMaterials::texturesReady(bool boost, bool strict)
+bool LLTerrainMaterials::makeTexturesReady(bool boost, bool strict)
 {
     bool ready[ASSET_COUNT];
-    // *NOTE: Calls to textureReady may boost textures. Do not early-return.
+    // *NOTE: Calls to makeTextureReady may boost textures. Do not early-return.
     for (S32 i = 0; i < ASSET_COUNT; i++)
     {
-        ready[i] = mDetailTextures[i].notNull() && textureReady(mDetailTextures[i], boost);
+        ready[i] = mDetailTextures[i].notNull() && makeTextureReady(mDetailTextures[i], boost);
     }
 
     bool one_ready = false;
@@ -251,7 +251,7 @@ namespace
     bool material_asset_ready(LLFetchedGLTFMaterial* mat) { return mat && mat->isLoaded(); }
 };
 
-bool LLTerrainMaterials::materialsReady(bool boost, bool strict)
+bool LLTerrainMaterials::makeMaterialsReady(bool boost, bool strict)
 {
     bool ready[ASSET_COUNT];
     // *NOTE: This section may boost materials/textures. Do not early-return if ready[i] is false.
@@ -315,7 +315,7 @@ bool LLTerrainMaterials::materialsReady(bool boost, bool strict)
 // Boost the texture loading priority
 // Return true when ready to use (i.e. texture is sufficiently loaded)
 // static
-bool LLTerrainMaterials::textureReady(LLPointer<LLViewerFetchedTexture>& tex, bool boost)
+bool LLTerrainMaterials::makeTextureReady(LLPointer<LLViewerFetchedTexture>& tex, bool boost)
 {
     llassert(tex);
     if (!tex) { return false; }
@@ -377,17 +377,17 @@ bool LLTerrainMaterials::materialTexturesReady(LLPointer<LLFetchedGLTFMaterial>&
         mat->mEmissiveTexture          = fetch_terrain_texture(mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE]);
     }
 
-    // *NOTE: Calls to textureReady may boost textures. Do not early-return.
+    // *NOTE: Calls to makeTextureReady may boost textures. Do not early-return.
     bool ready[LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT];
     ready[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR] =
-        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR].isNull() || textureReady(mat->mBaseColorTexture, boost);
+        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR].isNull() || makeTextureReady(mat->mBaseColorTexture, boost);
     ready[LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL] =
-        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL].isNull() || textureReady(mat->mNormalTexture, boost);
+        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL].isNull() || makeTextureReady(mat->mNormalTexture, boost);
     ready[LLGLTFMaterial::GLTF_TEXTURE_INFO_METALLIC_ROUGHNESS] =
         mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_METALLIC_ROUGHNESS].isNull() ||
-        textureReady(mat->mMetallicRoughnessTexture, boost);
+        makeTextureReady(mat->mMetallicRoughnessTexture, boost);
     ready[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE] =
-        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE].isNull() || textureReady(mat->mEmissiveTexture, boost);
+        mat->mTextureId[LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE].isNull() || makeTextureReady(mat->mEmissiveTexture, boost);
 
     if (strict)
     {
@@ -406,7 +406,7 @@ bool LLTerrainMaterials::materialTexturesReady(LLPointer<LLFetchedGLTFMaterial>&
 // Boost the loading priority of every known texture in the material
 // Return true when ready to use
 // static
-bool LLTerrainMaterials::materialReady(LLPointer<LLFetchedGLTFMaterial> &mat, bool &textures_set, bool boost, bool strict)
+bool LLTerrainMaterials::makeMaterialReady(LLPointer<LLFetchedGLTFMaterial> &mat, bool &textures_set, bool boost, bool strict)
 {
     if (!material_asset_ready(mat)) { return false; }
 
@@ -694,11 +694,11 @@ bool LLVLComposition::generateMinimapTileLand(const F32 x, const F32 y,
     const bool use_textures = getMaterialType() != LLTerrainMaterials::Type::PBR;
     if (use_textures)
     {
-        if (!texturesReady(true, true)) { return false; }
+        if (!makeTexturesReady(true, true)) { return false; }
     }
     else
     {
-        if (!materialsReady(true, true)) { return false; }
+        if (!makeMaterialsReady(true, true)) { return false; }
     }
 
     for (S32 i = 0; i < ASSET_COUNT; i++)

--- a/indra/newview/llvlcomposition.h
+++ b/indra/newview/llvlcomposition.h
@@ -74,18 +74,18 @@ public:
     const LLGLTFMaterial* getMaterialOverride(S32 asset) const override;
     virtual void setMaterialOverride(S32 asset, LLGLTFMaterial* mat_override);
     Type getMaterialType();
-    bool texturesReady(bool boost, bool strict);
+    bool makeTexturesReady(bool boost, bool strict);
     // strict = true -> all materials must be sufficiently loaded
     // strict = false -> at least one material must be loaded
-    bool materialsReady(bool boost, bool strict);
+    bool makeMaterialsReady(bool boost, bool strict);
 
 protected:
     void unboost();
-    static bool textureReady(LLPointer<LLViewerFetchedTexture>& tex, bool boost);
+    static bool makeTextureReady(LLPointer<LLViewerFetchedTexture>& tex, bool boost);
     // strict = true -> all materials must be sufficiently loaded
     // strict = false -> at least one material must be loaded
-    static bool materialReady(LLPointer<LLFetchedGLTFMaterial>& mat, bool& textures_set, bool boost, bool strict);
-    // *NOTE: Prefer calling materialReady if mat is known to be LLFetchedGLTFMaterial
+    static bool makeMaterialReady(LLPointer<LLFetchedGLTFMaterial>& mat, bool& textures_set, bool boost, bool strict);
+    // *NOTE: Prefer calling makeMaterialReady if mat is known to be LLFetchedGLTFMaterial
     static bool materialTexturesReady(LLPointer<LLFetchedGLTFMaterial>& mat, bool& textures_set, bool boost, bool strict);
 
     LLPointer<LLViewerFetchedTexture> mDetailTextures[ASSET_COUNT];


### PR DESCRIPTION
## Test plan

Please see https://github.com/secondlife/viewer/pull/1667