### PR TITLE
Fix two rare shutdown crashes in gCacheName and gObjectList

### DIFF
--- a/indra/llmessage/llcachename.cpp
+++ b/indra/llmessage/llcachename.cpp
@@ -53,7 +53,6 @@ const U32 PENDING_TIMEOUT_SECS = 5 * 60;
 
 // Globals
 LLCacheName* gCacheName = NULL;
-std::map<std::string, std::string> LLCacheName::sCacheName;
 
 /// ---------------------------------------------------------------------------
 /// class LLCacheNameEntry
@@ -215,7 +214,7 @@ public:
     Impl(LLMessageSystem* msg);
     ~Impl();
 
-    bool getName(const LLUUID& id, std::string& first, std::string& last);
+    bool getName(const LLUUID& id, std::string& first, std::string& last, std::map<std::string, std::string>& default_names);
 
     boost::signals2::connection addPending(const LLUUID& id, const LLCacheNameCallback& callback);
     void addPending(const LLUUID& id, const LLHost& host);
@@ -247,9 +246,9 @@ LLCacheName::LLCacheName(LLMessageSystem* msg)
 LLCacheName::LLCacheName(LLMessageSystem* msg, const LLHost& upstream_host)
     : impl(* new Impl(msg))
 {
-    sCacheName["waiting"] = "(Loading...)";
-    sCacheName["nobody"] = "(nobody)";
-    sCacheName["none"] = "(none)";
+    mCacheName["waiting"] = "(Loading...)";
+    mCacheName["nobody"] = "(nobody)";
+    mCacheName["none"] = "(none)";
     setUpstream(upstream_host);
 }
 
@@ -274,7 +273,7 @@ LLCacheName::Impl::Impl(LLMessageSystem* msg)
 
 LLCacheName::Impl::~Impl()
 {
-    for_each(mCache.begin(), mCache.end(), DeletePairedPointer());
+    std::for_each(mCache.begin(), mCache.end(), DeletePairedPointer());
     mCache.clear();
     for_each(mReplyQueue.begin(), mReplyQueue.end(), DeletePointer());
     mReplyQueue.clear();
@@ -402,11 +401,11 @@ void LLCacheName::exportFile(std::ostream& ostr)
 }
 
 
