### PR TITLE
#1831 Fix for redundantly rebuilding bounding boxes forever

### DIFF
--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -3676,7 +3676,7 @@ bool LLViewerObject::updateLOD()
 
 bool LLViewerObject::updateGeometry(LLDrawable *drawable)
 {
-    return false;
+    return true;
 }
 
 void LLViewerObject::updateGL()

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -2039,6 +2039,7 @@ bool LLVOVolume::updateGeometry(LLDrawable *drawable)
 
     if (mDrawable->isState(LLDrawable::REBUILD_RIGGED))
     {
+        LL_PROFILE_ZONE_NAMED_CATEGORY_VOLUME("rebuild rigged");
         updateRiggedVolume(false);
         genBBoxes(false);
         mDrawable->clearState(LLDrawable::REBUILD_RIGGED);


### PR DESCRIPTION
This might break other things, so we'll need a full regression test to be sure, but this change doubles my FPS in some scenes.  Returning false from updateGeometry tells pipeline  to try  again on the next frame.  The default case should be true, as all the subclasses return the default case as defined in LLViewerObject