### PR TITLE
Add LuaAutorunPath, LuaCommandPath and LuaRequirePath settings.

### DIFF
--- a/indra/llxml/tests/llcontrol_test.cpp
+++ b/indra/llxml/tests/llcontrol_test.cpp
@@ -97,7 +97,7 @@ namespace tut
     template<> template<>
     void control_group_t::test<1>()
     {
-        int results = mCG->loadFromFile(mTestConfigFile.c_str());
+        int results = mCG->loadFromFile(mTestConfigFile);
         ensure("number of settings", (results == 1));
         ensure("value of setting", (mCG->getU32("TestSetting") == 12));
     }
@@ -106,14 +106,14 @@ namespace tut
     template<> template<>
     void control_group_t::test<2>()
     {
-        int results = mCG->loadFromFile(mTestConfigFile.c_str());
+        int results = mCG->loadFromFile(mTestConfigFile);
         mCG->setU32("TestSetting", 13);
         ensure_equals("value of changed setting", mCG->getU32("TestSetting"), 13);
         LLControlGroup test_cg("foo2");
         std::string temp_test_file = (mTestConfigDir + "setting_llsd_temp.xml");
         mCleanups.push_back(temp_test_file);
         mCG->saveToFile(temp_test_file.c_str(), TRUE);
-        results = test_cg.loadFromFile(temp_test_file.c_str());
+        results = test_cg.loadFromFile(temp_test_file);
         ensure("number of changed settings loaded", (results == 1));
         ensure("value of changed settings loaded", (test_cg.getU32("TestSetting") == 13));
     }
@@ -126,7 +126,7 @@ namespace tut
         // a default settings file that declares variables, rather than a user
         // settings file. When loadFromFile() encounters an unrecognized user
         // settings variable, it forcibly preserves it (CHOP-962).
-        int results = mCG->loadFromFile(mTestConfigFile.c_str(), true);
+        int results = mCG->loadFromFile(mTestConfigFile, true);
         LLControlVariable* control = mCG->getControl("TestSetting");
         LLSD new_value = 13;
         control->setValue(new_value, FALSE);
@@ -135,7 +135,7 @@ namespace tut
         std::string temp_test_file = (mTestConfigDir + "setting_llsd_persist_temp.xml");
         mCleanups.push_back(temp_test_file);
         mCG->saveToFile(temp_test_file.c_str(), TRUE);
-        results = test_cg.loadFromFile(temp_test_file.c_str());
+        results = test_cg.loadFromFile(temp_test_file);
         //If we haven't changed any settings, then we shouldn't have any settings to load
         ensure("number of non-persisted changed settings loaded", (results == 0));
     }
