### PR TITLE
Raised the 512x512 limitation for uploading snapshots to inventory to 2048x2048

### DIFF
--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -195,6 +195,25 @@ S32 LLAgentBenefits::getTextureUploadCost(const LLImageBase* tex) const
     return getTextureUploadCost();
 }
 
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+S32 LLAgentBenefits::getTextureUploadCost(S32 w, S32 h) const
+{
+    if (w > 0 && h > 0)
+    {
+        S32 area = w * h;
+        if (area >= MIN_2K_TEXTURE_AREA)
+        {
+            return get2KTextureUploadCost(area);
+        }
+        else
+        {
+            return getTextureUploadCost();
+        }
+    }
+    return getTextureUploadCost();
+}
+// </FS:Chanayane>
+
 S32 LLAgentBenefits::get2KTextureUploadCost(S32 area) const
 {
     if (m_2k_texture_upload_cost.empty())

--- a/indra/newview/llagentbenefits.cpp
+++ b/indra/newview/llagentbenefits.cpp
@@ -195,7 +195,6 @@ S32 LLAgentBenefits::getTextureUploadCost(const LLImageBase* tex) const
     return getTextureUploadCost();
 }
 
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 S32 LLAgentBenefits::getTextureUploadCost(S32 w, S32 h) const
 {
     if (w > 0 && h > 0)
@@ -205,14 +204,9 @@ S32 LLAgentBenefits::getTextureUploadCost(S32 w, S32 h) const
         {
             return get2KTextureUploadCost(area);
         }
-        else
-        {
-            return getTextureUploadCost();
-        }
     }
     return getTextureUploadCost();
 }
