### PR TITLE
Fixes bad upload quality issue with OpenJPEG

### DIFF
--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -437,7 +437,7 @@ public:
             parameters.max_cs_size = 0; // do not limit size for reversible compression
             parameters.irreversible = 0; // should be the default, but, just in case
             parameters.tcp_numlayers = 1;
-            /* documentation seems to be wrong, should be 0.0f for lossless, not 1.0f 
+            /* documentation seems to be wrong, should be 0.0f for lossless, not 1.0f
                see https://github.com/uclouvain/openjpeg/blob/39e8c50a2f9bdcf36810ee3d41bcbf1cc78968ae/src/lib/openjp2/j2k.c#L7755
             */
             parameters.tcp_rates[0] = 0.0f;
@@ -538,7 +538,7 @@ public:
 
             //ensure that we have at least a minimal size
             max_cs_size = llmax(max_cs_size, (U32)FIRST_PACKET_SIZE);
-           
+
             parameters.max_cs_size = max_cs_size;
         }
 

--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -431,23 +431,20 @@ public:
         opj_set_default_encoder_parameters(&parameters);
         parameters.cod_format = OPJ_CODEC_J2K;
         parameters.cp_disto_alloc = 1;
-        parameters.max_cs_size = (1 << 15);
 
         if (reversible)
         {
+            parameters.max_cs_size = 0; // do not limit size for reversible compression
+            parameters.irreversible = 0; // should be the default, but, just in case
             parameters.tcp_numlayers = 1;
-            parameters.tcp_rates[0] = 1.0f;
+            /* documentation seems to be wrong, should be 0.0f for lossless, not 1.0f 
+               see https://github.com/uclouvain/openjpeg/blob/39e8c50a2f9bdcf36810ee3d41bcbf1cc78968ae/src/lib/openjp2/j2k.c#L7755
+            */
+            parameters.tcp_rates[0] = 0.0f;
         }
         else
         {
-            parameters.tcp_numlayers = 5;
-            parameters.tcp_rates[0] = 1920.0f;
-            parameters.tcp_rates[1] = 960.0f;
-            parameters.tcp_rates[2] = 480.0f;
-            parameters.tcp_rates[3] = 120.0f;
-            parameters.tcp_rates[4] = 30.0f;
             parameters.irreversible = 1;
-            parameters.tcp_mct = 1;
         }
 
         if (comment_text)
@@ -500,6 +497,50 @@ public:
         parameters.cod_format = OPJ_CODEC_J2K;
         parameters.prog_order = OPJ_RLCP;
         parameters.cp_disto_alloc = 1;
+
+        // if not lossless compression, computes tcp_numlayers and max_cs_size depending on the image dimensions
+        if( parameters.irreversible ) {
+
+            // computes a number of layers
+            U32 surface = rawImageIn.getWidth() * rawImageIn.getHeight();
+            U32 nb_layers = 1;
+            U32 s = 64*64;
+            while (surface > s)
+            {
+                nb_layers++;
+                s *= 4;
+            }
+            nb_layers = llclamp(nb_layers, 1, 6);
+
+            parameters.tcp_numlayers = nb_layers;
+            parameters.tcp_rates[nb_layers - 1] = (U32)(1.f / DEFAULT_COMPRESSION_RATE); // 1:8 by default
+
+            // for each subsequent layer, computes its rate and adds surface * numcomps * 1/rate to the max_cs_size
+            U32 max_cs_size = (U32)(surface * image->numcomps * DEFAULT_COMPRESSION_RATE);
+            U32 multiplier;
+            for (int i = nb_layers - 2; i >= 0; i--)
+            {
+                if( i == nb_layers - 2 )
+                {
+                    multiplier = 15;
+                }
+                else if( i == nb_layers - 3 )
+                {
+                    multiplier = 4;
+                }
+                else
+                {
+                    multiplier = 2;
+                }
+                parameters.tcp_rates[i] = parameters.tcp_rates[i + 1] * multiplier;
+                max_cs_size += (U32)(surface * image->numcomps * (1 / parameters.tcp_rates[i]));
+            }
+
+            //ensure that we have at least a minimal size
+            max_cs_size = llmax(max_cs_size, (U32)FIRST_PACKET_SIZE);
+           
+            parameters.max_cs_size = max_cs_size;
+        }
 
         if (!opj_setup_encoder(encoder, &parameters, image))
         {


### PR DESCRIPTION
I recently noticed that in my self-compiled viewers, all my uploads looked very bad, with a lot of compression artifacts. The greater the dimensions of the texture, the ugliest it looked, like, over-compressed JPEGs.

I do not have a KDU license, so I have to use the OpenJPEG implementation in my viewer. This affected the uploading of textures and the saving of snapshots to inventory.

This bothered me a lot so I started to investigate the issue.

I discovered that the culprit was indeed the OpenJPEG implementation. The maximum size for all encoded images was set to 32KB. So 1024x1024 and especially 2048x2048 textures looked really, really bad (as good as a 32KB 2048x2048 texture can look...).

The bad line:
`parameters.max_cs_size = (1 << 15);`

This was set in the constructor of the JPEG2KEncode class and applied to all pictures regardless of their dimensions.
The documentations says the following for max_cs_size: `Maximum size (in bytes) for the whole codestream. If == 0, codestream size limitation is not considered. If it does not comply with tcp_rates, max_cs_size prevails and a warning is issued`.

Also the number of layers was hardcoded to 5, which seemed wrong to me, it should depend on the surface of the texture.

My fix is:

1. Computing the number of layers depending on image surface, much like what is done in the KDU implementation. So I moved the definition of num_layers and tcp_rates values to the encode method.
2. Defining the rates according to the number of layers, the last one gets set to 1 / DEFAULT_COMPRESSION_RATE instead of the fixed 30.0f to avoid reducing quality of the topmost layer, and each previous layer multiplies its subsequent layer with a multiplier (I used 15, 4, 2... to be close to the previous defaults of 120, 480, 960 and 1920)
3. Computing max_cs_size: for each layer, multiply the surface by the number of components and by 1/layer rate and add the result to max_cs_size

So a big texture would be allowed more bytes and more layers than a tiny one.

After the fix, the quality of the uploaded textures has improved greatly. In some cases I can still see some very minor compression artefacts and blurriness but they are not too noticeable.