### PR TITLE
#2051 BugSplat Crash #1495268: LLVOAvatar::updateRiggingInfo()

### DIFF
--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2589,6 +2589,9 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
 
+    if (LLApp::isExiting())
+        return;
+
     if (isDead())
     {
         LL_INFOS() << "Warning!  Idle on dead avatar" << LL_ENDL;


### PR DESCRIPTION
The crash happens at the end of the shutdown process (see SecondLife_log.txt)
```
2024-07-17T08:44:43Z INFO # newview/llappviewer.cpp(2121) cleanup : Misc Cleanup
2024-07-17T08:44:43Z INFO # newview/llappviewer.cpp(2147) cleanup : Cleaning up LLProxy.
2024-07-17T08:44:43Z INFO #Cleanup# llcommon/llcleanup.cpp(29) log_subsystem_cleanup : newview/llappviewer.cpp(2148): calling LLProxy::cleanupClass() in virtual bool LLAppViewer::cleanup()
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(238) printActiveCoroutines : Number of active coroutines at entry to ~LLCoros(): 1
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(242) printActiveCoroutines : -------------- List of active coroutines ------------\nmain0  life: 5543.29
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(251) printActiveCoroutines : -----------------------------------------------------
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(238) printActiveCoroutines : Number of active coroutines after pumping: 1
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(242) printActiveCoroutines : -------------- List of active coroutines ------------\nmain0  life: 5543.29
2024-07-17T08:44:43Z INFO #LLCoros# llcommon/llcoros.cpp(251) printActiveCoroutines : -----------------------------------------------------
2024-07-17T08:44:43Z INFO # newview/llappviewer.cpp(2174) cleanup : Goodbye!
```