### PR TITLE
Fix: Stop textures from being set as inactive if still on a face.

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -926,6 +926,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     }
 
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
+    bool onFace = false;
     for (U32 i = 0; i < LLRender::NUM_TEXTURE_CHANNELS; ++i)
     {
         for (S32 fi = 0; fi < imagep->getNumFaces(i); ++fi)
@@ -934,6 +935,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
             if (face && face->getViewerObject())
             {
+                onFace = true;
                 F32 radius;
                 F32 cos_angle_to_view_dir;
                 bool in_frustum = face->calcPixelArea(cos_angle_to_view_dir, radius);
@@ -1031,7 +1033,8 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
             imagep->getLastReferencedTimer()->reset();
 
             //reset texture state.
-            imagep->setInactive();
+            if(!onFace)
+                imagep->setInactive();
         }
     }
 


### PR DESCRIPTION
Textures were being set to Inactive even if still in scene, causing them to be deleted and re-decoded in a loop.