### PR TITLE
Disable EmojiHelper if Digit before Colon

### DIFF
--- a/indra/llui/llemojihelper.cpp
+++ b/indra/llui/llemojihelper.cpp
@@ -78,7 +78,7 @@ bool LLEmojiHelper::isCursorInEmojiCode(const LLWString& wtext, S32 cursorPos, S
 
     bool isShortCode = (cursorPos - shortCodePos >= 2) && (L':' == wtext[shortCodePos - 1]);
     if(isShortCode && (shortCodePos >= 2) && isdigit(wtext[shortCodePos - 2])) // <TS:3T> Add qualifier to avoid emoji pop-up when typing times.
-        isShortCode = false; 
+        isShortCode = false;
     if (pShortCodePos)
         *pShortCodePos = (isShortCode) ? shortCodePos - 1 : -1;
     return isShortCode;

--- a/indra/llui/llemojihelper.cpp
+++ b/indra/llui/llemojihelper.cpp
@@ -76,7 +76,9 @@ bool LLEmojiHelper::isCursorInEmojiCode(const LLWString& wtext, S32 cursorPos, S
         shortCodePos--;
     }
 
-    bool isShortCode = (L':' == wtext[shortCodePos - 1]) && (cursorPos - shortCodePos >= 2);
+    bool isShortCode = (cursorPos - shortCodePos >= 2) && (L':' == wtext[shortCodePos - 1]);
+    if(isShortCode && (shortCodePos >= 2) && isdigit(wtext[shortCodePos - 2])) // <TS:3T> Add qualifier to avoid emoji pop-up when typing times.
+        isShortCode = false; 
     if (pShortCodePos)
         *pShortCodePos = (isShortCode) ? shortCodePos - 1 : -1;
     return isShortCode;


### PR DESCRIPTION
Typing in times with the new emoji helper pop-up can be frustrating, so I would like to propose disabling it when there is a number before the colon.