### PR TITLE
Update to Boost 1.85

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -104,11 +104,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>d8d9e1e15ec09c81acfa9ffb80c3f20435373543</string>
+              <string>d600779da508fbb64eb85957f2866fd2b039b674</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-boost/releases/download/v1.84.0-r1/boost-1.84-darwin64-8499892512.tar.zst</string>
+              <string>https://github.com/secondlife/3p-boost/releases/download/v1.85.0-r1/boost-1.85-darwin64-10124675220.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -118,11 +118,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>a5552fcd343179c4c7d6dd6289675431a8c0fe8d</string>
+              <string>ce39890fe263358d99c45f1b697107b72e3b6870</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-boost/releases/download/v1.84.0-r1/boost-1.84-linux64-8499892512.tar.zst</string>
+              <string>https://github.com/secondlife/3p-boost/releases/download/v1.85.0-r1/boost-1.85-linux64-10124675220.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -132,11 +132,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>5af9c69093e171eda552720a7acd570496db17db</string>
+              <string>2b0b0b0aaf3bdb1d36809db7d08bd60ae7e8fed1</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-boost/releases/download/v1.84.0-r1/boost-1.84-windows64-8499892512.tar.zst</string>
+              <string>https://github.com/secondlife/3p-boost/releases/download/v1.85.0-r1/boost-1.85-windows64-10124675220.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -149,7 +149,7 @@
         <key>copyright</key>
         <string>(see individual source files)</string>
         <key>version</key>
-        <string>1.81-09d25a7</string>
+        <string>1.85</string>
         <key>name</key>
         <string>boost</string>
         <key>description</key>
@@ -210,11 +210,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>fd656d2478728c4fc268478ec40d33b0ed1b7d83</string>
+              <string>a29852f41b77a26a2c10af1d179bf7c4b6a1b12b</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r4/colladadom-2.3.8500178177-darwin64-8500178177.tar.zst</string>
+              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r6/colladadom-2.3.10129939866-darwin64-10129939866.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -224,11 +224,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>aebc0ddcae18852e78143fbac793cd4a32f0f251</string>
+              <string>933c31aa8da53731c75c272b90a64dde08dc1f4d</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r4/colladadom-2.3.8500178177-linux64-8500178177.tar.zst</string>
+              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r6/colladadom-2.3.10129939866-linux64-10129939866.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -238,11 +238,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>3b25739b1a923c2edcf19864a1c82aeb5042567b</string>
+              <string>c01f1692a48d26436297bd5ac4b54fd3c71f7651</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r4/colladadom-2.3.8500178177-windows64-8500178177.tar.zst</string>
+              <string>https://github.com/secondlife/3p-colladadom/releases/download/v2.3-r6/colladadom-2.3.10129939866-windows64-10129939866.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -255,7 +255,7 @@
         <key>copyright</key>
         <string>Copyright 2006 Sony Computer Entertainment Inc.</string>
         <key>version</key>
-        <string>2.3.ab0c124</string>
+        <string>2.3.10129939866</string>
         <key>name</key>
         <string>colladadom</string>
       </map>

--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -108,11 +108,6 @@ if (WINDOWS)
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   endif()
 
-  # workaround for github runner image breakage:
-  # https://github.com/actions/runner-images/issues/10004#issuecomment-2153445161
-  # can be removed after the above issue is resolved and deployed across GHA
-  add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-
   # Allow use of sprintf etc
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif (WINDOWS)

--- a/indra/llmath/v3color.h
+++ b/indra/llmath/v3color.h
@@ -209,10 +209,6 @@ inline LLColor3::LLColor3(const F32 *vec)
     mV[VBLUE] = vec[VBLUE];
 }
 
