### PR TITLE
[WebRTC] Remove voice morphing UI

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -13043,7 +13043,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>1</integer>
+      <integer>0</integer>
     </map>
     <key>AutoDisengageMic</key>
     <map>

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -9342,15 +9342,6 @@ class LLUpdateMembershipLabel : public view_listener_t
     }
 };
 
-void handle_voice_morphing_subscribe()
-{
-    LLWeb::loadURL(LLTrans::getString("voice_morphing_url"));
-}
-
-void handle_premium_voice_morphing_subscribe()
-{
-    LLWeb::loadURL(LLTrans::getString("premium_voice_morphing_url"));
-}
 
 class LLToggleUIHints : public view_listener_t
 {
@@ -9550,16 +9541,6 @@ void initialize_menus()
 
     //Communicate Nearby chat
     view_listener_t::addMenu(new LLCommunicateNearbyChat(), "Communicate.NearbyChat");
-
-    // Communicate > Voice morphing > Subscribe...
-    commit.add("Communicate.VoiceMorphing.Subscribe", boost::bind(&handle_voice_morphing_subscribe));
-    // Communicate > Voice morphing > Premium perk...
-    commit.add("Communicate.VoiceMorphing.PremiumPerk", boost::bind(&handle_premium_voice_morphing_subscribe));
-    LLVivoxVoiceClient * voice_clientp = LLVivoxVoiceClient::getInstance();
-    enable.add("Communicate.VoiceMorphing.NoVoiceMorphing.Check"
-        , boost::bind(&LLVivoxVoiceClient::onCheckVoiceEffect, voice_clientp, "NoVoiceMorphing"));
-    commit.add("Communicate.VoiceMorphing.NoVoiceMorphing.Click"
-        , boost::bind(&LLVivoxVoiceClient::onClickVoiceEffect, voice_clientp, "NoVoiceMorphing"));
 
     // World menu
     view_listener_t::addMenu(new LLWorldAlwaysRun(), "World.AlwaysRun");

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -137,8 +137,9 @@ LLVoiceClient::LLVoiceClient(LLPumpIO *pump)
     mSpatialVoiceModule(NULL),
     mNonSpatialVoiceModule(NULL),
     m_servicePump(NULL),
-    mVoiceEffectEnabled(LLCachedControl<bool>(gSavedSettings, "VoiceMorphingEnabled", true)),
+    mVoiceEffectEnabled(LLCachedControl<bool>(gSavedSettings, "VoiceMorphingEnabled", false)),
     mVoiceEffectDefault(LLCachedControl<std::string>(gSavedPerAccountSettings, "VoiceEffectDefault", "00000000-0000-0000-0000-000000000000")),
+    mVoiceEffectSupportNotified(false),
     mPTTDirty(true),
     mPTT(true),
     mUsePTT(true),
@@ -569,11 +570,37 @@ void LLVoiceClient::setMicGain(F32 gain)
 //------------------------------------------
 // enable/disable voice features
 
+// static
+bool LLVoiceClient::onVoiceEffectsNotSupported(const LLSD &notification, const LLSD &response)
+{
+    S32 option = LLNotificationsUtil::getSelectedOption(notification, response);
+    switch (option)
+    {
+        case 0:  // "Okay"
+            gSavedSettings.setBOOL("VoiceMorphingEnabled", FALSE);
+            break;
+
+        case 1:  // "Cancel"
+            break;
+
+        default:
+            llassert(0);
+            break;
+    }
+    return false;
+}
+
 bool LLVoiceClient::voiceEnabled()
 {
     static LLCachedControl<bool> enable_voice_chat(gSavedSettings, "EnableVoiceChat");
     static LLCachedControl<bool> cmd_line_disable_voice(gSavedSettings, "CmdLineDisableVoice");
-    return enable_voice_chat && !cmd_line_disable_voice && !gNonInteractive;
+    bool enabled = enable_voice_chat && !cmd_line_disable_voice && !gNonInteractive;
+    if (enabled && !mVoiceEffectSupportNotified && getVoiceEffectEnabled() && !getVoiceEffectDefault().isNull())
+    {
+        LLNotificationsUtil::add("VoiceEffectsNotSupported", LLSD(), LLSD(), &LLVoiceClient::onVoiceEffectsNotSupported);
+        mVoiceEffectSupportNotified = true;
+    }
+    return enabled;
 }
 
 void LLVoiceClient::setVoiceEnabled(bool enabled)
@@ -812,7 +839,7 @@ std::string LLVoiceClient::sipURIFromID(const LLUUID &id)
 
 LLVoiceEffectInterface* LLVoiceClient::getVoiceEffectInterface() const
 {
-    return getVoiceEffectEnabled() ? dynamic_cast<LLVoiceEffectInterface*>(mSpatialVoiceModule) : NULL;
+    return NULL;
 }
 
 ///////////////////

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -508,6 +508,8 @@ public:
 
 protected:
 
+    static bool onVoiceEffectsNotSupported(const LLSD &notification, const LLSD &response);
+
     LLVoiceModuleInterface* mSpatialVoiceModule;
     LLVoiceModuleInterface* mNonSpatialVoiceModule;
     LLSD                    mSpatialCredentials;  // used to store spatial credentials for vivox
@@ -519,6 +521,7 @@ protected:
 
     LLCachedControl<bool> mVoiceEffectEnabled;
     LLCachedControl<std::string> mVoiceEffectDefault;
+    bool        mVoiceEffectSupportNotified;
 
     bool        mPTTDirty;
     bool        mPTT;

--- a/indra/newview/skins/default/xui/de/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/de/menu_viewer.xml
@@ -42,12 +42,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Voice-Morphing" name="VoiceMorphing">
-			<menu_item_check label="Kein Voice-Morphing" name="NoVoiceMorphing"/>
-			<menu_item_check label="Vorschau..." name="Preview"/>
-			<menu_item_call label="Abonnieren..." name="Subscribe"/>
-			<menu_item_call label="Premium-Vorteil..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Gesten..." name="Gestures"/>
 		<menu_item_check label="Freunde" name="My Friends"/>
 		<menu_item_check label="Gruppen" name="My Groups"/>

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -561,42 +561,6 @@
              parameter="conversation" />
         </menu_item_check>
         <menu_item_separator/>
-        <menu
-         label="Voice morphing"
-         name="VoiceMorphing"
-         visibility_control="VoiceMorphingEnabled">
-            <menu_item_check
-             label="No voice morphing"
-             name="NoVoiceMorphing">
-                <menu_item_check.on_check
-                 function="Communicate.VoiceMorphing.NoVoiceMorphing.Check" />
-                <menu_item_check.on_click
-                 function="Communicate.VoiceMorphing.NoVoiceMorphing.Click" />
-            </menu_item_check>
-            <menu_item_separator/>
-            <menu_item_check
-             label="Preview..."
-             name="Preview">
-                <menu_item_check.on_check
-                 function="Floater.Visible"
-                 parameter="voice_effect" />
-                <menu_item_check.on_click
-                 function="Floater.Toggle"
-                 parameter="voice_effect" />
-            </menu_item_check>
-            <menu_item_call
-             label="Subscribe..."
-             name="Subscribe">
-                <menu_item_call.on_click
-                 function="Communicate.VoiceMorphing.Subscribe" />
-            </menu_item_call>
-            <menu_item_call
-             label="Premium perk..."
-             name="PremiumPerk">
-                <menu_item_call.on_click
-                 function="Communicate.VoiceMorphing.PremiumPerk" />
-            </menu_item_call>
-        </menu>
         <menu_item_check
          label="Gestures..."
          name="Gestures"

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -8831,6 +8831,20 @@ New Voice Morphs are available!
   </notification>
 
   <notification
+    icon="alertmodal.tga"
+    name="VoiceEffectsNotSupported"
+    sound="UISndAlert"
+    persist="true"
+    type="alertmodal">
+Voice Morphs are not supported by this viewer.
+    <usetemplate
+        notext="Cancel"
+        name="okcancelbuttons"
+        yestext="Disable Voice Morphing"/>
+    <tag>voice</tag>
+  </notification>
+
+  <notification
    icon="notifytip.tga"
    name="Cannot enter parcel: not a group member"
    type="notifytip">

--- a/indra/newview/skins/default/xui/es/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/es/menu_viewer.xml
@@ -42,12 +42,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Transformación de voz" name="VoiceMorphing">
-			<menu_item_check label="Sin transformación de voz" name="NoVoiceMorphing"/>
-			<menu_item_check label="Probar..." name="Preview"/>
-			<menu_item_call label="Suscribir..." name="Subscribe"/>
-			<menu_item_call label="Ventaja Premium..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Gestos..." name="Gestures"/>
 		<menu_item_check label="Amigos" name="My Friends"/>
 		<menu_item_check label="Grupos" name="My Groups"/>

--- a/indra/newview/skins/default/xui/it/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/it/menu_viewer.xml
@@ -42,12 +42,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Manipolazione voce" name="VoiceMorphing">
-			<menu_item_check label="Nessuna manipolazione voce" name="NoVoiceMorphing"/>
-			<menu_item_check label="Anteprima..." name="Preview"/>
-			<menu_item_call label="Abbonati..." name="Subscribe"/>
-			<menu_item_call label="Vantaggio Premium..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Gesture..." name="Gestures"/>
 		<menu_item_check label="Amici" name="My Friends"/>
 		<menu_item_check label="Gruppi" name="My Groups"/>

--- a/indra/newview/skins/default/xui/ja/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/ja/menu_viewer.xml
@@ -74,7 +74,6 @@
 		<menu_item_check label="ボイスチャット" name="Speak"/>
 		<menu_item_check name="Conversation Log..." label="会話ログ…"/>
 		<menu_item_separator/>
-		<menu label="ボイスモーフィング" name="VoiceMorphing"/>
 		<menu_item_check label="ジェスチャー…" name="Gestures"/>
 		<menu_item_separator/>
 		<menu_item_check label="フレンド" name="My Friends"/>

--- a/indra/newview/skins/default/xui/pl/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/pl/menu_viewer.xml
@@ -35,11 +35,6 @@
 		<menu_item_check label="Czat lokalny..." name="Nearby Chat" />
 		<menu_item_check label="Mowa" name="Speak" />
 		<menu_item_check name="Conversation Log..." label="Dziennik rozmów..." />
-		<menu label="Przekształcanie głosu" name="VoiceMorphing">
-			<menu_item_check label="Bez przekształcania" name="NoVoiceMorphing" />
-			<menu_item_check label="Podgląd..." name="Preview" />
-			<menu_item_call label="Subskrybuj..." name="Subscribe" />
-		</menu>
 		<menu_item_check label="Gesty..." name="Gestures" />
 		<menu_item_check label="Znajomi" name="My Friends" />
 		<menu_item_check label="Grupy" name="My Groups" />

--- a/indra/newview/skins/default/xui/pt/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/pt/menu_viewer.xml
@@ -42,12 +42,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Distorção de voz" name="VoiceMorphing">
-			<menu_item_check label="Não distorcer voz" name="NoVoiceMorphing"/>
-			<menu_item_check label="Visualizar..." name="Preview"/>
-			<menu_item_call label="Assinar..." name="Subscribe"/>
-			<menu_item_call label="Benefício Premium..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Gestos..." name="Gestures"/>
 		<menu_item_check label="Amigos" name="My Friends"/>
 		<menu_item_check label="Grupos" name="My Groups"/>

--- a/indra/newview/skins/default/xui/ru/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/ru/menu_viewer.xml
@@ -40,12 +40,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Изменение голоса" name="VoiceMorphing">
-			<menu_item_check label="Без изменения голоса" name="NoVoiceMorphing"/>
-			<menu_item_check label="Просмотр..." name="Preview"/>
-			<menu_item_call label="Подписаться..." name="Subscribe"/>
-			<menu_item_call label="Премиум-бонус..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Жесты..." name="Gestures"/>
 		<menu_item_check label="Друзья" name="My Friends"/>
 		<menu_item_check label="Группы" name="My Groups"/>

--- a/indra/newview/skins/default/xui/tr/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/tr/menu_viewer.xml
@@ -40,12 +40,6 @@
 		<menu_item_call label="Facebook..." name="Facebook"/>
 		<menu_item_call label="Twitter..." name="Twitter"/>
 		<menu_item_call label="Flickr..." name="Flickr"/>
-		<menu label="Ses şekillendirme" name="VoiceMorphing">
-			<menu_item_check label="Ses şekillendirme yok" name="NoVoiceMorphing"/>
-			<menu_item_check label="Önizleme..." name="Preview"/>
-			<menu_item_call label="Abone ol..." name="Subscribe"/>
-			<menu_item_call label="Özel üye avantajı..." name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="Mimikler..." name="Gestures"/>
 		<menu_item_check label="Arkadaşlar" name="My Friends"/>
 		<menu_item_check label="Gruplar" name="My Groups"/>

--- a/indra/newview/skins/default/xui/zh/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/zh/menu_viewer.xml
@@ -40,12 +40,6 @@
 		<menu_item_call label="臉書…" name="Facebook"/>
 		<menu_item_call label="推特…" name="Twitter"/>
 		<menu_item_call label="Flickr…" name="Flickr"/>
-		<menu label="語音變聲" name="VoiceMorphing">
-			<menu_item_check label="沒有變聲效果" name="NoVoiceMorphing"/>
-			<menu_item_check label="預覽……" name="Preview"/>
-			<menu_item_call label="訂閱……" name="Subscribe"/>
-			<menu_item_call label="付費會員獨享…" name="PremiumPerk"/>
-		</menu>
 		<menu_item_check label="姿勢…" name="Gestures"/>
 		<menu_item_check label="朋友" name="My Friends"/>
 		<menu_item_check label="群組" name="My Groups"/>


### PR DESCRIPTION
Issue #1451 

* Remove voice morphing UI.
* Throw up a warning when voice morphs are enabled.

QA:
* Install and run the viewer with this feature.
* Log in to a vivox region without voice morphing enabled.  Verify no voice-morphing dialogues comes up.
* Disable and re-enable voice.  Verify no voice-morphing dialogues comes up.
* Validate the "communicate->voice morphing" menu item is not present.
* Exit.
* Run the release viewer on the same account.
* Install a voice morph the normal way.
* validate it works on a vivox region.
* Exit.
* Run the WebRTC viewer with this feature.
* Log in to a vivox region.
* Verify a dialog comes up indicating voice morphing does not work with the viewer.
* click cancel.
* disable and re-enable voice.
* Verify the dialog does not come up.
* exit and log in to a vivox region with the release viewer.
* verify voice morphing is still enabled, and works.
* Verify the dialogue does come up.
* click the button to disable voice morphing.
* disable and enable voice.
* verify the dialog does not come up.
* exit and login to a vivox region with the new viewer.
* verify the dialogue does not come up.
* Exit and login with the release viewer on a vivox region.
* verify voice morphing is disable and you don't hear yourself morphed.

