### PR TITLE
#1207 EEP: Water settings only displaying one decimal place

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_settings_water.xml
+++ b/indra/newview/skins/default/xui/en/panel_settings_water.xml
@@ -247,7 +247,7 @@
                         Reflection Wavelet Scale
                     </text>
                     <slider
-                            decimal_digits="1"
+                            decimal_digits="2"
                             follows="left|top"
                             increment="0.01"
                             height="16"
@@ -261,7 +261,7 @@
                             width="150"
                             can_edit_text="true"/>
                     <slider
-                            decimal_digits="1"
+                            decimal_digits="2"
                             follows="left|top"
                             increment="0.01"
                             initial_value="0.7"
@@ -274,7 +274,7 @@
                             width="150"
                             can_edit_text="true"/>
                     <slider
-                            decimal_digits="1"
+                            decimal_digits="2"
                             follows="left|top"
                             increment="0.01"
                             initial_value="0.7"


### PR DESCRIPTION
The "Density Exponent" slider shows 2 decimal digits:
![image](https://github.com/secondlife/viewer/assets/124201357/753c2adc-6759-474a-b5d1-ec4ab8a5824e)

Three "Reflection Wavelet Scale" sliders are being fixed by this change:
![image](https://github.com/secondlife/viewer/assets/124201357/9500701e-cf41-4b92-b563-81adad96f8fd)