@@ -144,7 +144,7 @@ namespace tut
     template<> template<>
     void control_group_t::test<4>()
     {
-        int results = mCG->loadFromFile(mTestConfigFile.c_str());
+        int results = mCG->loadFromFile(mTestConfigFile);
         ensure("number of settings", (results == 1));
         mCG->getControl("TestSetting")->getSignal()->connect(boost::bind(&this->handleListenerTest));
         mCG->setU32("TestSetting", 13);

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -346,7 +346,7 @@
       <key>Value</key>
       <real>0.5</real>
     </map>
-	<key>AudioStreamingMedia</key>
+    <key>AudioStreamingMedia</key>
     <map>
       <key>Comment</key>
       <string>Enable streaming</string>
@@ -1291,7 +1291,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-			<integer>0</integer>
+      <integer>0</integer>
     </map>
     <key>CameraPositionSmoothing</key>
     <map>
@@ -1907,17 +1907,17 @@
       <key>Value</key>
       <string />
     </map>
-	<key>DebugAvatarRezTime</key>
-	<map>
-		<key>Comment</key>
-		<string>Display times for avatars to resolve.</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    <key>DebugAvatarRezTime</key>
+    <map>
+        <key>Comment</key>
+        <string>Display times for avatars to resolve.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
   <key>DebugAvatarLocalTexLoadedTime</key>
   <map>
     <key>Comment</key>
@@ -2292,39 +2292,39 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>DefaultFemaleAvatar</key>
-	<map>
-	  <key>Comment</key>
-	  <string>Default Female Avatar</string>
-	  <key>Persist</key>
-	  <integer>1</integer>
-	  <key>Type</key>
-	  <string>String</string>
-	  <key>Value</key>
-	  <string>Female Shape &amp; Outfit</string>
-	</map>
-	<key>DefaultLoginLocation</key>
-	<map>
-		<key>Comment</key>
-		<string>Startup destination default (if not specified on command line)</string>
-		<key>Persist</key>
-		<integer>0</integer>
-		<key>Type</key>
-		<string>String</string>
-		<key>Value</key>
-		<string/>
-	</map>
-	<key>DefaultMaleAvatar</key>
-	<map>
-	  <key>Comment</key>
-	  <string>Default Male Avatar</string>
-	  <key>Persist</key>
-	  <integer>1</integer>
-	  <key>Type</key>
-	  <string>String</string>
-	  <key>Value</key>
-	  <string>Male Shape &amp; Outfit</string>
-	</map>
+    <key>DefaultFemaleAvatar</key>
+    <map>
+      <key>Comment</key>
+      <string>Default Female Avatar</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>String</string>
+      <key>Value</key>
+      <string>Female Shape &amp; Outfit</string>
+    </map>
+    <key>DefaultLoginLocation</key>
+    <map>
+        <key>Comment</key>
+        <string>Startup destination default (if not specified on command line)</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>String</string>
+        <key>Value</key>
+        <string/>
+    </map>
+    <key>DefaultMaleAvatar</key>
+    <map>
+      <key>Comment</key>
+      <string>Default Male Avatar</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>String</string>
+      <key>Value</key>
+      <string>Male Shape &amp; Outfit</string>
+    </map>
     <key>DestinationGuideURL</key>
     <map>
       <key>Comment</key>
@@ -2699,7 +2699,7 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>FirstSelectedEnabledPopups</key>
+    <key>FirstSelectedEnabledPopups</key>
     <map>
       <key>Comment</key>
       <string>Return false if there is not enable popup selected in the list of floater preferences popups</string>
@@ -3521,39 +3521,39 @@
         <key>Value</key>
         <integer>0</integer>
     </map>
-	<key>InventoryLinking</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable ability to create links to folders and items via "Paste as link".</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>1</integer>
-	</map>
-	<key>InventoryOutboxLogging</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable debug output associated with the Merchant Outbox.</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
-	<key>InventoryOutboxMakeVisible</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable making the Merchant Outbox and Inbox visible in the inventory for debug purposes.</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    <key>InventoryLinking</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable ability to create links to folders and items via "Paste as link".</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
+    <key>InventoryOutboxLogging</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable debug output associated with the Merchant Outbox.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
+    <key>InventoryOutboxMakeVisible</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable making the Merchant Outbox and Inbox visible in the inventory for debug purposes.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>InventoryOutboxMaxFolderCount</key>
     <map>
       <key>Comment</key>
@@ -3807,8 +3807,8 @@
       <key>Value</key>
         <real>0.25</real>
       </map>
-	<key>Jpeg2000AdvancedCompression</key>
-	  <map>
+    <key>Jpeg2000AdvancedCompression</key>
+      <map>
       <key>Comment</key>
         <string>Use advanced Jpeg2000 compression options (precincts, blocks, ordering, markers)</string>
       <key>Persist</key>
@@ -3817,9 +3817,9 @@
         <string>Boolean</string>
       <key>Value</key>
         <integer>0</integer>
-	  </map>
-	<key>Jpeg2000PrecinctsSize</key>
-	  <map>
+      </map>
+    <key>Jpeg2000PrecinctsSize</key>
+      <map>
       <key>Comment</key>
         <string>Size of image precincts. Assumed square and same for all levels. Must be power of 2.</string>
       <key>Persist</key>
@@ -3828,9 +3828,9 @@
         <string>S32</string>
       <key>Value</key>
         <integer>256</integer>
-	  </map>
-	<key>Jpeg2000BlocksSize</key>
-	  <map>
+      </map>
+    <key>Jpeg2000BlocksSize</key>
+      <map>
       <key>Comment</key>
         <string>Size of encoding blocks. Assumed square and same for all levels. Must be power of 2. Max 64, Min 4.</string>
       <key>Persist</key>
@@ -3839,7 +3839,7 @@
         <string>S32</string>
       <key>Value</key>
         <integer>64</integer>
-	  </map>
+      </map>
     <key>KeepAspectForSnapshot</key>
     <map>
       <key>Comment</key>
@@ -3917,10 +3917,23 @@
         <key>Value</key>
         <string>Monospace</string>
     </map>
+    <key>LuaAutorunPath</key>
+    <map>
+      <key>Comment</key>
+      <string>Directories containing scripts to autorun at viewer startup</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>LLSD</string>
+      <key>Value</key>
+      <array>
+        <string>scripts/lua/auto</string>
+      </array>
+    </map>
     <key>LuaChunk</key>
     <map>
       <key>Comment</key>
-      <string>Zero or more Lua chunks to run</string>
+      <string>Zero or more Lua chunks to run from command line</string>
       <key>Persist</key>
       <integer>0</integer>
       <key>Type</key>
@@ -3928,10 +3941,36 @@
       <key>Value</key>
       <array />
     </map>
+    <key>LuaCommandPath</key>
+    <map>
+      <key>Comment</key>
+      <string>Directories containing scripts recognized as chat slash commands</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>LLSD</string>
+      <key>Value</key>
+      <array>
+        <string>scripts/lua</string>
+      </array>
+    </map>
+    <key>LuaRequirePath</key>
+    <map>
+      <key>Comment</key>
+      <string>Directories containing Lua modules loadable by require()</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>LLSD</string>
+      <key>Value</key>
+      <array>
+        <string>scripts/lua/require</string>
+      </array>
+    </map>
     <key>LuaScript</key>
     <map>
       <key>Comment</key>
-      <string>Zero or more Lua script files to run</string>
+      <string>Zero or more Lua script files to run from command line</string>
       <key>Persist</key>
       <integer>0</integer>
       <key>Type</key>
@@ -4469,17 +4508,17 @@
       <key>Value</key>
       <string />
     </map>
-	<key>MarketplaceListingsLogging</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable debug output associated with the Marketplace Listings (SLM) API.</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    <key>MarketplaceListingsLogging</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable debug output associated with the Marketplace Listings (SLM) API.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>MarketplaceURL</key>
     <map>
       <key>Comment</key>
@@ -5365,28 +5404,28 @@
       <key>Value</key>
       <integer>1000</integer>
     </map>
-	<key>FakeInitialOutfitName</key>
-	<map>
-		<key>Comment</key>
-		<string>Pretend that this is first time login and specified name was chosen</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
+    <key>FakeInitialOutfitName</key>
+    <map>
+        <key>Comment</key>
+        <string>Pretend that this is first time login and specified name was chosen</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
         <string>String</string>
         <key>Value</key>
         <string />
-	</map>
-	<key>MyOutfitsAutofill</key>
-	<map>
-		<key>Comment</key>
-		<string>Always autofill My Outfits from library when empty (else happens just once).</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    </map>
+    <key>MyOutfitsAutofill</key>
+    <map>
+        <key>Comment</key>
+        <string>Always autofill My Outfits from library when empty (else happens just once).</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>NearMeRange</key>
     <map>
       <key>Comment</key>
@@ -5506,7 +5545,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-	  <integer>0</integer>
+      <integer>0</integer>
     </map>
     <key>NonvisibleObjectsInMemoryTime</key>
     <map>
@@ -5517,7 +5556,7 @@
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-			<integer>64</integer>
+            <integer>64</integer>
     </map>
     <key>NoPreload</key>
     <map>
@@ -6429,7 +6468,7 @@
       <key>Value</key>
       <real>6.0</real>
     </map>
-	<key>PreferredMaturity</key>
+    <key>PreferredMaturity</key>
     <map>
       <key>Comment</key>
       <string>Setting for the user's preferred maturity level (consts in indra_constants.h)</string>
@@ -6438,7 +6477,7 @@
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-	  <integer>13</integer>
+      <integer>13</integer>
     </map>
   <key>PreviewAmbientColor</key>
   <map>
@@ -6608,8 +6647,8 @@
   </map>
 
   <key>PrimMediaMasterEnabled</key>
-	<map>
-	  <key>Comment</key>
+    <map>
+      <key>Comment</key>
       <string>Whether or not Media on a Prim is enabled.</string>
       <key>Persist</key>
       <integer>1</integer>
@@ -6618,9 +6657,9 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-	<key>PrimMediaControlsUseHoverControlSet</key>
-	<map>
-	  <key>Comment</key>
+    <key>PrimMediaControlsUseHoverControlSet</key>
+    <map>
+      <key>Comment</key>
       <string>Whether or not hovering over prim media uses minimal "hover" controls or the authored control set.</string>
       <key>Persist</key>
       <integer>1</integer>
@@ -6629,17 +6668,17 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>PrimMediaDragNDrop</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable drag and drop of URLs onto prim faces</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>1</integer>
-	</map>
+    <key>PrimMediaDragNDrop</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable drag and drop of URLs onto prim faces</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
     <key>PrimMediaMaxRetries</key>
     <map>
       <key>Comment</key>
@@ -6673,7 +6712,7 @@
       <key>Value</key>
       <real>5.0</real>
     </map>
-	<key>PrimMediaMaxSortedQueueSize</key>
+    <key>PrimMediaMaxSortedQueueSize</key>
     <map>
       <key>Comment</key>
       <string>Maximum number of objects the viewer will load media for initially</string>
@@ -6684,7 +6723,7 @@
       <key>Value</key>
       <integer>100000</integer>
     </map>
-	<key>PrimMediaMaxRoundRobinQueueSize</key>
+    <key>PrimMediaMaxRoundRobinQueueSize</key>
     <map>
       <key>Comment</key>
       <string>Maximum number of objects the viewer will continuously update media for</string>
@@ -8788,17 +8827,17 @@
         <key>Value</key>
         <integer>1024</integer>
     </map>
-	<key>RenderHeroProbeDistance</key>
-	<map>
-		<key>Comment</key>
-		<string>Distance in meters for hero probes to render out to.</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>F32</string>
-		<key>Value</key>
-		<real>8</real>
-	</map>
+    <key>RenderHeroProbeDistance</key>
+    <map>
+        <key>Comment</key>
+        <string>Distance in meters for hero probes to render out to.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>8</real>
+    </map>
   <key>RenderHeroProbeUpdateRate</key>
   <map>
     <key>Comment</key>
@@ -9363,17 +9402,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-	<key>RenderTransparentWater</key>
-	<map>
-	  <key>Comment</key>
-	  <string>Render water as transparent.  Setting to false renders water as opaque with a simple texture applied.</string>
+    <key>RenderTransparentWater</key>
+    <map>
+      <key>Comment</key>
+      <string>Render water as transparent.  Setting to false renders water as opaque with a simple texture applied.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
       <integer>1</integer>
-	</map>
+    </map>
     <key>RenderTreeLODFactor</key>
     <map>
       <key>Comment</key>
@@ -9655,18 +9694,18 @@
     <key>Value</key>
     <integer>1</integer>
   </map>
-	<key>RenderPreferStreamDraw</key>
-	<map>
-		<key>Comment</key>
-		<string>Use GL_STREAM_DRAW in place of GL_DYNAMIC_DRAW</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
-	<key>RenderVolumeLODFactor</key>
+    <key>RenderPreferStreamDraw</key>
+    <map>
+        <key>Comment</key>
+        <string>Use GL_STREAM_DRAW in place of GL_DYNAMIC_DRAW</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
+    <key>RenderVolumeLODFactor</key>
     <map>
       <key>Comment</key>
       <string>Controls level of detail of primitives (multiplier for current screen area when calculated level of detail)</string>
@@ -9765,18 +9804,18 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-		<key>ReportBugURL</key>
-		<map>
-			<key>Comment</key>
-			<string>URL used for filing bugs from viewer</string>
-			<key>Persist</key>
-			<integer>1</integer>
-			<key>Type</key>
-			<string>String</string>
-			<key>Value</key>
-			<string>https://feedback.secondlife.com/</string>
-		</map>
-	<key>RevokePermsOnStopAnimation</key>
+        <key>ReportBugURL</key>
+        <map>
+            <key>Comment</key>
+            <string>URL used for filing bugs from viewer</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string>https://feedback.secondlife.com/</string>
+        </map>
+    <key>RevokePermsOnStopAnimation</key>
     <map>
       <key>Comment</key>
       <string>Clear animation permssions when choosing "Stop Animating Me"</string>
@@ -10029,39 +10068,39 @@
       <key>Value</key>
       <real>400.0</real>
     </map>
-	<key>SceneLoadingMonitorEnabled</key>
-	<map>
-		<key>Comment</key>
-		<string>Enabled scene loading monitor if set</string>
-		<key>Persist</key>
-		<integer>0</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
-	<key>SceneLoadingMonitorSampleTime</key>
-	<map>
-		<key>Comment</key>
-		<string>Time between screen samples when monitor scene load (seconds)</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>F32</string>
-		<key>Value</key>
-		<real>0.25</real>
-	</map>
-	<key>SceneLoadingMonitorPixelDiffThreshold</key>
-	<map>
-		<key>Comment</key>
-		<string>Amount of pixels changed required to consider the scene as still loading (square root of fraction of pixels on screen)</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>F32</string>
-		<key>Value</key>
-		<real>0.02</real>
-	</map>
+    <key>SceneLoadingMonitorEnabled</key>
+    <map>
+        <key>Comment</key>
+        <string>Enabled scene loading monitor if set</string>
+        <key>Persist</key>
+        <integer>0</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
+    <key>SceneLoadingMonitorSampleTime</key>
+    <map>
+        <key>Comment</key>
+        <string>Time between screen samples when monitor scene load (seconds)</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>0.25</real>
+    </map>
+    <key>SceneLoadingMonitorPixelDiffThreshold</key>
+    <map>
+        <key>Comment</key>
+        <string>Amount of pixels changed required to consider the scene as still loading (square root of fraction of pixels on screen)</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>0.02</real>
+    </map>
     <key>ScriptHelpFollowsCursor</key>
     <map>
       <key>Comment</key>
@@ -10238,7 +10277,7 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>AvatarNameTagMode</key>
+    <key>AvatarNameTagMode</key>
     <map>
       <key>Comment</key>
       <string>Select Avatar Name Tag Mode</string>
@@ -10447,7 +10486,7 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-	<key>ShowScriptErrors</key>
+    <key>ShowScriptErrors</key>
     <map>
       <key>Comment</key>
       <string>Show script errors</string>
@@ -10458,7 +10497,7 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-	<key>ShowScriptErrorsLocation</key>
+    <key>ShowScriptErrorsLocation</key>
     <map>
       <key>Comment</key>
       <string>Show script error in chat (0) or window (1).</string>
@@ -10717,8 +10756,8 @@
       <string>Display results of find events that are flagged as moderate</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10730,8 +10769,8 @@
       <string>Display results of find events that are flagged as adult</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10743,8 +10782,8 @@
       <string>Display results of find land sales that are flagged as general</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10756,8 +10795,8 @@
       <string>Display results of find land sales that are flagged as moderate</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10769,8 +10808,8 @@
       <string>Display results of find land sales that are flagged as adult</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10782,8 +10821,8 @@
       <string>Display results of find places or find popular that are in general sims</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10795,8 +10834,8 @@
       <string>Display results of find places or find popular that are in moderate sims</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10808,8 +10847,8 @@
       <string>Display results of find places or find popular that are in adult sims</string>
       <key>Persist</key>
       <integer>1</integer>
-	  <key>HideFromEditor</key>
-	  <integer>1</integer>
+      <key>HideFromEditor</key>
+      <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
@@ -10947,17 +10986,17 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>ShowTutorial</key>
-	<map>
-		<key>Comment</key>
-		<string>Show tutorial window on login</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    <key>ShowTutorial</key>
+    <map>
+        <key>Comment</key>
+        <string>Show tutorial window on login</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>ShowVoiceVisualizersInCalls</key>
     <map>
       <key>Comment</key>
@@ -13529,17 +13568,17 @@
       <key>Value</key>
       <real>0.40000000596</real>
     </map>
-	<key>moapbeacon</key>
-	<map>
-		<key>Comment</key>
-		<string>Beacon / Highlight media on a prim sources</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>0</integer>
-	</map>
+    <key>moapbeacon</key>
+    <map>
+        <key>Comment</key>
+        <string>Beacon / Highlight media on a prim sources</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>particlesbeacon</key>
     <map>
       <key>Comment</key>
@@ -13639,17 +13678,17 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>SLURLDragNDrop</key>
-	<map>
-		<key>Comment</key>
-		<string>Enable drag and drop of SLURLs onto the viewer</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>Boolean</string>
-		<key>Value</key>
-		<integer>1</integer>
-	</map>
+    <key>SLURLDragNDrop</key>
+    <map>
+        <key>Comment</key>
+        <string>Enable drag and drop of SLURLs onto the viewer</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
     <key>SLURLPassToOtherInstance</key>
     <map>
     <key>Comment</key>
@@ -13837,10 +13876,10 @@
       <string>LLSD</string>
       <key>Value</key>
       <array>
-	      <string>snapshot</string>
-	      <string>postcard</string>
-	      <string>mini_map</string>
-	      <string>beacons</string>
+          <string>snapshot</string>
+          <string>postcard</string>
+          <string>mini_map</string>
+          <string>beacons</string>
       </array>
     </map>
     <key>LandmarksSortedByDate</key>
@@ -14590,7 +14629,7 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-	<key>LocalTerrainAsset1</key>
+    <key>LocalTerrainAsset1</key>
     <map>
       <key>Comment</key>
       <string>If set to a non-null UUID, overrides the terrain asset locally for all regions with material assets. Local terrain assets are not visible to others. Please keep in mind that this debug setting may be temporary. Do not rely on this setting existing in future viewer builds.</string>
@@ -14601,7 +14640,7 @@
       <key>Value</key>
       <string>00000000-0000-0000-0000-000000000000</string>
     </map>
-	<key>LocalTerrainAsset2</key>
+    <key>LocalTerrainAsset2</key>
     <map>
       <key>Comment</key>
       <string>If set to a non-null UUID, overrides the terrain asset locally for all regions with material assets. Local terrain assets are not visible to others. Please keep in mind that this debug setting may be temporary. Do not rely on this setting existing in future viewer builds.</string>
@@ -14612,7 +14651,7 @@
       <key>Value</key>
       <string>00000000-0000-0000-0000-000000000000</string>
     </map>
-	<key>LocalTerrainAsset3</key>
+    <key>LocalTerrainAsset3</key>
     <map>
       <key>Comment</key>
       <string>If set to a non-null UUID, overrides the terrain asset locally for all regions with material assets. Local terrain assets are not visible to others. Please keep in mind that this debug setting may be temporary. Do not rely on this setting existing in future viewer builds.</string>
@@ -14623,7 +14662,7 @@
       <key>Value</key>
       <string>00000000-0000-0000-0000-000000000000</string>
     </map>
-	<key>LocalTerrainAsset4</key>
+    <key>LocalTerrainAsset4</key>
     <map>
       <key>Comment</key>
       <string>If set to a non-null UUID, overrides the terrain asset locally for all regions with material assets. Local terrain assets are not visible to others. Please keep in mind that this debug setting may be temporary. Do not rely on this setting existing in future viewer builds.</string>
@@ -14634,7 +14673,7 @@
       <key>Value</key>
       <string>00000000-0000-0000-0000-000000000000</string>
     </map>
-	<key>PathfindingRetrieveNeighboringRegion</key>
+    <key>PathfindingRetrieveNeighboringRegion</key>
     <map>
       <key>Comment</key>
       <string>Download a neighboring region when visualizing a pathfinding navmesh (default val 99 means do not download neighbors).</string>
@@ -14643,9 +14682,9 @@
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-	  <integer>99</integer>
+      <integer>99</integer>
     </map>
-	<key>PathfindingNavMeshClear</key>
+    <key>PathfindingNavMeshClear</key>
     <map>
       <key>Comment</key>
       <string>Background color when displaying pathfinding navmesh.</string>
@@ -14805,7 +14844,7 @@
         <real>1.0</real>
       </array>
     </map>
- 	 <key>PathfindingTestPathValidEndColor</key>
+    <key>PathfindingTestPathValidEndColor</key>
     <map>
       <key>Comment</key>
       <string>Color of the pathfinding test-pathing tool end-point when the path is valid.</string>
@@ -14837,7 +14876,7 @@
         <real>1.0</real>
       </array>
     </map>
-	 <key>PathfindingTestPathColor</key>
+    <key>PathfindingTestPathColor</key>
     <map>
       <key>Comment</key>
       <string>Color of the pathfinding test-path when the path is valid.</string>
@@ -15397,17 +15436,6 @@
     <key>Value</key>
     <integer>3</integer>
   </map>
-  <key>AutorunLuaScriptName</key>
-  <map>
-    <key>Comment</key>
-    <string>Script name to autorun after login.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>String</string>
-    <key>Value</key>
-    <string>default.lua</string>
-  </map>
   <key>ResetUIScaleOnFirstRun</key>
   <map>
     <key>Comment</key>
@@ -15485,17 +15513,17 @@
     <key>Value</key>
     <real>300</real>
   </map>
-	<key>StatsReportFileInterval</key>
-	<map>
-		<key>Comment</key>
-		<string>Interval to save viewer stats file data</string>
-		<key>Persist</key>
-		<integer>1</integer>
-		<key>Type</key>
-		<string>F32</string>
-		<key>Value</key>
-		<real>0.2</real>
-	</map>
+    <key>StatsReportFileInterval</key>
+    <map>
+        <key>Comment</key>
+        <string>Interval to save viewer stats file data</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>0.2</real>
+    </map>
   <key>StatsReportSkipZeroDataSaves</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -117,6 +117,7 @@
 #include "lldiriterator.h"
 #include "llexperiencecache.h"
 #include "llimagej2c.h"
+#include "llluamanager.h"
 #include "llmemory.h"
 #include "llprimitive.h"
 #include "llurlaction.h"
@@ -1217,6 +1218,24 @@ bool LLAppViewer::init()
         {
             // no completion callback: we don't need to know
             LLLUAmanager::runScriptFile(script);
+        });
+    processComposeSwitch(
+        "LuaAutorunPath", "LuaAutorunPath",
+        [](const LLSD& directory)
+        {
+            // each directory can be relative to the viewer's install
+            // directory -- if directory is already absolute, operator/()
+            // preserves it
+            auto abspath(fsyspath(gDirUtilp->getAppRODataDir()) / directory.asString());
+            std::string absdir(abspath.string());
+            LL_DEBUGS("InitInfo") << "LuaAutorunPath: " << absdir << LL_ENDL;
+            LLDirIterator scripts(absdir, "*.lua");
+            std::string script;
+            while (scripts.next(script))
+            {
+                LL_DEBUGS("InitInfo") << "LuaAutorunPath: " << absdir << ": " << script << LL_ENDL;
+                LLLUAmanager::runScriptFile((abspath / script).string());
+            }
         });
 
     if (gSavedSettings.getBOOL("QAMode") && gSavedSettings.getS32("QAModeEventHostPort") > 0)

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -309,31 +309,6 @@ LLRequireResolver::LLRequireResolver(lua_State *L, const std::string& path) :
         luaL_argerrorL(L, 1, "cannot require a full path");
 }
 
