### PR TITLE
viewer-private#247 Retry loading missing textures for model upload

### DIFF
--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -533,7 +533,7 @@ public:
     // Inherited from LLCore::HttpHandler
     virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * response);
 
-        LLViewerFetchedTexture* FindViewerTexture(const LLImportMaterial& material);
+    static LLViewerFetchedTexture* FindViewerTexture(const LLImportMaterial& material);
 
 private:
     LLHandle<LLWholeModelFeeObserver> mFeeObserverHandle;


### PR DESCRIPTION
in case user provided a texture later, after seeing a 'missing texture' error.