### PR TITLE
Fix broken hero probe feature table entries

### DIFF
--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -1,4 +1,4 @@
-version 61
+version 62
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -28,7 +28,6 @@ version 61
 //
 list all
 RenderAnisotropic			1	1
-RenderAvatarCloth			0	0
 RenderAvatarLODFactor		1	1.0
 RenderAvatarPhysicsLODFactor 1	1.0
 RenderAvatarMaxNonImpostors 1   16
@@ -65,7 +64,6 @@ RenderShaderLightingMaxLevel	1	3
 RenderReflectionProbeLevel  1   3
 RenderDeferred				1	1
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	2
 RenderUseStreamVBO			1	1
 RenderFSAASamples			1	16
@@ -107,7 +105,6 @@ RenderTerrainPBRPlanarSampleCount 1   1
 RenderTreeLODFactor			1	0
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	0
@@ -143,7 +140,6 @@ RenderTerrainPBRPlanarSampleCount 1   1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	0
@@ -177,7 +173,6 @@ RenderTerrainPBRPlanarSampleCount 1   1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -213,7 +208,6 @@ RenderTerrainPBRPlanarSampleCount 1   1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -249,7 +243,6 @@ RenderTerrainPBRPlanarSampleCount 1   3
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.5
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	1
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -285,7 +278,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.75
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	2
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -322,7 +314,6 @@ RenderVolumeLODFactor		1	2.0
 WindLightUseAtmosShaders	1	1
 WLSkyDetail					1	128
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -341,7 +332,6 @@ RenderHeroProbeConservativeUpdateMultiplier 1 4
 list Unknown
 RenderShadowDetail			1	0
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderMirrors				1	0
 
 //

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -76,6 +76,10 @@ RenderGLMultiThreadedMedia         1   1
 RenderReflectionProbeResolution 1 128
 RenderScreenSpaceReflections 1  1
 RenderMirrors				1	1
+RenderHeroProbeResolution	1	2048
+RenderHeroProbeDistance		1	16
+RenderHeroProbeUpdateRate	1	4
+RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderDownScaleMethod       1   1
 
 

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -1,4 +1,4 @@
-version 57
+version 58
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -28,7 +28,6 @@ version 57
 //
 list all
 RenderAnisotropic				1	0
-RenderAvatarCloth				0	0
 RenderAvatarLODFactor			1	1.0
 RenderAvatarPhysicsLODFactor 1	1.0
 RenderAvatarMaxNonImpostors     1   16
@@ -62,7 +61,6 @@ RenderCompressTextures		1	1
 RenderShaderLightingMaxLevel	1	3
 RenderDeferred				1	1
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	2
 RenderUseStreamVBO			1	1
 RenderFSAASamples			1	16
@@ -102,7 +100,6 @@ RenderTransparentWater		1	0
 RenderTreeLODFactor			1	0
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	0
@@ -138,7 +135,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	0
@@ -174,7 +170,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -210,7 +205,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	0
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -246,7 +240,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.5
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	1
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
@@ -283,7 +276,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.75
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
-RenderUseAdvancedAtmospherics 1 0
 WLSkyDetail					1	96
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -319,7 +311,6 @@ RenderVolumeLODFactor		1	2.0
 WindLightUseAtmosShaders	1	1
 WLSkyDetail					1	128
 RenderDeferredSSAO			1	1
-RenderUseAdvancedAtmospherics 1 0
 RenderShadowDetail			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -338,7 +329,6 @@ RenderHeroProbeConservativeUpdateMultiplier 1 4
 list Unknown
 RenderShadowDetail			1	0
 RenderDeferredSSAO			1	0
-RenderUseAdvancedAtmospherics 1 0
 RenderMirrors				1	0
 
 
@@ -359,7 +349,6 @@ RenderLocalLightCount		1	0
 RenderMaxPartCount			1	1024
 RenderTerrainDetail 		1	0
 RenderDeferredSSAO			0	0
-RenderUseAdvancedAtmospherics 0 0
 RenderShadowDetail			0	0
 RenderMirrors				0	0
 

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -75,6 +75,10 @@ RenderReflectionProbeDetail	1	2
 RenderScreenSpaceReflections 1  1
 RenderReflectionProbeLevel  1   3
 RenderMirrors				1	1
