### PR TITLE
[WebRTC] Implement a Logging Sink for WebRTC

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2909,11 +2909,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>f7017b791a42948c60e910482d7a8eec4df24418</string>
+              <string>baabb11f324be350253b1fb58cf262c1aa19fa70</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.66-debug/webrtc-m114.5735.08.66-debug.10166105889-darwin64-10166105889.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-darwin64-10190042668.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2923,11 +2923,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>8d379a82dcbf26b6a5ba1530afb8073451e27fba</string>
+              <string>a13776c8f99f8975665be66ff8b51a80ba46c718</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.66-debug/webrtc-m114.5735.08.66-debug.10166105889-linux64-10166105889.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-linux64-10190042668.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2937,11 +2937,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>9dd77b7f0b89b0fc0b0ad9f9e7df81e9ff5590e4</string>
+              <string>965ef5d65a14191a52ee9ec6a9a8a1d2ce3f2ffb</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.66-debug/webrtc-m114.5735.08.66-debug.10166105889-windows64-10166105889.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-windows64-10190042668.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2954,7 +2954,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.66-debug.10166105889</string>
+        <string>m114.5735.08.67-debug.10190042668</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -154,7 +154,8 @@ void LLCustomProcessor::Process(webrtc::AudioBuffer *audio_in)
 // LLWebRTCImpl implementation
 //
 
-LLWebRTCImpl::LLWebRTCImpl() :
+LLWebRTCImpl::LLWebRTCImpl(LLWebRTCLogCallback* logCallback) :
+    mLogSink(new LLWebRTCLogSink(logCallback)),
     mPeerCustomProcessor(nullptr),
     mMute(true),
     mTuningMode(false),
@@ -173,6 +174,7 @@ void LLWebRTCImpl::init()
     // Normal logging is rather spammy, so turn it off.
     rtc::LogMessage::LogToDebug(rtc::LS_NONE);
     rtc::LogMessage::SetLogToStderr(true);
+    rtc::LogMessage::AddLogToStream(mLogSink, rtc::LS_VERBOSE);
 
     mTaskQueueFactory = webrtc::CreateDefaultTaskQueueFactory();
 
@@ -312,6 +314,7 @@ void LLWebRTCImpl::terminate()
             mPeerDeviceModule   = nullptr;
             mTaskQueueFactory   = nullptr;
         });
+    rtc::LogMessage::RemoveLogToStream(mLogSink);
 }
 
 //
@@ -1327,9 +1330,9 @@ void freePeerConnection(LLWebRTCPeerConnectionInterface* peer_connection)
 }
 
 
