### PR TITLE
Fix a bunch of XUI warnings

### DIFF
--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -854,8 +854,9 @@ void LLPanelRegionInfo::initCtrl(const std::string& name)
 template<typename CTRL>
 void LLPanelRegionInfo::initAndSetCtrl(CTRL*& ctrl, const std::string& name)
 {
-    initCtrl(name);
     ctrl = findChild<CTRL>(name);
+    if (ctrl)
+        ctrl->setCommitCallback(boost::bind(&LLPanelRegionInfo::onChangeAnything, this));
 }
 
 void LLPanelRegionInfo::onClickManageTelehub()

--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -326,7 +326,6 @@ bool LLFloaterWorldMap::postBuild()
 
     mPeopleCheck = getChild<LLCheckBoxCtrl>("people_chk");
     mInfohubCheck = getChild<LLCheckBoxCtrl>("infohub_chk");
-    mTelehubCheck = getChild<LLCheckBoxCtrl>("telehub_chk");
     mLandSaleCheck = getChild<LLCheckBoxCtrl>("land_for_sale_chk");
     mEventsCheck = getChild<LLCheckBoxCtrl>("event_chk");
     mEventsMatureCheck = getChild<LLCheckBoxCtrl>("events_mature_chk");
@@ -572,7 +571,6 @@ void LLFloaterWorldMap::draw()
     bool enable = mMapView->showRegionInfo();
     mPeopleCheck->setEnabled(enable);
     mInfohubCheck->setEnabled(enable);
-    mTelehubCheck->setEnabled(enable);
     mLandSaleCheck->setEnabled(enable);
     mEventsCheck->setEnabled(enable);
     mEventsMatureCheck->setEnabled(enable);

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -206,7 +206,6 @@ private:
 
     LLCheckBoxCtrl*         mPeopleCheck = nullptr;
     LLCheckBoxCtrl*         mInfohubCheck = nullptr;
-    LLCheckBoxCtrl*         mTelehubCheck = nullptr;
     LLCheckBoxCtrl*         mLandSaleCheck = nullptr;
     LLCheckBoxCtrl*         mEventsCheck = nullptr;
     LLCheckBoxCtrl*         mEventsMatureCheck = nullptr;

--- a/indra/newview/llpanelgroup.cpp
+++ b/indra/newview/llpanelgroup.cpp
@@ -167,8 +167,6 @@ bool LLPanelGroup::postBuild()
     mButtonRefresh = getChild<LLButton>("btn_refresh");
     mButtonRefresh->setClickedCallback(onBtnRefresh, this);
 
-    mButtonCancel = getChild<LLButton>("btn_cancel");
-
     mGroupNameCtrl = getChild<LLUICtrl>("group_name");
 
     childSetCommitCallback("back",boost::bind(&LLPanelGroup::onBackBtnClick,this),NULL);
@@ -214,18 +212,8 @@ void LLPanelGroup::reposButton(LLButton* button)
 
 void LLPanelGroup::reposButtons()
 {
-    if(mButtonRefresh && mButtonCancel && mButtonRefresh->getVisible() && mButtonCancel->getVisible())
-    {
-        LLRect btn_refresh_rect = mButtonRefresh->getRect();
-        LLRect btn_cancel_rect = mButtonCancel->getRect();
-        btn_refresh_rect.setLeftTopAndSize( btn_cancel_rect.mLeft + btn_cancel_rect.getWidth() + 2,
-            btn_refresh_rect.getHeight() + 2, btn_refresh_rect.getWidth(), btn_refresh_rect.getHeight());
-        mButtonRefresh->setRect(btn_refresh_rect);
-    }
-
     reposButton(mButtonApply);
     reposButton(mButtonRefresh);
-    reposButton(mButtonCancel);
     reposButton(mButtonChat);
     reposButton(mButtonCall);
 }
@@ -375,9 +363,6 @@ void LLPanelGroup::setGroupID(const LLUUID& group_id)
         mButtonApply->setVisible(!is_null_group_id);
     if(mButtonRefresh)
         mButtonRefresh->setVisible(!is_null_group_id);
-
-    if(mButtonCancel)
-        mButtonCancel->setVisible(!is_null_group_id);
 
     if(mButtonCall)
             mButtonCall->setVisible(!is_null_group_id);

--- a/indra/newview/llpanelgroup.h
+++ b/indra/newview/llpanelgroup.h
@@ -123,7 +123,6 @@ protected:
     LLButton*       mButtonCall = nullptr;
     LLButton*       mButtonChat = nullptr;
     LLButton*       mButtonRefresh = nullptr;
-    LLButton*       mButtonCancel = nullptr;
     LLUICtrl*       mJoinText;
 };
 

--- a/indra/newview/skins/default/xui/en/floater_im_session.xml
+++ b/indra/newview/skins/default/xui/en/floater_im_session.xml
@@ -341,7 +341,6 @@
                  name="emoji_recent_empty_text"
                  follows="top|left|right"
                  layout="topleft"
-                 auto_resize="false"
                  h_pad="20"
                  v_pad="10"
                  top="0"

--- a/indra/newview/skins/default/xui/en/widgets/emoji_complete.xml
+++ b/indra/newview/skins/default/xui/en/widgets/emoji_complete.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <emoji_complete
   autosize="false"
-  hover_image="ListItem_Over"
   selected_image="ListItem_Select"
   max_visible="7"
   padding="8"


### PR DESCRIPTION
* PBR region terrain creates dummy widgets and thus never hooking up the commit callback properly to call LLPanelRegionInfo::onChangeAnything
* Telehub checkbox doesn't exist on the world map for quite a while
* Cancel button doesn't exist for group profiles

The region terrain issues also exists in Atlasaurus.