### PR TITLE
Initialize array before use

### DIFF
--- a/indra/newview/gltf/primitive.cpp
+++ b/indra/newview/gltf/primitive.cpp
@@ -109,7 +109,7 @@ struct MikktMesh
 
         for (U32 tri_idx = 0; tri_idx < U32(triangle_count); ++tri_idx)
         {
-            U32 idx[3];
+            U32 idx[3] = {0, 0, 0};
 
             if (prim->mMode == Primitive::Mode::TRIANGLES)
             {


### PR DESCRIPTION
gcc detects usage of this array as uninitialized, so make sure it's initialized. I am not sure if this is a legitimate warning, or if the code guarantees the array gets initialized before use in lines 140-142 and this is a performance optimization.