### PR TITLE
Remove ability to reuse a `LuaState` between `LLLUAmanager` functions.

### DIFF
--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -87,8 +87,6 @@ public:
 
     ~LuaState();
 
-    void initLuaState();
-
     bool checkLua(const std::string& desc, int r);
 
     // expr() is for when we want to capture any results left on the stack

--- a/indra/newview/llfloaterluadebug.cpp
+++ b/indra/newview/llfloaterluadebug.cpp
@@ -27,7 +27,6 @@
 
 #include "llfloaterluadebug.h"
 
-#include "llcheckboxctrl.h"
 #include "lllineeditor.h"
 #include "lltexteditor.h"
 #include "llviewermenufile.h" // LLFilePickerReplyThread
@@ -92,8 +91,7 @@ void LLFloaterLUADebug::onExecuteClicked()
     mResultOutput->setValue("");
 
     std::string cmd = mLineInput->getText();
-    cleanLuaState();
-    LLLUAmanager::runScriptLine(mState, cmd, [this](int count, const LLSD& result)
+    LLLUAmanager::runScriptLine(cmd, [this](int count, const LLSD& result)
         {
             completion(count, result);
         });
@@ -172,14 +170,5 @@ void LLFloaterLUADebug::completion(int count, const LLSD& result)
         mResultOutput->insertText(sep);
         mResultOutput->pasteTextWithLinebreaks(stringize(item));
         sep = ", ";
-    }
-}
-
-void LLFloaterLUADebug::cleanLuaState()
-{
-    if(getChild<LLCheckBoxCtrl>("clean_lua_state")->get())
-    {
-        //Reinit to clean lua_State
-        mState.initLuaState();
     }
 }

--- a/indra/newview/llfloaterluadebug.h
+++ b/indra/newview/llfloaterluadebug.h
@@ -58,14 +58,12 @@ class LLFloaterLUADebug :
 
 private:
     void completion(int count, const LLSD& result);
-    void cleanLuaState();
 
     LLTempBoundListener mOutConnection;
 
     LLTextEditor* mResultOutput;
     LLLineEditor* mLineInput;
     LLLineEditor* mScriptPath;
-    LuaState mState;
     U32 mAck{ 0 };
     bool mExecuting{ false };
 };

--- a/indra/newview/llluamanager.h
+++ b/indra/newview/llluamanager.h
@@ -55,32 +55,32 @@ public:
     // count >  1 with result.isArray() means the script returned multiple
     //            results, represented as the entries of the result array.
     typedef std::function<void(int count, const LLSD& result)> script_result_fn;
+    // same semantics as script_result_fn parameters
+    typedef std::pair<int, LLSD> script_result;
 
-    static void runScriptFile(const std::string &filename, script_result_fn result_cb = {}, script_finished_fn finished_cb = {});
+    static void runScriptFile(const std::string &filename, script_result_fn result_cb = {},
+                              script_finished_fn finished_cb = {});
     // Start running a Lua script file, returning an LLCoros::Future whose
     // get() method will pause the calling coroutine until it can deliver the
     // (count, result) pair described above. Between startScriptFile() and
     // Future::get(), the caller and the Lua script coroutine will run
     // concurrently.
-    static LLCoros::Future<std::pair<int, LLSD>>
-        startScriptFile(const std::string& filename);
+    static LLCoros::Future<script_result> startScriptFile(const std::string& filename);
     // Run a Lua script file, and pause the calling coroutine until it completes.
     // The return value is the (count, result) pair described above.
-    static std::pair<int, LLSD> waitScriptFile(const std::string& filename);
+    static script_result waitScriptFile(const std::string& filename);
 
-    static void runScriptLine(const std::string &chunk, script_finished_fn cb = {});
-    static void runScriptLine(const std::string &chunk, script_result_fn cb);
-    static void runScriptLine(LuaState& L, const std::string &chunk, script_result_fn cb = {});
+    static void runScriptLine(const std::string &chunk, script_result_fn result_cb = {},
+                              script_finished_fn finished_cb = {});
     // Start running a Lua chunk, returning an LLCoros::Future whose
     // get() method will pause the calling coroutine until it can deliver the
     // (count, result) pair described above. Between startScriptLine() and
     // Future::get(), the caller and the Lua script coroutine will run
     // concurrently.
