### PR TITLE
Introduce move support and string_view to LLSD

### DIFF
--- a/indra/llcommon/lldate.cpp
+++ b/indra/llcommon/lldate.cpp
@@ -41,19 +41,10 @@
 #include "llstring.h"
 #include "llfasttimer.h"
 
-static const F64 DATE_EPOCH = 0.0;
-
 static const F64 LL_APR_USEC_PER_SEC = 1000000.0;
     // should be APR_USEC_PER_SEC, but that relies on INT64_C which
     // isn't defined in glib under our build set up for some reason
 
-
-LLDate::LLDate() : mSecondsSinceEpoch(DATE_EPOCH)
-{}
-
-LLDate::LLDate(const LLDate& date) :
-    mSecondsSinceEpoch(date.mSecondsSinceEpoch)
-{}
 
 LLDate::LLDate(F64SecondsImplicit seconds_since_epoch) :
     mSecondsSinceEpoch(seconds_since_epoch.value())

--- a/indra/llcommon/lldate.h
+++ b/indra/llcommon/lldate.h
@@ -43,16 +43,13 @@
  */
 class LL_COMMON_API LLDate
 {
+    static constexpr F64 DATE_EPOCH = 0.0;
 public:
     /**
      * @brief Construct a date equal to epoch.
      */
-    LLDate();
-
-    /**
-     * @brief Construct a date equal to the source date.
-     */
-    LLDate(const LLDate& date);
+    constexpr LLDate() : mSecondsSinceEpoch(DATE_EPOCH)
+    {}
 
     /**
      * @brief Construct a date from a seconds since epoch value.

--- a/indra/llcommon/llsd.h
+++ b/indra/llcommon/llsd.h
@@ -306,25 +306,23 @@ public:
     //@{
         static LLSD emptyMap();
 
-        bool has(const String&) const;
-        LLSD get(const String&) const;
+        bool has(const std::string_view) const;
+        LLSD get(const std::string_view) const;
         LLSD getKeys() const;               // Return an LLSD array with keys as strings
-        void insert(const String&, const LLSD&);
+        void insert(std::string_view, const LLSD&);
         void erase(const String&);
-        LLSD& with(const String&, const LLSD&);
+        LLSD& with(std::string_view, const LLSD&);
 
-        LLSD& operator[](const String&);
+        LLSD& operator[](const std::string_view);
         LLSD& operator[](const char* c)
-        {
-            LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD;
-            return (*this)[String(c)];
-        }
-        const LLSD& operator[](const String&) const;
-        const LLSD& operator[](const char* c) const
-        {
-            LL_PROFILE_ZONE_SCOPED_CATEGORY_LLSD;
-            return (*this)[String(c)];
-        }
+		{
+			return c ? (*this)[std::string_view(c)] : *this;
+		}
+        const LLSD& operator[](const std::string_view) const;
+        const LLSD& operator[](const char* c) const 
+		{
+			return c ? (*this)[std::string_view(c)] : *this;
+		}
     //@}
 
     /** @name Array Values */

--- a/indra/llcommon/llsd.h
+++ b/indra/llcommon/llsd.h
@@ -188,6 +188,11 @@ public:
         LLSD(const Date&);
         LLSD(const URI&);
         LLSD(const Binary&);
+        LLSD(String&&);
+        LLSD(UUID&&);
+        LLSD(Date&&);
+        LLSD(URI&&);
+        LLSD(Binary&&);
     //@}
 
     /** @name Convenience Constructors */
@@ -215,6 +220,11 @@ public:
         void assign(const Date&);
         void assign(const URI&);
         void assign(const Binary&);
+        void assign(String&&);
+        void assign(UUID&&);
+        void assign(Date&&);
+        void assign(URI&&);
+        void assign(Binary&&);
 
         LLSD& operator=(Boolean v)          { assign(v); return *this; }
         LLSD& operator=(Integer v)          { assign(v); return *this; }
@@ -224,6 +234,11 @@ public:
         LLSD& operator=(const Date& v)      { assign(v); return *this; }
         LLSD& operator=(const URI& v)       { assign(v); return *this; }
         LLSD& operator=(const Binary& v)    { assign(v); return *this; }
+        LLSD& operator=(String&& v)         { assign(std::move(v)); return *this; }
+        LLSD& operator=(UUID&& v)               { assign(std::move(v)); return *this; }
+        LLSD& operator=(Date&& v)               { assign(std::move(v)); return *this; }
+        LLSD& operator=(URI&& v)                { assign(std::move(v)); return *this; }
+        LLSD& operator=(Binary&& v)         { assign(std::move(v)); return *this; }
     //@}
 
     /**

--- a/indra/llcommon/llsd.h
+++ b/indra/llcommon/llsd.h
@@ -161,6 +161,13 @@ public:
 
     //@}
 
+    /** @name Movable */
+    //@{
+        LLSD(LLSD&& other) noexcept;
+        void  assign(LLSD&& other);
+        LLSD& operator=(LLSD&& other) noexcept;
+    //@}
+
     void clear();   ///< resets to Undefined
 
 
@@ -330,14 +337,14 @@ public:
 
         LLSD& operator[](const std::string_view);
         LLSD& operator[](const char* c)
-		{
-			return c ? (*this)[std::string_view(c)] : *this;
-		}
+        {
+            return c ? (*this)[std::string_view(c)] : *this;
+        }
         const LLSD& operator[](const std::string_view) const;
-        const LLSD& operator[](const char* c) const 
-		{
-			return c ? (*this)[std::string_view(c)] : *this;
-		}
+        const LLSD& operator[](const char* c) const
+        {
+            return c ? (*this)[std::string_view(c)] : *this;
+        }
     //@}
 
     /** @name Array Values */

--- a/indra/llcommon/llsdutil.cpp
+++ b/indra/llcommon/llsdutil.cpp
@@ -51,7 +51,7 @@
 // U32
 LLSD ll_sd_from_U32(const U32 val)
 {
-    std::vector<U8> v;
+    LLSD::Binary v;
     U32 net_order = htonl(val);
 
     v.resize(4);
@@ -63,7 +63,7 @@ LLSD ll_sd_from_U32(const U32 val)
 U32 ll_U32_from_sd(const LLSD& sd)
 {
     U32 ret;
-    std::vector<U8> v = sd.asBinary();
+    const LLSD::Binary& v = sd.asBinary();
     if (v.size() < 4)
     {
         return 0;
@@ -76,7 +76,7 @@ U32 ll_U32_from_sd(const LLSD& sd)
 //U64
 LLSD ll_sd_from_U64(const U64 val)
 {
-    std::vector<U8> v;
+    LLSD::Binary v;
     U32 high, low;
 
     high = (U32)(val >> 32);
@@ -94,7 +94,7 @@ LLSD ll_sd_from_U64(const U64 val)
 U64 ll_U64_from_sd(const LLSD& sd)
 {
     U32 high, low;
-    std::vector<U8> v = sd.asBinary();
+    const LLSD::Binary& v = sd.asBinary();
 
     if (v.size() < 8)
     {
@@ -112,7 +112,7 @@ U64 ll_U64_from_sd(const LLSD& sd)
 // IP Address (stored in net order in a U32, so don't need swizzling)
 LLSD ll_sd_from_ipaddr(const U32 val)
 {
-    std::vector<U8> v;
+    LLSD::Binary v;
 
     v.resize(4);
     memcpy(&(v[0]), &val, 4);       /* Flawfinder: ignore */
@@ -123,7 +123,7 @@ LLSD ll_sd_from_ipaddr(const U32 val)
 U32 ll_ipaddr_from_sd(const LLSD& sd)
 {
     U32 ret;
-    std::vector<U8> v = sd.asBinary();
+    const LLSD::Binary& v = sd.asBinary();
     if (v.size() < 4)
     {
         return 0;
@@ -135,17 +135,17 @@ U32 ll_ipaddr_from_sd(const LLSD& sd)
 // Converts an LLSD binary to an LLSD string
 LLSD ll_string_from_binary(const LLSD& sd)
 {
-    std::vector<U8> value = sd.asBinary();
+    const LLSD::Binary& value = sd.asBinary();
     std::string str;
     str.resize(value.size());
-    memcpy(&str[0], &value[0], value.size());
+    memcpy(&str[0], value.data(), value.size());
     return str;
 }
 
 // Converts an LLSD string to an LLSD binary
 LLSD ll_binary_from_string(const LLSD& sd)
 {
-    std::vector<U8> binary_value;
+    LLSD::Binary binary_value;
 
     std::string string_value = sd.asString();
     for (const U8 c : string_value)
@@ -990,8 +990,7 @@ LLSD llsd_clone(LLSD value, LLSD filter)
 
     case LLSD::TypeBinary:
     {
-        LLSD::Binary bin(value.asBinary().begin(), value.asBinary().end());
-        clone = LLSD::Binary(bin);
+        clone = LLSD::Binary(value.asBinary().begin(), value.asBinary().end());
         break;
     }
     default:

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -2345,11 +2345,11 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
                 continue;
             }
 
-            LLSD::Binary pos = mdl[i]["Position"];
-            LLSD::Binary norm = mdl[i]["Normal"];
-            LLSD::Binary tangent = mdl[i]["Tangent"];
-            LLSD::Binary tc = mdl[i]["TexCoord0"];
-            LLSD::Binary idx = mdl[i]["TriangleList"];
+            const LLSD::Binary& pos = mdl[i]["Position"].asBinary();
+            const LLSD::Binary& norm = mdl[i]["Normal"].asBinary();
+            const LLSD::Binary& tangent = mdl[i]["Tangent"].asBinary();
+            const LLSD::Binary& tc = mdl[i]["TexCoord0"].asBinary();
+            const LLSD::Binary& idx = mdl[i]["TriangleList"].asBinary();
 
             //copy out indices
             auto num_indices = idx.size() / 2;
@@ -2538,7 +2538,7 @@ bool LLVolume::unpackVolumeFacesInternal(const LLSD& mdl)
                     continue;
                 }
 
-                LLSD::Binary weights = mdl[i]["Weights"];
+                const LLSD::Binary& weights = mdl[i]["Weights"].asBinary();
 
                 U32 idx = 0;
 

--- a/indra/llmessage/llcorehttputil.cpp
+++ b/indra/llmessage/llcorehttputil.cpp
@@ -523,7 +523,7 @@ LLSD HttpCoroRawHandler::handleSuccess(LLCore::HttpResponse * response, LLCore::
     bas >> std::noskipws;
     data.assign(std::istream_iterator<U8>(bas), std::istream_iterator<U8>());
 
-    result[HttpCoroutineAdapter::HTTP_RESULTS_RAW] = data;
+    result[HttpCoroutineAdapter::HTTP_RESULTS_RAW] = std::move(data);
 
 #else
     // This is disabled because it's dangerous.  See the other case for an

--- a/indra/llmessage/lltemplatemessagedispatcher.cpp
+++ b/indra/llmessage/lltemplatemessagedispatcher.cpp
@@ -43,7 +43,7 @@ void LLTemplateMessageDispatcher::dispatch(const std::string& msg_name,
                                            const LLSD& message,
                                            LLHTTPNode::ResponsePtr responsep)
 {
-    std::vector<U8> data = message["body"]["binary-template-data"].asBinary();
+    const LLSD::Binary& data = message["body"]["binary-template-data"].asBinary();
     auto size = data.size();
     if(size == 0)
     {
@@ -53,11 +53,11 @@ void LLTemplateMessageDispatcher::dispatch(const std::string& msg_name,
     LLHost host;
     host = gMessageSystem->getSender();
 
-    bool validate_message = mTemplateMessageReader.validateMessage(&(data[0]), static_cast<S32>(size), host, true);
+    bool validate_message = mTemplateMessageReader.validateMessage(data.data(), static_cast<S32>(size), host, true);
 
     if (validate_message)
     {
-        mTemplateMessageReader.readMessage(&(data[0]),host);
+        mTemplateMessageReader.readMessage(data.data(),host);
     }
     else
     {

--- a/indra/llprimitive/llmaterialid.cpp
+++ b/indra/llprimitive/llmaterialid.cpp
@@ -136,7 +136,7 @@ LLSD LLMaterialID::asLLSD() const
     materialIDBinary.resize(MATERIAL_ID_SIZE * sizeof(U8));
     memcpy(materialIDBinary.data(), mID, MATERIAL_ID_SIZE * sizeof(U8));
 
-    LLSD materialID = materialIDBinary;
+    LLSD materialID = std::move(materialIDBinary);
     return materialID;
 }
 

--- a/indra/llui/llnotifications.cpp
+++ b/indra/llui/llnotifications.cpp
@@ -861,7 +861,7 @@ void LLNotification::init(const std::string& template_name, const LLSD& form_ele
     for (LLStringUtil::format_map_t::const_iterator iter = default_args.begin();
          iter != default_args.end(); ++iter)
     {
-        mSubstitutions[iter->first] = iter->second;
+        mSubstitutions[std::string(iter->first)] = iter->second;
     }
     mSubstitutions["_URL"] = getURL();
     mSubstitutions["_NAME"] = template_name;


### PR DESCRIPTION
This set of changes introduces move operator and constructors as well as string_view support to LLSD to reduce temporaries 