### PR TITLE
#2100 BugSplat Crash #1497210: LLVOAvatar::updateImpostors()(10616)

### DIFF
--- a/indra/llcharacter/llcharacter.cpp
+++ b/indra/llcharacter/llcharacter.cpp
@@ -38,7 +38,7 @@
 
 LLStringTable LLCharacter::sVisualParamNames(1024);
 
-std::vector< LLCharacter* > LLCharacter::sInstances;
+std::list< LLCharacter* > LLCharacter::sInstances;
 bool LLCharacter::sAllowInstancesChange = true ;
 
 //-----------------------------------------------------------------------------
@@ -53,7 +53,6 @@ LLCharacter::LLCharacter()
     mSkeletonSerialNum( 0 )
 {
     llassert_always(sAllowInstancesChange) ;
-    sInstances.push_back(this);
 
     mMotionController.setCharacter( this );
     mPauseRequest = new LLPauseRequestHandle();
@@ -66,28 +65,12 @@ LLCharacter::LLCharacter()
 //-----------------------------------------------------------------------------
 LLCharacter::~LLCharacter()
 {
-    for (LLVisualParam *param = getFirstVisualParam();
-        param;
-        param = getNextVisualParam())
+    for (const auto& it : mVisualParamIndexMap)
     {
-        delete param;
+        delete it.second;
     }
-
-    size_t i ;
-    size_t size = sInstances.size() ;
-    for(i = 0 ; i < size ; i++)
-    {
-        if(sInstances[i] == this)
-        {
-            break ;
-        }
-    }
-
-    llassert_always(i < size) ;
 
     llassert_always(sAllowInstancesChange) ;
-    sInstances[i] = sInstances[size - 1] ;
-    sInstances.pop_back() ;
 }
 
 

--- a/indra/llcharacter/llcharacter.h
+++ b/indra/llcharacter/llcharacter.h
@@ -255,7 +255,7 @@ public:
     U32             getSkeletonSerialNum() const        { return mSkeletonSerialNum; }
     void            setSkeletonSerialNum( U32 num ) { mSkeletonSerialNum = num; }
 
-    static std::vector< LLCharacter* > sInstances;
+    static std::list< LLCharacter* > sInstances;
     static bool sAllowInstancesChange ; //debug use
 
     virtual void    setHoverOffset(const LLVector3& hover_offset, bool send_update=true) { mHoverOffset = hover_offset; }

--- a/indra/llcharacter/llkeyframemotion.cpp
+++ b/indra/llcharacter/llkeyframemotion.cpp
@@ -2407,13 +2407,10 @@ void LLKeyframeMotion::onLoadComplete(const LLUUID& asset_uuid,
 {
     LLUUID* id = (LLUUID*)user_data;
 
-    std::vector<LLCharacter* >::iterator char_iter = LLCharacter::sInstances.begin();
-
-    while(char_iter != LLCharacter::sInstances.end() &&
-            (*char_iter)->getID() != *id)
-    {
-        ++char_iter;
-    }
+    auto char_iter = std::find_if(LLCharacter::sInstances.begin(), LLCharacter::sInstances.end(), [&](LLCharacter* c)
+        {
+            return c->getID() == *id;
+        });
 
     delete id;
 

--- a/indra/newview/llavatarrenderinfoaccountant.cpp
+++ b/indra/newview/llavatarrenderinfoaccountant.cpp
@@ -226,14 +226,12 @@ void LLAvatarRenderInfoAccountant::avatarRenderInfoReportCoro(std::string url, U
     // Build the render info to POST to the region
     LLSD agents = LLSD::emptyMap();
 
-    std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-    while( iter != LLCharacter::sInstances.end() )
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(*iter);
-        if (avatar &&
-            avatar->getRezzedStatus() >= 2 &&                   // Mostly rezzed (maybe without baked textures downloaded)
-            !avatar->isDead() &&                                // Not dead yet
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead() &&                                // Not dead yet
             !avatar->isControlAvatar() &&                       // Not part of an animated object
+            avatar->getRezzedStatus() >= 2 &&                   // Mostly rezzed (maybe without baked textures downloaded)
             avatar->getObjectHost() == regionp->getHost())      // Ensure it's on the same region
         {
             LLSD info = LLSD::emptyMap();
@@ -243,15 +241,14 @@ void LLAvatarRenderInfoAccountant::avatarRenderInfoReportCoro(std::string url, U
                 // the weight/complexity is unsigned, but LLSD only stores signed integers,
                 // so if it's over that (which would be ridiculously high), just store the maximum signed int value
                 info[KEY_WEIGHT] = (S32)(avatar_complexity < S32_MAX ? avatar_complexity : S32_MAX);
-                info[KEY_TOO_COMPLEX]  = LLSD::Boolean(avatar->isTooComplex());
+                info[KEY_TOO_COMPLEX] = LLSD::Boolean(avatar->isTooComplex());
                 agents[avatar->getID().asString()] = info;
 
                 LL_DEBUGS("AvatarRenderInfo") << "Sending avatar render info for " << avatar->getID()
-                                              << ": " << info << LL_ENDL;
+                    << ": " << info << LL_ENDL;
                 num_avs++;
             }
         }
-        iter++;
     }
 
     // Reset this regions timer, moving to longer intervals if there are lots of avatars around

--- a/indra/newview/llcontrolavatar.cpp
+++ b/indra/newview/llcontrolavatar.cpp
@@ -699,14 +699,14 @@ bool LLControlAvatar::isImpostor()
     return LLVOAvatar::isImpostor();
 }
 
-//static
+// static
 void LLControlAvatar::onRegionChanged()
 {
-    std::vector<LLCharacter*>::iterator it = LLCharacter::sInstances.begin();
-    for ( ; it != LLCharacter::sInstances.end(); ++it)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLControlAvatar* cav = dynamic_cast<LLControlAvatar*>(*it);
-        if (!cav) continue;
-        cav->mRegionChanged = true;
+        if (LLControlAvatar* cav = dynamic_cast<LLControlAvatar*>(character))
+        {
+            cav->mRegionChanged = true;
+        }
     }
 }

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -793,12 +793,9 @@ void LLFloater360Capture::freezeWorld(bool enable)
         LLEnvironment::instance().pauseCloudScroll();
 
         // freeze all avatars
-        LLCharacter* avatarp;
-        for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-                iter != LLCharacter::sInstances.end(); ++iter)
+        for (LLCharacter* character : LLCharacter::sInstances)
         {
-            avatarp = *iter;
-            mAvatarPauseHandles.push_back(avatarp->requestPause());
+            mAvatarPauseHandles.push_back(character->requestPause());
         }
 
         // freeze everything else

