### PR TITLE
Fix warning for Type mismatch in LLMsgVarData::addData for SpaceIP

### DIFF
--- a/indra/newview/llcallingcard.cpp
+++ b/indra/newview/llcallingcard.cpp
@@ -451,7 +451,7 @@ void LLAvatarTracker::findAgent()
     msg->nextBlockFast(_PREHASH_AgentBlock);
     msg->addUUIDFast(_PREHASH_Hunter, gAgentID);
     msg->addUUIDFast(_PREHASH_Prey, mTrackingData->mAvatarID);
-    msg->addU32Fast(_PREHASH_SpaceIP, 0); // will get filled in by simulator
+    msg->addIPAddrFast(_PREHASH_SpaceIP, 0); // will get filled in by simulator
     msg->nextBlockFast(_PREHASH_LocationBlock);
     const F64 NO_LOCATION = 0.0;
     msg->addF64Fast(_PREHASH_GlobalX, NO_LOCATION);


### PR DESCRIPTION
Fixes warning about type mismatch when constructing FindAgent packet from finding another avatar on map

`2024-07-27T00:23:22Z WARNING # llmessage/llmessagetemplate.cpp(42) LLMsgVarData::addData : Type mismatch in LLMsgVarData::addData for SpaceIP`

Correct type is IPAddr as shown in message template https://github.com/secondlife/viewer/blob/develop/scripts/messages/message_template.msg#L5689