### PR TITLE
#1500 BugSplat Crash when out of disk space

### DIFF
--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -487,6 +487,33 @@ int LLApp::getPid()
 #endif
 }
 
+// static
+void LLApp::notifyOutOfDiskSpace()
+{
+    static const U32Seconds min_interval = U32Seconds(60);
+    static U32Seconds min_time_to_send = U32Seconds(0);
+    U32Seconds now = LLTimer::getTotalTime();
+    if (now < min_time_to_send)
+        return;
+
+    min_time_to_send = now + min_interval;
+
+    if (LLApp* app = instance())
+    {
+        app->sendOutOfDiskSpaceNotification();
+    }
+    else
+    {
+        LL_WARNS() << "No app instance" << LL_ENDL;
+    }
+}
+
+// virtual
+void LLApp::sendOutOfDiskSpaceNotification()
+{
+    LL_WARNS() << "Should never be called" << LL_ENDL; // Should be overridden
+}
+
 #ifndef LL_WINDOWS
 void setup_signals()
 {

--- a/indra/llcommon/llapp.h
+++ b/indra/llcommon/llapp.h
@@ -202,6 +202,8 @@ public:
     static bool isExiting(); // Either quitting or error (app is exiting, cleanly or not)
     static int getPid();
 
+    static void notifyOutOfDiskSpace();
+
     //
     // Sleep for specified time while still running
     //
@@ -300,6 +302,8 @@ protected:
       * @brief This method is called once a frame to do once a frame tasks.
       */
     void stepFrame();
+
+    virtual void sendOutOfDiskSpaceNotification();
 
 private:
     // Contains the filename of the minidump file after a crash.

--- a/indra/llcommon/llapr.cpp
+++ b/indra/llcommon/llapr.cpp
@@ -28,6 +28,7 @@
 
 #include "linden_common.h"
 #include "llapr.h"
+#include "llapp.h"
 #include "llmutex.h"
 #include "apr_dso.h"
 
@@ -606,7 +607,11 @@ S32 LLAPRFile::writeEx(const std::string& filename, const void *buf, S32 offset,
         apr_status_t s = apr_file_write(file_handle, buf, &bytes_written);
         if (s != APR_SUCCESS)
         {
-            LL_WARNS("APR") << " Attempting to write filename: " << filename << LL_ENDL;
+            LL_WARNS("APR") << "Attempting to write filename: " << filename << LL_ENDL;
+            if (APR_STATUS_IS_ENOSPC(s))
+            {
+                LLApp::notifyOutOfDiskSpace();
+            }
             ll_apr_warn_status(s);
             bytes_written = 0;
         }

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3067,6 +3067,13 @@ bool LLAppViewer::meetsRequirementsForMaximizedStart()
     return maximizedOk;
 }
 
+// virtual
+void LLAppViewer::sendOutOfDiskSpaceNotification()
+{
+    LL_WARNS() << "Out of disk space notification requested" << LL_ENDL;
+    LLNotificationsUtil::add("OutOfDiskSpace");
+}
+
 bool LLAppViewer::initWindow()
 {
     LL_INFOS("AppInit") << "Initializing window..." << LL_ENDL;

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -245,6 +245,8 @@ protected:
 
     virtual bool meetsRequirementsForMaximizedStart(); // Used on first login to decide to launch maximized
 
+    virtual void sendOutOfDiskSpaceNotification();
+
 private:
 
     bool doFrame();

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -3032,6 +3032,15 @@ This is usually a temporary failure. Please customize and save the wearable agai
   </notification>
 
   <notification
+   icon="notifytip.tga"
+   name="OutOfDiskSpace"
+   type="notifytip">
+The system is out of disk space. You will need to free up some space on your computer or clear the cache.
+<tag>fail</tag>
+    <unique/>
+  </notification>
+
+  <notification
    icon="alertmodal.tga"
    name="YouHaveBeenLoggedOut"
    type="alertmodal">


### PR DESCRIPTION
In case of out-of-disk-space error the viewer will display the following notification:
![image](https://github.com/user-attachments/assets/c36ae8c3-8603-4af6-93fb-00538be3e0b4)
(not more often than once per 60 seconds)