-/**
- * Remove a particular stack index on exit from enclosing scope.
- * If you pass a negative index (meaning relative to the current stack top),
- * converts to an absolute index. The point of LuaRemover is to remove the
- * entry at the specified index regardless of subsequent pushes to the stack.
- */
-class LuaRemover
-{
-public:
-    LuaRemover(lua_State* L, int index):
-        mState(L),
-        mIndex(lua_absindex(L, index))
-    {}
-    LuaRemover(const LuaRemover&) = delete;
-    LuaRemover& operator=(const LuaRemover&) = delete;
-    ~LuaRemover()
-    {
-        lua_remove(mState, mIndex);
-    }
-
-private:
-    lua_State* mState;
-    int mIndex;
-};
-
 // push the loaded module or throw a Lua error
 void LLRequireResolver::findModule()
 {

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -265,27 +265,6 @@ void LLLUAmanager::runScriptLine(LuaState& L, const std::string& chunk, script_r
     });
 }
 
-void LLLUAmanager::runScriptOnLogin()
-{
-#ifndef LL_TEST
-    std::string filename = gSavedSettings.getString("AutorunLuaScriptName");
-    if (filename.empty()) 
-    {
-        LL_INFOS() << "Script name wasn't set." << LL_ENDL;
-        return;
-    }
-
-    filename = gDirUtilp->getExpandedFilename(LL_PATH_USER_SETTINGS, filename);
-    if (!gDirUtilp->fileExists(filename)) 
-    {
-        LL_INFOS() << filename << " was not found." << LL_ENDL;
-        return;
-    }
-
-    runScriptFile(filename);
-#endif // ! LL_TEST
-}
-
 std::string read_file(const std::string &name)
 {
     llifstream in_file;

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -82,8 +82,6 @@ public:
     // The return value is the (count, result) pair described above.
     static std::pair<int, LLSD> waitScriptLine(LuaState& L, const std::string& chunk);
 
-    static void runScriptOnLogin();
-
     static const std::map<std::string, std::string> getScriptNames() { return sScriptNames; }
 
  private:

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -208,7 +208,6 @@
 #include "llstacktrace.h"
 
 #include "threadpool.h"
-#include "llluamanager.h"
 #include "llperfstats.h"
 
 
@@ -2421,8 +2420,6 @@ bool idle_startup()
         LLUIUsage::instance().clear();
 
         LLPerfStats::StatsRecorder::setAutotuneInit();
-
-        LLLUAmanager::runScriptOnLogin();
 
         return TRUE;
     }

