### PR TITLE
Fix texture fetch request getting canceled if request counter flips over

### DIFF
--- a/indra/llimage/llimageworker.h
+++ b/indra/llimage/llimageworker.h
@@ -30,6 +30,7 @@
 #include "llimage.h"
 #include "llpointer.h"
 #include "threadpool_fwd.h"
+#include <optional>
 
 class LLImageDecodeThread
 {
@@ -48,12 +49,11 @@ public:
 
     // meant to resemble LLQueuedThread::handle_t
     typedef U32 handle_t;
-    handle_t decodeImage(const LLPointer<LLImageFormatted>& image,
-                         S32 discard, bool needs_aux,
-                         const LLPointer<Responder>& responder);
+    std::optional<handle_t> decodeImage(const LLPointer<LLImageFormatted>& image,
+                                        S32 discard, bool needs_aux,
+                                        const LLPointer<Responder>& responder);
     size_t getPending();
     size_t update(F32 max_time_ms);
-    S32 getTotalDecodeCount() { return mDecodeCount; }
     void shutdown();
 
 private:
@@ -61,7 +61,7 @@ private:
     // LLQueuedThread - instead this is the API by which we submit work to the
     // "ImageDecode" ThreadPool.
     std::unique_ptr<LL::ThreadPool> mThreadPool;
-    LLAtomicU32 mDecodeCount;
+    LLAtomicU32 mDecodeHandle;
 };
 
 #endif

--- a/indra/llimage/tests/llimageworker_test.cpp
+++ b/indra/llimage/tests/llimageworker_test.cpp
@@ -151,7 +151,7 @@ namespace tut
         ensure("LLImageDecodeThread: threaded constructor failed", mThread != NULL);
         // Insert something in the queue
         bool done = false;
-        LLImageDecodeThread::handle_t decodeHandle = mThread->decodeImage(NULL, 0, false, new responder_test(&done));
+        auto decodeHandle = mThread->decodeImage(NULL, 0, false, new responder_test(&done));
         // Verifies we get back a valid handle
         ensure("LLImageDecodeThread:  threaded decodeImage(), returned handle is null", decodeHandle != 0);
         // Wait till the thread has time to handle the work order (though it doesn't do much per work order...)

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -1806,11 +1806,15 @@ bool LLTextureFetchWorker::doWork(S32 param)
         // In case worked manages to request decode, be shut down,
         // then init and request decode again with first decode
         // still in progress, assign a sufficiently unique id
-        mDecodeHandle = LLAppViewer::getImageDecodeThread()->decodeImage(mFormattedImage,
+        auto handle = LLAppViewer::getImageDecodeThread()->decodeImage(mFormattedImage,
                                                                        discard,
                                                                        mNeedsAux,
                                                                        new DecodeResponder(mFetcher, mID, this));
-        if (mDecodeHandle == 0)
+        if (handle.has_value())
+        {
+            mDecodeHandle = handle.value();
+        }
+        else
         {
             // Abort, failed to put into queue.
             // Happens if viewer is shutting down


### PR DESCRIPTION
Once request counter reaches U32_MAX and flips over to 0, the request being unlucky and getting request ID 0 gets canceled - poor request 😄 