### PR TITLE
EnableVoiceMorphing should default to true

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -13043,7 +13043,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>AutoDisengageMic</key>
     <map>

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -137,7 +137,7 @@ LLVoiceClient::LLVoiceClient(LLPumpIO *pump)
     mSpatialVoiceModule(NULL),
     mNonSpatialVoiceModule(NULL),
     m_servicePump(NULL),
-    mVoiceEffectEnabled(LLCachedControl<bool>(gSavedSettings, "VoiceMorphingEnabled", false)),
+    mVoiceEffectEnabled(LLCachedControl<bool>(gSavedSettings, "VoiceMorphingEnabled", true)),
     mVoiceEffectDefault(LLCachedControl<std::string>(gSavedPerAccountSettings, "VoiceEffectDefault", "00000000-0000-0000-0000-000000000000")),
     mVoiceEffectSupportNotified(false),
     mPTTDirty(true),

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -577,7 +577,7 @@ bool LLVoiceClient::onVoiceEffectsNotSupported(const LLSD &notification, const L
     switch (option)
     {
         case 0:  // "Okay"
-            gSavedSettings.setBOOL("VoiceMorphingEnabled", FALSE);
+            gSavedPerAccountSettings.setString("VoiceEffectDefault", LLUUID::null.asString());
             break;
 
         case 1:  // "Cancel"

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -2538,7 +2538,6 @@ void LLVivoxVoiceClient::sessionCreateSendMessage(const sessionStatePtr_t &sessi
     stream
         << "<ConnectAudio>" << (startAudio?"true":"false") << "</ConnectAudio>"
         << "<ConnectText>" << (startText?"true":"false") << "</ConnectText>"
-        << "<VoiceFontID>" << font_index << "</VoiceFontID>"
         << "<Name>" << mChannelName << "</Name>"
     << "</Request>\n\n\n";
     LL_WARNS("Voice") << "Session.Create: " << stream.str() << LL_ENDL;
@@ -2577,7 +2576,6 @@ void LLVivoxVoiceClient::sessionGroupAddSessionSendMessage(const sessionStatePtr
         << "<Name>" << mChannelName << "</Name>"
         << "<ConnectAudio>" << (startAudio?"true":"false") << "</ConnectAudio>"
         << "<ConnectText>" << (startText?"true":"false") << "</ConnectText>"
-        << "<VoiceFontID>" << font_index << "</VoiceFontID>"
         << "<Password>" << password << "</Password>"
         << "<PasswordHashAlgorithm>SHA1UserName</PasswordHashAlgorithm>"
     << "</Request>\n\n\n"
@@ -2601,7 +2599,6 @@ void LLVivoxVoiceClient::sessionMediaConnectSendMessage(const sessionStatePtr_t 
     << "<Request requestId=\"" << session->mHandle << "\" action=\"Session.MediaConnect.1\">"
         << "<SessionGroupHandle>" << session->mGroupHandle << "</SessionGroupHandle>"
         << "<SessionHandle>" << session->mHandle << "</SessionHandle>"
-        << "<VoiceFontID>" << font_index << "</VoiceFontID>"
         << "<Media>Audio</Media>"
     << "</Request>\n\n\n";
 


### PR DESCRIPTION
If the user has a voice morph and morphing is enabled, we throw up a dialog notifying them that voice
morphing is not available with the webrtc viewer.  We need to default EnableVoiceMorphing to true in order
to throw up that dialog by default.

EnableVoiceMorphing was incorrectly defaulted to false as part of the work that throws up the dialog.