### PR TITLE
secondlife/viewer#1885: Terrain texture repeats: Remove feature flag dependency on simulator feature in favor of cap

### DIFF
--- a/doc/testplans/pbr_terrain_composition.md
+++ b/doc/testplans/pbr_terrain_composition.md
@@ -44,6 +44,8 @@ The PBR terrain texture transform flag should be set automatically when logging 
 
 When the PBR terrain texture transform feature is enabled, the UI of the Terrain tab should be overhauled. Availability of features depends on the type of terrain.
 
+**Known issue:** The Region/Estate floater may have to be closed/reopened a second time in order for the UI overhaul to take effect, after teleporting between regions that do and do not have the feature flag set.
+
 When "PBR Metallic Roughness" is checked:
 
 - There should be a way for the user to change the texture transforms for the terrain in the current region

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9267,7 +9267,7 @@
     <key>RenderTerrainPBREnabled</key>
     <map>
       <key>Comment</key>
-      <string>EXPERIMENTAL: Enable PBR Terrain features.</string>
+      <string>Enable PBR Terrain features.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2496,10 +2496,10 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
                 gSavedSettings.setBOOL("GLTFEnabled", false);
             }
 
-            if (features.has("PBRTerrainTransformsEnabled"))
+            llassert(gAgent.getRegion());
+            if (gAgent.getRegion() && gAgent.getRegion()->isCapabilityAvailable("ModifyRegion"))
             {
-                bool enabled = features["PBRTerrainTransformsEnabled"];
-                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", enabled);
+                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", true);
             }
             else
             {


### PR DESCRIPTION
Please see https://github.com/secondlife/viewer/issues/1885 for the test plan