### PR TITLE
Fix PR builds from forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,14 +7,14 @@ on:
     tags: ["Second_Life*"]
 
 jobs:
-  # The whole point of the setvar job is that we want to set a variable once
-  # that will be consumed by multiple subsequent jobs. We tried setting it in
-  # the global env, but a job.env can't directly reference the global env
-  # context.
-  setvar:
+  # The whole point of the setup job is that we want to set variables once
+  # that will be consumed by multiple subsequent jobs.
+  setup:
     runs-on: ubuntu-latest
     outputs:
       release_run: ${{ steps.setvar.outputs.release_run }}
+      configurations: ${{ steps.setvar.outputs.configurations }}
+      bugsplat_db: ${{ steps.setvar.outputs.bugsplat_db }}
     env:
       # Build with a tag like "Second_Life#abcdef0" to generate a release page
       # (used for builds we are planning to deploy).
@@ -23,32 +23,34 @@ jobs:
       # its value when false is "false", which is interpreted as true.
       RELEASE_RUN: ${{ (github.event.inputs.release_run || github.ref_type == 'tag' && startsWith(github.ref_name, 'Second_Life')) && 'Y' || '' }}
     steps:
-      - name: Set Variable
+      - name: Set Variables
         id: setvar
         shell: bash
         run: |
           echo "release_run=$RELEASE_RUN" >> "$GITHUB_OUTPUT"
 
+          if [[ "$FROM_FORK" == "true" ]]; then
+            # PR from fork; don't build with Bugsplat, proprietary libs
+            echo 'configurations=["ReleaseOS"]' >> $GITHUB_OUTPUT
+            echo "bugsplat_db=" >> $GITHUB_OUTPUT
+          else
+            echo 'configurations=["Release"]' >> $GITHUB_OUTPUT
+            echo "bugsplat_db=SecondLife_Viewer_2018" >> $GITHUB_OUTPUT
+          fi
   build:
-    needs: setvar
+    needs: setup
     strategy:
       matrix:
         runner: [windows-large, macos-12-xl]
-        configuration: [Release]
-        Linden: [true]
-        include:
-          - runner: macos-12-xl
-            developer_dir: "/Applications/Xcode_14.0.1.app/Contents/Developer"
-          - runner: windows-large
-            configuration: ReleaseOS
-            Linden: false
+        configuration: ${{ fromJSON(needs.setup.outputs.configurations) }}
     runs-on: ${{ matrix.runner }}
     outputs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
       viewer_branch:  ${{ steps.which-branch.outputs.branch }}
       relnotes:       ${{ steps.which-branch.outputs.relnotes }}
-      imagename: ${{ steps.build.outputs.imagename }}
+      imagename:      ${{ steps.build.outputs.imagename }}
+      configuration:  ${{ matrix.configuration }}
     env:
       AUTOBUILD_ADDRSIZE: 64
       AUTOBUILD_BUILD_ID: ${{ github.run_id }}
@@ -61,12 +63,12 @@ jobs:
       # autobuild-package.xml.
       AUTOBUILD_VCS_INFO: "true"
       AUTOBUILD_VSVER: "170"
-      DEVELOPER_DIR: ${{ matrix.developer_dir }}
+      DEVELOPER_DIR: "/Applications/Xcode_14.0.1.app/Contents/Developer"
       # Ensure that Linden viewer builds engage Bugsplat.
-      BUGSPLAT_DB: ${{ matrix.Linden && 'SecondLife_Viewer_2018' || '' }}
+      BUGSPLAT_DB: ${{ needs.setup.outputs.bugsplat_db }}
       # Run BUILD steps for Release configuration.
       # Run BUILD steps for ReleaseOS configuration only for release runs.
-      BUILD: ${{ (matrix.Linden || needs.setvar.outputs.release_run) && 'Y' || '' }}
+      BUILD: ${{ needs.setup.outputs.build }}
       build_coverity: false
       build_log_dir: ${{ github.workspace }}/.logs
       build_viewer: true
