### PR TITLE
viewer#1772 Teleport History landing going higher and higher

### DIFF
--- a/indra/newview/llteleporthistorystorage.cpp
+++ b/indra/newview/llteleporthistorystorage.cpp
@@ -127,6 +127,12 @@ void LLTeleportHistoryStorage::addItem(const std::string title, const LLVector3d
     S32 removed_index = -1;
     if (item_iter != mItems.end())
     {
+        // When teleporting via history it's possible that there can be
+        // an offset applied to the position, so each new teleport can
+        // be a meter higher than the last.
+        // Avoid it by preserving original position.
+        item.mGlobalPos = item_iter->mGlobalPos;
+
         removed_index = item_iter - mItems.begin();
         mItems.erase(item_iter);
     }


### PR DESCRIPTION
Preserving last position shouldn't have any negative effects, at least can't think of any. So for now decided to avoid any 'was from history' special cases and keep things simple and uniform.