### PR TITLE
Fix trailing whitespaces in webrtc code to pass pre-commit

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -458,7 +458,7 @@ void ll_set_device_module_render_device(rtc::scoped_refptr<webrtc::AudioDeviceMo
     {
         device_module->SetPlayoutDevice(webrtc::AudioDeviceModule::kDefaultDevice);
     }
-    else 
+    else
     {
         device_module->SetPlayoutDevice(device);
     }
@@ -656,7 +656,7 @@ void LLWebRTCImpl::freePeerConnection(LLWebRTCPeerConnectionInterface* peer_conn
 // Most peer connection (signaling) happens on
 // the signaling thread.
 
-LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() : 
+LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
     mWebRTCImpl(nullptr),
     mPeerConnection(nullptr),
     mMute(false),
@@ -1171,7 +1171,7 @@ void LLWebRTCPeerConnectionImpl::OnSuccess(webrtc::SessionDescriptionInterface *
     {
         observer->OnOfferAvailable(mangled_sdp);
     }
-    
+
    mPeerConnection->SetLocalDescription(std::unique_ptr<webrtc::SessionDescriptionInterface>(
                                                      webrtc::CreateSessionDescription(webrtc::SdpType::kOffer, mangled_sdp)),
                                                  rtc::scoped_refptr<webrtc::SetLocalDescriptionObserverInterface>(this));

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -129,7 +129,7 @@ class LLWebRTCDeviceInterface
     };
 
     virtual void setAudioConfig(AudioConfig config) = 0;
-    
+
     // instructs webrtc to refresh the device list.
     virtual void refreshDevices() = 0;
 
@@ -231,7 +231,7 @@ class LLWebRTCSignalingObserver
 class LLWebRTCPeerConnectionInterface
 {
   public:
-    
+
     struct InitOptions
     {
         // equivalent of PeerConnectionInterface::IceServer

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -235,7 +235,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
 
     // The factory that allows creation of native webrtc PeerConnections.
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
-    
+
     rtc::scoped_refptr<webrtc::AudioProcessing>                mAudioProcessingModule;
 
     // more native webrtc stuff


### PR DESCRIPTION
likely caused by https://github.com/secondlife/viewer/commit/c826aea079c59950a4064a94825534884fed8bf8