### PR TITLE
Fix double variable name in initialization

### DIFF
--- a/indra/newview/llinventorygallerymenu.cpp
+++ b/indra/newview/llinventorygallerymenu.cpp
@@ -810,7 +810,7 @@ void LLInventoryGalleryContextMenu::updateMenuItemsVisibility(LLContextMenu* men
             items.push_back(std::string("Copy Asset UUID"));
             items.push_back(std::string("Copy Separator"));
 
-            bool is_asset_knowable = is_asset_knowable = LLAssetType::lookupIsAssetIDKnowable(obj->getType());
+            bool is_asset_knowable = LLAssetType::lookupIsAssetIDKnowable(obj->getType());
             if ( !is_asset_knowable // disable menu item for Inventory items with unknown asset. EXT-5308
                  || (! ( is_full_perm_item || gAgent.isGodlike())))
             {


### PR DESCRIPTION
is_asset_knowable variable name is duplicated, causing a compiler warning in gcc.