### PR TITLE
Reduce string temporaries in LLUI part 2

### DIFF
--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -164,13 +164,13 @@ std::string LLKeywords::getArguments(LLSD& arguments)
     return argString;
 }
 
-std::string LLKeywords::getAttribute(const std::string& key)
+std::string LLKeywords::getAttribute(std::string_view key)
 {
     attribute_iterator_t it = mAttributes.find(key);
     return (it != mAttributes.end()) ? it->second : "";
 }
 
-LLColor4 LLKeywords::getColorGroup(const std::string& key_in)
+LLColor4 LLKeywords::getColorGroup(std::string_view key_in)
 {
     std::string color_group = "ScriptText";
     if (key_in == "functions")
@@ -261,7 +261,7 @@ void LLKeywords::processTokens()
     LL_INFOS("SyntaxLSL") << "Finished processing tokens." << LL_ENDL;
 }
 
-void LLKeywords::processTokensGroup(const LLSD& tokens, const std::string& group)
+void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
 {
     LLColor4 color;
     LLColor4 color_group;
@@ -333,7 +333,7 @@ void LLKeywords::processTokensGroup(const LLSD& tokens, const std::string& group
                     case LLKeywordToken::TT_CONSTANT:
                         if (getAttribute("type").length() > 0)
                         {
-                            color_group = getColorGroup(group + "-" + getAttribute("type"));
+                            color_group = getColorGroup(std::string(group) + "-" + getAttribute("type"));
                         }
                         else
                         {

--- a/indra/llui/llkeywords.h
+++ b/indra/llui/llkeywords.h
@@ -111,7 +111,7 @@ public:
     ~LLKeywords();
 
     void        clearLoaded() { mLoaded = false; }
-    LLColor4    getColorGroup(const std::string& key_in);
+    LLColor4    getColorGroup(std::string_view key_in);
     bool        isLoaded() const    { return mLoaded; }
 
     void        findSegments(std::vector<LLTextSegmentPtr> *seg_list,
@@ -170,7 +170,7 @@ public:
 #endif
 
 protected:
-    void        processTokensGroup(const LLSD& Tokens, const std::string& Group);
+    void        processTokensGroup(const LLSD& Tokens, std::string_view Group);
     void        insertSegment(std::vector<LLTextSegmentPtr>& seg_list,
                               LLTextSegmentPtr new_segment,
                               S32 text_len,
@@ -194,10 +194,10 @@ protected:
     token_list_t mLineTokenList;
     token_list_t mDelimiterTokenList;
 
-    typedef  std::map<std::string, std::string> element_attributes_t;
+    typedef  std::map<std::string, std::string, std::less<>> element_attributes_t;
     typedef element_attributes_t::const_iterator attribute_iterator_t;
     element_attributes_t mAttributes;
-    std::string getAttribute(const std::string& key);
+    std::string getAttribute(std::string_view key);
 
     std::string getArguments(LLSD& arguments);
 };

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -548,7 +548,7 @@ LLLayoutPanel* LLLayoutStack::findEmbeddedPanel(LLPanel* panelp) const
     return NULL;
 }
 
-LLLayoutPanel* LLLayoutStack::findEmbeddedPanelByName(const std::string& name) const
+LLLayoutPanel* LLLayoutStack::findEmbeddedPanelByName(std::string_view name) const
 {
     LLLayoutPanel* result = NULL;
 

--- a/indra/llui/lllayoutstack.h
+++ b/indra/llui/lllayoutstack.h
@@ -111,7 +111,7 @@ private:
     e_panel_list_t mPanels;
 
     LLLayoutPanel* findEmbeddedPanel(LLPanel* panelp) const;
-    LLLayoutPanel* findEmbeddedPanelByName(const std::string& name) const;
+    LLLayoutPanel* findEmbeddedPanelByName(std::string_view name) const;
     void updateFractionalSizes();
     void normalizeFractionalSizes();
     void updatePanelRect( LLLayoutPanel* param1, const LLRect& new_rect );

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -2752,7 +2752,7 @@ void LLMenuGL::setEnabledSubMenus(bool enable)
 
 // setItemEnabled() - pass the label and the enable flag for a menu
 // item. true will make sure it's enabled, false will disable it.
-void LLMenuGL::setItemEnabled( const std::string& name, bool enable )
+void LLMenuGL::setItemEnabled(std::string_view name, bool enable )
 {
     item_list_t::iterator item_iter;
     for (item_iter = mItems.begin(); item_iter != mItems.end(); ++item_iter)
@@ -2766,7 +2766,7 @@ void LLMenuGL::setItemEnabled( const std::string& name, bool enable )
     }
 }
 
-void LLMenuGL::setItemVisible( const std::string& name, bool visible )
+void LLMenuGL::setItemVisible(std::string_view name, bool visible )
 {
     item_list_t::iterator item_iter;
     for (item_iter = mItems.begin(); item_iter != mItems.end(); ++item_iter)
@@ -3277,7 +3277,7 @@ void LLMenuGL::setVisible(bool visible)
     }
 }
 
-LLMenuGL* LLMenuGL::findChildMenuByName(const std::string& name, bool recurse) const
+LLMenuGL* LLMenuGL::findChildMenuByName(std::string_view name, bool recurse) const
 {
     LLView* view = findChildView(name, recurse);
     if (view)

--- a/indra/llui/llmenugl.h
+++ b/indra/llui/llmenugl.h
@@ -456,7 +456,7 @@ public:
     virtual bool hasAccelerator(const KEY &key, const MASK &mask) const;
     virtual bool handleAcceleratorKey(KEY key, MASK mask);
 
-    LLMenuGL* findChildMenuByName(const std::string& name, bool recurse) const;
+    LLMenuGL* findChildMenuByName(std::string_view name, bool recurse) const;
 
     bool clearHoverItem();
 
@@ -479,12 +479,12 @@ public:
     // setItemEnabled() - pass the name and the enable flag for a
     // menu item. true will make sure it's enabled, false will disable
     // it.
-    void setItemEnabled( const std::string& name, bool enable );
+    void setItemEnabled(std::string_view name, bool enable );
 
     // propagate message to submenus
     void setEnabledSubMenus(bool enable);
 
-    void setItemVisible( const std::string& name, bool visible);
+    void setItemVisible(std::string_view name, bool visible);
 
     void setItemLabel(const std::string &name, const std::string &label);
 

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -266,7 +266,7 @@ LLSD LLNotificationForm::asLLSD() const
     return mFormData;
 }
 
-LLSD LLNotificationForm::getElement(const std::string& element_name)
+LLSD LLNotificationForm::getElement(std::string_view element_name)
 {
     for (LLSD::array_const_iterator it = mFormData.beginArray();
         it != mFormData.endArray();
@@ -278,7 +278,7 @@ LLSD LLNotificationForm::getElement(const std::string& element_name)
 }
 
 
-bool LLNotificationForm::hasElement(const std::string& element_name) const
+bool LLNotificationForm::hasElement(std::string_view element_name) const
 {
     for (LLSD::array_const_iterator it = mFormData.beginArray();
         it != mFormData.endArray();
@@ -301,7 +301,7 @@ void LLNotificationForm::getElements(LLSD& elements, S32 offset)
     }
 }
 
-bool LLNotificationForm::getElementEnabled(const std::string& element_name) const
+bool LLNotificationForm::getElementEnabled(std::string_view element_name) const
 {
     for (LLSD::array_const_iterator it = mFormData.beginArray();
         it != mFormData.endArray();
@@ -316,7 +316,7 @@ bool LLNotificationForm::getElementEnabled(const std::string& element_name) cons
     return false;
 }
 
-void LLNotificationForm::setElementEnabled(const std::string& element_name, bool enabled)
+void LLNotificationForm::setElementEnabled(std::string_view element_name, bool enabled)
 {
     for (LLSD::array_iterator it = mFormData.beginArray();
         it != mFormData.endArray();
@@ -769,7 +769,7 @@ bool LLNotification::hasUniquenessConstraints() const
     return (mTemplatep ? mTemplatep->mUnique : false);
 }
 
-bool LLNotification::matchesTag(const std::string& tag)
+bool LLNotification::matchesTag(std::string_view tag)
 {
     bool result = false;
 
@@ -1443,11 +1443,12 @@ void LLNotifications::createDefaultChannels()
 }
 
 
-LLNotificationTemplatePtr LLNotifications::getTemplate(const std::string& name)
+LLNotificationTemplatePtr LLNotifications::getTemplate(std::string_view name)
 {
-    if (mTemplates.count(name))
+    auto it = mTemplates.find(name);
+    if (it != mTemplates.end())
     {
-        return mTemplates[name];
+        return it->second;
     }
     else
     {
@@ -1455,7 +1456,7 @@ LLNotificationTemplatePtr LLNotifications::getTemplate(const std::string& name)
     }
 }
 
-bool LLNotifications::templateExists(const std::string& name)
+bool LLNotifications::templateExists(std::string_view name)
 {
     return (mTemplates.count(name) != 0);
 }
@@ -1740,7 +1741,7 @@ void LLNotifications::cancel(LLNotificationPtr pNotif)
     }
 }
 
-void LLNotifications::cancelByName(const std::string& name)
+void LLNotifications::cancelByName(std::string_view name)
 {
     LLMutexLock lock(&mItemsMutex);
     std::vector<LLNotificationPtr> notifs_to_cancel;
@@ -1815,7 +1816,7 @@ LLNotificationPtr LLNotifications::find(LLUUID uuid)
     }
 }
 
-std::string LLNotifications::getGlobalString(const std::string& key) const
+std::string LLNotifications::getGlobalString(std::string_view key) const
 {
     GlobalStringMap::const_iterator it = mGlobalStrings.find(key);
     if (it != mGlobalStrings.end())
@@ -1826,7 +1827,7 @@ std::string LLNotifications::getGlobalString(const std::string& key) const
     {
         // if we don't have the key as a global, return the key itself so that the error
         // is self-diagnosing.
-        return key;
+        return std::string(key);
     }
 }
 
@@ -1839,13 +1840,13 @@ bool LLNotifications::getIgnoreAllNotifications()
     return mIgnoreAllNotifications;
 }
 
-void LLNotifications::setIgnored(const std::string& name, bool ignored)
+void LLNotifications::setIgnored(std::string_view name, bool ignored)
 {
     LLNotificationTemplatePtr templatep = getTemplate(name);
     templatep->mForm->setIgnored(ignored);
 }
 
-bool LLNotifications::getIgnored(const std::string& name)
+bool LLNotifications::getIgnored(std::string_view name)
 {
     LLNotificationTemplatePtr templatep = getTemplate(name);
     return (mIgnoreAllNotifications) || ( (templatep->mForm->getIgnoreType() != LLNotificationForm::IGNORE_NO) && (templatep->mForm->getIgnored()) );

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -251,11 +251,11 @@ public:
 
     S32 getNumElements() { return static_cast<S32>(mFormData.size()); }
     LLSD getElement(S32 index) { return mFormData.get(index); }
-    LLSD getElement(const std::string& element_name);
+    LLSD getElement(std::string_view element_name);
     void getElements(LLSD& elements, S32 offset = 0);
-    bool hasElement(const std::string& element_name) const;
-    bool getElementEnabled(const std::string& element_name) const;
-    void setElementEnabled(const std::string& element_name, bool enabled);
+    bool hasElement(std::string_view element_name) const;
+    bool getElementEnabled(std::string_view element_name) const;
+    void setElementEnabled(std::string_view element_name, bool enabled);
     void addElement(const std::string& type, const std::string& name, const LLSD& value = LLSD(), bool enabled = true);
     void formatElements(const LLSD& substitutions);
     // appends form elements from another form serialized as LLSD
@@ -641,7 +641,7 @@ public:
 
     bool hasUniquenessConstraints() const;
 
-    bool matchesTag(const std::string& tag);
+    bool matchesTag(std::string_view tag);
 
     virtual ~LLNotification() {}
 };
@@ -926,7 +926,7 @@ public:
     void add(const LLNotificationPtr pNotif);
     void load(const LLNotificationPtr pNotif);
     void cancel(LLNotificationPtr pNotif);
-    void cancelByName(const std::string& name);
+    void cancelByName(std::string_view name);
     void cancelByOwner(const LLUUID ownerId);
     void update(const LLNotificationPtr pNotif);
 
@@ -934,19 +934,19 @@ public:
 
     // This is all stuff for managing the templates
     // take your template out
-    LLNotificationTemplatePtr getTemplate(const std::string& name);
+    LLNotificationTemplatePtr getTemplate(std::string_view name);
 
     // get the whole collection
     typedef std::vector<std::string> TemplateNames;
     TemplateNames getTemplateNames() const;  // returns a list of notification names
 
-    typedef std::map<std::string, LLNotificationTemplatePtr> TemplateMap;
+    typedef std::map<std::string, LLNotificationTemplatePtr, std::less<>> TemplateMap;
 
     TemplateMap::const_iterator templatesBegin() { return mTemplates.begin(); }
     TemplateMap::const_iterator templatesEnd() { return mTemplates.end(); }
 
     // test for existence
-    bool templateExists(const std::string& name);
+    bool templateExists(std::string_view name);
 
     typedef std::list<LLNotificationVisibilityRulePtr> VisibilityRuleList;
 
@@ -956,13 +956,13 @@ public:
 
     LLNotificationChannelPtr getChannel(const std::string& channelName);
 
-    std::string getGlobalString(const std::string& key) const;
+    std::string getGlobalString(std::string_view key) const;
 
     void setIgnoreAllNotifications(bool ignore);
     bool getIgnoreAllNotifications();
 
-    void setIgnored(const std::string& name, bool ignored);
-    bool getIgnored(const std::string& name);
+    void setIgnored(std::string_view name, bool ignored);
+    bool getIgnored(std::string_view name);
 
     bool isVisibleByRules(LLNotificationPtr pNotification);
 
@@ -988,7 +988,7 @@ private:
 
     LLNotificationMap mUniqueNotifications;
 
-    typedef std::map<std::string, std::string> GlobalStringMap;
+    typedef std::map<std::string, std::string, std::less<>> GlobalStringMap;
     GlobalStringMap mGlobalStrings;
 
     bool mIgnoreAllNotifications;

--- a/indra/llui/llnotificationslistener.cpp
+++ b/indra/llui/llnotificationslistener.cpp
@@ -191,7 +191,7 @@ void LLNotificationsListener::ignore(const LLSD& params) const
     if (params["name"].isDefined())
     {
         // ["name"] was passed: ignore just that notification
-        LLNotificationTemplatePtr templatep = mNotifications.getTemplate(params["name"]);
+        LLNotificationTemplatePtr templatep = mNotifications.getTemplate(params["name"].asStringRef());
         if (templatep)
         {
             templatep->mForm->setIgnored(ignore);

--- a/indra/llui/llpanel.cpp
+++ b/indra/llui/llpanel.cpp
@@ -277,7 +277,7 @@ void LLPanel::setDefaultBtn(LLButton* btn)
     }
 }
 
-void LLPanel::setDefaultBtn(const std::string& id)
+void LLPanel::setDefaultBtn(std::string_view id)
 {
     LLButton *button = getChild<LLButton>(id);
     if (button)
@@ -593,12 +593,12 @@ bool LLPanel::initPanelXML(LLXMLNodePtr node, LLView *parent, LLXMLNodePtr outpu
     return true;
 }
 
-bool LLPanel::hasString(const std::string& name)
+bool LLPanel::hasString(std::string_view name)
 {
     return mUIStrings.find(name) != mUIStrings.end();
 }
 
-std::string LLPanel::getString(const std::string& name, const LLStringUtil::format_map_t& args) const
+std::string LLPanel::getString(std::string_view name, const LLStringUtil::format_map_t& args) const
 {
     ui_string_map_t::const_iterator found_it = mUIStrings.find(name);
     if (found_it != mUIStrings.end())
@@ -608,7 +608,7 @@ std::string LLPanel::getString(const std::string& name, const LLStringUtil::form
         formatted_string.setArgList(args);
         return formatted_string.getString();
     }
-    std::string err_str("Failed to find string " + name + " in panel " + getName()); //*TODO: Translate
+    std::string err_str("Failed to find string " + std::string(name) + " in panel " + getName()); //*TODO: Translate
     if(LLUI::getInstance()->mSettingGroups["config"]->getBOOL("QAMode"))
     {
         LL_ERRS() << err_str << LL_ENDL;
@@ -620,14 +620,14 @@ std::string LLPanel::getString(const std::string& name, const LLStringUtil::form
     return LLStringUtil::null;
 }
 
-std::string LLPanel::getString(const std::string& name) const
+std::string LLPanel::getString(std::string_view name) const
 {
     ui_string_map_t::const_iterator found_it = mUIStrings.find(name);
     if (found_it != mUIStrings.end())
     {
         return found_it->second;
     }
-    std::string err_str("Failed to find string " + name + " in panel " + getName()); //*TODO: Translate
+    std::string err_str("Failed to find string " + std::string(name) +" in panel " + getName()); //*TODO: Translate
     if(LLUI::getInstance()->mSettingGroups["config"]->getBOOL("QAMode"))
     {
         LL_ERRS() << err_str << LL_ENDL;
@@ -640,7 +640,7 @@ std::string LLPanel::getString(const std::string& name) const
 }
 
 
-void LLPanel::childSetVisible(const std::string& id, bool visible)
+void LLPanel::childSetVisible(std::string_view id, bool visible)
 {
     LLView* child = findChild<LLView>(id);
     if (child)
@@ -649,7 +649,7 @@ void LLPanel::childSetVisible(const std::string& id, bool visible)
     }
 }
 
-void LLPanel::childSetEnabled(const std::string& id, bool enabled)
+void LLPanel::childSetEnabled(std::string_view id, bool enabled)
 {
     LLView* child = findChild<LLView>(id);
     if (child)
@@ -658,7 +658,7 @@ void LLPanel::childSetEnabled(const std::string& id, bool enabled)
     }
 }
 
-void LLPanel::childSetFocus(const std::string& id, bool focus)
+void LLPanel::childSetFocus(std::string_view id, bool focus)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -667,7 +667,7 @@ void LLPanel::childSetFocus(const std::string& id, bool focus)
     }
 }
 
-bool LLPanel::childHasFocus(const std::string& id)
+bool LLPanel::childHasFocus(std::string_view id)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -684,7 +684,7 @@ bool LLPanel::childHasFocus(const std::string& id)
 // Prefer getChild<LLUICtrl>("foo")->setCommitCallback(boost:bind(...)),
 // which takes a generic slot.  Or use mCommitCallbackRegistrar.add() with
 // a named callback and reference it in XML.
-void LLPanel::childSetCommitCallback(const std::string& id, boost::function<void (LLUICtrl*,void*)> cb, void* data)
+void LLPanel::childSetCommitCallback(std::string_view id, boost::function<void (LLUICtrl*,void*)> cb, void* data)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -693,7 +693,7 @@ void LLPanel::childSetCommitCallback(const std::string& id, boost::function<void
     }
 }
 