--- a/indra/newview/llfloaterperformance.cpp
+++ b/indra/newview/llfloaterperformance.cpp
@@ -435,15 +435,12 @@ void LLFloaterPerformance::populateNearbyList()
     mNearbyList->updateColumns(true);
 
     static LLCachedControl<U32> max_render_cost(gSavedSettings, "RenderAvatarMaxComplexity", 0);
-    std::vector<LLCharacter*> valid_nearby_avs;
+    std::vector<LLVOAvatar*> valid_nearby_avs;
     mNearbyMaxGPUTime = LLWorld::getInstance()->getNearbyAvatarsAndMaxGPUTime(valid_nearby_avs);
 
-    std::vector<LLCharacter*>::iterator char_iter = valid_nearby_avs.begin();
-
-    while (char_iter != valid_nearby_avs.end())
+    for (LLVOAvatar* avatar : valid_nearby_avs)
     {
-        LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(*char_iter);
-        if (avatar && (LLVOAvatar::AOA_INVISIBLE != avatar->getOverallAppearance()))
+        if (LLVOAvatar::AOA_INVISIBLE != avatar->getOverallAppearance())
         {
             F32 render_av_gpu_ms = avatar->getGPURenderTime();
 
@@ -508,7 +505,6 @@ void LLFloaterPerformance::populateNearbyList()
                 }
             }
         }
-        char_iter++;
     }
     mNearbyList->sortByColumnIndex(1, false);
     mNearbyList->setScrollPos(prev_pos);

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -210,13 +210,10 @@ void LLFloaterSnapshotBase::ImplBase::updateLayout(LLFloaterSnapshotBase* floate
             previewp->setEnabled(true);
         }
 
