### PR TITLE
Reduce utf8 to wstring conversion and llwstring temporaries during text draw

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -406,7 +406,8 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
         // recursively render ellipses at end of string
         // we've already reserved enough room
         gGL.pushUIMatrix();
-        renderUTF8(std::string("..."),
+        static LLWString elipses_wstr(utf8string_to_wstring(std::string("...")));
+        render(elipses_wstr,
                 0,
                 (cur_x - origin.mV[VX]) / sScaleX, (F32)y,
                 color,

--- a/indra/llui/llbadge.cpp
+++ b/indra/llui/llbadge.cpp
@@ -231,8 +231,6 @@ void LLBadge::draw()
             // Calculate badge size based on label text
             //
 
-            LLWString badge_label_wstring = mLabel;
-
             S32 badge_label_begin_offset = 0;
             S32 badge_char_length = S32_MAX;
             S32 badge_pixel_length = S32_MAX;
@@ -240,7 +238,7 @@ void LLBadge::draw()
             bool do_not_use_ellipses = false;
 
             F32 badge_width = (2.0f * mPaddingHoriz) +
-                mGLFont->getWidthF32(badge_label_wstring.c_str(), badge_label_begin_offset, badge_char_length);
+                mGLFont->getWidthF32(mLabel.getWString().c_str(), badge_label_begin_offset, badge_char_length);
 
             F32 badge_height = (2.0f * mPaddingVert) + mGLFont->getLineHeight();
 
@@ -354,7 +352,7 @@ void LLBadge::draw()
             // Draw the label
             //
 
-            mGLFont->render(badge_label_wstring,
+            mGLFont->render(mLabel.getWString(),
                             badge_label_begin_offset,
                             badge_center_x + mLabelOffsetHoriz,
                             badge_center_y + mLabelOffsetVert,

--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -796,9 +796,6 @@ void LLButton::draw()
     if( ll::ui::SearchableControl::getHighlighted() )
         label_color = ll::ui::SearchableControl::getHighlightColor();
 
-    // Unselected label assignments
-    LLWString label = getCurrentLabel();
-
     // overlay with keyboard focus border
     if (hasFocus())
     {
@@ -927,8 +924,9 @@ void LLButton::draw()
     }
 
     // Draw label
-    if( !label.empty() )
+    if( !getCurrentLabel().empty() )    // Unselected label assignments
     {
+        LLWString label = getCurrentLabel();
         LLWStringUtil::trim(label);
 
         S32 x;
@@ -1082,10 +1080,10 @@ void LLButton::autoResize()
     resize(getCurrentLabel());
 }
 
-void LLButton::resize(LLUIString label)
+void LLButton::resize(const LLUIString& label)
 {
     // get label length
-    S32 label_width = mGLFont->getWidth(label.getString());
+    S32 label_width = mGLFont->getWidth(label.getWString().c_str());
     // get current btn length
     S32 btn_width =getRect().getWidth();
     // check if it need resize

--- a/indra/llui/llbutton.h
+++ b/indra/llui/llbutton.h
@@ -239,7 +239,7 @@ public:
     LLFontGL::HAlign getImageOverlayHAlign() const  { return mImageOverlayAlignment; }
 
     void            autoResize();   // resize with label of current btn state
-    void            resize(LLUIString label); // resize with label input
+    void            resize(const LLUIString& label); // resize with label input
     void            setLabel(const std::string& label);
     void            setLabel(const LLUIString& label);
     void            setLabel( const LLStringExplicit& label);

--- a/indra/llui/llconsole.cpp
+++ b/indra/llui/llconsole.cpp
@@ -183,7 +183,7 @@ void LLConsole::draw()
     static LLCachedControl<F32> console_bg_opacity(*LLUI::getInstance()->mSettingGroups["config"], "ConsoleBackgroundOpacity", 0.7f);
     F32 console_opacity = llclamp(console_bg_opacity(), 0.f, 1.f);
 
-    LLColor4 color = LLUIColorTable::instance().getColor("ConsoleBackground");
+    static LLColor4 color = LLUIColorTable::instance().getColor("ConsoleBackground");
     color.mV[VALPHA] *= console_opacity;
 
     F32 line_height = (F32)mFont->getLineHeight();

--- a/indra/llui/llcontainerview.cpp
+++ b/indra/llui/llcontainerview.cpp
@@ -46,7 +46,7 @@ static ContainerViewRegistry::Register<LLPanel> r3("panel", &LLPanel::fromXML);
 LLContainerView::LLContainerView(const LLContainerView::Params& p)
 :   LLView(p),
     mShowLabel(p.show_label),
-    mLabel(p.label),
+    mLabel(utf8str_to_wstring(p.label)),
     mDisplayChildren(p.display_children)
 {
     mScrollContainer = NULL;
@@ -120,8 +120,8 @@ void LLContainerView::draw()
     // Draw the label
     if (mShowLabel)
     {
-        LLFontGL::getFontMonospace()->renderUTF8(
-            mLabel, 0, 2, getRect().getHeight() - 2, LLColor4(1,1,1,1), LLFontGL::LEFT, LLFontGL::TOP);
+        LLFontGL::getFontMonospace()->render(
+            mLabel, 0, 2.f, (F32)(getRect().getHeight() - 2), LLColor4(1,1,1,1), LLFontGL::LEFT, LLFontGL::TOP);
     }
 
     LLView::draw();
@@ -285,7 +285,7 @@ LLRect LLContainerView::getRequiredRect()
 
 void LLContainerView::setLabel(const std::string& label)
 {
-    mLabel = label;
+    mLabel = utf8str_to_wstring(label);
 }
 
 void LLContainerView::setDisplayChildren(bool displayChildren)

--- a/indra/llui/llcontainerview.h
+++ b/indra/llui/llcontainerview.h
@@ -89,6 +89,6 @@ public:
 
 protected:
     bool mDisplayChildren;
-    std::string mLabel;
+    LLWString mLabel;
 };
 #endif // LL_CONTAINERVIEW_

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -211,7 +211,7 @@ LLFolderView::LLFolderView(const Params& p)
     //clear label
     // go ahead and render root folder as usual
     // just make sure the label ("Inventory Folder") never shows up
-    mLabel = LLStringUtil::null;
+    mLabel.clear();
 
     // Escape is handled by reverting the rename, not commiting it (default behavior)
     LLLineEditor::Params params;

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -140,7 +140,7 @@ LLFolderViewItem::LLFolderViewItem(const LLFolderViewItem::Params& p)
     mItemHeight(p.item_height),
     mControlLabelRotation(0.f),
     mDragAndDropTarget(false),
-    mLabel(p.name),
+    mLabel(utf8str_to_wstring(p.name)),
     mRoot(p.root),
     mViewModelItem(p.listener),
     mIsMouseOverTitle(false),
@@ -193,7 +193,7 @@ bool LLFolderViewItem::postBuild()
     {
         // getDisplayName() is expensive (due to internal getLabelSuffix() and name building)
         // it also sets search strings so it requires a filter reset
-        mLabel = vmi->getDisplayName();
+        mLabel = utf8str_to_wstring(vmi->getDisplayName());
         setToolTip(vmi->getName());
 
         // Dirty the filter flag of the model from the view (CHUI-849)
@@ -306,7 +306,7 @@ void LLFolderViewItem::refresh()
 {
     LLFolderViewModelItem& vmi = *getViewModelItem();
 
-    mLabel = vmi.getDisplayName();
+    mLabel = utf8str_to_wstring(vmi.getDisplayName());
     setToolTip(vmi.getName());
     // icons are slightly expensive to get, can be optimized
     // see LLInventoryIcon::getIcon()
@@ -319,7 +319,7 @@ void LLFolderViewItem::refresh()
         // Very Expensive!
         // Can do a number of expensive checks, like checking active motions, wearables or friend list
         mLabelStyle = vmi.getLabelStyle();
-        mLabelSuffix = vmi.getLabelSuffix();
+        mLabelSuffix = utf8str_to_wstring(vmi.getLabelSuffix());
     }
 
     // Dirty the filter flag of the model from the view (CHUI-849)
@@ -344,7 +344,7 @@ void LLFolderViewItem::refreshSuffix()
         // Very Expensive!
         // Can do a number of expensive checks, like checking active motions, wearables or friend list
         mLabelStyle = vmi->getLabelStyle();
-        mLabelSuffix = vmi->getLabelSuffix();
+        mLabelSuffix = utf8str_to_wstring(vmi->getLabelSuffix());
     }
 
     mLabelWidthDirty = true;
@@ -405,7 +405,7 @@ S32 LLFolderViewItem::arrange( S32* width, S32* height )
             // it is purely visual, so it is fine to do at our laisure
             refreshSuffix();
         }
-        mLabelWidth = getLabelXPos() + getLabelFontForStyle(mLabelStyle)->getWidth(mLabel) + getLabelFontForStyle(LLFontGL::NORMAL)->getWidth(mLabelSuffix) + mLabelPaddingRight;
+        mLabelWidth = getLabelXPos() + getLabelFontForStyle(mLabelStyle)->getWidth(mLabel.c_str()) + getLabelFontForStyle(LLFontGL::NORMAL)->getWidth(mLabelSuffix.c_str()) + mLabelPaddingRight;
         mLabelWidthDirty = false;
     }
 
@@ -890,7 +890,7 @@ void LLFolderViewItem::drawLabel(const LLFontGL * font, const F32 x, const F32 y
     //--------------------------------------------------------------------------------//
     // Draw the actual label text
     //
-    font->renderUTF8(mLabel, 0, x, y, color,
+    font->render(mLabel, 0, x, y, color,
         LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
         S32_MAX, getRect().getWidth() - (S32) x - mLabelPaddingRight, &right_x, /*use_ellipses*/true);
 }
@@ -944,7 +944,7 @@ void LLFolderViewItem::draw()
     F32 right_x  = 0;
     F32 y = (F32)getRect().getHeight() - font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
     F32 text_left = (F32)getLabelXPos();
-    std::string combined_string = mLabel + mLabelSuffix;
+    LLWString combined_string = mLabel + mLabelSuffix;
 
     const LLFontGL* suffix_font = getLabelFontForStyle(LLFontGL::NORMAL);
     S32 filter_offset = static_cast<S32>(mViewModelItem->getFilterStringOffset());
@@ -954,8 +954,8 @@ void LLFolderViewItem::draw()
         S32 top = getRect().getHeight() - TOP_PAD;
         if(mLabelSuffix.empty() || (font == suffix_font))
         {
-        S32 left = ll_round(text_left) + font->getWidth(combined_string, 0, static_cast<S32>(mViewModelItem->getFilterStringOffset())) - 2;
-        S32 right = left + font->getWidth(combined_string, static_cast<S32>(mViewModelItem->getFilterStringOffset()), filter_string_length) + 2;
+        S32 left = ll_round(text_left) + font->getWidth(combined_string.c_str(), 0, static_cast<S32>(mViewModelItem->getFilterStringOffset())) - 2;
+        S32 right = left + font->getWidth(combined_string.c_str(), static_cast<S32>(mViewModelItem->getFilterStringOffset()), filter_string_length) + 2;
 
         LLUIImage* box_image = default_params.selection_image;
         LLRect box_rect(left, top, right, bottom);
@@ -966,8 +966,8 @@ void LLFolderViewItem::draw()
             S32 label_filter_length = llmin((S32)mLabel.size() - filter_offset, (S32)filter_string_length);
             if(label_filter_length > 0)
             {
-                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel, 0, llmin(filter_offset, (S32)mLabel.size()))) - 2;
-                S32 right = left + (S32)font->getWidthF32(mLabel, filter_offset, label_filter_length) + 2;
+                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel.c_str(), 0, llmin(filter_offset, (S32)mLabel.size()))) - 2;
+                S32 right = left + (S32)font->getWidthF32(mLabel.c_str(), filter_offset, label_filter_length) + 2;
                 LLUIImage* box_image = default_params.selection_image;
                 LLRect box_rect(left, top, right, bottom);
                 box_image->draw(box_rect, sFilterBGColor);
@@ -976,8 +976,8 @@ void LLFolderViewItem::draw()
             if(suffix_filter_length > 0)
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
-                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset))- 2;
-                S32 right = left + (S32)suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length) + 2;
+                S32 left = (S32)(ll_round(text_left) + font->getWidthF32(mLabel.c_str(), 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix.c_str(), 0, suffix_offset)) - 2;
+                S32 right = left + (S32)suffix_font->getWidthF32(mLabelSuffix.c_str(), suffix_offset, suffix_filter_length) + 2;
                 LLUIImage* box_image = default_params.selection_image;
                 LLRect box_rect(left, top, right, bottom);
                 box_image->draw(box_rect, sFilterBGColor);
