### PR TITLE
viewer#1131 Fix gltf editor being a bit spamy

### DIFF
--- a/indra/newview/llfloatergltfasseteditor.cpp
+++ b/indra/newview/llfloatergltfasseteditor.cpp
@@ -54,7 +54,7 @@ LLFloaterGLTFAssetEditor::~LLFloaterGLTFAssetEditor()
 {
     if (mScroller)
     {
-        removeChild(mScroller);
+        mItemListPanel->removeChild(mScroller);
         delete mScroller;
         mScroller = NULL;
     }
@@ -345,13 +345,15 @@ void LLFloaterGLTFAssetEditor::dirty()
 {
     if (!mObject || !mAsset || !mFolderRoot)
     {
-        closeFloater();
         return;
     }
 
     if (LLSelectMgr::getInstance()->getSelection()->getObjectCount() > 1)
     {
-        closeFloater();
+        if (getVisible())
+        {
+            closeFloater();
+        }
         return;
     }
 
@@ -366,7 +368,10 @@ void LLFloaterGLTFAssetEditor::dirty()
     LLViewerObject* objectp = node->getObject();
     if (mObject != objectp || !objectp->mGLTFAsset)
     {
-        closeFloater();
+        if (getVisible())
+        {
+            closeFloater();
+        }
         return;
     }
 

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -7194,7 +7194,7 @@ void dialog_refresh_all()
         panel_task_info->dirty();
     }
 
-    LLFloaterGLTFAssetEditor * gltf_editor = LLFloaterReg::getTypedInstance<LLFloaterGLTFAssetEditor>("gltf_asset_editor");
+    LLFloaterGLTFAssetEditor * gltf_editor = LLFloaterReg::findTypedInstance<LLFloaterGLTFAssetEditor>("gltf_asset_editor");
     if (gltf_editor)
     {
         gltf_editor->dirty();


### PR DESCRIPTION
At the moment it's set to close if selection isn't an asset (if object is null, it isn't open), might need to make it act like editor does and just disable elements untill we get a proper selection.