-    static LLCoros::Future<std::pair<int, LLSD>>
-        startScriptLine(LuaState& L, const std::string& chunk);
+    static LLCoros::Future<script_result> startScriptLine(const std::string& chunk);
     // Run a Lua chunk, and pause the calling coroutine until it completes.
     // The return value is the (count, result) pair described above.
-    static std::pair<int, LLSD> waitScriptLine(LuaState& L, const std::string& chunk);
+    static script_result waitScriptLine(const std::string& chunk);
 
     static const std::map<std::string, std::string> getScriptNames() { return sScriptNames; }
 

--- a/indra/newview/scripts/lua/require/fiber.lua
+++ b/indra/newview/scripts/lua/require/fiber.lua
@@ -337,4 +337,10 @@ function fiber.run()
     return idle_done
 end
 
+-- Make sure we finish up with a call to run(). That allows a consuming script
+-- to kick off some number of fibers, do some work on the main thread and then
+-- fall off the end of the script without explicitly calling fiber.run().
+-- run() ensures the rest of the fibers run to completion (or error).
+LL.atexit(fiber.run)
+
 return fiber

--- a/indra/newview/skins/default/xui/en/floater_lua_debug.xml
+++ b/indra/newview/skins/default/xui/en/floater_lua_debug.xml
@@ -25,15 +25,6 @@
      width="100">
       LUA string:
     </text>
-    <check_box
-     follows="right|top"
-     height="15"
-     label="Use clean lua_State"
-     layout="topleft"
-     top="10"
-     right ="-70"
-     name="clean_lua_state"
-     width="70"/>
     <line_editor
      border_style="line"
      border_thickness="1"

--- a/indra/newview/tests/llluamanager_test.cpp
+++ b/indra/newview/tests/llluamanager_test.cpp
@@ -413,6 +413,12 @@ namespace tut
             "fiber.launch('catch_special', drain, catch_special)\n"
             "fiber.launch('requester(a)', requester, 'a')\n"
             "fiber.launch('requester(b)', requester, 'b')\n"
+            // A script can normally count on an implicit fiber.run() call
+            // because fiber.lua calls LL.atexit(fiber.run). But atexit()
+            // functions are called by ~LuaState(), which (in the code below)
+            // won't be called until *after* we expect to interact with the
+            // various fibers. So make an explicit call for test purposes.
+            "fiber.run()\n"
         );
 
         LLSD requests;

--- a/indra/newview/tests/llluamanager_test.cpp
+++ b/indra/newview/tests/llluamanager_test.cpp
@@ -123,11 +123,10 @@ namespace tut
     void object::test<1>()
     {
         set_test_name("test Lua results");
-        LuaState L;
         for (auto& luax : lua_expressions)
         {
             auto [count, result] =
-                LLLUAmanager::waitScriptLine(L, "return " + luax.expr);
+                LLLUAmanager::waitScriptLine("return " + luax.expr);
             auto desc{ stringize("waitScriptLine(", luax.desc, "): ") };
             // if count < 0, report Lua error message
             ensure_equals(desc + result.asString(), count, 1);
@@ -144,8 +143,7 @@ namespace tut
             "data = ", construct, "\n"
             "LL.post_on('testpump', data)\n"
         ));
-        LuaState L;
-        auto [count, result] = LLLUAmanager::waitScriptLine(L, lua);
+        auto [count, result] = LLLUAmanager::waitScriptLine(lua);
         // We woke up again ourselves because the coroutine running Lua has
         // finished. But our Lua chunk didn't actually return anything, so we
         // expect count to be 0 and result to be undefined.
@@ -182,11 +180,10 @@ namespace tut
             "LL.post_on('testpump', data)\n"
             "LL.post_on('testpump', 'exit')\n"
         );
-        LuaState L;
         // It's important to let the startScriptLine() coroutine run
         // concurrently with ours until we've had a chance to post() our
         // reply.
-        auto future = LLLUAmanager::startScriptLine(L, lua);
+        auto future = LLLUAmanager::startScriptLine(lua);
         StringVec expected{
             "entry",
             "get_event_pumps()",
@@ -217,8 +214,7 @@ namespace tut
             "pump, data = LL.get_event_next()\n"
             "return data\n"
         );
-        LuaState L;
-        auto future = LLLUAmanager::startScriptLine(L, lua);
+        auto future = LLLUAmanager::startScriptLine(lua);
         // We woke up again ourselves because the coroutine running Lua has
         // reached the get_event_next() call, which suspends the calling C++
         // coroutine (including the Lua code running on it) until we post
