### PR TITLE
Remove unused pcre library dependency

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2200,64 +2200,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>description</key>
         <string>Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) Library</string>
       </map>
-      <key>pcre</key>
-      <map>
-        <key>platforms</key>
-        <map>
-          <key>darwin64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>b372d37596474043a62568e569b0ce155192f484</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-pcre/releases/download/v8.35.979fd86/pcre-8.35.979fd86-darwin64-979fd86.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>darwin64</string>
-          </map>
-          <key>linux64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>0f058ca2176e7d02d51e54c66a96f336</string>
-              <key>url</key>
-              <string>http://automated-builds-secondlife-com.s3.amazonaws.com/ct2/908/2010/pcre-8.35.500898-linux64-500898.tar.bz2</string>
-            </map>
-            <key>name</key>
-            <string>linux64</string>
-          </map>
-          <key>windows64</key>
-          <map>
-            <key>archive</key>
-            <map>
-              <key>hash</key>
-              <string>166564afb60a7536a038fae80e2fc9a41d6dbccb</string>
-              <key>hash_algorithm</key>
-              <string>sha1</string>
-              <key>url</key>
-              <string>https://github.com/secondlife/3p-pcre/releases/download/v8.35.979fd86/pcre-8.35.979fd86-windows64-979fd86.tar.zst</string>
-            </map>
-            <key>name</key>
-            <string>windows64</string>
-          </map>
-        </map>
-        <key>license</key>
-        <string>bsd</string>
-        <key>license_file</key>
-        <string>LICENSES/pcre-license.txt</string>
-        <key>copyright</key>
-        <string>Copyright (c) 1997-2014 University of Cambridge; Copyright(c) 2009-2014 Zoltan Herczeg; Copyright (c) 2007-2012, Google Inc.</string>
-        <key>version</key>
-        <string>8.35.979fd86</string>
-        <key>name</key>
-        <string>pcre</string>
-        <key>description</key>
-        <string>PCRE Perl-compatible regular expression library</string>
-      </map>
       <key>slvoice</key>
       <map>
         <key>platforms</key>

--- a/indra/cmake/LLPrimitive.cmake
+++ b/indra/cmake/LLPrimitive.cmake
@@ -6,7 +6,6 @@ include(Boost)
 
 include_guard()
 
-add_library( ll::pcre INTERFACE IMPORTED )
 add_library( ll::minizip-ng INTERFACE IMPORTED )
 add_library( ll::libxml INTERFACE IMPORTED )
 add_library( ll::colladadom INTERFACE IMPORTED )
@@ -22,10 +21,7 @@ use_system_binary( colladadom )
 
 use_prebuilt_binary(colladadom)
 use_prebuilt_binary(minizip-ng) # needed for colladadom
-use_prebuilt_binary(pcre)
 use_prebuilt_binary(libxml2)
-
-target_link_libraries( ll::pcre INTERFACE pcrecpp pcre )
 
 if (WINDOWS)
     target_link_libraries( ll::minizip-ng INTERFACE libminizip )

--- a/indra/llprimitive/CMakeLists.txt
+++ b/indra/llprimitive/CMakeLists.txt
@@ -70,7 +70,6 @@ target_link_libraries(llprimitive
         llrender
         llphysicsextensions_impl
         ll::colladadom
-        ll::pcre
         ll::glh_linear
         )
 


### PR DESCRIPTION
Remove unused PCRE library dependency it was dropped with https://github.com/secondlife/3p-colladadom/pull/7