### PR TITLE
Break out common `LLAppearanceMgr::wearOutfit(LLInventoryCategory*)` method

### DIFF
--- a/indra/newview/llappearancelistener.cpp
+++ b/indra/newview/llappearancelistener.cpp
@@ -91,38 +91,15 @@ void LLAppearanceListener::wearOutfit(LLSD const &data)
 
 void LLAppearanceListener::wearItems(LLSD const &data)
 {
-    const LLSD& items_id{ data["items_id"] };
-    uuid_vec_t ids;
-    if (! items_id.isArray())
-    {
-        ids.push_back(items_id.asUUID());
-    }
-    else                            // array
-    {
-        for (const auto &id : llsd::inArray(items_id))
-        {
-            ids.push_back(id);
-        }
-    }
-    LLAppearanceMgr::instance().wearItemsOnAvatar(ids, true, data["replace"].asBoolean());
+    LLAppearanceMgr::instance().wearItemsOnAvatar(
+        LLSDParam<uuid_vec_t>(data["items_id"]),
+        true, data["replace"].asBoolean());
 }
 
 void LLAppearanceListener::detachItems(LLSD const &data)
 {
-    const LLSD& items_id{ data["items_id"] };
-    uuid_vec_t ids;
-    if (! items_id.isArray())
-    {
-        ids.push_back(items_id.asUUID());
-    }
-    else                            // array
-    {
-        for (const auto &id : llsd::inArray(items_id))
-        {
-            ids.push_back(id);
-        }
-    }
-    LLAppearanceMgr::instance().removeItemsFromAvatar(ids);
+    LLAppearanceMgr::instance().removeItemsFromAvatar(
+        LLSDParam<uuid_vec_t>(data["items_id"]));
 }
 
 void LLAppearanceListener::getOutfitsList(LLSD const &data)

--- a/indra/newview/llappearancelistener.cpp
+++ b/indra/newview/llappearancelistener.cpp
@@ -38,7 +38,7 @@ LLAppearanceListener::LLAppearanceListener()
                "API to wear a specified outfit and wear/remove individual items")
 {
     add("wearOutfit",
-        "Wear outfit by folder id: [folder_id] OR by folder name: [folder_name]\n"
+        "Wear outfit by folder id: [\"folder_id\"] OR by folder name: [\"folder_name\"]\n"
         "When [\"append\"] is true, outfit will be added to COF\n"
         "otherwise it will replace current oufit",
         &LLAppearanceListener::wearOutfit);

--- a/indra/newview/llappearancelistener.cpp
+++ b/indra/newview/llappearancelistener.cpp
@@ -91,36 +91,38 @@ void LLAppearanceListener::wearOutfit(LLSD const &data)
 
 void LLAppearanceListener::wearItems(LLSD const &data)
 {
-    if (data["items_id"].isArray())
+    const LLSD& items_id{ data["items_id"] };
+    uuid_vec_t ids;
+    if (! items_id.isArray())
     {
-        uuid_vec_t ids;
-        for (const auto &id : llsd::inArray(data["items_id"]))
+        ids.push_back(items_id.asUUID());
+    }
+    else                            // array
+    {
+        for (const auto &id : llsd::inArray(items_id))
         {
             ids.push_back(id);
         }
-        LLAppearanceMgr::instance().wearItemsOnAvatar(ids, true, data["replace"].asBoolean());
     }
-    else
-    {
-        LLAppearanceMgr::instance().wearItemOnAvatar(data["items_id"].asUUID(), true, data["replace"].asBoolean());
-    }
+    LLAppearanceMgr::instance().wearItemsOnAvatar(ids, true, data["replace"].asBoolean());
 }
 
 void LLAppearanceListener::detachItems(LLSD const &data)
 {
-    if (data["items_id"].isArray())
+    const LLSD& items_id{ data["items_id"] };
+    uuid_vec_t ids;
+    if (! items_id.isArray())
     {
-        uuid_vec_t ids;
-        for (const auto &id : llsd::inArray(data["items_id"]))
+        ids.push_back(items_id.asUUID());
+    }
+    else                            // array
+    {
+        for (const auto &id : llsd::inArray(items_id))
         {
             ids.push_back(id);
         }
-        LLAppearanceMgr::instance().removeItemsFromAvatar(ids);
     }
-    else
-    {
-        LLAppearanceMgr::instance().removeItemFromAvatar(data["items_id"].asUUID());
-    }
+    LLAppearanceMgr::instance().removeItemsFromAvatar(ids);
 }
 
 void LLAppearanceListener::getOutfitsList(LLSD const &data)

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -2948,7 +2948,7 @@ bool LLAppearanceMgr::wearOutfitByName(const std::string& name, std::string& err
         }
     }
 
-    return wearOutfit(std::quoted(name), cat, error_msg, copy_items, append);
+    return wearOutfit(stringize(std::quoted(name)), cat, error_msg, copy_items, append);
 }
 
 bool LLAppearanceMgr::wearOutfit(const LLUUID &cat_id, std::string &error_msg, bool append)

--- a/indra/newview/llappearancemgr.h
+++ b/indra/newview/llappearancemgr.h
@@ -263,6 +263,10 @@ private:
 
     static void onOutfitRename(const LLSD& notification, const LLSD& response);
 
+    // used by both wearOutfit(LLUUID) and wearOutfitByName(std::string)
+    bool wearOutfit(const std::string &desc, LLInventoryCategory* cat, 
+                    std::string &error_msg, bool copy_items, bool append);
+
     bool mAttachmentInvLinkEnabled;
     bool mOutfitIsDirty;
     bool mIsInUpdateAppearanceFromCOF; // to detect recursive calls.


### PR DESCRIPTION
and use it for both `LLAppearanceMgr::wearOutfit(LLUUID)` and `wearOutfitByName(std::string)`.

Also introduce `LLSDParam<std::vector<T>>` and `LLSDParam<std::map<std::string, T>>`, and use `LLSDParam<uuid_vec_t>` for `LLAppearanceListener::wearItems()` and `detachItems()`.