-void init()
+void init(LLWebRTCLogCallback* logCallback)
 {
-    gWebRTCImpl = new LLWebRTCImpl();
+    gWebRTCImpl = new LLWebRTCImpl(logCallback);
     gWebRTCImpl->init();
 }
 

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -56,6 +56,20 @@
 namespace llwebrtc
 {
 
+class LLWebRTCLogCallback
+{
+public:
+    typedef enum {
+        LOG_LEVEL_VERBOSE = 0,
+        LOG_LEVEL_INFO,
+        LOG_LEVEL_WARNING,
+        LOG_LEVEL_ERROR
+    } LogLevel;
+
+    virtual void LogMessage(LogLevel level, const std::string& message) = 0;
+};
+
+
 // LLWebRTCVoiceDevice is a simple representation of the
 // components of a device, used to communicate this
 // information to the viewer.
@@ -262,7 +276,7 @@ class LLWebRTCPeerConnectionInterface
 // exports.
 
 // This library must be initialized before use.
-LLSYMEXPORT void init();
+LLSYMEXPORT void init(LLWebRTCLogCallback* logSink);
 
 // And should be terminated as part of shutdown.
 LLSYMEXPORT void terminate();

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -69,6 +69,54 @@ namespace llwebrtc
 
 class LLWebRTCPeerConnectionImpl;
 
+class LLWebRTCLogSink : public rtc::LogSink {
+public:
+    LLWebRTCLogSink(LLWebRTCLogCallback* callback) :
+    mCallback(callback)
+    {
+    }
+
+    // Destructor: close the log file
+    ~LLWebRTCLogSink() override
+    {
+    }
+
+    void OnLogMessage(const std::string& msg,
+                      rtc::LoggingSeverity severity) override
+    {
+        if (mCallback)
+        {
+            switch(severity)
+            {
+                case rtc::LS_VERBOSE:
+                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    break;
+                case rtc::LS_INFO:
+                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    break;
+                case rtc::LS_WARNING:
+                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    break;
+                case rtc::LS_ERROR:
+                    mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    void OnLogMessage(const std::string& message) override
+    {
+        if (mCallback)
+        {
+            mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, message);
+        }
+    }
+
+private:
+    LLWebRTCLogCallback* mCallback;
+};
 
 // Implements a class allowing capture of audio data
 // to determine audio level of the microphone.
@@ -139,8 +187,11 @@ class LLCustomProcessor : public webrtc::CustomProcessing
 class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceSink
 {
   public:
-    LLWebRTCImpl();
-    ~LLWebRTCImpl() {}
+    LLWebRTCImpl(LLWebRTCLogCallback* logCallback);
+    ~LLWebRTCImpl()
+    {
+        delete mLogSink;
+    }
 
     void init();
     void terminate();
@@ -228,6 +279,8 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     void setRecording(bool recording);
 
   protected:
+    LLWebRTCLogSink*                                           mLogSink;
+
     // The native webrtc threads
     std::unique_ptr<rtc::Thread>                               mNetworkThread;
     std::unique_ptr<rtc::Thread>                               mWorkerThread;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -250,7 +250,7 @@ LLWebRTCVoiceClient::~LLWebRTCVoiceClient()
 void LLWebRTCVoiceClient::init(LLPumpIO* pump)
 {
     // constructor will set up LLVoiceClient::getInstance()
-    llwebrtc::init();
+    llwebrtc::init(this);
 
     mWebRTCDeviceInterface = llwebrtc::getDeviceInterface();
     mWebRTCDeviceInterface->setDevicesObserver(this);
@@ -279,6 +279,29 @@ void LLWebRTCVoiceClient::cleanUp()
     mNeighboringRegions.clear();
     sessionState::for_each(boost::bind(predShutdownSession, _1));
     LL_DEBUGS("Voice") << "Exiting" << LL_ENDL;
+}
+
+void LLWebRTCVoiceClient::LogMessage(llwebrtc::LLWebRTCLogCallback::LogLevel level, const std::string& message)
+{
+    switch (level)
+    {
+    case llwebrtc::LLWebRTCLogCallback::LOG_LEVEL_VERBOSE:
+        LL_DEBUGS("Voice") << message << LL_ENDL;
+        break;
+    case llwebrtc::LLWebRTCLogCallback::LOG_LEVEL_INFO:
+        LL_INFOS("Voice") << message << LL_ENDL;
+        break;
+    case llwebrtc::LLWebRTCLogCallback::LOG_LEVEL_WARNING:
+        LL_WARNS("Voice") << message << LL_ENDL;
+        break;
+    case llwebrtc::LLWebRTCLogCallback::LOG_LEVEL_ERROR:
+        // use WARN so that we don't crash on a webrtc error.
+        // webrtc will force a crash on a fatal error.
+        LL_WARNS("Voice") << message << LL_ENDL;
+        break;
+    default:
+        break;
+    }
 }
 
 // --------------------------------------------------

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -62,7 +62,8 @@ extern const std::string WEBRTC_VOICE_SERVER_TYPE;
 class LLWebRTCVoiceClient : public LLSingleton<LLWebRTCVoiceClient>,
                             virtual public LLVoiceModuleInterface,
                             public llwebrtc::LLWebRTCDevicesObserver,
-                            public LLMuteListObserver
+                            public LLMuteListObserver,
+                            public llwebrtc::LLWebRTCLogCallback
 {
     LLSINGLETON_C11(LLWebRTCVoiceClient);
     LOG_CLASS(LLWebRTCVoiceClient);
@@ -87,6 +88,12 @@ public:
     std::string sipURIFromID(const LLUUID &id) const override;
     LLSD getP2PChannelInfoTemplate(const LLUUID& id) const override;
 
+
+    ///////////////////
+    /// @name Logging
+    /// @{
+    void LogMessage(llwebrtc::LLWebRTCLogCallback::LogLevel level, const std::string& message) override;
+    //@}
 
     /////////////////////
     /// @name Tuning


### PR DESCRIPTION
WebRTC logs now pass out of the webrtc library into a logging sink, which converts them into SecondLife.log compatable logging calls.

This includes fatal errors and asserts, which are now logged into SecondLife.log, and should be available in the crash logger.