@@ -85,19 +87,16 @@ jobs:
       variants: ${{ matrix.configuration }}
     steps:
       - name: Checkout code
-        if: env.BUILD
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup python
-        if: env.BUILD
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Checkout build variables
-        if: env.BUILD
         uses: actions/checkout@v4
         with:
           repository: secondlife/build-variables
@@ -105,19 +104,16 @@ jobs:
           path: .build-variables
 
       - name: Checkout master-message-template
-        if: env.BUILD
         uses: actions/checkout@v4
         with:
           repository: secondlife/master-message-template
           path: .master-message-template
 
       - name: Install autobuild and python dependencies
-        if: env.BUILD
         run: pip3 install autobuild llsd
 
       - name: Cache autobuild packages
         id: cache-installables
-        if: env.BUILD
         uses: actions/cache@v4
         with:
           path: .autobuild-installables
@@ -127,19 +123,17 @@ jobs:
             ${{ runner.os }}-64-
 
       - name: Install windows dependencies
-        if: env.BUILD && runner.os == 'Windows'
+        if: runner.os == 'Windows'
         run: choco install nsis-unicode
 
       - name: Determine source branch
         id: which-branch
-        if: env.BUILD
         uses: secondlife/viewer-build-util/which-branch@v2
         with:
           token: ${{ github.token }}
 
       - name: Build
         id: build
-        if: env.BUILD
         shell: bash
         env:
           AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch }}
@@ -265,7 +259,7 @@ jobs:
           echo "artifact=$RUNNER_OS$cfg_suffix" >> $GITHUB_OUTPUT
 
       - name: Upload executable
-        if: matrix.Linden && steps.build.outputs.viewer_app
+        if: matrix.configuration == 'Release' && steps.build.outputs.viewer_app
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.build.outputs.artifact }}-app"
@@ -275,15 +269,13 @@ jobs:
       # The other upload of nontrivial size is the symbol file. Use a distinct
       # artifact for that too.
       - name: Upload symbol file
-        if: matrix.Linden
         uses: actions/upload-artifact@v4
+        if: matrix.configuration == 'Release'
         with:
           name: "${{ steps.build.outputs.artifact }}-symbols"
-          path: |
-            ${{ steps.build.outputs.symbolfile }}
+          path: ${{ steps.build.outputs.symbolfile }}
 
       - name: Upload metadata
-        if: matrix.Linden
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.build.outputs.artifact }}-metadata"
@@ -294,7 +286,7 @@ jobs:
       - name: Upload physics package
         uses: actions/upload-artifact@v4
         # should only be set for viewer-private
-        if: matrix.Linden && steps.build.outputs.physicstpv
+        if: matrix.configuration == 'Release' && steps.build.outputs.physicstpv
         with:
           name: "${{ steps.build.outputs.artifact }}-physics"
           # emitted by build.sh, zero or one lines
@@ -385,6 +377,7 @@ jobs:
       BUGSPLAT_USER: ${{ secrets.BUGSPLAT_USER }}
       BUGSPLAT_PASS: ${{ secrets.BUGSPLAT_PASS }}
     needs: build
+    if: needs.build.outputs.configuration == 'Release'
     runs-on: ubuntu-latest
     steps:
       - name: Post Mac symbols
@@ -398,9 +391,9 @@ jobs:
           version: ${{ needs.build.outputs.viewer_version }} (${{ needs.build.outputs.viewer_version }})
 
   release:
-    needs: [setvar, build, sign-and-package-windows, sign-and-package-mac]
+    needs: [setup, build, sign-and-package-windows, sign-and-package-mac]
     runs-on: ubuntu-latest
-    if: needs.setvar.outputs.release_run
+    if: needs.setup.outputs.release_run
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Build ReleaseOS when a PR is from a fork rather than Release. This fixes OSS PR builds which, until now, have been failing because they cannot access secrets. Having working builds before merging a PR seems somewhat important.