### PR TITLE
Reinstate Texture Deletion Grace Period

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1252,13 +1252,21 @@ void LLViewerFetchedTexture::setDeletionCandidate()
 }
 
 //set the texture inactive
-void LLViewerFetchedTexture::setInactive()
+// <TS:3T> Adjusted function to allow mTextureState to be flipped back to Active if sent a true bool.
+void LLViewerFetchedTexture::setInactive(bool found)
 {
-    if(mTextureState == ACTIVE && mGLTexturep.notNull() && mGLTexturep->getTexName() && !mGLTexturep->getBoundRecently())
+    if(mTextureState > DELETED && mTextureState != NO_DELETE && mGLTexturep.notNull() && mGLTexturep->getTexName() && !mGLTexturep->getBoundRecently())
     {
-        mTextureState = INACTIVE;
+        if (found) {
+            mTextureState = ACTIVE;
+        }
+        else {
+            if (mTextureState == ACTIVE) // Only active textures will be set inactive.
+                mTextureState = INACTIVE;
+        }
     }
 }
+// </TS:3T>
 
 bool LLViewerFetchedTexture::isFullyLoaded() const
 {

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -381,7 +381,7 @@ public:
     bool isInactive() ;
     bool isDeletionCandidate();
     void setDeletionCandidate() ;
-    void setInactive() ;
+    void setInactive(bool found);  // <TS:3T> Allow setInactive to receive a bool.
     bool getUseDiscard() const { return mUseMipMaps && !mDontDiscard; }
     //---------------
 

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -983,13 +983,18 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
     //imagep->setDebugText(llformat("%.3f - %d", sqrtf(imagep->getMaxVirtualSize()), imagep->getBoostLevel()));
 
-    F32 lazy_flush_timeout = 30.f; // stop decoding
-    F32 max_inactive_time = 20.f; // actually delete
+    F32 lazy_flush_timeout = 0.f;   // Delete after n seconds, or 0 to not delete until VRAM threshold reached.
+    F32 max_inactive_time = 60.f;   // Stop making changes to texture after n seconds.
+    F32 vram_max_percent = 0.95f;  // If vram reaches this percentage, we consider it full.
+    U32 current_free_vram = gViewerWindow->getWindow()->getAvailableVRAMMegabytes();
+    bool vram_full = (current_free_vram < gGLManager.mVRAMDetected * (1 - vram_max_percent));
     S32 min_refs = 3; // 1 for mImageList, 1 for mUUIDMap, 1 for local reference
 
     //
     // Flush formatted images using a lazy flush
     //
+    // Reset texture state if found on a face or not.
+    imagep->setInactive(onFace);
     S32 num_refs = imagep->getNumRefs();
     if (num_refs == min_refs)
     {
@@ -1015,7 +1020,9 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         {
             return;
         }
-        else if (imagep->isDeletionCandidate())
+        else if (imagep->isDeletionCandidate() &&
+            ((lazy_flush_timeout > 0 && imagep->getLastReferencedTimer()->getElapsedTimeF32() > lazy_flush_timeout)
+                || vram_full))
         {
             imagep->destroyTexture();
             return;
@@ -1031,10 +1038,6 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         else
         {
             imagep->getLastReferencedTimer()->reset();
-
-            //reset texture state.
-            if(!onFace)
-                imagep->setInactive();
         }
     }
 

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -986,8 +986,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
     F32 lazy_flush_timeout = 0.f;   // Delete after n seconds, or 0 to not delete until VRAM threshold reached.
     F32 max_inactive_time = 60.f;   // Stop making changes to texture after n seconds.
     F32 vram_max_percent = 0.95f;  // If vram reaches this percentage, we consider it full.
-    U32 current_free_vram = gViewerWindow->getWindow()->getAvailableVRAMMegabytes();
-    bool vram_full = (current_free_vram < gGLManager.mVRAMDetected * (1 - vram_max_percent));
+    bool vram_full = (LLViewerTexture::sFreeVRAMMegabytes < gGLManager.mVRAMDetected * (1 - vram_max_percent));
     S32 min_refs = 3; // 1 for mImageList, 1 for mUUIDMap, 1 for local reference
 
     //


### PR DESCRIPTION
Adjust logic of LLViewerFetchedTexture::setInactive to allow inactive state to be flipped and allow LLViewerTextureList::updateImageDecodePriority to offer a grace period of at least 60 seconds in inactive status before deletion.

Once those 60 seconds have passed, the texture is set to deletion candidate status.

While in deletion candidate status, the texture may be deleted if a further timeout is set or if VRAM has reached 5% remaining free memory.

The value for deletion timeout while a delete candidate is set as zero in this code to stop the timed deletion, but I hope to persuade stakeholders in a later PR to set this value to 60 seconds or at least a user defined setting.

Stakeholders: @Ansariel @vldevel @RunitaiLinden 

Previous discussion: https://github.com/secondlife/viewer/commit/27a2531c5bf375ed208d8fd5764a8797f08ce831