-        //RN: freeze all avatars
-        LLCharacter* avatarp;
-        for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-            iter != LLCharacter::sInstances.end(); ++iter)
+        // RN: freeze all avatars
+        for (LLCharacter* character : LLCharacter::sInstances)
         {
-            avatarp = *iter;
-            floaterp->impl->mAvatarPauseHandles.push_back(avatarp->requestPause());
+            floaterp->impl->mAvatarPauseHandles.push_back(character->requestPause());
         }
 
         // freeze everything else

--- a/indra/newview/llscenemonitor.cpp
+++ b/indra/newview/llscenemonitor.cpp
@@ -225,11 +225,10 @@ void LLSceneMonitor::freezeScene()
         return;
     }
 
-    //freeze all avatars
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-        iter != LLCharacter::sInstances.end(); ++iter)
+    // freeze all avatars
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        freezeAvatar((LLCharacter*)(*iter));
+        freezeAvatar((LLCharacter*)character);
     }
 
     // freeze everything else

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -1892,10 +1892,9 @@ class LLAdvancedForceParamsToDefault : public view_listener_t
 static void set_all_animation_time_factors(F32  time_factor)
 {
     LLMotionController::setCurrentTimeFactor(time_factor);
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-        iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        (*iter)->setAnimTimeFactor(time_factor);
+        character->setAnimTimeFactor(time_factor);
     }
 }
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -741,18 +741,16 @@ public:
         if (gSavedSettings.getBOOL("DebugShowAvatarRenderInfo"))
         {
             std::map<std::string, LLVOAvatar*> sorted_avs;
-
-            std::vector<LLCharacter*>::iterator sort_iter = LLCharacter::sInstances.begin();
-            while (sort_iter != LLCharacter::sInstances.end())
             {
-                LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(*sort_iter);
-                if (avatar &&
-                    !avatar->isDead())                      // Not dead yet
+                for (LLCharacter* character : LLCharacter::sInstances)
                 {
-                    // Stuff into a sorted map so the display is ordered
-                    sorted_avs[avatar->getFullname()] = avatar;
+                    LLVOAvatar* avatar = (LLVOAvatar*)character;
+                    if (!avatar->isDead()) // Not dead yet
+                    {
+                        // Stuff into a sorted map so the display is ordered
+                        sorted_avs[avatar->getFullname()] = avatar;
+                    }
                 }
-                sort_iter++;
             }
 
             std::string trunc_name;

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -768,6 +768,8 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
     }
 
     mVisuallyMuteSetting = LLVOAvatar::VisualMuteSettings(LLRenderMuteList::getInstance()->getSavedVisualMuteSetting(getID()));
+
+    sInstances.push_back(this);
 }
 
 std::string LLVOAvatar::avString() const
@@ -815,6 +817,8 @@ void LLVOAvatar::debugAvatarRezTime(std::string notification_name, std::string c
 //------------------------------------------------------------------------
 LLVOAvatar::~LLVOAvatar()
 {
+    sInstances.remove(this);
+
     if (!mFullyLoaded)
     {
         debugAvatarRezTime("AvatarRezLeftCloudNotification","left after ruth seconds as cloud");
@@ -957,26 +961,16 @@ void LLVOAvatar::deleteLayerSetCaches(bool clearAll)
 // static
 bool LLVOAvatar::areAllNearbyInstancesBaked(S32& grey_avatars)
 {
-    bool res = true;
     grey_avatars = 0;
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
-        if( inst->isDead() )
+        LLVOAvatar* inst = (LLVOAvatar*)character;
+        if (!inst->isDead() && inst->mHasGrey && !inst->isFullyBaked())
         {
-            continue;
-        }
-        else if( !inst->isFullyBaked() )
-        {
-            res = false;
-            if (inst->mHasGrey)
-            {
-                ++grey_avatars;
-            }
+            ++grey_avatars;
         }
     }
-    return res;
+    return !grey_avatars;
 }
 
 // static
@@ -987,11 +981,10 @@ void LLVOAvatar::getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_t
     avg_cloud_time = 0;
     cloud_avatars = 0;
     S32 count_avg = 0;
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
-        if (inst)
+        if (LLVOAvatar* inst = (LLVOAvatar*)character)
         {
             S32 rez_status = inst->getRezzedStatus();
             counts[rez_status]++;
@@ -1008,6 +1001,7 @@ void LLVOAvatar::getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_t
             }
         }
     }
