### PR TITLE
Fix failure to join or detach threads causing rare shutdown termination

### DIFF
--- a/indra/llcommon/llthread.cpp
+++ b/indra/llcommon/llthread.cpp
@@ -269,6 +269,7 @@ void LLThread::shutdown()
             mStatus = STOPPED;
             return;
         }
+        delete mThreadp;
         mThreadp = NULL;
     }
 
@@ -299,6 +300,7 @@ void LLThread::start()
     {
         mThreadp = new std::thread(std::bind(&LLThread::threadRun, this));
         mNativeHandle = mThreadp->native_handle();
+        mThreadp->detach();
     }
     catch (std::system_error& ex)
     {


### PR DESCRIPTION
This fixes a behavior where LLThreads were never detached or joined and could result in a crash on shutdown in rare instances .