+RenderHeroProbeResolution	1	2048
+RenderHeroProbeDistance		1	16
+RenderHeroProbeUpdateRate	1	4
+RenderHeroProbeConservativeUpdateMultiplier 1 16
 
 //
 // Low Graphics Settings

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
@@ -270,8 +270,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 {
     LLComboBox* ctrl_reflections   = getChild<LLComboBox>("Reflections");
     LLTextBox* reflections_text = getChild<LLTextBox>("ReflectionsText");
-    LLCheckBoxCtrl* ctrl_avatar_vp     = getChild<LLCheckBoxCtrl>("AvatarVertexProgram");
-    LLCheckBoxCtrl* ctrl_avatar_cloth  = getChild<LLCheckBoxCtrl>("AvatarCloth");
     LLCheckBoxCtrl* ctrl_wind_light    = getChild<LLCheckBoxCtrl>("WindLightUseAtmosShaders");
     LLCheckBoxCtrl* ctrl_deferred = getChild<LLCheckBoxCtrl>("UseLightShaders");
     LLComboBox* ctrl_shadows = getChild<LLComboBox>("ShadowDetail");
@@ -336,45 +334,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
         ctrl_shadows->setValue(0);
         shadows_text->setEnabled(false);
     }
-
-    // disabled reflections
-    if (!LLFeatureManager::getInstance()->isFeatureAvailable("RenderReflectionDetail"))
-    {
-        ctrl_reflections->setEnabled(false);
-        ctrl_reflections->setValue(false);
-        reflections_text->setEnabled(false);
-    }
-
-    // disabled av
-    if (!LLFeatureManager::getInstance()->isFeatureAvailable("RenderAvatarVP"))
-    {
-        ctrl_avatar_vp->setEnabled(false);
-        ctrl_avatar_vp->setValue(false);
-
-        ctrl_avatar_cloth->setEnabled(false);
-        ctrl_avatar_cloth->setValue(false);
-
-        //deferred needs AvatarVP, disable deferred
-        ctrl_shadows->setEnabled(false);
-        ctrl_shadows->setValue(0);
-        shadows_text->setEnabled(false);
-
-        ctrl_ssao->setEnabled(false);
-        ctrl_ssao->setValue(false);
-
-        ctrl_dof->setEnabled(false);
-        ctrl_dof->setValue(false);
-
-        ctrl_deferred->setEnabled(false);
-        ctrl_deferred->setValue(false);
-    }
-
-    // disabled cloth
-    if (!LLFeatureManager::getInstance()->isFeatureAvailable("RenderAvatarCloth"))
-    {
-        ctrl_avatar_cloth->setEnabled(false);
-        ctrl_avatar_cloth->setValue(false);
-    }
 }
 
 void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledState()
@@ -391,23 +350,6 @@ void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledState()
     LLCheckBoxCtrl* bumpshiny_ctrl = getChild<LLCheckBoxCtrl>("BumpShiny");
     bool bumpshiny = LLCubeMap::sUseCubeMaps && LLFeatureManager::getInstance()->isFeatureAvailable("RenderObjectBump");
     bumpshiny_ctrl->setEnabled(bumpshiny);
-
-    // Avatar Mode
-    // Enable Avatar Shaders
-    LLCheckBoxCtrl* ctrl_avatar_vp = getChild<LLCheckBoxCtrl>("AvatarVertexProgram");
-    // Avatar Render Mode
-    LLCheckBoxCtrl* ctrl_avatar_cloth = getChild<LLCheckBoxCtrl>("AvatarCloth");
-
-    bool avatar_vp_enabled = LLFeatureManager::getInstance()->isFeatureAvailable("RenderAvatarVP");
-    if (LLViewerShaderMgr::sInitialized)
-    {
-        S32 max_avatar_shader = LLViewerShaderMgr::instance()->mMaxAvatarShaderLevel;
-        avatar_vp_enabled = max_avatar_shader > 0;
-    }
-
-    ctrl_avatar_vp->setEnabled(avatar_vp_enabled);
-
-    ctrl_avatar_cloth->setEnabled(gSavedSettings.getBOOL("RenderAvatarVP"));
 
     // Vertex Shaders, Global Shader Enable
     // SL-12594 Basic shaders are always enabled. DJH TODO clean up now-orphaned state handling code


### PR DESCRIPTION
Fix the hero probe feature table entries emitting warnings upon graphics level change

```
2024-07-08T21:45:53Z WARNING #RenderInit# newview/llfeaturemanager.cpp(147) LLFeatureList::maskList : Feature RenderHeroProbeConservativeUpdateMultiplier in mask not in top level!
2024-07-08T21:45:53Z WARNING #RenderInit# newview/llfeaturemanager.cpp(147) LLFeatureList::maskList : Feature RenderHeroProbeDistance in mask not in top level!
2024-07-08T21:45:53Z WARNING #RenderInit# newview/llfeaturemanager.cpp(147) LLFeatureList::maskList : Feature RenderHeroProbeResolution in mask not in top level!
2024-07-08T21:45:53Z WARNING #RenderInit# newview/llfeaturemanager.cpp(147) LLFeatureList::maskList : Feature RenderHeroProbeUpdateRate in mask not in top level!
```