### PR TITLE
Destroy stream process when stopping audio stream to allow restarting when libvlc is stuck or errored internally

### DIFF
--- a/indra/newview/llviewermedia_streamingaudio.cpp
+++ b/indra/newview/llviewermedia_streamingaudio.cpp
@@ -70,6 +70,8 @@ void LLStreamingAudio_MediaPlugins::start(const std::string& url)
         LL_INFOS() << "setting stream to NULL"<< LL_ENDL;
         mURL.clear();
         mMediaPlugin->stop();
+        delete mMediaPlugin;
+        mMediaPlugin = nullptr;
     }
 }
 
@@ -79,6 +81,8 @@ void LLStreamingAudio_MediaPlugins::stop()
     if(mMediaPlugin)
     {
         mMediaPlugin->stop();
+        delete mMediaPlugin;
+        mMediaPlugin = nullptr;
     }
 
     mURL.clear();


### PR DESCRIPTION
This allows fully restarting the audio stream media plugin process when stopping/starting audio streams so that a broken media plugin won't hang/get stuck eternally. 