@@ -999,7 +999,7 @@ void LLFolderViewItem::draw()
     //
     if (!mLabelSuffix.empty())
     {
-        suffix_font->renderUTF8( mLabelSuffix, 0, right_x, y, isFadeItem() ? color : (LLColor4)sSuffixColor,
+        suffix_font->render( mLabelSuffix, 0, right_x, y, isFadeItem() ? color : (LLColor4)sSuffixColor,
                           LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                           S32_MAX, S32_MAX, &right_x);
     }
@@ -1011,9 +1011,9 @@ void LLFolderViewItem::draw()
     {
         if(mLabelSuffix.empty() || (font == suffix_font))
         {
-            F32 match_string_left = text_left + font->getWidthF32(combined_string, 0, filter_offset + filter_string_length) - font->getWidthF32(combined_string, filter_offset, filter_string_length);
+            F32 match_string_left = text_left + font->getWidthF32(combined_string.c_str(), 0, filter_offset + filter_string_length) - font->getWidthF32(combined_string.c_str(), filter_offset, filter_string_length);
             F32 yy = (F32)getRect().getHeight() - font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
-            font->renderUTF8(combined_string, filter_offset, match_string_left, yy,
+            font->render(combined_string, filter_offset, match_string_left, yy,
                 sFilterTextColor, LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                 filter_string_length, S32_MAX, &right_x);
         }
@@ -1022,9 +1022,9 @@ void LLFolderViewItem::draw()
             S32 label_filter_length = llmin((S32)mLabel.size() - filter_offset, (S32)filter_string_length);
             if(label_filter_length > 0)
             {
-                F32 match_string_left = text_left + font->getWidthF32(mLabel, 0, filter_offset + label_filter_length) - font->getWidthF32(mLabel, filter_offset, label_filter_length);
+                F32 match_string_left = text_left + font->getWidthF32(mLabel.c_str(), 0, filter_offset + label_filter_length) - font->getWidthF32(mLabel.c_str(), filter_offset, label_filter_length);
                 F32 yy = (F32)getRect().getHeight() - font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
-                font->renderUTF8(mLabel, filter_offset, match_string_left, yy,
+                font->render(mLabel, filter_offset, match_string_left, yy,
                     sFilterTextColor, LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                     label_filter_length, S32_MAX, &right_x);
             }
@@ -1033,9 +1033,9 @@ void LLFolderViewItem::draw()
             if(suffix_filter_length > 0)
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
-                F32 match_string_left = text_left + font->getWidthF32(mLabel, 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix, 0, suffix_offset + suffix_filter_length) - suffix_font->getWidthF32(mLabelSuffix, suffix_offset, suffix_filter_length);
+                F32 match_string_left = text_left + font->getWidthF32(mLabel.c_str(), 0, static_cast<S32>(mLabel.size())) + suffix_font->getWidthF32(mLabelSuffix.c_str(), 0, suffix_offset + suffix_filter_length) - suffix_font->getWidthF32(mLabelSuffix.c_str(), suffix_offset, suffix_filter_length);
                 F32 yy = (F32)getRect().getHeight() - suffix_font->getLineHeight() - (F32)mTextPad - (F32)TOP_PAD;
-                suffix_font->renderUTF8(mLabelSuffix, suffix_offset, match_string_left, yy, sFilterTextColor,
+                suffix_font->render(mLabelSuffix, suffix_offset, match_string_left, yy, sFilterTextColor,
                     LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                     suffix_filter_length, S32_MAX, &right_x);
             }

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -89,14 +89,14 @@ protected:
 
     LLFolderViewItem(const Params& p);
 
-    std::string                 mLabel;
+    LLWString                   mLabel;
     S32                         mLabelWidth;
     bool                        mLabelWidthDirty;
     S32                         mLabelPaddingRight;
     LLFolderViewFolder*         mParentFolder;
     LLPointer<LLFolderViewModelItem> mViewModelItem;
     LLFontGL::StyleFlags        mLabelStyle;
-    std::string                 mLabelSuffix;
+    LLWString                   mLabelSuffix;
     bool                        mSuffixNeedsRefresh; //suffix and icons
     LLUIImagePtr                mIcon,
                                 mIconOpen,
@@ -242,7 +242,7 @@ public:
     // This method returns the label displayed on the view. This
     // method was primarily added to allow sorting on the folder
     // contents possible before the entire view has been constructed.
-    const std::string& getLabel() const { return mLabel; }
+    const LLWString& getLabel() const { return mLabel; }
 
     LLFolderViewFolder* getParentFolder( void ) { return mParentFolder; }
     const LLFolderViewFolder* getParentFolder( void ) const { return mParentFolder; }

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -545,8 +545,8 @@ void LLMenuItemGL::draw( void )
         std::string::size_type offset = upper_case_label.find(mJumpKey);
         if (offset != std::string::npos)
         {
-            S32 x_begin = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, static_cast<S32>(offset));
-            S32 x_end = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel, 0, static_cast<S32>(offset) + 1);
+            S32 x_begin = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel.getWString().c_str(), 0, static_cast<S32>(offset));
+            S32 x_end = LEFT_PLAIN_PIXELS + mFont->getWidth(mLabel.getWString().c_str(), 0, static_cast<S32>(offset) + 1);
             gl_line_2d(x_begin, (MENU_ITEM_PADDING / 2) + 1, x_end, (MENU_ITEM_PADDING / 2) + 1);
         }
     }
