### PR TITLE
[WebRTC] Fix crash issue when echo cancellation is enabled/disabled.

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -1760,18 +1760,6 @@
       </map>
       <key>mikktspace</key>
       <map>
-        <key>canonical_repo</key>
-        <string>https://bitbucket.org/lindenlab/3p-mikktspace</string>
-        <key>copyright</key>
-        <string>Copyright (C) 2011 by Morten S. Mikkelsen, Copyright (C) 2022 Blender Authors</string>
-        <key>description</key>
-        <string>Mikktspace Tangent Generator</string>
-        <key>license</key>
-        <string>Apache 2.0</string>
-        <key>license_file</key>
-        <string>mikktspace.txt</string>
-        <key>name</key>
-        <string>mikktspace</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1817,8 +1805,20 @@
             <string>windows64</string>
           </map>
         </map>
+        <key>license</key>
+        <string>Apache 2.0</string>
+        <key>license_file</key>
+        <string>mikktspace.txt</string>
+        <key>copyright</key>
+        <string>Copyright (C) 2011 by Morten S. Mikkelsen, Copyright (C) 2022 Blender Authors</string>
         <key>version</key>
         <string>1</string>
+        <key>name</key>
+        <string>mikktspace</string>
+        <key>canonical_repo</key>
+        <string>https://bitbucket.org/lindenlab/3p-mikktspace</string>
+        <key>description</key>
+        <string>Mikktspace Tangent Generator</string>
       </map>
       <key>minizip-ng</key>
       <map>
@@ -2731,6 +2731,8 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <string>LICENSE</string>
         <key>copyright</key>
         <string>Copyright (c) 2000-2012, Linden Research, Inc.</string>
+        <key>version</key>
+        <string>3.0-f14b5ec</string>
         <key>name</key>
         <string>viewer-manager</string>
         <key>description</key>
@@ -2739,8 +2741,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <string>https://bitbucket.org/lindenlab/vmp-standalone</string>
         <key>source_type</key>
         <string>hg</string>
-        <key>version</key>
-        <string>3.0-f14b5ec</string>
       </map>
       <key>vlc-bin</key>
       <map>
@@ -2910,14 +2910,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
           <map>
             <key>archive</key>
             <map>
-              <key>creds</key>
-              <string>github</string>
               <key>hash</key>
-              <string>e89de3c1352589be64fd838f9b4c06927a139db3</string>
+              <string>0a0a972036f2b2c9c97dead40c91f7443b8ab339</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.59-debug/webrtc-m114.5735.08.59-debug.8823062977-darwin64-8823062977.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.61-debug/webrtc-m114.5735.08.61-debug.9571929057-darwin64-9571929057.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2927,11 +2925,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>b19afcf0dc6775c27f2d2e18f558f39180d04144</string>
+              <string>8725ad23f33d946bd5a4e5f28e8c8324925c71a7</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.59-debug/webrtc-m114.5735.08.59-debug.8823062977-linux64-8823062977.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.61-debug/webrtc-m114.5735.08.61-debug.9571929057-linux64-9571929057.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2940,14 +2938,12 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
           <map>
             <key>archive</key>
             <map>
-              <key>creds</key>
-              <string>github</string>
               <key>hash</key>
-              <string>abbd27bdbeec9b8c01ab7c176bee7bacbf7252f5</string>
+              <string>db560661807db276a3c7d1e7d9531198c9268f68</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.59-debug/webrtc-m114.5735.08.59-debug.8823062977-windows64-8823062977.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.61-debug/webrtc-m114.5735.08.61-debug.9571929057-windows64-9571929057.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2960,7 +2956,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.59-debug.8823062977</string>
+        <string>m114.5735.08.61-debug.9571929057</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/newview/skins/default/xui/en/panel_preferences_sound.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_sound.xml
@@ -508,7 +508,6 @@
   </text>
   <combo_box
       control_name="VoiceNoiseSuppressionLevel"
-      enabled_control="AudioStreamingMedia"
       layout="topleft"
       height="23"
       left_pad="10"


### PR DESCRIPTION
New webrtc library fixes an assert in webrtc when echo cancellation is enabled or disabled.

Also, fix an issue where disabling media grays out noise cancellation.