### PR TITLE
Revert "secondlife/viewer#1885: Terrain texture repeats: Remove feature flag dependency on simulator feature in favor of cap"

### DIFF
--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2496,10 +2496,10 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
                 gSavedSettings.setBOOL("GLTFEnabled", false);
             }
 
-            llassert(gAgent.getRegion());
-            if (gAgent.getRegion() && gAgent.getRegion()->isCapabilityAvailable("ModifyRegion"))
+            if (features.has("PBRTerrainTransformsEnabled"))
             {
-                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", true);
+                bool enabled = features["PBRTerrainTransformsEnabled"];
+                gSavedSettings.setBOOL("RenderTerrainPBRTransformsEnabled", enabled);
             }
             else
             {


### PR DESCRIPTION
Patially reverts secondlife/viewer#1982 . Some small unrelated changes were preserved.