@@ -1648,9 +1648,9 @@ void LLMenuItemBranchDownGL::draw( void )
         std::string::size_type offset = upper_case_label.find(getJumpKey());
         if (offset != std::string::npos)
         {
-            S32 x_offset = ll_round((F32)getRect().getWidth() / 2.f - getFont()->getWidthF32(mLabel.getString(), 0, S32_MAX) / 2.f);
-            S32 x_begin = x_offset + getFont()->getWidth(mLabel, 0, static_cast<S32>(offset));
-            S32 x_end = x_offset + getFont()->getWidth(mLabel, 0, static_cast<S32>(offset) + 1);
+            S32 x_offset = ll_round((F32)getRect().getWidth() / 2.f - getFont()->getWidthF32(mLabel.getWString().c_str(), 0, S32_MAX) / 2.f);
+            S32 x_begin = x_offset + getFont()->getWidth(mLabel.getWString().c_str(), 0, static_cast<S32>(offset));
+            S32 x_end = x_offset + getFont()->getWidth(mLabel.getWString().c_str(), 0, static_cast<S32>(offset) + 1);
             gl_line_2d(x_begin, LABEL_BOTTOM_PAD_PIXELS, x_end, LABEL_BOTTOM_PAD_PIXELS);
         }
     }

--- a/indra/llui/llmultisliderctrl.cpp
+++ b/indra/llui/llmultisliderctrl.cpp
@@ -245,7 +245,7 @@ bool LLMultiSliderCtrl::setLabelArg( const std::string& key, const LLStringExpli
         res = mLabelBox->setTextArg(key, text);
         if (res && mLabelWidth == 0)
         {
-            S32 label_width = mFont->getWidth(mLabelBox->getText());
+            S32 label_width = mFont->getWidth(mLabelBox->getWText().c_str());
             LLRect rect = mLabelBox->getRect();
             S32 prev_right = rect.mRight;
             rect.mRight = rect.mLeft + label_width;

--- a/indra/llui/llscrolllistcell.cpp
+++ b/indra/llui/llscrolllistcell.cpp
@@ -305,7 +305,7 @@ bool LLScrollListText::needsToolTip() const
         return LLScrollListCell::needsToolTip();
 
     // ...otherwise, show tooltips for truncated text
-    return mFont->getWidth(mText.getString()) > getWidth();
+    return mFont->getWidth(mText.getWString().c_str()) > getWidth();
 }
 
 //virtual
@@ -328,7 +328,7 @@ LLScrollListText::~LLScrollListText()
 
 S32 LLScrollListText::getContentWidth() const
 {
-    return mFont->getWidth(mText.getString());
+    return mFont->getWidth(mText.getWString().c_str());
 }
 
 
@@ -394,18 +394,18 @@ void LLScrollListText::draw(const LLColor4& color, const LLColor4& highlight_col
         switch(mFontAlignment)
         {
         case LLFontGL::LEFT:
-            left = mFont->getWidth(mText.getString(), 1, mHighlightOffset);
+            left = mFont->getWidth(mText.getWString().c_str(), 1, mHighlightOffset);
             break;
         case LLFontGL::RIGHT:
-            left = getWidth() - mFont->getWidth(mText.getString(), mHighlightOffset, S32_MAX);
+            left = getWidth() - mFont->getWidth(mText.getWString().c_str(), mHighlightOffset, S32_MAX);
             break;
         case LLFontGL::HCENTER:
-            left = (getWidth() - mFont->getWidth(mText.getString())) / 2;
+            left = (getWidth() - mFont->getWidth(mText.getWString().c_str())) / 2;
             break;
         }
         LLRect highlight_rect(left - 2,
                 mFont->getLineHeight() + 1,
-                left + mFont->getWidth(mText.getString(), mHighlightOffset, mHighlightCount) + 1,
+                left + mFont->getWidth(mText.getWString().c_str(), mHighlightOffset, mHighlightCount) + 1,
                 1);
         mRoundedRectImage->draw(highlight_rect, highlight_color);
     }
@@ -613,18 +613,18 @@ void LLScrollListIconText::draw(const LLColor4& color, const LLColor4& highlight
         switch (mFontAlignment)
         {
         case LLFontGL::LEFT:
-            left = mFont->getWidth(mText.getString(), icon_space + 1, mHighlightOffset);
+            left = mFont->getWidth(mText.getWString().c_str(), icon_space + 1, mHighlightOffset);
             break;
         case LLFontGL::RIGHT:
-            left = getWidth() - mFont->getWidth(mText.getString(), mHighlightOffset, S32_MAX) - icon_space;
+            left = getWidth() - mFont->getWidth(mText.getWString().c_str(), mHighlightOffset, S32_MAX) - icon_space;
             break;
         case LLFontGL::HCENTER:
-            left = (getWidth() - mFont->getWidth(mText.getString()) - icon_space) / 2;
+            left = (getWidth() - mFont->getWidth(mText.getWString().c_str()) - icon_space) / 2;
             break;
         }
         LLRect highlight_rect(left - 2,
             mFont->getLineHeight() + 1,
-            left + mFont->getWidth(mText.getString(), mHighlightOffset, mHighlightCount) + 1,
+            left + mFont->getWidth(mText.getWString().c_str(), mHighlightOffset, mHighlightCount) + 1,
             1);
         mRoundedRectImage->draw(highlight_rect, highlight_color);
     }
@@ -642,12 +642,12 @@ void LLScrollListIconText::draw(const LLColor4& color, const LLColor4& highlight
         break;
     case LLFontGL::RIGHT:
         start_text_x = (F32)getWidth();
-        start_icon_x = getWidth() - mFont->getWidth(mText.getString()) - icon_space;
+        start_icon_x = getWidth() - mFont->getWidth(mText.getWString().c_str()) - icon_space;
         break;
     case LLFontGL::HCENTER:
         F32 center = (F32)getWidth()* 0.5f;
         start_text_x = center + ((F32)icon_space * 0.5f);
-        start_icon_x = (S32)(center - (((F32)icon_space + mFont->getWidth(mText.getString())) * 0.5f));
+        start_icon_x = (S32)(center - (((F32)icon_space + mFont->getWidth(mText.getWString().c_str())) * 0.5f));
         break;
     }
     mFont->render(mText.getWString(), 0,

--- a/indra/llui/llscrolllistctrl.cpp
+++ b/indra/llui/llscrolllistctrl.cpp
@@ -659,7 +659,7 @@ S32 LLScrollListCtrl::calcMaxContentWidth()
         if (mColumnWidthsDirty)
         {
             // update max content width for this column, by looking at all items
-            column->mMaxContentWidth = column->mHeader ? LLFontGL::getFontSansSerifSmall()->getWidth(column->mLabel) + mColumnPadding + HEADING_TEXT_PADDING : 0;
+            column->mMaxContentWidth = column->mHeader ? LLFontGL::getFontSansSerifSmall()->getWidth(column->mLabel.getWString().c_str()) + mColumnPadding + HEADING_TEXT_PADDING : 0;
             item_list::iterator iter;
             for (iter = mItemList.begin(); iter != mItemList.end(); iter++)
             {

--- a/indra/llui/llsliderctrl.cpp
+++ b/indra/llui/llsliderctrl.cpp
@@ -225,7 +225,7 @@ bool LLSliderCtrl::setLabelArg( const std::string& key, const LLStringExplicit& 
         res = mLabelBox->setTextArg(key, text);
         if (res && mLabelFont && mLabelWidth == 0)
         {
-            S32 label_width = mLabelFont->getWidth(mLabelBox->getText());
+            S32 label_width = mLabelFont->getWidth(mLabelBox->getWText().c_str());
             LLRect rect = mLabelBox->getRect();
             S32 prev_right = rect.mRight;
             rect.mRight = rect.mLeft + label_width;

--- a/indra/llui/llstatbar.cpp
+++ b/indra/llui/llstatbar.cpp
@@ -598,7 +598,7 @@ LLRect LLStatBar::getRequiredRect()
 
 void LLStatBar::drawLabelAndValue( F32 value, std::string &label, LLRect &bar_rect, S32 decimal_digits )
 {
-    LLFontGL::getFontMonospace()->renderUTF8(mLabel, 0, 0, getRect().getHeight(), LLColor4(1.f, 1.f, 1.f, 1.f),
+    LLFontGL::getFontMonospace()->render(mLabel.getWString(), 0, 0.F, (F32)getRect().getHeight(), LLColor4(1.f, 1.f, 1.f, 1.f),
         LLFontGL::LEFT, LLFontGL::TOP);
 
     std::string value_str   = !llisnan(value)
@@ -673,14 +673,14 @@ void LLStatBar::drawTicks( F32 min, F32 max, F32 value_scale, LLRect &bar_rect )
             {
                 decimal_digits = 0;
             }
-            std::string tick_label = llformat("%.*f", decimal_digits, tick_value);
-            S32 tick_label_width = LLFontGL::getFontMonospace()->getWidth(tick_label);
+            LLWString tick_label = utf8str_to_wstring(llformat("%.*f", decimal_digits, tick_value));
+            S32 tick_label_width = LLFontGL::getFontMonospace()->getWidth(tick_label.c_str());
             if (mOrientation == HORIZONTAL)
             {
                 if (tick_begin > last_label + MIN_LABEL_SPACING)
                 {
                     gl_rect_2d(bar_rect.mLeft, tick_end, bar_rect.mRight - TICK_LENGTH, tick_begin, LLColor4(1.f, 1.f, 1.f, 0.25f));
-                    LLFontGL::getFontMonospace()->renderUTF8(tick_label, 0, bar_rect.mRight, tick_begin,
+                    LLFontGL::getFontMonospace()->render(tick_label, 0, (F32)bar_rect.mRight, (F32)tick_begin,
                         LLColor4(1.f, 1.f, 1.f, 0.5f),
                         LLFontGL::LEFT, LLFontGL::VCENTER);
                     last_label = tick_begin;
@@ -696,7 +696,7 @@ void LLStatBar::drawTicks( F32 min, F32 max, F32 value_scale, LLRect &bar_rect )
                 {
                     gl_rect_2d(tick_begin, bar_rect.mTop, tick_end, bar_rect.mBottom - TICK_LENGTH, LLColor4(1.f, 1.f, 1.f, 0.25f));
                     S32 label_pos = tick_begin - ll_round((F32)tick_label_width * ((F32)tick_begin / (F32)bar_rect.getWidth()));
-                    LLFontGL::getFontMonospace()->renderUTF8(tick_label, 0, label_pos, bar_rect.mBottom - TICK_LENGTH,
+                    LLFontGL::getFontMonospace()->render(tick_label, 0, (F32)label_pos, (F32)(bar_rect.mBottom - TICK_LENGTH),
                         LLColor4(1.f, 1.f, 1.f, 0.5f),
                         LLFontGL::LEFT, LLFontGL::TOP);
                     last_label = label_pos;

--- a/indra/llui/llstatgraph.cpp
+++ b/indra/llui/llstatgraph.cpp
@@ -93,8 +93,6 @@ void LLStatGraph::draw()
         mUpdateTimer.reset();
     }
 
-    LLColor4 color;
-
     threshold_vec_t::iterator it = std::lower_bound(mThresholds.begin(), mThresholds.end(), Threshold(mValue / mMax, LLUIColor()));
 
     if (it != mThresholds.begin())
@@ -102,15 +100,14 @@ void LLStatGraph::draw()
         it--;
     }
 
-    color = LLUIColorTable::instance().getColor( "MenuDefaultBgColor" );
-    gGL.color4fv(color.mV);
+    static LLColor4 default_color = LLUIColorTable::instance().getColor( "MenuDefaultBgColor" );
+    gGL.color4fv(default_color.mV);
     gl_rect_2d(0, getRect().getHeight(), getRect().getWidth(), 0, true);
 
     gGL.color4fv(LLColor4::black.mV);
     gl_rect_2d(0, getRect().getHeight(), getRect().getWidth(), 0, false);
 
-    color = it->mColor;
-    gGL.color4fv(color.mV);
+    gGL.color4fv(it->mColor().mV);
     gl_rect_2d(1, ll_round(frac*getRect().getHeight()), getRect().getWidth() - 1, 0, true);
 }
 

--- a/indra/newview/llexpandabletextbox.cpp
+++ b/indra/newview/llexpandabletextbox.cpp
@@ -41,7 +41,7 @@ public:
     :   LLTextSegment(start, end),
         mEditor(editor),
         mStyle(style),
-        mExpanderLabel(more_text)
+        mExpanderLabel(utf8str_to_wstring(more_text))
     {}
 
     /*virtual*/ bool    getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
@@ -80,7 +80,7 @@ public:
     /*virtual*/ F32     draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect)
     {
         F32 right_x;
-        mStyle->getFont()->renderUTF8(mExpanderLabel, start,
+        mStyle->getFont()->render(mExpanderLabel, start,
                                     draw_rect.mRight, draw_rect.mTop,
                                     mStyle->getColor(),
                                     LLFontGL::RIGHT, LLFontGL::TOP,
@@ -103,7 +103,7 @@ public:
 private:
     LLTextBase& mEditor;
     LLStyleSP   mStyle;
-    std::string mExpanderLabel;
+    LLWString mExpanderLabel;
 };
 
 LLExpandableTextBox::LLTextBoxEx::Params::Params()

--- a/indra/newview/llprogressview.cpp
+++ b/indra/newview/llprogressview.cpp
@@ -391,7 +391,7 @@ void LLProgressView::initLogos()
     S32 icon_width, icon_height;
 
     // We don't know final screen rect yet, so we can't precalculate position fully
-    S32 texture_start_x = (S32)mLogosLabel->getFont()->getWidthF32(mLogosLabel->getText()) + default_pad;
+    S32 texture_start_x = (S32)mLogosLabel->getFont()->getWidthF32(mLogosLabel->getWText().c_str()) + default_pad;
     S32 texture_start_y = -7;
 
     // Normally we would just preload these textures from textures.xml,

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -1023,18 +1023,20 @@ void LLWorldMapView::drawTracking(const LLVector3d& pos_global, const LLColor4& 
         drawImage(pos_global, sTrackCircleImage, color);
     }
 
-    // clamp text position to on-screen
-    const S32 TEXT_PADDING = DEFAULT_TRACKING_ARROW_SIZE + 2;
-    S32 half_text_width = llfloor(font->getWidthF32(label) * 0.5f);
-    text_x = llclamp(text_x, half_text_width + TEXT_PADDING, getRect().getWidth() - half_text_width - TEXT_PADDING);
-    text_y = llclamp(text_y + vert_offset, TEXT_PADDING + vert_offset, getRect().getHeight() - font->getLineHeight() - TEXT_PADDING - vert_offset);
-
     if (label != "")
     {
-        font->renderUTF8(
-            label, 0,
-            text_x,
-            text_y,
+        // clamp text position to on-screen
+        const S32 TEXT_PADDING = DEFAULT_TRACKING_ARROW_SIZE + 2;
+
+        LLWString wlabel = utf8string_to_wstring(label);
+        S32 half_text_width = llfloor(font->getWidthF32(wlabel.c_str()) * 0.5f);
+        text_x = llclamp(text_x, half_text_width + TEXT_PADDING, getRect().getWidth() - half_text_width - TEXT_PADDING);
+        text_y = llclamp(text_y + vert_offset, TEXT_PADDING + vert_offset, getRect().getHeight() - font->getLineHeight() - TEXT_PADDING - vert_offset);
+
+        font->render(
+            wlabel, 0,
+            (F32)text_x,
+            (F32)text_y,
             LLColor4::white, LLFontGL::HCENTER,
             LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::DROP_SHADOW);
 


### PR DESCRIPTION
This reduces the number of LLWString temporaries and needless utf8 to wstring conversions during various text draw calls.