### PR TITLE
Loop fixes

### DIFF
--- a/indra/llui/llaccordionctrl.cpp
+++ b/indra/llui/llaccordionctrl.cpp
@@ -379,12 +379,10 @@ void LLAccordionCtrl::initNoTabsWidget(const LLTextBox::Params& tb_params)
 
 void LLAccordionCtrl::updateNoTabsHelpTextVisibility()
 {
-    bool visible_exists = false;
-    std::vector<LLAccordionCtrlTab*>::const_iterator it = mAccordionTabs.begin();
-    const std::vector<LLAccordionCtrlTab*>::const_iterator it_end = mAccordionTabs.end();
-    while (it < it_end)
+    bool visible_exists{ false };
+    for (auto accordion_tab : mAccordionTabs)
     {
-        if ((*(it++))->getVisible())
+        if (accordion_tab->getVisible())
         {
             visible_exists = true;
             break;

--- a/indra/llui/llaccordionctrltab.cpp
+++ b/indra/llui/llaccordionctrltab.cpp
@@ -602,15 +602,13 @@ void LLAccordionCtrlTab::setSelected(bool is_selected)
 
 LLView* LLAccordionCtrlTab::findContainerView()
 {
-    child_list_const_iter_t it = getChildList()->begin(), it_end = getChildList()->end();
-    while (it != it_end)
+    for (auto child : *getChildList())
     {
-        LLView* child = *(it++);
         if (DD_HEADER_NAME != child->getName() && child->getVisible())
             return child;
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void LLAccordionCtrlTab::selectOnFocusReceived()

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -24,7 +24,6 @@
  * $/LicenseInfo$
  */
 #include <algorithm>
-#include <format>
 #include "llvoicewebrtc.h"
 
 #include "llsdutil.h"


### PR DESCRIPTION
LLFlatListView::detachItems was changed a while ago and now had a scoping issue for the "iter" variable, so I changed that and all the other strange loops introduced in the original commit.

Also removed the include of the format library, which a) isn't used, b) creates a compiler warning and c) can't be used without C++20 support anyway