### PR TITLE
Fix integer underflow causing issues with wearables

### DIFF
--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -2133,11 +2133,11 @@ void LLAppearanceMgr::filterWearableItems(
         items.clear();
         for (S32 i=0; i<LLWearableType::WT_COUNT; i++)
         {
-            auto size = items_by_type[i].size();
+            S32 size = (S32)items_by_type[i].size();
             if (size <= 0)
                 continue;
-            auto start_index = llmax(0,size-max_per_type);
-            for (size_t j = start_index; j<size; j++)
+            S32 start_index = llmax(0,size-max_per_type);
+            for (S32 j = start_index; j<size; j++)
             {
                 items.push_back(items_by_type[i][j]);
             }


### PR DESCRIPTION
@marchcat Can fixes still be merged into Atlasaurus?

The statement `size-max_per_type` in line 2139 could cause an integer underflow and result in incorrect wearables getting filtered out (usually all clothing layers). This will cause issues with every feature using LLAgentWearables::getWearableFromItemID(), e.g. LLAgentWearables::isWearingItem()