### PR TITLE
viewer#1821 Crash at getSessionID()

### DIFF
--- a/indra/newview/llspeakers.cpp
+++ b/indra/newview/llspeakers.cpp
@@ -288,6 +288,10 @@ LLSpeakerMgr::~LLSpeakerMgr()
 
 LLPointer<LLSpeaker> LLSpeakerMgr::setSpeaker(const LLUUID& id, const std::string& name, LLSpeaker::ESpeakerStatus status, LLSpeaker::ESpeakerType type)
 {
+    if (!mVoiceChannel)
+    {
+        return NULL;
+    }
     LLUUID session_id = getSessionID();
     if (id.isNull() || (id == session_id))
     {
@@ -490,7 +494,7 @@ void LLSpeakerMgr::updateSpeakerList()
                            (LLVoiceClient::getInstance()->isParticipantAvatar(*participant_it)?LLSpeaker::SPEAKER_AGENT:LLSpeaker::SPEAKER_EXTERNAL));
         }
     }
-    else
+    else if (mVoiceChannel)
     {
         // If not, check if the list is empty, except if it's Nearby Chat (session_id NULL).
         LLUUID session_id = getSessionID();
@@ -816,7 +820,7 @@ void LLIMSpeakerMgr::updateSpeakers(const LLSD& update)
 void LLIMSpeakerMgr::toggleAllowTextChat(const LLUUID& speaker_id)
 {
     LLPointer<LLSpeaker> speakerp = findSpeaker(speaker_id);
-    if (!speakerp) return;
+    if (!speakerp || !mVoiceChannel) return;
 
     std::string url = gAgent.getRegionCapability("ChatSessionRequest");
     LLSD data;
@@ -835,7 +839,7 @@ void LLIMSpeakerMgr::toggleAllowTextChat(const LLUUID& speaker_id)
 void LLIMSpeakerMgr::moderateVoiceParticipant(const LLUUID& avatar_id, bool unmute)
 {
     LLPointer<LLSpeaker> speakerp = findSpeaker(avatar_id);
-    if (!speakerp) return;
+    if (!speakerp || !mVoiceChannel) return;
 
     // *NOTE: mantipov: probably this condition will be incorrect when avatar will be blocked for
     // text chat via moderation (LLSpeaker::mModeratorMutedText == TRUE)


### PR DESCRIPTION
LLSpeaker was not checking whether mVoiceChannel could be null, which it can be now with the new WebRTC adhoc-based p2p mechanism.