-#if LL_WINDOWS
-# pragma warning( disable : 4996 ) // strncpy teh sux0r
-#endif
-
 inline LLColor3::LLColor3(const char* color_string) // takes a string of format "RRGGBB" where RR is hex 00..FF
 {
     if (strlen(color_string) <  6)      /* Flawfinder: ignore */

--- a/indra/llmessage/llcorehttputil.cpp
+++ b/indra/llmessage/llcorehttputil.cpp
@@ -585,7 +585,7 @@ LLSD HttpCoroJSONHandler::handleSuccess(LLCore::HttpResponse * response, LLCore:
 
     LLCore::BufferArrayStream bas(body);
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value jsonRoot = boost::json::parse(bas, ec);
     if(ec.failed())
     {   // deserialization failed.  Record the reason and pass back an empty map for markup.
@@ -610,7 +610,7 @@ LLSD HttpCoroJSONHandler::parseBody(LLCore::HttpResponse *response, bool &succes
 
     LLCore::BufferArrayStream bas(body);
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value jsonRoot = boost::json::parse(bas, ec);
     if (ec.failed())
     {

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -41,6 +41,7 @@
 #include "llwebrtc.h"
 // WebRTC Includes
 #ifdef WEBRTC_WIN
+#pragma warning(push)
 #pragma warning(disable : 4996) // ignore 'deprecated.'  We don't use the functions marked
                                 // deprecated in the webrtc headers, but msvc complains anyway.
                                 // Clang doesn't, and that's generally what webrtc uses.
@@ -62,7 +63,6 @@
 #include "api/task_queue/task_queue_factory.h"
 #include "api/task_queue/default_task_queue_factory.h"
 #include "modules/audio_device/include/audio_device_defines.h"
-
 
 namespace llwebrtc
 {
@@ -378,5 +378,9 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 };
 
 }
+
+#if WEBRTC_WIN
+#pragma warning(pop)
+#endif
 
 #endif // LLWEBRTC_IMPL_H

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -711,7 +711,7 @@ bool LLAppViewerWin32::init()
         }
         else
         {
-            boost::json::error_code ec;
+            boost::system::error_code ec;
             boost::json::value build_data = boost::json::parse(inf, ec);
             if(ec.failed())
             {

--- a/indra/newview/lltranslate.cpp
+++ b/indra/newview/lltranslate.cpp
@@ -398,7 +398,7 @@ bool LLGoogleTranslationHandler::parseResponse(
 {
     const std::string& text = !body.empty() ? body : http_response["error_body"].asStringRef();
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(text, ec);
     if (ec.failed())
     {
@@ -431,7 +431,7 @@ void LLGoogleTranslationHandler::parseErrorResponse(
     int& status,
     std::string& err_msg)
 {
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     auto message = root.find_pointer("/data/message", ec);
     auto code = root.find_pointer("/data/code", ec);
     if (!message || !code)
@@ -456,7 +456,7 @@ bool LLGoogleTranslationHandler::parseTranslation(
     std::string& translation,
     std::string& detected_lang)
 {
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     auto translated_text = root.find_pointer("/data/translations/0/translatedText", ec);
     if (!translated_text) return false;
 
@@ -656,7 +656,7 @@ bool LLAzureTranslationHandler::checkVerificationResponse(
     // Expected: "{\"error\":{\"code\":400000,\"message\":\"One of the request inputs is not valid.\"}}"
     // But for now just verify response is a valid json
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(response["error_body"].asString(), ec);
     if (ec.failed())
     {
@@ -686,7 +686,7 @@ bool LLAzureTranslationHandler::parseResponse(
     //Example:
     // "[{\"detectedLanguage\":{\"language\":\"en\",\"score\":1.0},\"translations\":[{\"text\":\"Hello, what is your name?\",\"to\":\"en\"}]}]"
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(body, ec);
     if (ec.failed())
     {
@@ -726,7 +726,7 @@ std::string LLAzureTranslationHandler::parseErrorResponse(
     // Expected: "{\"error\":{\"code\":400000,\"message\":\"One of the request inputs is not valid.\"}}"
     // But for now just verify response is a valid json with an error
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(body, ec);
     if (ec.failed())
     {
@@ -956,7 +956,7 @@ bool LLDeepLTranslationHandler::parseResponse(
     //Example:
     // "{\"translations\":[{\"detected_source_language\":\"EN\",\"text\":\"test\"}]}"
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(body, ec);
     if (ec.failed())
     {
@@ -1004,7 +1004,7 @@ std::string LLDeepLTranslationHandler::parseErrorResponse(
     const std::string& body)
 {
     // Example: "{\"message\":\"One of the request inputs is not valid.\"}"
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value root = boost::json::parse(body, ec);
     if (ec.failed())
     {

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2789,7 +2789,7 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
         return;
     }
 
-    boost::json::error_code ec;
+    boost::system::error_code ec;
     boost::json::value voice_data_parsed = boost::json::parse(data, ec);
     if (!ec)  // don't collect comments
     {

--- a/indra/test/CMakeLists.txt
+++ b/indra/test/CMakeLists.txt
@@ -71,6 +71,7 @@ if (WINDOWS)
           PROPERTIES 
           LINK_FLAGS "/NODEFAULTLIB:LIBCMT"
           LINK_FLAGS_DEBUG "/NODEFAULTLIB:\"LIBCMT;LIBCMTD;MSVCRT\""
+          RUNTIME_OUTPUT_DIRECTORY "${EXE_STAGING_DIR}"
           )
 elseif (DARWIN)
   # Support our "@executable_path/../Resources" load path for our test


### PR DESCRIPTION
This updates to Boost 1.85 and fixes related deprecation warnings.

This also reverts part of https://github.com/secondlife/viewer/commit/eaa04bddeb6ca3b0db14854c216c6c4ffe0319f4 and outputs the lltest binary to the sharedlibs staging dirs to use the correct MSVC redist to fix tests with new boost.

This will need verifying with a GHA build run with tests to ensure tests work correctly in that environment as I can only use free runners currently.