### PR TITLE
[WebRTC] control microphone gain via custom audio processor.

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -35,6 +35,7 @@
 #include "api/media_stream_interface.h"
 #include "api/media_stream_track.h"
 #include "modules/audio_processing/audio_buffer.h"
+#include "modules/audio_mixer/audio_mixer_impl.h"
 
 namespace llwebrtc
 {
@@ -88,7 +89,7 @@ void LLAudioDeviceObserver::OnRenderData(const void    *audio_samples,
 {
 }
 
-LLCustomProcessor::LLCustomProcessor() : mSampleRateHz(0), mNumChannels(0), mMicrophoneEnergy(0.0)
+LLCustomProcessor::LLCustomProcessor() : mSampleRateHz(0), mNumChannels(0), mMicrophoneEnergy(0.0), mGain(1.0)
 {
     memset(mSumVector, 0, sizeof(mSumVector));
 }
@@ -128,8 +129,12 @@ void LLCustomProcessor::Process(webrtc::AudioBuffer *audio_in)
     for (size_t index = 0; index < stream_config.num_samples(); index++)
     {
         float sample = frame_samples[index];
+        sample       = sample * mGain; // apply gain
+        frame_samples[index] = sample; // write processed sample back to buffer.
         energy += sample * sample;
     }
+
+    audio_in->CopyFrom(&frame[0], stream_config);
 
     // smooth it.
     size_t buffer_size = sizeof(mSumVector) / sizeof(mSumVector[0]);
@@ -236,9 +241,9 @@ void LLWebRTCImpl::init()
     webrtc::AudioProcessing::Config apm_config;
     apm_config.echo_canceller.enabled         = false;
     apm_config.echo_canceller.mobile_mode     = false;
-    apm_config.gain_controller1.enabled       = true;
+    apm_config.gain_controller1.enabled       = false;
     apm_config.gain_controller1.mode          = webrtc::AudioProcessing::Config::GainController1::kAdaptiveAnalog;
-    apm_config.gain_controller2.enabled       = true;
+    apm_config.gain_controller2.enabled       = false;
     apm_config.high_pass_filter.enabled       = true;
     apm_config.noise_suppression.enabled      = true;
     apm_config.noise_suppression.level        = webrtc::AudioProcessing::Config::NoiseSuppression::kVeryHigh;
@@ -259,6 +264,7 @@ void LLWebRTCImpl::init()
 
     mAudioProcessingModule->ApplyConfig(apm_config);
     mAudioProcessingModule->Initialize(processing_config);
+
 
     mPeerConnectionFactory = webrtc::CreatePeerConnectionFactory(mNetworkThread.get(),
                                                                  mWorkerThread.get(),
@@ -336,9 +342,9 @@ void LLWebRTCImpl::setAudioConfig(LLWebRTCDeviceInterface::AudioConfig config)
     webrtc::AudioProcessing::Config apm_config;
     apm_config.echo_canceller.enabled         = config.mEchoCancellation;
     apm_config.echo_canceller.mobile_mode     = false;
-    apm_config.gain_controller1.enabled       = true;
+    apm_config.gain_controller1.enabled       = config.mAGC;
     apm_config.gain_controller1.mode          = webrtc::AudioProcessing::Config::GainController1::kAdaptiveAnalog;
-    apm_config.gain_controller2.enabled       = true;
+    apm_config.gain_controller2.enabled       = false;
     apm_config.high_pass_filter.enabled       = true;
     apm_config.transient_suppression.enabled  = true;
     apm_config.pipeline.multi_channel_render  = true;
@@ -611,6 +617,8 @@ void LLWebRTCImpl::setTuningMode(bool enable)
 float LLWebRTCImpl::getTuningAudioLevel() { return -20 * log10f(mTuningAudioDeviceObserver->getMicrophoneEnergy()); }
 
 float LLWebRTCImpl::getPeerConnectionAudioLevel() { return -20 * log10f(mPeerCustomProcessor->getMicrophoneEnergy()); }
+
+void LLWebRTCImpl::setPeerConnectionGain(float gain) { mPeerCustomProcessor->setGain(gain); }
 
 
 //
@@ -937,7 +945,7 @@ void LLWebRTCPeerConnectionImpl::setSendVolume(float volume)
             {
                 for (auto &track : mLocalStream->GetAudioTracks())
                 {
-                    track->GetSource()->SetVolume(volume);
+                    track->GetSource()->SetVolume(volume*5.0);
                 }
             }
         });

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -145,6 +145,7 @@ class LLWebRTCDeviceInterface
     virtual void setTuningMode(bool enable) = 0;
     virtual float getTuningAudioLevel() = 0; // for use during tuning
     virtual float getPeerConnectionAudioLevel() = 0; // for use when not tuning
+    virtual void setPeerConnectionGain(float gain) = 0;
 };
 
 // LLWebRTCAudioInterface provides the viewer with a way

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -121,6 +121,8 @@ class LLCustomProcessor : public webrtc::CustomProcessing
 
     float getMicrophoneEnergy() { return mMicrophoneEnergy; }
 