+
     if (count_avg > 0)
     {
         avg_cloud_time /= count_avg;
@@ -1017,11 +1011,19 @@ void LLVOAvatar::getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_t
 // static
 std::string LLVOAvatar::rezStatusToString(S32 rez_status)
 {
-    if (rez_status==0) return "cloud";
-    if (rez_status==1) return "gray";
-    if (rez_status==2) return "downloading baked";
-    if (rez_status==3) return "loading attachments";
-    if (rez_status==4) return "full";
+    switch (rez_status)
+    {
+    case 0:
+        return "cloud";
+    case 1:
+        return "gray";
+    case 2:
+        return "downloading baked";
+    case 3:
+        return "loading attachments";
+    case 4:
+        return "full";
+    }
     return "unknown";
 }
 
@@ -1030,10 +1032,9 @@ void LLVOAvatar::dumpBakedStatus()
 {
     LLVector3d camera_pos_global = gAgentCamera.getCameraPositionGlobal();
 
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
+        LLVOAvatar* inst = (LLVOAvatar*)character;
         LL_INFOS() << "Avatar ";
 
         LLNameValue* firstname = inst->getNVPair("FirstName");
@@ -1128,10 +1129,9 @@ void LLVOAvatar::destroyGL()
 //static
 void LLVOAvatar::resetImpostors()
 {
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* avatar = (LLVOAvatar*) *iter;
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
         avatar->mImpostor.release();
         avatar->mNeedsImpostorUpdate = true;
         avatar->mLastImpostorUpdateReason = 1;
@@ -1143,11 +1143,9 @@ void LLVOAvatar::deleteCachedImages(bool clearAll)
 {
     if (LLViewerTexLayerSet::sHasCaches)
     {
-        for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-             iter != LLCharacter::sInstances.end(); ++iter)
+        for (LLCharacter* character : LLCharacter::sInstances)
         {
-            LLVOAvatar* inst = (LLVOAvatar*) *iter;
-            inst->deleteLayerSetCaches(clearAll);
+            ((LLVOAvatar*)character)->deleteLayerSetCaches(clearAll);
         }
         LLViewerTexLayerSet::sHasCaches = false;
     }
@@ -1202,7 +1200,7 @@ void LLVOAvatar::initInstance()
     //-------------------------------------------------------------------------
     if (LLCharacter::sInstances.size() == 1)
     {
-        registerMotion( ANIM_AGENT_DO_NOT_DISTURB,                  LLNullMotion::create );
+        registerMotion( ANIM_AGENT_DO_NOT_DISTURB,          LLNullMotion::create );
         registerMotion( ANIM_AGENT_CROUCH,                  LLKeyframeStandMotion::create );
         registerMotion( ANIM_AGENT_CROUCHWALK,              LLKeyframeWalkMotion::create );
         registerMotion( ANIM_AGENT_EXPRESS_AFRAID,          LLEmote::create );
@@ -3628,29 +3626,28 @@ void LLVOAvatar::clearNameTag()
     mTimeVisible.reset();
 }
 
-//static
+// static
 void LLVOAvatar::invalidateNameTag(const LLUUID& agent_id)
 {
-    LLViewerObject* obj = gObjectList.findObject(agent_id);
-    if (!obj) return;
-
-    LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(obj);
-    if (!avatar) return;
-
-    avatar->clearNameTag();
+    if (LLViewerObject* obj = gObjectList.findObject(agent_id))
+    {
+        if (LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(obj))
+        {
+            avatar->clearNameTag();
+        }
+    }
 }
 
-//static
+// static
 void LLVOAvatar::invalidateNameTags()
 {
-    std::vector<LLCharacter*>::iterator it = LLCharacter::sInstances.begin();
-    for ( ; it != LLCharacter::sInstances.end(); ++it)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(*it);
-        if (!avatar) continue;
-        if (avatar->isDead()) continue;
-
-        avatar->clearNameTag();
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead())
+        {
+            avatar->clearNameTag();
+        }
     }
 }
 
@@ -8261,15 +8258,13 @@ void LLVOAvatar::logPendingPhases()
 //static
 void LLVOAvatar::logPendingPhasesAllAvatars()
 {
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
-        if( inst->isDead() )
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead())
         {
-            continue;
+            avatar->logPendingPhases();
         }
-        inst->logPendingPhases();
     }
 }
 
