### PR TITLE
Use thread pool to create plugin processes to reduce created/destroyed threads

### DIFF
--- a/indra/llplugin/llpluginprocessparent.h
+++ b/indra/llplugin/llpluginprocessparent.h
@@ -69,11 +69,6 @@ public:
               const std::string &plugin_filename,
               bool debug);
 
-    // Creates a process
-    // returns true if process already exists or if created,
-    // false if failed to create
-    bool createPluginProcess();
-
     void idle(void);
 
     // returns true if the plugin is on its way to steady state
@@ -168,15 +163,13 @@ private:
 
     bool accept();
 
-    void clearProcessCreationThread();
-
     LLSocket::ptr_t mListenSocket;
     LLSocket::ptr_t mSocket;
     U32 mBoundPort;
 
     LLProcess::Params mProcessParams;
     LLProcessPtr mProcess;
-    LLThread *pProcessCreationThread;
+    bool mProcessCreationRequested = false;
 
     std::string mPluginFile;
     std::string mPluginDir;


### PR DESCRIPTION
This fixes a new thread being created and destroyed for every plugin process launched by utilizing the threadpool workers. It also fixes a few crashes I observed over the last few months.