@@ -356,8 +352,7 @@ namespace tut
                 sendReply(data, data);
             }));
 
-        LuaState L;
-        auto [count, result] = LLLUAmanager::waitScriptLine(L, lua);
+        auto [count, result] = LLLUAmanager::waitScriptLine(lua);
         ensure_equals("Lua script didn't return item", count, 1);
         ensure_equals("echo failed", result, llsd::map("a", "a", "b", "b"));
     }
@@ -371,18 +366,18 @@ namespace tut
             "\n"
             "fiber = require('fiber')\n"
             "leap = require('leap')\n"
-            "-- debug = require('printf')\n"
             "local function debug(...) end\n"
+            "-- debug = require('printf')\n"
             "\n"
             "-- negative priority ensures catchall is always last\n"
-            "catchall = leap.WaitFor:new(-1, 'catchall')\n"
+            "catchall = leap.WaitFor(-1, 'catchall')\n"
             "function catchall:filter(pump, data)\n"
             "    debug('catchall:filter(%s, %s)', pump, data)\n"
             "    return data\n"
             "end\n"
             "\n"
             "-- but first, catch events with 'special' key\n"
-            "catch_special = leap.WaitFor:new(2, 'catch_special')\n"
+            "catch_special = leap.WaitFor(2, 'catch_special')\n"
             "function catch_special:filter(pump, data)\n"
             "    debug('catch_special:filter(%s, %s)', pump, data)\n"
             "    return if data['special'] ~= nil then data else nil\n"
@@ -429,10 +424,7 @@ namespace tut
                 requests.append(data);
             }));
 
-        LuaState L;
-        auto future = LLLUAmanager::startScriptLine(L, lua);
-        auto replyname{ L.obtainListener().getReplyName() };
-        auto& replypump{ LLEventPumps::instance().obtain(replyname) };
+        auto future = LLLUAmanager::startScriptLine(lua);
         // LuaState::expr() periodically interrupts a running chunk to ensure
         // the rest of our coroutines get cycles. Nonetheless, for this test
         // we have to wait until both requester() coroutines have posted and
@@ -444,6 +436,8 @@ namespace tut
             llcoro::suspend();
         }
         ensure_equals("didn't get both requests", requests.size(), 2);
+        auto replyname{ requests[0]["reply"].asString() };
+        auto& replypump{ LLEventPumps::instance().obtain(replyname) };
         // moreover, we expect they arrived in the order they were created
         ensure_equals("a wasn't first",  requests[0]["name"].asString(), "a");
         ensure_equals("b wasn't second", requests[1]["name"].asString(), "b");
@@ -468,8 +462,7 @@ namespace tut
             "\n"
             "LL.get_event_next()\n"
         );
-        LuaState L;
-        auto future = LLLUAmanager::startScriptLine(L, lua);
+        auto future = LLLUAmanager::startScriptLine(lua);
         // Poke LLTestApp to send its preliminary shutdown message.
         mApp.setQuitting();
         // but now we have to give the startScriptLine() coroutine a chance to run
@@ -491,8 +484,7 @@ namespace tut
             "    x = 1\n"
             "end\n"
         );
-        LuaState L;
-        auto [count, result] = LLLUAmanager::waitScriptLine(L, lua);
+        auto [count, result] = LLLUAmanager::waitScriptLine(lua);
         // We expect the above erroneous script has been forcibly terminated
         // because it ran too long without doing any actual work.
         ensure_equals(desc + " count: " + result.asString(), count, -1);


### PR DESCRIPTION
Remove `LLLUAmanager::mumbleScriptLine()` `LuaState&` parameters. Make
`startScriptLine()`, `waitScriptLine()` and `runScriptLine()` exactly parallel to
`startScriptFile()`, `waitScriptFile()` and `runScriptFile()`. That means that
`runScriptLine()`'s C++ coroutine instantiates and destroys its own `LuaState`,
which means that `LL.atexit()` functions will run on the Lua-specific C++
coroutine rather than (say) the viewer's main coroutine.

Remove special-case `~LuaState()` code to call `fiber.run()`.
Instead, make `fiber.lua` call `LL.atexit(fiber.run)` to schedule that final `run()`
call at `~LuaState()` time using the generic mechanism.