+    void setGain(float gain) { mGain = gain; }
+
   protected:
     static const int NUM_PACKETS_TO_FILTER = 30;  // 300 ms of smoothing
     int              mSampleRateHz;
@@ -128,6 +130,7 @@ class LLCustomProcessor : public webrtc::CustomProcessing
 
     float mSumVector[NUM_PACKETS_TO_FILTER];
     float mMicrophoneEnergy;
+    float mGain;
 };
 
 
@@ -159,6 +162,8 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     void setTuningMode(bool enable) override;
     float getTuningAudioLevel() override;
     float getPeerConnectionAudioLevel() override;
+
+    void setPeerConnectionGain(float gain) override;
 
     //
     // AudioDeviceSink

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -87,7 +87,7 @@ namespace {
     const F32 VOLUME_SCALE_WEBRTC = 0.01f;
     const F32 LEVEL_SCALE_WEBRTC  = 0.008f;
 
-    const F32 SPEAKING_AUDIO_LEVEL = 0.35;
+    const F32 SPEAKING_AUDIO_LEVEL = 0.30;
 
     static const std::string REPORTED_VOICE_SERVER_TYPE = "Secondlife WebRTC Gateway";
 
@@ -1484,14 +1484,10 @@ void LLWebRTCVoiceClient::setMicGain(F32 gain)
     if (gain != mMicGain)
     {
         mMicGain = gain;
-        sessionState::for_each(boost::bind(predSetMicGain, _1, gain));
+        mWebRTCDeviceInterface->setPeerConnectionGain(gain);
     }
 }
 
-void LLWebRTCVoiceClient::predSetMicGain(const LLWebRTCVoiceClient::sessionStatePtr_t &session, F32 gain)
-{
-    session->setMicGain(gain);
-}
 
 void LLWebRTCVoiceClient::setVoiceEnabled(bool enabled)
 {
@@ -1690,7 +1686,6 @@ std::map<std::string, LLWebRTCVoiceClient::sessionState::ptr_t> LLWebRTCVoiceCli
 LLWebRTCVoiceClient::sessionState::sessionState() :
     mHangupOnLastLeave(false),
     mNotifyOnFirstJoin(false),
-    mMicGain(1.0),
     mMuted(false),
     mSpeakerVolume(1.0),
     mShuttingDown(false)
@@ -1732,15 +1727,6 @@ void LLWebRTCVoiceClient::sessionState::setMuteMic(bool muted)
     for (auto &connection : mWebRTCConnections)
     {
         connection->setMuteMic(muted);
-    }
-}
-
-void LLWebRTCVoiceClient::sessionState::setMicGain(F32 gain)
-{
-    mMicGain = gain;
-    for (auto &connection : mWebRTCConnections)
-    {
-        connection->setMicGain(gain);
     }
 }
 
@@ -1848,7 +1834,6 @@ LLWebRTCVoiceClient::sessionStatePtr_t LLWebRTCVoiceClient::addSession(const std
 
         LL_DEBUGS("Voice") << "adding new session with channel: " << channel_id << LL_ENDL;
         session->setMuteMic(mMuteMic);
-        session->setMicGain(mMicGain);
         session->setSpeakerVolume(mSpeakerVolume);
 
         sessionState::addSession(channel_id, session);
@@ -1974,7 +1959,6 @@ bool LLWebRTCVoiceClient::estateSessionState::processConnectionStates()
             connectionPtr_t connection(new LLVoiceWebRTCSpatialConnection(neighbor, INVALID_PARCEL_ID, mChannelID));
 
             mWebRTCConnections.push_back(connection);
-            connection->setMicGain(mMicGain);
             connection->setMuteMic(mMuted);
             connection->setSpeakerVolume(mSpeakerVolume);
         }