-bool LLCacheName::Impl::getName(const LLUUID& id, std::string& first, std::string& last)
+bool LLCacheName::Impl::getName(const LLUUID& id, std::string& first, std::string& last, std::map<std::string, std::string>& default_names)
 {
     if(id.isNull())
     {
-        first = sCacheName["nobody"];
+        first = default_names["nobody"];
         last.clear();
         return true;
     }
@@ -420,7 +419,7 @@ bool LLCacheName::Impl::getName(const LLUUID& id, std::string& first, std::strin
     }
     else
     {
-        first = sCacheName["waiting"];
+        first = default_names["waiting"];
         last.clear();
         if (!isRequestPending(id))
         {
@@ -434,8 +433,8 @@ bool LLCacheName::Impl::getName(const LLUUID& id, std::string& first, std::strin
 // static
 void LLCacheName::localizeCacheName(std::string key, std::string value)
 {
-    if (key!="" && value!= "" )
-        sCacheName[key]=value;
+    if (!key.empty() && !value.empty())
+        mCacheName[key]=value;
     else
         LL_WARNS()<< " Error localizing cache key " << key << " To "<< value<<LL_ENDL;
 }
@@ -443,7 +442,7 @@ void LLCacheName::localizeCacheName(std::string key, std::string value)
 bool LLCacheName::getFullName(const LLUUID& id, std::string& fullname)
 {
     std::string first_name, last_name;
-    bool res = impl.getName(id, first_name, last_name);
+    bool res = impl.getName(id, first_name, last_name, mCacheName);
     fullname = buildFullName(first_name, last_name);
     return res;
 }
@@ -454,7 +453,7 @@ bool LLCacheName::getGroupName(const LLUUID& id, std::string& group)
 {
     if(id.isNull())
     {
-        group = sCacheName["none"];
+        group = mCacheName["none"];
         return true;
     }
 
@@ -475,7 +474,7 @@ bool LLCacheName::getGroupName(const LLUUID& id, std::string& group)
     }
     else
     {
-        group = sCacheName["waiting"];
+        group = mCacheName["waiting"];
         if (!impl.isRequestPending(id))
         {
             impl.mAskGroupQueue.insert(id);
@@ -614,7 +613,7 @@ boost::signals2::connection LLCacheName::get(const LLUUID& id, bool is_group, co
     {
         LLCacheNameSignal signal;
         signal.connect(callback);
-        signal(id, sCacheName["nobody"], is_group);
+        signal(id, mCacheName["nobody"], is_group);
         return res;
     }
 
@@ -754,14 +753,14 @@ void LLCacheName::dumpStats()
 
 void LLCacheName::clear()
 {
-    for_each(impl.mCache.begin(), impl.mCache.end(), DeletePairedPointer());
+    std::for_each(impl.mCache.begin(), impl.mCache.end(), DeletePairedPointer());
     impl.mCache.clear();
 }
 
 //static
 std::string LLCacheName::getDefaultName()
 {
-    return sCacheName["waiting"];
+    return mCacheName["waiting"];
 }
 
 //static

--- a/indra/llmessage/llcachename.h
+++ b/indra/llmessage/llcachename.h
@@ -127,15 +127,16 @@ public:
     void dumpStats();   // Dumps the sizes of the cache and associated queues.
     void clear();       // Deletes all entries from the cache
 
-    static std::string getDefaultName();
+    std::string getDefaultName();
 
     // Returns "Resident", the default last name for SLID-based accounts
     // that have no last name.
     static std::string getDefaultLastName();
 
-    static void localizeCacheName(std::string key, std::string value);
-    static std::map<std::string, std::string> sCacheName;
+    void localizeCacheName(std::string key, std::string value);
+
 private:
+    std::map<std::string, std::string> mCacheName;
 
     class Impl;
     Impl& impl;

--- a/indra/newview/llfloateravatarpicker.cpp
+++ b/indra/newview/llfloateravatarpicker.cpp
@@ -300,7 +300,7 @@ void LLFloaterAvatarPicker::populateNearMe()
         if (!LLAvatarNameCache::get(av, &av_name))
         {
             element["columns"][0]["column"] = "name";
-            element["columns"][0]["value"] = LLCacheName::getDefaultName();
+            element["columns"][0]["value"] = gCacheName->getDefaultName();
             all_loaded = false;
         }
         else

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -6293,7 +6293,7 @@ void LLCallingCardBridge::performAction(LLInventoryModel* model, std::string act
         if (item && (item->getCreatorUUID() != gAgent.getID()) &&
             (!item->getCreatorUUID().isNull()))
         {
-            std::string callingcard_name = LLCacheName::getDefaultName();
+            std::string callingcard_name = gCacheName->getDefaultName();
             LLAvatarName av_name;
             if (LLAvatarNameCache::get(item->getCreatorUUID(), &av_name))
             {

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3602,7 +3602,7 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
         U32 local_id;
         mesgsys->getU32Fast(_PREHASH_ObjectData, _PREHASH_ID, local_id, i);
 
-        LLViewerObjectList::getUUIDFromLocal(id, local_id, ip, port);
+        gObjectList.getUUIDFromLocal(id, local_id, ip, port);
         if (id == LLUUID::null)
         {
             LL_DEBUGS("Messaging") << "Unknown kill for local " << local_id << LL_ENDL;

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -1940,14 +1940,14 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
 
                 if(mesgsys != NULL)
                 {
-                LLViewerObjectList::getUUIDFromLocal(parent_uuid,
+                    gObjectList.getUUIDFromLocal(parent_uuid,
                                                         parent_id,
                                                         mesgsys->getSenderIP(),
                                                         mesgsys->getSenderPort());
                 }
                 else
                 {
-                    LLViewerObjectList::getUUIDFromLocal(parent_uuid,
+                    gObjectList.getUUIDFromLocal(parent_uuid,
                                                         parent_id,
                                                         mRegionp->getHost().getAddress(),
                                                         mRegionp->getHost().getPort());
@@ -2062,7 +2062,7 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
 
                 // Debugging for suspected problems with local ids.
                 //LLUUID parent_uuid;
-                //LLViewerObjectList::getUUIDFromLocal(parent_uuid, parent_id, mesgsys->getSenderIP(), mesgsys->getSenderPort() );
+                //gObjectList.getUUIDFromLocal(parent_uuid, parent_id, mesgsys->getSenderIP(), mesgsys->getSenderPort() );
                 //if (parent_uuid != cur_parentp->getID() )
                 //{
                 //  LL_ERRS() << "Local ID match but UUID mismatch of viewer object" << LL_ENDL;
@@ -2085,14 +2085,14 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
 
                     if(mesgsys != NULL)
                     {
-                    LLViewerObjectList::getUUIDFromLocal(parent_uuid,
+                        gObjectList.getUUIDFromLocal(parent_uuid,
                                                         parent_id,
                                                         gMessageSystem->getSenderIP(),
                                                         gMessageSystem->getSenderPort());
                     }
                     else
                     {
-                        LLViewerObjectList::getUUIDFromLocal(parent_uuid,
+                        gObjectList.getUUIDFromLocal(parent_uuid,
                                                         parent_id,
                                                         mRegionp->getHost().getAddress(),
                                                         mRegionp->getHost().getPort());

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -99,8 +99,6 @@ extern LLPipeline   gPipeline;
 
 // Statics for object lookup tables.
 U32                     LLViewerObjectList::sSimulatorMachineIndex = 1; // Not zero deliberately, to speed up index check.
-std::map<U64, U32>      LLViewerObjectList::sIPAndPortToIndex;
-std::map<U64, LLUUID>   LLViewerObjectList::sIndexAndLocalIDToUUID;
 
 LLViewerObjectList::LLViewerObjectList()
 {
@@ -138,17 +136,17 @@ void LLViewerObjectList::getUUIDFromLocal(LLUUID &id,
 {
     U64 ipport = (((U64)ip) << 32) | (U64)port;
 
-    U32 index = sIPAndPortToIndex[ipport];
+    U32 index = mIPAndPortToIndex[ipport];
 
     if (!index)
     {
         index = sSimulatorMachineIndex++;
-        sIPAndPortToIndex[ipport] = index;
+        mIPAndPortToIndex[ipport] = index;
     }
 
     U64 indexid = (((U64)index) << 32) | (U64)local_id;
 
-    id = get_if_there(sIndexAndLocalIDToUUID, indexid, LLUUID::null);
+    id = get_if_there(mIndexAndLocalIDToUUID, indexid, LLUUID::null);
 }
 
 U64 LLViewerObjectList::getIndex(const U32 local_id,
@@ -157,7 +155,7 @@ U64 LLViewerObjectList::getIndex(const U32 local_id,
 {
     U64 ipport = (((U64)ip) << 32) | (U64)port;
 
-    U32 index = sIPAndPortToIndex[ipport];
+    U32 index = mIPAndPortToIndex[ipport];
 
     if (!index)
     {
@@ -177,14 +175,14 @@ bool LLViewerObjectList::removeFromLocalIDTable(const LLViewerObject* objectp)
         U32 ip = objectp->getRegion()->getHost().getAddress();
         U32 port = objectp->getRegion()->getHost().getPort();
         U64 ipport = (((U64)ip) << 32) | (U64)port;
-        U32 index = sIPAndPortToIndex[ipport];
+        U32 index = mIPAndPortToIndex[ipport];
 
         // LL_INFOS() << "Removing object from table, local ID " << local_id << ", ip " << ip << ":" << port << LL_ENDL;
 
         U64 indexid = (((U64)index) << 32) | (U64)local_id;
 
-        std::map<U64, LLUUID>::iterator iter = sIndexAndLocalIDToUUID.find(indexid);
-        if (iter == sIndexAndLocalIDToUUID.end())
+        std::map<U64, LLUUID>::iterator iter = mIndexAndLocalIDToUUID.find(indexid);
+        if (iter == mIndexAndLocalIDToUUID.end())
         {
             return false;
         }
@@ -192,7 +190,7 @@ bool LLViewerObjectList::removeFromLocalIDTable(const LLViewerObject* objectp)
         // Found existing entry
         if (iter->second == objectp->getID())
         {   // Full UUIDs match, so remove the entry
-            sIndexAndLocalIDToUUID.erase(iter);
+            mIndexAndLocalIDToUUID.erase(iter);
             return true;
         }
         // UUIDs did not match - this would zap a valid entry, so don't erase it
@@ -210,17 +208,17 @@ void LLViewerObjectList::setUUIDAndLocal(const LLUUID &id,
 {
     U64 ipport = (((U64)ip) << 32) | (U64)port;
 
-    U32 index = sIPAndPortToIndex[ipport];
+    U32 index = mIPAndPortToIndex[ipport];
 
     if (!index)
     {
         index = sSimulatorMachineIndex++;
-        sIPAndPortToIndex[ipport] = index;
+        mIPAndPortToIndex[ipport] = index;
     }
 
     U64 indexid = (((U64)index) << 32) | (U64)local_id;
 
-    sIndexAndLocalIDToUUID[indexid] = id;
+    mIndexAndLocalIDToUUID[indexid] = id;
 
     //LL_INFOS() << "Adding object to table, full ID " << id
     //  << ", local ID " << local_id << ", ip " << ip << ":" << port << LL_ENDL;

--- a/indra/newview/llviewerobjectlist.h
+++ b/indra/newview/llviewerobjectlist.h
@@ -171,18 +171,18 @@ public:
     // used to discount stats from this frame
     bool mWasPaused;
 
-    static void getUUIDFromLocal(LLUUID &id,
+    void getUUIDFromLocal(LLUUID &id,
                                 const U32 local_id,
                                 const U32 ip,
                                 const U32 port);
-    static void setUUIDAndLocal(const LLUUID &id,
+    void setUUIDAndLocal(const LLUUID &id,
                                 const U32 local_id,
                                 const U32 ip,
                                 const U32 port); // Requires knowledge of message system info!
 
-    static bool removeFromLocalIDTable(const LLViewerObject* objectp);
+    bool removeFromLocalIDTable(const LLViewerObject* objectp);
     // Used ONLY by the orphaned object code.
-    static U64 getIndex(const U32 local_id, const U32 ip, const U32 port);
+    U64 getIndex(const U32 local_id, const U32 ip, const U32 port);
 
     S32 mNumUnknownUpdates;
     S32 mNumDeadObjectUpdates;
@@ -216,9 +216,9 @@ protected:
     S32 mCurLazyUpdateIndex;
 
     static U32 sSimulatorMachineIndex;
-    static std::map<U64, U32> sIPAndPortToIndex;
+    std::map<U64, U32> mIPAndPortToIndex;
 
-    static std::map<U64, LLUUID> sIndexAndLocalIDToUUID;
+    std::map<U64, LLUUID> mIndexAndLocalIDToUUID;
 
     friend class LLViewerObject;
 
@@ -257,7 +257,7 @@ extern LLViewerObjectList gObjectList;
  */
 inline LLViewerObject *LLViewerObjectList::findObject(const LLUUID &id)
 {
-    std::map<LLUUID, LLPointer<LLViewerObject> >::iterator iter = mUUIDObjectMap.find(id);
+    auto iter = mUUIDObjectMap.find(id);
     if(iter != mUUIDObjectMap.end())
     {
         return iter->second;


### PR DESCRIPTION
This fixes two rare shutdown crashes I've observed caused by static construction/destruction order issues.