@@ -10443,15 +10438,16 @@ void LLVOAvatar::setVisibilityRank(U32 rank)
 S32 LLVOAvatar::getUnbakedPixelAreaRank()
 {
     S32 rank = 1;
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
+
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
-        if (inst == this)
+        if (character == this)
         {
             return rank;
         }
-        else if (!inst->isDead() && !inst->isFullyBaked())
+
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead() && !avatar->isFullyBaked())
         {
             rank++;
         }
@@ -10461,49 +10457,37 @@ S32 LLVOAvatar::getUnbakedPixelAreaRank()
     return 0;
 }
 
-struct CompareScreenAreaGreater
-{
-    bool operator()(const LLCharacter* const& lhs, const LLCharacter* const& rhs)
-    {
-        return lhs->getPixelArea() > rhs->getPixelArea();
-    }
-};
-
 // static
 void LLVOAvatar::cullAvatarsByPixelArea()
 {
-    std::sort(LLCharacter::sInstances.begin(), LLCharacter::sInstances.end(), CompareScreenAreaGreater());
+    LLCharacter::sInstances.sort([](LLCharacter* lhs, LLCharacter* rhs)
+        {
+            return lhs->getPixelArea() > rhs->getPixelArea();
+        });
 
     // Update the avatars that have changed status
-    U32 rank = 2; //1 is reserved for self.
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-         iter != LLCharacter::sInstances.end(); ++iter)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) *iter;
-        bool culled;
-        if (inst->isSelf() || inst->isFullyBaked())
+        U32 rank = 2; //1 is reserved for self.
+        for (LLCharacter* character : LLCharacter::sInstances)
         {
-            culled = false;
-        }
-        else
-        {
-            culled = true;
-        }
+            LLVOAvatar* inst = (LLVOAvatar*)character;
+            bool culled = !inst->isSelf() && !inst->isFullyBaked();
 
-        if (inst->mCulled != culled)
-        {
-            inst->mCulled = culled;
-            LL_DEBUGS() << "avatar " << inst->getID() << (culled ? " start culled" : " start not culled" ) << LL_ENDL;
-            inst->updateMeshTextures();
-        }
+            if (inst->mCulled != culled)
+            {
+                inst->mCulled = culled;
+                LL_DEBUGS() << "avatar " << inst->getID() << (culled ? " start culled" : " start not culled" ) << LL_ENDL;
+                inst->updateMeshTextures();
+            }
 
-        if (inst->isSelf())
-        {
-            inst->setVisibilityRank(1);
-        }
-        else if (inst->mDrawable.notNull() && inst->mDrawable->isVisible())
-        {
-            inst->setVisibilityRank(rank++);
+            if (inst->isSelf())
+            {
+                inst->setVisibilityRank(1);
+            }
+            else if (inst->mDrawable.notNull() && inst->mDrawable->isVisible())
+            {
+                inst->setVisibilityRank(rank++);
+            }
         }
     }
 
