### PR TITLE
viewer#1965 Fixed selection swirls swirling forever when the UI is hidden

### DIFF
--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1539,6 +1539,11 @@ void render_ui_3d()
         gObjectList.resetObjectBeacons();
         gSky.addSunMoonBeacons();
     }
+    else
+    {
+        // Make sure particle effects disappear
+        LLHUDObject::renderAllForTimer();
+    }
 
     stop_glerror();
 }


### PR DESCRIPTION
Update UI particle timers even if UI is hidden to let them die.