--- a/indra/newview/tests/llluamanager_test.cpp
+++ b/indra/newview/tests/llluamanager_test.cpp
@@ -69,7 +69,7 @@ namespace tut
             auto settings{ newview / "app_settings" / "settings.xml" };
             // true suppresses implicit declare; implicit declare requires
             // that every variable in settings.xml has a Comment, which many don't.
-            gSavedSettings.loadFromFile(settings.u8string().c_str(), true);
+            gSavedSettings.loadFromFile(settings.u8string(), true);
             // At test time, since we don't have the app bundle available,
             // extend LuaRequirePath to include the require directory in the
             // source tree.

--- a/indra/newview/tests/llluamanager_test.cpp
+++ b/indra/newview/tests/llluamanager_test.cpp
@@ -21,6 +21,7 @@
 #include "../llcommon/tests/StringVec.h"
 #include "../test/lltut.h"
 #include "llapp.h"
+#include "llcontrol.h"
 #include "lldate.h"
 #include "llevents.h"
 #include "lleventcoro.h"
@@ -38,6 +39,8 @@ public:
     bool cleanup() override { return true; }
     bool frame()   override { return true; }
 };
+
+LLControlGroup gSavedSettings("Global");
 
 template <typename CALLABLE>
 auto listener(CALLABLE&& callable)