-// </FS:Chanayane>
 
 S32 LLAgentBenefits::get2KTextureUploadCost(S32 area) const
 {

--- a/indra/newview/llagentbenefits.h
+++ b/indra/newview/llagentbenefits.h
@@ -54,6 +54,9 @@ public:
     S32 getTextureUploadCost() const;
     S32 getTextureUploadCost(const LLViewerTexture* tex) const;
     S32 getTextureUploadCost(const LLImageBase* tex) const;
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    S32 getTextureUploadCost(S32 w, S32 h) const;
+    // </FS:Chanayane>
     S32 get2KTextureUploadCost(S32 area) const;
 
     bool findUploadCost(LLAssetType::EType& asset_type, S32& cost) const;

--- a/indra/newview/llagentbenefits.h
+++ b/indra/newview/llagentbenefits.h
@@ -54,9 +54,7 @@ public:
     S32 getTextureUploadCost() const;
     S32 getTextureUploadCost(const LLViewerTexture* tex) const;
     S32 getTextureUploadCost(const LLImageBase* tex) const;
-    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
     S32 getTextureUploadCost(S32 w, S32 h) const;
-    // </FS:Chanayane>
     S32 get2KTextureUploadCost(S32 area) const;
 
     bool findUploadCost(LLAssetType::EType& asset_type, S32& cost) const;

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -51,7 +51,10 @@ LLSnapshotFloaterView* gSnapshotFloaterView = NULL;
 const F32 AUTO_SNAPSHOT_TIME_DELAY = 1.f;
 
 const S32 MAX_POSTCARD_DATASIZE = 1572864; // 1.5 megabyte, similar to simulator limit
-const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 static LLDefaultChildRegistry::Register<LLSnapshotFloaterView> r("snapshot_floater_view");
 

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -51,10 +51,7 @@ LLSnapshotFloaterView* gSnapshotFloaterView = NULL;
 const F32 AUTO_SNAPSHOT_TIME_DELAY = 1.f;
 
 const S32 MAX_POSTCARD_DATASIZE = 1572864; // 1.5 megabyte, similar to simulator limit
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
-//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
 const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 static LLDefaultChildRegistry::Register<LLSnapshotFloaterView> r("snapshot_floater_view");
 

--- a/indra/newview/llpanelsnapshot.cpp
+++ b/indra/newview/llpanelsnapshot.cpp
@@ -41,10 +41,7 @@
 
 #include "llagentbenefits.h"
 
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
-//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
 const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
-// </FS:Chanayane>
 
 S32 power_of_two(S32 sz, S32 upper)
 {
@@ -64,12 +61,9 @@ LLPanelSnapshot::LLPanelSnapshot()
 // virtual
 bool LLPanelSnapshot::postBuild()
 {
-    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
-    //getChild<LLUICtrl>("save_btn")->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost()));
     S32 w = getTypedPreviewWidth();
     S32 h = getTypedPreviewHeight();
     getChild<LLUICtrl>("save_btn")->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost(w, h)));
-    // </FS:Chanayane>
     getChild<LLUICtrl>(getImageSizeComboName())->setCommitCallback(boost::bind(&LLPanelSnapshot::onResolutionComboCommit, this, _1));
     if (!getWidthSpinnerName().empty())
     {

--- a/indra/newview/llpanelsnapshot.cpp
+++ b/indra/newview/llpanelsnapshot.cpp
@@ -41,7 +41,10 @@
 
 #include "llagentbenefits.h"
 
-constexpr S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// </FS:Chanayane>
 
 S32 power_of_two(S32 sz, S32 upper)
 {
@@ -61,7 +64,12 @@ LLPanelSnapshot::LLPanelSnapshot()
 // virtual
 bool LLPanelSnapshot::postBuild()
 {
-    getChild<LLUICtrl>("save_btn")->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost()));
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    //getChild<LLUICtrl>("save_btn")->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost()));
+    S32 w = getTypedPreviewWidth();
+    S32 h = getTypedPreviewHeight();
+    getChild<LLUICtrl>("save_btn")->setLabelArg("[UPLOAD_COST]", std::to_string(LLAgentBenefitsMgr::current().getTextureUploadCost(w, h)));
+    // </FS:Chanayane>
     getChild<LLUICtrl>(getImageSizeComboName())->setCommitCallback(boost::bind(&LLPanelSnapshot::onResolutionComboCommit, this, _1));
     if (!getWidthSpinnerName().empty())
     {

--- a/indra/newview/llpanelsnapshotinventory.cpp
+++ b/indra/newview/llpanelsnapshotinventory.cpp
@@ -155,7 +155,22 @@ void LLPanelSnapshotInventory::onResolutionCommit(LLUICtrl* ctrl)
 
 void LLPanelSnapshotInventoryBase::onSend()
 {
-    S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    S32 w = 0;
+    S32 h = 0;
+
+    if( mSnapshotFloater )
+    {
+        LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView();
+        if( preview )
+        {
+            preview->getSize(w, h);
+        }
+    }
+
+    S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
+    // </FS:Chanayane>
     if (can_afford_transaction(expected_upload_cost))
     {
         if (mSnapshotFloater)

--- a/indra/newview/llpanelsnapshotinventory.cpp
+++ b/indra/newview/llpanelsnapshotinventory.cpp
@@ -155,8 +155,6 @@ void LLPanelSnapshotInventory::onResolutionCommit(LLUICtrl* ctrl)
 
 void LLPanelSnapshotInventoryBase::onSend()
 {
-    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
-    //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
     S32 w = 0;
     S32 h = 0;
 
@@ -170,7 +168,6 @@ void LLPanelSnapshotInventoryBase::onSend()
     }
 
     S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
-    // </FS:Chanayane>
     if (can_afford_transaction(expected_upload_cost))
     {
         if (mSnapshotFloater)

--- a/indra/newview/llpanelsnapshotoptions.cpp
+++ b/indra/newview/llpanelsnapshotoptions.cpp
@@ -30,6 +30,7 @@
 #include "llsidetraypanelcontainer.h"
 
 #include "llfloatersnapshot.h" // FIXME: create a snapshot model
++#include "llsnapshotlivepreview.h" // <FS:Chanayane> 2048x2048 snapshots upload to inventory
 #include "llfloaterreg.h"
 
 #include "llagentbenefits.h"
@@ -89,7 +90,22 @@ void LLPanelSnapshotOptions::onOpen(const LLSD& key)
 
 void LLPanelSnapshotOptions::updateUploadCost()
 {
-    S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+    //S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+    S32 w = 0;
+    S32 h = 0;
+
+    if( mSnapshotFloater )
+    {
+        LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView();
+        if( preview )
+        {
+            preview->getSize(w, h);
+        }
+    }
+
+    S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
+    // </FS:Chanayane>
     getChild<LLUICtrl>("save_to_inventory_btn")->setLabelArg("[AMOUNT]", llformat("%d", upload_cost));
 }
 

--- a/indra/newview/llpanelsnapshotoptions.cpp
+++ b/indra/newview/llpanelsnapshotoptions.cpp
@@ -30,7 +30,7 @@
 #include "llsidetraypanelcontainer.h"
 
 #include "llfloatersnapshot.h" // FIXME: create a snapshot model
-+#include "llsnapshotlivepreview.h" // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+#include "llsnapshotlivepreview.h"
 #include "llfloaterreg.h"
 
 #include "llagentbenefits.h"
@@ -90,8 +90,6 @@ void LLPanelSnapshotOptions::onOpen(const LLSD& key)
 
 void LLPanelSnapshotOptions::updateUploadCost()
 {
-    // <FS:Chanayane> 2048x2048 snapshots upload to inventory
-    //S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
     S32 w = 0;
     S32 h = 0;
 
@@ -105,7 +103,6 @@ void LLPanelSnapshotOptions::updateUploadCost()
     }
 
     S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
-    // </FS:Chanayane>
     getChild<LLUICtrl>("save_to_inventory_btn")->setLabelArg("[AMOUNT]", llformat("%d", upload_cost));
 }
 

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -65,7 +65,10 @@ constexpr F32 FALL_TIME = 0.6f;
 constexpr S32 BORDER_WIDTH = 6;
 constexpr S32 TOP_PANEL_HEIGHT = 30;
 
-constexpr S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
+//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
+const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
+// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 std::set<LLSnapshotLivePreview*> LLSnapshotLivePreview::sList;
 LLPointer<LLImageFormatted> LLSnapshotLivePreview::sSaveLocalImage = NULL;
@@ -1024,7 +1027,10 @@ void LLSnapshotLivePreview::saveTexture(bool outfit_snapshot, std::string name)
         LLAgentUI::buildLocationString(pos_string, LLAgentUI::LOCATION_FORMAT_FULL);
         std::string who_took_it;
         LLAgentUI::buildFullname(who_took_it);
-        S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+        // <FS:Chanayane> 2048x2048 snapshots upload to inventory
+        //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
+        S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(scaled->getWidth(), scaled->getHeight());
+        // </FS:Chanayane>
         std::string res_name = outfit_snapshot ? name : "Snapshot : " + pos_string;
         std::string res_desc = outfit_snapshot ? "" : "Taken by " + who_took_it + " at " + pos_string;
         LLFolderType::EType folder_type = outfit_snapshot ? LLFolderType::FT_NONE : LLFolderType::FT_SNAPSHOT_CATEGORY;

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -65,10 +65,7 @@ constexpr F32 FALL_TIME = 0.6f;
 constexpr S32 BORDER_WIDTH = 6;
 constexpr S32 TOP_PANEL_HEIGHT = 30;
 
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
-//const S32 MAX_TEXTURE_SIZE = 512 ; //max upload texture size 512 * 512
 const S32 MAX_TEXTURE_SIZE = 2048 ; //max upload texture size 2048 * 2048
-// <FS:Chanayane> 2048x2048 snapshots upload to inventory
 
 std::set<LLSnapshotLivePreview*> LLSnapshotLivePreview::sList;
 LLPointer<LLImageFormatted> LLSnapshotLivePreview::sSaveLocalImage = NULL;
@@ -1027,10 +1024,7 @@ void LLSnapshotLivePreview::saveTexture(bool outfit_snapshot, std::string name)
         LLAgentUI::buildLocationString(pos_string, LLAgentUI::LOCATION_FORMAT_FULL);
         std::string who_took_it;
         LLAgentUI::buildFullname(who_took_it);
-        // <FS:Chanayane> 2048x2048 snapshots upload to inventory
-        //S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost();
         S32 expected_upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(scaled->getWidth(), scaled->getHeight());
-        // </FS:Chanayane>
         std::string res_name = outfit_snapshot ? name : "Snapshot : " + pos_string;
         std::string res_desc = outfit_snapshot ? "" : "Taken by " + who_took_it + " at " + pos_string;
         LLFolderType::EType folder_type = outfit_snapshot ? LLFolderType::FT_NONE : LLFolderType::FT_SNAPSHOT_CATEGORY;


### PR DESCRIPTION
I don't know if there is a reason why snapshots to inventory have been blocked to 512x512 until now. If there are no reasons, then here is a pull request that allow to upload snapshots to inventory up to 2048x2048.
The cost of the upload is updated according to the area of the snapshot.