-void LLPanel::childSetColor(const std::string& id, const LLColor4& color)
+void LLPanel::childSetColor(std::string_view id, const LLColor4& color)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -702,7 +702,7 @@ void LLPanel::childSetColor(const std::string& id, const LLColor4& color)
     }
 }
 
-LLCtrlSelectionInterface* LLPanel::childGetSelectionInterface(const std::string& id) const
+LLCtrlSelectionInterface* LLPanel::childGetSelectionInterface(std::string_view id) const
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -712,7 +712,7 @@ LLCtrlSelectionInterface* LLPanel::childGetSelectionInterface(const std::string&
     return NULL;
 }
 
-LLCtrlListInterface* LLPanel::childGetListInterface(const std::string& id) const
+LLCtrlListInterface* LLPanel::childGetListInterface(std::string_view id) const
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -722,7 +722,7 @@ LLCtrlListInterface* LLPanel::childGetListInterface(const std::string& id) const
     return NULL;
 }
 
-LLCtrlScrollInterface* LLPanel::childGetScrollInterface(const std::string& id) const
+LLCtrlScrollInterface* LLPanel::childGetScrollInterface(std::string_view id) const
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -732,7 +732,7 @@ LLCtrlScrollInterface* LLPanel::childGetScrollInterface(const std::string& id) c
     return NULL;
 }
 
