### PR TITLE
Fix texture fetch request getting canceled if request counter flips over

### DIFF
--- a/indra/llimage/llimageworker.cpp
+++ b/indra/llimage/llimageworker.cpp
@@ -97,6 +97,9 @@ LLImageDecodeThread::handle_t LLImageDecodeThread::decodeImage(
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
 
     U32 decode_id = ++mDecodeCount;
+    if (decode_id == 0)
+        decode_id = ++mDecodeCount;
+
     // Instantiate the ImageRequest right in the lambda, why not?
     bool posted = mThreadPool->getQueue().post(
         [req = ImageRequest(image, discard, needs_aux, responder, decode_id)]


### PR DESCRIPTION
Correct and easier fix this time: If mDecodeCount reaches U32_MAX and flips over to 0, ask for a new request ID, because 0 means the request couldn't be posted to the thread queue