### PR TITLE
viewer#2163 Crash at getReflectionProbeIsDynamic

### DIFF
--- a/indra/newview/llreflectionmap.cpp
+++ b/indra/newview/llreflectionmap.cpp
@@ -220,7 +220,7 @@ F32 LLReflectionMap::getNearClip()
 
     if (mViewerObject && mViewerObject->getVolume())
     {
-        ret = ((LLVOVolume*)mViewerObject)->getReflectionProbeNearClip();
+        ret = mViewerObject->getReflectionProbeNearClip();
     }
     else if (mGroup)
     {
@@ -240,7 +240,7 @@ bool LLReflectionMap::getIsDynamic()
         mViewerObject &&
         mViewerObject->getVolume())
     {
-        return ((LLVOVolume*)mViewerObject)->getReflectionProbeIsDynamic();
+        return mViewerObject->getReflectionProbeIsDynamic();
     }
 
     return false;

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -266,7 +266,11 @@ public:
     virtual bool isRiggedMesh() const               { return false; }
     virtual bool hasLightTexture() const            { return false; }
     virtual bool isReflectionProbe() const          { return false; }
+    virtual F32 getReflectionProbeAmbiance() const  { return 0.f; }
+    virtual F32 getReflectionProbeNearClip() const  { return 0.f; }
     virtual bool getReflectionProbeIsBox() const    { return false; }
+    virtual bool getReflectionProbeIsDynamic() const { return false; };
+    virtual bool getReflectionProbeIsMirror() const { return false; };
 
     // This method returns true if the object is over land owned by
     // the agent, one of its groups, or it encroaches and

--- a/indra/newview/llvovolume.h
+++ b/indra/newview/llvovolume.h
@@ -304,11 +304,11 @@ public:
     bool setReflectionProbeIsMirror(bool is_mirror);
 
     bool isReflectionProbe() const override;
-    F32 getReflectionProbeAmbiance() const;
-    F32 getReflectionProbeNearClip() const;
+    F32 getReflectionProbeAmbiance() const override;
+    F32 getReflectionProbeNearClip() const override;
     bool getReflectionProbeIsBox() const override;
-    bool getReflectionProbeIsDynamic() const;
-    bool getReflectionProbeIsMirror() const;
+    bool getReflectionProbeIsDynamic() const override;
+    bool getReflectionProbeIsMirror() const override;
 
     // Flexible Objects
     U32 getVolumeInterfaceID() const;


### PR DESCRIPTION
Looks like some object that isn't a llvovolume gets checked as a mirror probe.