### PR TITLE
viewer-private#255 p2p outgoing calls did not work correctly

### DIFF
--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -122,7 +122,13 @@ void LLVoiceChannel::onChange(EStatusType type, const LLSD& channelInfo, bool pr
 {
     LL_DEBUGS("Voice") << "Incoming channel info: " << channelInfo << LL_ENDL;
     LL_DEBUGS("Voice") << "Current channel info: " << mChannelInfo << LL_ENDL;
-    if (mChannelInfo.isUndefined() || (mChannelInfo.isMap() && mChannelInfo.size() == 0))
+    if (mChannelInfo.has("channel_uri")
+        && (!channelInfo.has("channel_uri") || mChannelInfo["channel_uri"] != channelInfo["channel_uri"]))
+    {
+        return;
+    }
+    if (mChannelInfo.isUndefined()
+        || (mChannelInfo.isMap() && mChannelInfo.size() <= 1)) // p2p will have uri beforehand
     {
         mChannelInfo = channelInfo;
     }
@@ -768,6 +774,11 @@ LLVoiceChannelP2P::LLVoiceChannelP2P(const LLUUID      &session_id,
     mReceivedCall(FALSE),
     mOutgoingCallInterface(outgoing_call_interface)
 {
+    std::string sip_uri = LLVoiceClient::getInstance()->sipURIFromID(other_user_id);
+    if (!sip_uri.empty())
+    {
+        mChannelInfo["channel_uri"] = sip_uri;
+    }
 }
 
 void LLVoiceChannelP2P::handleStatusChange(EStatusType type)

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -122,13 +122,7 @@ void LLVoiceChannel::onChange(EStatusType type, const LLSD& channelInfo, bool pr
 {
     LL_DEBUGS("Voice") << "Incoming channel info: " << channelInfo << LL_ENDL;
     LL_DEBUGS("Voice") << "Current channel info: " << mChannelInfo << LL_ENDL;
-    if (mChannelInfo.has("channel_uri")
-        && (!channelInfo.has("channel_uri") || mChannelInfo["channel_uri"] != channelInfo["channel_uri"]))
-    {
-        return;
-    }
-    if (mChannelInfo.isUndefined()
-        || (mChannelInfo.isMap() && mChannelInfo.size() <= 1)) // p2p will have uri beforehand
+    if (mChannelInfo.isUndefined() || (mChannelInfo.isMap() && mChannelInfo.size() == 0))
     {
         mChannelInfo = channelInfo;
     }
@@ -774,11 +768,7 @@ LLVoiceChannelP2P::LLVoiceChannelP2P(const LLUUID      &session_id,
     mReceivedCall(FALSE),
     mOutgoingCallInterface(outgoing_call_interface)
 {
-    std::string sip_uri = LLVoiceClient::getInstance()->sipURIFromID(other_user_id);
-    if (!sip_uri.empty())
-    {
-        mChannelInfo["channel_uri"] = sip_uri;
-    }
+    mChannelInfo = LLVoiceClient::getInstance()->getP2PChannelInfoTemplate(other_user_id);
 }
 
 void LLVoiceChannelP2P::handleStatusChange(EStatusType type)

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -826,7 +826,7 @@ void LLVoiceClient::removeObserver(LLVoiceClientParticipantObserver* observer)
     LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
 }
 
-std::string LLVoiceClient::sipURIFromID(const LLUUID &id)
+std::string LLVoiceClient::sipURIFromID(const LLUUID &id) const
 {
     if (mNonSpatialVoiceModule)
     {
@@ -839,6 +839,22 @@ std::string LLVoiceClient::sipURIFromID(const LLUUID &id)
     else
     {
         return std::string();
+    }
+}
+
+LLSD LLVoiceClient::getP2PChannelInfoTemplate(const LLUUID& id) const
+{
+    if (mNonSpatialVoiceModule)
+    {
+        return mNonSpatialVoiceModule->getP2PChannelInfoTemplate(id);
+    }
+    else if (mSpatialVoiceModule)
+    {
+        return mSpatialVoiceModule->getP2PChannelInfoTemplate(id);
+    }
+    else
+    {
+        return LLSD();
     }
 }
 

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -281,7 +281,8 @@ public:
     virtual void removeObserver(LLVoiceClientParticipantObserver* observer)=0;
     //@}
 
-    virtual std::string sipURIFromID(const LLUUID &id)=0;
+    virtual std::string sipURIFromID(const LLUUID &id) const=0;
+    virtual LLSD getP2PChannelInfoTemplate(const LLUUID& id) const=0;
     //@}
 
 };
@@ -488,7 +489,8 @@ public:
     void addObserver(LLVoiceClientParticipantObserver* observer);
     void removeObserver(LLVoiceClientParticipantObserver* observer);
 
-    std::string sipURIFromID(const LLUUID &id);
+    std::string sipURIFromID(const LLUUID &id) const;
+    LLSD getP2PChannelInfoTemplate(const LLUUID& id) const;
 
     //////////////////////////
     /// @name Voice effects

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5138,7 +5138,7 @@ bool LLVivoxVoiceClient::inProximalChannel()
     return result;
 }
 
-std::string LLVivoxVoiceClient::sipURIFromID(const LLUUID &id)
+std::string LLVivoxVoiceClient::sipURIFromID(const LLUUID &id) const
 {
     std::string result;
     result = "sip:";
@@ -5146,6 +5146,14 @@ std::string LLVivoxVoiceClient::sipURIFromID(const LLUUID &id)
     result += "@";
     result += mVoiceSIPURIHostName;
 
+    return result;
+}
+
+LLSD LLVivoxVoiceClient::getP2PChannelInfoTemplate(const LLUUID& id) const
+{
+    LLSD result;
+    result["channel_uri"] = sipURIFromID(id);
+    result["voice_server_type"] = VIVOX_VOICE_SERVER_TYPE;
     return result;
 }
 
@@ -5163,7 +5171,7 @@ std::string LLVivoxVoiceClient::sipURIFromAvatar(LLVOAvatar *avatar)
     return result;
 }
 
-std::string LLVivoxVoiceClient::nameFromID(const LLUUID &uuid)
+std::string LLVivoxVoiceClient::nameFromID(const LLUUID &uuid) const
 {
     std::string result;
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -296,7 +296,6 @@ LLVivoxVoiceClient::LLVivoxVoiceClient() :
     mDevicesListUpdated(false),
 
     mAudioSession(), // TBD - should be NULL
-    mAudioSessionChanged(false),
     mNextAudioSession(),
 
     mCurrentParcelLocalID(0),
@@ -1641,7 +1640,6 @@ bool LLVivoxVoiceClient::addAndJoinSession(const sessionStatePtr_t &nextSession)
     LL_INFOS("Voice") << "Adding or joining voice session " << nextSession->mHandle << LL_ENDL;
 
     mAudioSession = nextSession;
-    mAudioSessionChanged = true;
     if (!mAudioSession || !mAudioSession->mReconnect)
     {
         mNextAudioSession.reset();
@@ -1898,9 +1896,8 @@ bool LLVivoxVoiceClient::terminateAudioSession(bool wait)
 
         sessionStatePtr_t oldSession = mAudioSession;
 
+        notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL); // needs mAudioSession for uri
         mAudioSession.reset();
-        // We just notified status observers about this change.  Don't do it again.
-        mAudioSessionChanged = false;
 
         // The old session may now need to be deleted.
         reapSession(oldSession);
@@ -1908,9 +1905,9 @@ bool LLVivoxVoiceClient::terminateAudioSession(bool wait)
     else
     {
         LL_WARNS("Voice") << "terminateAudioSession(" << wait << ") with NULL mAudioSession" << LL_ENDL;
+        notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
     }
 
-    notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
 
     // Always reset the terminate request flag when we get here.
     // Some slower PCs have a race condition where they can switch to an incoming  P2P call faster than the state machine leaves
@@ -3832,7 +3829,6 @@ void LLVivoxVoiceClient::joinedAudioSession(const sessionStatePtr_t &session)
         sessionStatePtr_t oldSession = mAudioSession;
 
         mAudioSession = session;
-        mAudioSessionChanged = true;
 
         // The old session may now need to be deleted.
         reapSession(oldSession);
@@ -6147,7 +6143,6 @@ void LLVivoxVoiceClient::deleteSession(const sessionStatePtr_t &session)
     if(mAudioSession == session)
     {
         mAudioSession.reset();
-        mAudioSessionChanged = true;
     }
 
     // ditto for the next audio session
@@ -6256,9 +6251,10 @@ void LLVivoxVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESta
         }
     }
 
+    LLSD channel_info = getAudioSessionChannelInfo();
     LL_DEBUGS("Voice")
         << " " << LLVoiceClientStatusObserver::status2string(status)
-        << ", session channelInfo " << getAudioSessionChannelInfo()
+        << ", session channelInfo " << channel_info
         << ", proximal is " << inSpatialChannel()
         << LL_ENDL;
 
@@ -6273,7 +6269,7 @@ void LLVivoxVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESta
         )
     {
         LLVoiceClientStatusObserver* observer = *it;
-        observer->onChange(status, getAudioSessionChannelInfo(), inSpatialChannel());
+        observer->onChange(status, channel_info, inSpatialChannel());
         // In case onError() deleted an entry.
         it = mStatusObservers.upper_bound(observer);
     }

--- a/indra/newview/llvoicevivox.h
+++ b/indra/newview/llvoicevivox.h
@@ -706,7 +706,6 @@ private:
 
     std::string mChannelName;           // Name of the channel to be looked up
     sessionStatePtr_t mAudioSession;        // Session state for the current audio session
-    bool mAudioSessionChanged;          // set to true when the above pointer gets changed, so observers can be notified.
 
     sessionStatePtr_t mNextAudioSession;    // Session state for the audio session we're trying to join
 

--- a/indra/newview/llvoicevivox.h
+++ b/indra/newview/llvoicevivox.h
@@ -221,7 +221,8 @@ public:
     void removeObserver(LLVoiceClientParticipantObserver* observer) override;
     //@}
 
-    std::string sipURIFromID(const LLUUID &id) override;
+    std::string sipURIFromID(const LLUUID &id) const override;
+    LLSD getP2PChannelInfoTemplate(const LLUUID& id) const override;
     //@}
 
     /// @name LLVoiceEffectInterface virtual implementations
@@ -747,7 +748,7 @@ private:
     bool switchChannel(std::string uri = std::string(), bool spatial = true, bool no_reconnect = false, bool is_p2p = false, std::string hash = "");
     void joinSession(const sessionStatePtr_t &session);
 
-    std::string nameFromID(const LLUUID &id);
+    std::string nameFromID(const LLUUID &id) const;
     bool IDFromName(const std::string name, LLUUID &uuid);
     std::string sipURIFromAvatar(LLVOAvatar *avatar);
     std::string sipURIFromName(std::string &name);

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2066,9 +2066,14 @@ void LLWebRTCVoiceClient::avatarNameResolved(const LLUUID &id, const std::string
 }
 
 // Leftover from vivox PTSN
-std::string LLWebRTCVoiceClient::sipURIFromID(const LLUUID& id)
+std::string LLWebRTCVoiceClient::sipURIFromID(const LLUUID& id) const
 {
     return id.asString();
+}
+
+LLSD LLWebRTCVoiceClient::getP2PChannelInfoTemplate(const LLUUID& id) const
+{
+    return LLSD();
 }
 
 

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -84,7 +84,9 @@ public:
     // Returns true if WebRTC has successfully logged in and is not in error state
     bool isVoiceWorking() const override;
 
-    std::string sipURIFromID(const LLUUID &id) override;
+    std::string sipURIFromID(const LLUUID &id) const override;
+    LLSD getP2PChannelInfoTemplate(const LLUUID& id) const override;
+
 
     /////////////////////
     /// @name Tuning


### PR DESCRIPTION
Issue:
P2P was catching STATUS_LEFT_CHANNEL meant for nearby chat and adopting channel info for itself

Solution:
- Moved one of notifyStatusObservers calls so that it would have uri data instead of firing with no channel info
- Made p2p sessions init with uri data, like it was before webrtc. Which is used to distinguish observer notifications.
- Removed mAudioSessionChanged. It was unused yet confusing.