@@ -57,6 +60,36 @@ namespace tut
 {
     struct llluamanager_data
     {
+        llluamanager_data()
+        {
+            // Load gSavedSettings from source tree
+            // indra/newview/tests/llluamanager_test.cpp =>
+            // indra/newview
+            auto newview{ fsyspath(__FILE__).parent_path().parent_path() };
+            auto settings{ newview / "app_settings" / "settings.xml" };
+            // true suppresses implicit declare; implicit declare requires
+            // that every variable in settings.xml has a Comment, which many don't.
+            gSavedSettings.loadFromFile(settings.u8string().c_str(), true);
+            // At test time, since we don't have the app bundle available,
+            // extend LuaRequirePath to include the require directory in the
+            // source tree.
+            auto require{ (newview / "scripts" / "lua" / "require").u8string() };
+            auto paths{ gSavedSettings.getLLSD("LuaRequirePath") };
+            bool found = false;
+            for (const auto& path : llsd::inArray(paths))
+            {
+                if (path.asString() == require)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (! found)
+            {
+                paths.append(require);
+                gSavedSettings.setLLSD("LuaRequirePath", paths);
+            }
+        }
         // We need an LLApp instance because LLLUAmanager uses coroutines,
         // which suspend, and when a coroutine suspends it checks LLApp state,
         // and if it's not APP_STATUS_RUNNING the coroutine terminates.


### PR DESCRIPTION
Remove AutorunLuaScriptName and the `LLLUAmanager::runScriptOnLogin()` method that checked it.

Instead, iterate over LuaAutorunPath directories at viewer startup, iterate over *.lua files in each and implicitly run those.

Make require() implementation honor LuaRequirePath.

I wasn't intending to implement LuaCommandPath in this PR.