### PR TITLE
1836 dont store texture in system memory unless absolutely necessary (#1843) local crash fix

### DIFF
--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -76,10 +76,18 @@ void LLImageGLMemory::alloc_tex_image(U32 width, U32 height, U32 pixformat)
     llassert(size >= 0);
 
     sTexMemMutex.lock();
-    llassert(sTextureAllocs.find(texName) == sTextureAllocs.end());
 
-    sTextureAllocs[texName] = size;
-    sTextureBytes += size;
+    auto iter = sTextureAllocs.find(texName);
+    if (iter == sTextureAllocs.end())
+    {
+        sTextureBytes += size;
+        sTextureAllocs.emplace(texName, size);
+    }
+    else
+    {
+        sTextureBytes += size - iter->second;
+        iter->second = size;
+    }
 
     sTexMemMutex.unlock();
 }


### PR DESCRIPTION
This llassert can raise a crash (in dev build) when rotating the world moving camera far from the target

In fact the map `sTextureAllocs` is never used - so any algorithm replacing llassert will fix the crash well