### PR TITLE
Re-enable compiler warnings C4244 and C4396 except for lltracerecording.h and llunittype.h for now

### DIFF
--- a/indra/llappearance/llpolymorph.cpp
+++ b/indra/llappearance/llpolymorph.cpp
@@ -557,7 +557,7 @@ void LLPolyMorphTarget::apply( ESex avatar_sex )
     }
     if (mLastWeight != mLastWeight)
     {
-        mLastWeight = mCurWeight+.001;
+        mLastWeight = mCurWeight+.001f;
     }
 
     // perform differential update of morph

--- a/indra/llappearance/lltexlayer.cpp
+++ b/indra/llappearance/lltexlayer.cpp
@@ -106,7 +106,7 @@ void LLTexLayerSetBuffer::pushProjection() const
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, getCompositeWidth(), 0.0f, getCompositeHeight(), -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)getCompositeWidth(), 0.0f, (F32)getCompositeHeight(), -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();

--- a/indra/llcharacter/llkeyframewalkmotion.cpp
+++ b/indra/llcharacter/llkeyframewalkmotion.cpp
@@ -383,7 +383,7 @@ bool LLFlyAdjustMotion::onUpdate(F32 time, U8* joint_mask)
     F32 target_roll = llclamp(ang_vel.mV[VZ], -4.f, 4.f) * roll_factor;
 
     // roll is critically damped interpolation between current roll and angular velocity-derived target roll
-    mRoll = LLSmoothInterpolation::lerp(mRoll, target_roll, U32Milliseconds(100));
+    mRoll = LLSmoothInterpolation::lerp(mRoll, target_roll, F32Milliseconds(100.f));
 
     LLQuaternion roll(mRoll, LLVector3(0.f, 0.f, 1.f));
     mPelvisState->setRotation(roll);

--- a/indra/llcommon/llpreprocessor.h
+++ b/indra/llcommon/llpreprocessor.h
@@ -130,8 +130,6 @@
 #endif
 
 // level 4 warnings that we need to disable:
-#pragma warning (disable : 4244) // possible loss of data on conversions
-#pragma warning (disable : 4396) // the inline specifier cannot be used when a friend declaration refers to a specialization of a function template
 #pragma warning (disable : 4251) // member needs to have dll-interface to be used by clients of class
 #pragma warning (disable : 4275) // non dll-interface class used as base for dll-interface class
 #endif  //  LL_MSVC

--- a/indra/llcommon/llqueuedthread.cpp
+++ b/indra/llcommon/llqueuedthread.cpp
@@ -483,7 +483,7 @@ void LLQueuedThread::processRequest(LLQueuedThread::QueuedRequest* req)
 
                             if (sleep_time.count() > 0)
                             {
-                                ms_sleep(sleep_time.count());
+                                ms_sleep((U32)sleep_time.count());
                             }
                         }
                         processRequest(req);

--- a/indra/llcommon/llrand.cpp
+++ b/indra/llcommon/llrand.cpp
@@ -85,7 +85,7 @@ inline F32 ll_internal_random<F32>()
     // Per Monty, it's important to clamp using the correct fmodf() rather
     // than expanding to F64 for fmod() and then truncating back to F32. Prior
     // to this change, we were getting sporadic ll_frand() == 1.0 results.
-    F32 rv{ narrow<F32>(gRandomGenerator()) };
+    F32 rv{ narrow<F64>(gRandomGenerator()) };
     if(!((rv >= 0.0f) && (rv < 1.0f))) return fmodf(rv, 1.0f);
     return rv;
 }

--- a/indra/llcommon/llsdparam.cpp
+++ b/indra/llcommon/llsdparam.cpp
@@ -149,7 +149,7 @@ bool LLParamSDParser::readF32(Parser& parser, void* val_ptr)
 {
     LLParamSDParser& self = static_cast<LLParamSDParser&>(parser);
 
-    *((F32*)val_ptr) = self.mCurReadSD->asReal();
+    *((F32*)val_ptr) = (F32)self.mCurReadSD->asReal();
     return true;
 }
 

--- a/indra/llcommon/llsdserialize.cpp
+++ b/indra/llcommon/llsdserialize.cpp
@@ -231,7 +231,7 @@ bool LLSDSerialize::deserialize(LLSD& sd, std::istream& str, llssize max_bytes)
         }
         // Since we've already read 'inbuf' bytes into 'hdr_buf', prepend that
         // data to whatever remains in 'str'.
-        LLMemoryStreamBuf already(reinterpret_cast<const U8*>(hdr_buf), inbuf);
+        LLMemoryStreamBuf already(reinterpret_cast<const U8*>(hdr_buf), (S32)inbuf);
         cat_streambuf prebuff(&already, str.rdbuf());
         std::istream  prepend(&prebuff);
 #if 1
@@ -566,7 +566,7 @@ S32 LLSDNotationParser::doParse(std::istream& istr, LLSD& data, S32 max_depth) c
                 data,
                 NOTATION_FALSE_SERIAL,
                 false);
-            if(PARSE_FAILURE == cnt) parse_count = cnt;
+            if(PARSE_FAILURE == cnt) parse_count = (S32)cnt;
             else account(cnt);
         }
         else
@@ -592,7 +592,7 @@ S32 LLSDNotationParser::doParse(std::istream& istr, LLSD& data, S32 max_depth) c
         if(isalpha(c))
         {
             auto cnt = deserialize_boolean(istr,data,NOTATION_TRUE_SERIAL,true);
-            if(PARSE_FAILURE == cnt) parse_count = cnt;
+            if(PARSE_FAILURE == cnt) parse_count = (S32)cnt;
             else account(cnt);
         }
         else

--- a/indra/llcommon/llsdserialize_xml.cpp
+++ b/indra/llcommon/llsdserialize_xml.cpp
@@ -554,7 +554,7 @@ void LLSDXMLParser::Impl::parsePart(const char* buf, llssize len)
     if ( buf != NULL
         && len > 0 )
     {
-        XML_Status status = XML_Parse(mParser, buf, len, false);
+        XML_Status status = XML_Parse(mParser, buf, (int)len, 0);
         if (status == XML_STATUS_ERROR)
         {
             LL_INFOS() << "Unexpected XML parsing error at start" << LL_ENDL;

--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -37,7 +37,8 @@
 #include "llmainthreadtask.h"
 
 #ifdef LL_WINDOWS
-#pragma warning( disable : 4506 )   // no definition for inline function
+#pragma warning(push)
+#pragma warning(disable : 4506)   // no definition for inline function
 #endif
 
 class LLSingletonBase: private boost::noncopyable
@@ -860,5 +861,9 @@ private:
 
 template <class T>
 T* LLSimpleton<T>::sInstance{ nullptr };
+
+#ifdef LL_WINDOWS
+#pragma warning(pop)
+#endif
 
 #endif

--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -250,7 +250,7 @@ LLWString utf16str_to_wstring(const U16* utf16str, size_t len)
     while (i < len)
     {
         llwchar cur_char;
-        i += utf16chars_to_wchar(chars16+i, &cur_char);
+        i += (S32)utf16chars_to_wchar(chars16+i, &cur_char);
         wout += cur_char;
     }
     return wout;

--- a/indra/llcommon/lltimer.cpp
+++ b/indra/llcommon/lltimer.cpp
@@ -101,7 +101,7 @@ U32 micro_sleep(U64 us, U32 max_yields)
     WaitForSingleObject(timer, INFINITE);
     CloseHandle(timer);
 #else
-    Sleep(us / 1000);
+    Sleep((DWORD)(us / 1000));
 #endif
 
     return 0;

--- a/indra/llcommon/lltraceaccumulators.cpp
+++ b/indra/llcommon/lltraceaccumulators.cpp
@@ -100,7 +100,7 @@ bool AccumulatorBufferGroup::isCurrent() const
     return mCounts.isCurrent();
 }
 
-void AccumulatorBufferGroup::append( const AccumulatorBufferGroup& other )
+void AccumulatorBufferGroup::append(const AccumulatorBufferGroup& other)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_STATS;
     mCounts.addSamples(other.mCounts, SEQUENTIAL);
@@ -109,7 +109,7 @@ void AccumulatorBufferGroup::append( const AccumulatorBufferGroup& other )
     mStackTimers.addSamples(other.mStackTimers, SEQUENTIAL);
 }
 
-void AccumulatorBufferGroup::merge( const AccumulatorBufferGroup& other)
+void AccumulatorBufferGroup::merge(const AccumulatorBufferGroup& other)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_STATS;
     mCounts.addSamples(other.mCounts, NON_SEQUENTIAL);
@@ -140,7 +140,7 @@ void AccumulatorBufferGroup::sync()
 
 F64 SampleAccumulator::mergeSumsOfSquares(const SampleAccumulator& a, const SampleAccumulator& b)
 {
-    const F64 epsilon = 0.0000001;
+    constexpr F64 epsilon = 0.0000001;
 
     if (a.getSamplingTime() > epsilon && b.getSamplingTime() > epsilon)
     {
@@ -170,7 +170,7 @@ F64 SampleAccumulator::mergeSumsOfSquares(const SampleAccumulator& a, const Samp
     return a.getSumOfSquares();
 }
 
-void SampleAccumulator::addSamples( const SampleAccumulator& other, EBufferAppendType append_type )
+void SampleAccumulator::addSamples(const SampleAccumulator& other, EBufferAppendType append_type)
 {
     if (append_type == NON_SEQUENTIAL)
     {
@@ -205,7 +205,7 @@ void SampleAccumulator::addSamples( const SampleAccumulator& other, EBufferAppen
     }
 }
 
-void SampleAccumulator::reset( const SampleAccumulator* other )
+void SampleAccumulator::reset(const SampleAccumulator* other)
 {
     mLastValue = other ? other->mLastValue : NaN;
     mHasValue = other ? other->mHasValue : false;
@@ -243,7 +243,7 @@ F64 EventAccumulator::mergeSumsOfSquares(const EventAccumulator& a, const EventA
     return a.mSumOfSquares;
 }
 
-void EventAccumulator::addSamples( const EventAccumulator& other, EBufferAppendType append_type )
+void EventAccumulator::addSamples(const EventAccumulator& other, EBufferAppendType append_type)
 {
     if (other.mNumSamples)
     {
@@ -269,12 +269,12 @@ void EventAccumulator::addSamples( const EventAccumulator& other, EBufferAppendT
     }
 }
 
-void EventAccumulator::reset( const EventAccumulator* other )
+void EventAccumulator::reset(const EventAccumulator* other)
 {
     mNumSamples = 0;
     mSum = 0;
-    mMin = F32(NaN);
-    mMax = F32(NaN);
+    mMin = NaN;
+    mMax = NaN;
     mMean = NaN;
     mSumOfSquares = 0;
     mLastValue = other ? other->mLastValue : NaN;

--- a/indra/llcommon/lltraceaccumulators.h
+++ b/indra/llcommon/lltraceaccumulators.h
@@ -39,7 +39,7 @@
 
 namespace LLTrace
 {
-    const F64 NaN   = std::numeric_limits<double>::quiet_NaN();
+    constexpr F64 NaN = std::numeric_limits<double>::quiet_NaN();
 
     enum EBufferAppendType
     {
@@ -251,8 +251,8 @@ namespace LLTrace
 
         EventAccumulator()
         :   mSum(0),
-            mMin(F32(NaN)),
-            mMax(F32(NaN)),
+            mMin(NaN),
+            mMax(NaN),
             mMean(NaN),
             mSumOfSquares(0),
             mNumSamples(0),
@@ -288,11 +288,11 @@ namespace LLTrace
         void sync(F64SecondsImplicit) {}
 
         F64 getSum() const               { return mSum; }
-        F32 getMin() const               { return mMin; }
-        F32 getMax() const               { return mMax; }
+        F64 getMin() const               { return mMin; }
+        F64 getMax() const               { return mMax; }
         F64 getLastValue() const         { return mLastValue; }
         F64 getMean() const              { return mMean; }
-        F64 getStandardDeviation() const { return sqrtf(mSumOfSquares / mNumSamples); }
+        F64 getStandardDeviation() const { return sqrt(mSumOfSquares / mNumSamples); }
         F64 getSumOfSquares() const      { return mSumOfSquares; }
         S32 getSampleCount() const       { return mNumSamples; }
         bool hasValue() const            { return mNumSamples > 0; }
@@ -307,7 +307,7 @@ namespace LLTrace
         F64 mMean,
             mSumOfSquares;
 
-        F32 mMin,
+        F64 mMin,
             mMax;
 
         S32 mNumSamples;
@@ -322,8 +322,8 @@ namespace LLTrace
 
         SampleAccumulator()
         :   mSum(0),
-            mMin(F32(NaN)),
-            mMax(F32(NaN)),
+            mMin(NaN),
+            mMax(NaN),
             mMean(NaN),
             mSumOfSquares(0),
             mLastSampleTimeStamp(0),
@@ -378,11 +378,11 @@ namespace LLTrace
         }
 
         F64 getSum() const               { return mSum; }
-        F32 getMin() const               { return mMin; }
-        F32 getMax() const               { return mMax; }
+        F64 getMin() const               { return mMin; }
+        F64 getMax() const               { return mMax; }
         F64 getLastValue() const         { return mLastValue; }
         F64 getMean() const              { return mMean; }
-        F64 getStandardDeviation() const { return sqrtf(mSumOfSquares / mTotalSamplingTime); }
+        F64 getStandardDeviation() const { return sqrt(mSumOfSquares / mTotalSamplingTime); }
         F64 getSumOfSquares() const      { return mSumOfSquares; }
         F64SecondsImplicit getSamplingTime() const { return mTotalSamplingTime; }
         S32 getSampleCount() const       { return mNumSamples; }
@@ -402,7 +402,7 @@ namespace LLTrace
                 mLastSampleTimeStamp,
                 mTotalSamplingTime;
 
-        F32     mMin,
+        F64     mMin,
                 mMax;
 
         S32     mNumSamples;

--- a/indra/llcommon/lltracerecording.cpp
+++ b/indra/llcommon/lltracerecording.cpp
@@ -229,7 +229,7 @@ F32 Recording::getPerSec(const StatType<TimeBlockAccumulator::CallCountFacet>& s
     update();
     const TimeBlockAccumulator& accumulator = mBuffers->mStackTimers[stat.getIndex()];
     const TimeBlockAccumulator* active_accumulator = mActiveBuffers ? &mActiveBuffers->mStackTimers[stat.getIndex()] : NULL;
-    return (F32)(accumulator.mCalls + (active_accumulator ? active_accumulator->mCalls : 0)) / mElapsedSeconds.value();
+    return (F32)(accumulator.mCalls + (active_accumulator ? active_accumulator->mCalls : 0)) / (F32)mElapsedSeconds.value();
 }
 
 bool Recording::hasValue(const StatType<CountAccumulator>& stat)
@@ -296,11 +296,11 @@ F64 Recording::getMean( const StatType<SampleAccumulator>& stat )
     const SampleAccumulator* active_accumulator = mActiveBuffers ? &mActiveBuffers->mSamples[stat.getIndex()] : NULL;
     if (active_accumulator && active_accumulator->hasValue())
     {
-        F32 t = 0.0f;
+        F64 t = 0.0;
         S32 div = accumulator.getSampleCount() + active_accumulator->getSampleCount();
         if (div > 0)
         {
-            t = active_accumulator->getSampleCount() / div;
+            t = (F64)active_accumulator->getSampleCount() / (F64)div;
         }
         return lerp(accumulator.getMean(), active_accumulator->getMean(), t);
     }
@@ -319,7 +319,7 @@ F64 Recording::getStandardDeviation( const StatType<SampleAccumulator>& stat )
     if (active_accumulator && active_accumulator->hasValue())
     {
         F64 sum_of_squares = SampleAccumulator::mergeSumsOfSquares(accumulator, *active_accumulator);
-        return sqrtf(sum_of_squares / (accumulator.getSamplingTime() + active_accumulator->getSamplingTime()));
+        return sqrt(sum_of_squares / (F64)(accumulator.getSamplingTime() + active_accumulator->getSamplingTime()));
     }
     else
     {
@@ -382,11 +382,11 @@ F64 Recording::getMean( const StatType<EventAccumulator>& stat )
     const EventAccumulator* active_accumulator = mActiveBuffers ? &mActiveBuffers->mEvents[stat.getIndex()] : NULL;
     if (active_accumulator && active_accumulator->hasValue())
     {
-        F32 t = 0.0f;
+        F64 t = 0.0;
         S32 div = accumulator.getSampleCount() + active_accumulator->getSampleCount();
         if (div > 0)
         {
-            t = active_accumulator->getSampleCount() / div;
+            t = (F64)active_accumulator->getSampleCount() / (F64)div;
         }
         return lerp(accumulator.getMean(), active_accumulator->getMean(), t);
     }
@@ -405,7 +405,7 @@ F64 Recording::getStandardDeviation( const StatType<EventAccumulator>& stat )
     if (active_accumulator && active_accumulator->hasValue())
     {
         F64 sum_of_squares = EventAccumulator::mergeSumsOfSquares(accumulator, *active_accumulator);
-        return sqrtf(sum_of_squares / (accumulator.getSampleCount() + active_accumulator->getSampleCount()));
+        return sqrt(sum_of_squares / (F64)(accumulator.getSampleCount() + active_accumulator->getSampleCount()));
     }
     else
     {

--- a/indra/llcommon/lltracerecording.h
+++ b/indra/llcommon/lltracerecording.h
@@ -35,6 +35,11 @@
 #include "llpointer.h"
 #include <limits>
 
+#ifdef LL_WINDOWS
+#pragma warning(push)
+#pragma warning(disable : 4244) // possible loss of data on conversions
+#endif
+
 class LLStopWatchControlsMixinCommon
 {
 public:
@@ -713,5 +718,9 @@ namespace LLTrace
         PeriodicRecording mPotentialRecording;
     };
 }
+
+#ifdef LL_WINDOWS
+#pragma warning(pop)
+#endif
 
 #endif // LL_LLTRACERECORDING_H

--- a/indra/llcommon/llunittype.h
+++ b/indra/llcommon/llunittype.h
@@ -31,6 +31,11 @@
 #include "llpreprocessor.h"
 #include "llerror.h"
 
+#ifdef LL_WINDOWS
+#pragma warning(push)
+#pragma warning(disable : 4244) // possible loss of data on conversions
+#endif
+
 //lightweight replacement of type traits for simple type equality check
 template<typename S, typename T>
 struct LLIsSameType
@@ -845,5 +850,9 @@ LL_FORCE_INLINE S2 ll_convert_units(LLUnit<S1, base_unit_name> in, LLUnit<S2, un
     typedef LLUnitImplicit<U32, ns::unit_name> U32##unit_name##Implicit;\
     typedef LLUnit<U64, ns::unit_name> U64##unit_name;                  \
     typedef LLUnitImplicit<U64, ns::unit_name> U64##unit_name##Implicit
+
+#ifdef LL_WINDOWS
+#pragma warning(pop)
+#endif
 
 #endif //LL_UNITTYPE_H

--- a/indra/llcommon/tests/lleventfilter_test.cpp
+++ b/indra/llcommon/tests/lleventfilter_test.cpp
@@ -81,13 +81,13 @@ class TestEventThrottle: public LLEventThrottleBase
 public:
     TestEventThrottle(F32 interval):
         LLEventThrottleBase(interval),
-        mAlarmRemaining(-1),
-        mTimerRemaining(-1)
+        mAlarmRemaining(-1.f),
+        mTimerRemaining(-1.f)
     {}
     TestEventThrottle(LLEventPump& source, F32 interval):
         LLEventThrottleBase(source, interval),
-        mAlarmRemaining(-1),
-        mTimerRemaining(-1)
+        mAlarmRemaining(-1.f),
+        mTimerRemaining(-1.f)
     {}
 
     /*----- implementation of LLEventThrottleBase timing functionality -----*/
@@ -100,12 +100,12 @@ public:
     virtual bool alarmRunning() const /*override*/
     {
         // decrementing to exactly 0 should mean the alarm fires
-        return mAlarmRemaining > 0;
+        return mAlarmRemaining > 0.f;
     }
 
     virtual void alarmCancel() /*override*/
     {
-        mAlarmRemaining = -1;
+        mAlarmRemaining = -1.f;
     }
 
     virtual void timerSet(F32 interval) /*override*/
@@ -116,7 +116,7 @@ public:
     virtual F32  timerGetRemaining() const /*override*/
     {
         // LLTimer.getRemainingTimeF32() never returns negative; 0.0 means expired
-        return (mTimerRemaining > 0.0)? mTimerRemaining : 0.0;
+        return (mTimerRemaining > 0.0f)? mTimerRemaining : 0.0f;
     }
 
     /*------------------- methods for manipulating time --------------------*/

--- a/indra/llcommon/tests/llsdserialize_test.cpp
+++ b/indra/llcommon/tests/llsdserialize_test.cpp
@@ -1809,7 +1809,7 @@ namespace tut
         std::string q("\"");
         std::string qPYTHON(q + PYTHON + q);
         std::string qscript(q + scriptfile.getName() + q);
-        int rc = _spawnl(_P_WAIT, PYTHON.c_str(), qPYTHON.c_str(), qscript.c_str(),
+        int rc = (int)_spawnl(_P_WAIT, PYTHON.c_str(), qPYTHON.c_str(), qscript.c_str(),
                          std::forward<ARGS>(args)..., NULL);
         if (rc == -1)
         {

--- a/indra/llcommon/tests/lltrace_test.cpp
+++ b/indra/llcommon/tests/lltrace_test.cpp
@@ -32,6 +32,10 @@
 #include "lltracerecording.h"
 #include "../test/lltut.h"
 
+#ifdef LL_WINDOWS
+#pragma warning(disable : 4244) // possible loss of data on conversions
+#endif
+
 namespace LLUnits
 {
     // using powers of 2 to allow strict floating point equality

--- a/indra/llcommon/tests/llunits_test.cpp
+++ b/indra/llcommon/tests/llunits_test.cpp
@@ -262,7 +262,7 @@ namespace tut
         F32 float_val = quatloos_implicit;
         ensure("implicit units convert implicitly to regular values", float_val == 16);
 
-        S32 int_val = quatloos_implicit;
+        S32 int_val = (S32)quatloos_implicit;
         ensure("implicit units convert implicitly to regular values", int_val == 16);
 
         // conversion of implicits

--- a/indra/llcorehttp/_httpinternal.h
+++ b/indra/llcorehttp/_httpinternal.h
@@ -106,17 +106,17 @@ namespace LLCore
 // Maxium number of policy classes that can be defined.
 // *TODO:  Currently limited to the default class + 1, extend.
 // (TSN: should this be more dynamically sized.  Is there a reason to hard limit the number of policies?)
-const int HTTP_POLICY_CLASS_LIMIT = 32;
+constexpr int HTTP_POLICY_CLASS_LIMIT = 32;
 
 // Debug/informational tracing.  Used both
 // as a global option and in per-request traces.
-const int HTTP_TRACE_OFF = 0;
-const int HTTP_TRACE_LOW = 1;
-const int HTTP_TRACE_CURL_HEADERS = 2;
-const int HTTP_TRACE_CURL_BODIES = 3;
+constexpr int HTTP_TRACE_OFF = 0;
+constexpr int HTTP_TRACE_LOW = 1;
+constexpr int HTTP_TRACE_CURL_HEADERS = 2;
+constexpr int HTTP_TRACE_CURL_BODIES = 3;
 
-const int HTTP_TRACE_MIN = HTTP_TRACE_OFF;
-const int HTTP_TRACE_MAX = HTTP_TRACE_CURL_BODIES;
+constexpr int HTTP_TRACE_MIN = HTTP_TRACE_OFF;
+constexpr int HTTP_TRACE_MAX = HTTP_TRACE_CURL_BODIES;
 
 // Request retry limits
 //
@@ -127,41 +127,41 @@ const int HTTP_TRACE_MAX = HTTP_TRACE_CURL_BODIES;
 // We want to span a few windows to allow transport to slow
 // after onset of the throttles and then recover without a final
 // failure.  Other systems may need other constants.
-const int HTTP_RETRY_COUNT_DEFAULT = 5;
-const int HTTP_RETRY_COUNT_MIN = 0;
-const int HTTP_RETRY_COUNT_MAX = 100;
-const HttpTime HTTP_RETRY_BACKOFF_MIN_DEFAULT = 1E6L; // 1 sec
-const HttpTime HTTP_RETRY_BACKOFF_MAX_DEFAULT = 5E6L; // 5 sec
-const HttpTime HTTP_RETRY_BACKOFF_MAX = 20E6L; // 20 sec
+constexpr int HTTP_RETRY_COUNT_DEFAULT = 5;
+constexpr int HTTP_RETRY_COUNT_MIN = 0;
+constexpr int HTTP_RETRY_COUNT_MAX = 100;
+constexpr HttpTime HTTP_RETRY_BACKOFF_MIN_DEFAULT = 1000000UL; // 1 sec
+constexpr HttpTime HTTP_RETRY_BACKOFF_MAX_DEFAULT = 50000006UL; // 5 sec
+constexpr HttpTime HTTP_RETRY_BACKOFF_MAX = 20000000UL; // 20 sec
 
-const int HTTP_REDIRECTS_DEFAULT = 10;
+constexpr int HTTP_REDIRECTS_DEFAULT = 10;
 
 // Timeout value used for both connect and protocol exchange.
 // Retries and time-on-queue are not included and aren't
 // accounted for.
-const long HTTP_REQUEST_TIMEOUT_DEFAULT = 30L;
-const long HTTP_REQUEST_XFER_TIMEOUT_DEFAULT = 0L;
-const long HTTP_REQUEST_TIMEOUT_MIN = 0L;
-const long HTTP_REQUEST_TIMEOUT_MAX = 3600L;
+constexpr long HTTP_REQUEST_TIMEOUT_DEFAULT = 30L;
+constexpr long HTTP_REQUEST_XFER_TIMEOUT_DEFAULT = 0L;
+constexpr long HTTP_REQUEST_TIMEOUT_MIN = 0L;
+constexpr long HTTP_REQUEST_TIMEOUT_MAX = 3600L;
 
 // Limits on connection counts
-const int HTTP_CONNECTION_LIMIT_DEFAULT = 8;
-const int HTTP_CONNECTION_LIMIT_MIN = 1;
-const int HTTP_CONNECTION_LIMIT_MAX = 256;
+constexpr int HTTP_CONNECTION_LIMIT_DEFAULT = 8;
+constexpr int HTTP_CONNECTION_LIMIT_MIN = 1;
+constexpr int HTTP_CONNECTION_LIMIT_MAX = 256;
 
 // Pipelining limits
-const long HTTP_PIPELINING_DEFAULT = 0L;
-const long HTTP_PIPELINING_MAX = 20L;
+constexpr long HTTP_PIPELINING_DEFAULT = 0L;
+constexpr long HTTP_PIPELINING_MAX = 20L;
 
 // Miscellaneous defaults
-const bool HTTP_USE_RETRY_AFTER_DEFAULT = true;
-const long HTTP_THROTTLE_RATE_DEFAULT = 0L;
+constexpr bool HTTP_USE_RETRY_AFTER_DEFAULT = true;
+constexpr long HTTP_THROTTLE_RATE_DEFAULT = 0L;
 
 // Tuning parameters
 
 // Time worker thread sleeps after a pass through the
 // request, ready and active queues.
-const int HTTP_SERVICE_LOOP_SLEEP_NORMAL_MS = 2;
+constexpr int HTTP_SERVICE_LOOP_SLEEP_NORMAL_MS = 2;
 
 // Block allocation size (a tuning parameter) is found
 // in bufferarray.h.

--- a/indra/llcorehttp/httpstats.h
+++ b/indra/llcorehttp/httpstats.h
@@ -47,12 +47,12 @@ namespace LLCore
 
         void    recordDataDown(size_t bytes)
         {
-            mDataDown.push(bytes);
+            mDataDown.push((F32)bytes);
         }
 
         void    recordDataUp(size_t bytes)
         {
-            mDataUp.push(bytes);
+            mDataUp.push((F32)bytes);
         }
 
         void    recordHTTPRequest() { ++mRequests; }

--- a/indra/llcrashlogger/llcrashlock.cpp
+++ b/indra/llcrashlogger/llcrashlock.cpp
@@ -45,11 +45,10 @@
 
 bool LLCrashLock::isProcessAlive(U32 pid, const std::string& pname)
 {
-    std::wstring wpname;
-    wpname = std::wstring(pname.begin(), pname.end());
+    std::wstring wpname = ll_convert_string_to_wide(pname);
 
     HANDLE snapshot;
-    PROCESSENTRY32 pe32;
+    PROCESSENTRY32 pe32{};
 
     bool matched = false;
 
@@ -65,7 +64,7 @@ bool LLCrashLock::isProcessAlive(U32 pid, const std::string& pname)
         {
             do {
                 std::wstring wexecname = pe32.szExeFile;
-                std::string execname = std::string(wexecname.begin(), wexecname.end());
+                std::string execname = ll_convert_wide_to_string(wexecname);
                 if (!wpname.compare(pe32.szExeFile))
                 {
                     if (pid == (U32)pe32.th32ProcessID)

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -201,15 +201,15 @@ U32 LLDir::deleteDirAndContents(const std::string& dir_name)
         boost::filesystem::path dir_path(dir_name);
 #endif
 
-       if (boost::filesystem::exists (dir_path))
+       if (boost::filesystem::exists(dir_path))
        {
-          if (!boost::filesystem::is_empty (dir_path))
+          if (!boost::filesystem::is_empty(dir_path))
           {   // Directory has content
-             num_deleted = boost::filesystem::remove_all (dir_path);
+             num_deleted = (U32)boost::filesystem::remove_all(dir_path);
           }
           else
           {   // Directory is empty
-             boost::filesystem::remove (dir_path);
+             boost::filesystem::remove(dir_path);
           }
        }
     }

--- a/indra/llfilesystem/lldiskcache.cpp
+++ b/indra/llfilesystem/lldiskcache.cpp
@@ -325,8 +325,8 @@ const std::string LLDiskCache::getCacheInfo()
 {
     std::ostringstream cache_info;
 
-    F32 max_in_mb = (F32)mMaxSizeBytes / (1024.0 * 1024.0);
-    F32 percent_used = ((F32)dirFileSize(mCacheDir) / (F32)mMaxSizeBytes) * 100.0;
+    F32 max_in_mb = (F32)mMaxSizeBytes / (1024.0f * 1024.0f);
+    F32 percent_used = ((F32)dirFileSize(mCacheDir) / (F32)mMaxSizeBytes) * 100.0f;
 
     cache_info << std::fixed;
     cache_info << std::setprecision(1);

--- a/indra/llfilesystem/llfilesystem.cpp
+++ b/indra/llfilesystem/llfilesystem.cpp
@@ -148,7 +148,7 @@ S32 LLFileSystem::getFileSize(const LLUUID& file_id, const LLAssetType::EType fi
     if (file.is_open())
     {
         file.seekg(0, std::ios::end);
-        file_size = file.tellg();
+        file_size = (S32)file.tellg();
     }
 
     return file_size;
@@ -176,7 +176,7 @@ bool LLFileSystem::read(U8* buffer, S32 bytes)
         }
         else
         {
-            mBytesRead = file.gcount();
+            mBytesRead = (S32)file.gcount();
         }
 
         file.close();
@@ -217,7 +217,7 @@ bool LLFileSystem::write(const U8* buffer, S32 bytes)
         {
             ofs.write((const char*)buffer, bytes);
 
-            mPosition = ofs.tellp(); // <FS:Ansariel> Fix asset caching
+            mPosition = (S32)ofs.tellp(); // <FS:Ansariel> Fix asset caching
 
             success = true;
         }

--- a/indra/llimage/llimagefilter.cpp
+++ b/indra/llimage/llimagefilter.cpp
@@ -253,7 +253,7 @@ void LLImageFilter::executeFilter(LLPointer<LLImageRaw> raw_image)
             bool abs_value = (mFilterData[i][index++].asReal() > 0.0);
             for (S32 k = 0; k < NUM_VALUES_IN_MAT3; k++)
                 for (S32 j = 0; j < NUM_VALUES_IN_MAT3; j++)
-                    kernel.mMatrix[k][j] = mFilterData[i][index++].asReal();
+                    kernel.mMatrix[k][j] = (F32)mFilterData[i][index++].asReal();
             convolve(kernel,normalize,abs_value);
         }
         else if (filter_name == "colortransform")
@@ -262,7 +262,7 @@ void LLImageFilter::executeFilter(LLPointer<LLImageRaw> raw_image)
             S32 index = 1;
             for (S32 k = 0; k < NUM_VALUES_IN_MAT3; k++)
                 for (S32 j = 0; j < NUM_VALUES_IN_MAT3; j++)
-                    transform.mMatrix[k][j] = mFilterData[i][index++].asReal();
+                    transform.mMatrix[k][j] = (F32)mFilterData[i][index++].asReal();
             transform.transpose();
             colorTransform(transform);
         }
@@ -279,32 +279,32 @@ void LLImageFilter::executeFilter(LLPointer<LLImageRaw> raw_image)
 
 void LLImageFilter::blendStencil(F32 alpha, U8* pixel, U8 red, U8 green, U8 blue)
 {
-    F32 inv_alpha = 1.0 - alpha;
+    F32 inv_alpha = 1.0f - alpha;
     switch (mStencilBlendMode)
     {
         case STENCIL_BLEND_MODE_BLEND:
             // Classic blend of incoming color with the background image
-            pixel[VRED]   = inv_alpha * pixel[VRED]   + alpha * red;
-            pixel[VGREEN] = inv_alpha * pixel[VGREEN] + alpha * green;
-            pixel[VBLUE]  = inv_alpha * pixel[VBLUE]  + alpha * blue;
+            pixel[VRED]   = (U8)(inv_alpha * pixel[VRED]   + alpha * red);
+            pixel[VGREEN] = (U8)(inv_alpha * pixel[VGREEN] + alpha * green);
+            pixel[VBLUE]  = (U8)(inv_alpha * pixel[VBLUE]  + alpha * blue);
             break;
         case STENCIL_BLEND_MODE_ADD:
             // Add incoming color to the background image
-            pixel[VRED]   = llclampb(pixel[VRED]   + alpha * red);
-            pixel[VGREEN] = llclampb(pixel[VGREEN] + alpha * green);
-            pixel[VBLUE]  = llclampb(pixel[VBLUE]  + alpha * blue);
+            pixel[VRED]   = (U8)llclampb(pixel[VRED]   + alpha * red);
+            pixel[VGREEN] = (U8)llclampb(pixel[VGREEN] + alpha * green);
+            pixel[VBLUE]  = (U8)llclampb(pixel[VBLUE]  + alpha * blue);
             break;
         case STENCIL_BLEND_MODE_ABACK:
             // Add back background image to the incoming color
-            pixel[VRED]   = llclampb(inv_alpha * pixel[VRED]   + red);
-            pixel[VGREEN] = llclampb(inv_alpha * pixel[VGREEN] + green);
-            pixel[VBLUE]  = llclampb(inv_alpha * pixel[VBLUE]  + blue);
+            pixel[VRED]   = (U8)llclampb(inv_alpha * pixel[VRED]   + red);
+            pixel[VGREEN] = (U8)llclampb(inv_alpha * pixel[VGREEN] + green);
+            pixel[VBLUE]  = (U8)llclampb(inv_alpha * pixel[VBLUE]  + blue);
             break;
         case STENCIL_BLEND_MODE_FADE:
             // Fade incoming color to black
-            pixel[VRED]   = alpha * red;
-            pixel[VGREEN] = alpha * green;
-            pixel[VBLUE]  = alpha * blue;
+            pixel[VRED]   = (U8)(alpha * red);
+            pixel[VGREEN] = (U8)(alpha * green);
+            pixel[VBLUE]  = (U8)(alpha * blue);
             break;
     }
 }
@@ -348,7 +348,7 @@ void LLImageFilter::colorTransform(const LLMatrix3 &transform)
             dst.clamp(0.0f,255.0f);
 
             // Blend result
-            blendStencil(getStencilAlpha(i,j), dst_data, dst.mV[VRED], dst.mV[VGREEN], dst.mV[VBLUE]);
+            blendStencil(getStencilAlpha(i,j), dst_data, (U8)dst.mV[VRED], (U8)dst.mV[VGREEN], (U8)dst.mV[VBLUE]);
             dst_data += components;
         }
     }
@@ -463,7 +463,7 @@ void LLImageFilter::convolve(const LLMatrix3 &kernel, bool normalize, bool abs_v
             dst.clamp(0.0f,255.0f);
 
             // Blend result
-            blendStencil(getStencilAlpha(i,j), dst_data, dst.mV[VRED], dst.mV[VGREEN], dst.mV[VBLUE]);
+            blendStencil(getStencilAlpha(i,j), dst_data, (U8)dst.mV[VRED], (U8)dst.mV[VGREEN], (U8)dst.mV[VBLUE]);
 
             // Next pixel
             dst_data += components;
@@ -499,7 +499,7 @@ void LLImageFilter::filterScreen(EScreenMode mode, const F32 wave_length, const 
     S32 width  = mImage->getWidth();
     S32 height = mImage->getHeight();
 
-    F32 wave_length_pixels = wave_length * (F32)(height) / 2.0;
+    F32 wave_length_pixels = wave_length * (F32)(height) / 2.0f;
     F32 sin = sinf(angle*DEG_TO_RAD);
     F32 cos = cosf(angle*DEG_TO_RAD);
 
@@ -507,7 +507,7 @@ void LLImageFilter::filterScreen(EScreenMode mode, const F32 wave_length, const 
     U8 gamma[256];
     for (S32 i = 0; i < 256; i++)
     {
-        F32 gamma_i = llclampf((float)(powf((float)(i)/255.0,1.0/4.0)));
+        F32 gamma_i = llclampf((float)(powf((float)(i)/255.0f,1.0f/4.0f)));
         gamma[i] = (U8)(255.0 * gamma_i);
     }
 
@@ -525,11 +525,11 @@ void LLImageFilter::filterScreen(EScreenMode mode, const F32 wave_length, const 
                 case SCREEN_MODE_2DSINE:
                     di =  cos*i + sin*j;
                     dj = -sin*i + cos*j;
-                    value = (sinf(2*F_PI*di/wave_length_pixels)*sinf(2*F_PI*dj/wave_length_pixels)+1.0)*255.0/2.0;
+                    value = (sinf(2*F_PI*di/wave_length_pixels)*sinf(2*F_PI*dj/wave_length_pixels)+1.0f)*255.0f/2.0f;
                     break;
                 case SCREEN_MODE_LINE:
                     dj = sin*i - cos*j;
-                    value = (sinf(2*F_PI*dj/wave_length_pixels)+1.0)*255.0/2.0;
+                    value = (sinf(2*F_PI*dj/wave_length_pixels)+1.0f)*255.0f/2.0f;
                     break;
             }
             U8 dst_value = (dst_data[VRED] >= (U8)(value) ? gamma[dst_data[VRED] - (U8)(value)] : 0);
@@ -556,16 +556,16 @@ void LLImageFilter::setStencil(EStencilShape shape, EStencilBlendMode mode, F32 
     mStencilCenterX = (S32)(mImage->getWidth()  + params[0] * (F32)(mImage->getHeight()))/2;
     mStencilCenterY = (S32)(mImage->getHeight() + params[1] * (F32)(mImage->getHeight()))/2;
     mStencilWidth = (S32)(params[2] * (F32)(mImage->getHeight()))/2;
-    mStencilGamma = (params[3] <= 0.0 ? 1.0 : params[3]);
+    mStencilGamma = (params[3] <= 0.0f ? 1.0f : params[3]);
 
-    mStencilWavelength = (params[0] <= 0.0 ? 10.0 : params[0] * (F32)(mImage->getHeight()) / 2.0);
+    mStencilWavelength = (params[0] <= 0.0f ? 10.0f : params[0] * (F32)(mImage->getHeight()) / 2.0f);
     mStencilSine   = sinf(params[1]*DEG_TO_RAD);
     mStencilCosine = cosf(params[1]*DEG_TO_RAD);
 
-    mStencilStartX = ((F32)(mImage->getWidth())  + params[0] * (F32)(mImage->getHeight()))/2.0;
-    mStencilStartY = ((F32)(mImage->getHeight()) + params[1] * (F32)(mImage->getHeight()))/2.0;
-    F32 end_x      = ((F32)(mImage->getWidth())  + params[2] * (F32)(mImage->getHeight()))/2.0;
-    F32 end_y      = ((F32)(mImage->getHeight()) + params[3] * (F32)(mImage->getHeight()))/2.0;
+    mStencilStartX = ((F32)(mImage->getWidth())  + params[0] * (F32)(mImage->getHeight()))/2.0f;
+    mStencilStartY = ((F32)(mImage->getHeight()) + params[1] * (F32)(mImage->getHeight()))/2.0f;
+    F32 end_x      = ((F32)(mImage->getWidth())  + params[2] * (F32)(mImage->getHeight()))/2.0f;
+    F32 end_y      = ((F32)(mImage->getHeight()) + params[3] * (F32)(mImage->getHeight()))/2.0f;
     mStencilGradX  = end_x - mStencilStartX;
     mStencilGradY  = end_y - mStencilStartY;
     mStencilGradN  = mStencilGradX*mStencilGradX + mStencilGradY*mStencilGradY;
@@ -578,14 +578,14 @@ F32 LLImageFilter::getStencilAlpha(S32 i, S32 j)
     {
         // alpha is a modified gaussian value, with a center and fading in a circular pattern toward the edges
         // The gamma parameter controls the intensity of the drop down from alpha 1.0 (center) to 0.0
-        F32 d_center_square = (i - mStencilCenterX)*(i - mStencilCenterX) + (j - mStencilCenterY)*(j - mStencilCenterY);
+        F32 d_center_square = (F32)((i - mStencilCenterX)*(i - mStencilCenterX) + (j - mStencilCenterY)*(j - mStencilCenterY));
         alpha = powf(F_E, -(powf((d_center_square/(mStencilWidth*mStencilWidth)),mStencilGamma)/2.0f));
     }
     else if (mStencilShape == STENCIL_SHAPE_SCAN_LINES)
     {
         // alpha varies according to a squared sine function.
         F32 d = mStencilSine*i - mStencilCosine*j;
-        alpha = (sinf(2*F_PI*d/mStencilWavelength) > 0.0 ? 1.0 : 0.0);
+        alpha = (sinf(2*F_PI*d/mStencilWavelength) > 0.0f ? 1.0f : 0.0f);
     }
     else if (mStencilShape == STENCIL_SHAPE_GRADIENT)
     {
@@ -756,11 +756,11 @@ void LLImageFilter::filterGamma(F32 gamma, const LLColor3& alpha)
 
     for (S32 i = 0; i < 256; i++)
     {
-        F32 gamma_i = llclampf((float)(powf((float)(i)/255.0,1.0/gamma)));
+        F32 gamma_i = llclampf((float)(powf((float)(i)/255.0f,1.0f/gamma)));
         // Blend in with alpha values
-        gamma_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * 255.0 * gamma_i);
-        gamma_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * 255.0 * gamma_i);
-        gamma_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * 255.0 * gamma_i);
+        gamma_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * 255.0f * gamma_i);
+        gamma_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * 255.0f * gamma_i);
+        gamma_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * 255.0f * gamma_i);
     }
 
     colorCorrect(gamma_red_lut,gamma_green_lut,gamma_blue_lut);
@@ -808,23 +808,23 @@ void LLImageFilter::filterLinearize(F32 tail, const LLColor3& alpha)
         {
             U8 value_i = (i < min_v ? 0 : 255);
             // Blend in with alpha values
-            linear_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
-            linear_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
-            linear_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
+            linear_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
+            linear_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
+            linear_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
         }
     }
     else
     {
         // Linearize between min and max
-        F32 slope = 255.0 / (F32)(max_v - min_v);
+        F32 slope = 255.0f / (F32)(max_v - min_v);
         F32 translate = -min_v * slope;
         for (S32 i = 0; i < 256; i++)
         {
             U8 value_i = (U8)(llclampb((S32)(slope*i + translate)));
             // Blend in with alpha values
-            linear_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
-            linear_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
-            linear_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
+            linear_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
+            linear_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
+            linear_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
         }
     }
 
@@ -863,9 +863,9 @@ void LLImageFilter::filterEqualize(S32 nb_classes, const LLColor3& alpha)
     for (S32 i = 0; i < 256; i++)
     {
         // Blend in current_value with alpha values
-        equalize_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * current_value);
-        equalize_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * current_value);
-        equalize_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * current_value);
+        equalize_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * current_value);
+        equalize_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * current_value);
+        equalize_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * current_value);
         if (cumulated_histo[i] >= current_count)
         {
             current_count += delta_count;
@@ -884,15 +884,15 @@ void LLImageFilter::filterColorize(const LLColor3& color, const LLColor3& alpha)
     U8 green_lut[256];
     U8 blue_lut[256];
 
-    F32 red_composite   =  255.0 * alpha.mV[0] * color.mV[0];
-    F32 green_composite =  255.0 * alpha.mV[1] * color.mV[1];
-    F32 blue_composite  =  255.0 * alpha.mV[2] * color.mV[2];
+    F32 red_composite   =  255.0f * alpha.mV[0] * color.mV[0];
+    F32 green_composite =  255.0f * alpha.mV[1] * color.mV[1];
+    F32 blue_composite  =  255.0f * alpha.mV[2] * color.mV[2];
 
     for (S32 i = 0; i < 256; i++)
     {
-        red_lut[i]   = (U8)(llclampb((S32)((1.0 - alpha.mV[0]) * (F32)(i) + red_composite)));
-        green_lut[i] = (U8)(llclampb((S32)((1.0 - alpha.mV[1]) * (F32)(i) + green_composite)));
-        blue_lut[i]  = (U8)(llclampb((S32)((1.0 - alpha.mV[2]) * (F32)(i) + blue_composite)));
+        red_lut[i]   = (U8)(llclampb((S32)((1.0f - alpha.mV[0]) * (F32)(i) + red_composite)));
+        green_lut[i] = (U8)(llclampb((S32)((1.0f - alpha.mV[1]) * (F32)(i) + green_composite)));
+        blue_lut[i]  = (U8)(llclampb((S32)((1.0f - alpha.mV[2]) * (F32)(i) + blue_composite)));
     }
 
     colorCorrect(red_lut,green_lut,blue_lut);
@@ -904,15 +904,15 @@ void LLImageFilter::filterContrast(F32 slope, const LLColor3& alpha)
     U8 contrast_green_lut[256];
     U8 contrast_blue_lut[256];
 
-    F32 translate = 128.0 * (1.0 - slope);
+    F32 translate = 128.0f * (1.0f - slope);
 
     for (S32 i = 0; i < 256; i++)
     {
         U8 value_i = (U8)(llclampb((S32)(slope*i + translate)));
         // Blend in with alpha values
-        contrast_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
-        contrast_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
-        contrast_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
+        contrast_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
+        contrast_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
+        contrast_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
     }
 
     colorCorrect(contrast_red_lut,contrast_green_lut,contrast_blue_lut);
@@ -924,15 +924,15 @@ void LLImageFilter::filterBrightness(F32 add, const LLColor3& alpha)
     U8 brightness_green_lut[256];
     U8 brightness_blue_lut[256];
 
-    S32 add_value = (S32)(add * 255.0);
+    S32 add_value = (S32)(add * 255.0f);
 
     for (S32 i = 0; i < 256; i++)
     {
         U8 value_i = (U8)(llclampb(i + add_value));
         // Blend in with alpha values
-        brightness_red_lut[i]   = (U8)((1.0 - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
-        brightness_green_lut[i] = (U8)((1.0 - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
-        brightness_blue_lut[i]  = (U8)((1.0 - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
+        brightness_red_lut[i]   = (U8)((1.0f - alpha.mV[0]) * (float)(i) + alpha.mV[0] * value_i);
+        brightness_green_lut[i] = (U8)((1.0f - alpha.mV[1]) * (float)(i) + alpha.mV[1] * value_i);
+        brightness_blue_lut[i]  = (U8)((1.0f - alpha.mV[2]) * (float)(i) + alpha.mV[2] * value_i);
     }
 
     colorCorrect(brightness_red_lut,brightness_green_lut,brightness_blue_lut);

--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -557,7 +557,7 @@ public:
         {
             // "append" (set) the data we "streamed" (memcopied) for writing to the formatted image
             // with side-effect of setting the actually encoded size  to same
-            compressedImageOut.allocateData(offset);
+            compressedImageOut.allocateData((S32)offset);
             memcpy(compressedImageOut.getData(), buffer, offset);
             compressedImageOut.updateData(); // update width, height etc from header
         }

--- a/indra/llinventory/llparcel.cpp
+++ b/indra/llinventory/llparcel.cpp
@@ -1268,7 +1268,7 @@ void LLParcel::setExperienceKeyType( const LLUUID& experience_key, U32 type )
 
 U32 LLParcel::countExperienceKeyType( U32 type )
 {
-    return std::count_if(
+    return (U32)std::count_if(
         boost::begin(mExperienceKeys | boost::adaptors::map_values),
         boost::end(mExperienceKeys | boost::adaptors::map_values),
         [type](U32 key){ return (key == type); });

--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -278,11 +278,11 @@ LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD 
     {
         case LLSD::TypeInteger:
             // lerp between the two values rounding the result to the nearest integer.
-            new_value = LLSD::Integer(llroundf(lerp(value.asReal(), other_value.asReal(), mix)));
+            new_value = LLSD::Integer(llroundf(lerp((F32)value.asReal(), (F32)other_value.asReal(), (F32)mix)));
             break;
         case LLSD::TypeReal:
             // lerp between the two values.
-            new_value = LLSD::Real(lerp(value.asReal(), other_value.asReal(), mix));
+            new_value = LLSD::Real(lerp((F32)value.asReal(), (F32)other_value.asReal(), (F32)mix));
             break;
         case LLSD::TypeMap:
             // deep copy.
@@ -297,7 +297,7 @@ LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD 
             {
                 LLQuaternion a(value);
                 LLQuaternion b(other_value);
-                LLQuaternion q = slerp(mix, a, b);
+                LLQuaternion q = slerp((F32)mix, a, b);
                 new_array = q.getValue();
             }
             else
@@ -308,7 +308,7 @@ LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD 
                 for (size_t i = 0; i < len; ++i)
                 {
 
-                    new_array[i] = lerp(value[i].asReal(), other_value[i].asReal(), mix);
+                    new_array[i] = lerp((F32)value[i].asReal(), (F32)other_value[i].asReal(), (F32)mix);
                 }
             }
 
@@ -693,7 +693,7 @@ void LLSettingsBlender::update(const LLSettingsBase::BlendFactor& blendf)
 
 F64 LLSettingsBlender::setBlendFactor(const LLSettingsBase::BlendFactor& blendf_in)
 {
-    LLSettingsBase::TrackPosition blendf = blendf_in;
+    LLSettingsBase::TrackPosition blendf = (F32)blendf_in;
     llassert(!isnan(blendf));
     if (blendf >= 1.0)
     {
@@ -744,7 +744,7 @@ bool LLSettingsBlenderTimeDelta::applyTimeDelta(const LLSettingsBase::Seconds& t
         return false;
     }
 
-    LLSettingsBase::BlendFactor blendf = calculateBlend(mTimeSpent, mBlendSpan);
+    LLSettingsBase::BlendFactor blendf = calculateBlend((F32)mTimeSpent.value(), mBlendSpan);
 
     if (fabs(mLastBlendF - blendf) < mBlendFMinDelta)
     {

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -475,7 +475,7 @@ public:
     LLSettingsBlenderTimeDelta(const LLSettingsBase::ptr_t &target,
         const LLSettingsBase::ptr_t &initsetting, const LLSettingsBase::ptr_t &endsetting, const LLSettingsBase::Seconds& blend_span) :
         LLSettingsBlender(target, initsetting, endsetting),
-        mBlendSpan(blend_span),
+        mBlendSpan((F32)blend_span.value()),
         mLastUpdate(0.0f),
         mTimeSpent(0.0f),
         mBlendFMinDelta(MIN_BLEND_DELTA),

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -500,7 +500,7 @@ namespace
                     continue;
                 }
 
-                LLSettingsBase::TrackPosition frame = elem[LLSettingsDay::SETTING_KEYKFRAME].asReal();
+                LLSettingsBase::TrackPosition frame = (F32)elem[LLSettingsDay::SETTING_KEYKFRAME].asReal();
                 if ((frame < 0.0) || (frame > 1.0))
                 {
                     frame = llclamp(frame, 0.0f, 1.0f);

--- a/indra/llinventory/llsettingssky.cpp
+++ b/indra/llinventory/llsettingssky.cpp
@@ -480,19 +480,19 @@ void LLSettingsSky::blend(const LLSettingsBase::ptr_t &end, F64 blendf)
             // If there is no cloud texture in destination, reduce coverage to imitate disappearance
             // See LLDrawPoolWLSky::renderSkyClouds... we don't blend present texture with null
             // Note: Probably can be done by shader
-            cloud_shadow = lerp(mSettings[SETTING_CLOUD_SHADOW].asReal(), (F64)0.f, blendf);
+            cloud_shadow = lerp((F32)mSettings[SETTING_CLOUD_SHADOW].asReal(), 0.f, (F32)blendf);
             cloud_noise_id_next = cloud_noise_id;
         }
         else if (cloud_noise_id.isNull() && !cloud_noise_id_next.isNull())
         {
             // Source has no cloud texture, reduce initial coverage to imitate appearance
             // use same texture as destination
-            cloud_shadow = lerp((F64)0.f, other->mSettings[SETTING_CLOUD_SHADOW].asReal(), blendf);
+            cloud_shadow = lerp(0.f, (F32)other->mSettings[SETTING_CLOUD_SHADOW].asReal(), (F32)blendf);
             setCloudNoiseTextureId(cloud_noise_id_next);
         }
         else
         {
-            cloud_shadow = lerp(mSettings[SETTING_CLOUD_SHADOW].asReal(), other->mSettings[SETTING_CLOUD_SHADOW].asReal(), blendf);
+            cloud_shadow = lerp((F32)mSettings[SETTING_CLOUD_SHADOW].asReal(), (F32)other->mSettings[SETTING_CLOUD_SHADOW].asReal(), (F32)blendf);
         }
 
         LLSD blenddata = interpolateSDMap(mSettings, other->mSettings, other->getParameterMap(), blendf);
@@ -923,8 +923,8 @@ LLSD LLSettingsSky::translateLegacySettings(const LLSD& legacy)
     if (legacy.has(SETTING_LEGACY_EAST_ANGLE) && legacy.has(SETTING_LEGACY_SUN_ANGLE))
     {
         // get counter-clockwise radian angle from clockwise legacy WL east angle...
-        F32 azimuth  = -legacy[SETTING_LEGACY_EAST_ANGLE].asReal();
-        F32 altitude =  legacy[SETTING_LEGACY_SUN_ANGLE].asReal();
+        F32 azimuth  = -(F32)legacy[SETTING_LEGACY_EAST_ANGLE].asReal();
+        F32 altitude = (F32)legacy[SETTING_LEGACY_SUN_ANGLE].asReal();
 
         LLQuaternion sunquat  = convert_azimuth_and_altitude_to_quat(azimuth, altitude);
         // original WL moon dir was diametrically opposed to the sun dir
@@ -958,7 +958,7 @@ void LLSettingsSky::updateSettings()
 F32 LLSettingsSky::getSunMoonGlowFactor() const
 {
     return getIsSunUp()  ? 1.0f  :
-           getIsMoonUp() ? getMoonBrightness() * 0.25 : 0.0f;
+           getIsMoonUp() ? getMoonBrightness() * 0.25f : 0.0f;
 }
 
 bool LLSettingsSky::getIsSunUp() const
@@ -1043,11 +1043,11 @@ F32 LLSettingsSky::getFloat(const std::string& key, F32 default_value) const
     LL_PROFILE_ZONE_SCOPED_CATEGORY_ENVIRONMENT;
     if (mSettings.has(SETTING_LEGACY_HAZE) && mSettings[SETTING_LEGACY_HAZE].has(key))
     {
-        return mSettings[SETTING_LEGACY_HAZE][key].asReal();
+        return (F32)mSettings[SETTING_LEGACY_HAZE][key].asReal();
     }
     if (mSettings.has(key))
     {
-        return mSettings[key].asReal();
+        return (F32)mSettings[key].asReal();
     }
     return default_value;
 }
@@ -1307,7 +1307,7 @@ void LLSettingsSky::clampColor(LLColor3& color, F32 gamma, F32 scale) const
         color *= scale/max_color;
     }
     LLColor3 linear(color);
-    linear *= 1.0 / scale;
+    linear *= 1.0f / scale;
     linear = smear(1.0f) - linear;
     linear = componentPow(linear, gamma);
     linear *= scale;
@@ -1353,7 +1353,7 @@ void LLSettingsSky::calculateLightSettings() const
 
     F32 haze_horizon = getHazeHorizon();
 
-    sunlight *= 1.0 - cloud_shadow;
+    sunlight *= 1.0f - cloud_shadow;
     sunlight += tmpAmbient;
 
     mHazeColor = getBlueHorizon() * getBlueDensity() * sunlight;
@@ -1415,22 +1415,22 @@ LLUUID LLSettingsSky::GetDefaultHaloTextureId()
 
 F32 LLSettingsSky::getPlanetRadius() const
 {
-    return mSettings[SETTING_PLANET_RADIUS].asReal();
+    return (F32)mSettings[SETTING_PLANET_RADIUS].asReal();
 }
 
 F32 LLSettingsSky::getSkyMoistureLevel() const
 {
-    return mSettings[SETTING_SKY_MOISTURE_LEVEL].asReal();
+    return (F32)mSettings[SETTING_SKY_MOISTURE_LEVEL].asReal();
 }
 
 F32 LLSettingsSky::getSkyDropletRadius() const
 {
-    return mSettings[SETTING_SKY_DROPLET_RADIUS].asReal();
+    return (F32)mSettings[SETTING_SKY_DROPLET_RADIUS].asReal();
 }
 
 F32 LLSettingsSky::getSkyIceLevel() const
 {
-    return mSettings[SETTING_SKY_ICE_LEVEL].asReal();
+    return (F32)mSettings[SETTING_SKY_ICE_LEVEL].asReal();
 }
 
 F32 LLSettingsSky::getReflectionProbeAmbiance(bool auto_adjust) const
@@ -1440,27 +1440,27 @@ F32 LLSettingsSky::getReflectionProbeAmbiance(bool auto_adjust) const
         return sAutoAdjustProbeAmbiance;
     }
 
-    return mSettings[SETTING_REFLECTION_PROBE_AMBIANCE].asReal();
+    return (F32)mSettings[SETTING_REFLECTION_PROBE_AMBIANCE].asReal();
 }
 
 F32 LLSettingsSky::getSkyBottomRadius() const
 {
-    return mSettings[SETTING_SKY_BOTTOM_RADIUS].asReal();
+    return (F32)mSettings[SETTING_SKY_BOTTOM_RADIUS].asReal();
 }
 
 F32 LLSettingsSky::getSkyTopRadius() const
 {
-    return mSettings[SETTING_SKY_TOP_RADIUS].asReal();
+    return (F32)mSettings[SETTING_SKY_TOP_RADIUS].asReal();
 }
 
 F32 LLSettingsSky::getSunArcRadians() const
 {
-    return mSettings[SETTING_SUN_ARC_RADIANS].asReal();
+    return (F32)mSettings[SETTING_SUN_ARC_RADIANS].asReal();
 }
 
 F32 LLSettingsSky::getMieAnisotropy() const
 {
-    return getMieConfig()[SETTING_MIE_ANISOTROPY_FACTOR].asReal();
+    return (F32)getMieConfig()[SETTING_MIE_ANISOTROPY_FACTOR].asReal();
 }
 
 LLSD LLSettingsSky::getRayleighConfig() const
@@ -1569,7 +1569,7 @@ void LLSettingsSky::setCloudPosDensity2(const LLColor3 &val)
 
 F32 LLSettingsSky::getCloudScale() const
 {
-    return mSettings[SETTING_CLOUD_SCALE].asReal();
+    return (F32)mSettings[SETTING_CLOUD_SCALE].asReal();
 }
 
 void LLSettingsSky::setCloudScale(F32 val)
@@ -1601,7 +1601,7 @@ void LLSettingsSky::setCloudScrollRateY(F32 val)
 
 F32 LLSettingsSky::getCloudShadow() const
 {
-    return mSettings[SETTING_CLOUD_SHADOW].asReal();
+    return (F32)mSettings[SETTING_CLOUD_SHADOW].asReal();
 }
 
 void LLSettingsSky::setCloudShadow(F32 val)
@@ -1611,7 +1611,7 @@ void LLSettingsSky::setCloudShadow(F32 val)
 
 F32 LLSettingsSky::getCloudVariance() const
 {
-    return mSettings[SETTING_CLOUD_VARIANCE].asReal();
+    return (F32)mSettings[SETTING_CLOUD_VARIANCE].asReal();
 }
 
 void LLSettingsSky::setCloudVariance(F32 val)
@@ -1621,7 +1621,7 @@ void LLSettingsSky::setCloudVariance(F32 val)
 
 F32 LLSettingsSky::getDomeOffset() const
 {
-    //return mSettings[SETTING_DOME_OFFSET].asReal();
+    //return (F32)mSettings[SETTING_DOME_OFFSET].asReal();
     return DOME_OFFSET;
 }
 
@@ -1633,7 +1633,7 @@ F32 LLSettingsSky::getDomeRadius() const
 
 F32 LLSettingsSky::getGamma() const
 {
-    return mSettings[SETTING_GAMMA].asReal();
+    return (F32)mSettings[SETTING_GAMMA].asReal();
 }
 
 void LLSettingsSky::setGamma(F32 val)
@@ -1654,7 +1654,7 @@ void LLSettingsSky::setGlow(const LLColor3 &val)
 
 F32 LLSettingsSky::getMaxY() const
 {
-    return mSettings[SETTING_MAX_Y].asReal();
+    return (F32)mSettings[SETTING_MAX_Y].asReal();
 }
 
 void LLSettingsSky::setMaxY(F32 val)
@@ -1674,7 +1674,7 @@ void LLSettingsSky::setMoonRotation(const LLQuaternion &val)
 
 F32 LLSettingsSky::getMoonScale() const
 {
-    return mSettings[SETTING_MOON_SCALE].asReal();
+    return (F32)mSettings[SETTING_MOON_SCALE].asReal();
 }
 
 void LLSettingsSky::setMoonScale(F32 val)
@@ -1692,9 +1692,9 @@ void LLSettingsSky::setMoonTextureId(LLUUID id)
     setValue(SETTING_MOON_TEXTUREID, id);
 }
 
-F32  LLSettingsSky::getMoonBrightness() const
+F32 LLSettingsSky::getMoonBrightness() const
 {
-    return mSettings[SETTING_MOON_BRIGHTNESS].asReal();
+    return (F32)mSettings[SETTING_MOON_BRIGHTNESS].asReal();
 }
 
 void LLSettingsSky::setMoonBrightness(F32 brightness_factor)
@@ -1704,7 +1704,7 @@ void LLSettingsSky::setMoonBrightness(F32 brightness_factor)
 
 F32 LLSettingsSky::getStarBrightness() const
 {
-    return mSettings[SETTING_STAR_BRIGHTNESS].asReal();
+    return (F32)mSettings[SETTING_STAR_BRIGHTNESS].asReal();
 }
 
 void LLSettingsSky::setStarBrightness(F32 val)
@@ -1749,7 +1749,7 @@ void LLSettingsSky::setSunRotation(const LLQuaternion &val)
 
 F32 LLSettingsSky::getSunScale() const
 {
-    return mSettings[SETTING_SUN_SCALE].asReal();
+    return (F32)mSettings[SETTING_SUN_SCALE].asReal();
 }
 
 void LLSettingsSky::setSunScale(F32 val)

--- a/indra/llinventory/llsettingswater.h
+++ b/indra/llinventory/llsettingswater.h
@@ -72,7 +72,7 @@ public:
     //---------------------------------------------------------------------
     F32 getBlurMultiplier() const
     {
-        return mSettings[SETTING_BLUR_MULTIPLIER].asReal();
+        return (F32)mSettings[SETTING_BLUR_MULTIPLIER].asReal();
     }
 
     void setBlurMultiplier(F32 val)
@@ -92,7 +92,7 @@ public:
 
     F32 getWaterFogDensity() const
     {
-        return mSettings[SETTING_FOG_DENSITY].asReal();
+        return (F32)mSettings[SETTING_FOG_DENSITY].asReal();
     }
 
     F32 getModifiedWaterFogDensity(bool underwater) const;
@@ -104,7 +104,7 @@ public:
 
     F32 getFogMod() const
     {
-        return mSettings[SETTING_FOG_MOD].asReal();
+        return (F32)mSettings[SETTING_FOG_MOD].asReal();
     }
 
     void setFogMod(F32 val)
@@ -114,7 +114,7 @@ public:
 
     F32 getFresnelOffset() const
     {
-        return mSettings[SETTING_FRESNEL_OFFSET].asReal();
+        return (F32)mSettings[SETTING_FRESNEL_OFFSET].asReal();
     }
 
     void setFresnelOffset(F32 val)
@@ -124,7 +124,7 @@ public:
 
     F32 getFresnelScale() const
     {
-        return mSettings[SETTING_FRESNEL_SCALE].asReal();
+        return (F32)mSettings[SETTING_FRESNEL_SCALE].asReal();
     }
 
     void setFresnelScale(F32 val)
@@ -164,7 +164,7 @@ public:
 
     F32 getScaleAbove() const
     {
-        return mSettings[SETTING_SCALE_ABOVE].asReal();
+        return (F32)mSettings[SETTING_SCALE_ABOVE].asReal();
     }
 
     void setScaleAbove(F32 val)
@@ -174,7 +174,7 @@ public:
 
     F32 getScaleBelow() const
     {
-        return mSettings[SETTING_SCALE_BELOW].asReal();
+        return (F32)mSettings[SETTING_SCALE_BELOW].asReal();
     }
 
     void setScaleBelow(F32 val)

--- a/indra/llinventory/tests/inventorymisc_test.cpp
+++ b/indra/llinventory/tests/inventorymisc_test.cpp
@@ -61,7 +61,7 @@ LLPointer<LLInventoryItem> create_random_inventory_item()
     S32 price = rand();
     LLSaleInfo sale_info(LLSaleInfo::FS_COPY, price);
     U32 flags = rand();
-    S32 creation = time(NULL);
+    S32 creation = (S32)time(NULL);
 
     LLPointer<LLInventoryItem> item = new LLInventoryItem(
         item_id,
@@ -195,7 +195,7 @@ namespace tut
         src->setSaleInfo(new_sale_info);
 
         U32 new_flags = rand();
-        S32 new_creation = time(NULL);
+        S32 new_creation = (S32)time(NULL);
 
         LLPermissions new_perm;
 
@@ -266,7 +266,7 @@ namespace tut
         src->setSaleInfo(new_sale_info);
 
         U32 new_flags = rand();
-        S32 new_creation = time(NULL);
+        S32 new_creation = (S32)time(NULL);
 
         LLPermissions new_perm;
 

--- a/indra/llmath/llcalcparser.h
+++ b/indra/llmath/llcalcparser.h
@@ -175,7 +175,7 @@ private:
     F32 _exp(const F32& a) const { return exp(a); }
     F32 _fabs(const F32& a) const { return fabs(a); }
     F32 _floor(const F32& a) const { return (F32)llfloor(a); }
-    F32 _ceil(const F32& a) const { return llceil(a); }
+    F32 _ceil(const F32& a) const { return (F32)llceil(a); }
     F32 _atan2(const F32& a,const F32& b) const { return atan2(a,b); }
 
     LLCalc::calc_map_t* mConstants;

--- a/indra/llmath/llquaternion.h
+++ b/indra/llmath/llquaternion.h
@@ -186,10 +186,10 @@ inline LLSD LLQuaternion::getValue() const
 
 inline void LLQuaternion::setValue(const LLSD& sd)
 {
-    mQ[0] = sd[0].asReal();
-    mQ[1] = sd[1].asReal();
-    mQ[2] = sd[2].asReal();
-    mQ[3] = sd[3].asReal();
+    mQ[0] = (F32)sd[0].asReal();
+    mQ[1] = (F32)sd[1].asReal();
+    mQ[2] = (F32)sd[2].asReal();
+    mQ[3] = (F32)sd[3].asReal();
 }
 
 // checker

--- a/indra/llmath/v3color.h
+++ b/indra/llmath/v3color.h
@@ -517,9 +517,9 @@ inline const LLVector3 linearColor3v(const T& a) {
 template<typename T>
 const LLColor3& LLColor3::set(const std::vector<T>& v)
 {
-    for (S32 i = 0; i < llmin((S32)v.size(), 3); ++i)
+    for (size_t i = 0; i < llmin(v.size(), 3); ++i)
     {
-        mV[i] = v[i];
+        mV[i] = (F32)v[i];
     }
 
     return *this;
@@ -530,9 +530,9 @@ const LLColor3& LLColor3::set(const std::vector<T>& v)
 template<typename T>
 void LLColor3::write(std::vector<T>& v) const
 {
-    for (int i = 0; i < llmin((S32)v.size(), 3); ++i)
+    for (size_t i = 0; i < llmin(v.size(), 3); ++i)
     {
-        v[i] = mV[i];
+        v[i] = (T)mV[i];
     }
 }
 

--- a/indra/llmath/v4color.h
+++ b/indra/llmath/v4color.h
@@ -702,9 +702,9 @@ inline const LLColor4 linearColor4(const LLColor4 &a)
 template<typename T>
 const LLColor4& LLColor4::set(const std::vector<T>& v)
 {
-    for (S32 i = 0; i < llmin((S32)v.size(), 4); ++i)
+    for (size_t i = 0; i < llmin(v.size(), 4); ++i)
     {
-        mV[i] = v[i];
+        mV[i] = (F32)v[i];
     }
 
     return *this;
@@ -713,9 +713,9 @@ const LLColor4& LLColor4::set(const std::vector<T>& v)
 template<typename T>
 void LLColor4::write(std::vector<T>& v) const
 {
-    for (int i = 0; i < llmin((S32)v.size(), 4); ++i)
+    for (size_t i = 0; i < llmin(v.size(), 4); ++i)
     {
-        v[i] = mV[i];
+        v[i] = (T)mV[i];
     }
 }
 

--- a/indra/llmath/v4math.h
+++ b/indra/llmath/v4math.h
@@ -67,10 +67,10 @@ class LLVector4
 
         void setValue(const LLSD& sd)
         {
-            mV[0] = sd[0].asReal();
-            mV[1] = sd[1].asReal();
-            mV[2] = sd[2].asReal();
-            mV[3] = sd[3].asReal();
+            mV[0] = (F32)sd[0].asReal();
+            mV[1] = (F32)sd[1].asReal();
+            mV[2] = (F32)sd[2].asReal();
+            mV[3] = (F32)sd[3].asReal();
         }
 
 

--- a/indra/llmessage/llbuffer.cpp
+++ b/indra/llmessage/llbuffer.cpp
@@ -142,7 +142,7 @@ LLHeapBuffer::~LLHeapBuffer()
 
 S32 LLHeapBuffer::bytesLeft() const
 {
-    return (mSize - (mNextFree - mBuffer));
+    return (mSize - (S32)(mNextFree - mBuffer));
 }
 
 // virtual
@@ -371,11 +371,11 @@ LLBufferArray::segment_iterator_t LLBufferArray::splitAfter(U8* address)
         return it;
     }
     S32 channel = (*it).getChannel();
-    LLSegment segment1(channel, base, (address - base) + 1);
+    LLSegment segment1(channel, base, (S32)((address - base) + 1));
     *it = segment1;
     segment_iterator_t rv = it;
     ++it;
-    LLSegment segment2(channel, address + 1, size - (address - base) - 1);
+    LLSegment segment2(channel, address + 1, (S32)(size - (address - base) - 1));
     mSegments.insert(it, segment2);
     return rv;
 }
@@ -424,7 +424,7 @@ LLBufferArray::segment_iterator_t LLBufferArray::constructSegmentAfter(
                     segment = LLSegment(
                         (*rv).getChannel(),
                         address,
-                        (*rv).size() - (address - (*rv).data()));
+                        (*rv).size() - (S32)(address - (*rv).data()));
                 }
                 else
                 {
@@ -533,7 +533,7 @@ S32 LLBufferArray::countAfter(S32 channel, U8* start) const
         if(++start < ((*it).data() + (*it).size()))
         {
             // it's in the same segment
-            offset = start - (*it).data();
+            offset = (S32)(start - (*it).data());
         }
         else if(++it == end)
         {
@@ -586,7 +586,7 @@ U8* LLBufferArray::readAfter(
            && (*it).isOnChannel(channel))
         {
             // copy the data out of this segment
-            S32 bytes_in_segment = (*it).size() - (start - (*it).data());
+            S32 bytes_in_segment = (*it).size() - (S32)(start - (*it).data());
             bytes_to_copy = llmin(bytes_left, bytes_in_segment);
             memcpy(dest, start, bytes_to_copy); /*Flawfinder: ignore*/
             len += bytes_to_copy;
@@ -681,7 +681,7 @@ U8* LLBufferArray::seek(
         {
             if(delta > 0)
             {
-                S32 bytes_in_segment = (*it).size() - (start - (*it).data());
+                S32 bytes_in_segment = (*it).size() - (S32)(start - (*it).data());
                 S32 local_delta = llmin(delta, bytes_in_segment);
                 rv += local_delta;
                 delta -= local_delta;
@@ -689,7 +689,7 @@ U8* LLBufferArray::seek(
             }
             else
             {
-                S32 bytes_in_segment = start - (*it).data();
+                S32 bytes_in_segment = (S32)(start - (*it).data());
                 S32 local_delta = llmin(llabs(delta), bytes_in_segment);
                 rv -= local_delta;
                 delta += local_delta;

--- a/indra/llmessage/llbufferstream.cpp
+++ b/indra/llmessage/llbufferstream.cpp
@@ -273,7 +273,7 @@ streampos LLBufferStreamBuf::seekoff(
         }
 
         LLMutexLock lock(mBuffer->getMutex());
-        address = mBuffer->seek(mChannels.in(), base_addr, off);
+        address = mBuffer->seek(mChannels.in(), base_addr, (S32)off);
         if(address)
         {
             LLBufferArray::segment_iterator_t iter;
@@ -306,7 +306,7 @@ streampos LLBufferStreamBuf::seekoff(
         }
 
         LLMutexLock lock(mBuffer->getMutex());
-        address = mBuffer->seek(mChannels.out(), base_addr, off);
+        address = mBuffer->seek(mChannels.out(), base_addr, (S32)off);
         if(address)
         {
             LLBufferArray::segment_iterator_t iter;

--- a/indra/llmessage/llcircuit.cpp
+++ b/indra/llmessage/llcircuit.cpp
@@ -525,13 +525,13 @@ void LLCircuitData::checkPeriodTime()
     F64Seconds period_length = mt_sec - mPeriodTime;
     if ( period_length > TARGET_PERIOD_LENGTH)
     {
-        F32 bps_in = F32Bits(mBytesInThisPeriod).value() / period_length.value();
+        F32 bps_in = F32Bits(mBytesInThisPeriod).value() / (F32)period_length.value();
         if (bps_in > mPeakBPSIn)
         {
             mPeakBPSIn = bps_in;
         }
 
-        F32 bps_out = F32Bits(mBytesOutThisPeriod).value() / period_length.value();
+        F32 bps_out = F32Bits(mBytesOutThisPeriod).value() / (F32)period_length.value();
         if (bps_out > mPeakBPSOut)
         {
             mPeakBPSOut = bps_out;

--- a/indra/llmessage/lliohttpserver.cpp
+++ b/indra/llmessage/lliohttpserver.cpp
@@ -625,7 +625,7 @@ bool LLHTTPResponder::readHeaderLine(
         }
         return false;
     }
-    S32 offset = -((len - 1) - (newline - dest));
+    S32 offset = -((len - 1) - (S32)(newline - dest));
     ++newline;
     *newline = '\0';
     mLastRead = buffer->seek(channels.in(), last, offset);

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -107,7 +107,7 @@ bool get_dom_sources(const domInputLocalOffset_Array& inputs, S32& pos_offset, S
             {
                 if (strcmp(COMMON_PROFILE_INPUT_POSITION, v_inp[k]->getSemantic()) == 0)
                 {
-                    pos_offset = inputs[j]->getOffset();
+                    pos_offset = (S32)inputs[j]->getOffset();
 
                     const domURIFragmentType& uri = v_inp[k]->getSource();
                     daeElementRef elem = uri.getElement();
@@ -116,7 +116,7 @@ bool get_dom_sources(const domInputLocalOffset_Array& inputs, S32& pos_offset, S
 
                 if (strcmp(COMMON_PROFILE_INPUT_NORMAL, v_inp[k]->getSemantic()) == 0)
                 {
-                    norm_offset = inputs[j]->getOffset();
+                    norm_offset = (S32)inputs[j]->getOffset();
 
                     const domURIFragmentType& uri = v_inp[k]->getSource();
                     daeElementRef elem = uri.getElement();
@@ -128,14 +128,14 @@ bool get_dom_sources(const domInputLocalOffset_Array& inputs, S32& pos_offset, S
         if (strcmp(COMMON_PROFILE_INPUT_NORMAL, inputs[j]->getSemantic()) == 0)
         {
             //found normal array for this triangle list
-            norm_offset = inputs[j]->getOffset();
+            norm_offset = (S32)inputs[j]->getOffset();
             const domURIFragmentType& uri = inputs[j]->getSource();
             daeElementRef elem = uri.getElement();
             norm_source = (domSource*) elem.cast();
         }
         else if (strcmp(COMMON_PROFILE_INPUT_TEXCOORD, inputs[j]->getSemantic()) == 0)
         { //found texCoords
-            tc_offset = inputs[j]->getOffset();
+            tc_offset = (S32)inputs[j]->getOffset();
             const domURIFragmentType& uri = inputs[j]->getSource();
             daeElementRef elem = uri.getElement();
             tc_source = (domSource*) elem.cast();
@@ -201,8 +201,8 @@ LLModel::EModelStatus load_face_from_dom_triangles(
             return LLModel::BAD_ELEMENT;
         }
         // VFExtents change
-        face.mExtents[0].set(v[0], v[1], v[2]);
-        face.mExtents[1].set(v[0], v[1], v[2]);
+        face.mExtents[0].set((F32)v[0], (F32)v[1], (F32)v[2]);
+        face.mExtents[1].set((F32)v[0], (F32)v[1], (F32)v[2]);
     }
 
     LLVolumeFace::VertexMapData::PointMap point_map;
@@ -223,22 +223,22 @@ LLModel::EModelStatus load_face_from_dom_triangles(
         LLVolumeFace::VertexData cv;
         if (pos_source)
         {
-            cv.setPosition(LLVector4a(v[idx[i+pos_offset]*3+0],
-                                v[idx[i+pos_offset]*3+1],
-                                v[idx[i+pos_offset]*3+2]));
+            cv.setPosition(LLVector4a((F32)v[idx[i+pos_offset]*3+0],
+                                (F32)v[idx[i+pos_offset]*3+1],
+                                (F32)v[idx[i+pos_offset]*3+2]));
         }
 
         if (tc_source)
         {
-            cv.mTexCoord.setVec(tc[idx[i+tc_offset]*2+0],
-                                tc[idx[i+tc_offset]*2+1]);
+            cv.mTexCoord.setVec((F32)tc[idx[i+tc_offset]*2+0],
+                                (F32)tc[idx[i+tc_offset]*2+1]);
         }
 
         if (norm_source)
         {
-            cv.setNormal(LLVector4a(n[idx[i+norm_offset]*3+0],
-                                n[idx[i+norm_offset]*3+1],
-                                n[idx[i+norm_offset]*3+2]));
+            cv.setNormal(LLVector4a((F32)n[idx[i+norm_offset]*3+0],
+                                (F32)n[idx[i+norm_offset]*3+1],
+                                (F32)n[idx[i+norm_offset]*3+2]));
         }
 
         bool found = false;
@@ -326,8 +326,8 @@ LLModel::EModelStatus load_face_from_dom_triangles(
 
             face = LLVolumeFace();
             // VFExtents change
-            face.mExtents[0].set(v[0], v[1], v[2]);
-            face.mExtents[1].set(v[0], v[1], v[2]);
+            face.mExtents[0].set((F32)v[0], (F32)v[1], (F32)v[2]);
+            face.mExtents[1].set((F32)v[0], (F32)v[1], (F32)v[2]);
 
             verts.clear();
             indices.clear();
@@ -416,8 +416,8 @@ LLModel::EModelStatus load_face_from_dom_polylist(
     {
         v = pos_source->getFloat_array()->getValue();
         // VFExtents change
-        face.mExtents[0].set(v[0], v[1], v[2]);
-        face.mExtents[1].set(v[0], v[1], v[2]);
+        face.mExtents[0].set((F32)v[0], (F32)v[1], (F32)v[2]);
+        face.mExtents[1].set((F32)v[0], (F32)v[1], (F32)v[2]);
     }
 
     if (tc_source)
@@ -445,9 +445,9 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 
             if (pos_source)
             {
-                cv.getPosition().set(v[idx[cur_idx+pos_offset]*3+0],
-                                    v[idx[cur_idx+pos_offset]*3+1],
-                                    v[idx[cur_idx+pos_offset]*3+2]);
+                cv.getPosition().set((F32)v[idx[cur_idx+pos_offset]*3+0],
+                                    (F32)v[idx[cur_idx+pos_offset]*3+1],
+                                    (F32)v[idx[cur_idx+pos_offset]*3+2]);
                 if (!cv.getPosition().isFinite3())
                 {
                     LL_WARNS() << "Found NaN while loading position data from DAE-Model, invalid model." << LL_ENDL;
@@ -465,7 +465,7 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 
                 if (idx_y < tc.getCount())
                 {
-                    cv.mTexCoord.setVec(tc[idx_x], tc[idx_y]);
+                    cv.mTexCoord.setVec((F32)tc[idx_x], (F32)tc[idx_y]);
                 }
                 else if (log_tc_msg)
                 {
@@ -479,9 +479,9 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 
             if (norm_source)
             {
-                cv.getNormal().set(n[idx[cur_idx+norm_offset]*3+0],
-                                    n[idx[cur_idx+norm_offset]*3+1],
-                                    n[idx[cur_idx+norm_offset]*3+2]);
+                cv.getNormal().set((F32)n[idx[cur_idx+norm_offset]*3+0],
+                                    (F32)n[idx[cur_idx+norm_offset]*3+1],
+                                    (F32)n[idx[cur_idx+norm_offset]*3+2]);
 
                 if (!cv.getNormal().isFinite3())
                 {
@@ -607,8 +607,8 @@ LLModel::EModelStatus load_face_from_dom_polylist(
 
                 face = LLVolumeFace();
                 // VFExtents change
-                face.mExtents[0].set(v[0], v[1], v[2]);
-                face.mExtents[1].set(v[0], v[1], v[2]);
+                face.mExtents[0].set((F32)v[0], (F32)v[1], (F32)v[2]);
+                face.mExtents[1].set((F32)v[0], (F32)v[1], (F32)v[2]);
                 verts.clear();
                 indices.clear();
                 point_map.clear();
@@ -669,7 +669,7 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
 
         if (strcmp(COMMON_PROFILE_INPUT_VERTEX, inputs[i]->getSemantic()) == 0)
         { //found vertex array
-            v_offset = inputs[i]->getOffset();
+            v_offset = (S32)inputs[i]->getOffset();
 
             const domURIFragmentType& uri = inputs[i]->getSource();
             daeElementRef elem = uri.getElement();
@@ -697,7 +697,7 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
         }
         else if (strcmp(COMMON_PROFILE_INPUT_NORMAL, inputs[i]->getSemantic()) == 0)
         {
-            n_offset = inputs[i]->getOffset();
+            n_offset = (S32)inputs[i]->getOffset();
             //found normal array for this triangle list
             const domURIFragmentType& uri = inputs[i]->getSource();
             daeElementRef elem = uri.getElement();
@@ -710,7 +710,7 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
         }
         else if (strcmp(COMMON_PROFILE_INPUT_TEXCOORD, inputs[i]->getSemantic()) == 0 && inputs[i]->getSet() == 0)
         { //found texCoords
-            t_offset = inputs[i]->getOffset();
+            t_offset = (S32)inputs[i]->getOffset();
             const domURIFragmentType& uri = inputs[i]->getSource();
             daeElementRef elem = uri.getElement();
             domSource* src = (domSource*) elem.cast();
@@ -745,11 +745,11 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
 
             if (v)
             {
-                U32 v_idx = idx[j*stride+v_offset]*3;
+                U32 v_idx = (U32)idx[j*stride+v_offset]*3;
                 v_idx = llclamp(v_idx, (U32) 0, (U32) v->getCount());
-                vert.getPosition().set(v->get(v_idx),
-                                v->get(v_idx+1),
-                                v->get(v_idx+2));
+                vert.getPosition().set((F32)v->get(v_idx),
+                                (F32)v->get(v_idx+1),
+                                (F32)v->get(v_idx+2));
             }
 
             //bounds check n and t lookups because some FBX to DAE converters
@@ -757,11 +757,11 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
             //for a particular channel
             if (n && n->getCount() > 0)
             {
-                U32 n_idx = idx[j*stride+n_offset]*3;
+                U32 n_idx = (U32)idx[j*stride+n_offset]*3;
                 n_idx = llclamp(n_idx, (U32) 0, (U32) n->getCount());
-                vert.getNormal().set(n->get(n_idx),
-                                n->get(n_idx+1),
-                                n->get(n_idx+2));
+                vert.getNormal().set((F32)n->get(n_idx),
+                                (F32)n->get(n_idx+1),
+                                (F32)n->get(n_idx+2));
             }
             else
             {
@@ -771,10 +771,10 @@ LLModel::EModelStatus load_face_from_dom_polygons(std::vector<LLVolumeFace>& fac
 
             if (t && t->getCount() > 0)
             {
-                U32 t_idx = idx[j*stride+t_offset]*2;
+                U32 t_idx = (U32)idx[j*stride+t_offset]*2;
                 t_idx = llclamp(t_idx, (U32) 0, (U32) t->getCount());
-                vert.mTexCoord.setVec(t->get(t_idx),
-                                t->get(t_idx+1));
+                vert.mTexCoord.setVec((F32)t->get(t_idx),
+                                (F32)t->get(t_idx+1));
             }
             else
             {
@@ -1026,7 +1026,7 @@ bool LLDAELoader::OpenFile(const std::string& filename)
 
     if (unit)
     {
-        F32 meter = unit->getMeter();
+        F32 meter = (F32)unit->getMeter();
         mTransform.mMatrix[0][0] = meter;
         mTransform.mMatrix[1][1] = meter;
         mTransform.mMatrix[2][2] = meter;
@@ -1241,7 +1241,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
             {
                 for(int j = 0; j < 4; j++)
                 {
-                    mat.mMatrix[i][j] = dom_value[i + j*4];
+                    mat.mMatrix[i][j] = (F32)dom_value[i + j*4];
                 }
             }
 
@@ -1463,7 +1463,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                             {
                                 for(int j = 0; j < 4; j++)
                                 {
-                                    mat.mMatrix[i][j] = transform[k*16 + i + j*4];
+                                    mat.mMatrix[i][j] = (F32)transform[k*16 + i + j*4];
                                 }
                             }
                             model->mSkinInfo.mInvBindMatrix.push_back(LLMatrix4a(mat));
@@ -1581,7 +1581,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                                     LL_ERRS() << "Invalid position array size." << LL_ENDL;
                                 }
 
-                                LLVector3 v(pos[j], pos[j+1], pos[j+2]);
+                                LLVector3 v((F32)pos[j], (F32)pos[j+1], (F32)pos[j+2]);
 
                                 //transform from COLLADA space to volume space
                                 v = v * inverse_normalized_transformation;
@@ -1621,15 +1621,15 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                 U32 c_idx = 0;
                 for (size_t vc_idx = 0; vc_idx < vcount.getCount(); ++vc_idx)
                 { //for each vertex
-                    daeUInt count = vcount[vc_idx];
+                    daeUInt count = (daeUInt)vcount[vc_idx];
 
                     //create list of weights that influence this vertex
                     LLModel::weight_list weight_list;
 
                     for (daeUInt i = 0; i < count; ++i)
                     { //for each weight
-                        daeInt joint_idx = v[c_idx++];
-                        daeInt weight_idx = v[c_idx++];
+                        daeInt joint_idx = (daeInt)v[c_idx++];
+                        daeInt weight_idx = (daeInt)v[c_idx++];
 
                         if (joint_idx == -1)
                         {
@@ -1637,7 +1637,7 @@ void LLDAELoader::processDomModel(LLModel* model, DAE* dae, daeElement* root, do
                             continue;
                         }
 
-                        F32 weight_value = w[weight_idx];
+                        F32 weight_value = (F32)w[weight_idx];
 
                         weight_list.push_back(LLModel::JointWeight(joint_idx, weight_value));
                     }
@@ -1807,7 +1807,7 @@ bool LLDAELoader::verifyController( domController* pController )
         {
             //Skin is reference directly by geometry and get the vertex count from skin
             domSkin::domVertex_weights* pVertexWeights = pSkin->getVertex_weights();
-            U32 vertexWeightsCount = pVertexWeights->getCount();
+            U32 vertexWeightsCount = (U32)pVertexWeights->getCount();
             domGeometry* pGeometry = (domGeometry*) (domElement*) uri.getElement();
             domMesh* pMesh = pGeometry->getMesh();
 
@@ -1825,7 +1825,7 @@ bool LLDAELoader::verifyController( domController* pController )
                 {
                     xsAnyURI src = pVertices->getInput_array()[0]->getSource();
                     domSource* pSource = (domSource*) (domElement*) src.getElement();
-                    U32 verticesCount = pSource->getTechnique_common()->getAccessor()->getCount();
+                    U32 verticesCount = (U32)pSource->getTechnique_common()->getAccessor()->getCount();
                     result = verifyCount( verticesCount, vertexWeightsCount );
                     if ( !result )
                     {
@@ -1845,7 +1845,7 @@ bool LLDAELoader::verifyController( domController* pController )
             U32 sum = 0;
             for (size_t i=0; i<vcountCount; i++)
             {
-                sum += pVertexWeights->getVcount()->getValue()[i];
+                sum += (U32)pVertexWeights->getVcount()->getValue()[i];
             }
             result = verifyCount( sum * static_cast<U32>(inputs.getCount()), (domInt) static_cast<int>(pVertexWeights->getV()->getValue().getCount()) );
         }
@@ -1860,7 +1860,7 @@ bool LLDAELoader::verifyController( domController* pController )
 void LLDAELoader::extractTranslation( domTranslate* pTranslate, LLMatrix4& transform )
 {
     domFloat3 jointTrans = pTranslate->getValue();
-    LLVector3 singleJointTranslation( jointTrans[0], jointTrans[1], jointTrans[2] );
+    LLVector3 singleJointTranslation((F32)jointTrans[0], (F32)jointTrans[1], (F32)jointTrans[2]);
     transform.setTranslation( singleJointTranslation );
 }
 //-----------------------------------------------------------------------------
@@ -1872,7 +1872,7 @@ void LLDAELoader::extractTranslationViaElement( daeElement* pTranslateElement, L
     {
         domTranslate* pTranslateChild = static_cast<domTranslate*>( pTranslateElement );
         domFloat3 translateChild = pTranslateChild->getValue();
-        LLVector3 singleJointTranslation( translateChild[0], translateChild[1], translateChild[2] );
+        LLVector3 singleJointTranslation((F32)translateChild[0], (F32)translateChild[1], (F32)translateChild[2]);
         transform.setTranslation( singleJointTranslation );
     }
 }
@@ -1894,7 +1894,7 @@ void LLDAELoader::extractTranslationViaSID( daeElement* pElement, LLMatrix4& tra
             {
                 for( int j = 0; j < 4; j++ )
                 {
-                    workingTransform.mMatrix[i][j] = domArray[i + j*4];
+                    workingTransform.mMatrix[i][j] = (F32)domArray[i + j*4];
                 }
             }
             LLVector3 trans = workingTransform.getTranslation();
@@ -1957,7 +1957,7 @@ void LLDAELoader::processJointNode( domNode* pNode, JointTransformMap& jointTran
                         {
                             for (int j = 0; j < 4; j++)
                             {
-                                workingTransform.mMatrix[i][j] = domArray[i + j * 4];
+                                workingTransform.mMatrix[i][j] = (F32)domArray[i + j * 4];
                             }
                         }
                     }
@@ -2023,7 +2023,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
         domFloat3 dom_value = translate->getValue();
 
         LLMatrix4 translation;
-        translation.setTranslation(LLVector3(dom_value[0], dom_value[1], dom_value[2]));
+        translation.setTranslation(LLVector3((F32)dom_value[0], (F32)dom_value[1], (F32)dom_value[2]));
 
         translation *= mTransform;
         mTransform = translation;
@@ -2036,7 +2036,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
         domFloat4 dom_value = rotate->getValue();
 
         LLMatrix4 rotation;
-        rotation.initRotTrans(dom_value[3] * DEG_TO_RAD, LLVector3(dom_value[0], dom_value[1], dom_value[2]), LLVector3(0, 0, 0));
+        rotation.initRotTrans((F32)dom_value[3] * DEG_TO_RAD, LLVector3((F32)dom_value[0], (F32)dom_value[1], (F32)dom_value[2]), LLVector3(0, 0, 0));
 
         rotation *= mTransform;
         mTransform = rotation;
@@ -2049,7 +2049,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
         domFloat3 dom_value = scale->getValue();
 
 
-        LLVector3 scale_vector = LLVector3(dom_value[0], dom_value[1], dom_value[2]);
+        LLVector3 scale_vector = LLVector3((F32)dom_value[0], (F32)dom_value[1], (F32)dom_value[2]);
         scale_vector.abs(); // Set all values positive, since we don't currently support mirrored meshes
         LLMatrix4 scaling;
         scaling.initScale(scale_vector);
@@ -2070,7 +2070,7 @@ void LLDAELoader::processElement( daeElement* element, bool& badElement, DAE* da
         {
             for(int j = 0; j < 4; j++)
             {
-                matrix_transform.mMatrix[i][j] = dom_value[i + j*4];
+                matrix_transform.mMatrix[i][j] = (F32)dom_value[i + j*4];
             }
         }
 
@@ -2338,7 +2338,7 @@ LLImportMaterial LLDAELoader::profileToMaterial(domProfile_COMMON* material, DAE
         if (color)
         {
             domFx_color_common domfx_color = color->getValue();
-            LLColor4 value = LLColor4(domfx_color[0], domfx_color[1], domfx_color[2], domfx_color[3]);
+            LLColor4 value = LLColor4((F32)domfx_color[0], (F32)domfx_color[1], (F32)domfx_color[2], (F32)domfx_color[3]);
             mat.mDiffuseColor = value;
         }
     }
@@ -2450,7 +2450,7 @@ LLColor4 LLDAELoader::getDaeColor(daeElement* element)
     if (color)
     {
         domFx_color_common domfx_color = color->getValue();
-        value = LLColor4(domfx_color[0], domfx_color[1], domfx_color[2], domfx_color[3]);
+        value = LLColor4((F32)domfx_color[0], (F32)domfx_color[1], (F32)domfx_color[2], (F32)domfx_color[3]);
     }
 
     return value;

--- a/indra/llprimitive/llgltfmaterial.cpp
+++ b/indra/llprimitive/llgltfmaterial.cpp
@@ -790,7 +790,7 @@ void LLGLTFMaterial::applyOverrideLLSD(const LLSD& data)
     const LLSD& mf = data["mf"];
     if (mf.isReal())
     {
-        mMetallicFactor = mf.asReal();
+        mMetallicFactor = (F32)mf.asReal();
         if (mMetallicFactor == getDefaultMetallicFactor())
         {
             // HACK -- nudge by epsilon if we receive a default value (indicates override to default)
@@ -801,7 +801,7 @@ void LLGLTFMaterial::applyOverrideLLSD(const LLSD& data)
     const LLSD& rf = data["rf"];
     if (rf.isReal())
     {
-        mRoughnessFactor = rf.asReal();
+        mRoughnessFactor = (F32)rf.asReal();
         if (mRoughnessFactor == getDefaultRoughnessFactor())
         {
             // HACK -- nudge by epsilon if we receive a default value (indicates override to default)
@@ -819,7 +819,7 @@ void LLGLTFMaterial::applyOverrideLLSD(const LLSD& data)
     const LLSD& ac = data["ac"];
     if (ac.isReal())
     {
-        mAlphaCutoff = ac.asReal();
+        mAlphaCutoff = (F32)ac.asReal();
         if (mAlphaCutoff == getDefaultAlphaCutoff())
         {
             // HACK -- nudge by epsilon if we receive a default value (indicates override to default)
@@ -854,7 +854,7 @@ void LLGLTFMaterial::applyOverrideLLSD(const LLSD& data)
             const LLSD& r = ti[i]["r"];
             if (r.isReal())
             {
-                mTextureTransform[i].mRotation = r.asReal();
+                mTextureTransform[i].mRotation = (F32)r.asReal();
             }
         }
     }

--- a/indra/llprimitive/llmodel.cpp
+++ b/indra/llprimitive/llmodel.cpp
@@ -1487,7 +1487,7 @@ void LLMeshSkinInfo::fromLLSD(LLSD& skin)
             {
                 for (U32 k = 0; k < 4; k++)
                 {
-                    mat.mMatrix[j][k] = skin["inverse_bind_matrix"][i][j*4+k].asReal();
+                    mat.mMatrix[j][k] = (F32)skin["inverse_bind_matrix"][i][j*4+k].asReal();
                 }
             }
 
@@ -1510,7 +1510,7 @@ void LLMeshSkinInfo::fromLLSD(LLSD& skin)
         {
             for (U32 k = 0; k < 4; k++)
             {
-                mat.mMatrix[j][k] = skin["bind_shape_matrix"][j*4+k].asReal();
+                mat.mMatrix[j][k] = (F32)skin["bind_shape_matrix"][j*4+k].asReal();
             }
         }
         mBindShapeMatrix.loadu(mat);
@@ -1525,7 +1525,7 @@ void LLMeshSkinInfo::fromLLSD(LLSD& skin)
             {
                 for (U32 k = 0; k < 4; k++)
                 {
-                    mat.mMatrix[j][k] = skin["alt_inverse_bind_matrix"][i][j*4+k].asReal();
+                    mat.mMatrix[j][k] = (F32)skin["alt_inverse_bind_matrix"][i][j*4+k].asReal();
                 }
             }
 
@@ -1535,7 +1535,7 @@ void LLMeshSkinInfo::fromLLSD(LLSD& skin)
 
     if (skin.has("pelvis_offset"))
     {
-        mPelvisOffset = skin["pelvis_offset"].asReal();
+        mPelvisOffset = (F32)skin["pelvis_offset"].asReal();
     }
 
     if (skin.has("lock_scale_if_joint_position"))
@@ -1618,7 +1618,7 @@ void LLMeshSkinInfo::updateHash()
 
     for (size_t i = 0, count = mInvBindMatrix.size() * 16; i < count; ++i)
     {
-        S32 t = llround(src[i] * 10000.f);
+        S32 t = ll_round(src[i] * 10000.f);
         hash.update((const void*)&t, sizeof(S32));
     }
     //hash.update((const void*)mInvBindMatrix.data(), sizeof(LLMatrix4a) * mInvBindMatrix.size());

--- a/indra/llprimitive/lltreeparams.cpp
+++ b/indra/llprimitive/lltreeparams.cpp
@@ -178,7 +178,7 @@ F32 LLTreeParams::ShapeRatio(EShapeRatio shape, F32 ratio)
         case (SR_SPHERICAL):
             return (.2f + .8f * sinf(F_PI*ratio));
         case (SR_HEMISPHERICAL):
-            return (.2f + .8f * sinf(.5*F_PI*ratio));
+            return (.2f + .8f * sinf(.5f*F_PI*ratio));
         case (SR_CYLINDRICAL):
             return (1);
         case (SR_TAPERED_CYLINDRICAL):

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -178,7 +178,7 @@ unsigned long ft_read_cb(FT_Stream stream, unsigned long offset, unsigned char *
     llifstream *file_stream = static_cast<llifstream *>(stream->descriptor.pointer);
     file_stream->seekg(offset, std::ios::beg);
     file_stream->read((char*)buffer, count);
-    return file_stream->gcount();
+    return (unsigned long)file_stream->gcount();
 }
 
 void ft_close_cb(FT_Stream stream) {

--- a/indra/llrender/llfontfreetypesvg.cpp
+++ b/indra/llrender/llfontfreetypesvg.cpp
@@ -136,18 +136,18 @@ FT_Error LLFontFreeTypeSvgRenderer::OnPresetGlypthSlot(FT_GlyphSlot glyph_slot, 
     float svg_scale = llmin(svg_x_scale, svg_y_scale);
     datap->Scale = svg_scale;
 
-    glyph_slot->bitmap.width = floorf(svg_width) * svg_scale;
-    glyph_slot->bitmap.rows = floorf(svg_height) * svg_scale;
+    glyph_slot->bitmap.width = (unsigned int)(floorf(svg_width) * svg_scale);
+    glyph_slot->bitmap.rows = (unsigned int)(floorf(svg_height) * svg_scale);
     glyph_slot->bitmap_left = (document->metrics.x_ppem - glyph_slot->bitmap.width) / 2;
-    glyph_slot->bitmap_top = glyph_slot->face->size->metrics.ascender / 64.f;
+    glyph_slot->bitmap_top = (FT_Int)(glyph_slot->face->size->metrics.ascender / 64.f);
     glyph_slot->bitmap.pitch = glyph_slot->bitmap.width * 4;
     glyph_slot->bitmap.pixel_mode = FT_PIXEL_MODE_BGRA;
 
     /* Copied as-is from fcft (MIT license) */
 
     // Compute all the bearings and set them correctly. The outline is scaled already, we just need to use the bounding box.
-    float horiBearingX = 0.;
-    float horiBearingY = -glyph_slot->bitmap_top;
+    float horiBearingX = 0.f;
+    float horiBearingY = -(float)glyph_slot->bitmap_top;
 
     // XXX parentheses correct?
     float vertBearingX = glyph_slot->metrics.horiBearingX / 64.0f - glyph_slot->metrics.horiAdvance / 64.0f / 2;
@@ -156,13 +156,13 @@ FT_Error LLFontFreeTypeSvgRenderer::OnPresetGlypthSlot(FT_GlyphSlot glyph_slot, 
     // Do conversion in two steps to avoid 'bad function cast' warning
     glyph_slot->metrics.width = glyph_slot->bitmap.width * 64;
     glyph_slot->metrics.height = glyph_slot->bitmap.rows * 64;
-    glyph_slot->metrics.horiBearingX = horiBearingX * 64;
-    glyph_slot->metrics.horiBearingY = horiBearingY * 64;
-    glyph_slot->metrics.vertBearingX = vertBearingX * 64;
-    glyph_slot->metrics.vertBearingY = vertBearingY * 64;
+    glyph_slot->metrics.horiBearingX = (FT_Pos)(horiBearingX * 64);
+    glyph_slot->metrics.horiBearingY = (FT_Pos)(horiBearingY * 64);
+    glyph_slot->metrics.vertBearingX = (FT_Pos)(vertBearingX * 64);
+    glyph_slot->metrics.vertBearingY = (FT_Pos)(vertBearingY * 64);
     if (glyph_slot->metrics.vertAdvance == 0)
     {
-        glyph_slot->metrics.vertAdvance = glyph_slot->bitmap.rows * 1.2f * 64;
+        glyph_slot->metrics.vertAdvance = (FT_Pos)(glyph_slot->bitmap.rows * 1.2f * 64);
     }
 
     return FT_Err_Ok;

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -112,7 +112,7 @@ S32 LLFontGL::getNumFaces(const std::string& filename)
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRect& rect, const LLColor4 &color, HAlign halign, VAlign valign, U8 style,
     ShadowType shadow, S32 max_chars, F32* right_x, bool use_ellipses, bool use_color) const
 {
-    LLRectf rect_float(rect.mLeft, rect.mTop, rect.mRight, rect.mBottom);
+    LLRectf rect_float((F32)rect.mLeft, (F32)rect.mTop, (F32)rect.mRight, (F32)rect.mBottom);
     return render(wstr, begin_offset, rect_float, color, halign, valign, style, shadow, max_chars, right_x, use_ellipses, use_color);
 }
 
@@ -138,7 +138,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRectf& rec
         y = rect.mBottom;
         break;
     }
-    return render(wstr, begin_offset, x, y, color, halign, valign, style, shadow, max_chars, rect.getWidth(), right_x, use_ellipses, use_color);
+    return render(wstr, begin_offset, x, y, color, halign, valign, style, shadow, max_chars, (S32)rect.getWidth(), right_x, use_ellipses, use_color);
 }
 
 

--- a/indra/llrender/llfontregistry.cpp
+++ b/indra/llrender/llfontregistry.cpp
@@ -500,7 +500,7 @@ LLFontGL *LLFontRegistry::createFont(const LLFontDescriptor& desc)
         // *HACK: Fallback fonts don't render, so we can use that to suppress
         // creation of OpenGL textures for test apps. JC
         bool is_fallback = !is_first_found || !mCreateGLTextures;
-        F32 extra_scale = (is_fallback)?fallback_scale:1.0;
+        F32 extra_scale = (is_fallback) ? fallback_scale : 1.0f;
         F32 point_size_scale = extra_scale * point_size;
         bool is_font_loaded = false;
         for(string_vec_t::iterator font_search_path_it = font_search_paths.begin();

--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -190,7 +190,7 @@ void LLGLSLShader::dumpStats()
         tris_sec /= seconds;
 
         F32 pct_samples = (F32)((F64)mSamplesDrawn / (F64)sTotalSamplesDrawn) * 100.f;
-        F32 samples_sec = (F32)mSamplesDrawn / 1000000000.0;
+        F32 samples_sec = (F32)(mSamplesDrawn / 1000000000.0);
         samples_sec /= seconds;
 
         F32 pct_binds = (F32)mBinds / (F32)sTotalBinds * 100.f;
@@ -1265,7 +1265,7 @@ void LLGLSLShader::uniform1i(U32 index, GLint x)
             if (iter == mValue.end() || iter->second.mV[0] != x)
             {
                 glUniform1i(mUniform[index], x);
-                mValue[mUniform[index]] = LLVector4(x, 0.f, 0.f, 0.f);
+                mValue[mUniform[index]] = LLVector4((F32)x, 0.f, 0.f, 0.f);
             }
         }
     }
@@ -1405,7 +1405,7 @@ void LLGLSLShader::uniform1iv(U32 index, U32 count, const GLint* v)
         if (mUniform[index] >= 0)
         {
             const auto& iter = mValue.find(mUniform[index]);
-            LLVector4 vec(v[0], 0.f, 0.f, 0.f);
+            LLVector4 vec((F32)v[0], 0.f, 0.f, 0.f);
             if (iter == mValue.end() || shouldChange(iter->second, vec) || count != 1)
             {
                 glUniform1iv(mUniform[index], count, v);
@@ -1432,7 +1432,7 @@ void LLGLSLShader::uniform4iv(U32 index, U32 count, const GLint* v)
         if (mUniform[index] >= 0)
         {
             const auto& iter = mValue.find(mUniform[index]);
-            LLVector4 vec(v[0], v[1], v[2], v[3]);
+            LLVector4 vec((F32)v[0], (F32)v[1], (F32)v[2], (F32)v[3]);
             if (iter == mValue.end() || shouldChange(iter->second, vec) || count != 1)
             {
                 glUniform1iv(mUniform[index], count, v);
@@ -1702,7 +1702,7 @@ void LLGLSLShader::uniform1i(const LLStaticHashedString& uniform, GLint v)
     if (location >= 0)
     {
         const auto& iter = mValue.find(location);
-        LLVector4 vec(v, 0.f, 0.f, 0.f);
+        LLVector4 vec((F32)v, 0.f, 0.f, 0.f);
         if (iter == mValue.end() || shouldChange(iter->second, vec))
         {
             glUniform1i(location, v);
@@ -1718,7 +1718,7 @@ void LLGLSLShader::uniform1iv(const LLStaticHashedString& uniform, U32 count, co
 
     if (location >= 0)
     {
-        LLVector4 vec(v[0], 0, 0, 0);
+        LLVector4 vec((F32)v[0], 0.f, 0.f, 0.f);
         const auto& iter = mValue.find(location);
         if (iter == mValue.end() || shouldChange(iter->second, vec) || count != 1)
         {
@@ -1736,7 +1736,7 @@ void LLGLSLShader::uniform4iv(const LLStaticHashedString& uniform, U32 count, co
 
     if (location >= 0)
     {
-        LLVector4 vec(v[0], v[1], v[2], v[3]);
+        LLVector4 vec((F32)v[0], (F32)v[1], (F32)v[2], (F32)v[3]);
         const auto& iter = mValue.find(location);
         if (iter == mValue.end() || shouldChange(iter->second, vec) || count != 1)
         {
@@ -1755,7 +1755,7 @@ void LLGLSLShader::uniform2i(const LLStaticHashedString& uniform, GLint i, GLint
     if (location >= 0)
     {
         const auto& iter = mValue.find(location);
-        LLVector4 vec(i, j, 0.f, 0.f);
+        LLVector4 vec((F32)i, (F32)j, 0.f, 0.f);
         if (iter == mValue.end() || shouldChange(iter->second, vec))
         {
             glUniform2i(location, i, j);

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -738,7 +738,7 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
                 }
                 if (is_compressed)
                 {
-                    S32 tex_size = dataFormatBytes(mFormatPrimary, w, h);
+                    GLsizei tex_size = (GLsizei)dataFormatBytes(mFormatPrimary, w, h);
                     glCompressedTexImage2D(mTarget, gl_level, mFormatPrimary, w, h, 0, tex_size, (GLvoid *)data_in);
                     stop_glerror();
                 }
@@ -941,7 +941,7 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */, S32
         S32 h = getHeight();
         if (is_compressed)
         {
-            S32 tex_size = dataFormatBytes(mFormatPrimary, w, h);
+            GLsizei tex_size = (GLsizei)dataFormatBytes(mFormatPrimary, w, h);
             glCompressedTexImage2D(mTarget, 0, mFormatPrimary, w, h, 0, tex_size, (GLvoid *)data_in);
             stop_glerror();
         }
@@ -2418,7 +2418,7 @@ bool LLImageGL::scaleDown(S32 desired_discard)
         if (size > sScratchPBOSize)
         {
             glBufferData(GL_PIXEL_PACK_BUFFER, size, NULL, GL_STREAM_COPY);
-            sScratchPBOSize = size;
+            sScratchPBOSize = (U32)size;
         }
 
         glGetTexImage(mTarget, mip, mFormatPrimary, mFormatType, nullptr);

--- a/indra/llrender/llpostprocess.cpp
+++ b/indra/llrender/llpostprocess.cpp
@@ -343,7 +343,7 @@ void LLPostProcess::viewOrthogonal(unsigned int width, unsigned int height)
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho( 0.f, (GLdouble) width , (GLdouble) height , 0.f, -1.f, 1.f );
+    gGL.ortho( 0.f, (GLfloat) width , (GLfloat) height , 0.f, -1.f, 1.f );
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
     gGL.loadIdentity();

--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -364,7 +364,7 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTex
     {
         // add in offset of current image to current UI translation
         const LLVector3 ui_scale = gGL.getUIScale();
-        const LLVector3 ui_translation = (gGL.getUITranslation() + LLVector3(x, y, 0.f)).scaledVec(ui_scale);
+        const LLVector3 ui_translation = (gGL.getUITranslation() + LLVector3((F32)x, (F32)y, 0.f)).scaledVec(ui_scale);
 
         F32 uv_width = uv_outer_rect.getWidth();
         F32 uv_height = uv_outer_rect.getHeight();
@@ -375,8 +375,8 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTex
                                 uv_outer_rect.mLeft + (center_rect.mRight * uv_width),
                                 uv_outer_rect.mBottom + (center_rect.mBottom * uv_height));
 
-        F32 image_width = image->getWidth(0);
-        F32 image_height = image->getHeight(0);
+        F32 image_width = (F32)image->getWidth(0);
+        F32 image_height = (F32)image->getHeight(0);
 
         S32 image_natural_width = ll_round(image_width * uv_width);
         S32 image_natural_height = ll_round(image_height * uv_height);
@@ -413,10 +413,10 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTex
             draw_center_rect.setCenterAndSize(uv_center_rect.getCenterX() * width, uv_center_rect.getCenterY() * height, scaled_width, scaled_height);
         }
 
-        draw_center_rect.mLeft   = ll_round(ui_translation.mV[VX] + (F32)draw_center_rect.mLeft * ui_scale.mV[VX]);
-        draw_center_rect.mTop    = ll_round(ui_translation.mV[VY] + (F32)draw_center_rect.mTop * ui_scale.mV[VY]);
-        draw_center_rect.mRight  = ll_round(ui_translation.mV[VX] + (F32)draw_center_rect.mRight * ui_scale.mV[VX]);
-        draw_center_rect.mBottom = ll_round(ui_translation.mV[VY] + (F32)draw_center_rect.mBottom * ui_scale.mV[VY]);
+        draw_center_rect.mLeft   = (F32)ll_round(ui_translation.mV[VX] + (F32)draw_center_rect.mLeft * ui_scale.mV[VX]);
+        draw_center_rect.mTop    = (F32)ll_round(ui_translation.mV[VY] + (F32)draw_center_rect.mTop * ui_scale.mV[VY]);
+        draw_center_rect.mRight  = (F32)ll_round(ui_translation.mV[VX] + (F32)draw_center_rect.mRight * ui_scale.mV[VX]);
+        draw_center_rect.mBottom = (F32)ll_round(ui_translation.mV[VY] + (F32)draw_center_rect.mBottom * ui_scale.mV[VY]);
 
         LLRectf draw_outer_rect(ui_translation.mV[VX],
                                 ui_translation.mV[VY] + height * ui_scale.mV[VY],

--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -124,7 +124,7 @@ bool LLRenderTarget::allocate(U32 resx, U32 resy, U32 color_fmt, bool depth, LLT
 
     if (mGenerateMipMaps != LLTexUnit::TMG_NONE) {
         // Calculate the number of mip levels based upon resolution that we should have.
-        mMipLevels = 1 + floor(log10((float)llmax(mResX, mResY))/log10(2.0));
+        mMipLevels = 1 + (U32)floor(log10((float)llmax(mResX, mResY)) / log10(2.0));
     }
 
     if (depth)

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1003,7 +1003,7 @@ void LLShaderMgr::initShaderCache(bool enabled, const LLUUID& old_cache_version,
                     ProgramBinaryData binary_info = ProgramBinaryData();
                     binary_info.mBinaryFormat = data_pair.second["binary_format"].asInteger();
                     binary_info.mBinaryLength = data_pair.second["binary_size"].asInteger();
-                    binary_info.mLastUsedTime = data_pair.second["last_used"].asReal();
+                    binary_info.mLastUsedTime = (F32)data_pair.second["last_used"].asReal();
                     mShaderBinaryCache.insert_or_assign(LLUUID(data_pair.first), binary_info);
                 }
             }
@@ -1034,7 +1034,7 @@ void LLShaderMgr::persistShaderCacheMetadata()
     LLSD out = LLSD::emptyMap();
 
     static const F32 LRU_TIME = (60.f * 60.f) * 24.f * 7.f; // 14 days
-    const F32 current_time = LLTimer::getTotalSeconds();
+    const F32 current_time = (F32)LLTimer::getTotalSeconds();
     for (auto it = mShaderBinaryCache.begin(); it != mShaderBinaryCache.end();)
     {
         const ProgramBinaryData& shader_metadata = it->second;
@@ -1093,7 +1093,7 @@ bool LLShaderMgr::loadCachedProgramBinary(LLGLSLShader* shader)
                     glGetProgramiv(shader->mProgramObject, GL_LINK_STATUS, &success);
                     if (error == GL_NO_ERROR && success == GL_TRUE)
                     {
-                        binary_iter->second.mLastUsedTime = LLTimer::getTotalSeconds();
+                        binary_iter->second.mLastUsedTime = (F32)LLTimer::getTotalSeconds();
                         LL_INFOS() << "Loaded cached binary for shader: " << shader->mName << LL_ENDL;
                         return true;
                     }
@@ -1131,7 +1131,7 @@ bool LLShaderMgr::saveCachedProgramBinary(LLGLSLShader* shader)
                 fwrite(program_binary.data(), sizeof(U8), program_binary.size(), outfile);
                 outfile.close();
 
-                binary_info.mLastUsedTime = LLTimer::getTotalSeconds();
+                binary_info.mLastUsedTime = (F32)LLTimer::getTotalSeconds();
 
                 mShaderBinaryCache.insert_or_assign(shader->mShaderHash, binary_info);
                 return true;

--- a/indra/llrender/lluiimage.cpp
+++ b/indra/llrender/lluiimage.cpp
@@ -83,7 +83,7 @@ void LLUIImage::draw3D(const LLVector3& origin_agent, const LLVector3& x_axis, c
 
     LLRender2D::getInstance()->pushMatrix();
     {
-        LLVector3 rect_origin = origin_agent + (rect.mLeft * x_axis) + (rect.mBottom * y_axis);
+        LLVector3 rect_origin = origin_agent + ((F32)rect.mLeft * x_axis) + ((F32)rect.mBottom * y_axis);
         LLRender2D::getInstance()->translate(rect_origin.mV[VX],
                                             rect_origin.mV[VY],
                                             rect_origin.mV[VZ]);
@@ -100,8 +100,8 @@ void LLUIImage::draw3D(const LLVector3& origin_agent, const LLVector3& x_axis, c
                                         (rect.getHeight() - (border_height * border_scale * 0.5f)) / (F32)rect.getHeight(),
                                         (rect.getWidth() - (border_width * border_scale * 0.5f)) / (F32)rect.getWidth(),
                                         (border_height * border_scale * 0.5f) / (F32)rect.getHeight()),
-                                rect.getWidth() * x_axis,
-                                rect.getHeight() * y_axis);
+                                (F32)rect.getWidth() * x_axis,
+                                (F32)rect.getHeight() * y_axis);
 
     } LLRender2D::getInstance()->popMatrix();
 }

--- a/indra/llui/llbadge.cpp
+++ b/indra/llui/llbadge.cpp
@@ -197,10 +197,10 @@ void renderBadgeBackground(F32 centerX, F32 centerY, F32 width, F32 height, cons
     F32 x = LLFontGL::sCurOrigin.mX + centerX - width * 0.5f;
     F32 y = LLFontGL::sCurOrigin.mY + centerY - height * 0.5f;
 
-    LLRectf screen_rect(ll_round(x),
-                        ll_round(y),
-                        ll_round(x) + width,
-                        ll_round(y) + height);
+    LLRectf screen_rect((F32)ll_round(x),
+                        (F32)ll_round(y),
+                        (F32)ll_round(x) + width,
+                        (F32)ll_round(y) + height);
 
     LLVector3 vertices[4];
     vertices[0] = LLVector3(screen_rect.mRight, screen_rect.mTop,    1.0f);
@@ -302,7 +302,7 @@ void LLBadge::draw()
             }
             else
             {
-                badge_center_x = location_offset_horiz;
+                badge_center_x = (F32)location_offset_horiz;
             }
 
             // Compute y position
@@ -319,7 +319,7 @@ void LLBadge::draw()
             }
             else
             {
-                badge_center_y = location_offset_vert;
+                badge_center_y = (F32)location_offset_vert;
             }
 
             //

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -188,7 +188,7 @@ LLButton::LLButton(const LLButton::Params& p)
         // Likewise, missing "p.button_flash_rate" is replaced by gSavedSettings.getF32("FlashPeriod").
         // Note: flashing should be allowed in settings.xml (boolean key "EnableButtonFlashing").
         S32 flash_count = p.button_flash_count.isProvided()? p.button_flash_count : 0;
-        F32 flash_rate = p.button_flash_rate.isProvided()? p.button_flash_rate : 0.0;
+        F32 flash_rate = p.button_flash_rate.isProvided()? p.button_flash_rate : 0.0f;
         mFlashingTimer = new LLFlashTimer ((LLFlashTimer::callback_t)NULL, flash_count, flash_rate);
     }
     else

--- a/indra/llui/llconsole.cpp
+++ b/indra/llui/llconsole.cpp
@@ -80,7 +80,7 @@ void LLConsole::setLinePersistTime(F32 seconds)
 void LLConsole::reshape(S32 width, S32 height, bool called_from_parent)
 {
     S32 new_width = llmax(50, llmin(getRect().getWidth(), width));
-    S32 new_height = llmax(llfloor(mFont->getLineHeight()) + 15, llmin(getRect().getHeight(), height));
+    S32 new_height = llmax(mFont->getLineHeight() + 15, llmin(getRect().getHeight(), height));
 
     if (   mConsoleWidth == new_width
         && mConsoleHeight == new_height )
@@ -186,7 +186,7 @@ void LLConsole::draw()
     LLColor4 color = LLUIColorTable::instance().getColor("ConsoleBackground");
     color.mV[VALPHA] *= console_opacity;
 
-    F32 line_height = mFont->getLineHeight();
+    F32 line_height = (F32)mFont->getLineHeight();
 
     for(paragraph_it = mParagraphs.rbegin(); paragraph_it != mParagraphs.rend(); paragraph_it++)
     {

--- a/indra/llui/llf32uictrl.cpp
+++ b/indra/llui/llf32uictrl.cpp
@@ -37,7 +37,7 @@
 
 LLF32UICtrl::LLF32UICtrl(const Params& p)
 :   LLUICtrl(p),
-    mInitialValue(p.initial_value().asReal()),
+    mInitialValue((F32)p.initial_value().asReal()),
     mMinValue(p.min_value),
     mMaxValue(p.max_value),
     mIncrement(p.increment)
@@ -47,5 +47,5 @@ LLF32UICtrl::LLF32UICtrl(const Params& p)
 
 F32 LLF32UICtrl::getValueF32() const
 {
-    return mViewModel->getValue().asReal();
+    return (F32)mViewModel->getValue().asReal();
 }

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -960,8 +960,8 @@ bool LLFloater::applyRectControl()
             && !x_control->isDefault()
             && !y_control->isDefault())
         {
-            mPosition.mX = x_control->getValue().asReal();
-            mPosition.mY = y_control->getValue().asReal();
+            mPosition.mX = (LL_COORD_FLOATER::value_t)x_control->getValue().asReal();
+            mPosition.mY = (LL_COORD_FLOATER::value_t)y_control->getValue().asReal();
             mPositioning = LLFloaterEnums::POSITIONING_RELATIVE;
             applyRelativePosition();
 
@@ -3618,7 +3618,7 @@ void LLFloater::applyRelativePosition()
 
 
 LLCoordFloater::LLCoordFloater(F32 x, F32 y, LLFloater& floater)
-:   coord_t((S32)x, (S32)y)
+:   coord_t(x, y)
 {
     mFloater = floater.getHandle();
 }
@@ -3661,28 +3661,28 @@ LLCoordCommon LL_COORD_FLOATER::convertToCommon() const
     LLCoordCommon out;
     if (self.mX < -0.5f)
     {
-        out.mX = ll_round(rescale(self.mX, -1.f, -0.5f, snap_rect.mLeft - (floater_width - FLOATER_MIN_VISIBLE_PIXELS), snap_rect.mLeft));
+        out.mX = ll_round(rescale(self.mX, -1.f, -0.5f, (F32)(snap_rect.mLeft - (floater_width - FLOATER_MIN_VISIBLE_PIXELS)), (F32)snap_rect.mLeft));
     }
     else if (self.mX > 0.5f)
     {
-        out.mX = ll_round(rescale(self.mX, 0.5f, 1.f, snap_rect.mRight - floater_width, snap_rect.mRight - FLOATER_MIN_VISIBLE_PIXELS));
+        out.mX = ll_round(rescale(self.mX, 0.5f, 1.f, (F32)(snap_rect.mRight - floater_width), (F32)(snap_rect.mRight - FLOATER_MIN_VISIBLE_PIXELS)));
     }
     else
     {
-        out.mX = ll_round(rescale(self.mX, -0.5f, 0.5f, snap_rect.mLeft, snap_rect.mRight - floater_width));
+        out.mX = ll_round(rescale(self.mX, -0.5f, 0.5f, (F32)snap_rect.mLeft, (F32)(snap_rect.mRight - floater_width)));
     }
 
     if (self.mY < -0.5f)
     {
-        out.mY = ll_round(rescale(self.mY, -1.f, -0.5f, snap_rect.mBottom - (floater_height - FLOATER_MIN_VISIBLE_PIXELS), snap_rect.mBottom));
+        out.mY = ll_round(rescale(self.mY, -1.f, -0.5f, (F32)(snap_rect.mBottom - (floater_height - FLOATER_MIN_VISIBLE_PIXELS)), (F32)snap_rect.mBottom));
     }
     else if (self.mY > 0.5f)
     {
-        out.mY = ll_round(rescale(self.mY, 0.5f, 1.f, snap_rect.mTop - floater_height, snap_rect.mTop - FLOATER_MIN_VISIBLE_PIXELS));
+        out.mY = ll_round(rescale(self.mY, 0.5f, 1.f, (F32)(snap_rect.mTop - floater_height), (F32)(snap_rect.mTop - FLOATER_MIN_VISIBLE_PIXELS)));
     }
     else
     {
-        out.mY = ll_round(rescale(self.mY, -0.5f, 0.5f, snap_rect.mBottom, snap_rect.mTop - floater_height));
+        out.mY = ll_round(rescale(self.mY, -0.5f, 0.5f, (F32)snap_rect.mBottom, (F32)(snap_rect.mTop - floater_height)));
     }
 
     // return center point instead of lower left
@@ -3709,27 +3709,27 @@ void LL_COORD_FLOATER::convertFromCommon(const LLCoordCommon& from)
 
     if (from_x < snap_rect.mLeft)
     {
-        self.mX = rescale(from_x, snap_rect.mLeft - (floater_width - FLOATER_MIN_VISIBLE_PIXELS), snap_rect.mLeft, -1.f, -0.5f);
+        self.mX = rescale((F32)from_x, (F32)(snap_rect.mLeft - (floater_width - FLOATER_MIN_VISIBLE_PIXELS)), (F32)snap_rect.mLeft, -1.f, -0.5f);
     }
     else if (from_x + floater_width > snap_rect.mRight)
     {
-        self.mX = rescale(from_x, snap_rect.mRight - floater_width, snap_rect.mRight - FLOATER_MIN_VISIBLE_PIXELS, 0.5f, 1.f);
+        self.mX = rescale((F32)from_x, (F32)(snap_rect.mRight - floater_width), (F32)(snap_rect.mRight - FLOATER_MIN_VISIBLE_PIXELS), 0.5f, 1.f);
     }
     else
     {
-        self.mX = rescale(from_x, snap_rect.mLeft, snap_rect.mRight - floater_width, -0.5f, 0.5f);
+        self.mX = rescale((F32)from_x, (F32)snap_rect.mLeft, (F32)(snap_rect.mRight - floater_width), -0.5f, 0.5f);
     }
 
     if (from_y < snap_rect.mBottom)
     {
-        self.mY = rescale(from_y, snap_rect.mBottom - (floater_height - FLOATER_MIN_VISIBLE_PIXELS), snap_rect.mBottom, -1.f, -0.5f);
+        self.mY = rescale((F32)from_y, (F32)(snap_rect.mBottom - (floater_height - FLOATER_MIN_VISIBLE_PIXELS)), (F32)snap_rect.mBottom, -1.f, -0.5f);
     }
     else if (from_y + floater_height > snap_rect.mTop)
     {
-        self.mY = rescale(from_y, snap_rect.mTop - floater_height, snap_rect.mTop - FLOATER_MIN_VISIBLE_PIXELS, 0.5f, 1.f);
+        self.mY = rescale((F32)from_y, (F32)(snap_rect.mTop - floater_height), (F32)(snap_rect.mTop - FLOATER_MIN_VISIBLE_PIXELS), 0.5f, 1.f);
     }
     else
     {
-        self.mY = rescale(from_y, snap_rect.mBottom, snap_rect.mTop - floater_height, -0.5f, 0.5f);
+        self.mY = rescale((F32)from_y, (F32)snap_rect.mBottom, (F32)(snap_rect.mTop - floater_height), -0.5f, 0.5f);
     }
 }

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -950,7 +950,7 @@ void LLFolderViewItem::draw()
     S32 filter_offset = static_cast<S32>(mViewModelItem->getFilterStringOffset());
     if (filter_string_length > 0)
     {
-        S32 bottom = llfloor(getRect().getHeight() - font->getLineHeight() - 3 - TOP_PAD);
+        S32 bottom = getRect().getHeight() - font->getLineHeight() - 3 - TOP_PAD;
         S32 top = getRect().getHeight() - TOP_PAD;
         if(mLabelSuffix.empty() || (font == suffix_font))
         {
@@ -966,8 +966,8 @@ void LLFolderViewItem::draw()
             S32 label_filter_length = llmin((S32)mLabel.size() - filter_offset, (S32)filter_string_length);
             if(label_filter_length > 0)
             {
-                S32 left = ll_round(text_left) + font->getWidthF32(mLabel, 0, llmin(filter_offset, (S32)mLabel.size())) - 2;
-                S32 right = left + font->getWidthF32(mLabel, filter_offset, label_filter_length) + 2;
+                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel, 0, llmin(filter_offset, (S32)mLabel.size()))) - 2;
+                S32 right = left + (S32)font->getWidthF32(mLabel, filter_offset, label_filter_length) + 2;
                 LLUIImage* box_image = default_params.selection_image;
                 LLRect box_rect(left, top, right, bottom);
                 box_image->draw(box_rect, sFilterBGColor);
@@ -976,8 +976,8 @@ void LLFolderViewItem::draw()
             if(suffix_filter_length > 0)
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
-                S32 left = ll_round(text_left) + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset) - 2;
-                S32 right = left + suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length) + 2;
+                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset))- 2;
+                S32 right = left + (S32)suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length) + 2;
                 LLUIImage* box_image = default_params.selection_image;
                 LLRect box_rect(left, top, right, bottom);
                 box_image->draw(box_rect, sFilterBGColor);

--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -501,7 +501,7 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
         {
             if( *cur == '\n' )
             {
-                LLTextSegmentPtr text_segment = new LLLineBreakTextSegment(style, cur-base);
+                LLTextSegmentPtr text_segment = new LLLineBreakTextSegment(style, (S32)(cur - base));
                 text_segment->setToken( 0 );
                 insertSegment( *seg_list, text_segment, text_len, style, editor);
                 cur++;
@@ -532,13 +532,13 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
                     LLKeywordToken* cur_token = *iter;
                     if( cur_token->isHead( cur ) )
                     {
-                        S32 seg_start = cur - base;
+                        S32 seg_start = (S32)(cur - base);
                         while( *cur && *cur != '\n' )
                         {
                             // skip the rest of the line
                             cur++;
                         }
-                        S32 seg_end = cur - base;
+                        S32 seg_end = (S32)(cur - base);
 
                         //create segments from seg_start to seg_end
                         insertSegments(wtext, *seg_list,cur_token, text_len, seg_start, seg_end, style, editor);
@@ -582,7 +582,7 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
                     S32 between_delimiters = 0;
                     S32 seg_end = 0;
 
-                    seg_start = cur - base;
+                    seg_start = (S32)(cur - base);
                     cur += cur_delimiter->getLengthHead();
 
                     LLKeywordToken::ETokenType type = cur_delimiter->getType();
@@ -669,7 +669,7 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
                 {
                     p++;
                 }
-                S32 seg_len = p - cur;
+                S32 seg_len = (S32)(p - cur);
                 if( seg_len > 0 )
                 {
                     WStringMapIndex word( cur, seg_len );
@@ -677,7 +677,7 @@ void LLKeywords::findSegments(std::vector<LLTextSegmentPtr>* seg_list, const LLW
                     if( map_iter != mWordTokenMap.end() )
                     {
                         LLKeywordToken* cur_token = map_iter->second;
-                        S32 seg_start = cur - base;
+                        S32 seg_start = (S32)(cur - base);
                         S32 seg_end = seg_start + seg_len;
 
                         // LL_INFOS("SyntaxLSL") << "Seg: [" << word.c_str() << "]" << LL_ENDL;

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -131,7 +131,7 @@ void LLLayoutPanel::setTargetDim(S32 value)
 
 S32 LLLayoutPanel::getVisibleDim() const
 {
-    F32 min_dim = getRelevantMinDim();
+    F32 min_dim = (F32)getRelevantMinDim();
     return ll_round(mVisibleAmt
                     * (min_dim
                         + (((F32)mTargetDim - min_dim) * (1.f - mCollapseAmt))));
@@ -445,7 +445,7 @@ void LLLayoutStack::updateLayout()
 
     for (LLLayoutPanel* panelp : mPanels)
     {
-        F32 panel_dim = llmax(panelp->getExpandedMinDim(), panelp->mTargetDim);
+        F32 panel_dim = (F32)llmax(panelp->getExpandedMinDim(), panelp->mTargetDim);
 
         LLRect panel_rect;
         if (mOrientation == HORIZONTAL)
@@ -465,7 +465,7 @@ void LLLayoutStack::updateLayout()
 
         LLRect resize_bar_rect(panel_rect);
         F32 panel_spacing = (F32)mPanelSpacing * panelp->getVisibleAmount();
-        F32 panel_visible_dim = panelp->getVisibleDim();
+        F32 panel_visible_dim = (F32)panelp->getVisibleDim();
         S32 panel_spacing_round = (S32)(ll_round(panel_spacing));
 
         if (mOrientation == HORIZONTAL)

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -2109,7 +2109,7 @@ void LLLineEditor::draw()
         if (0 == mText.length() && (mReadOnly || mShowLabelFocused))
         {
             mGLFont->render(mLabel.getWString(), 0,
-                            mTextLeftEdge, (F32)text_bottom,
+                            (F32)mTextLeftEdge, (F32)text_bottom,
                             label_color,
                             LLFontGL::LEFT,
                             LLFontGL::BOTTOM,
@@ -2134,7 +2134,7 @@ void LLLineEditor::draw()
         if (0 == mText.length())
         {
             mGLFont->render(mLabel.getWString(), 0,
-                            mTextLeftEdge, (F32)text_bottom,
+                            (F32)mTextLeftEdge, (F32)text_bottom,
                             label_color,
                             LLFontGL::LEFT,
                             LLFontGL::BOTTOM,

--- a/indra/llui/llscrolllistcell.cpp
+++ b/indra/llui/llscrolllistcell.cpp
@@ -209,7 +209,7 @@ void LLScrollListBar::setValue(const LLSD& value)
 {
     if (value.has("ratio"))
     {
-        mRatio = value["ratio"].asReal();
+        mRatio = (F32)value["ratio"].asReal();
     }
     if (value.has("bottom"))
     {
@@ -239,7 +239,7 @@ S32 LLScrollListBar::getWidth() const
 void LLScrollListBar::draw(const LLColor4& color, const LLColor4& highlight_color)   const
 {
     S32 bar_width = getWidth() - mLeftPad - mRightPad;
-    S32 left = bar_width - bar_width * mRatio;
+    S32 left = (S32)(bar_width - bar_width * mRatio);
     left = llclamp(left, mLeftPad, getWidth() - mRightPad - 1);
 
     gl_rect_2d(left, mBottom, getWidth() - mRightPad, mBottom - 1, mColor);
@@ -637,7 +637,7 @@ void LLScrollListIconText::draw(const LLColor4& color, const LLColor4& highlight
     switch (mFontAlignment)
     {
     case LLFontGL::LEFT:
-        start_text_x = icon_space + 1;
+        start_text_x = icon_space + 1.f;
         start_icon_x = 1;
         break;
     case LLFontGL::RIGHT:
@@ -647,7 +647,7 @@ void LLScrollListIconText::draw(const LLColor4& color, const LLColor4& highlight
     case LLFontGL::HCENTER:
         F32 center = (F32)getWidth()* 0.5f;
         start_text_x = center + ((F32)icon_space * 0.5f);
-        start_icon_x = center - (((F32)icon_space + mFont->getWidth(mText.getString())) * 0.5f);
+        start_icon_x = (S32)(center - (((F32)icon_space + mFont->getWidth(mText.getString())) * 0.5f));
         break;
     }
     mFont->render(mText.getWString(), 0,

--- a/indra/llui/llspellcheck.cpp
+++ b/indra/llui/llspellcheck.cpp
@@ -448,7 +448,7 @@ void LLSpellChecker::removeDictionary(const std::string& dict_language)
             {
                 LLFile::remove(dict_aff);
             }
-            dict_map.erase(it - dict_map.beginArray());
+            dict_map.erase((LLSD::Integer)(it - dict_map.beginArray()));
             break;
         }
     }

--- a/indra/llui/llstatbar.cpp
+++ b/indra/llui/llstatbar.cpp
@@ -66,7 +66,7 @@ F32 calc_tick_value(F32 min, F32 max)
         S32 num_whole_digits = llceil(logf(llabs(min + possible_tick_value)) * OO_LN10);
         for (S32 digit_count = -(num_whole_digits - 1); digit_count < 6; digit_count++)
         {
-            F32 test_tick_value = min + (possible_tick_value * pow(10.0, digit_count));
+            F32 test_tick_value = min + (possible_tick_value * (F32)pow(10.0, digit_count));
 
             if (is_approx_equal((F32)(S32)test_tick_value, test_tick_value))
             {
@@ -99,7 +99,7 @@ void calc_auto_scale_range(F32& min, F32& max, F32& tick)
                             : llceil(logf(llabs(min)) * OO_LN10);
 
     const S32 num_digits = llmax(num_digits_max, num_digits_min);
-    const F32 power_of_10 = pow(10.0, num_digits - 1);
+    const F32 power_of_10 = (F32)pow(10.0, num_digits - 1);
     const F32 starting_max = power_of_10 * ((max < 0.f) ? -1 : 1);
     const F32 starting_min = power_of_10 * ((min < 0.f) ? -1 : 1);
 
@@ -313,13 +313,13 @@ void LLStatBar::draw()
             const LLTrace::StatType<LLTrace::CountAccumulator>& count_stat = *mStat.countStatp;
 
             unit_label    = std::string(count_stat.getUnitLabel()) + "/s";
-            current       = last_frame_recording.getPerSec(count_stat);
-            min           = frame_recording.getPeriodMinPerSec(count_stat, num_frames);
-            max           = frame_recording.getPeriodMaxPerSec(count_stat, num_frames);
-            mean          = frame_recording.getPeriodMeanPerSec(count_stat, num_frames);
+            current       = (F32)last_frame_recording.getPerSec(count_stat);
+            min           = (F32)frame_recording.getPeriodMinPerSec(count_stat, num_frames);
+            max           = (F32)frame_recording.getPeriodMaxPerSec(count_stat, num_frames);
+            mean          = (F32)frame_recording.getPeriodMeanPerSec(count_stat, num_frames);
             if (mShowMedian)
             {
-                display_value = frame_recording.getPeriodMedianPerSec(count_stat, num_frames);
+                display_value = (F32)frame_recording.getPeriodMedianPerSec(count_stat, num_frames);
             }
             else
             {
@@ -332,10 +332,10 @@ void LLStatBar::draw()
             const LLTrace::StatType<LLTrace::EventAccumulator>& event_stat = *mStat.eventStatp;
 
             unit_label        = mUnitLabel.empty() ? event_stat.getUnitLabel() : mUnitLabel;
-            current           = last_frame_recording.getLastValue(event_stat);
-            min               = frame_recording.getPeriodMin(event_stat, num_frames);
-            max               = frame_recording.getPeriodMax(event_stat, num_frames);
-            mean              = frame_recording.getPeriodMean(event_stat, num_frames);
+            current           = (F32)last_frame_recording.getLastValue(event_stat);
+            min               = (F32)frame_recording.getPeriodMin(event_stat, num_frames);
+            max               = (F32)frame_recording.getPeriodMax(event_stat, num_frames);
+            mean              = (F32)frame_recording.getPeriodMean(event_stat, num_frames);
             display_value     = mean;
         }
         break;
@@ -344,15 +344,15 @@ void LLStatBar::draw()
             const LLTrace::StatType<LLTrace::SampleAccumulator>& sample_stat = *mStat.sampleStatp;
 
             unit_label        = mUnitLabel.empty() ? sample_stat.getUnitLabel() : mUnitLabel;
-            current           = last_frame_recording.getLastValue(sample_stat);
-            min               = frame_recording.getPeriodMin(sample_stat, num_frames);
-            max               = frame_recording.getPeriodMax(sample_stat, num_frames);
-            mean              = frame_recording.getPeriodMean(sample_stat, num_frames);
+            current           = (F32)last_frame_recording.getLastValue(sample_stat);
+            min               = (F32)frame_recording.getPeriodMin(sample_stat, num_frames);
+            max               = (F32)frame_recording.getPeriodMax(sample_stat, num_frames);
+            mean              = (F32)frame_recording.getPeriodMean(sample_stat, num_frames);
             num_rapid_changes = calc_num_rapid_changes(frame_recording, sample_stat, RAPID_CHANGE_WINDOW);
 
             if (mShowMedian)
             {
-                display_value = frame_recording.getPeriodMedian(sample_stat, num_frames);
+                display_value = (F32)frame_recording.getPeriodMedian(sample_stat, num_frames);
             }
             else if (num_rapid_changes / RAPID_CHANGE_WINDOW.value() > MAX_RAPID_CHANGES_PER_SEC)
             {
@@ -450,8 +450,8 @@ void LLStatBar::draw()
             }
 
             F32 span = (mOrientation == HORIZONTAL)
-                    ? (bar_rect.getWidth())
-                    : (bar_rect.getHeight());
+                    ? (F32)(bar_rect.getWidth())
+                    : (F32)(bar_rect.getHeight());
 
             if (mDisplayHistory && mStat.valid)
             {
@@ -471,18 +471,18 @@ void LLStatBar::draw()
                     switch(mStatType)
                     {
                         case STAT_COUNT:
-                            min_value       = recording.getPerSec(*mStat.countStatp);
+                            min_value       = (F32)recording.getPerSec(*mStat.countStatp);
                             max_value       = min_value;
                             num_samples     = recording.getSampleCount(*mStat.countStatp);
                             break;
                         case STAT_EVENT:
-                            min_value       = recording.getMin(*mStat.eventStatp);
-                            max_value       = recording.getMax(*mStat.eventStatp);
+                            min_value       = (F32)recording.getMin(*mStat.eventStatp);
+                            max_value       = (F32)recording.getMax(*mStat.eventStatp);
                             num_samples     = recording.getSampleCount(*mStat.eventStatp);
                             break;
                         case STAT_SAMPLE:
-                            min_value       = recording.getMin(*mStat.sampleStatp);
-                            max_value       = recording.getMax(*mStat.sampleStatp);
+                            min_value       = (F32)recording.getMin(*mStat.sampleStatp);
+                            max_value       = (F32)recording.getMax(*mStat.sampleStatp);
                             num_samples     = recording.getSampleCount(*mStat.sampleStatp);
                             break;
                         default:

--- a/indra/llui/llstatgraph.cpp
+++ b/indra/llui/llstatgraph.cpp
@@ -70,11 +70,11 @@ void LLStatGraph::draw()
 
         if (mPerSec)
         {
-            mValue = recording.getPerSec(*mNewStatFloatp);
+            mValue = (F32)recording.getPerSec(*mNewStatFloatp);
         }
         else
         {
-            mValue = recording.getSum(*mNewStatFloatp);
+            mValue = (F32)recording.getSum(*mNewStatFloatp);
         }
     }
 

--- a/indra/llui/lltabcontainer.cpp
+++ b/indra/llui/lltabcontainer.cpp
@@ -2189,7 +2189,7 @@ void LLTabContainer::setTabVisibility( LLPanel const *aPanel, bool aVisible )
         LLTabTuple const *pTT = *itr;
         if( pTT->mVisible )
         {
-            this->selectTab( itr - mTabList.begin() );
+            this->selectTab((S32)(itr - mTabList.begin()));
             foundTab = true;
             break;
         }

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -401,8 +401,8 @@ std::vector<LLRect> LLTextBase::getSelectionRects()
 
             // Use F32 otherwise a string of multiple segments
             // will accumulate a large error
-            F32 left_precise = line_iter->mRect.mLeft;
-            F32 right_precise = line_iter->mRect.mLeft;
+            F32 left_precise = (F32)line_iter->mRect.mLeft;
+            F32 right_precise = (F32)line_iter->mRect.mLeft;
 
             for (; segment_iter != mSegments.end(); ++segment_iter, segment_offset = 0)
             {
@@ -448,8 +448,8 @@ std::vector<LLRect> LLTextBase::getSelectionRects()
             }
 
             LLRect selection_rect;
-            selection_rect.mLeft = left_precise;
-            selection_rect.mRight = right_precise;
+            selection_rect.mLeft = (S32)left_precise;
+            selection_rect.mRight = (S32)right_precise;
             selection_rect.mBottom = line_iter->mRect.mBottom;
             selection_rect.mTop = line_iter->mRect.mTop;
 
@@ -598,7 +598,7 @@ void LLTextBase::drawCursor()
 
             // Make sure the IME is in the right place
             LLRect screen_pos = calcScreenRect();
-            LLCoordGL ime_pos( screen_pos.mLeft + llfloor(cursor_rect.mLeft), screen_pos.mBottom + llfloor(cursor_rect.mTop) );
+            LLCoordGL ime_pos( screen_pos.mLeft + cursor_rect.mLeft, screen_pos.mBottom + cursor_rect.mTop );
 
             ime_pos.mX = (S32) (ime_pos.mX * LLUI::getScaleFactor().mV[VX]);
             ime_pos.mY = (S32) (ime_pos.mY * LLUI::getScaleFactor().mV[VY]);
@@ -755,9 +755,9 @@ void LLTextBase::drawText()
             line_end = next_start;
         }
 
-        LLRectf text_rect(line.mRect.mLeft, line.mRect.mTop, line.mRect.mRight, line.mRect.mBottom);
-        text_rect.mRight = mDocumentView->getRect().getWidth(); // clamp right edge to document extents
-        text_rect.translate(mDocumentView->getRect().mLeft, mDocumentView->getRect().mBottom); // adjust by scroll position
+        LLRectf text_rect((F32)line.mRect.mLeft, (F32)line.mRect.mTop, (F32)line.mRect.mRight, (F32)line.mRect.mBottom);
+        text_rect.mRight = (F32)mDocumentView->getRect().getWidth(); // clamp right edge to document extents
+        text_rect.translate((F32)mDocumentView->getRect().mLeft, (F32)mDocumentView->getRect().mBottom); // adjust by scroll position
 
         // draw a single line of text
         S32 seg_start = line_start;
@@ -802,13 +802,13 @@ void LLTextBase::drawText()
                 S32 squiggle_start = 0, squiggle_end = 0, pony = 0;
                 cur_segment->getDimensions(seg_start - cur_segment->getStart(), misspell_start - seg_start, squiggle_start, pony);
                 cur_segment->getDimensions(misspell_start - cur_segment->getStart(), misspell_end - misspell_start, squiggle_end, pony);
-                squiggle_start += text_rect.mLeft;
+                squiggle_start += (S32)text_rect.mLeft;
 
                 pony = (squiggle_end + 3) / 6;
                 squiggle_start += squiggle_end / 2 - pony * 3;
                 squiggle_end = squiggle_start + pony * 6;
 
-                S32 squiggle_bottom = text_rect.mBottom + (S32)cur_segment->getStyle()->getFont()->getDescenderHeight();
+                S32 squiggle_bottom = (S32)text_rect.mBottom + (S32)cur_segment->getStyle()->getFont()->getDescenderHeight();
 
                 gGL.color4ub(255, 0, 0, 200);
                 while (squiggle_start + 1 < squiggle_end)
@@ -1674,7 +1674,7 @@ void LLTextBase::reflow()
         segment_set_t::iterator seg_iter = mSegments.begin();
         S32 seg_offset = 0;
         S32 line_start_index = 0;
-        const F32 text_available_width = mVisibleTextRect.getWidth() - mHPad;  // reserve room for margin
+        const F32 text_available_width = (F32)(mVisibleTextRect.getWidth() - mHPad);  // reserve room for margin
         F32 remaining_pixels = text_available_width;
         S32 line_count = 0;
 
@@ -1881,7 +1881,7 @@ S32 LLTextBase::getLineNumFromDocIndex( S32 doc_index, bool include_wordwrap) co
         line_list_t::const_iterator iter = std::upper_bound(mLineInfoList.begin(), mLineInfoList.end(), doc_index, line_end_compare());
         if (include_wordwrap)
         {
-            return iter - mLineInfoList.begin();
+            return (S32)(iter - mLineInfoList.begin());
         }
         else
         {
@@ -1918,7 +1918,7 @@ S32 LLTextBase::getFirstVisibleLine() const
     // binary search for line that starts before top of visible buffer
     line_list_t::const_iterator iter = std::lower_bound(mLineInfoList.begin(), mLineInfoList.end(), visible_region.mTop, compare_bottom());
 
-    return iter - mLineInfoList.begin();
+    return (S32)(iter - mLineInfoList.begin());
 }
 
 std::pair<S32, S32> LLTextBase::getVisibleLines(bool require_fully_visible)
@@ -1940,7 +1940,7 @@ std::pair<S32, S32> LLTextBase::getVisibleLines(bool require_fully_visible)
         first_iter = std::upper_bound(mLineInfoList.begin(), mLineInfoList.end(), visible_region.mTop, compare_bottom());
         last_iter = std::lower_bound(mLineInfoList.begin(), mLineInfoList.end(), visible_region.mBottom, compare_top());
     }
-    return std::pair<S32, S32>(first_iter - mLineInfoList.begin(), last_iter - mLineInfoList.begin());
+    return std::pair<S32, S32>((S32)(first_iter - mLineInfoList.begin()), (S32)(last_iter - mLineInfoList.begin()));
 }
 
 
@@ -2608,7 +2608,7 @@ S32 LLTextBase::getDocIndexFromLocalCoord( S32 local_x, S32 local_y, bool round,
     }
 
     S32 pos = getLength();
-    F32 start_x = line_iter->mRect.mLeft + doc_rect.mLeft;
+    F32 start_x = (F32)(line_iter->mRect.mLeft + doc_rect.mLeft);
 
     segment_set_t::iterator line_seg_iter;
     S32 line_seg_offset;
@@ -2626,7 +2626,7 @@ S32 LLTextBase::getDocIndexFromLocalCoord( S32 local_x, S32 local_y, bool round,
 
         if(newline)
         {
-            pos = segment_line_start + segmentp->getOffset(local_x - start_x, line_seg_offset, segment_line_length, round);
+            pos = segment_line_start + segmentp->getOffset(local_x - (S32)start_x, line_seg_offset, segment_line_length, round);
             break;
         }
 
@@ -2656,7 +2656,7 @@ S32 LLTextBase::getDocIndexFromLocalCoord( S32 local_x, S32 local_y, bool round,
             }
             else
             {
-                offset = segmentp->getOffset(local_x - start_x, line_seg_offset, segment_line_length, round);
+                offset = segmentp->getOffset(local_x - (S32)start_x, line_seg_offset, segment_line_length, round);
             }
             pos = segment_line_start + offset;
             break;
@@ -2703,7 +2703,7 @@ LLRect LLTextBase::getDocRectFromDocIndex(S32 pos) const
     getSegmentAndOffset(line_iter->mDocIndexStart, &line_seg_iter, &line_seg_offset);
     getSegmentAndOffset(pos, &cursor_seg_iter, &cursor_seg_offset);
 
-    F32 doc_left_precise = line_iter->mRect.mLeft;
+    F32 doc_left_precise = (F32)line_iter->mRect.mLeft;
 
     while(line_seg_iter != mSegments.end())
     {
@@ -2734,7 +2734,7 @@ LLRect LLTextBase::getDocRectFromDocIndex(S32 pos) const
     }
 
     LLRect doc_rect;
-    doc_rect.mLeft = doc_left_precise;
+    doc_rect.mLeft = (S32)doc_left_precise;
     doc_rect.mBottom = line_iter->mRect.mBottom;
     doc_rect.mTop = line_iter->mRect.mTop;
 
@@ -3720,7 +3720,7 @@ bool LLInlineViewSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& w
     }
     else
     {
-        width = mLeftPad + mRightPad + mView->getRect().getWidth();
+        width = (F32)(mLeftPad + mRightPad + mView->getRect().getWidth());
         height = mBottomPad + mTopPad + mView->getRect().getHeight();
     }
 
@@ -3871,10 +3871,10 @@ F32 LLImageTextSegment::draw(S32 start, S32 end, S32 selection_start, S32 select
             S32 style_image_width = image->getWidth();
             // Text is drawn from the top of the draw_rect downward
 
-            S32 text_center = draw_rect.mTop - (draw_rect.getHeight() / 2);
+            S32 text_center = (S32)(draw_rect.mTop - (draw_rect.getHeight() / 2.f));
             // Align image to center of draw rect
             S32 image_bottom = text_center - (style_image_height / 2);
-            image->draw(draw_rect.mLeft, image_bottom,
+            image->draw((S32)draw_rect.mLeft, image_bottom,
                 style_image_width, style_image_height, color);
 
             const S32 IMAGE_HPAD = 3;

--- a/indra/llui/lltexteditor.cpp
+++ b/indra/llui/lltexteditor.cpp
@@ -2315,17 +2315,17 @@ void LLTextEditor::drawPreeditMarker()
                 if (mPreeditStandouts[i])
                 {
                     gl_rect_2d(preedit_left + preedit_standout_gap,
-                               text_rect.mBottom + mFont->getDescenderHeight() - 1,
+                               text_rect.mBottom + (S32)mFont->getDescenderHeight() - 1,
                                preedit_right - preedit_standout_gap - 1,
-                               text_rect.mBottom + mFont->getDescenderHeight() - 1 - preedit_standout_thickness,
+                               text_rect.mBottom + (S32)mFont->getDescenderHeight() - 1 - preedit_standout_thickness,
                                (mCursorColor.get() * preedit_standout_brightness + mWriteableBgColor.get() * (1 - preedit_standout_brightness)).setAlpha(1.0f));
                 }
                 else
                 {
                     gl_rect_2d(preedit_left + preedit_marker_gap,
-                               text_rect.mBottom + mFont->getDescenderHeight() - 1,
+                               text_rect.mBottom + (S32)mFont->getDescenderHeight() - 1,
                                preedit_right - preedit_marker_gap - 1,
-                               text_rect.mBottom + mFont->getDescenderHeight() - 1 - preedit_marker_thickness,
+                               text_rect.mBottom + (S32)mFont->getDescenderHeight() - 1 - preedit_marker_thickness,
                                (mCursorColor.get() * preedit_marker_brightness + mWriteableBgColor.get() * (1 - preedit_marker_brightness)).setAlpha(1.0f));
                 }
             }

--- a/indra/llui/llvirtualtrackball.cpp
+++ b/indra/llui/llvirtualtrackball.cpp
@@ -217,19 +217,19 @@ void LLVirtualTrackball::draw()
 
     S32 halfwidth = mTouchArea->getRect().getWidth() / 2;
     S32 halfheight = mTouchArea->getRect().getHeight() / 2;
-    draw_point.mV[VX] = (draw_point.mV[VX] + 1.0) * halfwidth + mTouchArea->getRect().mLeft;
-    draw_point.mV[VY] = (draw_point.mV[VY] + 1.0) * halfheight + mTouchArea->getRect().mBottom;
+    draw_point.mV[VX] = (draw_point.mV[VX] + 1.0f) * halfwidth + mTouchArea->getRect().mLeft;
+    draw_point.mV[VY] = (draw_point.mV[VY] + 1.0f) * halfheight + mTouchArea->getRect().mBottom;
     bool upper_hemisphere = (draw_point.mV[VZ] >= 0.f);
 
     mImgSphere->draw(mTouchArea->getRect(), upper_hemisphere ? UI_VERTEX_COLOR : UI_VERTEX_COLOR % 0.5f);
-    drawThumb(draw_point.mV[VX], draw_point.mV[VY], mThumbMode, upper_hemisphere);
+    drawThumb((S32)draw_point.mV[VX], (S32)draw_point.mV[VY], mThumbMode, upper_hemisphere);
 
 
     if (LLView::sDebugRects)
     {
         gGL.color4fv(LLColor4::red.mV);
-        gl_circle_2d(mTouchArea->getRect().getCenterX(), mTouchArea->getRect().getCenterY(), mImgSphere->getWidth() / 2, 60, false);
-        gl_circle_2d(draw_point.mV[VX], draw_point.mV[VY], mImgSunFront->getWidth() / 2, 12, false);
+        gl_circle_2d((F32)mTouchArea->getRect().getCenterX(), (F32)mTouchArea->getRect().getCenterY(), (F32)mImgSphere->getWidth() / 2.f, 60, false);
+        gl_circle_2d(draw_point.mV[VX], draw_point.mV[VY], (F32)mImgSunFront->getWidth() / 2.f, 12, false);
     }
 
     // hide the direction labels when disabled
@@ -392,20 +392,20 @@ bool LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
         { // trackball (move to roll) mode
             LLQuaternion delta;
 
-            F32 rotX = x - mPrevX;
-            F32 rotY = y - mPrevY;
+            F32 rotX = (F32)(x - mPrevX);
+            F32 rotY = (F32)(y - mPrevY);
 
             if (abs(rotX) > 1)
             {
-                F32 direction = (rotX < 0) ? -1 : 1;
-                delta.setAngleAxis(mIncrementMouse * abs(rotX), 0, direction, 0);  // changing X - rotate around Y axis
+                F32 direction = (rotX < 0) ? -1.f : 1.f;
+                delta.setAngleAxis(mIncrementMouse * abs(rotX), 0.f, direction, 0.f);  // changing X - rotate around Y axis
                 mValue *= delta;
             }
 
             if (abs(rotY) > 1)
             {
-                F32 direction = (rotY < 0) ? 1 : -1; // reverse for Y (value increases from bottom to top)
-                delta.setAngleAxis(mIncrementMouse * abs(rotY), direction, 0, 0);  // changing Y - rotate around X axis
+                F32 direction = (rotY < 0) ? 1.f : -1.f; // reverse for Y (value increases from bottom to top)
+                delta.setAngleAxis(mIncrementMouse * abs(rotY), direction, 0.f, 0.f);  // changing Y - rotate around X axis
                 mValue *= delta;
             }
         }
@@ -416,10 +416,10 @@ bool LLVirtualTrackball::handleHover(S32 x, S32 y, MASK mask)
                 return true; // don't drag outside the circle
             }
 
-            F32 radius = mTouchArea->getRect().getWidth() / 2;
-            F32 xx = x - mTouchArea->getRect().getCenterX();
-            F32 yy = y - mTouchArea->getRect().getCenterY();
-            F32 dist = sqrt(pow(xx, 2) + pow(yy, 2));
+            F32 radius = (F32)mTouchArea->getRect().getWidth() / 2.f;
+            F32 xx = (F32)(x - mTouchArea->getRect().getCenterX());
+            F32 yy = (F32)(y - mTouchArea->getRect().getCenterY());
+            F32 dist = (F32)(sqrt(pow(xx, 2) + pow(yy, 2)));
 
             F32 azimuth = llclamp(acosf(xx / dist), 0.0f, F_PI);
             F32 altitude = llclamp(acosf(dist / radius), 0.0f, F_PI_BY_TWO);

--- a/indra/llui/llxyvector.cpp
+++ b/indra/llui/llxyvector.cpp
@@ -159,15 +159,15 @@ void drawArrow(S32 tailX, S32 tailY, S32 tipX, S32 tipY, LLColor4 color)
 
     S32 arrowLength = (abs(dx) < ARROW_LENGTH_LONG && abs(dy) < ARROW_LENGTH_LONG) ? ARROW_LENGTH_SHORT : ARROW_LENGTH_LONG;
 
-    F32 theta = std::atan2(dy, dx);
+    F32 theta = (F32)std::atan2(dy, dx);
 
-    F32 rad = ARROW_ANGLE * std::atan(1) * 4 / 180;
+    F32 rad = (F32)(ARROW_ANGLE * std::atan(1) * 4 / 180);
     F32 x = tipX - arrowLength * cos(theta + rad);
     F32 y = tipY - arrowLength * sin(theta + rad);
-    F32 rad2 = -1 * ARROW_ANGLE * std::atan(1) * 4 / 180;
+    F32 rad2 = (F32)(-1 * ARROW_ANGLE * std::atan(1) * 4 / 180);
     F32 x2 = tipX - arrowLength * cos(theta + rad2);
     F32 y2 = tipY - arrowLength * sin(theta + rad2);
-    gl_triangle_2d(tipX, tipY, x, y, x2, y2, color, true);
+    gl_triangle_2d(tipX, tipY, (S32)x, (S32)y, (S32)x2, (S32)y2, color, true);
 }
 
 void LLXYVector::draw()
@@ -179,18 +179,18 @@ void LLXYVector::draw()
 
     if (mLogarithmic)
     {
-        pointX = (log(llabs(mValueX) + 1)) / mLogScaleX;
+        pointX = (S32)((log(llabs(mValueX) + 1)) / mLogScaleX);
         pointX *= (mValueX < 0) ? -1 : 1;
         pointX += centerX;
 
-        pointY = (log(llabs(mValueY) + 1)) / mLogScaleY;
+        pointY = (S32)((log(llabs(mValueY) + 1)) / mLogScaleY);
         pointY *= (mValueY < 0) ? -1 : 1;
         pointY += centerY;
     }
     else // linear
     {
-        pointX = centerX + (mValueX * mTouchArea->getRect().getWidth() / (2 * mMaxValueX));
-        pointY = centerY + (mValueY * mTouchArea->getRect().getHeight() / (2 * mMaxValueY));
+        pointX = centerX + (S32)(mValueX * mTouchArea->getRect().getWidth() / (2 * mMaxValueX));
+        pointY = centerY + (S32)(mValueY * mTouchArea->getRect().getHeight() / (2 * mMaxValueY));
     }
 
     // fill
@@ -223,7 +223,7 @@ void LLXYVector::draw()
     }
 
     // draw center circle
-    gl_circle_2d(centerX, centerY, CENTER_CIRCLE_RADIUS, 12, true);
+    gl_circle_2d((F32)centerX, (F32)centerY, CENTER_CIRCLE_RADIUS, 12, true);
 
     LLView::draw();
 }
@@ -232,7 +232,7 @@ void LLXYVector::onEditChange()
 {
     if (getEnabled())
     {
-        setValueAndCommit(mXEntry->getValue().asReal(), mYEntry->getValue().asReal());
+        setValueAndCommit((F32)mXEntry->getValue().asReal(), (F32)mYEntry->getValue().asReal());
     }
 }
 
@@ -240,7 +240,7 @@ void LLXYVector::setValue(const LLSD& value)
 {
     if (value.isArray())
     {
-        setValue(value[0].asReal(), value[1].asReal());
+        setValue((F32)value[0].asReal(), (F32)value[1].asReal());
     }
 }
 

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -343,7 +343,7 @@ std::string LLDXHardware::getDriverVersionWMI(EGPUVendor vendor)
 
             //convert BSTR to std::string
             std::wstring ws(caption, SysStringLen(caption));
-            std::string caption_str(ws.begin(), ws.end());
+            std::string caption_str = ll_convert_wide_to_string(ws);
             LLStringUtil::toLower(caption_str);
 
             bool found = false;
@@ -395,7 +395,7 @@ std::string LLDXHardware::getDriverVersionWMI(EGPUVendor vendor)
 
         //convert BSTR to std::string
         std::wstring ws(driverVersion, SysStringLen(driverVersion));
-        std::string str(ws.begin(), ws.end());
+        std::string str = ll_convert_wide_to_string(ws);
         LL_INFOS("AppInit") << " DriverVersion : " << str << LL_ENDL;
 
         if (mDriverVersion.empty())

--- a/indra/media_plugins/libvlc/media_plugin_libvlc.cpp
+++ b/indra/media_plugins/libvlc/media_plugin_libvlc.cpp
@@ -585,7 +585,7 @@ void MediaPluginLibVLC::receiveMessage(const char* message_string)
                         mTextureWidth = texture_width;
                         mTextureHeight = texture_height;
 
-                        libvlc_time_t time = 1000.0 * mCurTime;
+                        libvlc_time_t time = (libvlc_time_t)(1000.0 * mCurTime);
 
                         playMedia();
 
@@ -655,7 +655,7 @@ void MediaPluginLibVLC::receiveMessage(const char* message_string)
                 {
                     if (mLibVLCMediaPlayer)
                     {
-                        libvlc_time_t time = 1000.0 * message_in.getValueReal("time");
+                        libvlc_time_t time = (libvlc_time_t)(1000.0 * message_in.getValueReal("time"));
                         libvlc_media_player_set_time(mLibVLCMediaPlayer, time);
                         time = libvlc_media_player_get_time(mLibVLCMediaPlayer);
                         if (time < 0)

--- a/indra/newview/gltf/accessor.cpp
+++ b/indra/newview/gltf/accessor.cpp
@@ -104,7 +104,7 @@ namespace LL
 
 void Buffer::erase(Asset& asset, S32 offset, S32 length)
 {
-    S32 idx = this - &asset.mBuffers[0];
+    S32 idx = (S32)(this - &asset.mBuffers[0]);
 
     mData.erase(mData.begin() + offset, mData.begin() + offset + length);
 
@@ -197,7 +197,7 @@ bool Buffer::save(Asset& asset, const std::string& folder)
     {
         if (mName.empty())
         {
-            S32 idx = this - &asset.mBuffers[0];
+            S32 idx = (S32)(this - &asset.mBuffers[0]);
             mUri = llformat("buffer_%d.bin", idx);
         }
         else

--- a/indra/newview/gltf/animation.cpp
+++ b/indra/newview/gltf/animation.cpp
@@ -127,8 +127,8 @@ void Animation::apply(Asset& asset, float time)
 bool Animation::Sampler::prep(Asset& asset)
 {
     Accessor& accessor = asset.mAccessors[mInput];
-    mMinTime = accessor.mMin[0];
-    mMaxTime = accessor.mMax[0];
+    mMinTime = (F32)accessor.mMin[0];
+    mMaxTime = (F32)accessor.mMax[0];
 
     mFrameTimes.resize(accessor.mCount);
 

--- a/indra/newview/gltf/asset.cpp
+++ b/indra/newview/gltf/asset.cpp
@@ -105,7 +105,7 @@ void Node::updateTransforms(Asset& asset, const mat4& parentMatrix)
 
     mAssetMatrixInv = glm::inverse(mAssetMatrix);
 
-    S32 my_index = this - &asset.mNodes[0];
+    S32 my_index = (S32)(this - &asset.mNodes[0]);
 
     for (auto& childIndex : mChildren)
     {
@@ -271,11 +271,11 @@ S32 Asset::lineSegmentIntersect(const LLVector4a& start, const LLVector4a& end,
                     local_end = p;
 
                     // pointer math to get the node index
-                    node_hit = &node - &mNodes[0];
+                    node_hit = (S32)(&node - &mNodes[0]);
                     llassert(&mNodes[node_hit] == &node);
 
                     //pointer math to get the primitive index
-                    primitive_hit = &primitive - &mesh.mPrimitives[0];
+                    primitive_hit = (S32)(&primitive - &mesh.mPrimitives[0]);
                     llassert(&mesh.mPrimitives[primitive_hit] == &primitive);
                 }
             }
@@ -1028,7 +1028,7 @@ bool Image::save(Asset& asset, const std::string& folder)
     const std::string& delim = gDirUtilp->getDirDelimiter();
     if (name.empty())
     {
-        S32 idx = this - asset.mImages.data();
+        S32 idx = (S32)(this - asset.mImages.data());
         name = llformat("image_%d", idx);
     }
 

--- a/indra/newview/gltf/buffer_util.h
+++ b/indra/newview/gltf/buffer_util.h
@@ -161,7 +161,7 @@ namespace LL
         template<>
         inline void copyVec3<U16, LLColor4U>(U16* src, LLColor4U& dst)
         {
-            dst.set(src[0], src[1], src[2], 255);
+            dst.set((U8)(src[0]), (U8)(src[1]), (U8)(src[2]), 255);
         }
 
         template<>
@@ -193,13 +193,13 @@ namespace LL
         template<>
         inline void copyVec4<U16, LLColor4U>(U16* src, LLColor4U& dst)
         {
-            dst.set(src[0], src[1], src[2], src[3]);
+            dst.set((U8)(src[0]), (U8)(src[1]), (U8)(src[2]), ((U8)src[3]));
         }
 
         template<>
         inline void copyVec4<F32, LLColor4U>(F32* src, LLColor4U& dst)
         {
-            dst.set(src[0]*255, src[1]*255, src[2]*255, src[3]*255);
+            dst.set((U8)(src[0]*255.f), (U8)(src[1]*255.f), (U8)(src[2]*255.f), (U8)(src[3]*255.f));
         }
 
         template<>
@@ -902,7 +902,7 @@ namespace LL
         {
             if (src.is_int64())
             {
-                dst = src.get_int64();
+                dst = (U32)src.get_int64();
                 return true;
             }
             return false;
@@ -957,7 +957,7 @@ namespace LL
         {
             if (src.is_int64())
             {
-                dst = src.get_int64();
+                dst = (U32)src.get_int64();
                 return true;
             }
             return false;

--- a/indra/newview/gltfscenemanager.cpp
+++ b/indra/newview/gltfscenemanager.cpp
@@ -782,7 +782,7 @@ void GLTFSceneManager::bind(Asset& asset, Material& material)
         bindTexture(asset, TextureType::EMISSIVE, material.mEmissiveTexture, LLViewerFetchedTexture::sWhiteImagep);
     }
 
-    shader->uniform1i(LLShaderMgr::GLTF_MATERIAL_ID, &material - &asset.mMaterials[0]);
+    shader->uniform1i(LLShaderMgr::GLTF_MATERIAL_ID, (GLint)(&material - &asset.mMaterials[0]));
 }
 
 LLMatrix4a inverse(const LLMatrix4a& mat)

--- a/indra/newview/llaccountingcostmanager.cpp
+++ b/indra/newview/llaccountingcostmanager.cpp
@@ -150,9 +150,9 @@ void LLAccountingCostManager::accountingCostCoro(std::string url,
                 F32 networkCost = 0.0f;
                 F32 simulationCost = 0.0f;
 
-                physicsCost = selected["physics"].asReal();
-                networkCost = selected["streaming"].asReal();
-                simulationCost = selected["simulation"].asReal();
+                physicsCost = (F32)selected["physics"].asReal();
+                networkCost = (F32)selected["streaming"].asReal();
+                simulationCost = (F32)selected["simulation"].asReal();
 
                 SelectionCost selectionCost( physicsCost, networkCost, simulationCost);
 

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -2662,9 +2662,9 @@ void LLAgent::setStartPositionSuccess(const LLSD &result)
                 (!result["HomeLocation"]["LocationPos"].has("Z")))
             break;
 
-        agent_pos.mV[VX] = result["HomeLocation"]["LocationPos"]["X"].asInteger();
-        agent_pos.mV[VY] = result["HomeLocation"]["LocationPos"]["Y"].asInteger();
-        agent_pos.mV[VZ] = result["HomeLocation"]["LocationPos"]["Z"].asInteger();
+        agent_pos.mV[VX] = (F32)result["HomeLocation"]["LocationPos"]["X"].asInteger();
+        agent_pos.mV[VY] = (F32)result["HomeLocation"]["LocationPos"]["Y"].asInteger();
+        agent_pos.mV[VZ] = (F32)result["HomeLocation"]["LocationPos"]["Z"].asInteger();
 
         error = false;
 
@@ -2778,7 +2778,7 @@ bool LLAgent::canAccessMaturityInRegion( U64 region_handle ) const
 
 bool LLAgent::canAccessMaturityAtGlobal( LLVector3d pos_global ) const
 {
-    U64 region_handle = to_region_handle_global( pos_global.mdV[0], pos_global.mdV[1] );
+    U64 region_handle = to_region_handle_global((F32)pos_global.mdV[0], (F32)pos_global.mdV[1]);
     return canAccessMaturityInRegion( region_handle );
 }
 

--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -2114,14 +2114,14 @@ void LLAgentCamera::handleScrollWheel(S32 clicks)
             F32 camera_offset_initial_mag = getCameraOffsetInitial().magVec();
 
             F32 current_zoom_fraction = mTargetCameraDistance / (camera_offset_initial_mag * gSavedSettings.getF32("CameraOffsetScale"));
-            current_zoom_fraction *= 1.f - pow(ROOT_ROOT_TWO, clicks);
+            current_zoom_fraction *= 1.f - (F32)pow(ROOT_ROOT_TWO, clicks);
 
             cameraOrbitIn(current_zoom_fraction * camera_offset_initial_mag * gSavedSettings.getF32("CameraOffsetScale"));
         }
         else
         {
             F32 current_zoom_fraction = (F32)mCameraFocusOffsetTarget.magVec();
-            cameraOrbitIn(current_zoom_fraction * (1.f - pow(ROOT_ROOT_TWO, clicks)));
+            cameraOrbitIn(current_zoom_fraction * (1.f - (F32)pow(ROOT_ROOT_TWO, clicks)));
         }
     }
 }

--- a/indra/newview/llagentlistener.cpp
+++ b/indra/newview/llagentlistener.cpp
@@ -156,9 +156,9 @@ void LLAgentListener::requestTeleport(LLSD const & event_data) const
     else
     {
         std::string url = LLSLURL(event_data["regionname"],
-                                  LLVector3(event_data["x"].asReal(),
-                                            event_data["y"].asReal(),
-                                            event_data["z"].asReal())).getSLURLString();
+                                  LLVector3((F32)event_data["x"].asReal(),
+                                            (F32)event_data["y"].asReal(),
+                                            (F32)event_data["z"].asReal())).getSLURLString();
         LLURLDispatcher::dispatch(url, LLCommandHandler::NAV_TYPE_CLICKED, NULL, false);
     }
 }
@@ -344,7 +344,7 @@ void LLAgentListener::startAutoPilot(LLSD const & event_data)
     F32 rotation_threshold = 0.03f;
     if (event_data.has("rotation_threshold"))
     {
-        rotation_threshold = event_data["rotation_threshold"].asReal();
+        rotation_threshold = (F32)event_data["rotation_threshold"].asReal();
     }
 
     bool allow_flying = true;
@@ -357,7 +357,7 @@ void LLAgentListener::startAutoPilot(LLSD const & event_data)
     F32 stop_distance = 0.f;
     if (event_data.has("stop_distance"))
     {
-        stop_distance = event_data["stop_distance"].asReal();
+        stop_distance = (F32)event_data["stop_distance"].asReal();
     }
 
     // Clear follow target, this is doing a path
@@ -446,7 +446,7 @@ void LLAgentListener::startFollowPilot(LLSD const & event_data)
     F32 stop_distance = 0.f;
     if (event_data.has("stop_distance"))
     {
-        stop_distance = event_data["stop_distance"].asReal();
+        stop_distance = (F32)event_data["stop_distance"].asReal();
     }
 
     if (target_id.notNull())

--- a/indra/newview/llagentpilot.cpp
+++ b/indra/newview/llagentpilot.cpp
@@ -145,7 +145,7 @@ void LLAgentPilot::loadXML(const std::string& filename)
         Action action;
         action.mTime = record["time"].asReal();
         action.mType = (EActionType)record["type"].asInteger();
-        action.mCameraView = record["camera_view"].asReal();
+        action.mCameraView = (F32)record["camera_view"].asReal();
         action.mTarget = ll_vector3d_from_sd(record["target"]);
         action.mCameraOrigin = ll_vector3_from_sd(record["camera_origin"]);
         action.mCameraXAxis = ll_vector3_from_sd(record["camera_xaxis"]);
@@ -297,8 +297,8 @@ void LLAgentPilot::moveCamera()
         S32 start_index = llmax(mCurrentAction-1,0);
         S32 end_index = mCurrentAction;
         F32 t = 0.0;
-        F32 timedelta = mActions[end_index].mTime - mActions[start_index].mTime;
-        F32 tickelapsed = mTimer.getElapsedTimeF32()-mActions[start_index].mTime;
+        F32 timedelta = (F32)(mActions[end_index].mTime - mActions[start_index].mTime);
+        F32 tickelapsed = mTimer.getElapsedTimeF32()-(F32)mActions[start_index].mTime;
         if (timedelta > 0.0)
         {
             t = tickelapsed/timedelta;

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -3934,7 +3934,7 @@ void LLAppearanceMgr::serverAppearanceUpdateCoro(LLCoreHttpUtil::HttpCoroutineAd
                     LL_WARNS("Avatar") << "Bake retry count exceeded!" << LL_ENDL;
                     break;
                 }
-                F32 timeout = pow(BAKE_RETRY_TIMEOUT, static_cast<float>(retryCount)) - 1.0;
+                F32 timeout = pow(BAKE_RETRY_TIMEOUT, static_cast<float>(retryCount)) - 1.0f;
 
                 LL_WARNS("Avatar") << "Bake retry #" << retryCount << " in " << timeout << " seconds." << LL_ENDL;
 
@@ -4329,7 +4329,7 @@ LLAppearanceMgr::LLAppearanceMgr():
     outfit_observer.addCOFSavedCallback(boost::bind(
             &LLAppearanceMgr::setOutfitLocked, this, false));
 
-    mUnlockOutfitTimer.reset(new LLOutfitUnLockTimer(gSavedSettings.getS32(
+    mUnlockOutfitTimer.reset(new LLOutfitUnLockTimer((F32)gSavedSettings.getS32(
             "OutfitOperationsTimeout")));
 
     gIdleCallbacks.addFunction(&LLAttachmentsMgr::onIdle, NULL);

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -456,7 +456,7 @@ void idle_afk_check()
 {
     // check idle timers
     F32 current_idle = gAwayTriggerTimer.getElapsedTimeF32();
-    F32 afk_timeout  = gSavedSettings.getS32("AFKTimeout");
+    F32 afk_timeout  = (F32)gSavedSettings.getS32("AFKTimeout");
     if (afk_timeout && (current_idle > afk_timeout) && ! gAgent.getAFK())
     {
         LL_INFOS("IdleAway") << "Idle more than " << afk_timeout << " seconds: automatically changing to Away status" << LL_ENDL;
@@ -1959,7 +1959,7 @@ bool LLAppViewer::cleanup()
     LL_INFOS() << "Saving Data" << LL_ENDL;
 
     // Store the time of our current logoff
-    gSavedPerAccountSettings.setU32("LastLogoff", time_corrected());
+    gSavedPerAccountSettings.setU32("LastLogoff", (U32)time_corrected());
 
     if (LLEnvironment::instanceExists())
     {
@@ -2332,7 +2332,7 @@ void LLAppViewer::initLoggingAndGetLastDuration()
         int log_stat_result = LLFile::stat(log_file, &log_file_stat);
         if (0 == start_stat_result && 0 == log_stat_result)
         {
-            int elapsed_seconds = log_file_stat.st_ctime - start_marker_stat.st_ctime;
+            int elapsed_seconds = (int)(log_file_stat.st_ctime - start_marker_stat.st_ctime);
             // only report a last run time if the last viewer was the same version
             // because this stat will be counted against this version
             if (markerIsSameVersion(start_marker_file_name))
@@ -3434,7 +3434,7 @@ LLSD LLAppViewer::getViewerInfo() const
     info["LIBVLC_VERSION"] = "Undefined";
 #endif
 
-    S32 packets_in = LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_IN);
+    S32 packets_in = (S32)LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_IN);
     if (packets_in > 0)
     {
         info["PACKETS_LOST"] = LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_LOST);

--- a/indra/newview/llavatarpropertiesprocessor.cpp
+++ b/indra/newview/llavatarpropertiesprocessor.cpp
@@ -695,7 +695,7 @@ bool LLAvatarPropertiesProcessor::isPendingRequest(const LLUUID& avatar_id, EAva
     if (it == mRequestTimestamps.end()) return false;
 
     // We found a request, check if it has timed out
-    U32 now = time(nullptr);
+    U32 now = (U32)time(nullptr);
     const U32 REQUEST_EXPIRE_SECS = 5;
     U32 expires = it->second + REQUEST_EXPIRE_SECS;
 
@@ -709,7 +709,7 @@ bool LLAvatarPropertiesProcessor::isPendingRequest(const LLUUID& avatar_id, EAva
 void LLAvatarPropertiesProcessor::addPendingRequest(const LLUUID& avatar_id, EAvatarProcessorType type)
 {
     timestamp_map_t::key_type key = std::make_pair(avatar_id, type);
-    U32 now = time(nullptr);
+    U32 now = (U32)time(nullptr);
     // Add or update existing (expired) request
     mRequestTimestamps[ key ] = now;
 }

--- a/indra/newview/llavatarrenderinfoaccountant.cpp
+++ b/indra/newview/llavatarrenderinfoaccountant.cpp
@@ -84,7 +84,7 @@ void LLAvatarRenderInfoAccountant::avatarRenderInfoGetCoro(std::string url, U64 
     // Going to request each 15 seconds either way, so don't wait
     // too long and don't repeat
     httpOpts->setRetries(0);
-    httpOpts->setTimeout(SECS_BETWEEN_REGION_REQUEST);
+    httpOpts->setTimeout((unsigned int)SECS_BETWEEN_REGION_REQUEST);
 
     LLSD result = httpAdapter->getAndSuspend(httpRequest, url, httpOpts);
 

--- a/indra/newview/llavatarrendernotifier.cpp
+++ b/indra/newview/llavatarrendernotifier.cpp
@@ -172,7 +172,7 @@ void LLAvatarRenderNotifier::updateNotificationRegion(U32 agentcount, U32 overLi
     // save current values for later use
     mLatestAgentsCount = agentcount > overLimit ? agentcount - 1 : agentcount; // subtract self
     mLatestOverLimitAgents = overLimit;
-    mLatestOverLimitPct = mLatestAgentsCount != 0 ? ((F32)overLimit / (F32)mLatestAgentsCount) * 100.0 : 0;
+    mLatestOverLimitPct = mLatestAgentsCount != 0 ? ((F32)overLimit / (F32)mLatestAgentsCount) * 100.0f : 0.f;
 
     if (mAgentsCount == mLatestAgentsCount
         && mOverLimitAgents == mLatestOverLimitAgents)
@@ -191,7 +191,7 @@ void LLAvatarRenderNotifier::updateNotificationRegion(U32 agentcount, U32 overLi
 
         // default timeout before next notification
         static LLCachedControl<U32> pop_up_delay(gSavedSettings, "ComplexityChangesPopUpDelay", 300);
-        mPopUpDelayTimer.resetWithExpiry(pop_up_delay);
+        mPopUpDelayTimer.resetWithExpiry((F32)pop_up_delay);
     }
 }
 
@@ -500,6 +500,6 @@ void LLHUDRenderNotifier::displayHUDNotification(EWarnLevel warn_type, LLUUID ob
         .name("HUDComplexityWarning")
         .expiry(expire_date)
         .substitutions(msg_args));
-    mHUDPopUpDelayTimer.resetWithExpiry(pop_up_delay);
+    mHUDPopUpDelayTimer.resetWithExpiry((F32)pop_up_delay);
 }
 

--- a/indra/newview/llchannelmanager.cpp
+++ b/indra/newview/llchannelmanager.cpp
@@ -148,7 +148,7 @@ void LLChannelManager::onLoginCompleted()
             mStartUpChannel->setMouseDownCallback(boost::bind(&LLFloaterNotificationsTabbed::onStartUpToastClick, LLFloaterNotificationsTabbed::getInstance(), _2, _3, _4));
 
             mStartUpChannel->setCommitCallback(boost::bind(&LLChannelManager::onStartUpToastClose, this));
-            mStartUpChannel->createStartUpToast(away_notifications, gSavedSettings.getS32("StartUpToastLifeTime"));
+            mStartUpChannel->createStartUpToast(away_notifications, (F32)gSavedSettings.getS32("StartUpToastLifeTime"));
         }
     }
 

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -423,7 +423,7 @@ public:
             if (mTime > 0) // have frame time
             {
                 time_t current_time = time_corrected();
-                time_t message_time = current_time - LLFrameTimer::getElapsedSeconds() + mTime;
+                time_t message_time = (time_t)(current_time - LLFrameTimer::getElapsedSeconds() + mTime);
 
                 time_string = "[" + LLTrans::getString("TimeMonth") + "]/["
                     + LLTrans::getString("TimeDay") + "]/["

--- a/indra/newview/llchatitemscontainerctrl.cpp
+++ b/indra/newview/llchatitemscontainerctrl.cpp
@@ -135,7 +135,7 @@ void LLFloaterIMNearbyChatToastPanel::addMessage(LLSD& notification)
     std::string color_name = notification["text_color"].asString();
 
     LLColor4 textColor = LLUIColorTable::instance().getColor(color_name);
-    textColor.mV[VALPHA] =notification["color_alpha"].asReal();
+    textColor.mV[VALPHA] = (F32)notification["color_alpha"].asReal();
 
     S32 font_size = notification["font_size"].asInteger();
 
@@ -191,7 +191,7 @@ void LLFloaterIMNearbyChatToastPanel::init(LLSD& notification)
     std::string color_name = notification["text_color"].asString();
 
     LLColor4 textColor = LLUIColorTable::instance().getColor(color_name);
-    textColor.mV[VALPHA] =notification["color_alpha"].asReal();
+    textColor.mV[VALPHA] = (F32)notification["color_alpha"].asReal();
 
     S32 font_size = notification["font_size"].asInteger();
 

--- a/indra/newview/lldateutil.cpp
+++ b/indra/newview/lldateutil.cpp
@@ -211,5 +211,5 @@ S32 LLDateUtil::secondsSinceEpochFromString(const std::string& format, const std
     // is calculated with no time zone corrections.
     time_duration diff = time_t_date - time_t_epoch;
 
-    return diff.total_seconds();
+    return (S32)diff.total_seconds();
 }

--- a/indra/newview/lldrawpoolwater.cpp
+++ b/indra/newview/lldrawpoolwater.cpp
@@ -215,7 +215,7 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
         LLViewerTexture* tex_a = mWaterNormp[0];
         LLViewerTexture* tex_b = mWaterNormp[1];
 
-        F32 blend_factor = pwater->getBlendFactor();
+        F32 blend_factor = (F32)pwater->getBlendFactor();
 
         gGL.getTexUnit(bumpTex)->unbind(LLTexUnit::TT_TEXTURE);
         gGL.getTexUnit(bumpTex2)->unbind(LLTexUnit::TT_TEXTURE);
@@ -256,7 +256,7 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
 
         if (mShaderLevel == 1)
         {
-            fog_color.mV[VALPHA] = log(fog_density) / log(2);
+            fog_color.mV[VALPHA] = (F32)(log(fog_density) / log(2));
         }
 
         F32 water_height = environment.getWaterHeight();

--- a/indra/newview/lldrawpoolwlsky.cpp
+++ b/indra/newview/lldrawpoolwlsky.cpp
@@ -242,7 +242,7 @@ void LLDrawPoolWLSky::renderStarsDeferred(const LLVector3& camPosLocal) const
     LLViewerTexture* tex_a = gSky.mVOSkyp->getBloomTex();
     LLViewerTexture* tex_b = gSky.mVOSkyp->getBloomTexNext();
 
-    F32 blend_factor = LLEnvironment::instance().getCurrentSky()->getBlendFactor();
+    F32 blend_factor = (F32)LLEnvironment::instance().getCurrentSky()->getBlendFactor();
 
     if (tex_a && (!tex_b || (tex_a == tex_b)))
     {
@@ -309,8 +309,8 @@ void LLDrawPoolWLSky::renderSkyCloudsDeferred(const LLVector3& camPosLocal, F32 
         gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
         gGL.getTexUnit(1)->unbind(LLTexUnit::TT_TEXTURE);
 
-        F32 cloud_variance = psky ? psky->getCloudVariance() : 0.0f;
-        F32 blend_factor   = psky ? psky->getBlendFactor() : 0.0f;
+        F32 cloud_variance = psky ? (F32)psky->getCloudVariance() : 0.0f;
+        F32 blend_factor   = psky ? (F32)psky->getBlendFactor() : 0.0f;
 
         if (psky->getCloudScrollRate().isExactlyZero())
         {
@@ -364,7 +364,7 @@ void LLDrawPoolWLSky::renderHeavenlyBodies()
 
     LLFace * face = gSky.mVOSkyp->mFace[LLVOSky::FACE_SUN];
 
-    F32 blend_factor = LLEnvironment::instance().getCurrentSky()->getBlendFactor();
+    F32 blend_factor = (F32)LLEnvironment::instance().getCurrentSky()->getBlendFactor();
     bool can_use_vertex_shaders = gPipeline.shadersLoaded();
     bool can_use_windlight_shaders = gPipeline.canUseWindLightShaders();
 

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -209,7 +209,7 @@ namespace
 
             mInitial = (*initial.first).second;
             mFinal = (*initial.second).second;
-            mBlendSpan = getSpanTime(initial);
+            mBlendSpan = (LLSettingsBase::TrackPosition)getSpanTime(initial);
 
             initializeTarget(now);
             setOnFinished([this](const LLSettingsBlender::ptr_t &){ onFinishedSpan(); });
@@ -237,7 +237,7 @@ namespace
             LLSettingsBase::BlendFactor blendf = calculateBlend(targetpos, targetspan);
             pendsetting->blend((*bounds.second).second, blendf);
 
-            reset(pstartsetting, pendsetting, LLEnvironment::TRANSITION_ALTITUDE);
+            reset(pstartsetting, pendsetting, (LLSettingsBase::TrackPosition)LLEnvironment::TRANSITION_ALTITUDE);
         }
 
     protected:
@@ -304,7 +304,7 @@ namespace
             LLSettingsDay::TrackBound_t next = getBoundingEntries(adjusted_now);
             LLSettingsBase::Seconds nextspan = getSpanTime(next);
 
-            reset((*next.first).second, (*next.second).second, nextspan);
+            reset((*next.first).second, (*next.second).second, (LLSettingsBase::TrackPosition)nextspan);
 
             // Recalculate (reinitialize) position. Because:
             // - 'delta' from applyTimeDelta accumulates errors (probably should be fixed/changed to absolute time)
@@ -695,7 +695,7 @@ namespace
             // Ideally we need to check for texture in injection, but
             // in this case user is setting value explicitly, potentially
             // with different transitions, don't ignore it
-            F64 result = lerp(value, injection->mValue.asReal(), mix);
+            F64 result = lerp((F32)value, (F32)injection->mValue.asReal(), (F32)mix);
             injection->mLastValue = LLSD::Real(result);
             this->mSettings[injection->mKeyName] = injection->mLastValue;
         }
@@ -898,7 +898,7 @@ void LLEnvironment::initSingleton()
     gSavedSettings.getControl("RenderSkyAutoAdjustProbeAmbiance")->getSignal()->connect(
         [](LLControlVariable*, const LLSD& new_val, const LLSD& old_val)
         {
-            LLSettingsSky::sAutoAdjustProbeAmbiance = new_val.asReal();
+            LLSettingsSky::sAutoAdjustProbeAmbiance = (F32)new_val.asReal();
         }
     );
     LLSettingsSky::sAutoAdjustProbeAmbiance = gSavedSettings.getF32("RenderSkyAutoAdjustProbeAmbiance");
@@ -967,11 +967,11 @@ LLSettingsWater::ptr_t LLEnvironment::getCurrentWater() const
 
 void LayerConfigToDensityLayer(const LLSD& layerConfig, DensityLayer& layerOut)
 {
-    layerOut.constant_term  = layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
-    layerOut.exp_scale      = layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
-    layerOut.exp_term       = layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
-    layerOut.linear_term    = layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
-    layerOut.width          = layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
+    layerOut.constant_term  = (F32)layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
+    layerOut.exp_scale      = (F32)layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
+    layerOut.exp_term       = (F32)layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
+    layerOut.linear_term    = (F32)layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
+    layerOut.width          = (F32)layerConfig[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
 }
 
 void LLEnvironment::getAtmosphericModelSettings(AtmosphericModelSettings& settingsOut, const LLSettingsSky::ptr_t &psky)
@@ -1758,7 +1758,7 @@ void LLEnvironment::updateGLVariablesForSettings(LLShaderUniforms* uniforms, con
             //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << value << LL_ENDL;
             break;
         case LLSD::TypeReal:
-            shader->uniform1f(it.second.getShaderKey(), value.asReal());
+            shader->uniform1f(it.second.getShaderKey(), (F32)value.asReal());
             //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << value << LL_ENDL;
             break;
 
@@ -1928,8 +1928,8 @@ void LLEnvironment::adjustRegionOffset(F32 adjust)
 
     if (mEnvironments[ENV_REGION])
     {
-        F32 day_length = mEnvironments[ENV_REGION]->getDayLength();
-        F32 day_offset = mEnvironments[ENV_REGION]->getDayOffset();
+        F32 day_length = (F32)mEnvironments[ENV_REGION]->getDayLength();
+        F32 day_offset = (F32)mEnvironments[ENV_REGION]->getDayOffset();
 
         F32 day_adjustment = adjust * day_length;
 
@@ -2345,7 +2345,7 @@ LLEnvironment::EnvironmentInfo::ptr_t LLEnvironment::EnvironmentInfo::extract(LL
     {
         for (int idx = 0; idx < 3; idx++)
         {
-            pinfo->mAltitudes[idx+1] = environment[KEY_TRACKALTS][idx].asReal();
+            pinfo->mAltitudes[idx+1] = (F32)environment[KEY_TRACKALTS][idx].asReal();
         }
         pinfo->mAltitudes[0] = 0;
     }
@@ -2569,7 +2569,7 @@ void LLEnvironment::handleEnvironmentPush(LLSD &message)
     std::string action = message[KEY_ACTION].asString();
     LLUUID experience_id = message[KEY_EXPERIENCEID].asUUID();
     LLSD action_data = message[KEY_ACTIONDATA];
-    F32 transition_time = action_data[KEY_TRANSITIONTIME].asReal();
+    F32 transition_time = (F32)action_data[KEY_TRANSITIONTIME].asReal();
 
     //TODO: Check here that the viewer thinks the experience is still valid.
 
@@ -2601,7 +2601,7 @@ void LLEnvironment::handleEnvironmentPushFull(LLUUID experience_id, LLSD &messag
 {
     LLUUID asset_id(message[KEY_ASSETID].asUUID());
 
-    setExperienceEnvironment(experience_id, asset_id, LLSettingsBase::Seconds(transition));
+    setExperienceEnvironment(experience_id, asset_id, (F32)LLSettingsBase::Seconds(transition));
 }
 
 void LLEnvironment::handleEnvironmentPushPartial(LLUUID experience_id, LLSD &message, F32 transition)
@@ -2611,7 +2611,7 @@ void LLEnvironment::handleEnvironmentPushPartial(LLUUID experience_id, LLSD &mes
     if (settings.isUndefined())
         return;
 
-    setExperienceEnvironment(experience_id, settings, LLSettingsBase::Seconds(transition));
+    setExperienceEnvironment(experience_id, settings, (F32)LLSettingsBase::Seconds(transition));
 }
 
 void LLEnvironment::clearExperienceEnvironment(LLUUID experience_id, LLSettingsBase::Seconds transition_time)
@@ -2968,7 +2968,7 @@ void LLEnvironment::DayTransition::animate()
 
 
     // pause probe updates and reset reflection maps on sky change
-    gPipeline.mReflectionMapManager.pause(mTransitionTime);
+    gPipeline.mReflectionMapManager.pause((F32)mTransitionTime);
     gPipeline.mReflectionMapManager.reset();
 
     mSky = mStartSky->buildClone();
@@ -3286,7 +3286,7 @@ void LLTrackBlenderLoopingManual::switchTrack(S32 trackno, const LLSettingsBase:
 {
     mTrackNo = trackno;
 
-    LLSettingsBase::TrackPosition useposition = (position < 0.0) ? mPosition : position;
+    LLSettingsBase::TrackPosition useposition = (position < 0.0) ? (LLSettingsBase::TrackPosition)mPosition : position;
 
     setPosition(useposition);
 }
@@ -3297,7 +3297,7 @@ LLSettingsDay::TrackBound_t LLTrackBlenderLoopingManual::getBoundingEntries(F64 
 
     mEndMarker = wtrack.end();
 
-    LLSettingsDay::TrackBound_t bounds = get_bounding_entries(wtrack, position);
+    LLSettingsDay::TrackBound_t bounds = get_bounding_entries(wtrack, (LLSettingsBase::TrackPosition)position);
     return bounds;
 }
 
@@ -3571,7 +3571,7 @@ namespace
             mInjectedSky->setSource(target_sky);
 
             // clear reflection probes and pause updates during sky change
-            gPipeline.mReflectionMapManager.pause(transition);
+            gPipeline.mReflectionMapManager.pause((F32)transition);
             gPipeline.mReflectionMapManager.reset();
 
             mBlenderSky = std::make_shared<LLSettingsBlenderTimeDelta>(target_sky, start_sky, psky, transition);

--- a/indra/newview/llexpandabletextbox.cpp
+++ b/indra/newview/llexpandabletextbox.cpp
@@ -54,7 +54,7 @@ public:
         }
         else
         {
-            width = mEditor.getDocumentView()->getRect().getWidth() - mEditor.getHPad();
+            width = (F32)(mEditor.getDocumentView()->getRect().getWidth() - mEditor.getHPad());
             height = mStyle->getFont()->getLineHeight();
         }
         return true;
@@ -86,7 +86,7 @@ public:
                                     LLFontGL::RIGHT, LLFontGL::TOP,
                                     0,
                                     mStyle->getShadowType(),
-                                    end - start, draw_rect.getWidth(),
+                                    end - start, (S32)draw_rect.getWidth(),
                                     &right_x,
                                     mEditor.getUseEllipses(), mEditor.getUseColor());
         return right_x;

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2275,7 +2275,7 @@ F32 LLFace::adjustPixelArea(F32 importance, F32 pixel_area)
         {
             if(importance < LEAST_IMPORTANCE_FOR_LARGE_IMAGE)//if the face is not important, do not load hi-res.
             {
-                pixel_area = LLViewerTexture::sMinLargeImageSize ;
+                pixel_area = (F32)LLViewerTexture::sMinLargeImageSize ;
             }
         }
     }

--- a/indra/newview/llfasttimerview.cpp
+++ b/indra/newview/llfasttimerview.cpp
@@ -279,9 +279,9 @@ bool LLFastTimerView::handleHover(S32 x, S32 y, MASK mask)
                 // so we can create a new tooltip
                 LLToolTipMgr::instance().unblockToolTips();
                 mHoverTimer = mHoverID;
-                mToolTipRect.set(mBarRect.mLeft + (hover_bar->mSelfStart / mTotalTimeDisplay) * mBarRect.getWidth(),
+                mToolTipRect.set((S32)(mBarRect.mLeft + (hover_bar->mSelfStart / mTotalTimeDisplay) * mBarRect.getWidth()),
                                 row.mTop,
-                                mBarRect.mLeft + (hover_bar->mSelfEnd / mTotalTimeDisplay) * mBarRect.getWidth(),
+                                (S32)(mBarRect.mLeft + (hover_bar->mSelfEnd / mTotalTimeDisplay) * mBarRect.getWidth()),
                                 row.mBottom);
             }
         }
@@ -626,7 +626,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
             gGL.begin(LLRender::TRIANGLE_STRIP);
             gGL.vertex3fv(last_p.mV);
             gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
-            last_p.set((F32)i/(F32) base_times.size(), base_times[i]/max_time, 0.f);
+            last_p.set((F32)i/(F32) base_times.size(), (F32)(base_times[i]/max_time), 0.f);
             gGL.vertex3fv(last_p.mV);
             gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
             gGL.end();
@@ -645,7 +645,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
                 gGL.begin(LLRender::TRIANGLE_STRIP);
                 gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
                 gGL.vertex3fv(last_p.mV);
-                last_p.set((F32) i / (F32) cur_times.size(), cur_times[i]/max_time, 0.f);
+                last_p.set((F32) i / (F32) cur_times.size(), (F32)(cur_times[i]/max_time), 0.f);
                 gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
                 gGL.vertex3fv(last_p.mV);
                 gGL.end();
@@ -715,7 +715,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
             gGL.begin(LLRender::TRIANGLE_STRIP);
             gGL.vertex3fv(last_p.mV);
             gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
-            last_p.set((F32)count/(F32)total_count, *iter/max_execution, 0.f);
+            last_p.set((F32)count/(F32)total_count, (F32)(*iter/max_execution), 0.f);
             gGL.vertex3fv(last_p.mV);
             gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
             gGL.end();
@@ -735,7 +735,7 @@ void LLFastTimerView::exportCharts(const std::string& base, const std::string& t
                 gGL.begin(LLRender::TRIANGLE_STRIP);
                 gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
                 gGL.vertex3fv(last_p.mV);
-                last_p.set((F32)count/(F32)total_count, *iter/max_execution, 0.f);
+                last_p.set((F32)count/(F32)total_count, (F32)(*iter/max_execution), 0.f);
                 gGL.vertex3f(last_p.mV[0], 0.f, 0.f);
                 gGL.vertex3fv(last_p.mV);
                 gGL.end();
@@ -787,8 +787,8 @@ LLSD LLFastTimerView::analyzePerformanceLogDefault(std::istream& is)
             {
                 LLSD::Integer samples = iter->second["Calls"].asInteger();
 
-                time_stats[label].push(time);
-                sample_stats[label].push(samples);
+                time_stats[label].push((F32)time);
+                sample_stats[label].push((F32)samples);
             }
         }
         total_frames++;
@@ -1112,7 +1112,7 @@ void LLFastTimerView::drawLineGraph()
                 break;
             }
             gGL.vertex2f(x,y);
-            gGL.vertex2f(x,mGraphRect.mBottom);
+            gGL.vertex2f(x,(GLfloat)mGraphRect.mBottom);
         }
         gGL.end();
 
@@ -1432,7 +1432,7 @@ void LLFastTimerView::updateTotalTime()
         break;
     }
 
-    mTotalTimeDisplay = LLUnits::Milliseconds::fromValue(llceil(mTotalTimeDisplay.valueInUnits<LLUnits::Milliseconds>() / 20.f) * 20.f);
+    mTotalTimeDisplay = LLUnits::Milliseconds::fromValue(llceil((F32)mTotalTimeDisplay.valueInUnits<LLUnits::Milliseconds>() / 20.f) * 20.f);
 }
 
 void LLFastTimerView::drawBars()
@@ -1491,7 +1491,7 @@ void LLFastTimerView::drawBars()
         LLRect frame_bar_rect;
         frame_bar_rect.setLeftTopAndSize(mBarRect.mLeft,
                                         bars_top,
-                                        ll_round((mAverageTimerRow.mBars[0].mTotalTime / mTotalTimeDisplay) * mBarRect.getWidth()),
+                                        (S32)ll_round((mAverageTimerRow.mBars[0].mTotalTime / mTotalTimeDisplay) * mBarRect.getWidth()),
                                         bar_height);
         mAverageTimerRow.mTop = frame_bar_rect.mTop;
         mAverageTimerRow.mBottom = frame_bar_rect.mBottom;
@@ -1505,7 +1505,7 @@ void LLFastTimerView::drawBars()
             row.mTop = frame_bar_rect.mTop;
             row.mBottom = frame_bar_rect.mBottom;
             frame_bar_rect.mRight = frame_bar_rect.mLeft
-                                    + ll_round((row.mBars[0].mTotalTime / mTotalTimeDisplay) * mBarRect.getWidth());
+                                    + (S32)ll_round((row.mBars[0].mTotalTime / mTotalTimeDisplay) * mBarRect.getWidth());
             drawBar(frame_bar_rect, row, image_width, image_height);
 
             frame_bar_rect.translate(0, -(bar_height + vpad));
@@ -1633,8 +1633,8 @@ S32 LLFastTimerView::drawBar(LLRect bar_rect, TimerBarRow& row, S32 image_width,
     }
 
     LLRect children_rect;
-    children_rect.mLeft  = ll_round(timer_bar.mChildrenStart / mTotalTimeDisplay * (F32)mBarRect.getWidth()) + mBarRect.mLeft;
-    children_rect.mRight = ll_round(timer_bar.mChildrenEnd   / mTotalTimeDisplay * (F32)mBarRect.getWidth()) + mBarRect.mLeft;
+    children_rect.mLeft  = (S32)ll_round(timer_bar.mChildrenStart / mTotalTimeDisplay * (F32)mBarRect.getWidth()) + mBarRect.mLeft;
+    children_rect.mRight = (S32)ll_round(timer_bar.mChildrenEnd   / mTotalTimeDisplay * (F32)mBarRect.getWidth()) + mBarRect.mLeft;
 
     if (bar_rect.getHeight() > MIN_BAR_HEIGHT)
     {

--- a/indra/newview/llflexibleobject.cpp
+++ b/indra/newview/llflexibleobject.cpp
@@ -94,7 +94,7 @@ void LLVolumeImplFlexible::updateClass()
 {
     LL_PROFILE_ZONE_SCOPED;
 
-    U64 virtual_frame_num = LLTimer::getElapsedSeconds() / SEC_PER_FLEXI_FRAME;
+    U64 virtual_frame_num = (U64)(LLTimer::getElapsedSeconds() / SEC_PER_FLEXI_FRAME);
     for (std::vector<LLVolumeImplFlexible*>::iterator iter = sInstanceList.begin();
             iter != sInstanceList.end();
             ++iter)
@@ -362,7 +362,7 @@ void LLVolumeImplFlexible::doIdleUpdate()
                 update_period = llclamp(update_period, 1U, 32U);
 
                 // We control how fast flexies update, buy splitting updates among frames
-                U64 virtual_frame_num = LLTimer::getElapsedSeconds() / SEC_PER_FLEXI_FRAME;
+                U64 virtual_frame_num = (U64)(LLTimer::getElapsedSeconds() / SEC_PER_FLEXI_FRAME);
 
                 if  (visible)
                 {

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -488,7 +488,7 @@ void LLFloater360Capture::capture360Images()
     // 'GPano:InitialViewHeadingDegrees' field.
     // We need to convert from the angle getYaw() gives us into something
     // the XMP data field wants (N=0, E=90, S=180, W= 270 etc.)
-    mInitialHeadingDeg  = (360 + 90 - (int)(camera->getYaw() * RAD_TO_DEG)) % 360;
+    mInitialHeadingDeg  = (float)((360 + 90 - (int)(camera->getYaw() * RAD_TO_DEG)) % 360);
     LL_INFOS("360Capture") << "Recording a heading of " << (int)(mInitialHeadingDeg)
         << " Image size: " << (S32)mSourceImageSize << LL_ENDL;
 

--- a/indra/newview/llfloaterbanduration.cpp
+++ b/indra/newview/llfloaterbanduration.cpp
@@ -82,7 +82,7 @@ void LLFloaterBanDuration::onClickBan()
             LLSpinCtrl* hours_spin = getChild<LLSpinCtrl>("ban_hours");
             if (hours_spin)
             {
-                time = LLDate::now().secondsSinceEpoch() + (hours_spin->getValue().asInteger() * 3600);
+                time = (S32)(LLDate::now().secondsSinceEpoch() + (hours_spin->getValue().asInteger() * 3600));
             }
         }
         mSelectionCallback(mAvatar_ids, time);

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -1086,7 +1086,7 @@ bool    LLPreviewAnimation::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, mFullWidth, 0.0f, mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();

--- a/indra/newview/llfloaterconversationpreview.cpp
+++ b/indra/newview/llfloaterconversationpreview.cpp
@@ -111,8 +111,8 @@ void LLFloaterConversationPreview::setPages(std::list<LLSD>* messages, const std
         mCurrentPage = (mMessages->size() ? (static_cast<int>(mMessages->size()) - 1) / mPageSize : 0);
 
         mPageSpinner->setEnabled(true);
-        mPageSpinner->setMaxValue(mCurrentPage+1);
-        mPageSpinner->set(mCurrentPage+1);
+        mPageSpinner->setMaxValue((F32)(mCurrentPage+1));
+        mPageSpinner->set((F32)(mCurrentPage+1));
 
         std::string total_page_num = llformat("/ %d", mCurrentPage+1);
         getChild<LLTextBox>("page_num_label")->setValue(total_page_num);

--- a/indra/newview/llfloatereditextdaycycle.cpp
+++ b/indra/newview/llfloatereditextdaycycle.cpp
@@ -313,7 +313,7 @@ void LLFloaterEditExtDayCycle::onOpen(const LLSD& key)
     mDayLength.value(0);
     if (key.has(KEY_DAY_LENGTH))
     {
-        mDayLength.value(key[KEY_DAY_LENGTH].asReal());
+        mDayLength.value(key[KEY_DAY_LENGTH].asInteger());
     }
 
     // Time&Percentage labels
@@ -352,7 +352,7 @@ void LLFloaterEditExtDayCycle::onOpen(const LLSD& key)
 
     // Adjust Time&Percentage labels' location according to length
     LLRect label_rect = getChild<LLTextBox>("p0", true)->getRect();
-    F32 slider_width = mFramesSlider->getRect().getWidth();
+    F32 slider_width = (F32)mFramesSlider->getRect().getWidth();
     for (int i = 1; i < max_elm; i++)
     {
         LLTextBox *pcnt_label = getChild<LLTextBox>("p" + llformat("%d", i), true);
@@ -705,7 +705,7 @@ void LLFloaterEditExtDayCycle::onAddFrame()
         LL_WARNS("ENVDAYEDIT") << "Attempt to add new frame while waiting for day(asset) to load." << LL_ENDL;
         return;
     }
-    if ((mEditDay->getSettingsNearKeyframe(frame, mCurrentTrack, LLSettingsDay::DEFAULT_FRAME_SLOP_FACTOR)).second)
+    if ((mEditDay->getSettingsNearKeyframe((LLSettingsBase::TrackPosition)frame, mCurrentTrack, LLSettingsDay::DEFAULT_FRAME_SLOP_FACTOR)).second)
     {
         LL_WARNS("ENVDAYEDIT") << "Attempt to add new frame too close to existing frame." << LL_ENDL;
         return;
@@ -722,17 +722,17 @@ void LLFloaterEditExtDayCycle::onAddFrame()
         // scratch water should always have the current water settings.
         LLSettingsWater::ptr_t water(mScratchWater->buildClone());
         setting = water;
-        mEditDay->setWaterAtKeyframe( std::static_pointer_cast<LLSettingsWater>(setting), frame);
+        mEditDay->setWaterAtKeyframe( std::static_pointer_cast<LLSettingsWater>(setting), (LLSettingsBase::TrackPosition)frame);
     }
     else
     {
         // scratch sky should always have the current sky settings.
         LLSettingsSky::ptr_t sky(mScratchSky->buildClone());
         setting = sky;
-        mEditDay->setSkyAtKeyframe(sky, frame, mCurrentTrack);
+        mEditDay->setSkyAtKeyframe(sky, (LLSettingsBase::TrackPosition)frame, mCurrentTrack);
     }
     setDirtyFlag();
-    addSliderFrame(frame, setting);
+    addSliderFrame((F32)frame, setting);
     updateTabs();
 }
 
@@ -1316,7 +1316,7 @@ void LLFloaterEditExtDayCycle::removeCurrentSliderFrame()
     {
         LL_DEBUGS("ENVDAYEDIT") << "Removing frame from " << iter->second.mFrame << LL_ENDL;
         LLSettingsBase::Seconds seconds(iter->second.mFrame);
-        mEditDay->removeTrackKeyframe(mCurrentTrack, seconds);
+        mEditDay->removeTrackKeyframe(mCurrentTrack, (LLSettingsBase::TrackPosition)seconds);
         mSliderKeyMap.erase(iter);
     }
 
@@ -1474,17 +1474,17 @@ void LLFloaterEditExtDayCycle::reblendSettings()
     {
         if ((mSkyBlender->getTrack() != mCurrentTrack) && (mCurrentTrack != LLSettingsDay::TRACK_WATER))
         {
-            mSkyBlender->switchTrack(mCurrentTrack, position);
+            mSkyBlender->switchTrack(mCurrentTrack, (LLSettingsBase::TrackPosition)position);
         }
         else
         {
-            mSkyBlender->setPosition(position);
+            mSkyBlender->setPosition((LLSettingsBase::TrackPosition)position);
         }
     }
 
     if (mWaterBlender)
     {
-        mWaterBlender->setPosition(position);
+        mWaterBlender->setPosition((LLSettingsBase::TrackPosition)position);
     }
 }
 
@@ -1517,7 +1517,7 @@ bool LLFloaterEditExtDayCycle::isAddingFrameAllowed()
     if (!mFramesSlider->getCurSlider().empty() || !mEditDay) return false;
 
     LLSettingsBase::Seconds frame(mTimeSlider->getCurSliderValue());
-    if ((mEditDay->getSettingsNearKeyframe(frame, mCurrentTrack, LLSettingsDay::DEFAULT_FRAME_SLOP_FACTOR)).second)
+    if ((mEditDay->getSettingsNearKeyframe((LLSettingsBase::TrackPosition)frame, mCurrentTrack, LLSettingsDay::DEFAULT_FRAME_SLOP_FACTOR)).second)
     {
         return false;
     }

--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -101,7 +101,7 @@ public:
         LLScrollingPanel::draw();
 
         F32 x = 4; // padding-left
-        F32 y = getRect().getHeight() / 2;
+        F32 y = (F32)(getRect().getHeight() / 2);
         LLFontGL::getFontSansSerif()->render(
             mText,                           // wstr
             0,                               // begin_offset
@@ -137,8 +137,8 @@ public:
     {
         LLScrollingPanel::draw();
 
-        F32 x = getRect().getWidth() / 2;
-        F32 y = getRect().getHeight() / 2;
+        F32 x = (F32)(getRect().getWidth() / 2);
+        F32 y = (F32)(getRect().getHeight() / 2);
         LLFontGL::getFontEmojiLarge()->render(
             mChar,                      // wstr
             0,                          // begin_offset
@@ -206,7 +206,7 @@ public:
         static LLColor4 defaultColor(0.75f, 0.75f, 0.75f, 1.0f);
         LLColor4 textColor = LLUIColorTable::instance().getColor("MenuItemEnabledColor", defaultColor);
         S32 max_pixels = clientWidth - iconWidth;
-        drawName(iconWidth, centerY, max_pixels, textColor);
+        drawName((F32)iconWidth, centerY, max_pixels, textColor);
     }
 
 protected:
@@ -229,7 +229,7 @@ protected:
     void drawName(F32 x, F32 y, S32 max_pixels, LLColor4& color)
     {
         F32 x0 = x;
-        F32 x1 = max_pixels;
+        F32 x1 = (F32)max_pixels;
         LLFontGL* font = LLFontGL::getFontEmojiLarge();
         if (mBegin)
         {
@@ -245,7 +245,7 @@ protected:
                 LLFontGL::NORMAL,              // style
                 LLFontGL::DROP_SHADOW_SOFT,    // shadow
                 static_cast<S32>(text.size()), // max_chars
-                x1);                           // max_pixels
+                (S32)x1);                      // max_pixels
             F32 dx = font->getWidthF32(text);
             x0 += dx;
             x1 -= dx;
@@ -264,7 +264,7 @@ protected:
                 LLFontGL::NORMAL,              // style
                 LLFontGL::DROP_SHADOW_SOFT,    // shadow
                 static_cast<S32>(text.size()), // max_chars
-                x1);                           // max_pixels
+                (S32)x1);                      // max_pixels
             F32 dx = font->getWidthF32(text);
             x0 += dx;
             x1 -= dx;
@@ -283,7 +283,7 @@ protected:
                 LLFontGL::NORMAL,              // style
                 LLFontGL::DROP_SHADOW_SOFT,    // shadow
                 static_cast<S32>(text.size()), // max_chars
-                x1);                           // max_pixels
+                (S32)x1);                      // max_pixels
         }
     }
 
@@ -864,7 +864,7 @@ void LLFloaterEmojiPicker::onGroupButtonClick(LLUICtrl* ctrl)
         if (it == mGroupButtons.end())
             return;
 
-        selectEmojiGroup(it - mGroupButtons.begin());
+        selectEmojiGroup((U32)(it - mGroupButtons.begin()));
     }
 }
 

--- a/indra/newview/llfloaterenvironmentadjust.cpp
+++ b/indra/newview/llfloaterenvironmentadjust.cpp
@@ -292,7 +292,7 @@ void LLFloaterEnvironmentAdjust::onHazeHorizonChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setHazeHorizon(getChild<LLUICtrl>(FIELD_SKY_HAZE_HORIZON)->getValue().asReal());
+    mLiveSky->setHazeHorizon((F32)getChild<LLUICtrl>(FIELD_SKY_HAZE_HORIZON)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -300,7 +300,7 @@ void LLFloaterEnvironmentAdjust::onHazeDensityChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setHazeDensity(getChild<LLUICtrl>(FIELD_SKY_HAZE_DENSITY)->getValue().asReal());
+    mLiveSky->setHazeDensity((F32)getChild<LLUICtrl>(FIELD_SKY_HAZE_DENSITY)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -308,7 +308,7 @@ void LLFloaterEnvironmentAdjust::onSceneGammaChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setGamma(getChild<LLUICtrl>(FIELD_SKY_SCENE_GAMMA)->getValue().asReal());
+    mLiveSky->setGamma((F32)getChild<LLUICtrl>(FIELD_SKY_SCENE_GAMMA)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -324,7 +324,7 @@ void LLFloaterEnvironmentAdjust::onCloudCoverageChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setCloudShadow(getChild<LLUICtrl>(FIELD_SKY_CLOUD_COVERAGE)->getValue().asReal());
+    mLiveSky->setCloudShadow((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_COVERAGE)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -332,7 +332,7 @@ void LLFloaterEnvironmentAdjust::onCloudScaleChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setCloudScale(getChild<LLUICtrl>(FIELD_SKY_CLOUD_SCALE)->getValue().asReal());
+    mLiveSky->setCloudScale((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_SCALE)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -340,7 +340,7 @@ void LLFloaterEnvironmentAdjust::onGlowChanged()
 {
     if (!mLiveSky)
         return;
-    LLColor3 glow(getChild<LLUICtrl>(FIELD_SKY_GLOW_SIZE)->getValue().asReal(), 0.0f, getChild<LLUICtrl>(FIELD_SKY_GLOW_FOCUS)->getValue().asReal());
+    LLColor3 glow((F32)getChild<LLUICtrl>(FIELD_SKY_GLOW_SIZE)->getValue().asReal(), 0.0f, (F32)getChild<LLUICtrl>(FIELD_SKY_GLOW_FOCUS)->getValue().asReal());
 
     // takes 0 - 1.99 UI range -> 40 -> 0.2 range
     glow.mV[0] = (2.0f - glow.mV[0]) * SLIDER_SCALE_GLOW_R;
@@ -354,7 +354,7 @@ void LLFloaterEnvironmentAdjust::onStarBrightnessChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setStarBrightness(getChild<LLUICtrl>(FIELD_SKY_STAR_BRIGHTNESS)->getValue().asReal());
+    mLiveSky->setStarBrightness((F32)getChild<LLUICtrl>(FIELD_SKY_STAR_BRIGHTNESS)->getValue().asReal());
     mLiveSky->update();
 }
 
@@ -375,8 +375,8 @@ void LLFloaterEnvironmentAdjust::onSunRotationChanged()
 
 void LLFloaterEnvironmentAdjust::onSunAzimElevChanged()
 {
-    F32 azimuth = getChild<LLUICtrl>(FIELD_SKY_SUN_AZIMUTH)->getValue().asReal();
-    F32 elevation = getChild<LLUICtrl>(FIELD_SKY_SUN_ELEVATION)->getValue().asReal();
+    F32 azimuth = (F32)getChild<LLUICtrl>(FIELD_SKY_SUN_AZIMUTH)->getValue().asReal();
+    F32 elevation = (F32)getChild<LLUICtrl>(FIELD_SKY_SUN_ELEVATION)->getValue().asReal();
     LLQuaternion quat;
 
     azimuth *= DEG_TO_RAD;
@@ -405,7 +405,7 @@ void LLFloaterEnvironmentAdjust::onSunScaleChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setSunScale((getChild<LLUICtrl>(FIELD_SKY_SUN_SCALE)->getValue().asReal()));
+    mLiveSky->setSunScale((F32)(getChild<LLUICtrl>(FIELD_SKY_SUN_SCALE)->getValue().asReal()));
     mLiveSky->update();
 }
 
@@ -426,8 +426,8 @@ void LLFloaterEnvironmentAdjust::onMoonRotationChanged()
 
 void LLFloaterEnvironmentAdjust::onMoonAzimElevChanged()
 {
-    F32 azimuth = getChild<LLUICtrl>(FIELD_SKY_MOON_AZIMUTH)->getValue().asReal();
-    F32 elevation = getChild<LLUICtrl>(FIELD_SKY_MOON_ELEVATION)->getValue().asReal();
+    F32 azimuth = (F32)getChild<LLUICtrl>(FIELD_SKY_MOON_AZIMUTH)->getValue().asReal();
+    F32 elevation = (F32)getChild<LLUICtrl>(FIELD_SKY_MOON_ELEVATION)->getValue().asReal();
     LLQuaternion quat;
 
     azimuth *= DEG_TO_RAD;
@@ -483,7 +483,7 @@ void LLFloaterEnvironmentAdjust::onSunColorChanged()
 void LLFloaterEnvironmentAdjust::onReflectionProbeAmbianceChanged()
 {
     if (!mLiveSky) return;
-    F32 ambiance = getChild<LLUICtrl>(FIELD_REFLECTION_PROBE_AMBIANCE)->getValue().asReal();
+    F32 ambiance = (F32)getChild<LLUICtrl>(FIELD_REFLECTION_PROBE_AMBIANCE)->getValue().asReal();
     mLiveSky->setReflectionProbeAmbiance(ambiance);
 
     updateGammaLabel();

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -671,7 +671,7 @@ bool LLImagePreviewAvatar::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, mFullWidth, 0.0f, mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -875,7 +875,7 @@ bool LLImagePreviewSculpted::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, mFullWidth, 0.0f, mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();

--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -263,8 +263,8 @@ bool    LLFloaterIMNearbyChatScreenChannel::createPoolToast()
 
     LLToast::Params p;
     p.panel = panel;
-    p.lifetime_secs = gSavedSettings.getS32("NearbyToastLifeTime");
-    p.fading_time_secs = gSavedSettings.getS32("NearbyToastFadingTime");
+    p.lifetime_secs = (F32)gSavedSettings.getS32("NearbyToastLifeTime");
+    p.fading_time_secs = (F32)gSavedSettings.getS32("NearbyToastFadingTime");
 
     LLToast* toast = new LLFloaterIMNearbyChatToast(p, this);
 

--- a/indra/newview/llfloaterland.cpp
+++ b/indra/newview/llfloaterland.cpp
@@ -1706,7 +1706,7 @@ void LLPanelLandObjects::processParcelObjectOwnersReply(LLMessageSystem *msg, vo
 
         object_count_str = llformat("%d", object_count);
         item_params.columns.add().value(object_count_str).font(FONT).column("count");
-        item_params.columns.add().value(LLDate((time_t)most_recent_time)).font(FONT).column("mostrecent").type("date");
+        item_params.columns.add().value(LLDate((double)most_recent_time)).font(FONT).column("mostrecent").type("date");
 
         self->mOwnerList->addNameItemRow(item_params);
         LL_DEBUGS() << "object owner " << owner_id << " (" << (is_group_owned ? "group" : "agent")
@@ -2527,7 +2527,7 @@ void LLPanelLandAccess::refresh()
                 if (entry.mTime != 0)
                 {
                     LLStringUtil::format_map_t args;
-                    S32 now = time(NULL);
+                    S32 now = (S32)time(NULL);
                     S32 seconds = entry.mTime - now;
                     if (seconds < 0) seconds = 0;
                     prefix.assign(" (");
@@ -2576,7 +2576,7 @@ void LLPanelLandAccess::refresh()
                 if (entry.mTime != 0)
                 {
                     LLStringUtil::format_map_t args;
-                    S32 now = time(NULL);
+                    S32 now = (S32)time(NULL);
                     seconds = entry.mTime - now;
                     if (seconds < 0) seconds = 0;
 

--- a/indra/newview/llfloatermemleak.cpp
+++ b/indra/newview/llfloatermemleak.cpp
@@ -60,7 +60,7 @@ LLFloaterMemLeak::LLFloaterMemLeak(const LLSD& key)
 bool LLFloaterMemLeak::postBuild(void)
 {
     F32 a, b ;
-    a = getChild<LLUICtrl>("leak_speed")->getValue().asReal();
+    a = (F32)getChild<LLUICtrl>("leak_speed")->getValue().asReal();
     if(a > (F32)(0xFFFFFFFF))
     {
         sMemLeakingSpeed = 0xFFFFFFFF ;
@@ -69,7 +69,7 @@ bool LLFloaterMemLeak::postBuild(void)
     {
         sMemLeakingSpeed = (U32)a ;
     }
-    b = getChild<LLUICtrl>("max_leak")->getValue().asReal();
+    b = (F32)getChild<LLUICtrl>("max_leak")->getValue().asReal();
     if(b > (F32)0xFFF)
     {
         sMaxLeakedMem = 0xFFFFFFFF ;
@@ -150,8 +150,7 @@ void LLFloaterMemLeak::idle()
 //----------------------
 void LLFloaterMemLeak::onChangeLeakingSpeed()
 {
-    F32 tmp ;
-    tmp =getChild<LLUICtrl>("leak_speed")->getValue().asReal();
+    F32 tmp = (F32)getChild<LLUICtrl>("leak_speed")->getValue().asReal();
 
     if(tmp > (F32)0xFFFFFFFF)
     {
@@ -161,14 +160,11 @@ void LLFloaterMemLeak::onChangeLeakingSpeed()
     {
         sMemLeakingSpeed = (U32)tmp ;
     }
-
 }
 
 void LLFloaterMemLeak::onChangeMaxMemLeaking()
 {
-
-    F32 tmp ;
-    tmp =getChild<LLUICtrl>("max_leak")->getValue().asReal();
+    F32 tmp = (F32)getChild<LLUICtrl>("max_leak")->getValue().asReal();
     if(tmp > (F32)0xFFF)
     {
         sMaxLeakedMem = 0xFFFFFFFF ;
@@ -177,7 +173,6 @@ void LLFloaterMemLeak::onChangeMaxMemLeaking()
     {
         sMaxLeakedMem = ((U32)tmp) << 20 ;
     }
-
 }
 
 void LLFloaterMemLeak::onClickStart()

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -1198,7 +1198,7 @@ void LLFloaterModelPreview::initDecompControls()
                 else if (LLSpinCtrl* spinner = dynamic_cast<LLSpinCtrl*>(ctrl))
                 {
                     bool is_retain_ctrl = "Retain%" == name;
-                    double coefficient = is_retain_ctrl ? RETAIN_COEFFICIENT : 1.f;
+                    float coefficient = is_retain_ctrl ? (F32)RETAIN_COEFFICIENT : 1.f;
 
                     spinner->setMinValue(param[i].mDetails.mRange.mLow.mFloat * coefficient);
                     spinner->setMaxValue(param[i].mDetails.mRange.mHigh.mFloat * coefficient);
@@ -1238,10 +1238,10 @@ void LLFloaterModelPreview::initDecompControls()
                 LLUICtrl* ctrl = getChild<LLUICtrl>(name);
                 if (LLSliderCtrl* slider = dynamic_cast<LLSliderCtrl*>(ctrl))
                 {
-                    slider->setMinValue(param[i].mDetails.mRange.mLow.mIntOrEnumValue);
-                    slider->setMaxValue(param[i].mDetails.mRange.mHigh.mIntOrEnumValue);
-                    slider->setIncrement(param[i].mDetails.mRange.mDelta.mIntOrEnumValue);
-                    slider->setValue(param[i].mDefault.mIntOrEnumValue);
+                    slider->setMinValue((F32)param[i].mDetails.mRange.mLow.mIntOrEnumValue);
+                    slider->setMaxValue((F32)param[i].mDetails.mRange.mHigh.mIntOrEnumValue);
+                    slider->setIncrement((F32)param[i].mDetails.mRange.mDelta.mIntOrEnumValue);
+                    slider->setValue((F32)param[i].mDefault.mIntOrEnumValue);
                     slider->setCommitCallback(onPhysicsParamCommit, (void*) &param[i]);
                 }
                 else if (LLComboBox* combo_box = dynamic_cast<LLComboBox*>(ctrl))

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1101,7 +1101,7 @@ void LLFloaterPreference::onNameTagOpacityChange(const LLSD& newvalue)
     if (color_swatch)
     {
         LLColor4 new_color = color_swatch->get();
-        color_swatch->set( new_color.setAlpha(newvalue.asReal()) );
+        color_swatch->set(new_color.setAlpha((F32)newvalue.asReal()));
     }
 }
 

--- a/indra/newview/llfloaterprofiletexture.cpp
+++ b/indra/newview/llfloaterprofiletexture.cpp
@@ -244,8 +244,8 @@ void LLFloaterProfileTexture::updateDimensions()
     if (biggest_dim > MAX_DIMENTIONS)
     {
         F32 scale_down = MAX_DIMENTIONS / (F32)biggest_dim;
-        width *= scale_down;
-        height *= scale_down;
+        width = (S32)(width * scale_down);
+        height = (S32)(height * scale_down);
     }
 
     //reshape floater

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -519,7 +519,7 @@ void LLFloaterRegionInfo::processRegionInfo(LLMessageSystem* msg)
     panel->getChild<LLUICtrl>("object_bonus_spin")->setValue(LLSD(object_bonus_factor));
     panel->getChild<LLUICtrl>("access_combo")->setValue(LLSD(sim_access));
 
-    panel->getChild<LLSpinCtrl>("agent_limit_spin")->setMaxValue(hard_agent_limit);
+    panel->getChild<LLSpinCtrl>("agent_limit_spin")->setMaxValue((F32)hard_agent_limit);
 
     LLPanelRegionGeneralInfo* panel_general = LLFloaterRegionInfo::getPanelGeneral();
     if (panel)
@@ -1931,11 +1931,11 @@ bool LLPanelRegionTerrainInfo::sendUpdate()
                 for (U32 tt = 0; tt < LLGLTFMaterial::GLTF_TEXTURE_INFO_COUNT; ++tt)
                 {
                     LLGLTFMaterial::TextureTransform& transform = mat_override->mTextureTransform[tt];
-                    transform.mScale.mV[VX] = mMaterialScaleUCtrl[i]->getValue().asReal();
-                    transform.mScale.mV[VY] = mMaterialScaleVCtrl[i]->getValue().asReal();
-                    transform.mRotation = mMaterialRotationCtrl[i]->getValue().asReal() * DEG_TO_RAD;
-                    transform.mOffset.mV[VX] = mMaterialOffsetUCtrl[i]->getValue().asReal();
-                    transform.mOffset.mV[VY] = mMaterialOffsetVCtrl[i]->getValue().asReal();
+                    transform.mScale.mV[VX] = (F32)mMaterialScaleUCtrl[i]->getValue().asReal();
+                    transform.mScale.mV[VY] = (F32)mMaterialScaleVCtrl[i]->getValue().asReal();
+                    transform.mRotation = (F32)mMaterialRotationCtrl[i]->getValue().asReal() * DEG_TO_RAD;
+                    transform.mOffset.mV[VX] = (F32)mMaterialOffsetUCtrl[i]->getValue().asReal();
+                    transform.mOffset.mV[VY] = (F32)mMaterialOffsetVCtrl[i]->getValue().asReal();
                 }
             }
 

--- a/indra/newview/llfloatersettingsdebug.cpp
+++ b/indra/newview/llfloatersettingsdebug.cpp
@@ -131,10 +131,10 @@ void LLFloaterSettingsDebug::onCommitSettings()
         controlp->set(vectord.getValue());
         break;
       case TYPE_QUAT:
-        quat.mQ[VX] = getChild<LLUICtrl>("val_spinner_1")->getValue().asReal();
-        quat.mQ[VY] = getChild<LLUICtrl>("val_spinner_2")->getValue().asReal();
-        quat.mQ[VZ] = getChild<LLUICtrl>("val_spinner_3")->getValue().asReal();
-        quat.mQ[VS] = getChild<LLUICtrl>("val_spinner_4")->getValue().asReal();;
+        quat.mQ[VX] = (F32)getChild<LLUICtrl>("val_spinner_1")->getValue().asReal();
+        quat.mQ[VY] = (F32)getChild<LLUICtrl>("val_spinner_2")->getValue().asReal();
+        quat.mQ[VZ] = (F32)getChild<LLUICtrl>("val_spinner_3")->getValue().asReal();
+        quat.mQ[VS] = (F32)getChild<LLUICtrl>("val_spinner_4")->getValue().asReal();;
         controlp->set(quat.getValue());
         break;
       case TYPE_RECT:

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -168,10 +168,10 @@ void LLFloaterSnapshotBase::ImplBase::updateLayout(LLFloaterSnapshotBase* floate
         panel_width = 700.f;
     }
 
-    S32 floater_width = 224.f;
+    S32 floater_width{ 224 };
     if(mAdvanced)
     {
-        floater_width = floater_width + panel_width;
+        floater_width = floater_width + (S32)panel_width;
     }
 
     LLUICtrl* thumbnail_placeholder = floaterp->getChild<LLUICtrl>("thumbnail_placeholder");
@@ -185,7 +185,7 @@ void LLFloaterSnapshotBase::ImplBase::updateLayout(LLFloaterSnapshotBase* floate
     }
     if (!mSkipReshaping)
     {
-        thumbnail_placeholder->reshape(panel_width, thumbnail_placeholder->getRect().getHeight());
+        thumbnail_placeholder->reshape((S32)panel_width, thumbnail_placeholder->getRect().getHeight());
         if (!floaterp->isMinimized())
         {
             floaterp->reshape(floater_width, floaterp->getRect().getHeight());
@@ -283,7 +283,7 @@ void LLFloaterSnapshot::Impl::updateControls(LLFloaterSnapshotBase* floater)
             width_ctrl->setValue(w);
             if (getActiveSnapshotType(floater) == LLSnapshotModel::SNAPSHOT_TEXTURE)
             {
-                width_ctrl->setIncrement(w >> 1);
+                width_ctrl->setIncrement((F32)(w >> 1));
             }
         }
         if (height_ctrl->getValue().asInteger() == 0)
@@ -293,7 +293,7 @@ void LLFloaterSnapshot::Impl::updateControls(LLFloaterSnapshotBase* floater)
             height_ctrl->setValue(h);
             if (getActiveSnapshotType(floater) == LLSnapshotModel::SNAPSHOT_TEXTURE)
             {
-                height_ctrl->setIncrement(h >> 1);
+                height_ctrl->setIncrement((F32)(h >> 1));
             }
         }
 
@@ -303,9 +303,9 @@ void LLFloaterSnapshot::Impl::updateControls(LLFloaterSnapshotBase* floater)
             S32 width = gViewerWindow->getWindowWidthRaw();
             S32 height = gViewerWindow->getWindowHeightRaw();
 
-            width_ctrl->setMaxValue(width);
+            width_ctrl->setMaxValue((F32)width);
 
-            height_ctrl->setMaxValue(height);
+            height_ctrl->setMaxValue((F32)height);
 
             if (width_ctrl->getValue().asInteger() > width)
             {
@@ -761,8 +761,8 @@ void LLFloaterSnapshot::Impl::updateResolution(LLUICtrl* ctrl, void* data, bool 
             getHeightSpinner(view)->setValue(height);
             if (getActiveSnapshotType(view) == LLSnapshotModel::SNAPSHOT_TEXTURE)
             {
-                getWidthSpinner(view)->setIncrement(width >> 1);
-                getHeightSpinner(view)->setIncrement(height >> 1);
+                getWidthSpinner(view)->setIncrement((F32)(width >> 1));
+                getHeightSpinner(view)->setIncrement((F32)(height >> 1));
             }
         }
 
@@ -882,8 +882,8 @@ void LLFloaterSnapshot::Impl::setImageSizeSpinnersValues(LLFloaterSnapshotBase* 
     getHeightSpinner(view)->forceSetValue(height);
     if (getActiveSnapshotType(view) == LLSnapshotModel::SNAPSHOT_TEXTURE)
     {
-        getWidthSpinner(view)->setIncrement(width >> 1);
-        getHeightSpinner(view)->setIncrement(height >> 1);
+        getWidthSpinner(view)->setIncrement((F32)(width >> 1));
+        getHeightSpinner(view)->setIncrement((F32)(height >> 1));
     }
 }
 

--- a/indra/newview/llfloatertopobjects.cpp
+++ b/indra/newview/llfloatertopobjects.cpp
@@ -195,7 +195,7 @@ void LLFloaterTopObjects::handleReply(LLMessageSystem *msg, void** data)
             {
                 parcel_buf = parcel_name;
                 script_memory = script_size;
-                total_memory += script_size;
+                total_memory += (U64)script_size;
             }
         }
 
@@ -233,7 +233,7 @@ void LLFloaterTopObjects::handleReply(LLMessageSystem *msg, void** data)
 
         columns[column_num]["column"] = "time";
         columns[column_num]["type"] = "date";
-        columns[column_num]["value"] = LLDate((time_t)time_stamp);
+        columns[column_num]["value"] = LLDate((double)time_stamp);
         columns[column_num++]["font"] = "SANSSERIF";
 
         if (mCurrentMode == STAT_REPORT_TOP_SCRIPTS

--- a/indra/newview/llfloateruipreview.cpp
+++ b/indra/newview/llfloateruipreview.cpp
@@ -1598,7 +1598,7 @@ void LLOverlapPanel::draw()
 
     if(!LLView::sPreviewClickedElement)
     {
-        LLUI::translate(5,getRect().getHeight()-20);    // translate to top-5,left-5
+        LLUI::translate(5.f, (F32)getRect().getHeight() - 20.f);    // translate to top-5,left-5
         LLView::sDrawPreviewHighlights = false;
         LLFontGL::getFontSansSerifSmall()->renderUTF8(current_selection_text, 0, 0, 0, text_color,
                 LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::NO_SHADOW);
@@ -1614,7 +1614,7 @@ void LLOverlapPanel::draw()
         std::list<LLView*> overlappers = mOverlapMap[LLView::sPreviewClickedElement];
         if(overlappers.size() == 0)
         {
-            LLUI::translate(5,getRect().getHeight()-20);    // translate to top-5,left-5
+            LLUI::translate(5.f, (F32)getRect().getHeight() - 20.f);    // translate to top-5,left-5
             LLView::sDrawPreviewHighlights = false;
             std::string current_selection = std::string(current_selection_text + LLView::sPreviewClickedElement->getName() + " (no elements overlap)");
             S32 text_width = LLFontGL::getFontSansSerifSmall()->getWidth(current_selection) + 10;
@@ -1679,14 +1679,14 @@ void LLOverlapPanel::draw()
             setRect(LLRect(rect.mLeft,rect.mTop,rect.mRight,rect.mTop-height_sum));
         }
 
-        LLUI::translate(5,getRect().getHeight()-10);    // translate to top left
+        LLUI::translate(5.f, (F32)getRect().getHeight() - 10.f);    // translate to top left
         LLView::sDrawPreviewHighlights = false;
 
         // draw currently-selected element at top of overlappers
-        LLUI::translate(0,-mSpacing);
+        LLUI::translate(0.f, -(F32)mSpacing);
         LLFontGL::getFontSansSerifSmall()->renderUTF8(current_selection_text + LLView::sPreviewClickedElement->getName(), 0, 0, 0, text_color,
                 LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::NO_SHADOW);
-        LLUI::translate(0,-mSpacing-LLView::sPreviewClickedElement->getRect().getHeight()); // skip spacing distance + height
+        LLUI::translate(0.f, -(F32)mSpacing - (F32)LLView::sPreviewClickedElement->getRect().getHeight()); // skip spacing distance + height
         LLView::sPreviewClickedElement->draw();
 
         for(std::list<LLView*>::iterator overlap_it = overlappers.begin(); overlap_it != overlappers.end(); ++overlap_it)
@@ -1694,16 +1694,16 @@ void LLOverlapPanel::draw()
             LLView* viewp = *overlap_it;
 
             // draw separating line
-            LLUI::translate(0,-mSpacing);
+            LLUI::translate(0.f, -(F32)mSpacing);
             gl_line_2d(0,0,getRect().getWidth()-10,0,LLColor4(192.0f/255.0f,192.0f/255.0f,192.0f/255.0f));
 
             // draw name
-            LLUI::translate(0,-mSpacing);
+            LLUI::translate(0.f, -(F32)mSpacing);
             LLFontGL::getFontSansSerifSmall()->renderUTF8(overlapper_text + viewp->getName(), 0, 0, 0, text_color,
                     LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::NO_SHADOW);
 
             // draw element
-            LLUI::translate(0,-mSpacing-viewp->getRect().getHeight());  // skip spacing distance + height
+            LLUI::translate(0.f, -(F32)mSpacing - (F32)viewp->getRect().getHeight());  // skip spacing distance + height
             viewp->draw();
         }
         mLastClickedElement = LLView::sPreviewClickedElement;

--- a/indra/newview/llglsandbox.cpp
+++ b/indra/newview/llglsandbox.cpp
@@ -893,7 +893,7 @@ void LLSky::renderSunMoonBeacons(const LLVector3& pos_agent, const LLVector3& di
     {
         pos_end.mV[i] = pos_agent.mV[i] + (50 * direction.mV[i]);
     }
-    glLineWidth(LLPipeline::DebugBeaconLineWidth);
+    glLineWidth((GLfloat)LLPipeline::DebugBeaconLineWidth);
     gGL.begin(LLRender::LINES);
     color.mV[3] *= 0.5f;
     gGL.color4fv(color.mV);
@@ -1190,8 +1190,8 @@ F32 gpu_benchmark()
     F32 ms = gBenchmarkProgram.mTimeElapsed/1000000.f;
     F32 seconds = ms/1000.f;
 
-    F64 samples_drawn = gBenchmarkProgram.mSamplesDrawn;
-    F32 samples_sec = (samples_drawn/1000000000.0)/seconds;
+    F64 samples_drawn = (F64)gBenchmarkProgram.mSamplesDrawn;
+    F32 samples_sec = (F32)((samples_drawn/1000000000.0)/seconds);
     gbps = samples_sec*4;  // 4 bytes per sample
 
     LL_INFOS("Benchmark") << "Memory bandwidth is " << llformat("%.3f", gbps) << " GB/sec according to ARB_timer_query, total time " << seconds << " seconds" << LL_ENDL;

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -462,7 +462,7 @@ bool LLGLTFPreviewTexture::render()
     // Set up camera and viewport
     const LLVector3 origin(0.0, 0.0, 0.0);
     camera.lookAt(origin, object_position);
-    camera.setAspect(mFullHeight / mFullWidth);
+    camera.setAspect((F32)(mFullHeight / mFullWidth));
     const LLRect texture_rect(0, mFullHeight, mFullWidth, 0);
     camera.setPerspective(NOT_FOR_SELECTION, texture_rect.mLeft, texture_rect.mBottom, texture_rect.getWidth(), texture_rect.getHeight(), false, camera.getNear(), MAX_FAR_CLIP*2.f);
 

--- a/indra/newview/llgroupmgr.cpp
+++ b/indra/newview/llgroupmgr.cpp
@@ -190,7 +190,7 @@ S32 LLGroupRoleData::getMembersInRole(uuid_vec_t members,
     in_role_end = std::set_intersection(mMemberIDs.begin(), mMemberIDs.end(),
                                     members.begin(), members.end(),
                                     in_role.begin());
-    return in_role_end - in_role.begin();
+    return (S32)(in_role_end - in_role.begin());
 }
 
 void LLGroupRoleData::addMember(const LLUUID& member)
@@ -1569,7 +1569,7 @@ void LLGroupMgr::addGroup(LLGroupMgrGroupData* group_datap)
     {
         // LRU: Remove the oldest un-observed group from cache until group size is small enough
 
-        F32 oldest_access = LLFrameTimer::getTotalSeconds();
+        F32 oldest_access = (F32)LLFrameTimer::getTotalSeconds();
         group_map_t::iterator oldest_gi = mGroups.end();
 
         for (group_map_t::iterator gi = mGroups.begin(); gi != mGroups.end(); ++gi )

--- a/indra/newview/llheroprobemanager.cpp
+++ b/indra/newview/llheroprobemanager.cpp
@@ -98,7 +98,7 @@ void LLHeroProbeManager::update()
     if (mMipChain.empty())
     {
         U32 res = mProbeResolution;
-        U32 count = log2((F32)res) + 0.5f;
+        U32 count = (U32)(log2((F32)res) + 0.5f);
 
         mMipChain.resize(count);
         for (U32 i = 0; i < count; ++i)
@@ -341,7 +341,7 @@ void LLHeroProbeManager::updateProbeFace(LLReflectionMap* probe, U32 face, bool 
             gGaussianProgram.unbind();
         }
 
-        S32 mips = log2((F32)mProbeResolution) + 0.5f;
+        S32 mips = (S32)(log2((F32)mProbeResolution) + 0.5f);
 
         gReflectionMipProgram.bind();
         S32 diffuseChannel = gReflectionMipProgram.enableTexture(LLShaderMgr::DEFERRED_DIFFUSE, LLTexUnit::TT_TEXTURE);
@@ -431,7 +431,7 @@ void LLHeroProbeManager::generateRadiance(LLReflectionMap* probe)
                 static LLStaticHashedString sStrength("probe_strength");
 
                 gHeroRadianceGenProgram.uniform1f(sRoughness, (F32) i / (F32) (mMipChain.size() - 1));
-                gHeroRadianceGenProgram.uniform1f(sMipLevel, i);
+                gHeroRadianceGenProgram.uniform1f(sMipLevel, (GLfloat)i);
                 gHeroRadianceGenProgram.uniform1i(sWidth, mProbeResolution);
                 gHeroRadianceGenProgram.uniform1f(sStrength, 1);
 
@@ -533,7 +533,7 @@ void LLHeroProbeManager::initReflectionMaps()
         mReset = false;
         mReflectionProbeCount = count;
         mProbeResolution      = gSavedSettings.getS32("RenderHeroProbeResolution");
-        mMaxProbeLOD = log2f(mProbeResolution) - 1.f; // number of mips - 1
+        mMaxProbeLOD = log2f((F32)mProbeResolution) - 1.f; // number of mips - 1
 
         mTexture = new LLCubeMapArray();
 

--- a/indra/newview/llhttpretrypolicy.cpp
+++ b/indra/newview/llhttpretrypolicy.cpp
@@ -180,7 +180,7 @@ bool LLAdaptiveRetryPolicy::getSecondsUntilRetryAfter(const std::string& retry_a
     time_t date = curl_getdate(retry_after.c_str(), NULL);
     if (-1 == date) return false;
 
-    seconds_to_wait = (F64)date - LLTimer::getTotalSeconds();
+    seconds_to_wait = (F32)((F64)date - LLTimer::getTotalSeconds());
 
     return true;
 }

--- a/indra/newview/llhudnametag.cpp
+++ b/indra/newview/llhudnametag.cpp
@@ -449,7 +449,7 @@ void LLHUDNameTag::addLine(const std::string &text_utf8,
                         // token does does not fit into signle line, need to draw "...".
                         // Use four dots for ellipsis width to generate padding
                         const LLWString dots_pad(utf8str_to_wstring(std::string("....")));
-                        S32 elipses_width = font->getWidthF32(dots_pad.c_str());
+                        S32 elipses_width = (S32)font->getWidthF32(dots_pad.c_str());
                         // truncated string length
                         segment_length = font->maxDrawableChars(iter->substr(line_length).c_str(), max_pixels - elipses_width, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
                         const LLWString dots(utf8str_to_wstring(std::string("...")));
@@ -780,7 +780,7 @@ void LLHUDNameTag::updateAll()
     }
 
     LLTrace::CountStatHandle<>* camera_vel_stat = LLViewerCamera::getVelocityStat();
-    F32 camera_vel = LLTrace::get_frame_recording().getLastRecording().getPerSec(*camera_vel_stat);
+    F32 camera_vel = (F32)LLTrace::get_frame_recording().getLastRecording().getPerSec(*camera_vel_stat);
     if (camera_vel > MAX_STABLE_CAMERA_VELOCITY)
     {
         return;

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -1607,7 +1607,7 @@ void LLIMProcessing::requestOfflineMessagesCoro(std::string url)
         }
         else
         {
-            position.set(message_data["local_x"].asReal(), message_data["local_y"].asReal(), message_data["local_z"].asReal());
+            position.set((F32)message_data["local_x"].asReal(), (F32)message_data["local_y"].asReal(), (F32)message_data["local_z"].asReal());
         }
 
         std::vector<U8> bin_bucket;

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -4242,7 +4242,7 @@ public:
                 message_params["region_id"].asUUID(),
                 ll_vector3_from_sd(message_params["position"]),
                 false,      // is_region_message
-                timestamp);
+                (U32)timestamp);
 
             if (LLMuteList::getInstance()->isMuted(from_id, name, LLMute::flagTextChat))
             {

--- a/indra/newview/llinspecttexture.cpp
+++ b/indra/newview/llinspecttexture.cpp
@@ -152,7 +152,7 @@ void LLTexturePreviewView::draw()
 
         bool isLoading = (!m_Image->isFullyLoaded()) && (m_Image->getDiscardLevel() > 0);
         if (isLoading)
-            LLFontGL::getFontSansSerif()->renderUTF8(mLoadingText, 0, llfloor(rctClient.mLeft + 3),  llfloor(rctClient.mTop - 25), LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
+            LLFontGL::getFontSansSerif()->renderUTF8(mLoadingText, 0, rctClient.mLeft + 3, rctClient.mTop - 25, LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
         m_Image->addTextureStats((isLoading) ? MAX_IMAGE_AREA : (F32)(rctClient.getWidth() * rctClient.getHeight()));
     }
 }

--- a/indra/newview/llinventoryfilter.cpp
+++ b/indra/newview/llinventoryfilter.cpp
@@ -1519,7 +1519,7 @@ LLInventoryFilter& LLInventoryFilter::operator=( const  LLInventoryFilter&  othe
 
 void LLInventoryFilter::toParams(Params& params) const
 {
-    params.filter_ops.types = getFilterObjectTypes();
+    params.filter_ops.types = (U32)getFilterObjectTypes();
     params.filter_ops.category_types = getFilterCategoryTypes();
     if (getFilterObjectTypes() & FILTERTYPE_WEARABLE)
     {
@@ -1532,7 +1532,7 @@ void LLInventoryFilter::toParams(Params& params) const
     params.filter_ops.show_folder_state = getShowFolderState();
     params.filter_ops.creator_type = getFilterCreatorType();
     params.filter_ops.permissions = getFilterPermissions();
-    params.filter_ops.search_visibility = getSearchVisibilityTypes();
+    params.filter_ops.search_visibility = (U32)getSearchVisibilityTypes();
     params.substring = getFilterSubString();
     params.since_logoff = isSinceLogoff();
 }
@@ -1646,7 +1646,7 @@ bool LLInventoryFilter::isTimedOut()
 void LLInventoryFilter::resetTime(S32 timeout)
 {
     mFilterTime.reset();
-    F32 time_in_sec = (F32)(timeout)/1000.0;
+    F32 time_in_sec = (F32)(timeout)/1000.0f;
     mFilterTime.setTimerExpirySec(time_in_sec);
 }
 

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -2641,7 +2641,7 @@ bool LLInventoryGallery::checkAgainstFilterType(const LLUUID& object_id)
     {
         object_type = inv_item->getInventoryType();
     }
-    const U32 filterTypes = mFilter->getFilterTypes();
+    const U32 filterTypes = (U32)mFilter->getFilterTypes();
 
     if ((filterTypes & LLInventoryFilter::FILTERTYPE_OBJECT) && inv_item)
     {

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -425,7 +425,7 @@ void LLInventoryPanel::setFilterWorn()
 
 U32 LLInventoryPanel::getFilterObjectTypes() const
 {
-    return getFilter().getFilterObjectTypes();
+    return (U32)getFilter().getFilterObjectTypes();
 }
 
 U32 LLInventoryPanel::getFilterPermMask() const

--- a/indra/newview/lljoystickbutton.cpp
+++ b/indra/newview/lljoystickbutton.cpp
@@ -732,8 +732,8 @@ LLJoystickQuaternion::LLJoystickQuaternion(const LLJoystickQuaternion::Params &p
 {
     for (int i = 0; i < 3; ++i)
     {
-        mLfRtAxis.mV[i] = (mXAxisIndex == i) ? 1.0 : 0.0;
-        mUpDnAxis.mV[i] = (mYAxisIndex == i) ? 1.0 : 0.0;
+        mLfRtAxis.mV[i] = (mXAxisIndex == i) ? 1.0f : 0.0f;
+        mUpDnAxis.mV[i] = (mYAxisIndex == i) ? 1.0f : 0.0f;
     }
 }
 
@@ -864,8 +864,8 @@ void LLJoystickQuaternion::draw()
     LLVector3 draw_point = mVectorZero * mRotation;
     S32 halfwidth = getRect().getWidth() / 2;
     S32 halfheight = getRect().getHeight() / 2;
-    draw_point.mV[mXAxisIndex] = (draw_point.mV[mXAxisIndex] + 1.0) * halfwidth;
-    draw_point.mV[mYAxisIndex] = (draw_point.mV[mYAxisIndex] + 1.0) * halfheight;
+    draw_point.mV[mXAxisIndex] = (draw_point.mV[mXAxisIndex] + 1.0f) * halfwidth;
+    draw_point.mV[mYAxisIndex] = (draw_point.mV[mYAxisIndex] + 1.0f) * halfheight;
 
     gl_circle_2d(draw_point.mV[mXAxisIndex], draw_point.mV[mYAxisIndex], 4, 8,
         draw_point.mV[mZAxisIndex] >= 0.f);

--- a/indra/newview/llmachineid.cpp
+++ b/indra/newview/llmachineid.cpp
@@ -293,7 +293,7 @@ bool LLWMIMethods::getGenericSerialNumber(const BSTR &select, const LPCWSTR &var
         if (validate_as_uuid)
         {
             std::wstring ws(serialNumber, serial_size);
-            std::string str(ws.begin(), ws.end());
+            std::string str = ll_convert_wide_to_string(ws);
 
             if (!LLUUID::validate(str))
             {

--- a/indra/newview/llmanip.cpp
+++ b/indra/newview/llmanip.cpp
@@ -450,10 +450,10 @@ void LLManip::renderXYZ(const LLVector3 &vec)
         gGL.color4f(0.f, 0.f, 0.f, 0.7f);
 
         imagep->draw(
-            (window_center_x - 115) * display_scale.mV[VX],
-            (window_center_y + vertical_offset - PAD) * display_scale.mV[VY],
-            235 * display_scale.mV[VX],
-            (PAD * 2 + 10) * display_scale.mV[VY],
+            (S32)((window_center_x - 115) * display_scale.mV[VX]),
+            (S32)((window_center_y + vertical_offset - PAD) * display_scale.mV[VY]),
+            (S32)(235 * display_scale.mV[VX]),
+            (S32)((PAD * 2 + 10) * display_scale.mV[VY]),
             LLColor4(0.f, 0.f, 0.f, 0.7f) );
 
         LLFontGL* font = LLFontGL::getFontSansSerif();
@@ -463,33 +463,33 @@ void LLManip::renderXYZ(const LLVector3 &vec)
         // render drop shadowed text (manually because of bigger 'distance')
         F32 right_x;
         feedback_string = llformat("X: %.3f", vec.mV[VX]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 102.f + 1.f, window_center_y + vertical_offset - 2.f, LLColor4::black,
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 102.f + 1.f, (F32)(window_center_y + vertical_offset) - 2.f, LLColor4::black,
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
 
         feedback_string = llformat("Y: %.3f", vec.mV[VY]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 27.f + 1.f, window_center_y + vertical_offset - 2.f, LLColor4::black,
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 27.f + 1.f, (F32)(window_center_y + vertical_offset) - 2.f, LLColor4::black,
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
 
         feedback_string = llformat("Z: %.3f", vec.mV[VZ]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x + 48.f + 1.f, window_center_y + vertical_offset - 2.f, LLColor4::black,
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x + 48.f + 1.f, (F32)(window_center_y + vertical_offset) - 2.f, LLColor4::black,
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
 
         // render text on top
         feedback_string = llformat("X: %.3f", vec.mV[VX]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 102.f, window_center_y + vertical_offset, LLColor4(1.f, 0.5f, 0.5f, 1.f),
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 102.f, (F32)(window_center_y + vertical_offset), LLColor4(1.f, 0.5f, 0.5f, 1.f),
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
 
         feedback_string = llformat("Y: %.3f", vec.mV[VY]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 27.f, window_center_y + vertical_offset, LLColor4(0.5f, 1.f, 0.5f, 1.f),
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x - 27.f, (F32)(window_center_y + vertical_offset), LLColor4(0.5f, 1.f, 0.5f, 1.f),
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
 
         feedback_string = llformat("Z: %.3f", vec.mV[VZ]);
-        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x + 48.f, window_center_y + vertical_offset, LLColor4(0.5f, 0.5f, 1.f, 1.f),
+        font->render(utf8str_to_wstring(feedback_string), 0, window_center_x + 48.f, (F32)(window_center_y + vertical_offset), LLColor4(0.5f, 0.5f, 1.f, 1.f),
             LLFontGL::LEFT, LLFontGL::BASELINE,
             LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, 1000, &right_x);
     }

--- a/indra/newview/llmanipscale.cpp
+++ b/indra/newview/llmanipscale.cpp
@@ -884,7 +884,7 @@ void LLManipScale::dragCorner( S32 x, S32 y )
     {
         F32 drag_dist = mScaleDir * projected_drag_pos1; // Projecting the drag position allows for negative results, vs using the length which will result in a "reverse scaling" bug.
 
-        F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + projected_drag_pos1, mScaleDir, mScaleSnapUnit1, mTickPixelSpacing1), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
+        F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + projected_drag_pos1, mScaleDir, mScaleSnapUnit1, (S32)mTickPixelSpacing1), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
         F32 snap_dist = mScaleSnapUnit1 / (2.f * cur_subdivisions);
         F32 relative_snap_dist = fmodf(drag_dist + snap_dist, mScaleSnapUnit1 / cur_subdivisions);
 
@@ -902,7 +902,7 @@ void LLManipScale::dragCorner( S32 x, S32 y )
     {
         F32 drag_dist = mScaleDir * projected_drag_pos2; // Projecting the drag position allows for negative results, vs using the length which will result in a "reverse scaling" bug.
 
-        F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + projected_drag_pos2, mScaleDir, mScaleSnapUnit2, mTickPixelSpacing2), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
+        F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + projected_drag_pos2, mScaleDir, mScaleSnapUnit2, (S32)mTickPixelSpacing2), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
         F32 snap_dist = mScaleSnapUnit2 / (2.f * cur_subdivisions);
         F32 relative_snap_dist = fmodf(drag_dist + snap_dist, mScaleSnapUnit2 / cur_subdivisions);
 
@@ -1113,7 +1113,7 @@ void LLManipScale::dragFace( S32 x, S32 y )
         else
         {
             F32 drag_dist = scale_center_to_mouse * mScaleDir;
-            F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + mScaleDir * drag_dist, mScaleDir, mScaleSnapUnit1, mTickPixelSpacing1), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
+            F32 cur_subdivisions = llclamp(getSubdivisionLevel(mScaleCenter + mScaleDir * drag_dist, mScaleDir, mScaleSnapUnit1, (S32)mTickPixelSpacing1), sGridMinSubdivisionLevel, sGridMaxSubdivisionLevel);
             F32 snap_dist = mScaleSnapUnit1 / (2.f * cur_subdivisions);
             F32 relative_snap_dist = fmodf(drag_dist + snap_dist, mScaleSnapUnit1 / cur_subdivisions);
             relative_snap_dist -= snap_dist;
@@ -1542,8 +1542,8 @@ void LLManipScale::updateSnapGuides(const LLBBox& bbox)
     mScaleSnapUnit1 = mScaleSnapUnit1 / (mSnapDir1 * mScaleDir);
     mScaleSnapUnit2 = mScaleSnapUnit2 / (mSnapDir2 * mScaleDir);
 
-    mTickPixelSpacing1 = ll_round((F32)MIN_DIVISION_PIXEL_WIDTH / (mScaleDir % mSnapGuideDir1).length());
-    mTickPixelSpacing2 = ll_round((F32)MIN_DIVISION_PIXEL_WIDTH / (mScaleDir % mSnapGuideDir2).length());
+    mTickPixelSpacing1 = (F32)ll_round((F32)MIN_DIVISION_PIXEL_WIDTH / (mScaleDir % mSnapGuideDir1).length());
+    mTickPixelSpacing2 = (F32)ll_round((F32)MIN_DIVISION_PIXEL_WIDTH / (mScaleDir % mSnapGuideDir2).length());
 
     if (uniform)
     {
@@ -1608,8 +1608,8 @@ void LLManipScale::renderSnapGuides(const LLBBox& bbox)
         F32 dist_scale_units_2 = dist_grid_axis / smallest_subdivision2;
 
         // find distance to nearest smallest grid unit
-        F32 grid_multiple1 = llfloor(dist_scale_units_1);
-        F32 grid_multiple2 = llfloor(dist_scale_units_2);
+        F32 grid_multiple1 = (F32)llfloor(dist_scale_units_1);
+        F32 grid_multiple2 = (F32)llfloor(dist_scale_units_2);
         F32 grid_offset1 = fmodf(dist_grid_axis, smallest_subdivision1);
         F32 grid_offset2 = fmodf(dist_grid_axis, smallest_subdivision2);
 

--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -648,7 +648,7 @@ void LLMaterialEditor::setBaseColor(const LLColor4& color)
 
 F32 LLMaterialEditor::getTransparency()
 {
-    return childGetValue("transparency").asReal();
+    return (F32)childGetValue("transparency").asReal();
 }
 
 void LLMaterialEditor::setTransparency(F32 transparency)
@@ -668,7 +668,7 @@ void LLMaterialEditor::setAlphaMode(const std::string& alpha_mode)
 
 F32 LLMaterialEditor::getAlphaCutoff()
 {
-    return childGetValue("alpha cutoff").asReal();
+    return (F32)childGetValue("alpha cutoff").asReal();
 }
 
 void LLMaterialEditor::setAlphaCutoff(F32 alpha_cutoff)
@@ -708,7 +708,7 @@ void LLMaterialEditor::setMetallicRoughnessUploadId(const LLUUID& id)
 
 F32 LLMaterialEditor::getMetalnessFactor()
 {
-    return childGetValue("metalness factor").asReal();
+    return (F32)childGetValue("metalness factor").asReal();
 }
 
 void LLMaterialEditor::setMetalnessFactor(F32 factor)
@@ -718,7 +718,7 @@ void LLMaterialEditor::setMetalnessFactor(F32 factor)
 
 F32 LLMaterialEditor::getRoughnessFactor()
 {
-    return childGetValue("roughness factor").asReal();
+    return (F32)childGetValue("roughness factor").asReal();
 }
 
 void LLMaterialEditor::setRoughnessFactor(F32 factor)
@@ -2618,13 +2618,13 @@ bool LLMaterialEditor::setFromGltfModel(const tinygltf::Model& model, S32 index,
         }
 
         setAlphaMode(material_in.alphaMode);
-        setAlphaCutoff(material_in.alphaCutoff);
+        setAlphaCutoff((F32)material_in.alphaCutoff);
 
         setBaseColor(LLTinyGLTFHelper::getColor(material_in.pbrMetallicRoughness.baseColorFactor));
         setEmissiveColor(LLTinyGLTFHelper::getColor(material_in.emissiveFactor));
 
-        setMetalnessFactor(material_in.pbrMetallicRoughness.metallicFactor);
-        setRoughnessFactor(material_in.pbrMetallicRoughness.roughnessFactor);
+        setMetalnessFactor((F32)material_in.pbrMetallicRoughness.metallicFactor);
+        setRoughnessFactor((F32)material_in.pbrMetallicRoughness.roughnessFactor);
 
         setDoubleSided(material_in.doubleSided);
     }

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -1869,7 +1869,7 @@ EMeshProcessingResult LLMeshRepoThread::headerReceived(const LLVolumeParams& mes
         llssize dsize = data_size;
         char* result_ptr = strip_deprecated_header((char*)data, dsize, &header_size);
 
-        data_size = dsize;
+        data_size = (S32)dsize;
 
         boost::iostreams::stream<boost::iostreams::array_source> stream(result_ptr, data_size);
 
@@ -1910,8 +1910,8 @@ EMeshProcessingResult LLMeshRepoThread::headerReceived(const LLVolumeParams& mes
 
         {
             LLMutexLock lock(mHeaderMutex);
-            mMeshHeader[mesh_id] = { header_size, header };
-            LLMeshRepository::sCacheBytesHeaders += header_size;
+            mMeshHeader[mesh_id] = { (U32)header_size, header };
+            LLMeshRepository::sCacheBytesHeaders += (U32)header_size;
         }
 
         LLMutexLock lock(mMutex); // make sure only one thread access mPendingLOD at the same time.
@@ -4763,7 +4763,7 @@ F32 LLMeshCostData::getRadiusBasedStreamingCost(F32 radius)
 
 F32 LLMeshCostData::getTriangleBasedStreamingCost()
 {
-    F32 result = ANIMATED_OBJECT_COST_PER_KTRI * 0.001 * getEstTrisForStreamingCost();
+    F32 result = ANIMATED_OBJECT_COST_PER_KTRI * 0.001f * getEstTrisForStreamingCost();
     return result;
 }
 
@@ -5473,7 +5473,7 @@ void on_new_single_inventory_upload_complete(
                 LL_INFOS() << "inventory_item_flags " << inventory_item_flags << LL_ENDL;
             }
         }
-        S32 creation_date_now = time_corrected();
+        S32 creation_date_now = (S32)time_corrected();
         LLPointer<LLViewerInventoryItem> item = new LLViewerInventoryItem(
             server_response["new_inventory_item"].asUUID(),
             item_folder_id,

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -242,7 +242,7 @@ void LLModelPreview::updateDimentionsAndOffsets()
 
     std::set<LLModel*> accounted;
 
-    mPelvisZOffset = mFMP ? mFMP->childGetValue("pelvis_offset").asReal() : 3.0f;
+    mPelvisZOffset = mFMP ? (F32)mFMP->childGetValue("pelvis_offset").asReal() : 3.0f;
 
     if (mFMP && mFMP->childGetValue("upload_joints").asBoolean())
     {
@@ -272,7 +272,7 @@ void LLModelPreview::updateDimentionsAndOffsets()
         }
     }
 
-    F32 scale = mFMP ? mFMP->childGetValue("import_scale").asReal()*2.f : 2.f;
+    F32 scale = mFMP ? (F32)mFMP->childGetValue("import_scale").asReal()*2.f : 2.f;
 
     mDetailsSignal((F32)(mPreviewScale[0] * scale), (F32)(mPreviewScale[1] * scale), (F32)(mPreviewScale[2] * scale));
 
@@ -293,7 +293,7 @@ void LLModelPreview::rebuildUploadData()
 
     LLSpinCtrl* scale_spinner = mFMP->getChild<LLSpinCtrl>("import_scale");
 
-    F32 scale = scale_spinner->getValue().asReal();
+    F32 scale = (F32)scale_spinner->getValue().asReal();
 
     LLMatrix4 scale_mat;
     scale_mat.initScale(LLVector3(scale, scale, scale));
@@ -1290,7 +1290,7 @@ void LLModelPreview::generateNormals()
         return;
     }
 
-    F32 angle_cutoff = mFMP->childGetValue("crease_angle").asReal();
+    F32 angle_cutoff = (F32)mFMP->childGetValue("crease_angle").asReal();
 
     mRequestedCreaseAngle[which_lod] = angle_cutoff;
 
@@ -1489,7 +1489,7 @@ F32 LLModelPreview::genMeshOptimizerPerModel(LLModel *base_model, LLModel *targe
         target_indices = 3;
     }
 
-    size_new_indices = LLMeshOptimizer::simplifyU32(
+    size_new_indices = (S32)LLMeshOptimizer::simplifyU32(
         output_indices,
         source_indices,
         size_indices,
@@ -1730,7 +1730,7 @@ F32 LLModelPreview::genMeshOptimizerPerFace(LLModel *base_model, LLModel *target
         target_indices = 3;
     }
 
-    size_new_indices = LLMeshOptimizer::simplify(
+    size_new_indices = (S32)LLMeshOptimizer::simplify(
         output_indices,
         source_indices,
         size_indices,
@@ -1851,7 +1851,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
         {
             if (!enforce_tri_limit)
             {
-                triangle_limit = base_triangle_count;
+                triangle_limit = (F32)base_triangle_count;
                 // reset to default value for this lod
                 F32 pw = pow((F32)decimation, (F32)(LLModel::LOD_HIGH - which_lod));
 
@@ -1861,7 +1861,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
             {
 
                 // UI spacifies limit for all models of single lod
-                triangle_limit = mFMP->childGetValue("lod_triangle_limit_" + lod_name[which_lod]).asInteger();
+                triangle_limit = (F32)mFMP->childGetValue("lod_triangle_limit_" + lod_name[which_lod]).asReal();
 
             }
             // meshoptimizer doesn't use triangle limit, it uses indices limit, so convert it to aproximate ratio
@@ -1871,14 +1871,14 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
         else
         {
             // UI shows 0 to 100%, but meshoptimizer works with 0 to 1
-            lod_error_threshold = mFMP->childGetValue("lod_error_threshold_" + lod_name[which_lod]).asReal() / 100.f;
+            lod_error_threshold = (F32)mFMP->childGetValue("lod_error_threshold_" + lod_name[which_lod]).asReal() / 100.f;
         }
     }
     else
     {
         // we are genrating all lods and each lod will get own indices_decimator
         indices_decimator = 1;
-        triangle_limit = base_triangle_count;
+        triangle_limit = (F32)base_triangle_count;
     }
 
     mMaxTriangleLimit = base_triangle_count;
@@ -1906,7 +1906,7 @@ void LLModelPreview::genMeshOptimizerLODs(S32 which_lod, S32 meshopt_mode, U32 d
             }
         }
 
-        mRequestedTriangleCount[lod] = triangle_limit;
+        mRequestedTriangleCount[lod] = (S32)triangle_limit;
         mRequestedErrorThreshold[lod] = lod_error_threshold * 100;
         mRequestedLoDMode[lod] = lod_mode;
 
@@ -2748,7 +2748,7 @@ void LLModelPreview::updateLodControls(S32 lod)
         LLSpinCtrl* threshold = mFMP->getChild<LLSpinCtrl>("lod_error_threshold_" + lod_name[lod]);
         LLSpinCtrl* limit = mFMP->getChild<LLSpinCtrl>("lod_triangle_limit_" + lod_name[lod]);
 
-        limit->setMaxValue(mMaxTriangleLimit);
+        limit->setMaxValue((F32)mMaxTriangleLimit);
         limit->forceSetValue(mRequestedTriangleCount[lod]);
 
         threshold->forceSetValue(mRequestedErrorThreshold[lod]);
@@ -2760,8 +2760,8 @@ void LLModelPreview::updateLodControls(S32 lod)
             limit->setVisible(true);
             threshold->setVisible(false);
 
-            limit->setMaxValue(mMaxTriangleLimit);
-            limit->setIncrement(llmax((U32)1, mMaxTriangleLimit / 32));
+            limit->setMaxValue((F32)mMaxTriangleLimit);
+            limit->setIncrement((F32)llmax((U32)1, mMaxTriangleLimit / 32));
         }
         else
         {
@@ -3222,7 +3222,7 @@ bool LLModelPreview::render()
         gGL.matrixMode(LLRender::MM_PROJECTION);
         gGL.pushMatrix();
         gGL.loadIdentity();
-        gGL.ortho(0.0f, width, 0.0f, height, -1.0f, 1.0f);
+        gGL.ortho(0.0f, (F32)width, 0.0f, (F32)height, -1.0f, 1.0f);
 
         gGL.matrixMode(LLRender::MM_MODELVIEW);
         gGL.pushMatrix();
@@ -3360,7 +3360,7 @@ bool LLModelPreview::render()
         mFMP->childSetEnabled("upload_joints", upload_skin);
     }
 
-    F32 explode = mFMP->childGetValue("physics_explode").asReal();
+    F32 explode = (F32)mFMP->childGetValue("physics_explode").asReal();
 
     LLGLDepthTest gls_depth(GL_TRUE); // SL-12781 re-enable z-buffer for 3D model preview
 

--- a/indra/newview/llnavigationbar.cpp
+++ b/indra/newview/llnavigationbar.cpp
@@ -705,7 +705,7 @@ void LLNavigationBar::resizeLayoutPanel()
 {
     LLRect nav_bar_rect = mNavigationPanel->getRect();
 
-    S32 nav_panel_width = (nav_bar_rect.getWidth() + mFavoritePanel->getRect().getWidth()) * gSavedPerAccountSettings.getF32("NavigationBarRatio");
+    S32 nav_panel_width = (S32)((nav_bar_rect.getWidth() + mFavoritePanel->getRect().getWidth()) * gSavedPerAccountSettings.getF32("NavigationBarRatio"));
 
     nav_bar_rect.setLeftTopAndSize(nav_bar_rect.mLeft, nav_bar_rect.mTop, nav_panel_width, nav_bar_rect.getHeight());
     mNavigationPanel->handleReshape(nav_bar_rect,true);

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -435,7 +435,7 @@ void LLNetMap::draw()
             }
 
             F32 dist_to_cursor_squared = dist_vec_squared(LLVector2(pos_map.mV[VX], pos_map.mV[VY]),
-                                          LLVector2(local_mouse_x,local_mouse_y));
+                                          LLVector2((F32)local_mouse_x, (F32)local_mouse_y));
             if(dist_to_cursor_squared < min_pick_dist_squared && dist_to_cursor_squared < closest_dist_squared)
             {
                 closest_dist_squared = dist_to_cursor_squared;
@@ -475,7 +475,7 @@ void LLNetMap::draw()
                       dot_width);
 
             F32 dist_to_cursor_squared = dist_vec_squared(LLVector2(pos_map.mV[VX], pos_map.mV[VY]),
-                                          LLVector2(local_mouse_x,local_mouse_y));
+                                          LLVector2((F32)local_mouse_x, (F32)local_mouse_y));
             if(dist_to_cursor_squared < min_pick_dist_squared && dist_to_cursor_squared < closest_dist_squared)
             {
                 mClosestAgentToCursor = gAgent.getID();
@@ -671,7 +671,7 @@ LLVector3d LLNetMap::viewPosToGlobal( S32 x, S32 y )
 bool LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
 {
     // note that clicks are reversed from what you'd think: i.e. > 0  means zoom out, < 0 means zoom in
-    F32 new_scale = mScale * pow(MAP_SCALE_ZOOM_FACTOR, -clicks);
+    F32 new_scale = mScale * (F32)pow(MAP_SCALE_ZOOM_FACTOR, -clicks);
     F32 old_scale = mScale;
 
     setScale(new_scale);
@@ -681,8 +681,8 @@ bool LLNetMap::handleScrollWheel(S32 x, S32 y, S32 clicks)
     {
         // Adjust pan to center the zoom on the mouse pointer
         LLVector2 zoom_offset;
-        zoom_offset.mV[VX] = x - getRect().getWidth() / 2;
-        zoom_offset.mV[VY] = y - getRect().getHeight() / 2;
+        zoom_offset.mV[VX] = (F32)(x - getRect().getWidth() / 2);
+        zoom_offset.mV[VY] = (F32)(y - getRect().getHeight() / 2);
         mCurPan -= zoom_offset * mScale / old_scale - zoom_offset;
     }
 

--- a/indra/newview/llnotificationtiphandler.cpp
+++ b/indra/newview/llnotificationtiphandler.cpp
@@ -121,12 +121,12 @@ bool LLTipHandler::processNotification(const LLNotificationPtr& notification, bo
     if (exp_time > cur_time)
     {
         // we have non-default expiration time - keep visible until expires
-        p.lifetime_secs = exp_time.secondsSinceEpoch() - cur_time.secondsSinceEpoch();
+        p.lifetime_secs = (F32)(exp_time.secondsSinceEpoch() - cur_time.secondsSinceEpoch());
     }
     else
     {
         // use default time
-        p.lifetime_secs = gSavedSettings.getS32("NotificationTipToastLifeTime");
+        p.lifetime_secs = (F32)gSavedSettings.getS32("NotificationTipToastLifeTime");
     }
 
     LLScreenChannel* channel = dynamic_cast<LLScreenChannel*>(mChannel.get());

--- a/indra/newview/llpanelclassified.cpp
+++ b/indra/newview/llpanelclassified.cpp
@@ -479,8 +479,8 @@ void LLPanelClassifiedInfo::stretchSnapshot()
     // Lets increase texture height to force texture look as expected.
     rc.mBottom -= BTN_HEIGHT_SMALL;
 
-    F32 t_width = texture->getFullWidth();
-    F32 t_height = texture->getFullHeight();
+    F32 t_width = (F32)texture->getFullWidth();
+    F32 t_height = (F32)texture->getFullHeight();
 
     F32 ratio = llmin<F32>( (rc.getWidth() / t_width), (rc.getHeight() / t_height) );
 

--- a/indra/newview/llpaneleditsky.cpp
+++ b/indra/newview/llpaneleditsky.cpp
@@ -248,7 +248,7 @@ void LLPanelSettingsSkyAtmosTab::onBlueDensityChanged()
 void LLPanelSettingsSkyAtmosTab::onHazeHorizonChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setHazeHorizon(getChild<LLUICtrl>(FIELD_SKY_HAZE_HORIZON)->getValue().asReal());
+    mSkySettings->setHazeHorizon((F32)getChild<LLUICtrl>(FIELD_SKY_HAZE_HORIZON)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -256,7 +256,7 @@ void LLPanelSettingsSkyAtmosTab::onHazeHorizonChanged()
 void LLPanelSettingsSkyAtmosTab::onHazeDensityChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setHazeDensity(getChild<LLUICtrl>(FIELD_SKY_HAZE_DENSITY)->getValue().asReal());
+    mSkySettings->setHazeDensity((F32)getChild<LLUICtrl>(FIELD_SKY_HAZE_DENSITY)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -264,7 +264,7 @@ void LLPanelSettingsSkyAtmosTab::onHazeDensityChanged()
 void LLPanelSettingsSkyAtmosTab::onSceneGammaChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setGamma(getChild<LLUICtrl>(FIELD_SKY_SCENE_GAMMA)->getValue().asReal());
+    mSkySettings->setGamma((F32)getChild<LLUICtrl>(FIELD_SKY_SCENE_GAMMA)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -272,7 +272,7 @@ void LLPanelSettingsSkyAtmosTab::onSceneGammaChanged()
 void LLPanelSettingsSkyAtmosTab::onDensityMultipChanged()
 {
     if (!mSkySettings) return;
-    F32 density_mult = getChild<LLUICtrl>(FIELD_SKY_DENSITY_MULTIP)->getValue().asReal();
+    F32 density_mult = (F32)getChild<LLUICtrl>(FIELD_SKY_DENSITY_MULTIP)->getValue().asReal();
     density_mult *= SLIDER_SCALE_DENSITY_MULTIPLIER;
     mSkySettings->setDensityMultiplier(density_mult);
     mSkySettings->update();
@@ -282,7 +282,7 @@ void LLPanelSettingsSkyAtmosTab::onDensityMultipChanged()
 void LLPanelSettingsSkyAtmosTab::onDistanceMultipChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setDistanceMultiplier(getChild<LLUICtrl>(FIELD_SKY_DISTANCE_MULTIP)->getValue().asReal());
+    mSkySettings->setDistanceMultiplier((F32)getChild<LLUICtrl>(FIELD_SKY_DISTANCE_MULTIP)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -290,7 +290,7 @@ void LLPanelSettingsSkyAtmosTab::onDistanceMultipChanged()
 void LLPanelSettingsSkyAtmosTab::onMaxAltChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setMaxY(getChild<LLUICtrl>(FIELD_SKY_MAX_ALT)->getValue().asReal());
+    mSkySettings->setMaxY((F32)getChild<LLUICtrl>(FIELD_SKY_MAX_ALT)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -298,7 +298,7 @@ void LLPanelSettingsSkyAtmosTab::onMaxAltChanged()
 void LLPanelSettingsSkyAtmosTab::onMoistureLevelChanged()
 {
     if (!mSkySettings) return;
-    F32 moisture_level  = getChild<LLUICtrl>(FIELD_SKY_DENSITY_MOISTURE_LEVEL)->getValue().asReal();
+    F32 moisture_level = (F32)getChild<LLUICtrl>(FIELD_SKY_DENSITY_MOISTURE_LEVEL)->getValue().asReal();
     mSkySettings->setSkyMoistureLevel(moisture_level);
     mSkySettings->update();
     setIsDirty();
@@ -307,7 +307,7 @@ void LLPanelSettingsSkyAtmosTab::onMoistureLevelChanged()
 void LLPanelSettingsSkyAtmosTab::onDropletRadiusChanged()
 {
     if (!mSkySettings) return;
-    F32 droplet_radius = getChild<LLUICtrl>(FIELD_SKY_DENSITY_DROPLET_RADIUS)->getValue().asReal();
+    F32 droplet_radius = (F32)getChild<LLUICtrl>(FIELD_SKY_DENSITY_DROPLET_RADIUS)->getValue().asReal();
     mSkySettings->setSkyDropletRadius(droplet_radius);
     mSkySettings->update();
     setIsDirty();
@@ -316,7 +316,7 @@ void LLPanelSettingsSkyAtmosTab::onDropletRadiusChanged()
 void LLPanelSettingsSkyAtmosTab::onIceLevelChanged()
 {
     if (!mSkySettings) return;
-    F32 ice_level = getChild<LLUICtrl>(FIELD_SKY_DENSITY_ICE_LEVEL)->getValue().asReal();
+    F32 ice_level = (F32)getChild<LLUICtrl>(FIELD_SKY_DENSITY_ICE_LEVEL)->getValue().asReal();
     mSkySettings->setSkyIceLevel(ice_level);
     mSkySettings->update();
     setIsDirty();
@@ -325,7 +325,7 @@ void LLPanelSettingsSkyAtmosTab::onIceLevelChanged()
 void LLPanelSettingsSkyAtmosTab::onReflectionProbeAmbianceChanged()
 {
     if (!mSkySettings) return;
-    F32 ambiance = getChild<LLUICtrl>(FIELD_REFLECTION_PROBE_AMBIANCE)->getValue().asReal();
+    F32 ambiance = (F32)getChild<LLUICtrl>(FIELD_REFLECTION_PROBE_AMBIANCE)->getValue().asReal();
 
     mSkySettings->setReflectionProbeAmbiance(ambiance);
     mSkySettings->update();
@@ -446,7 +446,7 @@ void LLPanelSettingsSkyCloudTab::onCloudColorChanged()
 void LLPanelSettingsSkyCloudTab::onCloudCoverageChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setCloudShadow(getChild<LLUICtrl>(FIELD_SKY_CLOUD_COVERAGE)->getValue().asReal());
+    mSkySettings->setCloudShadow((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_COVERAGE)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -454,14 +454,14 @@ void LLPanelSettingsSkyCloudTab::onCloudCoverageChanged()
 void LLPanelSettingsSkyCloudTab::onCloudScaleChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setCloudScale(getChild<LLUICtrl>(FIELD_SKY_CLOUD_SCALE)->getValue().asReal());
+    mSkySettings->setCloudScale((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_SCALE)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsSkyCloudTab::onCloudVarianceChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setCloudVariance(getChild<LLUICtrl>(FIELD_SKY_CLOUD_VARIANCE)->getValue().asReal());
+    mSkySettings->setCloudVariance((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_VARIANCE)->getValue().asReal());
     setIsDirty();
 }
 
@@ -484,9 +484,9 @@ void LLPanelSettingsSkyCloudTab::onCloudMapChanged()
 void LLPanelSettingsSkyCloudTab::onCloudDensityChanged()
 {
     if (!mSkySettings) return;
-    LLColor3 density(getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_X)->getValue().asReal(),
-        getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_Y)->getValue().asReal(),
-        getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_D)->getValue().asReal());
+    LLColor3 density((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_X)->getValue().asReal(),
+        (F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_Y)->getValue().asReal(),
+        (F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DENSITY_D)->getValue().asReal());
 
     mSkySettings->setCloudPosDensity1(density);
     setIsDirty();
@@ -495,9 +495,9 @@ void LLPanelSettingsSkyCloudTab::onCloudDensityChanged()
 void LLPanelSettingsSkyCloudTab::onCloudDetailChanged()
 {
     if (!mSkySettings) return;
-    LLColor3 detail(getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_X)->getValue().asReal(),
-        getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_Y)->getValue().asReal(),
-        getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_D)->getValue().asReal());
+    LLColor3 detail((F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_X)->getValue().asReal(),
+        (F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_Y)->getValue().asReal(),
+        (F32)getChild<LLUICtrl>(FIELD_SKY_CLOUD_DETAIL_D)->getValue().asReal());
 
     mSkySettings->setCloudPosDensity2(detail);
     setIsDirty();
@@ -626,7 +626,7 @@ void LLPanelSettingsSkySunMoonTab::onSunMoonColorChanged()
 void LLPanelSettingsSkySunMoonTab::onGlowChanged()
 {
     if (!mSkySettings) return;
-    LLColor3 glow(getChild<LLUICtrl>(FIELD_SKY_GLOW_SIZE)->getValue().asReal(), 0.0f, getChild<LLUICtrl>(FIELD_SKY_GLOW_FOCUS)->getValue().asReal());
+    LLColor3 glow((F32)getChild<LLUICtrl>(FIELD_SKY_GLOW_SIZE)->getValue().asReal(), 0.0f, (F32)getChild<LLUICtrl>(FIELD_SKY_GLOW_FOCUS)->getValue().asReal());
 
     // takes 0 - 1.99 UI range -> 40 -> 0.2 range
     glow.mV[0] = (2.0f - glow.mV[0]) * SLIDER_SCALE_GLOW_R;
@@ -640,7 +640,7 @@ void LLPanelSettingsSkySunMoonTab::onGlowChanged()
 void LLPanelSettingsSkySunMoonTab::onStarBrightnessChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setStarBrightness(getChild<LLUICtrl>(FIELD_SKY_STAR_BRIGHTNESS)->getValue().asReal());
+    mSkySettings->setStarBrightness((F32)getChild<LLUICtrl>(FIELD_SKY_STAR_BRIGHTNESS)->getValue().asReal());
     mSkySettings->update();
     setIsDirty();
 }
@@ -663,8 +663,8 @@ void LLPanelSettingsSkySunMoonTab::onSunRotationChanged()
 
 void LLPanelSettingsSkySunMoonTab::onSunAzimElevChanged()
 {
-    F32 azimuth = getChild<LLUICtrl>(FIELD_SKY_SUN_AZIMUTH)->getValue().asReal();
-    F32 elevation = getChild<LLUICtrl>(FIELD_SKY_SUN_ELEVATION)->getValue().asReal();
+    F32 azimuth = (F32)getChild<LLUICtrl>(FIELD_SKY_SUN_AZIMUTH)->getValue().asReal();
+    F32 elevation = (F32)getChild<LLUICtrl>(FIELD_SKY_SUN_ELEVATION)->getValue().asReal();
     LLQuaternion quat;
 
     azimuth *= DEG_TO_RAD;
@@ -693,7 +693,7 @@ void LLPanelSettingsSkySunMoonTab::onSunAzimElevChanged()
 void LLPanelSettingsSkySunMoonTab::onSunScaleChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setSunScale((getChild<LLUICtrl>(FIELD_SKY_SUN_SCALE)->getValue().asReal()));
+    mSkySettings->setSunScale((F32)(getChild<LLUICtrl>(FIELD_SKY_SUN_SCALE)->getValue().asReal()));
     mSkySettings->update();
     setIsDirty();
 }
@@ -725,8 +725,8 @@ void LLPanelSettingsSkySunMoonTab::onMoonRotationChanged()
 
 void LLPanelSettingsSkySunMoonTab::onMoonAzimElevChanged()
 {
-    F32 azimuth = getChild<LLUICtrl>(FIELD_SKY_MOON_AZIMUTH)->getValue().asReal();
-    F32 elevation = getChild<LLUICtrl>(FIELD_SKY_MOON_ELEVATION)->getValue().asReal();
+    F32 azimuth = (F32)getChild<LLUICtrl>(FIELD_SKY_MOON_AZIMUTH)->getValue().asReal();
+    F32 elevation = (F32)getChild<LLUICtrl>(FIELD_SKY_MOON_ELEVATION)->getValue().asReal();
     LLQuaternion quat;
 
     azimuth *= DEG_TO_RAD;
@@ -763,7 +763,7 @@ void LLPanelSettingsSkySunMoonTab::onMoonImageChanged()
 void LLPanelSettingsSkySunMoonTab::onMoonScaleChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setMoonScale((getChild<LLUICtrl>(FIELD_SKY_MOON_SCALE)->getValue().asReal()));
+    mSkySettings->setMoonScale((F32)(getChild<LLUICtrl>(FIELD_SKY_MOON_SCALE)->getValue().asReal()));
     mSkySettings->update();
     setIsDirty();
 }
@@ -771,7 +771,7 @@ void LLPanelSettingsSkySunMoonTab::onMoonScaleChanged()
 void LLPanelSettingsSkySunMoonTab::onMoonBrightnessChanged()
 {
     if (!mSkySettings) return;
-    mSkySettings->setMoonBrightness((getChild<LLUICtrl>(FIELD_SKY_MOON_BRIGHTNESS)->getValue().asReal()));
+    mSkySettings->setMoonBrightness((F32)(getChild<LLUICtrl>(FIELD_SKY_MOON_BRIGHTNESS)->getValue().asReal()));
     mSkySettings->update();
     setIsDirty();
 }
@@ -851,24 +851,24 @@ void LLPanelSettingsSkyDensityTab::refresh()
     LLSD mie_config         = mSkySettings->getMieConfig();
     LLSD absorption_config  = mSkySettings->getAbsorptionConfig();
 
-    F32 rayleigh_exponential_term    = rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
-    F32 rayleigh_exponential_scale   = rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
-    F32 rayleigh_linear_term         = rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
-    F32 rayleigh_constant_term       = rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
-    F32 rayleigh_max_alt             = rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
+    F32 rayleigh_exponential_term    = (F32)rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
+    F32 rayleigh_exponential_scale   = (F32)rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
+    F32 rayleigh_linear_term         = (F32)rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
+    F32 rayleigh_constant_term       = (F32)rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
+    F32 rayleigh_max_alt             = (F32)rayleigh_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
 
-    F32 mie_exponential_term         = mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
-    F32 mie_exponential_scale        = mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
-    F32 mie_linear_term              = mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
-    F32 mie_constant_term            = mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
-    F32 mie_aniso_factor             = mie_config[LLSettingsSky::SETTING_MIE_ANISOTROPY_FACTOR].asReal();
-    F32 mie_max_alt                  = mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
+    F32 mie_exponential_term         = (F32)mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
+    F32 mie_exponential_scale        = (F32)mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
+    F32 mie_linear_term              = (F32)mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
+    F32 mie_constant_term            = (F32)mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_CONSTANT_TERM].asReal();
+    F32 mie_aniso_factor             = (F32)mie_config[LLSettingsSky::SETTING_MIE_ANISOTROPY_FACTOR].asReal();
+    F32 mie_max_alt                  = (F32)mie_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
 
-    F32 absorption_exponential_term  = absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
-    F32 absorption_exponential_scale = absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
-    F32 absorption_linear_term       = absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
-    F32 absorption_constant_term     = absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
-    F32 absorption_max_alt           = absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
+    F32 absorption_exponential_term  = (F32)absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
+    F32 absorption_exponential_scale = (F32)absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_SCALE_FACTOR].asReal();
+    F32 absorption_linear_term       = (F32)absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_LINEAR_TERM].asReal();
+    F32 absorption_constant_term     = (F32)absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_EXP_TERM].asReal();
+    F32 absorption_max_alt           = (F32)absorption_config[LLSettingsSky::SETTING_DENSITY_PROFILE_WIDTH].asReal();
 
     getChild<LLUICtrl>(FIELD_SKY_DENSITY_RAYLEIGH_EXPONENTIAL)->setValue(rayleigh_exponential_term);
     getChild<LLUICtrl>(FIELD_SKY_DENSITY_RAYLEIGH_EXPONENTIAL_SCALE)->setValue(rayleigh_exponential_scale);

--- a/indra/newview/llpaneleditwater.cpp
+++ b/indra/newview/llpaneleditwater.cpp
@@ -170,14 +170,14 @@ void LLPanelSettingsWaterMainTab::onFogColorChanged()
 void LLPanelSettingsWaterMainTab::onFogDensityChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setWaterFogDensity(getChild<LLUICtrl>(FIELD_WATER_FOG_DENSITY)->getValue().asReal());
+    mWaterSettings->setWaterFogDensity((F32)getChild<LLUICtrl>(FIELD_WATER_FOG_DENSITY)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsWaterMainTab::onFogUnderWaterChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setFogMod(getChild<LLUICtrl>(FIELD_WATER_UNDERWATER_MOD)->getValue().asReal());
+    mWaterSettings->setFogMod((F32)getChild<LLUICtrl>(FIELD_WATER_UNDERWATER_MOD)->getValue().asReal());
     setIsDirty();
 }
 
@@ -210,7 +210,7 @@ void LLPanelSettingsWaterMainTab::onSmallWaveChanged()
 void LLPanelSettingsWaterMainTab::onNormalScaleChanged()
 {
     if (!mWaterSettings) return;
-    LLVector3 vect(getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_X)->getValue().asReal(), getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_Y)->getValue().asReal(), getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_Z)->getValue().asReal());
+    LLVector3 vect((F32)getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_X)->getValue().asReal(), (F32)getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_Y)->getValue().asReal(), (F32)getChild<LLUICtrl>(FIELD_WATER_NORMAL_SCALE_Z)->getValue().asReal());
     mWaterSettings->setNormalScale(vect);
     setIsDirty();
 }
@@ -218,34 +218,34 @@ void LLPanelSettingsWaterMainTab::onNormalScaleChanged()
 void LLPanelSettingsWaterMainTab::onFresnelScaleChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setFresnelScale(getChild<LLUICtrl>(FIELD_WATER_FRESNEL_SCALE)->getValue().asReal());
+    mWaterSettings->setFresnelScale((F32)getChild<LLUICtrl>(FIELD_WATER_FRESNEL_SCALE)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsWaterMainTab::onFresnelOffsetChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setFresnelOffset(getChild<LLUICtrl>(FIELD_WATER_FRESNEL_OFFSET)->getValue().asReal());
+    mWaterSettings->setFresnelOffset((F32)getChild<LLUICtrl>(FIELD_WATER_FRESNEL_OFFSET)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsWaterMainTab::onScaleAboveChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setScaleAbove(getChild<LLUICtrl>(FIELD_WATER_SCALE_ABOVE)->getValue().asReal());
+    mWaterSettings->setScaleAbove((F32)getChild<LLUICtrl>(FIELD_WATER_SCALE_ABOVE)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsWaterMainTab::onScaleBelowChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setScaleBelow(getChild<LLUICtrl>(FIELD_WATER_SCALE_BELOW)->getValue().asReal());
+    mWaterSettings->setScaleBelow((F32)getChild<LLUICtrl>(FIELD_WATER_SCALE_BELOW)->getValue().asReal());
     setIsDirty();
 }
 
 void LLPanelSettingsWaterMainTab::onBlurMultipChanged()
 {
     if (!mWaterSettings) return;
-    mWaterSettings->setBlurMultiplier(getChild<LLUICtrl>(FIELD_WATER_BLUR_MULTIP)->getValue().asReal());
+    mWaterSettings->setBlurMultiplier((F32)getChild<LLUICtrl>(FIELD_WATER_BLUR_MULTIP)->getValue().asReal());
     setIsDirty();
 }

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -110,8 +110,8 @@ void LLPanelEmojiComplete::draw()
 
     F32 iconCenterX = mRenderRect.mLeft + (F32)mEmojiWidth / 2;
     F32 iconCenterY = mRenderRect.mTop - (F32)mEmojiHeight / 2;
-    F32 textLeft = mVertical ? mRenderRect.mLeft + mEmojiWidth + mPadding : 0;
-    F32 textWidth = mVertical ? getRect().getWidth() - textLeft - mPadding : 0;
+    F32 textLeft = mVertical ? (F32)(mRenderRect.mLeft + mEmojiWidth + mPadding) : 0.f;
+    F32 textWidth = mVertical ? (F32)(getRect().getWidth() - textLeft - mPadding) : 0.f;
 
     for (size_t curIdx = firstVisibleIdx; curIdx < lastVisibleIdx; curIdx++)
     {
@@ -129,7 +129,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(0, mEmojis[curIdx].Begin);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::white,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    static_cast<S32>(text.size()), x1);
+                    static_cast<S32>(text.size()), (S32)x1);
                 x0 += mTextFont->getWidthF32(text);
                 x1 = textLeft + textWidth - x0;
             }
@@ -138,7 +138,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(mEmojis[curIdx].Begin, mEmojis[curIdx].End - mEmojis[curIdx].Begin);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::yellow6,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    static_cast<S32>(text.size()), x1);
+                    static_cast<S32>(text.size()), (S32)x1);
                 x0 += mTextFont->getWidthF32(text);
                 x1 = textLeft + textWidth - x0;
             }
@@ -147,7 +147,7 @@ void LLPanelEmojiComplete::draw()
                 std::string text = shortCode.substr(mEmojis[curIdx].End);
                 mTextFont->renderUTF8(text, 0, x0, iconCenterY, LLColor4::white,
                     LLFontGL::LEFT, LLFontGL::VCENTER, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
-                    static_cast<S32>(text.size()), x1);
+                    static_cast<S32>(text.size()), (S32)x1);
             }
             iconCenterY -= mEmojiHeight;
         }
@@ -163,7 +163,7 @@ bool LLPanelEmojiComplete::handleHover(S32 x, S32 y, MASK mask)
     if (mScrollbar && mScrollbar->getVisible() && childrenHandleHover(x, y, mask))
         return true;
 
-    LLVector2 curHover(x, y);
+    LLVector2 curHover((F32)x, (F32)y);
     if ((mLastHover - curHover).lengthSquared() > MIN_MOUSE_MOVE_DELTA)
     {
         size_t index = posToIndex(x, y);
@@ -235,7 +235,7 @@ bool LLPanelEmojiComplete::handleMouseDown(S32 x, S32 y, MASK mask)
         return true;
 
     mCurSelected = posToIndex(x, y);
-    mLastHover = LLVector2(x, y);
+    mLastHover = LLVector2((F32)x, (F32)y);
 
     return true;
 }
@@ -438,7 +438,7 @@ void LLPanelEmojiComplete::updateConstraints()
 {
     mRenderRect = getLocalRect();
 
-    mEmojiWidth = mIconFont->getWidthF32(u8"\U0001F431") + mPadding * 2;
+    mEmojiWidth = (U16)(mIconFont->getWidthF32(u8"\U0001F431") + mPadding * 2);
     if (mVertical)
     {
         mEmojiHeight = mIconFont->getLineHeight() + mPadding * 2;
@@ -481,7 +481,7 @@ void LLPanelEmojiComplete::updateScrollPos()
     }
     else
     {
-        mScrollPos = mCurSelected - ((float)mCurSelected / (mTotalEmojis - 2) * (mVisibleEmojis - 2));
+        mScrollPos = (size_t)(mCurSelected - ((float)mCurSelected / (mTotalEmojis - 2) * (mVisibleEmojis - 2)));
     }
 
     if (mScrollbar && mScrollbar->getVisible())

--- a/indra/newview/llpanelenvironment.cpp
+++ b/indra/newview/llpanelenvironment.cpp
@@ -173,10 +173,10 @@ bool LLPanelEnvironmentInfo::postBuild()
     getChild<LLUICtrl>(BTN_EDIT)->setCommitCallback([this](LLUICtrl *, const LLSD &){ onBtnEdit(); });
     getChild<LLUICtrl>(BTN_RST_ALTITUDES)->setCommitCallback([this](LLUICtrl *, const LLSD &){ onBtnRstAltitudes(); });
 
-    getChild<LLUICtrl>(SLD_DAYLENGTH)->setCommitCallback([this](LLUICtrl *, const LLSD &value) { onSldDayLengthChanged(value.asReal()); });
+    getChild<LLUICtrl>(SLD_DAYLENGTH)->setCommitCallback([this](LLUICtrl *, const LLSD &value) { onSldDayLengthChanged((F32)value.asReal()); });
     getChild<LLSliderCtrl>(SLD_DAYLENGTH)->setSliderMouseUpCallback([this](LLUICtrl *, const LLSD &) { onDayLenOffsetMouseUp(); });
     getChild<LLSliderCtrl>(SLD_DAYLENGTH)->setSliderEditorCommitCallback([this](LLUICtrl *, const LLSD &) { onDayLenOffsetMouseUp(); });
-    getChild<LLUICtrl>(SLD_DAYOFFSET)->setCommitCallback([this](LLUICtrl *, const LLSD &value) { onSldDayOffsetChanged(value.asReal()); });
+    getChild<LLUICtrl>(SLD_DAYOFFSET)->setCommitCallback([this](LLUICtrl *, const LLSD &value) { onSldDayOffsetChanged((F32)value.asReal()); });
     getChild<LLSliderCtrl>(SLD_DAYOFFSET)->setSliderMouseUpCallback([this](LLUICtrl *, const LLSD &) { onDayLenOffsetMouseUp(); });
     getChild<LLSliderCtrl>(SLD_DAYOFFSET)->setSliderEditorCommitCallback([this](LLUICtrl *, const LLSD &) { onDayLenOffsetMouseUp(); });
 
@@ -193,7 +193,7 @@ bool LLPanelEnvironmentInfo::postBuild()
             drop_target->setPanel(this, alt_sliders[idx]);
         }
         // set initial values to prevent [ALTITUDE] from displaying
-        updateAltLabel(alt_prefixes[idx], idx + 2, idx * 1000);
+        updateAltLabel(alt_prefixes[idx], idx + 2, (F32)(idx * 1000));
     }
     getChild<LLSettingsDropTarget>("sdt_" + alt_prefixes[3])->setPanel(this, alt_prefixes[3]);
     getChild<LLSettingsDropTarget>("sdt_" + alt_prefixes[4])->setPanel(this, alt_prefixes[4]);
@@ -554,7 +554,7 @@ void LLPanelEnvironmentInfo::updateAltLabel(const std::string &alt_prefix, U32 s
     S32 sld_range = sld_rect.getHeight();
     S32 sld_bottom = sld_rect.mBottom;
     S32 sld_offset = sld_rect.getWidth(); // Roughly identical to thumb's width in slider.
-    S32 pos = (sld_range - sld_offset) * ((alt_value - 100) / (4000 - 100));
+    S32 pos = (S32)((sld_range - sld_offset) * ((alt_value - 100) / (4000 - 100)));
 
     // get related views
     LLTextBox* text = findChild<LLTextBox>("txt_" + alt_prefix);
@@ -647,15 +647,15 @@ void LLPanelEnvironmentInfo::readjustAltLabels()
     // Account for edges
     LLRect midle_rect = view_midle->getRect();
     F32 factor = 0.5f;
-    S32 edge_zone_height = midle_rect.getHeight() * 1.5f;
+    S32 edge_zone_height = (S32)(midle_rect.getHeight() * 1.5f);
 
     if (midle_rect.mBottom - sld_rect.mBottom < edge_zone_height)
     {
-        factor = 1 - ((midle_rect.mBottom - sld_rect.mBottom) / (edge_zone_height * 2));
+        factor = 1.f - (F32)((midle_rect.mBottom - sld_rect.mBottom) / (edge_zone_height * 2));
     }
     else if (sld_rect.mTop - midle_rect.mTop < edge_zone_height )
     {
-        factor = ((sld_rect.mTop - midle_rect.mTop) / (edge_zone_height * 2));
+        factor = (F32)((sld_rect.mTop - midle_rect.mTop) / (edge_zone_height * 2));
     }
 
     S32 shift_middle = (S32)(((F32)shift_down * factor) + ((F32)shift_up * (1.f - factor)));
@@ -739,8 +739,8 @@ void LLPanelEnvironmentInfo::commitDayLenOffsetChanges(bool need_callback)
         {
             LLEnvironment::instance().updateParcel(getParcelId(),
                                                    LLSettingsDay::ptr_t(),
-                                                   mCurrentEnvironment->mDayLength.value(),
-                                                   mCurrentEnvironment->mDayOffset.value(),
+                                                   (S32)mCurrentEnvironment->mDayLength.value(),
+                                                   (S32)mCurrentEnvironment->mDayOffset.value(),
                                                    LLEnvironment::altitudes_vect_t(),
                                                    [that_h](S32 parcel_id, LLEnvironment::EnvironmentInfo::ptr_t envifo) { _onEnvironmentReceived(that_h, parcel_id, envifo); });
         }
@@ -748,8 +748,8 @@ void LLPanelEnvironmentInfo::commitDayLenOffsetChanges(bool need_callback)
         {
             LLEnvironment::instance().updateParcel(getParcelId(),
                                                    LLSettingsDay::ptr_t(),
-                                                   mCurrentEnvironment->mDayLength.value(),
-                                                   mCurrentEnvironment->mDayOffset.value(),
+                                                   (S32)mCurrentEnvironment->mDayLength.value(),
+                                                   (S32)mCurrentEnvironment->mDayOffset.value(),
                                                    LLEnvironment::altitudes_vect_t());
         }
 
@@ -813,8 +813,8 @@ void LLPanelEnvironmentInfo::onAltSliderMouseUp()
         setControlsEnabled(false);
         LLEnvironment::instance().updateParcel(getParcelId(),
                                                LLSettingsDay::ptr_t(),
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayLength.value() : -1,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayOffset.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayLength.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayOffset.value() : -1,
                                                alts);
     }
 }
@@ -894,8 +894,8 @@ void LLPanelEnvironmentInfo::onBtnRstAltitudes()
 
         LLEnvironment::instance().updateParcel(getParcelId(),
                                                LLSettingsDay::ptr_t(),
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayLength.value() : -1,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayOffset.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayLength.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayOffset.value() : -1,
                                                alts,
             [that_h](S32 parcel_id, LLEnvironment::EnvironmentInfo::ptr_t envifo) { _onEnvironmentReceived(that_h, parcel_id, envifo); });
     }
@@ -912,7 +912,7 @@ void LLPanelEnvironmentInfo::udpateApparentTimeOfDay()
     }
     getChild<LLUICtrl>(LBL_TIMEOFDAY)->setVisible(true);
 
-    S32Seconds  now(LLDate::now().secondsSinceEpoch());
+    S32Seconds now((S32)LLDate::now().secondsSinceEpoch());
 
     now += mCurrentEnvironment->mDayOffset;
 
@@ -984,8 +984,8 @@ void LLPanelEnvironmentInfo::onPickerCommitted(LLUUID item_id, S32 track_num)
                                                itemp->getAssetUUID(),
                                                itemp->getName(),
                                                track_num,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayLength.value() : -1,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayOffset.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayLength.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayOffset.value() : -1,
                                                flags,
                                                LLEnvironment::altitudes_vect_t(),
             [that_h](S32 parcel_id, LLEnvironment::EnvironmentInfo::ptr_t envifo) { _onEnvironmentReceived(that_h, parcel_id, envifo); });
@@ -1018,8 +1018,8 @@ void LLPanelEnvironmentInfo::onEditCommitted(LLSettingsDay::ptr_t newday)
 
         LLEnvironment::instance().updateParcel(getParcelId(),
                                                newday,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayLength.value() : -1,
-                                               mCurrentEnvironment ? mCurrentEnvironment->mDayOffset.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayLength.value() : -1,
+                                               mCurrentEnvironment ? (S32)mCurrentEnvironment->mDayOffset.value() : -1,
                                                LLEnvironment::altitudes_vect_t(),
             [that_h](S32 parcel_id, LLEnvironment::EnvironmentInfo::ptr_t envifo) { _onEnvironmentReceived(that_h, parcel_id, envifo); });
     }

--- a/indra/newview/llpanelexperiencelog.cpp
+++ b/indra/newview/llpanelexperiencelog.cpp
@@ -76,7 +76,7 @@ bool LLPanelExperienceLog::postBuild()
 
 
     LLSpinCtrl* spin = getChild<LLSpinCtrl>("logsizespinner");
-    spin->set(log->getMaxDays());
+    spin->set((F32)log->getMaxDays());
     spin->setCommitCallback(boost::bind(&LLPanelExperienceLog::logSizeChanged, this));
 
     mPageSize = log->getPageSize();

--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -245,19 +245,19 @@ LLUUID  LLPanelFace::getCurrentSpecularMap()        { return getChild<LLTextureC
 U32     LLPanelFace::getCurrentShininess()          { return getChild<LLComboBox>("combobox shininess")->getCurrentIndex();         }
 U32     LLPanelFace::getCurrentBumpiness()          { return getChild<LLComboBox>("combobox bumpiness")->getCurrentIndex();         }
 U8          LLPanelFace::getCurrentDiffuseAlphaMode()   { return (U8)getChild<LLComboBox>("combobox alphamode")->getCurrentIndex(); }
-U8          LLPanelFace::getCurrentAlphaMaskCutoff()    { return (U8)getChild<LLUICtrl>("maskcutoff")->getValue().asInteger();          }
-U8          LLPanelFace::getCurrentEnvIntensity()       { return (U8)getChild<LLUICtrl>("environment")->getValue().asInteger();         }
-U8          LLPanelFace::getCurrentGlossiness()         { return (U8)getChild<LLUICtrl>("glossiness")->getValue().asInteger();          }
-F32     LLPanelFace::getCurrentBumpyRot()           { return getChild<LLUICtrl>("bumpyRot")->getValue().asReal();                       }
-F32     LLPanelFace::getCurrentBumpyScaleU()        { return getChild<LLUICtrl>("bumpyScaleU")->getValue().asReal();                    }
-F32     LLPanelFace::getCurrentBumpyScaleV()        { return getChild<LLUICtrl>("bumpyScaleV")->getValue().asReal();                    }
-F32     LLPanelFace::getCurrentBumpyOffsetU()       { return getChild<LLUICtrl>("bumpyOffsetU")->getValue().asReal();                   }
-F32     LLPanelFace::getCurrentBumpyOffsetV()       { return getChild<LLUICtrl>("bumpyOffsetV")->getValue().asReal();                   }
-F32     LLPanelFace::getCurrentShinyRot()           { return getChild<LLUICtrl>("shinyRot")->getValue().asReal();                       }
-F32     LLPanelFace::getCurrentShinyScaleU()        { return getChild<LLUICtrl>("shinyScaleU")->getValue().asReal();                    }
-F32     LLPanelFace::getCurrentShinyScaleV()        { return getChild<LLUICtrl>("shinyScaleV")->getValue().asReal();                    }
-F32     LLPanelFace::getCurrentShinyOffsetU()       { return getChild<LLUICtrl>("shinyOffsetU")->getValue().asReal();                   }
-F32     LLPanelFace::getCurrentShinyOffsetV()       { return getChild<LLUICtrl>("shinyOffsetV")->getValue().asReal();                   }
+U8          LLPanelFace::getCurrentAlphaMaskCutoff()    { return (U8)getChild<LLUICtrl>("maskcutoff")->getValue().asInteger();      }
+U8          LLPanelFace::getCurrentEnvIntensity()       { return (U8)getChild<LLUICtrl>("environment")->getValue().asInteger();     }
+U8          LLPanelFace::getCurrentGlossiness()         { return (U8)getChild<LLUICtrl>("glossiness")->getValue().asInteger();      }
+F32     LLPanelFace::getCurrentBumpyRot()           { return (F32)getChild<LLUICtrl>("bumpyRot")->getValue().asReal();              }
+F32     LLPanelFace::getCurrentBumpyScaleU()        { return (F32)getChild<LLUICtrl>("bumpyScaleU")->getValue().asReal();           }
+F32     LLPanelFace::getCurrentBumpyScaleV()        { return (F32)getChild<LLUICtrl>("bumpyScaleV")->getValue().asReal();           }
+F32     LLPanelFace::getCurrentBumpyOffsetU()       { return (F32)getChild<LLUICtrl>("bumpyOffsetU")->getValue().asReal();          }
+F32     LLPanelFace::getCurrentBumpyOffsetV()       { return (F32)getChild<LLUICtrl>("bumpyOffsetV")->getValue().asReal();          }
+F32     LLPanelFace::getCurrentShinyRot()           { return (F32)getChild<LLUICtrl>("shinyRot")->getValue().asReal();              }
+F32     LLPanelFace::getCurrentShinyScaleU()        { return (F32)getChild<LLUICtrl>("shinyScaleU")->getValue().asReal();           }
+F32     LLPanelFace::getCurrentShinyScaleV()        { return (F32)getChild<LLUICtrl>("shinyScaleV")->getValue().asReal();           }
+F32     LLPanelFace::getCurrentShinyOffsetU()       { return (F32)getChild<LLUICtrl>("shinyOffsetU")->getValue().asReal();          }
+F32     LLPanelFace::getCurrentShinyOffsetV()       { return (F32)getChild<LLUICtrl>("shinyOffsetV")->getValue().asReal();          }
 
 //
 // Methods
@@ -1854,13 +1854,13 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
 
         // Set variable values for numeric expressions
         LLCalc* calcp = LLCalc::getInstance();
-        calcp->setVar(LLCalc::TEX_U_SCALE, childGetValue("TexScaleU").asReal());
-        calcp->setVar(LLCalc::TEX_V_SCALE, childGetValue("TexScaleV").asReal());
-        calcp->setVar(LLCalc::TEX_U_OFFSET, childGetValue("TexOffsetU").asReal());
-        calcp->setVar(LLCalc::TEX_V_OFFSET, childGetValue("TexOffsetV").asReal());
-        calcp->setVar(LLCalc::TEX_ROTATION, childGetValue("TexRot").asReal());
-        calcp->setVar(LLCalc::TEX_TRANSPARENCY, childGetValue("ColorTrans").asReal());
-        calcp->setVar(LLCalc::TEX_GLOW, childGetValue("glow").asReal());
+        calcp->setVar(LLCalc::TEX_U_SCALE, (F32)childGetValue("TexScaleU").asReal());
+        calcp->setVar(LLCalc::TEX_V_SCALE, (F32)childGetValue("TexScaleV").asReal());
+        calcp->setVar(LLCalc::TEX_U_OFFSET, (F32)childGetValue("TexOffsetU").asReal());
+        calcp->setVar(LLCalc::TEX_V_OFFSET, (F32)childGetValue("TexOffsetV").asReal());
+        calcp->setVar(LLCalc::TEX_ROTATION, (F32)childGetValue("TexRot").asReal());
+        calcp->setVar(LLCalc::TEX_TRANSPARENCY, (F32)childGetValue("ColorTrans").asReal());
+        calcp->setVar(LLCalc::TEX_GLOW, (F32)childGetValue("glow").asReal());
     }
     else
     {
@@ -3777,7 +3777,7 @@ void LLPanelFace::onCommitTextureScaleX( LLUICtrl* ctrl, void* userdata )
     LLPanelFace* self = (LLPanelFace*) userdata;
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
-        F32 bumpy_scale_u = self->getChild<LLUICtrl>("TexScaleU")->getValue().asReal();
+        F32 bumpy_scale_u = (F32)self->getChild<LLUICtrl>("TexScaleU")->getValue().asReal();
         if (self->isIdenticalPlanarTexgen())
         {
             bumpy_scale_u *= 0.5f;
@@ -3797,7 +3797,7 @@ void LLPanelFace::onCommitTextureScaleY( LLUICtrl* ctrl, void* userdata )
     LLPanelFace* self = (LLPanelFace*) userdata;
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
-        F32 bumpy_scale_v = self->getChild<LLUICtrl>("TexScaleV")->getValue().asReal();
+        F32 bumpy_scale_v = (F32)self->getChild<LLUICtrl>("TexScaleV")->getValue().asReal();
         if (self->isIdenticalPlanarTexgen())
         {
             bumpy_scale_v *= 0.5f;
@@ -3818,7 +3818,7 @@ void LLPanelFace::onCommitTextureRot( LLUICtrl* ctrl, void* userdata )
 
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
-        syncMaterialRot(self, self->getChild<LLUICtrl>("TexRot")->getValue().asReal());
+        syncMaterialRot(self, (F32)self->getChild<LLUICtrl>("TexRot")->getValue().asReal());
     }
     else
     {
@@ -3833,7 +3833,7 @@ void LLPanelFace::onCommitTextureOffsetX( LLUICtrl* ctrl, void* userdata )
     LLPanelFace* self = (LLPanelFace*) userdata;
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
-        syncOffsetX(self, self->getChild<LLUICtrl>("TexOffsetU")->getValue().asReal());
+        syncOffsetX(self, (F32)self->getChild<LLUICtrl>("TexOffsetU")->getValue().asReal());
     }
     else
     {
@@ -3848,7 +3848,7 @@ void LLPanelFace::onCommitTextureOffsetY( LLUICtrl* ctrl, void* userdata )
     LLPanelFace* self = (LLPanelFace*) userdata;
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
-        syncOffsetY(self, self->getChild<LLUICtrl>("TexOffsetV")->getValue().asReal());
+        syncOffsetY(self, (F32)self->getChild<LLUICtrl>("TexOffsetV")->getValue().asReal());
     }
     else
     {
@@ -3861,27 +3861,27 @@ void LLPanelFace::onCommitTextureOffsetY( LLUICtrl* ctrl, void* userdata )
 // static
 void LLPanelFace::onCommitRepeatsPerMeter(LLUICtrl* ctrl, void* userdata)
 {
-    LLPanelFace* self = (LLPanelFace*) userdata;
+    LLPanelFace *self = (LLPanelFace *) userdata;
 
-    LLUICtrl*   repeats_ctrl    = self->getChild<LLUICtrl>("rptctrl");
+    LLUICtrl *repeats_ctrl = self->getChild<LLUICtrl>("rptctrl");
 
     U32 materials_media = self->mComboMatMedia->getCurrentIndex();
-    U32 material_type = 0;
+    U32 material_type   = 0;
     if (materials_media == MATMEDIA_PBR)
     {
-        LLRadioGroup* radio_mat_type = self->getChild<LLRadioGroup>("radio_pbr_type");
-        material_type = radio_mat_type->getSelectedIndex();
+        LLRadioGroup *radio_mat_type = self->getChild<LLRadioGroup>("radio_pbr_type");
+        material_type                = radio_mat_type->getSelectedIndex();
     }
     if (materials_media == MATMEDIA_MATERIAL)
     {
-        LLRadioGroup* radio_mat_type = self->getChild<LLRadioGroup>("radio_material_type");
-        material_type = radio_mat_type->getSelectedIndex();
+        LLRadioGroup *radio_mat_type = self->getChild<LLRadioGroup>("radio_material_type");
+        material_type                = radio_mat_type->getSelectedIndex();
     }
 
-    F32 repeats_per_meter   = repeats_ctrl->getValue().asReal();
+    F32 repeats_per_meter = (F32) repeats_ctrl->getValue().asReal();
 
-   F32 obj_scale_s = 1.0f;
-   F32 obj_scale_t = 1.0f;
+    F32 obj_scale_s = 1.0f;
+    F32 obj_scale_t = 1.0f;
 
     bool identical_scale_s = false;
     bool identical_scale_t = false;
@@ -3889,10 +3889,10 @@ void LLPanelFace::onCommitRepeatsPerMeter(LLUICtrl* ctrl, void* userdata)
     LLSelectedTE::getObjectScaleS(obj_scale_s, identical_scale_s);
     LLSelectedTE::getObjectScaleS(obj_scale_t, identical_scale_t);
 
-    LLUICtrl* bumpy_scale_u = self->getChild<LLUICtrl>("bumpyScaleU");
-    LLUICtrl* bumpy_scale_v = self->getChild<LLUICtrl>("bumpyScaleV");
-    LLUICtrl* shiny_scale_u = self->getChild<LLUICtrl>("shinyScaleU");
-    LLUICtrl* shiny_scale_v = self->getChild<LLUICtrl>("shinyScaleV");
+    LLUICtrl *bumpy_scale_u = self->getChild<LLUICtrl>("bumpyScaleU");
+    LLUICtrl *bumpy_scale_v = self->getChild<LLUICtrl>("bumpyScaleV");
+    LLUICtrl *shiny_scale_u = self->getChild<LLUICtrl>("shinyScaleU");
+    LLUICtrl *shiny_scale_v = self->getChild<LLUICtrl>("shinyScaleV");
 
     if (gSavedSettings.getBOOL("SyncMaterialSettings"))
     {
@@ -5085,7 +5085,7 @@ bool LLPanelFace::Selection::compareSelection()
 
 void LLPanelFace::onCommitGLTFTextureScaleU(LLUICtrl* ctrl)
 {
-    const float value = ctrl->getValue().asReal();
+    const float value = (F32)ctrl->getValue().asReal();
     const U32 pbr_type = findChild<LLRadioGroup>("radio_pbr_type")->getSelectedIndex();
     updateGLTFTextureTransform(value, pbr_type, [&](LLGLTFMaterial::TextureTransform* new_transform)
     {
@@ -5095,7 +5095,7 @@ void LLPanelFace::onCommitGLTFTextureScaleU(LLUICtrl* ctrl)
 
 void LLPanelFace::onCommitGLTFTextureScaleV(LLUICtrl* ctrl)
 {
-    const float value = ctrl->getValue().asReal();
+    const float value = (F32)ctrl->getValue().asReal();
     const U32 pbr_type = findChild<LLRadioGroup>("radio_pbr_type")->getSelectedIndex();
     updateGLTFTextureTransform(value, pbr_type, [&](LLGLTFMaterial::TextureTransform* new_transform)
     {
@@ -5105,7 +5105,7 @@ void LLPanelFace::onCommitGLTFTextureScaleV(LLUICtrl* ctrl)
 
 void LLPanelFace::onCommitGLTFRotation(LLUICtrl* ctrl)
 {
-    const float value = ctrl->getValue().asReal() * DEG_TO_RAD;
+    const float value = (F32)ctrl->getValue().asReal() * DEG_TO_RAD;
     const U32 pbr_type = findChild<LLRadioGroup>("radio_pbr_type")->getSelectedIndex();
     updateGLTFTextureTransform(value, pbr_type, [&](LLGLTFMaterial::TextureTransform* new_transform)
     {
@@ -5115,7 +5115,7 @@ void LLPanelFace::onCommitGLTFRotation(LLUICtrl* ctrl)
 
 void LLPanelFace::onCommitGLTFTextureOffsetU(LLUICtrl* ctrl)
 {
-    const float value = ctrl->getValue().asReal();
+    const float value = (F32)ctrl->getValue().asReal();
     const U32 pbr_type = findChild<LLRadioGroup>("radio_pbr_type")->getSelectedIndex();
     updateGLTFTextureTransform(value, pbr_type, [&](LLGLTFMaterial::TextureTransform* new_transform)
     {
@@ -5125,7 +5125,7 @@ void LLPanelFace::onCommitGLTFTextureOffsetU(LLUICtrl* ctrl)
 
 void LLPanelFace::onCommitGLTFTextureOffsetV(LLUICtrl* ctrl)
 {
-    const float value = ctrl->getValue().asReal();
+    const float value = (F32)ctrl->getValue().asReal();
     const U32 pbr_type = findChild<LLRadioGroup>("radio_pbr_type")->getSelectedIndex();
     updateGLTFTextureTransform(value, pbr_type, [&](LLGLTFMaterial::TextureTransform* new_transform)
     {

--- a/indra/newview/llpanelmaininventory.cpp
+++ b/indra/newview/llpanelmaininventory.cpp
@@ -1177,7 +1177,7 @@ void LLFloaterInventoryFinder::updateElementsFromFilter()
         return;
 
     // Get data needed for filter display
-    U32 filter_types = mFilter->getFilterObjectTypes();
+    U32 filter_types = (U32)mFilter->getFilterObjectTypes();
     LLInventoryFilter::EFolderShow show_folders = mFilter->getShowFolderState();
     U32 hours = mFilter->getHoursAgo();
     U32 date_search_direction = mFilter->getDateSearchDirection();

--- a/indra/newview/llpanelmarketplaceinbox.cpp
+++ b/indra/newview/llpanelmarketplaceinbox.cpp
@@ -119,7 +119,7 @@ void LLPanelMarketplaceInbox::onFocusReceived()
         sidepanel_inventory->clearSelections(true, false);
         }
 
-    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", time_corrected());
+    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", (U32)time_corrected());
 }
 
 bool LLPanelMarketplaceInbox::handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop, EDragAndDropType cargo_type, void *cargo_data, EAcceptance *accept, std::string& tooltip_msg)

--- a/indra/newview/llpanelmarketplaceinboxinventory.cpp
+++ b/indra/newview/llpanelmarketplaceinboxinventory.cpp
@@ -225,7 +225,7 @@ void LLInboxFolderViewFolder::deFreshify()
 {
     mFresh = false;
 
-    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", time_corrected());
+    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", (U32)time_corrected());
     LLInboxNewItemsStorage::getInstance()->removeItem(static_cast<LLFolderViewModelItemInventory*>(getViewModelItem())->getUUID());
 }
 
@@ -304,7 +304,7 @@ void LLInboxFolderViewItem::deFreshify()
 {
     mFresh = false;
 
-    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", time_corrected());
+    gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", (U32)time_corrected());
 }
 
 LLInboxNewItemsStorage::LLInboxNewItemsStorage()

--- a/indra/newview/llpanelpermissions.cpp
+++ b/indra/newview/llpanelpermissions.cpp
@@ -986,7 +986,7 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
 
     LLWString wline = utf8str_to_wstring(name);
     // panel supports two lines long names
-    S32 segment_length = font->maxDrawableChars(wline.c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
+    S32 segment_length = font->maxDrawableChars(wline.c_str(), (F32)max_pixels, static_cast<S32>(wline.length()), LLFontGL::WORD_BOUNDARY_IF_POSSIBLE);
     if (segment_length == wline.length())
     {
         // no work needed
@@ -994,7 +994,7 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
     }
 
     S32 first_line_length = segment_length;
-    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
+    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), (F32)max_pixels, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
     if (segment_length + first_line_length == wline.length())
     {
         // no work needed
@@ -1003,8 +1003,8 @@ void shorten_name(std::string &name, const LLStyle::Params& style_params, S32 ma
 
     // name does not fit, cut it, add ...
     const LLWString dots_pad(utf8str_to_wstring(std::string("....")));
-    S32 elipses_width = font->getWidthF32(dots_pad.c_str());
-    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), max_pixels - elipses_width, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
+    F32 elipses_width = font->getWidthF32(dots_pad.c_str());
+    segment_length = font->maxDrawableChars(wline.substr(first_line_length).c_str(), (F32)max_pixels - elipses_width, static_cast<S32>(wline.length()), LLFontGL::ANYWHERE);
 
     name = name.substr(0, segment_length + first_line_length) + std::string("...");
 }

--- a/indra/newview/llpanelplaceprofile.cpp
+++ b/indra/newview/llpanelplaceprofile.cpp
@@ -395,9 +395,9 @@ void LLPanelPlaceProfile::displaySelectedParcelInfo(LLParcel* parcel,
     mPosRegion.setVec((F32)fmod(pos_global.mdV[VX], (F64)REGION_WIDTH_METERS),
                       (F32)fmod(pos_global.mdV[VY], (F64)REGION_WIDTH_METERS),
                       (F32)pos_global.mdV[VZ]);
-    parcel_data.global_x = pos_global.mdV[VX];
-    parcel_data.global_y = pos_global.mdV[VY];
-    parcel_data.global_z = pos_global.mdV[VZ];
+    parcel_data.global_x = (F32)pos_global.mdV[VX];
+    parcel_data.global_y = (F32)pos_global.mdV[VY];
+    parcel_data.global_z = (F32)pos_global.mdV[VZ];
     parcel_data.owner_id = parcel->getOwnerID();
 
     std::string on = getString("on");

--- a/indra/newview/llpanelprimmediacontrols.cpp
+++ b/indra/newview/llpanelprimmediacontrols.cpp
@@ -421,7 +421,7 @@ void LLPanelPrimMediaControls::updateShape()
             if(mUpdateSlider && mMovieDuration!= 0)
             {
                 F64 current_time =  media_plugin->getCurrentTime();
-                F32 percent = current_time / mMovieDuration;
+                F32 percent = (F32)(current_time / mMovieDuration);
                 mMediaPlaySliderCtrl->setValue(percent);
                 mMediaPlaySliderCtrl->setEnabled(true);
             }
@@ -1309,7 +1309,7 @@ void LLPanelPrimMediaControls::onMediaPlaySliderCtrlMouseUp()
             }
             else
             {
-                media_impl->seek(cur_value * mMovieDuration);
+                media_impl->seek((F32)(cur_value * mMovieDuration));
             }
         }
 

--- a/indra/newview/llpanelsnapshot.cpp
+++ b/indra/newview/llpanelsnapshot.cpp
@@ -211,12 +211,12 @@ void LLPanelSnapshot::onCustomResolutionCommit()
         S32 width = widthSpinner->getValue().asInteger();
         width = power_of_two(width, MAX_TEXTURE_SIZE);
         info["w"] = width;
-        widthSpinner->setIncrement(width >> 1);
+        widthSpinner->setIncrement((F32)(width >> 1));
         widthSpinner->forceSetValue(width);
         S32 height =  heightSpinner->getValue().asInteger();
         height = power_of_two(height, MAX_TEXTURE_SIZE);
-        heightSpinner->setIncrement(height >> 1);
-        heightSpinner->forceSetValue(height);
+        heightSpinner->setIncrement((F32)(height >> 1));
+        heightSpinner->forceSetValue((F32)height);
         info["h"] = height;
     }
     else

--- a/indra/newview/llpanelvolume.cpp
+++ b/indra/newview/llpanelvolume.cpp
@@ -899,25 +899,25 @@ void LLPanelVolume::sendPhysicsShapeType(LLUICtrl* ctrl, void* userdata)
 
 void LLPanelVolume::sendPhysicsGravity(LLUICtrl* ctrl, void* userdata)
 {
-    F32 val = ctrl->getValue().asReal();
+    F32 val = (F32)ctrl->getValue().asReal();
     LLSelectMgr::getInstance()->selectionSetGravity(val);
 }
 
 void LLPanelVolume::sendPhysicsFriction(LLUICtrl* ctrl, void* userdata)
 {
-    F32 val = ctrl->getValue().asReal();
+    F32 val = (F32)ctrl->getValue().asReal();
     LLSelectMgr::getInstance()->selectionSetFriction(val);
 }
 
 void LLPanelVolume::sendPhysicsRestitution(LLUICtrl* ctrl, void* userdata)
 {
-    F32 val = ctrl->getValue().asReal();
+    F32 val = (F32)ctrl->getValue().asReal();
     LLSelectMgr::getInstance()->selectionSetRestitution(val);
 }
 
 void LLPanelVolume::sendPhysicsDensity(LLUICtrl* ctrl, void* userdata)
 {
-    F32 val = ctrl->getValue().asReal();
+    F32 val = (F32)ctrl->getValue().asReal();
     LLSelectMgr::getInstance()->selectionSetDensity(val);
 }
 
@@ -1099,10 +1099,10 @@ void LLPanelVolume::onPasteFeatures()
 
         objectp->setMaterial(material);
         objectp->sendMaterialUpdate();
-        objectp->setPhysicsGravity(clipboard["physics"]["gravity"].asReal());
-        objectp->setPhysicsFriction(clipboard["physics"]["friction"].asReal());
-        objectp->setPhysicsDensity(clipboard["physics"]["density"].asReal());
-        objectp->setPhysicsRestitution(clipboard["physics"]["restitution"].asReal());
+        objectp->setPhysicsGravity((F32)clipboard["physics"]["gravity"].asReal());
+        objectp->setPhysicsFriction((F32)clipboard["physics"]["friction"].asReal());
+        objectp->setPhysicsDensity((F32)clipboard["physics"]["density"].asReal());
+        objectp->setPhysicsRestitution((F32)clipboard["physics"]["restitution"].asReal());
         objectp->updateFlags(true);
     }
 
@@ -1127,10 +1127,10 @@ void LLPanelVolume::onPasteFeatures()
             LLFlexibleObjectData new_attributes;
             new_attributes = *attributes;
             new_attributes.setSimulateLOD(clipboard["flex"]["lod"].asInteger());
-            new_attributes.setGravity(clipboard["flex"]["gav"].asReal());
-            new_attributes.setTension(clipboard["flex"]["ten"].asReal());
-            new_attributes.setAirFriction(clipboard["flex"]["fri"].asReal());
-            new_attributes.setWindSensitivity(clipboard["flex"]["sen"].asReal());
+            new_attributes.setGravity((F32)clipboard["flex"]["gav"].asReal());
+            new_attributes.setTension((F32)clipboard["flex"]["ten"].asReal());
+            new_attributes.setAirFriction((F32)clipboard["flex"]["fri"].asReal());
+            new_attributes.setWindSensitivity((F32)clipboard["flex"]["sen"].asReal());
             F32 fx = (F32)clipboard["flex"]["forx"].asReal();
             F32 fy = (F32)clipboard["flex"]["fory"].asReal();
             F32 fz = (F32)clipboard["flex"]["forz"].asReal();

--- a/indra/newview/llpathfindingcharacter.cpp
+++ b/indra/newview/llpathfindingcharacter.cpp
@@ -83,7 +83,7 @@ void LLPathfindingCharacter::parseCharacterData(const LLSD &pCharacterData)
 {
     llassert(pCharacterData.has(CHARACTER_CPU_TIME_FIELD));
     llassert(pCharacterData.get(CHARACTER_CPU_TIME_FIELD).isReal());
-    mCPUTime = pCharacterData.get(CHARACTER_CPU_TIME_FIELD).asReal();
+    mCPUTime = (F32)pCharacterData.get(CHARACTER_CPU_TIME_FIELD).asReal();
 
     llassert(pCharacterData.has(CHARACTER_HORIZONTAL_FIELD));
     llassert(pCharacterData.get(CHARACTER_HORIZONTAL_FIELD).isBoolean());
@@ -91,9 +91,9 @@ void LLPathfindingCharacter::parseCharacterData(const LLSD &pCharacterData)
 
     llassert(pCharacterData.has(CHARACTER_LENGTH_FIELD));
     llassert(pCharacterData.get(CHARACTER_LENGTH_FIELD).isReal());
-    mLength = pCharacterData.get(CHARACTER_LENGTH_FIELD).asReal();
+    mLength = (F32)pCharacterData.get(CHARACTER_LENGTH_FIELD).asReal();
 
     llassert(pCharacterData.has(CHARACTER_RADIUS_FIELD));
     llassert(pCharacterData.get(CHARACTER_RADIUS_FIELD).isReal());
-    mRadius = pCharacterData.get(CHARACTER_RADIUS_FIELD).asReal();
+    mRadius = (F32)pCharacterData.get(CHARACTER_RADIUS_FIELD).asReal();
 }

--- a/indra/newview/llperfstats.cpp
+++ b/indra/newview/llperfstats.cpp
@@ -91,7 +91,7 @@ namespace LLPerfStats
         const auto newval = gSavedSettings.getF32("RenderAvatarMaxART");
         if(newval < log10(LLPerfStats::ART_UNLIMITED_NANOS/1000))
         {
-            LLPerfStats::renderAvatarMaxART_ns = pow(10,newval)*1000;
+            LLPerfStats::renderAvatarMaxART_ns = (U64)pow(10,newval)*1000;
         }
         else
         {
@@ -301,7 +301,7 @@ namespace LLPerfStats
 
         std::vector<LLVector3d> positions;
         uuid_vec_t avatar_ids;
-        LLWorld::getInstance()->getAvatars(&avatar_ids, &positions, our_pos, distance);
+        LLWorld::getInstance()->getAvatars(&avatar_ids, &positions, our_pos, (F32)distance);
         return static_cast<int>(positions.size());
     }
 
@@ -375,7 +375,7 @@ namespace LLPerfStats
         {
             // if we have less than the user's "max Non-Impostors" avatars within the desired range then adjust the limit.
             // also adjusts back up again for nearby crowds.
-            auto count = countNearbyAvatars(std::min(LLPipeline::RenderFarClip, tunables.userImpostorDistance));
+            auto count = countNearbyAvatars((S32)std::min(LLPipeline::RenderFarClip, tunables.userImpostorDistance));
             if( count != tunables.nonImpostors )
             {
                 tunables.updateNonImposters(((U32)count < LLVOAvatar::NON_IMPOSTORS_MAX_SLIDER) ? count : 0);
@@ -476,7 +476,7 @@ namespace LLPerfStats
                 // max render this frame may be higher than the last (cos new entrants and jitter) so make sure we are heading in the right direction
                 if( new_render_limit_ns > renderAvatarMaxART_ns )
                 {
-                    new_render_limit_ns = renderAvatarMaxART_ns;
+                    new_render_limit_ns = (double)renderAvatarMaxART_ns;
                 }
 
                 if (new_render_limit_ns > LLPerfStats::ART_MIN_ADJUST_DOWN_NANOS)
@@ -485,12 +485,12 @@ namespace LLPerfStats
                 }
 
                 // bounce at the bottom to prevent "no limit"
-                new_render_limit_ns = std::max((U64)new_render_limit_ns, (U64)LLPerfStats::ART_MINIMUM_NANOS);
+                new_render_limit_ns = (double)std::max((U64)new_render_limit_ns, (U64)LLPerfStats::ART_MINIMUM_NANOS);
 
                 // assign the new value
                 if (renderAvatarMaxART_ns != new_render_limit_ns)
                 {
-                    renderAvatarMaxART_ns = new_render_limit_ns;
+                    renderAvatarMaxART_ns = (U64)new_render_limit_ns;
                     tunables.updateSettingsFromRenderCostLimit();
                 }
                 // LL_DEBUGS() << "AUTO_TUNE: avatar_budget adjusted to:" << new_render_limit_ns << LL_ENDL;

--- a/indra/newview/llphysicsmotion.cpp
+++ b/indra/newview/llphysicsmotion.cpp
@@ -445,8 +445,8 @@ F32 LLPhysicsMotion::calculateAcceleration_local(const F32 velocity_local, const
         const F32 acceleration_local = (velocity_local - mVelocityJoint_local) / time_delta;
 
         const F32 smoothed_acceleration_local =
-                acceleration_local * 1.0/smoothing +
-                mAccelerationJoint_local * (smoothing-1.0)/smoothing;
+                acceleration_local * 1.0f/smoothing +
+                mAccelerationJoint_local * (smoothing-1.0f)/smoothing;
 
         return smoothed_acceleration_local;
 }
@@ -603,7 +603,7 @@ bool LLPhysicsMotion::onUpdate(F32 time)
 
         // Drag is a force imparted by velocity (intuitively it is similar to wind resistance)
         // F = .5kv^2
-        const F32 force_drag = .5*behavior_drag*velocity_joint_local*velocity_joint_local*llsgn(velocity_joint_local);
+        const F32 force_drag = (F32)(.5 * behavior_drag * velocity_joint_local * velocity_joint_local * llsgn(velocity_joint_local));
 
         const F32 force_net = (force_accel +
                        force_gravity +
@@ -631,7 +631,7 @@ bool LLPhysicsMotion::onUpdate(F32 time)
         // Temporary debugging setting to cause all avatars to move, for profiling purposes.
         if (physics_test)
         {
-            velocity_new_local = sin(time*4.0);
+            velocity_new_local = sin(time*4.0f);
         }
         // Calculate the new parameters, or remain unchanged if max speed is 0.
         F32 position_new_local = position_current_local + velocity_new_local*time_iteration_step;
@@ -697,7 +697,7 @@ bool LLPhysicsMotion::onUpdate(F32 time)
         // For non-self, if the avatar is small enough visually, then don't update.
         const F32 area_for_max_settings = 0.0;
         const F32 area_for_min_settings = 1400.0;
-        const F32 area_for_this_setting = area_for_max_settings + (area_for_min_settings-area_for_max_settings)*(1.0-lod_factor);
+        const F32 area_for_this_setting = area_for_max_settings + (area_for_min_settings-area_for_max_settings)*(1.0f-lod_factor);
             const F32 pixel_area = sqrtf(mCharacter->getPixelArea());
 
         const bool is_self = (dynamic_cast<LLVOAvatarSelf *>(mCharacter) != NULL);
@@ -763,8 +763,8 @@ void LLPhysicsMotion::setParamValue(const LLViewerVisualParam *param,
 {
         const F32 value_min_local = param->getMinWeight();
         const F32 value_max_local = param->getMaxWeight();
-        const F32 min_val = 0.5f-behavior_maxeffect/2.0;
-        const F32 max_val = 0.5f+behavior_maxeffect/2.0;
+        const F32 min_val = 0.5f-behavior_maxeffect/2.0f;
+        const F32 max_val = 0.5f+behavior_maxeffect/2.0f;
 
     // Scale from [0,1] to [min_val,max_val]
     const F32 new_value_rescaled = min_val + (max_val-min_val) * new_value_normalized;

--- a/indra/newview/llpreviewtexture.cpp
+++ b/indra/newview/llpreviewtexture.cpp
@@ -657,7 +657,7 @@ void LLPreviewTexture::adjustAspectRatio()
     S32 num = mImage->getFullWidth() / divisor;
     S32 denom = mImage->getFullHeight() / divisor;
 
-    if (setAspectRatio(num, denom))
+    if (setAspectRatio((F32)num, (F32)denom))
     {
         // Select corresponding ratio entry in the combo list
         LLComboBox* combo = getChild<LLComboBox>("combo_aspect_ratio");
@@ -677,7 +677,7 @@ void LLPreviewTexture::adjustAspectRatio()
             }
             else
             {
-                combo->setCurrentByIndex(found - mRatiosList.begin());
+                combo->setCurrentByIndex((S32)(found - mRatiosList.begin()));
             }
         }
     }

--- a/indra/newview/llprogressview.cpp
+++ b/indra/newview/llprogressview.cpp
@@ -388,7 +388,7 @@ void LLProgressView::initLogos()
 
     // We don't know final screen rect yet, so we can't precalculate position fully
     LLTextBox *logos_label = getChild<LLTextBox>("logos_lbl");
-    S32 texture_start_x = logos_label->getFont()->getWidthF32(logos_label->getText()) + default_pad;
+    S32 texture_start_x = (S32)logos_label->getFont()->getWidthF32(logos_label->getText()) + default_pad;
     S32 texture_start_y = -7;
 
     // Normally we would just preload these textures from textures.xml,
@@ -590,7 +590,7 @@ bool LLProgressView::handleUpdate(const LLSD& event_data)
 
     if(percent.isDefined())
     {
-        setPercent(percent.asReal());
+        setPercent((F32)percent.asReal());
     }
     return false;
 }

--- a/indra/newview/llrecentpeople.cpp
+++ b/indra/newview/llrecentpeople.cpp
@@ -114,8 +114,8 @@ F32 LLRecentPeople::getArrivalTimeByID(const LLUUID& id)
 
     if (it != mAvatarsArrivalTime.end())
     {
-        return it->second;
+        return (F32)(it->second);
     }
-    return LLDate::now().secondsSinceEpoch();
+    return (F32)LLDate::now().secondsSinceEpoch();
 }
 

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -230,7 +230,7 @@ void LLReflectionMapManager::update()
     if (mMipChain.empty())
     {
         U32 res = mProbeResolution;
-        U32 count = log2((F32)res) + 0.5f;
+        U32 count = (U32)(log2((F32)res) + 0.5f);
 
         mMipChain.resize(count);
         for (U32 i = 0; i < count; ++i)
@@ -251,7 +251,7 @@ void LLReflectionMapManager::update()
         auto const & iter = std::find(mProbes.begin(), mProbes.end(), probe);
         if (iter != mProbes.end())
         {
-            deleteProbe(iter - mProbes.begin());
+            deleteProbe((U32)(iter - mProbes.begin()));
         }
     }
 
@@ -761,7 +761,7 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
         }
 
 
-        S32 mips = log2((F32)mProbeResolution) + 0.5f;
+        S32 mips = (S32)(log2((F32)mProbeResolution) + 0.5f);
 
         gReflectionMipProgram.bind();
         S32 diffuseChannel = gReflectionMipProgram.enableTexture(LLShaderMgr::DEFERRED_DIFFUSE, LLTexUnit::TT_TEXTURE);
@@ -839,7 +839,7 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
                 static LLStaticHashedString sWidth("u_width");
 
                 gRadianceGenProgram.uniform1f(sRoughness, (F32)i / (F32)(mMipChain.size() - 1));
-                gRadianceGenProgram.uniform1f(sMipLevel, i);
+                gRadianceGenProgram.uniform1f(sMipLevel, (GLfloat)i);
                 gRadianceGenProgram.uniform1i(sWidth, mProbeResolution);
 
                 for (int cf = 0; cf < 6; ++cf)
@@ -1378,7 +1378,7 @@ void LLReflectionMapManager::initReflectionMaps()
         mReset = false;
         mReflectionProbeCount = count;
         mProbeResolution = nhpo2(llclamp(gSavedSettings.getU32("RenderReflectionProbeResolution"), (U32)64, (U32)512));
-        mMaxProbeLOD = log2f(mProbeResolution) - 1.f; // number of mips - 1
+        mMaxProbeLOD = log2f((F32)mProbeResolution) - 1.f; // number of mips - 1
 
         if (mTexture.isNull() ||
             mTexture->getWidth() != mProbeResolution ||

--- a/indra/newview/llscripteditor.cpp
+++ b/indra/newview/llscripteditor.cpp
@@ -127,7 +127,7 @@ void LLScriptEditor::drawLineNumbers()
                                  ltext, // string to draw
                                  0, // begin offset
                                  UI_TEXTEDITOR_LINE_NUMBER_MARGIN - 2, // x
-                                 line_bottom, // y
+                                 (F32)line_bottom, // y
                                  fg_color,
                                  LLFontGL::RIGHT, // horizontal alignment
                                  LLFontGL::BOTTOM, // vertical alignment

--- a/indra/newview/llsechandler_basic.cpp
+++ b/indra/newview/llsechandler_basic.cpp
@@ -901,7 +901,7 @@ void _validateCert(int validation_policy,
 
     if (validation_policy & VALIDATION_POLICY_TIME)
     {
-        LLDate validation_date(time(NULL));
+        LLDate validation_date((double)time(NULL));
         if(validation_params.has(CERT_VALIDATION_DATE))
         {
             validation_date = validation_params[CERT_VALIDATION_DATE];
@@ -1111,7 +1111,7 @@ void LLBasicCertificateStore::validate(int validation_policy,
             }
             else
             {
-                validation_date = LLDate(time(NULL)); // current time
+                validation_date = LLDate((double)time(NULL)); // current time
             }
 
             if((validation_date < cache_entry->second.first) ||
@@ -1358,8 +1358,8 @@ void LLSecAPIBasicHandler::_readProtectedData(unsigned char *unique_id, U32 id_l
             protected_data_stream.read((char *)buffer, BUFFER_READ_SIZE);
 
             EVP_DecryptUpdate(ctx, decrypted_buffer, &decrypted_length,
-                              buffer, protected_data_stream.gcount());
-            decrypted_data.append((const char *)decrypted_buffer, protected_data_stream.gcount());
+                              buffer, (int)protected_data_stream.gcount());
+            decrypted_data.append((const char *)decrypted_buffer, (int)protected_data_stream.gcount());
         }
 
         // RC4 is a stream cipher, so we don't bother to EVP_DecryptFinal, as there is
@@ -1447,7 +1447,7 @@ void LLSecAPIBasicHandler::_writeProtectedData()
             }
             int encrypted_length;
             EVP_EncryptUpdate(ctx, encrypted_buffer, &encrypted_length,
-                          buffer, formatted_data_istream.gcount());
+                          buffer, (int)formatted_data_istream.gcount());
             protected_data_stream.write((const char *)encrypted_buffer, encrypted_length);
         }
 

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -609,8 +609,8 @@ LLSD LLSettingsVOSky::convertToLegacy(const LLSettingsSky::ptr_t &psky, bool isA
     legacy[SETTING_CLOUD_POS_DENSITY2] = ensure_array_4(settings[SETTING_CLOUD_POS_DENSITY2], 1.0);
     legacy[SETTING_CLOUD_SCALE] = llsd::array(settings[SETTING_CLOUD_SCALE], LLSD::Real(0.0), LLSD::Real(0.0), LLSD::Real(1.0));
     legacy[SETTING_CLOUD_SCROLL_RATE] = settings[SETTING_CLOUD_SCROLL_RATE];
-    legacy[SETTING_LEGACY_ENABLE_CLOUD_SCROLL] = llsd::array(LLSD::Boolean(!is_approx_zero(settings[SETTING_CLOUD_SCROLL_RATE][0].asReal())),
-        LLSD::Boolean(!is_approx_zero(settings[SETTING_CLOUD_SCROLL_RATE][1].asReal())));
+    legacy[SETTING_LEGACY_ENABLE_CLOUD_SCROLL] = llsd::array(LLSD::Boolean(!is_approx_zero((F32)settings[SETTING_CLOUD_SCROLL_RATE][0].asReal())),
+        LLSD::Boolean(!is_approx_zero((F32)settings[SETTING_CLOUD_SCROLL_RATE][1].asReal())));
     legacy[SETTING_CLOUD_SHADOW] = llsd::array(settings[SETTING_CLOUD_SHADOW].asReal(), 0.0f, 0.0f, 1.0f);
     legacy[SETTING_GAMMA] = llsd::array(settings[SETTING_GAMMA], 0.0f, 0.0f, 1.0f);
     legacy[SETTING_GLOW] = ensure_array_4(settings[SETTING_GLOW], 1.0);
@@ -756,7 +756,7 @@ void LLSettingsVOSky::applySpecial(void *ptarget, bool force)
         if (psky->getReflectionProbeAmbiance() != 0.f)
         {
             shader->uniform3fv(LLShaderMgr::AMBIENT, LLVector3(ambient.mV));
-            shader->uniform1f(LLShaderMgr::SKY_HDR_SCALE, sqrtf(g)*2.0); // use a modifier here so 1.0 maps to the "most desirable" default and the maximum value doesn't go off the rails
+            shader->uniform1f(LLShaderMgr::SKY_HDR_SCALE, sqrtf(g)*2.0f); // use a modifier here so 1.0 maps to the "most desirable" default and the maximum value doesn't go off the rails
         }
         else if (psky->canAutoAdjust() && should_auto_adjust)
         { // auto-adjust legacy sky to take advantage of probe ambiance
@@ -1055,7 +1055,7 @@ void LLSettingsVOWater::applySpecial(void *ptarget, bool force)
 
         shader->uniform3fv(LLShaderMgr::WATER_FOGCOLOR_LINEAR, linearColor3(fog_color).mV);
 
-        F32 blend_factor = env.getCurrentWater()->getBlendFactor();
+        F32 blend_factor = (F32)env.getCurrentWater()->getBlendFactor();
         shader->uniform1f(LLShaderMgr::BLEND_FACTOR, blend_factor);
 
         // update to normal lightnorm, water shader itself will use rotated lightnorm as necessary

--- a/indra/newview/llsidepanelinventory.cpp
+++ b/indra/newview/llsidepanelinventory.cpp
@@ -372,7 +372,7 @@ void LLSidepanelInventory::onToggleInboxBtn()
         mInboxLayoutPanel->setTargetDim(gSavedPerAccountSettings.getS32("InventoryInboxHeight"));
         if (mInboxLayoutPanel->isInVisibleChain())
     {
-        gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", time_corrected());
+        gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", (U32)time_corrected());
     }
 }
     else
@@ -397,7 +397,7 @@ void LLSidepanelInventory::onOpen(const LLSD& key)
 #else
     if (mInboxEnabled && getChild<LLButton>(INBOX_BUTTON_NAME)->getToggleState())
     {
-        gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", time_corrected());
+        gSavedPerAccountSettings.setU32("LastInventoryInboxActivity", (U32)time_corrected());
     }
 #endif
 

--- a/indra/newview/llslurl.cpp
+++ b/indra/newview/llslurl.cpp
@@ -342,7 +342,7 @@ LLSLURL::LLSLURL(const std::string& grid,
     S32 y = ll_round((F32)fmod(position[VY], (F32)REGION_WIDTH_METERS));
     S32 z = ll_round((F32)position[VZ]);
     mType = LOCATION;
-    mPosition = LLVector3(x, y, z);
+    mPosition = LLVector3((F32)x, (F32)y, (F32)z);
 }
 
 // create a simstring
@@ -358,7 +358,7 @@ LLSLURL::LLSLURL(const std::string& grid,
          const LLVector3d& global_position)
 {
     *this = LLSLURL(LLGridManager::getInstance()->getGridId(grid), region,
-        LLVector3(global_position.mdV[VX], global_position.mdV[VY], global_position.mdV[VZ]));
+        LLVector3((F32)global_position.mdV[VX], (F32)global_position.mdV[VY], (F32)global_position.mdV[VZ]));
 }
 
 // create a slurl from a global position

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -906,7 +906,7 @@ void LLSnapshotLivePreview::estimateDataSize()
                 break;
             case LLSnapshotModel::SNAPSHOT_FORMAT_JPEG:
                 // Observed from JPG compression tests
-                ratio = (110 - mSnapshotQuality) / 2;
+                ratio = (F32)(110 - mSnapshotQuality) / 2.f;
                 break;
             case LLSnapshotModel::SNAPSHOT_FORMAT_BMP:
                 ratio = 1.0;    // No compression with BMP

--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -2035,7 +2035,7 @@ void renderNormals(LLDrawable *drawablep)
             obj_scale.normalize3();
 
             // Create inverse-scale vector for normals
-            inv_scale.set(1.0 / scale_v3.mV[VX], 1.0 / scale_v3.mV[VY], 1.0 / scale_v3.mV[VZ], 0.0);
+            inv_scale.set(1.0f / scale_v3.mV[VX], 1.0f / scale_v3.mV[VY], 1.0f/ scale_v3.mV[VZ], 0.0f);
             inv_scale.mul(inv_scale);  // Squared, to apply inverse scale twice
 
             inv_scale.normalize3fast();
@@ -2763,7 +2763,7 @@ void renderTexelDensity(LLDrawable* drawable)
             break;
         }
 
-        checkerboard_matrix.initScale(LLVector3(texturep->getWidth(discard_level) / 8, texturep->getHeight(discard_level) / 8, 1.f));
+        checkerboard_matrix.initScale(LLVector3((F32)texturep->getWidth(discard_level) / 8.f, (F32)texturep->getHeight(discard_level) / 8.f, 1.f));
 
         gGL.getTexUnit(0)->bind(LLViewerTexture::sCheckerBoardImagep, true);
         gGL.matrixMode(LLRender::MM_TEXTURE);

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -957,7 +957,7 @@ bool idle_startup()
         // and startup time is close enough if we don't have a real value.
         if (gSavedPerAccountSettings.getU32("LastLogoff") == 0)
         {
-            gSavedPerAccountSettings.setU32("LastLogoff", time_corrected());
+            gSavedPerAccountSettings.setU32("LastLogoff", (U32)time_corrected());
         }
 
         //Default the path if one isn't set.
@@ -3665,7 +3665,7 @@ bool process_login_success_response()
         if(server_utc_time)
         {
             time_t now = time(NULL);
-            gUTCOffset = (server_utc_time - now);
+            gUTCOffset = (S32)(server_utc_time - now);
 
             // Print server timestamp
             LLSD substitution;

--- a/indra/newview/llteleporthistorystorage.cpp
+++ b/indra/newview/llteleporthistorystorage.cpp
@@ -127,7 +127,7 @@ void LLTeleportHistoryStorage::addItem(const std::string title, const LLVector3d
     S32 removed_index = -1;
     if (item_iter != mItems.end())
     {
-        removed_index = item_iter - mItems.begin();
+        removed_index = (S32)(item_iter - mItems.begin());
         mItems.erase(item_iter);
     }
 

--- a/indra/newview/lltexturecache.cpp
+++ b/indra/newview/lltexturecache.cpp
@@ -1260,7 +1260,7 @@ void LLTextureCache::updateEntryTimeStamp(S32 idx, Entry& entry)
     {
         if (!mReadOnly)
         {
-            entry.mTime = time(NULL);
+            entry.mTime = (U32)time(NULL);
             mUpdatedEntryMap[idx] = entry ;
         }
     }
@@ -1299,7 +1299,7 @@ bool LLTextureCache::updateEntry(S32& idx, Entry& entry, S32 new_image_size, S32
             mTexturesSizeTotal -= entry.mBodySize ;
             mTexturesSizeTotal += new_body_size ;
         }
-        entry.mTime = time(NULL);
+        entry.mTime = (U32)time(NULL);
         entry.mImageSize = new_image_size ;
         entry.mBodySize = new_body_size ;
 

--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -2308,8 +2308,8 @@ void LLTextureCtrl::draw()
             font->renderUTF8(
                 mLoadingPlaceholderString,
                 0,
-                llfloor(interior.mLeft+3),
-                llfloor(interior.mTop-v_offset),
+                (interior.mLeft+3),
+                (interior.mTop-v_offset),
                 LLColor4::white,
                 LLFontGL::LEFT,
                 LLFontGL::BASELINE,
@@ -2325,17 +2325,17 @@ void LLTextureCtrl::draw()
 
             v_offset += 12;
             tdesc = llformat("  PK  : %d%%", U32(mTexturep->getDownloadProgress()*100.0));
-            font->renderUTF8(tdesc, 0, llfloor(interior.mLeft+3), llfloor(interior.mTop-v_offset),
+            font->renderUTF8(tdesc, 0, interior.mLeft+3, interior.mTop-v_offset,
                              LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
 
             v_offset += 12;
             tdesc = llformat("  LVL: %d", mTexturep->getDiscardLevel());
-            font->renderUTF8(tdesc, 0, llfloor(interior.mLeft+3), llfloor(interior.mTop-v_offset),
+            font->renderUTF8(tdesc, 0, interior.mLeft+3, interior.mTop-v_offset,
                              LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
 
             v_offset += 12;
             tdesc = llformat("  ID  : %s...", (mImageAssetID.asString().substr(0,7)).c_str());
-            font->renderUTF8(tdesc, 0, llfloor(interior.mLeft+3), llfloor(interior.mTop-v_offset),
+            font->renderUTF8(tdesc, 0, interior.mLeft+3, interior.mTop-v_offset,
                              LLColor4::white, LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::DROP_SHADOW);
         }
     }

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -3210,7 +3210,7 @@ S32 LLTextureFetch::getFetchState(const LLUUID& id, F32& data_progress_p, F32& r
         {
             requested_priority = worker->mImagePriority;
         }
-        fetch_priority = worker->getImagePriority();
+        fetch_priority = (U32)worker->getImagePriority();
         can_use_http = worker->getCanUseHTTP() ;
         worker->unlockWorkMutex();                                      // -Mw
     }

--- a/indra/newview/lltextureinfo.cpp
+++ b/indra/newview/lltextureinfo.cpp
@@ -214,7 +214,7 @@ void LLTextureInfo::setRequestCompleteTimeAndLog(const LLUUID& id, U64Microsecon
                 F64 region_vocache_hit_rate = 0;
                 if (region_hit_count > 0 || region_miss_count > 0)
                 {
-                    region_vocache_hit_rate = region_hit_count / (region_hit_count + region_miss_count);
+                    region_vocache_hit_rate = (F64)region_hit_count / (region_hit_count + region_miss_count);
                 }
                 object_cache["vo_region_hitcount"] = ll_sd_from_U64(region_hit_count);
                 object_cache["vo_region_misscount"] = ll_sd_from_U64(region_miss_count);

--- a/indra/newview/lltextureview.cpp
+++ b/indra/newview/lltextureview.cpp
@@ -481,8 +481,8 @@ private:
 void LLGLTexMemBar::draw()
 {
     F32 discard_bias = LLViewerTexture::sDesiredDiscardBias;
-    F32 cache_usage = LLAppViewer::getTextureCache()->getUsage().valueInUnits<LLUnits::Megabytes>();
-    F32 cache_max_usage = LLAppViewer::getTextureCache()->getMaxUsage().valueInUnits<LLUnits::Megabytes>();
+    F32 cache_usage = (F32)LLAppViewer::getTextureCache()->getUsage().valueInUnits<LLUnits::Megabytes>();
+    F32 cache_max_usage = (F32)LLAppViewer::getTextureCache()->getMaxUsage().valueInUnits<LLUnits::Megabytes>();
     S32 line_height = LLFontGL::getFontMonospace()->getLineHeight();
     S32 v_offset = 0;//(S32)((texture_bar_height + 2.2f) * mTextureView->mNumTextureBars + 2.0f);
     F32Bytes total_texture_downloaded = gTotalTextureData;
@@ -631,8 +631,8 @@ void LLGLTexMemBar::draw()
                     LLAppViewer::getImageDecodeThread()->getPending(),
                     gTextureList.mCreateTextureList.size());
 
-    x_right = 550.0;
-    LLFontGL::getFontMonospace()->renderUTF8(text, 0, 0, v_offset + line_height*3,
+    x_right = 550.0f;
+    LLFontGL::getFontMonospace()->renderUTF8(text, 0, 0.f, (F32)(v_offset + line_height*3),
                                              text_color, LLFontGL::LEFT, LLFontGL::TOP,
                                              LLFontGL::NORMAL, LLFontGL::NO_SHADOW, S32_MAX, S32_MAX, &x_right);
 
@@ -641,7 +641,7 @@ void LLGLTexMemBar::draw()
     color = bandwidth > max_bandwidth ? LLColor4::red : bandwidth > max_bandwidth*.75f ? LLColor4::yellow : text_color;
     color[VALPHA] = text_color[VALPHA];
     text = llformat("BW:%.0f/%.0f",bandwidth.value(), max_bandwidth.value());
-    LLFontGL::getFontMonospace()->renderUTF8(text, 0, x_right, v_offset + line_height*3,
+    LLFontGL::getFontMonospace()->renderUTF8(text, 0, (S32)x_right, v_offset + line_height*3,
                                              color, LLFontGL::LEFT, LLFontGL::TOP);
 
     // Mesh status line

--- a/indra/newview/llthumbnailctrl.cpp
+++ b/indra/newview/llthumbnailctrl.cpp
@@ -164,8 +164,8 @@ void LLThumbnailCtrl::draw()
             font->renderUTF8(
                 mLoadingPlaceholderString,
                 0,
-                llfloor(draw_rect.mLeft+3),
-                llfloor(draw_rect.mTop-v_offset),
+                (draw_rect.mLeft+3),
+                (draw_rect.mTop-v_offset),
                 LLColor4::white,
                 LLFontGL::LEFT,
                 LLFontGL::BASELINE,

--- a/indra/newview/lltinygltfhelper.cpp
+++ b/indra/newview/lltinygltfhelper.cpp
@@ -140,7 +140,7 @@ LLColor4 LLTinyGLTFHelper::getColor(const std::vector<double>& in)
     LLColor4 out;
     for (S32 i = 0; i < llmin((S32)in.size(), 4); ++i)
     {
-        out.mV[i] = in[i];
+        out.mV[i] = (F32)in[i];
     }
 
     return out;

--- a/indra/newview/lltoast.cpp
+++ b/indra/newview/lltoast.cpp
@@ -94,8 +94,8 @@ LLToast::Params::Params()
     enable_hide_btn("enable_hide_btn", true),
     force_show("force_show", false),
     force_store("force_store", false),
-    fading_time_secs("fading_time_secs", gSavedSettings.getS32("ToastFadingTime")),
-    lifetime_secs("lifetime_secs", gSavedSettings.getS32("NotificationToastLifeTime"))
+    fading_time_secs("fading_time_secs", (F32)gSavedSettings.getS32("ToastFadingTime")),
+    lifetime_secs("lifetime_secs", (F32)gSavedSettings.getS32("NotificationToastLifeTime"))
 {};
 
 LLToast::LLToast(const LLToast::Params& p)
@@ -256,12 +256,12 @@ void LLToast::onFocusReceived()
 
 void LLToast::setLifetime(S32 seconds)
 {
-    mToastLifetime = seconds;
+    mToastLifetime = (F32)seconds;
 }
 
 void LLToast::setFadingTime(S32 seconds)
 {
-    mToastFadingTime = seconds;
+    mToastFadingTime = (F32)seconds;
 }
 
 void LLToast::closeToast()

--- a/indra/newview/lltoolbrush.cpp
+++ b/indra/newview/lltoolbrush.cpp
@@ -547,7 +547,7 @@ void LLToolBrushLand::renderOverlay(LLSurface& land, const LLVector3& pos_region
                 wz = land.getZ((i+di)+(j+dj)*land.mGridsPerEdge),
                 norm_dist = sqrt((float)di*di + dj*dj) / half_edge,
                 force_scale = sqrt(2.f) - norm_dist, // 1 at center, 0 at corner
-                wz2 = wz + .2 + (.2 + force/100) * force_scale, // top vertex
+                wz2 = wz + .2f + (.2f + force/100.f) * force_scale, // top vertex
                 tic = .075f; // arrowhead size
             // vertical line
             gGL.vertex3f(wx, wy, wz);

--- a/indra/newview/lltoolfocus.cpp
+++ b/indra/newview/lltoolfocus.cpp
@@ -440,7 +440,7 @@ bool LLToolCamera::handleHover(S32 x, S32 y, MASK mask)
                     }
                     else
                     {
-                        gAgentCamera.cameraZoomIn( pow( IN_FACTOR, dy ) );
+                        gAgentCamera.cameraZoomIn((F32)pow( IN_FACTOR, dy ) );
                     }
                 }
 

--- a/indra/newview/lltoolmorph.cpp
+++ b/indra/newview/lltoolmorph.cpp
@@ -189,7 +189,7 @@ bool LLVisualParamHint::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, mFullWidth, 0.0f, mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();

--- a/indra/newview/lltracker.cpp
+++ b/indra/newview/lltracker.cpp
@@ -516,7 +516,7 @@ void LLTracker::drawBeacon(LLVector3 pos_agent, std::string direction, LLColor4 
         height = pos_agent.mV[2];
     }
 
-    nRows = ceil((BEACON_ROWS * height) / MAX_HEIGHT);
+    nRows = (U32)ceil((BEACON_ROWS * height) / MAX_HEIGHT);
     if(nRows<2) nRows=2;
     rowHeight = height / nRows;
 

--- a/indra/newview/llurldispatcher.cpp
+++ b/indra/newview/llurldispatcher.cpp
@@ -306,9 +306,9 @@ public:
         LLVector3 coords(128, 128, 0);
         if (tokens.size() <= 4)
         {
-            coords = LLVector3(tokens[1].asReal(),
-                               tokens[2].asReal(),
-                               tokens[3].asReal());
+            coords = LLVector3((F32)tokens[1].asReal(),
+                               (F32)tokens[2].asReal(),
+                               (F32)tokens[3].asReal());
         }
 
         // Region names may be %20 escaped.
@@ -332,9 +332,9 @@ public:
         {
             // region specified, coordinates (if any) are region-local
             LLVector3 local_pos(
-                params.has("x")? params["x"].asReal() : 128,
-                params.has("y")? params["y"].asReal() : 128,
-                params.has("z")? params["z"].asReal() : 0);
+                params.has("x")? (F32)params["x"].asReal() : 128.f,
+                params.has("y")? (F32)params["y"].asReal() : 128.f,
+                params.has("z")? (F32)params["z"].asReal() : 0.f);
             std::string regionname(params["regionname"]);
             std::string destination(LLSLURL(regionname, local_pos).getSLURLString());
             // have to resolve region's global coordinates first

--- a/indra/newview/llviewerassetupload.cpp
+++ b/indra/newview/llviewerassetupload.cpp
@@ -226,7 +226,7 @@ LLUUID LLResourceUploadInfo::finishUpload(LLSD &result)
             LL_INFOS() << "inventory_item_flags " << flagsInventoryItem << LL_ENDL;
         }
     }
-    S32 creationDate = time_corrected();
+    S32 creationDate = (S32)time_corrected();
 
     LLUUID serverInventoryItem = result["new_inventory_item"].asUUID();
     LLUUID serverAssetId = result["new_asset"].asUUID();

--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -153,12 +153,12 @@ void LLViewerCamera::updateCameraLocation(const LLVector3 &center, const LLVecto
     add(sVelocityStat, dpos);
     add(sAngularVelocityStat, drot);
 
-    mAverageSpeed = LLTrace::get_frame_recording().getPeriodMeanPerSec(sVelocityStat, 50);
-    mAverageAngularSpeed = LLTrace::get_frame_recording().getPeriodMeanPerSec(sAngularVelocityStat);
+    mAverageSpeed = (F32)LLTrace::get_frame_recording().getPeriodMeanPerSec(sVelocityStat, 50);
+    mAverageAngularSpeed = (F32)LLTrace::get_frame_recording().getPeriodMeanPerSec(sAngularVelocityStat);
     mCosHalfCameraFOV = cosf(0.5f * getView() * llmax(1.0f, getAspect()));
 
     // update pixel meter ratio using default fov, not modified one
-    mPixelMeterRatio = getViewHeightInPixels()/ (2.f*tanf(mCameraFOVDefault*0.5));
+    mPixelMeterRatio = (F32)(getViewHeightInPixels()/ (2.f*tanf(mCameraFOVDefault*0.5f)));
     // update screen pixel area
     mScreenPixelArea =(S32)((F32)getViewHeightInPixels() * ((F32)getViewHeightInPixels() * getAspect()));
 }
@@ -903,6 +903,6 @@ bool LLViewerCamera::isDefaultFOVChanged()
 
 void LLViewerCamera::updateCameraAngle(const LLSD& value)
 {
-    setDefaultFOV(value.asReal());
+    setDefaultFOV((F32)value.asReal());
 }
 

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -634,7 +634,7 @@ void handleAutoTuneFPSChanged(const LLSD& newValue)
     LLPerfStats::tunables.userAutoTuneEnabled = newval;
     if(newval && LLPerfStats::renderAvatarMaxART_ns == 0) // If we've enabled autotune we override "unlimited" to max
     {
-        gSavedSettings.setF32("RenderAvatarMaxART",log10(LLPerfStats::ART_UNLIMITED_NANOS-1000));//triggers callback to update static var
+        gSavedSettings.setF32("RenderAvatarMaxART", (F32)log10(LLPerfStats::ART_UNLIMITED_NANOS-1000));//triggers callback to update static var
     }
 }
 

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1642,11 +1642,11 @@ void render_ui_2d()
         S32 height = gViewerWindow->getWindowHeightScaled();
         gGL.getTexUnit(0)->bind(&gPipeline.mRT->uiScreen);
         gGL.begin(LLRender::TRIANGLE_STRIP);
-        gGL.color4f(1,1,1,1);
-        gGL.texCoord2f(0, 0);           gGL.vertex2i(0, 0);
-        gGL.texCoord2f(width, 0);       gGL.vertex2i(width, 0);
-        gGL.texCoord2f(0, height);      gGL.vertex2i(0, height);
-        gGL.texCoord2f(width, height);  gGL.vertex2i(width, height);
+        gGL.color4f(1.f,1.f,1.f,1.f);
+        gGL.texCoord2f(0.f, 0.f);                 gGL.vertex2i(0, 0);
+        gGL.texCoord2f((F32)width, 0.f);          gGL.vertex2i(width, 0);
+        gGL.texCoord2f(0.f, (F32)height);         gGL.vertex2i(0, height);
+        gGL.texCoord2f((F32)width, (F32)height);  gGL.vertex2i(width, height);
         gGL.end();
     }
     else

--- a/indra/newview/llviewerinventory.cpp
+++ b/indra/newview/llviewerinventory.cpp
@@ -334,7 +334,7 @@ LLViewerInventoryItem::LLViewerInventoryItem(const LLUUID& uuid,
                                              U32 flags,
                                              time_t creation_date_utc) :
     LLInventoryItem(uuid, parent_uuid, perm, asset_uuid, type, inv_type,
-                    name, desc, sale_info, flags, creation_date_utc),
+                    name, desc, sale_info, flags, (S32)creation_date_utc),
     mIsComplete(true)
 {
 }
@@ -534,7 +534,7 @@ void LLViewerInventoryItem::packMessage(LLMessageSystem* msg) const
     mSaleInfo.packMessage(msg);
     msg->addStringFast(_PREHASH_Name, mName);
     msg->addStringFast(_PREHASH_Description, mDescription);
-    msg->addS32Fast(_PREHASH_CreationDate, mCreationDate);
+    msg->addS32Fast(_PREHASH_CreationDate, (S32)mCreationDate);
     U32 crc = getCRC32();
     msg->addU32Fast(_PREHASH_CRC, crc);
 }
@@ -675,7 +675,7 @@ bool LLViewerInventoryCategory::fetch(S32 expiry_seconds)
     {
         LL_DEBUGS(LOG_INV) << "Fetching category children: " << mName << ", UUID: " << mUUID << LL_ENDL;
         mDescendentsRequested.reset();
-        mDescendentsRequested.setTimerExpirySec(expiry_seconds);
+        mDescendentsRequested.setTimerExpirySec((F32)expiry_seconds);
 
         std::string url;
         if (gAgent.getRegion())
@@ -721,7 +721,7 @@ void LLViewerInventoryCategory::setFetching(LLViewerInventoryCategory::EFetchTyp
             mDescendentsRequested.reset();
             if (AISAPI::isAvailable())
             {
-                mDescendentsRequested.setTimerExpirySec(AISAPI::HTTP_TIMEOUT);
+                mDescendentsRequested.setTimerExpirySec((F32)AISAPI::HTTP_TIMEOUT);
             }
             else
             {

--- a/indra/newview/llviewerjoystick.cpp
+++ b/indra/newview/llviewerjoystick.cpp
@@ -329,7 +329,7 @@ LLViewerJoystick::LLViewerJoystick()
     memset(mBtn, 0, sizeof(mBtn));
 
     // factor in bandwidth? bandwidth = gViewerStats->mKBitStat
-    mPerfScale = 4000.f / gSysCPU.getMHz(); // hmm.  why?
+    mPerfScale = 4000.f / (F32)gSysCPU.getMHz(); // hmm.  why?
 
     mLastDeviceUUID = LLSD::Integer(1);
 }

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -1906,7 +1906,7 @@ void LLViewerMediaImpl::loadURI()
         // or a seek happened before the media loaded.  In either case, seek to the saved time.
         if(mPreviousMediaTime != 0.0f)
         {
-            seek(mPreviousMediaTime);
+            seek((F32)mPreviousMediaTime);
         }
 
         if(mPreviousMediaState == MEDIA_PLAYING)
@@ -2041,7 +2041,7 @@ void LLViewerMediaImpl::skipBack(F32 step_scale)
             {
                 back_step = 0.0;
             }
-            mMediaSource->seek(back_step);
+            mMediaSource->seek((F32)back_step);
         }
     }
 }
@@ -2058,7 +2058,7 @@ void LLViewerMediaImpl::skipForward(F32 step_scale)
             {
                 forward_step = mMediaSource->getDuration();
             }
-            mMediaSource->seek(forward_step);
+            mMediaSource->seek((F32)forward_step);
         }
     }
 }
@@ -2107,7 +2107,7 @@ void LLViewerMediaImpl::updateVolume()
                 F64 attenuation = 1.0 + (gSavedSettings.getF32("MediaRollOffRate") * adjusted_distance);
                 attenuation = 1.0 / (attenuation * attenuation);
                 // the attenuation multiplier should never be more than one since that would increase volume
-                volume = volume * llmin(1.0, attenuation);
+                volume = volume * (F32)llmin(1.0, attenuation);
             }
         }
 
@@ -2237,11 +2237,11 @@ void LLViewerMediaImpl::scaleTextureCoords(const LLVector2& texture_coords, S32 
     // Deal with repeating textures by wrapping the coordinates into the range [0, 1.0)
     texture_x = fmodf(texture_x, 1.0f);
     if(texture_x < 0.0f)
-        texture_x = 1.0 + texture_x;
+        texture_x = 1.0f + texture_x;
 
     texture_y = fmodf(texture_y, 1.0f);
     if(texture_y < 0.0f)
-        texture_y = 1.0 + texture_y;
+        texture_y = 1.0f + texture_y;
 
     // scale x and y to texel units.
     *x = ll_round(texture_x * mMediaSource->getTextureWidth());

--- a/indra/newview/llviewermediafocus.cpp
+++ b/indra/newview/llviewermediafocus.cpp
@@ -241,19 +241,19 @@ LLVector3d LLViewerMediaFocus::setCameraZoom(LLViewerObject* object, LLVector3 n
         if(camera_aspect < 1.0f || invert)
         {
             angle_of_view = llmax(0.1f, LLViewerCamera::getInstance()->getView() * LLViewerCamera::getInstance()->getAspect());
-            distance = width * 0.5 * padding_factor / tan(angle_of_view * 0.5f );
+            distance = width * 0.5f * padding_factor / tanf(angle_of_view * 0.5f );
 
             LL_DEBUGS() << "using width (" << width << "), angle_of_view = " << angle_of_view << ", distance = " << distance << LL_ENDL;
         }
         else
         {
             angle_of_view = llmax(0.1f, LLViewerCamera::getInstance()->getView());
-            distance = height * 0.5 * padding_factor / tan(angle_of_view * 0.5f );
+            distance = height * 0.5f * padding_factor / tanf(angle_of_view * 0.5f );
 
             LL_DEBUGS() << "using height (" << height << "), angle_of_view = " << angle_of_view << ", distance = " << distance << LL_ENDL;
         }
 
-        distance += depth * 0.5;
+        distance += depth * 0.5f;
 
         // Finally animate the camera to this new position and focal point
         LLVector3d target_pos;

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3672,7 +3672,7 @@ void process_time_synch(LLMessageSystem *mesgsys, void **user_data)
 
     LLWorld::getInstance()->setSpaceTimeUSec(space_time_usec);
 
-    LL_DEBUGS("WindlightSync") << "Sun phase: " << phase << " rad = " << fmodf(phase / F_TWO_PI + 0.25, 1.f) * 24.f << " h" << LL_ENDL;
+    LL_DEBUGS("WindlightSync") << "Sun phase: " << phase << " rad = " << fmodf(phase / F_TWO_PI + 0.25f, 1.f) * 24.f << " h" << LL_ENDL;
 
     /* LAPRAS
         We decode these parts of the message but ignore them
@@ -3691,7 +3691,7 @@ void process_sound_trigger(LLMessageSystem *msg, void **)
     }
 
     U64     region_handle = 0;
-    F32     gain = 0;
+    F32     gain = 0.f;
     LLUUID  sound_id;
     LLUUID  owner_id;
     LLUUID  object_id;

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -2451,7 +2451,7 @@ void LLViewerObject::idleUpdate(LLAgent &agent, const F64 &frame_time)
         {
             // calculate dt from last update
             F32 time_dilation = mRegionp ? mRegionp->getTimeDilation() : 1.0f;
-            F32 dt_raw = ((F64Seconds)frame_time - mLastInterpUpdateSecs).value();
+            F32 dt_raw = (F32)((F64Seconds)frame_time - mLastInterpUpdateSecs).value();
             F32 dt = time_dilation * dt_raw;
 
             applyAngularVelocity(dt);
@@ -2950,7 +2950,7 @@ void LLViewerObject::fetchInventoryDelayed(const F64 &time_seconds)
 //static
 void LLViewerObject::fetchInventoryDelayedCoro(const LLUUID task_inv, const F64 time_seconds)
 {
-    llcoro::suspendUntilTimeout(time_seconds);
+    llcoro::suspendUntilTimeout((float)time_seconds);
     LLViewerObject *obj = gObjectList.findObject(task_inv);
     if (obj)
     {

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -1129,10 +1129,10 @@ void LLViewerObjectList::fetchObjectCostsCoro(std::string url)
         {
             LLSD objectData = result[it->asString()];
 
-            F32 linkCost = objectData["linked_set_resource_cost"].asReal();
-            F32 objectCost = objectData["resource_cost"].asReal();
-            F32 physicsCost = objectData["physics_cost"].asReal();
-            F32 linkPhysicsCost = objectData["linked_set_physics_cost"].asReal();
+            F32 linkCost = (F32)objectData["linked_set_resource_cost"].asReal();
+            F32 objectCost = (F32)objectData["resource_cost"].asReal();
+            F32 physicsCost = (F32)objectData["physics_cost"].asReal();
+            F32 linkPhysicsCost = (F32)objectData["linked_set_physics_cost"].asReal();
 
             gObjectList.updateObjectCost(objectId, objectCost, linkCost, physicsCost, linkPhysicsCost);
         }
@@ -1257,10 +1257,10 @@ void LLViewerObjectList::fetchPhisicsFlagsCoro(std::string url)
 
             if (data.has("Density"))
             {
-                F32 density = data["Density"].asReal();
-                F32 friction = data["Friction"].asReal();
-                F32 restitution = data["Restitution"].asReal();
-                F32 gravityMult = data["GravityMultiplier"].asReal();
+                F32 density = (F32)data["Density"].asReal();
+                F32 friction = (F32)data["Friction"].asReal();
+                F32 restitution = (F32)data["Restitution"].asReal();
+                F32 gravityMult = (F32)data["GravityMultiplier"].asReal();
 
                 gObjectList.updatePhysicsProperties(objectId, density,
                     friction, restitution, gravityMult);

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -1282,7 +1282,7 @@ void LLViewerRegion::updateReflectionProbes(bool full_update)
 
     F32 start = probe_spacing * 0.5f;
 
-    U32 grid_width = REGION_WIDTH_METERS / probe_spacing;
+    U32 grid_width = (U32)(REGION_WIDTH_METERS / probe_spacing);
 
     mReflectionMaps.resize(grid_width * grid_width);
 
@@ -3739,7 +3739,7 @@ void LLViewerRegion::resetMaterialsCapThrottle()
     if (   mSimulatorFeatures.has("RenderMaterialsCapability")
         && mSimulatorFeatures["RenderMaterialsCapability"].isReal() )
     {
-        requests_per_sec = mSimulatorFeatures["RenderMaterialsCapability"].asReal();
+        requests_per_sec = (F32)mSimulatorFeatures["RenderMaterialsCapability"].asReal();
         if ( requests_per_sec == 0.0f )
         {
             requests_per_sec = 1.0f;

--- a/indra/newview/llviewerstats.cpp
+++ b/indra/newview/llviewerstats.cpp
@@ -284,13 +284,13 @@ void LLViewerStats::updateFrameStats(const F64Seconds time_diff)
         add(LLStatViewer::LOSS_5_PERCENT_TIME, time_diff);
     }
 
-    F32 sim_fps = getRecording().getLastValue(LLStatViewer::SIM_FPS);
+    F32 sim_fps = (F32)getRecording().getLastValue(LLStatViewer::SIM_FPS);
     if (0.f < sim_fps && sim_fps < 20.f)
     {
         add(LLStatViewer::SIM_20_FPS_TIME, time_diff);
     }
 
-    F32 sim_physics_fps = getRecording().getLastValue(LLStatViewer::SIM_PHYSICS_FPS);
+    F32 sim_physics_fps = (F32)getRecording().getLastValue(LLStatViewer::SIM_PHYSICS_FPS);
 
     if (0.f < sim_physics_fps && sim_physics_fps < 20.f)
     {

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -220,7 +220,7 @@ public:
         LLRectf image_rect = draw_rect;
         image_rect.mRight = image_rect.mLeft + mImage->getWidth();
         image_rect.mTop = image_rect.mBottom + mImage->getHeight();
-        mImage->draw(LLRect(image_rect.mLeft, image_rect.mTop, image_rect.mRight, image_rect.mBottom));
+        mImage->draw(LLRect((S32)image_rect.mLeft, (S32)image_rect.mTop, (S32)image_rect.mRight, (S32)image_rect.mBottom));
 
         LLColor4 color;
         if (mEditor.getReadOnly())

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -507,7 +507,7 @@ void LLViewerTexture::updateClass()
     // NOTE: our metrics miss about half the vram we use, so this biases high but turns out to typically be within 5% of the real number
     F32 used = (F32)ll_round(texture_bytes_alloc + vertex_bytes_alloc + render_bytes_alloc);
 
-    F32 budget = max_vram_budget == 0 ? gGLManager.mVRAM : max_vram_budget;
+    F32 budget = max_vram_budget == 0 ? (F32)gGLManager.mVRAM : (F32)max_vram_budget;
 
     // try to leave half a GB for everyone else, but keep at least 768MB for ourselves
     F32 target = llmax(budget - 512.f, MIN_VRAM_BUDGET);
@@ -534,7 +534,7 @@ void LLViewerTexture::updateClass()
 
         if (sDesiredDiscardBias > 1.f && over_pct < 0.f)
         {
-            sDesiredDiscardBias -= gFrameIntervalSeconds * 0.01;
+            sDesiredDiscardBias -= gFrameIntervalSeconds * 0.01f;
         }
     }
 
@@ -2862,7 +2862,7 @@ LLViewerLODTexture::LLViewerLODTexture(const std::string& url, FTType f_type, co
 
 void LLViewerLODTexture::init(bool firstinit)
 {
-    mTexelsPerImage = 64.f*64.f;
+    mTexelsPerImage = 64*64;
     mDiscardVirtualSize = 0.f;
     mCalculatedDiscardLevel = -1.f;
 }
@@ -3857,8 +3857,8 @@ LLMetricPerformanceTesterWithSession::LLTestSession* LLTexturePipelineTester::lo
         }
 
         //time
-        F32 start_time = (*log)[label]["StartFetchingTime"].asReal();
-        F32 cur_time   = (*log)[label]["Time"].asReal();
+        F32 start_time = (F32)(*log)[label]["StartFetchingTime"].asReal();
+        F32 cur_time   = (F32)(*log)[label]["Time"].asReal();
         if(start_time - start_fetching_time > F_ALMOST_ZERO) //fetching has paused for a while
         {
             sessionp->mTotalGrayTime += total_gray_time;
@@ -3874,13 +3874,13 @@ LLMetricPerformanceTesterWithSession::LLTestSession* LLTexturePipelineTester::lo
         }
         else
         {
-            total_gray_time = (*log)[label]["TotalGrayTime"].asReal();
-            total_stablizing_time = (*log)[label]["TotalStablizingTime"].asReal();
+            total_gray_time = (F32)(*log)[label]["TotalGrayTime"].asReal();
+            total_stablizing_time = (F32)(*log)[label]["TotalStablizingTime"].asReal();
 
-            total_loading_sculpties_time = (*log)[label]["EndTimeLoadingSculpties"].asReal() - (*log)[label]["StartTimeLoadingSculpties"].asReal();
+            total_loading_sculpties_time = (F32)(*log)[label]["EndTimeLoadingSculpties"].asReal() - (F32)(*log)[label]["StartTimeLoadingSculpties"].asReal();
             if(start_fetching_sculpties_time < 0.f && total_loading_sculpties_time > 0.f)
             {
-                start_fetching_sculpties_time = (*log)[label]["StartTimeLoadingSculpties"].asReal();
+                start_fetching_sculpties_time = (F32)(*log)[label]["StartTimeLoadingSculpties"].asReal();
             }
         }
 
@@ -3896,7 +3896,7 @@ LLMetricPerformanceTesterWithSession::LLTestSession* LLTexturePipelineTester::lo
         sessionp->mInstantPerformanceList[sessionp->mInstantPerformanceListCounter].mAverageBytesUsedForLargeImagePerSecond +=
             (*log)[label]["TotalBytesBoundForLargeImage"].asInteger();
         sessionp->mInstantPerformanceList[sessionp->mInstantPerformanceListCounter].mAveragePercentageBytesUsedPerSecond +=
-            (*log)[label]["PercentageBytesBound"].asReal();
+            (F32)(*log)[label]["PercentageBytesBound"].asReal();
         frame_count++;
         if(cur_time - last_time >= 1.0f)
         {

--- a/indra/newview/llviewertextureanim.cpp
+++ b/indra/newview/llviewertextureanim.cpp
@@ -217,7 +217,7 @@ S32 LLViewerTextureAnim::animateTextures(F32 &off_s, F32 &off_t,
                 result |= SCALE;
                 mScaleS = scale_s = 1.f/mSizeX;
                 mScaleT = scale_t = 1.f/mSizeY;
-                x_frame = fmod(frame_counter, mSizeX);
+                x_frame = fmodf(frame_counter, mSizeX);
                 y_frame = (S32)(frame_counter / mSizeX);
                 x_pos = x_frame * scale_s;
                 y_pos = y_frame * scale_t;

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -833,7 +833,7 @@ void LLViewerTextureList::updateImages(F32 max_time)
     }
     cleared = false;
 
-    LLAppViewer::getTextureFetch()->setTextureBandwidth(LLTrace::get_frame_recording().getPeriodMeanPerSec(LLStatViewer::TEXTURE_NETWORK_DATA_RECEIVED).value());
+    LLAppViewer::getTextureFetch()->setTextureBandwidth((F32)LLTrace::get_frame_recording().getPeriodMeanPerSec(LLStatViewer::TEXTURE_NETWORK_DATA_RECEIVED).value());
 
     {
         using namespace LLStatViewer;
@@ -963,7 +963,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                 if (apply_bias)
                 {
                     F32 bias = powf(4, LLViewerTexture::sDesiredDiscardBias - 1.f);
-                    bias = llround(bias);
+                    bias = (F32)llround(bias);
                     vsize /= bias;
                 }
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -805,8 +805,8 @@ public:
             LLCoordGL coord = gViewerWindow->getCurrentMouse();
 
             // Convert x,y to raw pixel coords
-            S32 x_raw = llround(coord.mX * gViewerWindow->getWindowWidthRaw() / (F32) gViewerWindow->getWindowWidthScaled());
-            S32 y_raw = llround(coord.mY * gViewerWindow->getWindowHeightRaw() / (F32) gViewerWindow->getWindowHeightScaled());
+            S32 x_raw = (S32)llround(coord.mX * gViewerWindow->getWindowWidthRaw() / (F32) gViewerWindow->getWindowWidthScaled());
+            S32 y_raw = (S32)llround(coord.mY * gViewerWindow->getWindowHeightRaw() / (F32) gViewerWindow->getWindowHeightScaled());
 
             glReadPixels(x_raw, y_raw, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, color);
             addText(xpos, ypos, llformat("Pixel <%1d, %1d> R:%1d G:%1d B:%1d A:%1d", x_raw, y_raw, color[0], color[1], color[2], color[3]));
@@ -4479,8 +4479,8 @@ LLVector3 LLViewerWindow::mouseDirectionGlobal(const S32 x, const S32 y) const
     F32         fov = LLViewerCamera::getInstance()->getView();
 
     // find world view center in scaled ui coordinates
-    F32         center_x = getWorldViewRectScaled().getCenterX();
-    F32         center_y = getWorldViewRectScaled().getCenterY();
+    F32         center_x = (F32)getWorldViewRectScaled().getCenterX();
+    F32         center_y = (F32)getWorldViewRectScaled().getCenterY();
 
     // calculate pixel distance to screen
     F32         distance = ((F32)getWorldViewHeightScaled() * 0.5f) / (tan(fov / 2.f));
@@ -4505,8 +4505,8 @@ LLVector3 LLViewerWindow::mousePointHUD(const S32 x, const S32 y) const
     S32         height = getWorldViewHeightScaled();
 
     // find world view center
-    F32         center_x = getWorldViewRectScaled().getCenterX();
-    F32         center_y = getWorldViewRectScaled().getCenterY();
+    F32         center_x = (F32)getWorldViewRectScaled().getCenterX();
+    F32         center_y = (F32)getWorldViewRectScaled().getCenterY();
 
     // remap with uniform scale (1/height) so that top is -0.5, bottom is +0.5
     F32 hud_x = -((F32)x - center_x)  / height;
@@ -4528,8 +4528,8 @@ LLVector3 LLViewerWindow::mouseDirectionCamera(const S32 x, const S32 y) const
     S32         width = getWorldViewWidthScaled();
 
     // find world view center
-    F32         center_x = getWorldViewRectScaled().getCenterX();
-    F32         center_y = getWorldViewRectScaled().getCenterY();
+    F32         center_x = (F32)getWorldViewRectScaled().getCenterX();
+    F32         center_y = (F32)getWorldViewRectScaled().getCenterY();
 
     // calculate click point relative to middle of screen
     F32         click_x = (((F32)x - center_x) / (F32)width) * fov_width * -1.f;
@@ -4777,7 +4777,7 @@ void LLViewerWindow::saveImageLocal(LLImageFormatted *image, const snapshot_save
         args["NEED_MEMORY"] = needM_bytes_string;
 
         std::string freeM_bytes_string;
-        LLResMgr::getInstance()->getIntegerString(freeM_bytes_string, (b_space.free) >> 10);
+        LLResMgr::getInstance()->getIntegerString(freeM_bytes_string, (S32)(b_space.free >> 10));
         args["FREE_MEMORY"] = freeM_bytes_string;
 
         LLNotificationsUtil::add("SnapshotToComputerFailed", args);

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -4531,7 +4531,7 @@ void LLVOAvatar::updateRootPositionAndRotation(LLAgent& agent, F32 speed, bool w
             root_pos += LLVector3d(getHoverOffset());
             if (getOverallAppearance() == AOA_JELLYDOLL)
             {
-                F32 offz = -0.5 * (getScale()[VZ] - mBodySize.mV[VZ]);
+                F32 offz = -0.5f * (getScale()[VZ] - mBodySize.mV[VZ]);
                 root_pos[2] += offz;
                 // if (!isSelf() && !isControlAvatar())
                 // {
@@ -4778,8 +4778,8 @@ bool LLVOAvatar::updateCharacter(LLAgent &agent)
     if (!getParent() && (isSitting() || was_sit_ground_constrained))
     {
 
-        F32 off_z = LLVector3d(getHoverOffset()).mdV[VZ];
-        if (off_z != 0.0)
+        F32 off_z = (F32)LLVector3d(getHoverOffset()).mdV[VZ];
+        if (off_z != 0.0f)
         {
             LLVector3 pos = mRoot->getWorldPosition();
             pos.mV[VZ] += off_z;
@@ -8529,7 +8529,7 @@ void LLVOAvatar::updateTooSlow()
         auto it = std::find(sAVsIgnoringARTLimit.begin(), sAVsIgnoringARTLimit.end(), mID);
         if (it != sAVsIgnoringARTLimit.end())
         {
-            S32 index = it - sAVsIgnoringARTLimit.begin();
+            S32 index = (S32)(it - sAVsIgnoringARTLimit.begin());
             ignore_tune = (index < (MIN_NONTUNED_AVS - sAvatarsNearby + 1 + LLPerfStats::tunedAvatars));
         }
     }
@@ -9505,7 +9505,7 @@ void LLVOAvatar::parseAppearanceMessage(LLMessageSystem* mesgsys, LLAppearanceMe
         std::vector<LLVisualParam*>::iterator it = std::find(contents.mParams.begin(), contents.mParams.end(),appearance_version_param);
         if (it != contents.mParams.end())
         {
-            S32 index = it - contents.mParams.begin();
+            S32 index = (S32)(it - contents.mParams.begin());
             contents.mParamAppearanceVersion = ll_round(contents.mParamWeights[index]);
             //LL_DEBUGS("Avatar") << "appversion req by appearance_version param: " << contents.mParamAppearanceVersion << LL_ENDL;
         }
@@ -11101,7 +11101,7 @@ void LLVOAvatar::accountRenderComplexityForObject(
                     LLObjectComplexity object_complexity;
                     object_complexity.objectName = attached_object->getAttachmentItemName();
                     object_complexity.objectId = attached_object->getAttachmentItemID();
-                    object_complexity.objectCost = attachment_total_cost;
+                    object_complexity.objectCost = (U32)attachment_total_cost;
                     object_complexity_list.push_back(object_complexity);
                 }
             }

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -2346,7 +2346,7 @@ LLSD summarize_by_buckets(std::vector<LLSD> in_records,
             key[field] = record[field];
         }
         LLViewerStats::StatsAccumulator& stats = accum[key];
-        F32 value = record[val_field].asReal();
+        F32 value = (F32)record[val_field].asReal();
         stats.push(value);
     }
     for (std::map<LLSD,LLViewerStats::StatsAccumulator>::iterator accum_it = accum.begin();

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -479,8 +479,8 @@ void LLVOCacheEntry::updateDebugSettings()
     LLMemory::updateMemoryInfo() ;
     U32 allocated_mem = LLMemory::getAllocatedMemKB().value();
     static const F32 KB_to_MB = 1.f / 1024.f;
-    U32 clamped_memory = llclamp(allocated_mem * KB_to_MB, (F32) low_mem_bound_MB, (F32) high_mem_bound_MB);
-    const F32 adjust_range = high_mem_bound_MB - low_mem_bound_MB;
+    U32 clamped_memory = (U32)llclamp(allocated_mem * KB_to_MB, (F32) low_mem_bound_MB, (F32) high_mem_bound_MB);
+    const F32 adjust_range = (F32)(high_mem_bound_MB - low_mem_bound_MB);
     const F32 adjust_factor = (high_mem_bound_MB - clamped_memory) / adjust_range; // [0, 1]
 
     //min radius: all objects within this radius remain loaded in memory
@@ -502,7 +502,7 @@ void LLVOCacheEntry::updateDebugSettings()
     static const U32 MIN_FRAMES = 10;
     static const U32 MAX_FRAMES = 64;
     const U32 clamped_frames = inv_obj_time ? llclamp((U32) inv_obj_time, MIN_FRAMES, MAX_FRAMES) : MAX_FRAMES; // [10, 64], with zero => 64
-    sMinFrameRange = MIN_FRAMES + ((clamped_frames - MIN_FRAMES) * adjust_factor);
+    sMinFrameRange = MIN_FRAMES + (U32)((clamped_frames - MIN_FRAMES) * adjust_factor);
 }
 #endif // LL_TEST
 
@@ -1762,7 +1762,7 @@ void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry:
 
         entry = new HeaderEntryInfo();
         entry->mHandle = handle ;
-        entry->mTime = time(NULL) ;
+        entry->mTime = (U32)time(NULL) ;
         entry->mIndex = mNumEntries++;
         mHeaderEntryQueue.insert(entry) ;
         mHandleEntryMap[handle] = entry ;
@@ -1775,7 +1775,7 @@ void LLVOCache::writeToCache(U64 handle, const LLUUID& id, const LLVOCacheEntry:
         //resort
         mHeaderEntryQueue.erase(entry) ;
 
-        entry->mTime = time(NULL) ;
+        entry->mTime = (U32)time(NULL) ;
         mHeaderEntryQueue.insert(entry) ;
     }
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -1284,7 +1284,7 @@ bool LLVivoxVoiceClient::establishVoiceConnection()
             {
                 if (result.has("retry") && ++retries <= CONNECT_RETRY_MAX && !sShuttingDown)
                 {
-                    F32 timeout = LLSD::Real(result["retry"]);
+                    F32 timeout = (F32)LLSD::Real(result["retry"]);
                     timeout *= retries;
                     LL_INFOS("Voice") << "Retry connection to voice service in " << timeout << " seconds" << LL_ENDL;
                     llcoro::suspendUntilTimeout(timeout);

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -710,7 +710,7 @@ void LLWebRTCVoiceClient::tuningSetSpeakerVolume(float volume)
 
     if (volume != mTuningSpeakerVolume)
     {
-        mTuningSpeakerVolume = volume;
+        mTuningSpeakerVolume = (int)volume;
     }
 }
 
@@ -718,11 +718,11 @@ float LLWebRTCVoiceClient::getAudioLevel()
 {
     if (mIsInTuningMode)
     {
-        return (1.0 - mWebRTCDeviceInterface->getTuningAudioLevel() * LEVEL_SCALE_WEBRTC) * mTuningMicGain / 2.1;
+        return (1.0f - mWebRTCDeviceInterface->getTuningAudioLevel() * LEVEL_SCALE_WEBRTC) * mTuningMicGain / 2.1f;
     }
     else
     {
-        return (1.0 - mWebRTCDeviceInterface->getPeerConnectionAudioLevel() * LEVEL_SCALE_WEBRTC) * mMicGain / 2.1;
+        return (1.0f - mWebRTCDeviceInterface->getPeerConnectionAudioLevel() * LEVEL_SCALE_WEBRTC) * mMicGain / 2.1f;
     }
 }
 
@@ -2096,7 +2096,7 @@ LLVoiceWebRTCConnection::LLVoiceWebRTCConnection(const LLUUID &regionID, const s
 {
     // retries wait a short period...randomize it so
     // all clients don't try to reconnect at once.
-    mRetryWaitSecs = ((F32) rand() / (RAND_MAX)) + 0.5;
+    mRetryWaitSecs = (F32)((F32) rand() / (RAND_MAX)) + 0.5f;
 
     mWebRTCPeerConnectionInterface = llwebrtc::newPeerConnection();
     mWebRTCPeerConnectionInterface->setSignalingObserver(this);
@@ -2678,7 +2678,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
         case VOICE_STATE_SESSION_UP:
         {
             mRetryWaitPeriod = 0;
-            mRetryWaitSecs   = ((F32) rand() / (RAND_MAX)) + 0.5;
+            mRetryWaitSecs   = (F32)((F32) rand() / (RAND_MAX)) + 0.5f;
 
             // we'll stay here as long as the session remains up.
             if (mShutDown)
@@ -2700,7 +2700,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
                 {
                     // back off the retry period, and do it by a small random
                     // bit so all clients don't reconnect at once.
-                    mRetryWaitSecs += ((F32) rand() / (RAND_MAX)) + 0.5;
+                    mRetryWaitSecs += (F32)((F32) rand() / (RAND_MAX)) + 0.5f;
                     mRetryWaitPeriod = 0;
                 }
             }

--- a/indra/newview/llvosky.cpp
+++ b/indra/newview/llvosky.cpp
@@ -107,7 +107,7 @@ void LLSkyTex::init(bool isShiny)
     {
         mTexture[i] = LLViewerTextureManager::getLocalTexture(false);
         mTexture[i]->setAddressMode(LLTexUnit::TAM_CLAMP);
-        mImageRaw[i] = new LLImageRaw(SKYTEX_RESOLUTION, SKYTEX_RESOLUTION, SKYTEX_COMPONENTS);
+        mImageRaw[i] = new LLImageRaw((U16)SKYTEX_RESOLUTION, (U16)SKYTEX_RESOLUTION, (S8)SKYTEX_COMPONENTS);
 
         initEmpty(i);
     }
@@ -139,7 +139,7 @@ LLSkyTex::~LLSkyTex()
 
 S32 LLSkyTex::getResolution()
 {
-    return SKYTEX_RESOLUTION;
+    return (S32)SKYTEX_RESOLUTION;
 }
 
 S32 LLSkyTex::getCurrent()
@@ -172,8 +172,8 @@ void LLSkyTex::initEmpty(const S32 tex)
     {
         for (S32 j = 0; j < SKYTEX_RESOLUTION; ++j)
         {
-            const S32 basic_offset = (i * SKYTEX_RESOLUTION + j);
-            S32 offset = basic_offset * SKYTEX_COMPONENTS;
+            const S32 basic_offset = (i * (S32)SKYTEX_RESOLUTION + j);
+            S32 offset = basic_offset * (S32)SKYTEX_COMPONENTS;
             data[offset] = 0;
             data[offset+1] = 0;
             data[offset+2] = 0;
@@ -194,8 +194,8 @@ void LLSkyTex::create()
     {
         for (S32 j = 0; j < SKYTEX_RESOLUTION; ++j)
         {
-            const S32 basic_offset = (i * SKYTEX_RESOLUTION + j);
-            S32 offset = basic_offset * SKYTEX_COMPONENTS;
+            const S32 basic_offset = (i * (S32)SKYTEX_RESOLUTION + j);
+            S32 offset = basic_offset * (S32)SKYTEX_COMPONENTS;
             U32* pix = (U32*)(data + offset);
             LLColor4U temp = LLColor4U(mSkyData[basic_offset]);
             *pix = temp.asRGBA();
@@ -392,8 +392,8 @@ const LLVector3* LLHeavenBody::corners() const
         Sky
 ***************************************/
 
-const S32 SKYTEX_TILE_RES_X = SKYTEX_RESOLUTION / NUM_TILES_X;
-const S32 SKYTEX_TILE_RES_Y = SKYTEX_RESOLUTION / NUM_TILES_Y;
+const S32 SKYTEX_TILE_RES_X = (S32)SKYTEX_RESOLUTION / NUM_TILES_X;
+const S32 SKYTEX_TILE_RES_Y = (S32)SKYTEX_RESOLUTION / NUM_TILES_Y;
 
 LLVOSky::LLVOSky(const LLUUID &id, const LLPCode pcode, LLViewerRegion *regionp)
 :   LLStaticViewerObject(id, pcode, regionp, true),

--- a/indra/newview/llvosky.h
+++ b/indra/newview/llvosky.h
@@ -83,26 +83,26 @@ protected:
 
     void setDir(const LLVector3 &dir, const S32 i, const S32 j)
     {
-        S32 offset = i * SKYTEX_RESOLUTION + j;
+        S32 offset = (S32)(i * SKYTEX_RESOLUTION + j);
         mSkyDirs[offset] = dir;
     }
 
     const LLVector3 &getDir(const S32 i, const S32 j) const
     {
-        S32 offset = i * SKYTEX_RESOLUTION + j;
+        S32 offset = (S32)(i * SKYTEX_RESOLUTION + j);
         return mSkyDirs[offset];
     }
 
     void setPixel(const LLColor4 &col, const S32 i, const S32 j)
     {
-        S32 offset = i * SKYTEX_RESOLUTION + j;
+        S32 offset = (S32)(i * SKYTEX_RESOLUTION + j);
         mSkyData[offset] = col;
     }
 
     void setPixel(const LLColor4U &col, const S32 i, const S32 j)
     {
         LLImageDataSharedLock lock(mImageRaw[sCurrent]);
-        S32 offset = (i * SKYTEX_RESOLUTION + j) * SKYTEX_COMPONENTS;
+        S32 offset = (S32)((i * SKYTEX_RESOLUTION + j) * SKYTEX_COMPONENTS);
         U32* pix = (U32*) &(mImageRaw[sCurrent]->getData()[offset]);
         *pix = col.asRGBA();
     }
@@ -111,7 +111,7 @@ protected:
     {
         LLColor4U col;
         LLImageDataSharedLock lock(mImageRaw[sCurrent]);
-        S32 offset = (i * SKYTEX_RESOLUTION + j) * SKYTEX_COMPONENTS;
+        S32 offset = (S32)((i * SKYTEX_RESOLUTION + j) * SKYTEX_COMPONENTS);
         U32* pix = (U32*) &(mImageRaw[sCurrent]->getData()[offset]);
         col.fromRGBA( *pix );
         return col;

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -1275,8 +1275,8 @@ void LLVOVolume::sculpt()
         if(current_discard < -2)
         {
             static S32 low_sculpty_discard_warning_count = 1;
-            S32 exponent = llmax(1, llfloor( log10((F64) low_sculpty_discard_warning_count) ));
-            S32 interval = pow(10.0, exponent);
+            S32 exponent = llmax(1, llfloor((F32)log10((F64) low_sculpty_discard_warning_count)));
+            S32 interval = (S32)pow(10.0, exponent);
             if ( low_sculpty_discard_warning_count < 10 ||
                 (low_sculpty_discard_warning_count % interval) == 0)
             {   // Log first 10 time, then decreasing intervals afterwards otherwise this can flood the logs
@@ -1294,8 +1294,8 @@ void LLVOVolume::sculpt()
         else if (current_discard > MAX_DISCARD_LEVEL)
         {
             static S32 high_sculpty_discard_warning_count = 1;
-            S32 exponent = llmax(1, llfloor( log10((F64) high_sculpty_discard_warning_count) ));
-            S32 interval = pow(10.0, exponent);
+            S32 exponent = llmax(1, llfloor((F32)log10((F64) high_sculpty_discard_warning_count)));
+            S32 interval = (S32)pow(10.0, exponent);
             if ( high_sculpty_discard_warning_count < 10 ||
                 (high_sculpty_discard_warning_count % interval) == 0)
             {   // Log first 10 time, then decreasing intervals afterwards otherwise this can flood the logs
@@ -1541,7 +1541,7 @@ bool LLVOVolume::calcLOD()
         if (isRootEdit())
         {
             S32 total_tris = recursiveGetTriangleCount();
-            S32 est_max_tris = recursiveGetEstTrianglesMax();
+            S32 est_max_tris = (S32)recursiveGetEstTrianglesMax();
             setDebugText(llformat("TRIS SHOWN %d EST %d", total_tris, est_max_tris));
         }
     }
@@ -4053,12 +4053,12 @@ U32 LLVOVolume::getRenderCost(texture_cost_t &textures) const
             // Scaling here is to make animated object vs
             // non-animated object ARC proportional to the
             // corresponding calculations for streaming cost.
-            num_triangles = (ANIMATED_OBJECT_COST_PER_KTRI * 0.001 * costs.getEstTrisForStreamingCost())/0.06;
+            num_triangles = (U32)((ANIMATED_OBJECT_COST_PER_KTRI * 0.001f * costs.getEstTrisForStreamingCost())/0.06f);
         }
         else
         {
             F32 radius = getScale().length()*0.5f;
-            num_triangles = costs.getRadiusWeightedTris(radius);
+            num_triangles = (U32)costs.getRadiusWeightedTris(radius);
         }
     }
 
@@ -4534,7 +4534,7 @@ F32 LLVOVolume::getBinRadius()
     }
     else
     {
-        F32 szf = size_factor;
+        F32 szf = (F32)size_factor;
         radius = llmax(mDrawable->getRadius(), szf);
         //radius = llmax(radius, mDrawable->mDistanceWRTCamera * distance_factor[0]);
     }
@@ -5879,7 +5879,7 @@ void LLVolumeGeometryManager::rebuildGeom(LLSpatialGroup* group)
                             F32 alpha;
                             if (is_pbr)
                             {
-                                alpha = gltf_mat ? gltf_mat->mBaseColor.mV[3] : 1.0;
+                                alpha = gltf_mat ? gltf_mat->mBaseColor.mV[3] : 1.0f;
                             }
                             else
                             {

--- a/indra/newview/llvowater.cpp
+++ b/indra/newview/llvowater.cpp
@@ -138,8 +138,8 @@ bool LLVOWater::updateGeometry(LLDrawable *drawable)
     S32 size_y = LLPipeline::sRenderTransparentWater ? 8 : 1;
 
     const LLVector3& scale = getScale();
-    size_x *= llmin(llround(scale.mV[0] / 256.f), 8);
-    size_y *= llmin(llround(scale.mV[1] / 256.f), 8);
+    size_x *= (S32)llmin(llround(scale.mV[0] / 256.f), 8);
+    size_y *= (S32)llmin(llround(scale.mV[1] / 256.f), 8);
 
     const S32 num_quads = size_x * size_y;
     face->setSize(vertices_per_quad * num_quads,
@@ -191,8 +191,8 @@ bool LLVOWater::updateGeometry(LLDrawable *drawable)
             position_agent.mV[VX] += (x + 0.5f) * step_x;
             position_agent.mV[VY] += (y + 0.5f) * step_y;
 
-            position_agent.mV[VX] = llround(position_agent.mV[VX]);
-            position_agent.mV[VY] = llround(position_agent.mV[VY]);
+            position_agent.mV[VX] = (F32)llround(position_agent.mV[VX]);
+            position_agent.mV[VY] = (F32)llround(position_agent.mV[VY]);
 
             *verticesp++  = position_agent - right + up;
             *verticesp++  = position_agent - right - up;

--- a/indra/newview/llworld.cpp
+++ b/indra/newview/llworld.cpp
@@ -805,10 +805,10 @@ void LLWorld::updateNetStats()
     add(LLStatViewer::PACKETS_OUT, packets_out);
     add(LLStatViewer::PACKETS_LOST, packets_lost);
 
-    F32 total_packets_in = LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_IN);
-    if (total_packets_in > 0)
+    F32 total_packets_in = (F32)LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_IN);
+    if (total_packets_in > 0.f)
     {
-        F32 total_packets_lost = LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_LOST);
+        F32 total_packets_lost = (F32)LLViewerStats::instance().getRecording().getSum(LLStatViewer::PACKETS_LOST);
         sample(LLStatViewer::PACKETS_LOST_PERCENT, LLUnits::Ratio::fromValue((F32)total_packets_lost/(F32)total_packets_in));
     }
 

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -255,7 +255,7 @@ void LLWorldMapView::zoom(F32 zoom)
 void LLWorldMapView::zoomWithPivot(F32 zoom, S32 x, S32 y)
 {
     mTargetMapScale = scaleFromZoom(zoom);
-    sZoomPivot      = LLVector2(x, y);
+    sZoomPivot      = LLVector2((F32)x, (F32)y);
     if (!sZoomTimer.getStarted() && mMapScale != mTargetMapScale)
     {
         sZoomTimer.start();
@@ -297,8 +297,8 @@ void LLWorldMapView::setScale(F32 scale, bool snap)
         if (!sZoomPivot.isExactlyZero())
         {
             LLVector2 relative_pivot;
-            relative_pivot.mV[VX]     = sZoomPivot.mV[VX] - (getRect().getWidth() / 2.0);
-            relative_pivot.mV[VY]     = sZoomPivot.mV[VY] - (getRect().getHeight() / 2.0);
+            relative_pivot.mV[VX]     = sZoomPivot.mV[VX] - (getRect().getWidth() / 2.0f);
+            relative_pivot.mV[VY]     = sZoomPivot.mV[VY] - (getRect().getHeight() / 2.0f);
             LLVector2 zoom_pan_offset = relative_pivot - (relative_pivot * scale / old_scale);
             mPanX += zoom_pan_offset.mV[VX];
             mPanY += zoom_pan_offset.mV[VY];
@@ -422,8 +422,8 @@ void LLWorldMapView::draw()
 
         // Find x and y position relative to camera's center.
         LLVector3d rel_region_pos = origin_global - camera_global;
-        F32 relative_x = (rel_region_pos.mdV[0] / REGION_WIDTH_METERS) * mMapScale;
-        F32 relative_y = (rel_region_pos.mdV[1] / REGION_WIDTH_METERS) * mMapScale;
+        F32 relative_x = (F32)(rel_region_pos.mdV[0] / REGION_WIDTH_METERS) * mMapScale;
+        F32 relative_y = (F32)(rel_region_pos.mdV[1] / REGION_WIDTH_METERS) * mMapScale;
 
         // Coordinates of the sim in pixels in the UI panel
         // When the view isn't panned, 0,0 = center of rectangle
@@ -514,11 +514,11 @@ void LLWorldMapView::draw()
             {
                 font->renderUTF8(
                     mesg, 0,
-                    llfloor(left + 3), llfloor(bottom + 2),
+                    (F32)llfloor(left + 3), (F32)llfloor(bottom + 2),
                     LLColor4::white,
                     LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::DROP_SHADOW,
                     S32_MAX, //max_chars
-                    mMapScale, //max_pixels
+                    (S32)mMapScale, //max_pixels
                     NULL,
                     /*use_ellipses*/true);
             }

--- a/indra/newview/llxmlrpctransaction.cpp
+++ b/indra/newview/llxmlrpctransaction.cpp
@@ -278,8 +278,8 @@ LLXMLRPCTransaction::Impl::Impl
     httpOpts = LLCore::HttpOptions::ptr_t(new LLCore::HttpOptions());
 
     // Delay between repeats will start from 5 sec and grow to 20 sec with each repeat
-    httpOpts->setMinBackoff(5E6L);
-    httpOpts->setMaxBackoff(20E6L);
+    httpOpts->setMinBackoff((LLCore::HttpTime)5E6L);
+    httpOpts->setMaxBackoff((LLCore::HttpTime)20E6L);
 
     httpOpts->setTimeout(http_params.has("timeout") ? http_params["timeout"].asInteger() : 40L);
     if (http_params.has("retries"))

--- a/indra/newview/noise.h
+++ b/indra/newview/noise.h
@@ -344,7 +344,7 @@ static void init(void)
     }
 
     // reintroduce entropy
-    srand(time(NULL));      // Flawfinder: ignore
+    srand((unsigned int)time(NULL));      // Flawfinder: ignore
 }
 
 #undef B

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -1241,7 +1241,7 @@ void LLPipeline::createGLBuffers()
         F32 noise[noiseRes*noiseRes*3];
         for (U32 i = 0; i < noiseRes*noiseRes*3; i++)
         {
-            noise[i] = ll_frand()*2.0-1.0;
+            noise[i] = ll_frand()*2.0f-1.0f;
         }
 
         LLImageGL::generateTextures(1, &mTrueNoiseMap);
@@ -6914,7 +6914,7 @@ void LLPipeline::generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool
             }
         }
         shader->uniform1f(dt, gFrameIntervalSeconds);
-        shader->uniform2f(noiseVec, ll_frand() * 2.0 - 1.0, ll_frand() * 2.0 - 1.0);
+        shader->uniform2f(noiseVec, ll_frand() * 2.0f - 1.0f, ll_frand() * 2.0f - 1.0f);
         shader->uniform3f(dynamic_exposure_params, dynamic_exposure_coefficient, exp_min, exp_max);
 
         mScreenTriangleVB->setBuffer();
@@ -6960,7 +6960,7 @@ void LLPipeline::gammaCorrect(LLRenderTarget* src, LLRenderTarget* dst) {
 
         shader.bindTexture(LLShaderMgr::EXPOSURE_MAP, &mExposureMap);
 
-        shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, src->getWidth(), src->getHeight());
+        shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)src->getWidth(), (GLfloat)src->getHeight());
 
         static LLCachedControl<F32> exposure(gSavedSettings, "RenderExposure", 1.f);
 
@@ -7039,8 +7039,8 @@ void LLPipeline::generateGlow(LLRenderTarget* src)
                 gGL.getTexUnit(channel)->setTextureFilteringOption(LLTexUnit::TFO_POINT);
             }
             gGlowExtractProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
-                                          mGlow[2].getWidth(),
-                                          mGlow[2].getHeight());
+                                          (GLfloat)mGlow[2].getWidth(),
+                                          (GLfloat)mGlow[2].getHeight());
         }
 
         {
@@ -7365,7 +7365,7 @@ void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
 
                 gDeferredCoFProgram.uniform1f(LLShaderMgr::DEFERRED_DEPTH_CUTOFF, RenderEdgeDepthCutoff);
                 gDeferredCoFProgram.uniform1f(LLShaderMgr::DEFERRED_NORM_CUTOFF, RenderEdgeNormCutoff);
-                gDeferredCoFProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, dst->getWidth(), dst->getHeight());
+                gDeferredCoFProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)dst->getWidth(), (GLfloat)dst->getHeight());
                 gDeferredCoFProgram.uniform1f(LLShaderMgr::DOF_FOCAL_DISTANCE, -subject_distance / 1000.f);
                 gDeferredCoFProgram.uniform1f(LLShaderMgr::DOF_BLUR_CONSTANT, blur_constant);
                 gDeferredCoFProgram.uniform1f(LLShaderMgr::DOF_TAN_PIXEL_ANGLE, tanf(1.f / LLDrawable::sCurPixelAngle));
@@ -7391,7 +7391,7 @@ void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
                 gDeferredPostProgram.bind();
                 gDeferredPostProgram.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, &mRT->deferredLight, LLTexUnit::TFO_POINT);
 
-                gDeferredPostProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, dst->getWidth(), dst->getHeight());
+                gDeferredPostProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)dst->getWidth(), (GLfloat)dst->getHeight());
                 gDeferredPostProgram.uniform1f(LLShaderMgr::DOF_MAX_COF, CameraMaxCoF);
                 gDeferredPostProgram.uniform1f(LLShaderMgr::DOF_RES_SCALE, CameraDoFResScale);
 
@@ -7424,7 +7424,7 @@ void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
                 gDeferredDoFCombineProgram.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, src, LLTexUnit::TFO_POINT);
                 gDeferredDoFCombineProgram.bindTexture(LLShaderMgr::DEFERRED_LIGHT, &mRT->deferredLight, LLTexUnit::TFO_POINT);
 
-                gDeferredDoFCombineProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, dst->getWidth(), dst->getHeight());
+                gDeferredDoFCombineProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)dst->getWidth(), (GLfloat)dst->getHeight());
                 gDeferredDoFCombineProgram.uniform1f(LLShaderMgr::DOF_MAX_COF, CameraMaxCoF);
                 gDeferredDoFCombineProgram.uniform1f(LLShaderMgr::DOF_RES_SCALE, CameraDoFResScale);
                 gDeferredDoFCombineProgram.uniform1f(LLShaderMgr::DOF_WIDTH, (dof_width - 1) / (F32)src->getWidth());
@@ -7787,15 +7787,15 @@ void LLPipeline::bindDeferredShader(LLGLSLShader& shader, LLRenderTarget* light_
     shader.uniform1f(LLShaderMgr::DEFERRED_BLUR_SIZE, RenderShadowBlurSize);
 
     shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_RADIUS, RenderSSAOScale);
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_MAX_RADIUS, RenderSSAOMaxScale);
+    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_MAX_RADIUS, (GLfloat)RenderSSAOMaxScale);
 
     F32 ssao_factor = RenderSSAOFactor;
     shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_FACTOR, ssao_factor);
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_FACTOR_INV, 1.0/ssao_factor);
+    shader.uniform1f(LLShaderMgr::DEFERRED_SSAO_FACTOR_INV, 1.0f/ssao_factor);
 
     LLVector3 ssao_effect = RenderSSAOEffect;
-    F32 matrix_diag = (ssao_effect[0] + 2.0*ssao_effect[1])/3.0;
-    F32 matrix_nondiag = (ssao_effect[0] - ssao_effect[1])/3.0;
+    F32 matrix_diag = (ssao_effect[0] + 2.0f*ssao_effect[1])/3.0f;
+    F32 matrix_nondiag = (ssao_effect[0] - ssao_effect[1])/3.0f;
     // This matrix scales (proj of color onto <1/rt(3),1/rt(3),1/rt(3)>) by
     // value factor, and scales remainder by saturation factor
     F32 ssao_effect_mat[] = {   matrix_diag, matrix_nondiag, matrix_nondiag,
@@ -7807,7 +7807,7 @@ void LLPipeline::bindDeferredShader(LLGLSLShader& shader, LLRenderTarget* light_
     F32 shadow_bias_error = RenderShadowBiasError * fabsf(LLViewerCamera::getInstance()->getOrigin().mV[2])/3000.f;
     F32 shadow_bias       = RenderShadowBias + shadow_bias_error;
 
-    shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, deferred_target->getWidth(), deferred_target->getHeight());
+    shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)deferred_target->getWidth(), (GLfloat)deferred_target->getHeight());
     shader.uniform1f(LLShaderMgr::DEFERRED_NEAR_CLIP, LLViewerCamera::getInstance()->getNear()*2.f);
     shader.uniform1f (LLShaderMgr::DEFERRED_SHADOW_OFFSET, RenderShadowOffset); //*shadow_offset_error);
     shader.uniform1f(LLShaderMgr::DEFERRED_SHADOW_BIAS, shadow_bias);
@@ -7816,8 +7816,8 @@ void LLPipeline::bindDeferredShader(LLGLSLShader& shader, LLRenderTarget* light_
 
     shader.uniform3fv(LLShaderMgr::DEFERRED_SUN_DIR, 1, mTransformedSunDir.mV);
     shader.uniform3fv(LLShaderMgr::DEFERRED_MOON_DIR, 1, mTransformedMoonDir.mV);
-    shader.uniform2f(LLShaderMgr::DEFERRED_SHADOW_RES, mRT->shadow[0].getWidth(), mRT->shadow[0].getHeight());
-    shader.uniform2f(LLShaderMgr::DEFERRED_PROJ_SHADOW_RES, mSpotShadow[0].getWidth(), mSpotShadow[0].getHeight());
+    shader.uniform2f(LLShaderMgr::DEFERRED_SHADOW_RES, (GLfloat)mRT->shadow[0].getWidth(), (GLfloat)mRT->shadow[0].getHeight());
+    shader.uniform2f(LLShaderMgr::DEFERRED_PROJ_SHADOW_RES, (GLfloat)mSpotShadow[0].getWidth(), (GLfloat)mSpotShadow[0].getHeight());
     shader.uniform1f(LLShaderMgr::DEFERRED_DEPTH_CUTOFF, RenderEdgeDepthCutoff);
     shader.uniform1f(LLShaderMgr::DEFERRED_NORM_CUTOFF, RenderEdgeNormCutoff);
 
@@ -7948,8 +7948,8 @@ void LLPipeline::renderDeferredLighting()
 
                 gDeferredSunProgram.uniform3fv(sOffset, slice, offset);
                 gDeferredSunProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
-                                              deferred_light_target->getWidth(),
-                                              deferred_light_target->getHeight());
+                                              (GLfloat)deferred_light_target->getWidth(),
+                                              (GLfloat)deferred_light_target->getHeight());
 
                 {
                     LLGLDisable   blend(GL_BLEND);
@@ -8648,7 +8648,7 @@ void LLPipeline::setupSpotLight(LLGLSLShader& shader, LLDrawable* drawablep)
         {
             gGL.getTexUnit(channel)->bind(img);
 
-            F32 lod_range = logf(img->getWidth())/logf(2.f);
+            F32 lod_range = logf((F32)img->getWidth())/logf(2.f);
 
             shader.uniform1f(LLShaderMgr::PROJECTOR_FOCUS, focus);
             shader.uniform1f(LLShaderMgr::PROJECTOR_LOD, lod_range);
@@ -8773,17 +8773,17 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
     }
 
 
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, RenderScreenSpaceReflectionIterations);
+    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_ITR_COUNT, (GLfloat)RenderScreenSpaceReflectionIterations);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_DIST_BIAS, RenderScreenSpaceReflectionDistanceBias);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_RAY_STEP, RenderScreenSpaceReflectionRayStep);
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, RenderScreenSpaceReflectionGlossySamples);
+    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_GLOSSY_SAMPLES, (GLfloat)RenderScreenSpaceReflectionGlossySamples);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_REJECT_BIAS, RenderScreenSpaceReflectionDepthRejectBias);
     mPoissonOffset++;
 
     if (mPoissonOffset > 128 - RenderScreenSpaceReflectionGlossySamples)
         mPoissonOffset = 0;
 
-    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, mPoissonOffset);
+    shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_ADAPTIVE_STEP_MULT, RenderScreenSpaceReflectionAdaptiveStepMultiplier);
 
     channel = shader.enableTexture(LLShaderMgr::SCENE_DEPTH);
@@ -9949,7 +9949,7 @@ void LLPipeline::generateSunShadow(LLCamera& camera)
         {
             LLTrace::CountStatHandle<>* velocity_stat = LLViewerCamera::getVelocityStat();
             F32 fade_amt = gFrameIntervalSeconds.value()
-                * llmax(LLTrace::get_frame_recording().getLastRecording().getSum(*velocity_stat) / LLTrace::get_frame_recording().getLastRecording().getDuration().value(), 1.0);
+                * (F32)llmax(LLTrace::get_frame_recording().getLastRecording().getSum(*velocity_stat) / LLTrace::get_frame_recording().getLastRecording().getDuration().value(), 1.0);
 
             // should never happen
             llassert(mTargetShadowSpotLight[0] != mTargetShadowSpotLight[1] || mTargetShadowSpotLight[0].isNull());
@@ -10116,8 +10116,8 @@ void LLPipeline::generateSunShadow(LLCamera& camera)
 
     for (U32 i = 0; i < 16; i++)
     {
-        gGLLastModelView[i] = last_modelview[i];
-        gGLLastProjection[i] = last_projection[i];
+        gGLLastModelView[i] = (F32)last_modelview[i];
+        gGLLastProjection[i] = (F32)last_projection[i];
     }
 
     popRenderTypeMask();

--- a/indra/test/io.cpp
+++ b/indra/test/io.cpp
@@ -293,7 +293,7 @@ namespace tut
             len = BUFFER_LEN;
             last = mBuffer.readAfter(ch.in(), last, (U8*)buf, len);
             char* newline = strchr((char*)buf, '\n');
-            S32 offset = -((len - 1) - (newline - buf));
+            S32 offset = -((len - 1) - (S32)(newline - buf));
             ++newline;
             *newline = '\0';
             last_line.assign(buf);


### PR DESCRIPTION
@marchcat Had to disable C4244 for lltracerecording. and llunittype.h since the templates defined there are somewhat a mess and will need a closer look why and where exactly C4244 is still happening in them.

Since this is is an OS build, I can't say if there are still occurrances in llkdu