### PR TITLE
Fix: Update calcDataSizeJ2C to pyramid-base file size estimation

### DIFF
--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -283,7 +283,7 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     while (surface > s)
     {
         if (nb_layers <= (5 - discard_level))
-            totalbytes += s * comp * precision * rate;
+            totalbytes += (S32)(s * comp * precision * rate);
         nb_layers++;
         s *= 4;
     }

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -279,7 +279,7 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 surface = w*h;
     S32 s = 64*64;
     S32 precision = 8; // assumed bitrate per component channel, might change in future for HDR support
-    S32 totalbytes = s * comp * precision * rate; // first level computed before loop
+    S32 totalbytes = (S32)(s * comp * precision * rate); // first level computed before loop
     while (surface > s)
     {
         if (nb_layers <= (5 - discard_level))

--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -278,12 +278,19 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 nb_layers = 1;
     S32 surface = w*h;
     S32 s = 64*64;
+    S32 precision = 8; // assumed bitrate per component channel, might change in future for HDR support
+    S32 totalbytes = s * comp * precision * rate; // first level computed before loop
     while (surface > s)
     {
+        if (nb_layers <= (5 - discard_level))
+            totalbytes += s * comp * precision * rate;
         nb_layers++;
         s *= 4;
     }
     F32 layer_factor =  3.0f * (7 - llclamp(nb_layers,1,6));
+
+    totalbytes /= 8; // to bytes
+    totalbytes += calcHeaderSizeJ2C();  // header
 
     // Compute w/pow(2,discard_level) and h/pow(2,discard_level)
     w >>= discard_level;
@@ -297,7 +304,9 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 new_bytes = (S32) (sqrt((F32)(w*h))*(F32)(comp)*rate*1000.f/layer_factor);
     S32 old_bytes = (S32)((F32)(w*h*comp)*rate);
     bytes = (LLImage::useNewByteRange() && (new_bytes < old_bytes) ? new_bytes : old_bytes);
-    bytes = llmax(bytes, calcHeaderSizeJ2C());
+    bytes = llmax(totalbytes, calcHeaderSizeJ2C());
+    //LL_WARNS() << "calcDataSizeJ2C w-h-c-d-p " << w << "-" << h << "-" << comp << "-" << discard_level << "-" << precision
+    //           << " Pyramid: " << (S32)totalbytes << " LayerFactored: " << new_bytes << " WJCR: " << old_bytes << LL_ENDL;
     return bytes;
 }
 


### PR DESCRIPTION
Used the loop from the previous LayerFactored method to create a more accurate file size estimation by walking up the pyramid tiles.

Sizes are much larger in many cases and eliminate partial decoder issues with OpenJPEG.

KDU not tested but expected to produce better files as well.

Should also stop decode failures on tiny or very rectangular dimensions.