-void LLPanel::childSetValue(const std::string& id, LLSD value)
+void LLPanel::childSetValue(std::string_view id, LLSD value)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -741,7 +741,7 @@ void LLPanel::childSetValue(const std::string& id, LLSD value)
     }
 }
 
-LLSD LLPanel::childGetValue(const std::string& id) const
+LLSD LLPanel::childGetValue(std::string_view id) const
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -752,7 +752,7 @@ LLSD LLPanel::childGetValue(const std::string& id) const
     return LLSD();
 }
 
-bool LLPanel::childSetTextArg(const std::string& id, const std::string& key, const LLStringExplicit& text)
+bool LLPanel::childSetTextArg(std::string_view id, const std::string& key, const LLStringExplicit& text)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)
@@ -762,7 +762,7 @@ bool LLPanel::childSetTextArg(const std::string& id, const std::string& key, con
     return false;
 }
 
-bool LLPanel::childSetLabelArg(const std::string& id, const std::string& key, const LLStringExplicit& text)
+bool LLPanel::childSetLabelArg(std::string_view id, const std::string& key, const LLStringExplicit& text)
 {
     LLView* child = findChild<LLView>(id);
     if (child)
@@ -772,7 +772,7 @@ bool LLPanel::childSetLabelArg(const std::string& id, const std::string& key, co
     return false;
 }
 
-void LLPanel::childSetAction(const std::string& id, const commit_signal_t::slot_type& function)
+void LLPanel::childSetAction(std::string_view id, const commit_signal_t::slot_type& function)
 {
     LLButton* button = findChild<LLButton>(id);
     if (button)
@@ -781,7 +781,7 @@ void LLPanel::childSetAction(const std::string& id, const commit_signal_t::slot_
     }
 }
 
-void LLPanel::childSetAction(const std::string& id, boost::function<void(void*)> function, void* value)
+void LLPanel::childSetAction(std::string_view id, boost::function<void(void*)> function, void* value)
 {
     LLButton* button = findChild<LLButton>(id);
     if (button)

--- a/indra/llui/llpanel.h
+++ b/indra/llui/llpanel.h
@@ -149,7 +149,7 @@ public:
     void            setBackgroundOpaque(bool b)     { mBgOpaque = b; }
     bool            isBackgroundOpaque() const { return mBgOpaque; }
     void            setDefaultBtn(LLButton* btn = NULL);
-    void            setDefaultBtn(const std::string& id);
+    void            setDefaultBtn(std::string_view id);
     void            updateDefaultBtn();
     void            setLabel(const LLStringExplicit& label) { mLabel = label; }
     std::string     getLabel() const { return mLabel; }
@@ -169,47 +169,47 @@ public:
     void initFromParams(const Params& p);
     bool initPanelXML(  LLXMLNodePtr node, LLView *parent, LLXMLNodePtr output_node, const LLPanel::Params& default_params);
 
-    bool hasString(const std::string& name);
-    std::string getString(const std::string& name, const LLStringUtil::format_map_t& args) const;
-    std::string getString(const std::string& name) const;
+    bool hasString(std::string_view name);
+    std::string getString(std::string_view name, const LLStringUtil::format_map_t& args) const;
+    std::string getString(std::string_view name) const;
 
     // ** Wrappers for setting child properties by name ** -TomY
     // WARNING: These are deprecated, please use getChild<T>("name")->doStuff() idiom instead
 
     // LLView
-    void childSetVisible(const std::string& name, bool visible);
+    void childSetVisible(std::string_view name, bool visible);
 
-    void childSetEnabled(const std::string& name, bool enabled);
-    void childEnable(const std::string& name)   { childSetEnabled(name, true); }
-    void childDisable(const std::string& name) { childSetEnabled(name, false); };
+    void childSetEnabled(std::string_view name, bool enabled);
+    void childEnable(std::string_view name)   { childSetEnabled(name, true); }
+    void childDisable(std::string_view name) { childSetEnabled(name, false); };
 
     // LLUICtrl
-    void childSetFocus(const std::string& id, bool focus = true);
-    bool childHasFocus(const std::string& id);
+    void childSetFocus(std::string_view id, bool focus = true);
+    bool childHasFocus(std::string_view id);
 
     // *TODO: Deprecate; for backwards compatability only:
     // Prefer getChild<LLUICtrl>("foo")->setCommitCallback(boost:bind(...)),
     // which takes a generic slot.  Or use mCommitCallbackRegistrar.add() with
     // a named callback and reference it in XML.
-    void childSetCommitCallback(const std::string& id, boost::function<void (LLUICtrl*,void*)> cb, void* data);
-    void childSetColor(const std::string& id, const LLColor4& color);
+    void childSetCommitCallback(std::string_view id, boost::function<void (LLUICtrl*,void*)> cb, void* data);
+    void childSetColor(std::string_view id, const LLColor4& color);
 
-    LLCtrlSelectionInterface* childGetSelectionInterface(const std::string& id) const;
-    LLCtrlListInterface* childGetListInterface(const std::string& id) const;
-    LLCtrlScrollInterface* childGetScrollInterface(const std::string& id) const;
+    LLCtrlSelectionInterface* childGetSelectionInterface(std::string_view id) const;
+    LLCtrlListInterface* childGetListInterface(std::string_view id) const;
+    LLCtrlScrollInterface* childGetScrollInterface(std::string_view id) const;
 
     // This is the magic bullet for data-driven UI
-    void childSetValue(const std::string& id, LLSD value);
-    LLSD childGetValue(const std::string& id) const;
+    void childSetValue(std::string_view id, LLSD value);
+    LLSD childGetValue(std::string_view id) const;
 
     // For setting text / label replacement params, e.g. "Hello [NAME]"
     // Not implemented for all types, defaults to noop, returns false if not applicaple
-    bool childSetTextArg(const std::string& id, const std::string& key, const LLStringExplicit& text);
-    bool childSetLabelArg(const std::string& id, const std::string& key, const LLStringExplicit& text);
+    bool childSetTextArg(std::string_view id, const std::string& key, const LLStringExplicit& text);
+    bool childSetLabelArg(std::string_view id, const std::string& key, const LLStringExplicit& text);
 
     // LLButton
-    void childSetAction(const std::string& id, boost::function<void(void*)> function, void* value);
-    void childSetAction(const std::string& id, const commit_signal_t::slot_type& function);
+    void childSetAction(std::string_view id, boost::function<void(void*)> function, void* value);
+    void childSetAction(std::string_view id, const commit_signal_t::slot_type& function);
 
     static LLView*  fromXML(LLXMLNodePtr node, LLView *parent, LLXMLNodePtr output_node = NULL);
 
@@ -250,7 +250,7 @@ private:
     LLButton*       mDefaultBtn;
     LLUIString      mLabel;
 
-    typedef std::map<std::string, std::string> ui_string_map_t;
+    typedef std::map<std::string, std::string, std::less<>> ui_string_map_t;
     ui_string_map_t mUIStrings;
 
 
@@ -277,7 +277,7 @@ public:
         mPanelClassesNames[tag] = func;
     }
 
-    LLPanel* createPanelClass(const std::string& tag)
+    LLPanel* createPanelClass(std::string_view tag)
     {
         param_name_map_t::iterator iT =  mPanelClassesNames.find(tag);
         if(iT == mPanelClassesNames.end())
@@ -292,7 +292,7 @@ public:
     }
 
 private:
-    typedef std::map< std::string, LLPanelClassCreatorFunc> param_name_map_t;
+    typedef std::map< std::string, LLPanelClassCreatorFunc, std::less<>> param_name_map_t;
 
     param_name_map_t mPanelClassesNames;
 };

