### PR TITLE
Fix tp mirror crashes

### DIFF
--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -338,7 +338,7 @@ private:
 };
 
 // consts from viewer.h
-const S32 AGENT_UPDATES_PER_SECOND  = 10;
+const S32 AGENT_UPDATES_PER_SECOND  = 125; // Value derived experimentally to avoid Input Delays with latest PBR-Capable Viewers when viewer FPS is highly volatile.
 const S32 AGENT_FORCE_UPDATES_PER_SECOND  = 1;
 
 // Globals with external linkage. From viewer.h

--- a/indra/newview/llheroprobemanager.cpp
+++ b/indra/newview/llheroprobemanager.cpp
@@ -121,6 +121,7 @@ void LLHeroProbeManager::update()
         // Find our nearest hero candidate.
         float last_distance = 99999.f;
         float camera_center_distance = 99999.f;
+        mNearestHero = nullptr;
         for (auto vo : mHeroVOList)
         {
             if (vo && !vo->isDead() && vo->mDrawable.notNull() && vo->isReflectionProbe() && vo->getReflectionProbeIsBox())
@@ -194,11 +195,17 @@ void LLHeroProbeManager::update()
         else
         {
             mNearestHero = nullptr;
+            mDefaultProbe->mViewerObject = nullptr;
         }
 
         mHeroProbeStrength = 1;
     }
+    else
+    {
+        mNearestHero = nullptr;
+        mDefaultProbe->mViewerObject = nullptr;
     }
+}
 
 void LLHeroProbeManager::renderProbes()
 {


### PR DESCRIPTION
This should fix #1880 #1866 #1881 and similar.

Note: The important part is resetting the object pointed to by the DefaultProbe. I have also included an additional change at line 124, which we have as part of our fixes for "mirrors do not stop rendering." 
You (already) have your own internal fixes for that, so that may be redundant for you. As best I can tell, it is still needed or, at the very least, does no harm.