@@ -10762,11 +10746,9 @@ void LLVOAvatar::updateImpostors()
 {
     LLViewerCamera::sCurCameraID = LLViewerCamera::CAMERA_WORLD;
 
-    std::vector<LLCharacter*> instances_copy = LLCharacter::sInstances;
-    for (std::vector<LLCharacter*>::iterator iter = instances_copy.begin();
-        iter != instances_copy.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* avatar = (LLVOAvatar*) *iter;
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
         if (!avatar->isDead()
             && avatar->isVisible()
             && avatar->isImpostor()
@@ -10923,21 +10905,17 @@ void LLVOAvatar::updateNearbyAvatarCount()
         S32 avs_nearby = 0;
         static LLCachedControl<F32> render_far_clip(gSavedSettings, "RenderFarClip", 64);
         F32 radius = render_far_clip * render_far_clip;
-        std::vector<LLCharacter *>::iterator char_iter = LLCharacter::sInstances.begin();
-        while (char_iter != LLCharacter::sInstances.end())
+        for (LLCharacter* character : LLCharacter::sInstances)
         {
-            LLVOAvatar *avatar = dynamic_cast<LLVOAvatar *>(*char_iter);
-            if (avatar && !avatar->isDead() && !avatar->isControlAvatar())
+            LLVOAvatar* avatar = (LLVOAvatar*)character;
+            if (!avatar->isDead() && !avatar->isControlAvatar())
             {
-                if ((dist_vec_squared(avatar->getPositionGlobal(), gAgent.getPositionGlobal()) > radius) &&
-                    (dist_vec_squared(avatar->getPositionGlobal(), gAgentCamera.getCameraPositionGlobal()) > radius))
+                if ((dist_vec_squared(avatar->getPositionGlobal(), gAgent.getPositionGlobal()) <= radius) ||
+                    (dist_vec_squared(avatar->getPositionGlobal(), gAgentCamera.getCameraPositionGlobal()) <= radius))
                 {
-                    char_iter++;
-                    continue;
+                    avs_nearby++;
                 }
-                avs_nearby++;
             }
-            char_iter++;
         }
         sAvatarsNearby = avs_nearby;
         agent_update_timer.reset();
@@ -11710,10 +11688,9 @@ F32 LLVOAvatar::getTotalGPURenderTime()
 
     F32 ret = 0.f;
 
-    for (LLCharacter* iter : LLCharacter::sInstances)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*) iter;
-        ret += inst->getGPURenderTime();
+        ret += ((LLVOAvatar*)character)->getGPURenderTime();
     }
 
     return ret;
@@ -11725,10 +11702,9 @@ F32 LLVOAvatar::getMaxGPURenderTime()
 
     F32 ret = 0.f;
 
-    for (LLCharacter* iter : LLCharacter::sInstances)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*)iter;
-        ret = llmax(inst->getGPURenderTime(), ret);
+        ret = llmax(((LLVOAvatar*)character)->getGPURenderTime(), ret);
     }
 
     return ret;
@@ -11742,12 +11718,12 @@ F32 LLVOAvatar::getAverageGPURenderTime()
 
     S32 count = 0;
 
-    for (LLCharacter* iter : LLCharacter::sInstances)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* inst = (LLVOAvatar*)iter;
-        if (!inst->isTooSlow())
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isTooSlow())
         {
-            ret += inst->getGPURenderTime();
+            ret += avatar->getGPURenderTime();
             ++count;
         }
     }
@@ -11759,6 +11735,7 @@ F32 LLVOAvatar::getAverageGPURenderTime()
 
     return ret;
 }
+
 bool LLVOAvatar::isBuddy() const
 {
     return LLAvatarTracker::instance().isBuddy(getID());

--- a/indra/newview/llworld.cpp
+++ b/indra/newview/llworld.cpp
@@ -1320,35 +1320,32 @@ void LLWorld::getAvatars(uuid_vec_t* avatar_ids, std::vector<LLVector3d>* positi
     }
     // get the list of avatars from the character list first, so distances are correct
     // when agent is above 1020m and other avatars are nearby
-    for (std::vector<LLCharacter*>::iterator iter = LLCharacter::sInstances.begin();
-        iter != LLCharacter::sInstances.end(); ++iter)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* pVOAvatar = (LLVOAvatar*) *iter;
-
-        if (!pVOAvatar->isDead() && !pVOAvatar->mIsDummy && !pVOAvatar->isOrphaned())
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead() && !avatar->mIsDummy && !avatar->isOrphaned())
         {
-            LLVector3d pos_global = pVOAvatar->getPositionGlobal();
-            LLUUID uuid = pVOAvatar->getID();
+            LLVector3d pos_global = avatar->getPositionGlobal();
+            LLUUID uuid = avatar->getID();
 
             if (!uuid.isNull()
                 && dist_vec_squared(pos_global, relative_to) <= radius_squared)
             {
-                if(positions != NULL)
+                if (positions != NULL)
                 {
                     positions->push_back(pos_global);
                 }
-                if(avatar_ids !=NULL)
+                if (avatar_ids != NULL)
                 {
                     avatar_ids->push_back(uuid);
                 }
             }
         }
     }
+
     // region avatars added for situations where radius is greater than RenderFarClip
-    for (LLWorld::region_list_t::const_iterator iter = LLWorld::getInstance()->getRegionList().begin();
-        iter != LLWorld::getInstance()->getRegionList().end(); ++iter)
+    for (const LLViewerRegion* regionp : LLWorld::getInstance()->getRegionList())
     {
-        LLViewerRegion* regionp = *iter;
         const LLVector3d& origin_global = regionp->getOriginGlobal();
         auto count = regionp->mMapAvatars.size();
         for (size_t i = 0; i < count; i++)
@@ -1371,33 +1368,31 @@ void LLWorld::getAvatars(uuid_vec_t* avatar_ids, std::vector<LLVector3d>* positi
     }
 }
 
