### PR TITLE
viewer#1916 Updated default Chat Window behavior

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1508,7 +1508,11 @@ bool idle_startup()
 
         // create a container's instance for start a controlling conversation windows
         // by the voice's events
-        LLFloaterIMContainer::getInstance();
+        LLFloaterIMContainer *im_inst = LLFloaterIMContainer::getInstance();
+        if(gAgent.isFirstLogin())
+        {
+            im_inst->openFloater(im_inst->getKey());
+        }
         if (gSavedSettings.getS32("ParcelMediaAutoPlayEnable") == 2)
         {
             LLViewerParcelAskPlay::getInstance()->loadSettings();

--- a/indra/newview/skins/default/xui/en/floater_im_container.xml
+++ b/indra/newview/skins/default/xui/en/floater_im_container.xml
@@ -14,7 +14,7 @@
  reuse_instance="true"
  title="CONVERSATIONS"
  bottom="-50"
- right="-5"
+ left="5"
  width="450"
  min_width="38">
     <string


### PR DESCRIPTION
- Conversations window open by default via user settings.
- Chat window to be on the lower left by default instead of lower right