--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -1401,7 +1401,7 @@ S32 LLTabContainer::getIndexForPanel(LLPanel* panel)
     return -1;
 }
 
-S32 LLTabContainer::getPanelIndexByTitle(const std::string& title)
+S32 LLTabContainer::getPanelIndexByTitle(std::string_view title)
 {
     for (S32 index = 0 ; index < (S32)mTabList.size(); index++)
     {
@@ -1413,7 +1413,7 @@ S32 LLTabContainer::getPanelIndexByTitle(const std::string& title)
     return -1;
 }
 
-LLPanel* LLTabContainer::getPanelByName(const std::string& name)
+LLPanel* LLTabContainer::getPanelByName(std::string_view name)
 {
     for (S32 index = 0 ; index < (S32)mTabList.size(); index++)
     {
@@ -1637,7 +1637,7 @@ bool LLTabContainer::setTab(S32 which)
     return is_visible;
 }
 
-bool LLTabContainer::selectTabByName(const std::string& name)
+bool LLTabContainer::selectTabByName(std::string_view name)
 {
     LLPanel* panel = getPanelByName(name);
     if (!panel)

--- a/indra/llui/lltabcontainer.h
+++ b/indra/llui/lltabcontainer.h
@@ -190,8 +190,8 @@ public:
     S32         getTabCount();
     LLPanel*    getPanelByIndex(S32 index);
     S32         getIndexForPanel(LLPanel* panel);
-    S32         getPanelIndexByTitle(const std::string& title);
-    LLPanel*    getPanelByName(const std::string& name);
+    S32         getPanelIndexByTitle(std::string_view title);
+    LLPanel*    getPanelByName(std::string_view name);
     S32         getTotalTabWidth() const;
     void        setCurrentTabName(const std::string& name);
 
@@ -201,7 +201,7 @@ public:
     void        selectPrevTab();
     bool        selectTabPanel( LLPanel* child );
     bool        selectTab(S32 which);
-    bool        selectTabByName(const std::string& title);
+    bool        selectTabByName(std::string_view title);
     void        setCurrentPanelIndex(S32 index) { mCurrentTabIdx = index; }
 
     bool        getTabPanelFlashing(LLPanel* child);

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1910,7 +1910,7 @@ void LLFloaterPreference::setCacheLocation(const LLStringExplicit& location)
 void LLFloaterPreference::selectPanel(const LLSD& name)
 {
     LLTabContainer * tab_containerp = getChild<LLTabContainer>("pref core");
-    LLPanel * panel = tab_containerp->getPanelByName(name);
+    LLPanel * panel = tab_containerp->getPanelByName(name.asStringRef());
     if (NULL != panel)
     {
         tab_containerp->selectTabPanel(panel);


### PR DESCRIPTION
Further reduce the number of string temporaries generated from UI operations