### PR TITLE
build.yaml: Fix FROM_FORK value, ReleaseOS PR builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
       # important to ensure it's the empty string when false. If you omit || '',
       # its value when false is "false", which is interpreted as true.
       RELEASE_RUN: ${{ (github.event.inputs.release_run || github.ref_type == 'tag' && startsWith(github.ref_name, 'Second_Life')) && 'Y' || '' }}
+      FROM_FORK: ${{ github.event.pull_request.head.repo.organization != 'secondlife' }}
     steps:
       - name: Set Variables
         id: setvar

--- a/build.sh
+++ b/build.sh
@@ -156,8 +156,6 @@ pre_build()
 
         if [[ "$arch" == "Darwin" ]]
         then
-            RELEASE_CRASH_REPORTING=ON
-            HAVOK=ON
             SIGNING=("-DENABLE_SIGNING:BOOL=YES" \
                           "-DSIGNING_IDENTITY:STRING=Developer ID Application: Linden Research, Inc.")
         fi

--- a/build.sh
+++ b/build.sh
@@ -149,8 +149,10 @@ pre_build()
     RELEASE_CRASH_REPORTING=OFF
     HAVOK=OFF
     SIGNING=()
-    if [[ "$variant" == "Release" ]]
+    if [[ "$variant" != *OS ]]
     then
+        # Proprietary builds
+
         RELEASE_CRASH_REPORTING=ON
         HAVOK=ON
 

--- a/build.sh
+++ b/build.sh
@@ -146,12 +146,21 @@ pre_build()
     && [ -r "$master_message_template_checkout/message_template.msg" ] \
     && template_verifier_master_url="-DTEMPLATE_VERIFIER_MASTER_URL=file://$master_message_template_checkout/message_template.msg"
 
-    RELEASE_CRASH_REPORTING=ON
-    HAVOK=ON
+    RELEASE_CRASH_REPORTING=OFF
+    HAVOK=OFF
     SIGNING=()
-    if [[ "$arch" == "Darwin" && "$variant" == "Release" ]]
-    then SIGNING=("-DENABLE_SIGNING:BOOL=YES" \
-                  "-DSIGNING_IDENTITY:STRING=Developer ID Application: Linden Research, Inc.")
+    if [[ "$variant" == "Release" ]]
+    then
+        RELEASE_CRASH_REPORTING=ON
+        HAVOK=ON
+
+        if [[ "$arch" == "Darwin" ]]
+        then
+            RELEASE_CRASH_REPORTING=ON
+            HAVOK=ON
+            SIGNING=("-DENABLE_SIGNING:BOOL=YES" \
+                          "-DSIGNING_IDENTITY:STRING=Developer ID Application: Linden Research, Inc.")
+        fi
     fi
 
     if [ "${RELEASE_CRASH_REPORTING:-}" != "OFF" ]


### PR DESCRIPTION
Fix up builds from PRs by adding the missing `FROM_FORK` environment variable which must have gone missing during a rebase.