### PR TITLE
Fix typo in PrimTextMaxDrawDistance cachecontrol

### DIFF
--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -392,7 +392,7 @@ void LLHUDText::updateVisibility()
 
     LLVector3 pos_agent_center = gAgent.getPosAgentFromGlobal(mPositionGlobal) - dir_from_camera;
     F32 last_distance_center = (pos_agent_center - LLViewerCamera::getInstance()->getOrigin()).magVec();
-    static LLCachedControl<bool> prim_text_max_dist(gSavedSettings, "PrimTextMaxDrawDistance");
+    static LLCachedControl<F32> prim_text_max_dist(gSavedSettings, "PrimTextMaxDrawDistance");
     F32 max_draw_distance = prim_text_max_dist;
 
     if(max_draw_distance < 0)


### PR DESCRIPTION
Fix typo in cache control setup meant to be F32 not bool