-F32 LLWorld::getNearbyAvatarsAndMaxGPUTime(std::vector<LLCharacter*> &valid_nearby_avs)
+F32 LLWorld::getNearbyAvatarsAndMaxGPUTime(std::vector<LLVOAvatar*> &valid_nearby_avs)
 {
     static LLCachedControl<F32> render_far_clip(gSavedSettings, "RenderFarClip", 64);
+
     F32 nearby_max_complexity = 0;
     F32 radius = render_far_clip * render_far_clip;
-    std::vector<LLCharacter*>::iterator char_iter = LLCharacter::sInstances.begin();
-    while (char_iter != LLCharacter::sInstances.end())
-    {
-        LLVOAvatar* avatar = dynamic_cast<LLVOAvatar*>(*char_iter);
-        if (avatar && !avatar->isDead() && !avatar->isControlAvatar())
-        {
-            if ((dist_vec_squared(avatar->getPositionGlobal(), gAgent.getPositionGlobal()) > radius) &&
-                (dist_vec_squared(avatar->getPositionGlobal(), gAgentCamera.getCameraPositionGlobal()) > radius))
-            {
-                char_iter++;
-                continue;
-            }
 
-            if (!avatar->isTooSlow())
+    for (LLCharacter* character : LLCharacter::sInstances)
+    {
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (!avatar->isDead() && !avatar->isControlAvatar())
+        {
+            if ((dist_vec_squared(avatar->getPositionGlobal(), gAgent.getPositionGlobal()) <= radius) ||
+                (dist_vec_squared(avatar->getPositionGlobal(), gAgentCamera.getCameraPositionGlobal()) <= radius))
             {
-                gPipeline.profileAvatar(avatar);
+                if (!avatar->isTooSlow())
+                {
+                    gPipeline.profileAvatar(avatar);
+                }
+                nearby_max_complexity = llmax(nearby_max_complexity, avatar->getGPURenderTime());
+                valid_nearby_avs.push_back(avatar);
             }
-            nearby_max_complexity = llmax(nearby_max_complexity, avatar->getGPURenderTime());
-            valid_nearby_avs.push_back(*char_iter);
         }
-        char_iter++;
     }
+
     return nearby_max_complexity;
 }
 

--- a/indra/newview/llworld.h
+++ b/indra/newview/llworld.h
@@ -172,7 +172,7 @@ public:
 
     // profile nearby avatars using gPipeline.profileAvatar and update their render times
     // return max GPU time
-    F32 getNearbyAvatarsAndMaxGPUTime(std::vector<LLCharacter*> &valid_nearby_avs);
+    F32 getNearbyAvatarsAndMaxGPUTime(std::vector<LLVOAvatar*> &valid_nearby_avs);
 
 private:
     void clearHoleWaterObjects();

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -6438,16 +6438,14 @@ LLViewerObject* LLPipeline::lineSegmentIntersectInWorld(const LLVector4a& start,
         }
     }
 
-    //check all avatar nametags (silly, isn't it?)
-    for (std::vector< LLCharacter* >::iterator iter = LLCharacter::sInstances.begin();
-        iter != LLCharacter::sInstances.end();
-        ++iter)
+    // check all avatar nametags (silly, isn't it?)
+    for (LLCharacter* character : LLCharacter::sInstances)
     {
-        LLVOAvatar* av = (LLVOAvatar*) *iter;
-        if (av->mNameText.notNull()
-            && av->mNameText->lineSegmentIntersect(start, local_end, position))
+        LLVOAvatar* avatar = (LLVOAvatar*)character;
+        if (avatar->mNameText.notNull() &&
+            avatar->mNameText->lineSegmentIntersect(start, local_end, position))
         {
-            drawable = av->mDrawable;
+            drawable = avatar->mDrawable;
             local_end = position;
         }
     }


### PR DESCRIPTION
Key ideas
1. Make `LLCharacter::sInstances` a `std::list` instead of a `std::vector`
2. Avoid of using a temporary copy of the global static array (crash fix)