### PR TITLE
Fix trying to bind to non-existent texunit sampler during water draw

### DIFF
--- a/indra/newview/lldrawpoolwater.cpp
+++ b/indra/newview/lldrawpoolwater.cpp
@@ -241,8 +241,6 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
 
         F32 screenRes[] = { 1.f / gGLViewport[2], 1.f / gGLViewport[3] };
 
-        S32 diffTex = shader->enableTexture(LLShaderMgr::DIFFUSE_MAP);
-
         shader->uniform2fv(LLShaderMgr::DEFERRED_SCREEN_RES, 1, screenRes);
         shader->uniform1f(LLShaderMgr::BLEND_FACTOR, blend_factor);
 
@@ -316,8 +314,6 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
             water = static_cast<LLVOWater*>(face->getViewerObject());
             if (!water) continue;
 
-            gGL.getTexUnit(diffTex)->bind(face->getTexture());
-
             if ((bool)edge == (bool)water->getIsEdgePatch())
             {
                 face->renderIndexed();
@@ -334,7 +330,6 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
         shader->disableTexture(LLShaderMgr::ENVIRONMENT_MAP, LLTexUnit::TT_CUBE_MAP);
         shader->disableTexture(LLShaderMgr::WATER_SCREENTEX);
         shader->disableTexture(LLShaderMgr::BUMP_MAP);
-        shader->disableTexture(LLShaderMgr::DIFFUSE_MAP);
         shader->disableTexture(LLShaderMgr::WATER_REFTEX);
 
         // clean up


### PR DESCRIPTION
This fixes trying to bind to a texture sampler that doesn't exist in the shader. Noticed it in debug log spam.

`2024-07-27T16:41:17Z DEBUG # llrender/llrender.cpp(1500) LLRender::getTexUnit : Non-existing texture unit layer requested: 4294967295`