### PR TITLE
Reduce string temporaries from frequently called llui find and get functions

### DIFF
--- a/indra/llcommon/llstl.h
+++ b/indra/llcommon/llstl.h
@@ -226,11 +226,11 @@ void delete_and_clear_array(T*& ptr)
 //  foo[2] = "hello";
 //  const char* bar = get_ptr_in_map(foo, 2); // bar -> "hello"
 //  const char* baz = get_ptr_in_map(foo, 3); // baz == NULL
-template <typename K, typename T>
-inline T* get_ptr_in_map(const std::map<K,T*>& inmap, const K& key)
+template <typename T>
+inline typename T::mapped_type get_ptr_in_map(const T& inmap, typename T::key_type const& key)
 {
     // Typedef here avoids warnings because of new c++ naming rules.
-    typedef typename std::map<K,T*>::const_iterator map_iter;
+    typedef T::const_iterator map_iter;
     map_iter iter = inmap.find(key);
     if(iter == inmap.end())
     {

--- a/indra/llcommon/llstl.h
+++ b/indra/llcommon/llstl.h
@@ -230,7 +230,7 @@ template <typename T>
 inline typename T::mapped_type get_ptr_in_map(const T& inmap, typename T::key_type const& key)
 {
     // Typedef here avoids warnings because of new c++ naming rules.
-    typedef T::const_iterator map_iter;
+    typedef typename T::const_iterator map_iter;
     map_iter iter = inmap.find(key);
     if(iter == inmap.end())
     {

--- a/indra/llui/llbadge.cpp
+++ b/indra/llui/llbadge.cpp
@@ -36,7 +36,7 @@ static LLDefaultChildRegistry::Register<LLBadge> r("badge");
 static const S32 BADGE_OFFSET_NOT_SPECIFIED = 0x7FFFFFFF;
 
 // Compiler optimization, generate extern template
-template class LLBadge* LLView::getChild<class LLBadge>(const std::string& name, bool recurse) const;
+template class LLBadge* LLView::getChild<class LLBadge>(std::string_view name, bool recurse) const;
 
 
 LLBadge::Params::Params()

--- a/indra/llui/llbadge.h
+++ b/indra/llui/llbadge.h
@@ -171,7 +171,7 @@ private:
 
 // Build time optimization, generate once in .cpp file
 #ifndef LLBADGE_CPP
-extern template class LLBadge* LLView::getChild<class LLBadge>(const std::string& name, bool recurse) const;
+extern template class LLBadge* LLView::getChild<class LLBadge>(std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_LLBADGE_H

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -1273,7 +1273,7 @@ void LLButton::setFloaterToggle(LLUICtrl* ctrl, const LLSD& sdname)
     // Set the button control value (toggle state) to the floater visibility control (Sets the value as well)
     button->setControlVariable(LLFloater::getControlGroup()->getControl(vis_control_name));
     // Set the clicked callback to toggle the floater
-    button->setClickedCallback(boost::bind(&LLFloaterReg::toggleInstance, sdname, LLSD()));
+    button->setClickedCallback([=](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::toggleInstance(sdname.asString(), LLSD()); });
 }
 
 // static

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -56,7 +56,7 @@ static LLDefaultChildRegistry::Register<LLButton> r("button");
 
 // Compiler optimization, generate extern template
 template class LLButton* LLView::getChild<class LLButton>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 // globals
 S32 LLBUTTON_H_PAD  = 4;

--- a/indra/llui/llbutton.h
+++ b/indra/llui/llbutton.h
@@ -400,7 +400,7 @@ protected:
 // Build time optimization, generate once in .cpp file
 #ifndef LLBUTTON_CPP
 extern template class LLButton* LLView::getChild<class LLButton>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_LLBUTTON_H

--- a/indra/llui/llcheckboxctrl.cpp
+++ b/indra/llui/llcheckboxctrl.cpp
@@ -45,7 +45,7 @@ static LLDefaultChildRegistry::Register<LLCheckBoxCtrl> r("check_box");
 
 // Compiler optimization, generate extern template
 template class LLCheckBoxCtrl* LLView::getChild<class LLCheckBoxCtrl>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 void LLCheckBoxCtrl::WordWrap::declareValues()
 {

--- a/indra/llui/llcheckboxctrl.h
+++ b/indra/llui/llcheckboxctrl.h
@@ -151,7 +151,7 @@ protected:
 // Build time optimization, generate once in .cpp file
 #ifndef LLCHECKBOXCTRL_CPP
 extern template class LLCheckBoxCtrl* LLView::getChild<class LLCheckBoxCtrl>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_LLCHECKBOXCTRL_H

--- a/indra/llui/llfloaterreg.h
+++ b/indra/llui/llfloaterreg.h
@@ -51,26 +51,26 @@ public:
     // 2) We can change the key of a floater without altering the list.
     typedef std::list<LLFloater*> instance_list_t;
     typedef const instance_list_t const_instance_list_t;
-    typedef std::map<std::string, instance_list_t> instance_map_t;
+    typedef std::map<std::string, instance_list_t, std::less<>> instance_map_t;
 
     struct BuildData
     {
         LLFloaterBuildFunc mFunc;
         std::string mFile;
     };
-    typedef std::map<std::string, BuildData> build_map_t;
+    typedef std::map<std::string, BuildData, std::less<>> build_map_t;
 
 private:
     friend class LLFloaterRegListener;
     static instance_list_t sNullInstanceList;
     static instance_map_t sInstanceMap;
     static build_map_t sBuildMap;
-    static std::map<std::string,std::string> sGroupMap;
+    static std::map<std::string, std::string, std::less<>> sGroupMap;
     static bool sBlockShowFloaters;
     /**
      * Defines list of floater names that can be shown despite state of sBlockShowFloaters.
      */
-    static std::set<std::string> sAlwaysShowableList;
+    static std::set<std::string, std::less<>> sAlwaysShowableList;
 
 public:
     // Registration
@@ -85,30 +85,30 @@ public:
 
     static void add(const std::string& name, const std::string& file, const LLFloaterBuildFunc& func,
                     const std::string& groupname = LLStringUtil::null);
-    static bool isRegistered(const std::string& name);
+    static bool isRegistered(std::string_view name);
 
     // Helpers
-    static LLFloater* getLastFloaterInGroup(const std::string& name);
+    static LLFloater* getLastFloaterInGroup(std::string_view name);
     static LLFloater* getLastFloaterCascading();
 
     // Find / get (create) / remove / destroy
-    static LLFloater* findInstance(const std::string& name, const LLSD& key = LLSD());
-    static LLFloater* getInstance(const std::string& name, const LLSD& key = LLSD());
-    static LLFloater* removeInstance(const std::string& name, const LLSD& key = LLSD());
-    static bool destroyInstance(const std::string& name, const LLSD& key = LLSD());
+    static LLFloater* findInstance(std::string_view name, const LLSD& key = LLSD());
+    static LLFloater* getInstance(std::string_view name, const LLSD& key = LLSD());
+    static LLFloater* removeInstance(std::string_view name, const LLSD& key = LLSD());
+    static bool destroyInstance(std::string_view name, const LLSD& key = LLSD());
 
     // Iterators
-    static const_instance_list_t& getFloaterList(const std::string& name);
+    static const_instance_list_t& getFloaterList(std::string_view name);
 
     // Visibility Management
     // return NULL if instance not found or can't create instance (no builder)
-    static LLFloater* showInstance(const std::string& name, const LLSD& key = LLSD(), bool focus = false);
+    static LLFloater* showInstance(std::string_view name, const LLSD& key = LLSD(), bool focus = false);
     // Close a floater (may destroy or set invisible)
     // return false if can't find instance
-    static bool hideInstance(const std::string& name, const LLSD& key = LLSD());
+    static bool hideInstance(std::string_view name, const LLSD& key = LLSD());
     // return true if instance is visible:
-    static bool toggleInstance(const std::string& name, const LLSD& key = LLSD());
-    static bool instanceVisible(const std::string& name, const LLSD& key = LLSD());
+    static bool toggleInstance(std::string_view name, const LLSD& key = LLSD());
+    static bool instanceVisible(std::string_view name, const LLSD& key = LLSD());
 
     static void showInitialVisibleInstances();
     static void hideVisibleInstances(const std::set<std::string>& exceptions = std::set<std::string>());
@@ -133,19 +133,19 @@ public:
 
     // Typed find / get / show
     template <class T>
-    static T* findTypedInstance(const std::string& name, const LLSD& key = LLSD())
+    static T* findTypedInstance(std::string_view name, const LLSD& key = LLSD())
     {
         return dynamic_cast<T*>(findInstance(name, key));
     }
 
     template <class T>
-    static T* getTypedInstance(const std::string& name, const LLSD& key = LLSD())
+    static T* getTypedInstance(std::string_view name, const LLSD& key = LLSD())
     {
         return dynamic_cast<T*>(getInstance(name, key));
     }
 
     template <class T>
-    static T* showTypedInstance(const std::string& name, const LLSD& key = LLSD(), bool focus = false)
+    static T* showTypedInstance(std::string_view name, const LLSD& key = LLSD(), bool focus = false)
     {
         return dynamic_cast<T*>(showInstance(name, key, focus));
     }

--- a/indra/llui/llfloaterreglistener.cpp
+++ b/indra/llui/llfloaterreglistener.cpp
@@ -131,7 +131,7 @@ void LLFloaterRegListener::clickButton(const LLSD& event) const
     {
         // Here 'floater' points to an LLFloater instance with the specified
         // name and key which isShown().
-        LLButton* button = floater->findChild<LLButton>(event["button"]);
+        LLButton* button = floater->findChild<LLButton>(event["button"].asString());
         if (! LLButton::isAvailable(button))
         {
             reply["type"]  = "LLButton";

--- a/indra/llui/llfloaterreglistener.cpp
+++ b/indra/llui/llfloaterreglistener.cpp
@@ -94,22 +94,22 @@ void LLFloaterRegListener::getBuildMap(const LLSD& event) const
 
 void LLFloaterRegListener::showInstance(const LLSD& event) const
 {
-    LLFloaterReg::showInstance(event["name"], event["key"], event["focus"]);
+    LLFloaterReg::showInstance(event["name"].asString(), event["key"], event["focus"]);
 }
 
 void LLFloaterRegListener::hideInstance(const LLSD& event) const
 {
-    LLFloaterReg::hideInstance(event["name"], event["key"]);
+    LLFloaterReg::hideInstance(event["name"].asString(), event["key"]);
 }
 
 void LLFloaterRegListener::toggleInstance(const LLSD& event) const
 {
-    LLFloaterReg::toggleInstance(event["name"], event["key"]);
+    LLFloaterReg::toggleInstance(event["name"].asString(), event["key"]);
 }
 
 void LLFloaterRegListener::instanceVisible(const LLSD& event) const
 {
-    sendReply(LLSDMap("visible", LLFloaterReg::instanceVisible(event["name"], event["key"])),
+    sendReply(LLSDMap("visible", LLFloaterReg::instanceVisible(event["name"].asString(), event["key"])),
               event);
 }
 
@@ -119,7 +119,7 @@ void LLFloaterRegListener::clickButton(const LLSD& event) const
     LLReqID reqID(event);
     LLSD reply(reqID.makeResponse());
 
-    LLFloater* floater = LLFloaterReg::findInstance(event["name"], event["key"]);
+    LLFloater* floater = LLFloaterReg::findInstance(event["name"].asString(), event["key"]);
     if (! LLFloater::isShown(floater))
     {
         reply["type"]  = "LLFloater";

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -74,7 +74,7 @@ static LLDefaultChildRegistry::Register<LLLineEditor> r1("line_editor");
 
 // Compiler optimization, generate extern template
 template class LLLineEditor* LLView::getChild<class LLLineEditor>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 //
 // Member functions

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -466,7 +466,7 @@ private:
 // Build time optimization, generate once in .cpp file
 #ifndef LLLINEEDITOR_CPP
 extern template class LLLineEditor* LLView::getChild<class LLLineEditor>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_LINEEDITOR_

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -988,7 +988,7 @@ LLMenuItemBranchGL::~LLMenuItemBranchGL()
 
 
 // virtual
-LLView* LLMenuItemBranchGL::getChildView(const std::string& name, bool recurse) const
+LLView* LLMenuItemBranchGL::getChildView(std::string_view name, bool recurse) const
 {
     LLMenuGL* branch = getBranch();
     if (branch)
@@ -1005,7 +1005,7 @@ LLView* LLMenuItemBranchGL::getChildView(const std::string& name, bool recurse) 
     return LLView::getChildView(name, recurse);
 }
 
-LLView* LLMenuItemBranchGL::findChildView(const std::string& name, bool recurse) const
+LLView* LLMenuItemBranchGL::findChildView(std::string_view name, bool recurse) const
 {
     LLMenuGL* branch = getBranch();
     if (branch)

--- a/indra/llui/llmenugl.h
+++ b/indra/llui/llmenugl.h
@@ -687,8 +687,8 @@ public:
 
     virtual void openMenu();
 
-    virtual LLView* getChildView(const std::string& name, bool recurse = true) const;
-    virtual LLView* findChildView(const std::string& name, bool recurse = true) const;
+    virtual LLView* getChildView(std::string_view name, bool recurse = true) const;
+    virtual LLView* findChildView(std::string_view name, bool recurse = true) const;
 
 private:
     LLHandle<LLView> mBranchHandle;

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -439,7 +439,7 @@ LLNotificationTemplate::LLNotificationTemplate(const LLNotificationTemplate::Par
     mSoundName("")
 {
     if (p.sound.isProvided()
-        && LLUI::getInstance()->mSettingGroups["config"]->controlExists(p.sound))
+        && LLUI::getInstance()->mSettingGroups["config"]->controlExists(p.sound()))
     {
         mSoundName = p.sound;
     }

--- a/indra/llui/llpanel.cpp
+++ b/indra/llui/llpanel.cpp
@@ -55,7 +55,7 @@ LLPanel::factory_stack_t    LLPanel::sFactoryStack;
 
 // Compiler optimization, generate extern template
 template class LLPanel* LLView::getChild<class LLPanel>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 LLPanel::LocalizedString::LocalizedString()
 :   name("name"),

--- a/indra/llui/llpanel.h
+++ b/indra/llui/llpanel.h
@@ -259,7 +259,7 @@ private:
 // Build time optimization, generate once in .cpp file
 #ifndef LLPANEL_CPP
 extern template class LLPanel* LLView::getChild<class LLPanel>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 typedef boost::function<LLPanel* (void)> LLPanelClassCreatorFunc;

--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -315,7 +315,7 @@ void LLTabContainer::reshape(S32 width, S32 height, bool called_from_parent)
 }
 
 //virtual
-LLView* LLTabContainer::getChildView(const std::string& name, bool recurse) const
+LLView* LLTabContainer::getChildView(std::string_view name, bool recurse) const
 {
     tuple_list_t::const_iterator itor;
     for (itor = mTabList.begin(); itor != mTabList.end(); ++itor)
@@ -343,7 +343,7 @@ LLView* LLTabContainer::getChildView(const std::string& name, bool recurse) cons
 }
 
 //virtual
-LLView* LLTabContainer::findChildView(const std::string& name, bool recurse) const
+LLView* LLTabContainer::findChildView(std::string_view name, bool recurse) const
 {
     tuple_list_t::const_iterator itor;
     for (itor = mTabList.begin(); itor != mTabList.end(); ++itor)

--- a/indra/llui/lltabcontainer.h
+++ b/indra/llui/lltabcontainer.h
@@ -149,8 +149,8 @@ public:
     /*virtual*/ bool handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,
                                        EDragAndDropType type, void* cargo_data,
                                        EAcceptance* accept, std::string& tooltip);
-    /*virtual*/ LLView* getChildView(const std::string& name, bool recurse = true) const;
-    /*virtual*/ LLView* findChildView(const std::string& name, bool recurse = true) const;
+    /*virtual*/ LLView* getChildView(std::string_view name, bool recurse = true) const;
+    /*virtual*/ LLView* findChildView(std::string_view name, bool recurse = true) const;
     /*virtual*/ void initFromParams(const LLPanel::Params& p);
     /*virtual*/ bool addChild(LLView* view, S32 tab_group = 0);
     /*virtual*/ bool postBuild();

--- a/indra/llui/lltextbox.cpp
+++ b/indra/llui/lltextbox.cpp
@@ -39,7 +39,7 @@ static LLDefaultChildRegistry::Register<LLTextBox> r("text");
 
 // Compiler optimization, generate extern template
 template class LLTextBox* LLView::getChild<class LLTextBox>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 LLTextBox::LLTextBox(const LLTextBox::Params& p)
 :   LLTextBase(p),

--- a/indra/llui/lltextbox.h
+++ b/indra/llui/lltextbox.h
@@ -81,7 +81,7 @@ protected:
 // Build time optimization, generate once in .cpp file
 #ifndef LLTEXTBOX_CPP
 extern template class LLTextBox* LLView::getChild<class LLTextBox>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif

--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -71,7 +71,7 @@ static LLDefaultChildRegistry::Register<LLTextEditor> r("simple_text_editor");
 
 // Compiler optimization, generate extern template
 template class LLTextEditor* LLView::getChild<class LLTextEditor>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 //
 // Constants

--- a/indra/llui/lltexteditor.h
+++ b/indra/llui/lltexteditor.h
@@ -345,7 +345,7 @@ private:
 // Build time optimization, generate once in .cpp file
 #ifndef LLTEXTEDITOR_CPP
 extern template class LLTextEditor* LLView::getChild<class LLTextEditor>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_TEXTEDITOR_H

--- a/indra/llui/lltrans.cpp
+++ b/indra/llui/lltrans.cpp
@@ -65,7 +65,7 @@ bool LLTrans::parseStrings(LLXMLNodePtr &root, const std::set<std::string>& defa
     if (!root->hasName("strings"))
     {
         LL_ERRS() << "Invalid root node name in " << xml_filename
-            << ": was " << root->getName() << ", expected \"strings\"" << LL_ENDL;
+            << ": was " << root->getName()->mString << ", expected \"strings\"" << LL_ENDL;
     }
 
     StringTable string_table;
@@ -113,7 +113,7 @@ bool LLTrans::parseLanguageStrings(LLXMLNodePtr &root)
     if (!root->hasName("strings"))
     {
         LL_ERRS() << "Invalid root node name in " << xml_filename
-        << ": was " << root->getName() << ", expected \"strings\"" << LL_ENDL;
+        << ": was " << root->getName()->mString << ", expected \"strings\"" << LL_ENDL;
     }
 
     StringTable string_table;
@@ -143,7 +143,7 @@ bool LLTrans::parseLanguageStrings(LLXMLNodePtr &root)
 static LLTrace::BlockTimerStatHandle FTM_GET_TRANS("Translate string");
 
 //static
-std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::format_map_t& msg_args, bool def_string)
+std::string LLTrans::getString(std::string_view xml_desc, const LLStringUtil::format_map_t& msg_args, bool def_string)
 {
     // Don't care about time as much as call count.  Make sure we're not
     // calling LLTrans::getString() in an inner loop. JC
@@ -167,12 +167,12 @@ std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::
     else
     {
         LL_WARNS_ONCE("configuration") << "Missing String in strings.xml: [" << xml_desc << "]" << LL_ENDL;
-        return "MissingString("+xml_desc+")";
+        return "MissingString(" + std::string(xml_desc) + ")";
     }
 }
 
 //static
-std::string LLTrans::getDefString(const std::string &xml_desc, const LLStringUtil::format_map_t& msg_args)
+std::string LLTrans::getDefString(std::string_view xml_desc, const LLStringUtil::format_map_t& msg_args)
 {
     template_map_t::iterator iter = sDefaultStringTemplates.find(xml_desc);
     if (iter != sDefaultStringTemplates.end())
@@ -187,12 +187,12 @@ std::string LLTrans::getDefString(const std::string &xml_desc, const LLStringUti
     else
     {
         LL_WARNS_ONCE("configuration") << "Missing String in strings.xml: [" << xml_desc << "]" << LL_ENDL;
-        return "MissingString(" + xml_desc + ")";
+        return "MissingString(" + std::string(xml_desc) + ")";
     }
 }
 
 //static
-std::string LLTrans::getString(const std::string &xml_desc, const LLSD& msg_args, bool def_string)
+std::string LLTrans::getString(std::string_view xml_desc, const LLSD& msg_args, bool def_string)
 {
     // Don't care about time as much as call count.  Make sure we're not
     // calling LLTrans::getString() in an inner loop. JC
@@ -213,12 +213,12 @@ std::string LLTrans::getString(const std::string &xml_desc, const LLSD& msg_args
     else
     {
         LL_WARNS_ONCE("configuration") << "Missing String in strings.xml: [" << xml_desc << "]" << LL_ENDL;
-        return "MissingString("+xml_desc+")";
+        return "MissingString(" + std::string(xml_desc) + ")";
     }
 }
 
 //static
-std::string LLTrans::getDefString(const std::string &xml_desc, const LLSD& msg_args)
+std::string LLTrans::getDefString(std::string_view xml_desc, const LLSD& msg_args)
 {
     template_map_t::iterator iter = sDefaultStringTemplates.find(xml_desc);
     if (iter != sDefaultStringTemplates.end())
@@ -230,12 +230,12 @@ std::string LLTrans::getDefString(const std::string &xml_desc, const LLSD& msg_a
     else
     {
         LL_WARNS_ONCE("configuration") << "Missing String in strings.xml: [" << xml_desc << "]" << LL_ENDL;
-        return "MissingString(" + xml_desc + ")";
+        return "MissingString(" + std::string(xml_desc) + ")";
     }
 }
 
 //static
-bool LLTrans::findString(std::string &result, const std::string &xml_desc, const LLStringUtil::format_map_t& msg_args)
+bool LLTrans::findString(std::string &result, std::string_view xml_desc, const LLStringUtil::format_map_t& msg_args)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 
@@ -257,7 +257,7 @@ bool LLTrans::findString(std::string &result, const std::string &xml_desc, const
 }
 
 //static
-bool LLTrans::findString(std::string &result, const std::string &xml_desc, const LLSD& msg_args)
+bool LLTrans::findString(std::string &result, std::string_view xml_desc, const LLSD& msg_args)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 

--- a/indra/llui/lltrans.h
+++ b/indra/llui/lltrans.h
@@ -76,12 +76,12 @@ public:
      * @param args A list of substrings to replace in the string
      * @returns Translated string
      */
-    static std::string getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
-    static std::string getDefString(const std::string &xml_desc, const LLStringUtil::format_map_t& args);
-    static std::string getString(const std::string &xml_desc, const LLSD& args, bool def_string = false);
-    static std::string getDefString(const std::string &xml_desc, const LLSD& args);
-    static bool findString(std::string &result, const std::string &xml_desc, const LLStringUtil::format_map_t& args);
-    static bool findString(std::string &result, const std::string &xml_desc, const LLSD& args);
+    static std::string getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
+    static std::string getDefString(std::string_view xml_desc, const LLStringUtil::format_map_t& args);
+    static std::string getString(std::string_view xml_desc, const LLSD& args, bool def_string = false);
+    static std::string getDefString(std::string_view xml_desc, const LLSD& args);
+    static bool findString(std::string &result, std::string_view xml_desc, const LLStringUtil::format_map_t& args);
+    static bool findString(std::string &result, std::string_view xml_desc, const LLSD& args);
 
     // Returns translated string with [COUNT] replaced with a number, following
     // special per-language logic for plural nouns.  For example, some languages
@@ -94,23 +94,22 @@ public:
      * @param xml_desc String's description
      * @returns Translated string
      */
-    static std::string getString(const std::string &xml_desc, bool def_string = false)
+    static std::string getString(std::string_view xml_desc, bool def_string = false)
     {
         LLStringUtil::format_map_t empty;
         return getString(xml_desc, empty);
     }
 
-    static bool findString(std::string &result, const std::string &xml_desc)
+    static bool findString(std::string &result, std::string_view xml_desc)
     {
         LLStringUtil::format_map_t empty;
         return findString(result, xml_desc, empty);
     }
 
-    static std::string getKeyboardString(const char* keystring)
+    static std::string getKeyboardString(const std::string_view keystring)
     {
-        std::string key_str(keystring);
         std::string trans_str;
-        return findString(trans_str, key_str) ? trans_str : key_str;
+        return findString(trans_str, keystring) ? trans_str : std::string(keystring);
     }
 
     // get the default args
@@ -128,7 +127,7 @@ public:
     }
 
 private:
-    typedef std::map<std::string, LLTransTemplate > template_map_t;
+    typedef std::map<std::string, LLTransTemplate, std::less<>> template_map_t;
     static template_map_t sStringTemplates;
     static template_map_t sDefaultStringTemplates;
     static LLStringUtil::format_map_t sDefaultArgs;

--- a/indra/llui/llui.cpp
+++ b/indra/llui/llui.cpp
@@ -170,11 +170,11 @@ mHelpImpl(NULL)
     LLUICtrl::CommitCallbackRegistry::Registrar& reg = LLUICtrl::CommitCallbackRegistry::defaultRegistrar();
 
     // Callbacks for associating controls with floater visibility:
-    reg.add("Floater.Toggle", boost::bind(&LLFloaterReg::toggleInstance, _2, LLSD()));
-    reg.add("Floater.ToggleOrBringToFront", boost::bind(&LLFloaterReg::toggleInstanceOrBringToFront, _2, LLSD()));
-    reg.add("Floater.Show", boost::bind(&LLFloaterReg::showInstance, _2, LLSD(), false));
-    reg.add("Floater.ShowOrBringToFront", boost::bind(&LLFloaterReg::showInstanceOrBringToFront, _2, LLSD()));
-    reg.add("Floater.Hide", boost::bind(&LLFloaterReg::hideInstance, _2, LLSD()));
+    reg.add("Floater.Toggle", [](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::toggleInstance(param.asStringRef()); });
+    reg.add("Floater.ToggleOrBringToFront", [](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::toggleInstanceOrBringToFront(param.asStringRef()); });
+    reg.add("Floater.Show", [](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::showInstance(param.asStringRef(), LLSD(), false); });
+    reg.add("Floater.ShowOrBringToFront", [](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::showInstanceOrBringToFront(param.asStringRef(), LLSD()); });
+    reg.add("Floater.Hide", [](LLUICtrl* ctrl, const LLSD& param) -> void { LLFloaterReg::hideInstance(param.asStringRef()); });
 
     // Button initialization callback for toggle buttons
     reg.add("Button.SetFloaterToggle", boost::bind(&LLButton::setFloaterToggle, _1, _2));
@@ -189,8 +189,8 @@ mHelpImpl(NULL)
     reg.add("Button.ToggleFloater", boost::bind(&LLButton::toggleFloaterAndSetToggleState, _1, _2));
 
     // Used by menus along with Floater.Toggle to display visibility as a check-mark
-    LLUICtrl::EnableCallbackRegistry::defaultRegistrar().add("Floater.Visible", boost::bind(&LLFloaterReg::instanceVisible, _2, LLSD()));
-    LLUICtrl::EnableCallbackRegistry::defaultRegistrar().add("Floater.IsOpen", boost::bind(&LLFloaterReg::instanceVisible, _2, LLSD()));
+    LLUICtrl::EnableCallbackRegistry::defaultRegistrar().add("Floater.Visible", [](LLUICtrl* ctrl, const LLSD& param) -> bool { return LLFloaterReg::instanceVisible(param.asStringRef(), LLSD()); });
+    LLUICtrl::EnableCallbackRegistry::defaultRegistrar().add("Floater.IsOpen",  [](LLUICtrl* ctrl, const LLSD& param) -> bool { return LLFloaterReg::instanceVisible(param.asStringRef(), LLSD()); });
 
     // Parse the master list of commands
     LLCommandManager::load();

--- a/indra/llui/llui.cpp
+++ b/indra/llui/llui.cpp
@@ -529,7 +529,7 @@ namespace LLInitParam
     {
         if (control.isProvided() && !control().empty())
         {
-            updateValue(LLUIColorTable::instance().getColor(control));
+            updateValue(LLUIColorTable::instance().getColor(control()));
         }
         else
         {

--- a/indra/llui/llui.cpp
+++ b/indra/llui/llui.cpp
@@ -367,7 +367,7 @@ void LLUI::glRectToScreen(const LLRect& gl, LLRect *screen)
 }
 
 
-LLControlGroup& LLUI::getControlControlGroup (const std::string& controlname)
+LLControlGroup& LLUI::getControlControlGroup (std::string_view controlname)
 {
     for (settings_map_t::iterator itor = mSettingGroups.begin();
          itor != mSettingGroups.end(); ++itor)

--- a/indra/llui/llui.h
+++ b/indra/llui/llui.h
@@ -115,7 +115,7 @@ typedef void (*LLUIAudioCallback)(const LLUUID& uuid);
 class LLUI : public LLParamSingleton<LLUI>
 {
 public:
-    typedef std::map<std::string, LLControlGroup*> settings_map_t;
+    typedef std::map<std::string, LLControlGroup*, std::less<> > settings_map_t;
 
 private:
     LLSINGLETON(LLUI , const settings_map_t &settings,
@@ -295,7 +295,7 @@ public:
     void screenRectToGL(const LLRect& screen, LLRect *gl);
     void glRectToScreen(const LLRect& gl, LLRect *screen);
     // Returns the control group containing the control name, or the default group
-    LLControlGroup& getControlControlGroup (const std::string& controlname);
+    LLControlGroup& getControlControlGroup (std::string_view controlname);
     F32 getMouseIdleTime() { return mMouseIdleTimer.getElapsedTimeF32(); }
     void resetMouseIdleTimer() { mMouseIdleTimer.reset(); }
     LLWindow* getWindow() { return mWindow; }

--- a/indra/llui/lluicolortable.cpp
+++ b/indra/llui/lluicolortable.cpp
@@ -63,7 +63,7 @@ void LLUIColorTable::insertFromParams(const Params& p, string_color_map_t& table
         ColorEntryParams color_entry = *it;
         if(color_entry.color.value.isChosen())
         {
-            setColor(color_entry.name, color_entry.color.value, table);
+            setColor(color_entry.name(), color_entry.color.value, table);
         }
         else
         {
@@ -176,7 +176,7 @@ void LLUIColorTable::clear()
     clearTable(mUserSetColors);
 }
 
-LLUIColor LLUIColorTable::getColor(const std::string& name, const LLColor4& default_color) const
+LLUIColor LLUIColorTable::getColor(std::string_view name, const LLColor4& default_color) const
 {
     string_color_map_t::const_iterator iter = mUserSetColors.find(name);
 
@@ -196,7 +196,7 @@ LLUIColor LLUIColorTable::getColor(const std::string& name, const LLColor4& defa
 }
 
 // update user color, loaded colors are parsed on initialization
-void LLUIColorTable::setColor(const std::string& name, const LLColor4& color)
+void LLUIColorTable::setColor(std::string_view name, const LLColor4& color)
 {
     setColor(name, color, mUserSetColors);
 }
@@ -258,7 +258,7 @@ void LLUIColorTable::saveUserSettings() const
     }
 }
 
-bool LLUIColorTable::colorExists(const std::string& color_name) const
+bool LLUIColorTable::colorExists(std::string_view color_name) const
 {
     return ((mLoadedColors.find(color_name) != mLoadedColors.end())
          || (mUserSetColors.find(color_name) != mUserSetColors.end()));
@@ -276,7 +276,7 @@ void LLUIColorTable::clearTable(string_color_map_t& table)
 
 // this method inserts a color into the table if it does not exist
 // if the color already exists it changes the color
-void LLUIColorTable::setColor(const std::string& name, const LLColor4& color, string_color_map_t& table)
+void LLUIColorTable::setColor(std::string_view name, const LLColor4& color, string_color_map_t& table)
 {
     string_color_map_t::iterator it = table.lower_bound(name);
     if(it != table.end()

--- a/indra/llui/lluicolortable.h
+++ b/indra/llui/lluicolortable.h
@@ -42,7 +42,7 @@ class LLUIColorTable : public LLSingleton<LLUIColorTable>
     LOG_CLASS(LLUIColorTable);
 
     // consider using sorted vector, can be much faster
-    typedef std::map<std::string, LLUIColor>  string_color_map_t;
+    typedef std::map<std::string, LLUIColor, std::less<>>  string_color_map_t;
 
 public:
     struct ColorParams : LLInitParam::ChoiceBlock<ColorParams>
@@ -75,13 +75,13 @@ public:
     void clear();
 
     // color lookup
-    LLUIColor getColor(const std::string& name, const LLColor4& default_color = LLColor4::magenta) const;
+    LLUIColor getColor(std::string_view name, const LLColor4& default_color = LLColor4::magenta) const;
 
     // if the color is in the table, it's value is changed, otherwise it is added
-    void setColor(const std::string& name, const LLColor4& color);
+    void setColor(std::string_view name, const LLColor4& color);
 
     // returns true if color_name exists in the table
-    bool colorExists(const std::string& color_name) const;
+    bool colorExists(std::string_view color_name) const;
 
     // loads colors from settings files
     bool loadFromSettings();
@@ -95,7 +95,7 @@ private:
     void insertFromParams(const Params& p, string_color_map_t& table);
 
     void clearTable(string_color_map_t& table);
-    void setColor(const std::string& name, const LLColor4& color, string_color_map_t& table);
+    void setColor(std::string_view name, const LLColor4& color, string_color_map_t& table);
 
     string_color_map_t mLoadedColors;
     string_color_map_t mUserSetColors;

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -44,7 +44,7 @@ F32 LLUICtrl::sInactiveControlTransparency = 1.0f;
 
 // Compiler optimization, generate extern template
 template class LLUICtrl* LLView::getChild<class LLUICtrl>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 LLUICtrl::CallbackParam::CallbackParam()
 :   name("name"),

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -135,7 +135,7 @@ void LLUICtrl::initFromParams(const Params& p)
     {
         if (p.enabled_controls.enabled.isChosen())
         {
-            LLControlVariable* control = findControl(p.enabled_controls.enabled);
+            LLControlVariable* control = findControl(p.enabled_controls.enabled());
             if (control)
             {
                 setEnabledControlVariable(control);
@@ -149,7 +149,7 @@ void LLUICtrl::initFromParams(const Params& p)
         }
         else if(p.enabled_controls.disabled.isChosen())
         {
-            LLControlVariable* control = findControl(p.enabled_controls.disabled);
+            LLControlVariable* control = findControl(p.enabled_controls.disabled());
             if (control)
             {
                 setDisabledControlVariable(control);
@@ -166,7 +166,7 @@ void LLUICtrl::initFromParams(const Params& p)
     {
         if (p.controls_visibility.visible.isChosen())
         {
-            LLControlVariable* control = findControl(p.controls_visibility.visible);
+            LLControlVariable* control = findControl(p.controls_visibility.visible());
             if (control)
             {
                 setMakeVisibleControlVariable(control);
@@ -180,7 +180,7 @@ void LLUICtrl::initFromParams(const Params& p)
         }
         else if (p.controls_visibility.invisible.isChosen())
         {
-            LLControlVariable* control = findControl(p.controls_visibility.invisible);
+            LLControlVariable* control = findControl(p.controls_visibility.invisible());
             if (control)
             {
                 setMakeInvisibleControlVariable(control);

--- a/indra/llui/lluictrl.h
+++ b/indra/llui/lluictrl.h
@@ -335,7 +335,7 @@ private:
 // Build time optimization, generate once in .cpp file
 #ifndef LLUICTRL_CPP
 extern template class LLUICtrl* LLView::getChild<class LLUICtrl>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif  // LL_LLUICTRL_H

--- a/indra/llui/lluictrlfactory.h
+++ b/indra/llui/lluictrlfactory.h
@@ -182,10 +182,10 @@ fail:
     }
 
     template<class T>
-    static T* getDefaultWidget(const std::string& name)
+    static T* getDefaultWidget(std::string_view name)
     {
         typename T::Params widget_params;
-        widget_params.name = name;
+        widget_params.name = std::string(name);
         return create<T>(widget_params);
     }
 

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -85,7 +85,7 @@ bool LLView::sIsDrawing = false;
 
 // Compiler optimization, generate extern template
 template class LLView* LLView::getChild<class LLView>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 
 static LLDefaultChildRegistry::Register<LLView> r("view");
 
@@ -729,7 +729,7 @@ void LLView::logMouseEvent()
 }
 
 template <typename METHOD, typename CHARTYPE>
-LLView* LLView::childrenHandleCharEvent(const std::string& desc, const METHOD& method,
+LLView* LLView::childrenHandleCharEvent(std::string_view desc, const METHOD& method,
                                         CHARTYPE c, MASK mask)
 {
     if ( getVisible() && getEnabled() )
@@ -1613,7 +1613,7 @@ bool LLView::hasAncestor(const LLView* parentp) const
 
 //-----------------------------------------------------------------------------
 
-bool LLView::childHasKeyboardFocus( const std::string& childname ) const
+bool LLView::childHasKeyboardFocus(std::string_view childname) const
 {
     LLView *focus = dynamic_cast<LLView *>(gFocusMgr.getKeyboardFocus());
 
@@ -1632,7 +1632,7 @@ bool LLView::childHasKeyboardFocus( const std::string& childname ) const
 
 //-----------------------------------------------------------------------------
 
-bool LLView::hasChild(const std::string& childname, bool recurse) const
+bool LLView::hasChild(std::string_view childname, bool recurse) const
 {
     return findChildView(childname, recurse) != NULL;
 }
@@ -1640,12 +1640,12 @@ bool LLView::hasChild(const std::string& childname, bool recurse) const
 //-----------------------------------------------------------------------------
 // getChildView()
 //-----------------------------------------------------------------------------
-LLView* LLView::getChildView(const std::string& name, bool recurse) const
+LLView* LLView::getChildView(std::string_view name, bool recurse) const
 {
     return getChild<LLView>(name, recurse);
 }
 
-LLView* LLView::findChildView(const std::string& name, bool recurse) const
+LLView* LLView::findChildView(std::string_view name, bool recurse) const
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 

--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -2312,18 +2312,20 @@ LLView* LLView::findSnapEdge(S32& new_edge_val, const LLCoordGL& mouse_dir, ESna
 //-----------------------------------------------------------------------------
 
 
-LLControlVariable *LLView::findControl(const std::string& name)
+LLControlVariable *LLView::findControl(std::string_view name)
 {
+    auto uiInst = LLUI::getInstance();
     // parse the name to locate which group it belongs to
     std::size_t key_pos= name.find(".");
-    if(key_pos!=  std::string::npos )
+    if(key_pos !=  std::string_view::npos )
     {
-        std::string control_group_key = name.substr(0, key_pos);
+        std::string_view control_group_key = name.substr(0, key_pos);
         LLControlVariable* control;
         // check if it's in the control group that name indicated
-        if(LLUI::getInstance()->mSettingGroups[control_group_key])
+        auto it = uiInst->mSettingGroups.find(control_group_key);
+        if(it != uiInst->mSettingGroups.end() && it->second)
         {
-            control = LLUI::getInstance()->mSettingGroups[control_group_key]->getControl(name);
+            control = it->second->getControl(name);
             if (control)
             {
                 return control;
@@ -2331,7 +2333,7 @@ LLControlVariable *LLView::findControl(const std::string& name)
         }
     }
 
-    LLControlGroup& control_group = LLUI::getInstance()->getControlControlGroup(name);
+    LLControlGroup& control_group = uiInst->getControlControlGroup(name);
     return control_group.getControl(name);
 }
 

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -416,7 +416,7 @@ public:
     void screenRectToLocal( const LLRect& screen, LLRect* local ) const;
     void localRectToScreen( const LLRect& local, LLRect* screen ) const;
 
-    LLControlVariable *findControl(const std::string& name);
+    LLControlVariable *findControl(std::string_view name);
 
     const child_list_t* getChildList() const { return &mChildList; }
     child_list_const_iter_t beginChild() const { return mChildList.begin(); }

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -341,8 +341,8 @@ public:
     S32         getChildCount() const           { return (S32)mChildList.size(); }
     template<class _Pr3> void sortChildren(_Pr3 _Pred) { mChildList.sort(_Pred); }
     bool        hasAncestor(const LLView* parentp) const;
-    bool        hasChild(const std::string& childname, bool recurse = false) const;
-    bool        childHasKeyboardFocus( const std::string& childname ) const;
+    bool        hasChild(std::string_view childname, bool recurse = false) const;
+    bool        childHasKeyboardFocus( std::string_view childname ) const;
 
     // these iterators are used for collapsing various tree traversals into for loops
     typedef LLTreeDFSIter<LLView, child_list_const_iter_t> tree_iterator_t;
@@ -452,24 +452,24 @@ public:
     // static method handles NULL pointer too
     static std::string getPathname(const LLView*);
 
-    template <class T> T* findChild(const std::string& name, bool recurse = true) const
+    template <class T> T* findChild(std::string_view name, bool recurse = true) const
     {
         LLView* child = findChildView(name, recurse);
         T* result = dynamic_cast<T*>(child);
         return result;
     }
 
-    template <class T> T* getChild(const std::string& name, bool recurse = true) const;
+    template <class T> T* getChild(std::string_view name, bool recurse = true) const;
 
-    template <class T> T& getChildRef(const std::string& name, bool recurse = true) const
+    template <class T> T& getChildRef(std::string_view name, bool recurse = true) const
     {
         return *getChild<T>(name, recurse);
     }
 
-    virtual LLView* getChildView(const std::string& name, bool recurse = true) const;
-    virtual LLView* findChildView(const std::string& name, bool recurse = true) const;
+    virtual LLView* getChildView(std::string_view name, bool recurse = true) const;
+    virtual LLView* findChildView(std::string_view name, bool recurse = true) const;
 
-    template <class T> T* getDefaultWidget(const std::string& name) const
+    template <class T> T* getDefaultWidget(std::string_view name) const
     {
         LLView* widgetp = getDefaultWidgetContainer().findChildView(name);
         return dynamic_cast<T*>(widgetp);
@@ -576,7 +576,7 @@ private:
     LLView* childrenHandleMouseEvent(const METHOD& method, S32 x, S32 y, XDATA extra, bool allow_mouse_block = true);
 
     template <typename METHOD, typename CHARTYPE>
-    LLView* childrenHandleCharEvent(const std::string& desc, const METHOD& method,
+    LLView* childrenHandleCharEvent(std::string_view desc, const METHOD& method,
                                     CHARTYPE c, MASK mask);
 
     // adapter to blur distinction between handleKey() and handleUnicodeChar()
@@ -696,7 +696,7 @@ struct TypeValues<LLView::EOrientation> : public LLInitParam::TypeValuesHelper<L
 };
 }
 
-template <class T> T* LLView::getChild(const std::string& name, bool recurse) const
+template <class T> T* LLView::getChild(std::string_view name, bool recurse) const
 {
     LLView* child = findChildView(name, recurse);
     T* result = dynamic_cast<T*>(child);
@@ -731,7 +731,7 @@ template <class T> T* LLView::getChild(const std::string& name, bool recurse) co
 // require explicit specialization.  See llbutton.cpp for an example.
 #ifndef LLVIEW_CPP
 extern template class LLView* LLView::getChild<class LLView>(
-    const std::string& name, bool recurse) const;
+    std::string_view name, bool recurse) const;
 #endif
 
 #endif //LL_LLVIEW_H

--- a/indra/llwindow/llkeyboard.cpp
+++ b/indra/llwindow/llkeyboard.cpp
@@ -359,7 +359,7 @@ std::string LLKeyboard::stringFromKey(KEY key, bool translate)
         LLKeyStringTranslatorFunc *trans = gKeyboard->mStringTranslator;
         if (trans != NULL)
         {
-            res = trans(res.c_str());
+            res = trans(res);
         }
     }
 
@@ -399,7 +399,7 @@ std::string LLKeyboard::stringFromMouse(EMouseClickType click, bool translate)
         LLKeyStringTranslatorFunc* trans = gKeyboard->mStringTranslator;
         if (trans != NULL)
         {
-            res = trans(res.c_str());
+            res = trans(res);
         }
     }
     return res;

--- a/indra/llwindow/llkeyboard.h
+++ b/indra/llwindow/llkeyboard.h
@@ -42,7 +42,7 @@ enum EKeystate
 };
 
 typedef boost::function<bool(EKeystate keystate)> LLKeyFunc;
-typedef std::string (LLKeyStringTranslatorFunc)(const char *label);
+typedef std::string (LLKeyStringTranslatorFunc)(std::string_view);
 
 enum EKeyboardInsertMode
 {

--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -348,7 +348,7 @@ LLPointer<LLControlVariable> LLControlGroup::getControl(std::string_view name)
         incrCount(name);
     }
 
-    ctrl_name_table_t::iterator iter = mNameTable.find(name.data());
+    ctrl_name_table_t::iterator iter = mNameTable.find(name);
     return iter == mNameTable.end() ? LLPointer<LLControlVariable>() : iter->second;
 }
 
@@ -657,7 +657,7 @@ LLSD LLControlGroup::asLLSD(bool diffs_only)
     return result;
 }
 
-bool LLControlGroup::controlExists(const std::string& name)
+bool LLControlGroup::controlExists(std::string_view name)
 {
     ctrl_name_table_t::iterator iter = mNameTable.find(name);
     return iter != mNameTable.end();

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -189,7 +189,7 @@ class LLControlGroup : public LLInstanceTracker<LLControlGroup, std::string>
     LOG_CLASS(LLControlGroup);
 
 protected:
-    typedef std::map<std::string, LLControlVariablePtr > ctrl_name_table_t;
+    typedef std::map<std::string, LLControlVariablePtr, std::less<> > ctrl_name_table_t;
     ctrl_name_table_t mNameTable;
     static const std::string mTypeString[TYPE_COUNT];
 
@@ -295,7 +295,7 @@ public:
         }
     }
 
-    bool    controlExists(const std::string& name);
+    bool    controlExists(std::string_view name);
 
     // Returns number of controls loaded, 0 if failed
     // If require_declaration is false, will auto-declare controls it finds

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2393,7 +2393,7 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
             std::string full_settings_path;
 
             if (file.file_name_setting.isProvided()
-                && gSavedSettings.controlExists(file.file_name_setting))
+                && gSavedSettings.controlExists(file.file_name_setting()))
             {
                 // try to find filename stored in file_name_setting control
                 full_settings_path = gSavedSettings.getString(file.file_name_setting());

--- a/indra/newview/llfloatersidepanelcontainer.cpp
+++ b/indra/newview/llfloatersidepanelcontainer.cpp
@@ -113,7 +113,7 @@ LLFloater* LLFloaterSidePanelContainer::getTopmostInventoryFloater()
     return topmost_floater;
 }
 
-LLPanel* LLFloaterSidePanelContainer::openChildPanel(const std::string& panel_name, const LLSD& params)
+LLPanel* LLFloaterSidePanelContainer::openChildPanel(std::string_view panel_name, const LLSD& params)
 {
     LLView* view = findChildView(panel_name, true);
     if (!view)
@@ -144,7 +144,7 @@ LLPanel* LLFloaterSidePanelContainer::openChildPanel(const std::string& panel_na
     return panel;
 }
 
-void LLFloaterSidePanelContainer::showPanel(const std::string& floater_name, const LLSD& key)
+void LLFloaterSidePanelContainer::showPanel(std::string_view floater_name, const LLSD& key)
 {
     LLFloaterSidePanelContainer* floaterp = LLFloaterReg::getTypedInstance<LLFloaterSidePanelContainer>(floater_name);
     if (floaterp)
@@ -153,7 +153,7 @@ void LLFloaterSidePanelContainer::showPanel(const std::string& floater_name, con
     }
 }
 
-void LLFloaterSidePanelContainer::showPanel(const std::string& floater_name, const std::string& panel_name, const LLSD& key)
+void LLFloaterSidePanelContainer::showPanel(std::string_view floater_name, std::string_view panel_name, const LLSD& key)
 {
     LLFloaterSidePanelContainer* floaterp = LLFloaterReg::getTypedInstance<LLFloaterSidePanelContainer>(floater_name);
     if (floaterp)
@@ -162,7 +162,7 @@ void LLFloaterSidePanelContainer::showPanel(const std::string& floater_name, con
     }
 }
 
-LLPanel* LLFloaterSidePanelContainer::getPanel(const std::string& floater_name, const std::string& panel_name)
+LLPanel* LLFloaterSidePanelContainer::getPanel(std::string_view floater_name, std::string_view panel_name)
 {
     LLFloaterSidePanelContainer* floaterp = LLFloaterReg::getTypedInstance<LLFloaterSidePanelContainer>(floater_name);
 
@@ -174,7 +174,7 @@ LLPanel* LLFloaterSidePanelContainer::getPanel(const std::string& floater_name, 
     return NULL;
 }
 
-LLPanel* LLFloaterSidePanelContainer::findPanel(const std::string& floater_name, const std::string& panel_name)
+LLPanel* LLFloaterSidePanelContainer::findPanel(std::string_view floater_name, std::string_view panel_name)
 {
     LLFloaterSidePanelContainer* floaterp = LLFloaterReg::findTypedInstance<LLFloaterSidePanelContainer>(floater_name);
 

--- a/indra/newview/llfloatersidepanelcontainer.h
+++ b/indra/newview/llfloatersidepanelcontainer.h
@@ -55,17 +55,17 @@ public:
 
     void cleanup() { destroy(); }
 
-    LLPanel* openChildPanel(const std::string& panel_name, const LLSD& params);
+    LLPanel* openChildPanel(std::string_view panel_name, const LLSD& params);
 
     static LLFloater* getTopmostInventoryFloater();
 
-    static void showPanel(const std::string& floater_name, const LLSD& key);
+    static void showPanel(std::string_view floater_name, const LLSD& key);
 
-    static void showPanel(const std::string& floater_name, const std::string& panel_name, const LLSD& key);
+    static void showPanel(std::string_view floater_name, std::string_view panel_name, const LLSD& key);
 
-    static LLPanel* getPanel(const std::string& floater_name, const std::string& panel_name = sMainPanelName);
+    static LLPanel* getPanel(std::string_view floater_name, std::string_view panel_name = sMainPanelName);
 
-    static LLPanel* findPanel(const std::string& floater_name, const std::string& panel_name = sMainPanelName);
+    static LLPanel* findPanel(std::string_view floater_name, std::string_view panel_name = sMainPanelName);
 
     /**
      * Gets the panel of given type T (doesn't show it or do anything else with it).
@@ -75,7 +75,7 @@ public:
      * @returns a pointer to the panel of given type T.
      */
     template <typename T>
-    static T* getPanel(const std::string& floater_name, const std::string& panel_name = sMainPanelName)
+    static T* getPanel(std::string_view floater_name, std::string_view panel_name = sMainPanelName)
     {
         T* panel = dynamic_cast<T*>(getPanel(floater_name, panel_name));
         if (!panel)

--- a/indra/newview/llfloaterwebcontent.cpp
+++ b/indra/newview/llfloaterwebcontent.cpp
@@ -220,7 +220,7 @@ void LLFloaterWebContent::preCreate(LLFloaterWebContent::Params& p)
         // showInstance will open a new window.  Figure out how many web browsers are already open,
         // and close the least recently opened one if this will put us over the limit.
 
-        LLFloaterReg::const_instance_list_t &instances = LLFloaterReg::getFloaterList(p.window_class);
+        LLFloaterReg::const_instance_list_t &instances = LLFloaterReg::getFloaterList(p.window_class());
 
         if(instances.size() >= (size_t)browser_window_limit)
         {

--- a/indra/newview/lllogininstance.cpp
+++ b/indra/newview/lllogininstance.cpp
@@ -447,7 +447,7 @@ void LLLoginInstance::handleLoginFailure(const LLSD& event)
             gViewerWindow->setShowProgress(false);
         }
 
-        showMFAChallange(LLTrans::getString(response["message_id"]));
+        showMFAChallange(LLTrans::getString(response["message_id"].asString()));
     }
     else if(   reason_response == "key"
             || reason_response == "presence"

--- a/indra/newview/llsidetraypanelcontainer.cpp
+++ b/indra/newview/llsidetraypanelcontainer.cpp
@@ -62,10 +62,10 @@ void LLSideTrayPanelContainer::onOpen(const LLSD& key)
     getCurrentPanel()->onOpen(key);
 }
 
-void LLSideTrayPanelContainer::openPanel(const std::string& panel_name, const LLSD& key)
+void LLSideTrayPanelContainer::openPanel(std::string_view panel_name, const LLSD& key)
 {
     LLSD combined_key = key;
-    combined_key[PARAM_SUB_PANEL_NAME] = panel_name;
+    combined_key[PARAM_SUB_PANEL_NAME] = std::string(panel_name);
     onOpen(combined_key);
 }
 

--- a/indra/newview/llsidetraypanelcontainer.h
+++ b/indra/newview/llsidetraypanelcontainer.h
@@ -59,7 +59,7 @@ public:
     /**
      * Opens given subpanel.
      */
-    void openPanel(const std::string& panel_name, const LLSD& key = LLSD::emptyMap());
+    void openPanel(std::string_view panel_name, const LLSD& key = LLSD::emptyMap());
 
     /**
     * Opens previous panel from panel navigation history.

--- a/indra/newview/tests/lldateutil_test.cpp
+++ b/indra/newview/tests/lldateutil_test.cpp
@@ -38,18 +38,23 @@
 
 
 // Baked-in return values for getString()
-std::map< std::string, std::string > gString;
+std::map< std::string, std::string, std::less<>> gString;
 
 // Baked-in return values for getCountString()
 // map of pairs of input xml_desc and integer count
 typedef std::pair< std::string, int > count_string_t;
 std::map< count_string_t, std::string > gCountString;
 
-std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
+std::string LLTrans::getString(const std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
 {
-    std::string text = gString[xml_desc];
-    LLStringUtil::format(text, args);
-    return text;
+    auto it = gString.find(xml_desc);
+    if (it != gString.end())
+    {
+        std::string text = it->second;
+        LLStringUtil::format(text, args);
+        return text;
+    }
+    return {};
 }
 
 std::string LLTrans::getCountString(const std::string& language, const std::string& xml_desc, S32 count)

--- a/indra/newview/tests/lllogininstance_test.cpp
+++ b/indra/newview/tests/lllogininstance_test.cpp
@@ -79,7 +79,7 @@ LLProgressView * LLViewerWindow::getProgressView(void) const { return 0; }
 
 LLViewerWindow* gViewerWindow;
 
-std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
+std::string LLTrans::getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
 {
     return std::string("test_trans");
 }
@@ -235,7 +235,7 @@ static LLEventPump * gTOSReplyPump = NULL;
 LLPointer<LLSecAPIHandler> gSecAPIHandler;
 
 //static
-LLFloater* LLFloaterReg::showInstance(const std::string& name, const LLSD& key, bool focus)
+LLFloater* LLFloaterReg::showInstance(std::string_view name, const LLSD& key, bool focus)
 {
     gTOSType = name;
     gTOSReplyPump = &LLEventPumps::instance().obtain(key["reply_pump"]);

--- a/indra/newview/tests/llslurl_test.cpp
+++ b/indra/newview/tests/llslurl_test.cpp
@@ -46,10 +46,10 @@ static const char * const TEST_FILENAME("llslurl_test.xml");
 class LLTrans
 {
 public:
-    static std::string getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
+    static std::string getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
 };
 
-std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
+std::string LLTrans::getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
 {
     return std::string();
 }

--- a/indra/newview/tests/llviewernetwork_test.cpp
+++ b/indra/newview/tests/llviewernetwork_test.cpp
@@ -45,10 +45,10 @@ static const char * const TEST_FILENAME("llviewernetwork_test.xml");
 class LLTrans
 {
 public:
-    static std::string getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
+    static std::string getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string = false);
 };
 
-std::string LLTrans::getString(const std::string &xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
+std::string LLTrans::getString(std::string_view xml_desc, const LLStringUtil::format_map_t& args, bool def_string)
 {
     std::string grid_label = std::string();
     if(xml_desc == "AgniGridLabel")

--- a/indra/newview/tests/llworldmap_test.cpp
+++ b/indra/newview/tests/llworldmap_test.cpp
@@ -66,7 +66,7 @@ void LLWorldMipmap::equalizeBoostLevels() { }
 LLPointer<LLViewerFetchedTexture> LLWorldMipmap::getObjectsTile(U32 grid_x, U32 grid_y, S32 level, bool load) { return NULL; }
 
 // Stub other stuff
-std::string LLTrans::getString(const std::string &, const LLStringUtil::format_map_t&, bool def_string) { return std::string("test_trans"); }
+std::string LLTrans::getString(std::string_view, const LLStringUtil::format_map_t&, bool def_string) { return std::string("test_trans"); }
 void LLUIString::updateResult() const { }
 void LLUIString::setArg(const std::string& , const std::string& ) { }
 void LLUIString::assign(const std::string& ) { }


### PR DESCRIPTION
This set of changes reduces the number of string temporaries created from calling various find and get functions in llui by modernizing to use std::string_view