### PR TITLE
viewer#2157 Toolbar's drop position indicator does not appear

### DIFF
--- a/indra/llui/lltoolbar.cpp
+++ b/indra/llui/lltoolbar.cpp
@@ -1073,7 +1073,7 @@ bool LLToolBar::handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,
             int orig_rank = getRankFromPosition(dragged_command);
             mDragRank = getRankFromPosition(x, y);
             // Don't DaD if we're dragging a command on itself
-            mDragAndDropTarget = ((orig_rank != RANK_NONE) && ((mDragRank == orig_rank) || ((mDragRank - 1) == orig_rank)));
+            mDragAndDropTarget = (orig_rank == RANK_NONE) || ((mDragRank != orig_rank) && ((mDragRank - 1) != orig_rank));
             //LL_INFOS() << "Merov debug : DaD, rank = " << mDragRank << ", dragged uui = " << inv_item->getUUID() << LL_ENDL;
             /* Do the following if you want to animate the button itself
             LLCommandId dragged_command(inv_item->getUUID());


### PR DESCRIPTION
Regression from maint-a's changes. Originaly it was '? FALSE : TRUE', so I flipped the logic.

Basically logic is supposed to dibale indication right after current spot (mDragRank) and before current spot (mDragRank-1).