@@ -2104,7 +2088,6 @@ LLVoiceWebRTCConnection::LLVoiceWebRTCConnection(const LLUUID &regionID, const s
     mShutDown(false),
     mIceCompleted(false),
     mSpeakerVolume(0.0),
-    mMicGain(0.0),
     mOutstandingRequests(0),
     mChannelID(channelID),
     mRegionID(regionID),
@@ -2364,15 +2347,6 @@ void LLVoiceWebRTCConnection::setMuteMic(bool muted)
     if (mWebRTCAudioInterface)
     {
         mWebRTCAudioInterface->setMute(muted);
-    }
-}
-
-void LLVoiceWebRTCConnection::setMicGain(F32 gain)
-{
-    mMicGain = gain;
-    if (mWebRTCAudioInterface)
-    {
-        mWebRTCAudioInterface->setSendVolume(gain);
     }
 }
 
@@ -2683,7 +2657,6 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
             // this connection.
             mWebRTCAudioInterface->setMute(mMuted);
             mWebRTCAudioInterface->setReceiveVolume(mSpeakerVolume);
-            mWebRTCAudioInterface->setSendVolume(mMicGain);
             LLWebRTCVoiceClient::getInstance()->OnConnectionEstablished(mChannelID, mRegionID);
             setVoiceConnectionState(VOICE_STATE_WAIT_FOR_DATA_CHANNEL);
             break;

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -282,7 +282,6 @@ public:
         virtual void sendData(const std::string &data);
 
         void setMuteMic(bool muted);
-        void setMicGain(F32 volume);
         void setSpeakerVolume(F32 volume);
         void setUserVolume(const LLUUID& id, F32 volume);
 
@@ -303,7 +302,6 @@ public:
         std::string mName;
 
         bool    mMuted;          // this session is muted.
-        F32     mMicGain;        // gain for this session.
         F32     mSpeakerVolume;  // volume for this session.
 
         bool        mShuttingDown;
@@ -382,7 +380,6 @@ public:
     static void predSendData(const LLWebRTCVoiceClient::sessionStatePtr_t &session, const std::string& spatial_data);
     static void predUpdateOwnVolume(const LLWebRTCVoiceClient::sessionStatePtr_t &session, F32 audio_level);
     static void predSetMuteMic(const LLWebRTCVoiceClient::sessionStatePtr_t &session, bool mute);
-    static void predSetMicGain(const LLWebRTCVoiceClient::sessionStatePtr_t &session, F32 volume);
     static void predSetSpeakerVolume(const LLWebRTCVoiceClient::sessionStatePtr_t &session, F32 volume);
     static void predShutdownSession(const LLWebRTCVoiceClient::sessionStatePtr_t &session);
     static void predSetUserMute(const LLWebRTCVoiceClient::sessionStatePtr_t &session, const LLUUID& id, bool mute);
@@ -607,7 +604,6 @@ class LLVoiceWebRTCConnection :
     void processIceUpdatesCoro();
 
     virtual void setMuteMic(bool muted);
-    virtual void setMicGain(F32 volume);
     virtual void setSpeakerVolume(F32 volume);
 
     void setUserVolume(const LLUUID& id, F32 volume);
@@ -686,7 +682,6 @@ class LLVoiceWebRTCConnection :
     std::string mRemoteChannelSDP;
 
     bool mMuted;
-    F32  mMicGain;
     F32  mSpeakerVolume;
 
     bool mShutDown;


### PR DESCRIPTION
Fix for #1828 

Previously, there were two places audio gain could be controlled:
- the device manager
- the audio track

The device manager audio gain control sets the system gain for all applications, not just the webrtc application.

The audio track gain happens well after the audio processing where we want it to happen.

So, gain control was added to the existing custom audio processor, which previously only handled calculating and retrieving the audio levels.

After these changes, the microphone gain slider does impact the audio volume heard by peers.