### PR TITLE
Introduce LLUIColorTable debug-settings-alike floater and fix various color system bugs

### DIFF
--- a/indra/llui/llbutton.cpp
+++ b/indra/llui/llbutton.cpp
@@ -1127,12 +1127,12 @@ void LLButton::setImageSelected(LLPointer<LLUIImage> image)
     mImageSelected = image;
 }
 
-void LLButton::setImageColor(const LLColor4& c)
+void LLButton::setImageColor(const LLUIColor& c)
 {
     mImageColor = c;
 }
 
-void LLButton::setColor(const LLColor4& color)
+void LLButton::setColor(const LLUIColor& color)
 {
     setImageColor(color);
 }

--- a/indra/llui/llbutton.h
+++ b/indra/llui/llbutton.h
@@ -172,8 +172,8 @@ public:
 
     virtual void    onCommit();
 
-    void            setUnselectedLabelColor( const LLColor4& c )        { mUnselectedLabelColor = c; }
-    void            setSelectedLabelColor( const LLColor4& c )          { mSelectedLabelColor = c; }
+    void            setUnselectedLabelColor( const LLUIColor& c )        { mUnselectedLabelColor = c; }
+    void            setSelectedLabelColor( const LLUIColor& c )          { mSelectedLabelColor = c; }
     void            setUseEllipses( bool use_ellipses )                 { mUseEllipses = use_ellipses; }
     void            setUseFontColor( bool use_font_color)               { mUseFontColor = use_font_color; }
 
@@ -224,14 +224,14 @@ public:
     const std::string   getLabelSelected() const { return wstring_to_utf8str(mSelectedLabel); }
 
     void            setImageColor(const std::string& color_control);
-    void            setImageColor(const LLColor4& c);
-    /*virtual*/ void    setColor(const LLColor4& c);
+    void            setImageColor(const LLUIColor& c);
+    /*virtual*/ void    setColor(const LLUIColor& c);
 
     void            setImages(const std::string &image_name, const std::string &selected_name);
 
-    void            setDisabledImageColor(const LLColor4& c)        { mDisabledImageColor = c; }
+    void            setDisabledImageColor(const LLUIColor& c)        { mDisabledImageColor = c; }
 
-    void            setDisabledSelectedLabelColor( const LLColor4& c )  { mDisabledSelectedLabelColor = c; }
+    void            setDisabledSelectedLabelColor( const LLUIColor& c )  { mDisabledSelectedLabelColor = c; }
 
     void            setImageOverlay(const std::string& image_name, LLFontGL::HAlign alignment = LLFontGL::HCENTER, const LLColor4& color = LLColor4::white);
     void            setImageOverlay(const LLUUID& image_id, LLFontGL::HAlign alignment = LLFontGL::HCENTER, const LLColor4& color = LLColor4::white);
@@ -246,7 +246,7 @@ public:
     virtual bool    setLabelArg( const std::string& key, const LLStringExplicit& text );
     void            setLabelUnselected(const LLStringExplicit& label);
     void            setLabelSelected(const LLStringExplicit& label);
-    void            setDisabledLabelColor( const LLColor4& c )      { mDisabledLabelColor = c; }
+    void            setDisabledLabelColor( const LLUIColor& c )      { mDisabledLabelColor = c; }
 
     void            setFont(const LLFontGL *font)
         { mGLFont = ( font ? font : LLFontGL::getFontSansSerif()); }

--- a/indra/llui/llcheckboxctrl.cpp
+++ b/indra/llui/llcheckboxctrl.cpp
@@ -172,11 +172,11 @@ void LLCheckBoxCtrl::setEnabled(bool b)
 
     if (b)
     {
-        mLabel->setColor( mTextEnabledColor.get() );
+        mLabel->setColor( mTextEnabledColor );
     }
     else
     {
-        mLabel->setColor( mTextDisabledColor.get() );
+        mLabel->setColor( mTextDisabledColor );
     }
 }
 

--- a/indra/llui/llcheckboxctrl.h
+++ b/indra/llui/llcheckboxctrl.h
@@ -110,8 +110,8 @@ public:
 
     void                setBtnFocus() { mButton->setFocus(true); }
 
-    void                setEnabledColor( const LLColor4 &color ) { mTextEnabledColor = color; }
-    void                setDisabledColor( const LLColor4 &color ) { mTextDisabledColor = color; }
+    void                setEnabledColor( const LLUIColor&color ) { mTextEnabledColor = color; }
+    void                setDisabledColor( const LLUIColor&color ) { mTextDisabledColor = color; }
 
     void                setLabel( const LLStringExplicit& label );
     std::string         getLabel() const;

--- a/indra/llui/llconsole.cpp
+++ b/indra/llui/llconsole.cpp
@@ -183,7 +183,8 @@ void LLConsole::draw()
     static LLCachedControl<F32> console_bg_opacity(*LLUI::getInstance()->mSettingGroups["config"], "ConsoleBackgroundOpacity", 0.7f);
     F32 console_opacity = llclamp(console_bg_opacity(), 0.f, 1.f);
 
-    static LLColor4 color = LLUIColorTable::instance().getColor("ConsoleBackground");
+    static LLUIColor console_color = LLUIColorTable::instance().getColor("ConsoleBackground");
+    LLColor4 color = console_color;
     color.mV[VALPHA] *= console_opacity;
 
     F32 line_height = (F32)mFont->getLineHeight();

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -784,7 +784,7 @@ void LLFolderViewItem::drawHighlight(const bool showContent, const bool hasKeybo
     const S32 FOCUS_LEFT = 1;
 
     // Determine which background color to use for highlighting
-    LLUIColor bgColor = (isFlashing() ? flashColor : selectColor);
+    const LLUIColor& bgColor = (isFlashing() ? flashColor : selectColor);
 
     //--------------------------------------------------------------------------------//
     // Draw highlight for selected items
@@ -999,7 +999,7 @@ void LLFolderViewItem::draw()
     //
     if (!mLabelSuffix.empty())
     {
-        suffix_font->render( mLabelSuffix, 0, right_x, y, isFadeItem() ? color : (LLColor4)sSuffixColor,
+        suffix_font->render( mLabelSuffix, 0, right_x, y, isFadeItem() ? color : sSuffixColor.get(),
                           LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                           S32_MAX, S32_MAX, &right_x);
     }

--- a/indra/llui/lliconctrl.h
+++ b/indra/llui/lliconctrl.h
@@ -79,7 +79,7 @@ public:
 
     std::string getImageName() const;
 
-    void            setColor(const LLColor4& color) { mColor = color; }
+    void            setColor(const LLUIColor& color) { mColor = color; }
     void            setImage(LLPointer<LLUIImage> image) { mImagep = image; }
     const LLPointer<LLUIImage> getImage() { return mImagep; }
 

--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -296,7 +296,7 @@ void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
     }
 
     color_group = getColorGroup(group);
-    LL_DEBUGS("SyntaxLSL") << "Group: '" << group << "', using color: '" << color_group << "'" << LL_ENDL;
+    LL_DEBUGS("SyntaxLSL") << "Group: '" << group << "', using color: '" << color_group.get() << "'" << LL_ENDL;
 
     if (tokens.isMap())
     {
@@ -378,7 +378,7 @@ void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
     }
     else if (tokens.isArray())  // Currently nothing should need this, but it's here for completeness
     {
-        LL_INFOS("SyntaxLSL") << "Curious, shouldn't be an array here; adding all using color " << color << LL_ENDL;
+        LL_INFOS("SyntaxLSL") << "Curious, shouldn't be an array here; adding all using color " << color.get() << LL_ENDL;
         for (S32 count = 0; count < tokens.size(); ++count)
         {
             addToken(token_type, tokens[count], color, "");

--- a/indra/llui/llkeywords.cpp
+++ b/indra/llui/llkeywords.cpp
@@ -85,7 +85,7 @@ LLKeywords::~LLKeywords()
 // Add the token as described
 void LLKeywords::addToken(LLKeywordToken::ETokenType type,
                           const std::string& key_in,
-                          const LLColor4& color,
+                          const LLUIColor& color,
                           const std::string& tool_tip_in,
                           const std::string& delimiter_in)
 {
@@ -170,7 +170,7 @@ std::string LLKeywords::getAttribute(std::string_view key)
     return (it != mAttributes.end()) ? it->second : "";
 }
 
-LLColor4 LLKeywords::getColorGroup(std::string_view key_in)
+LLUIColor LLKeywords::getColorGroup(std::string_view key_in)
 {
     std::string color_group = "ScriptText";
     if (key_in == "functions")
@@ -263,10 +263,10 @@ void LLKeywords::processTokens()
 
 void LLKeywords::processTokensGroup(const LLSD& tokens, std::string_view group)
 {
-    LLColor4 color;
-    LLColor4 color_group;
-    LLColor4 color_deprecated = getColorGroup("deprecated");
-    LLColor4 color_god_mode = getColorGroup("god-mode");
+    LLUIColor color;
+    LLUIColor color_group;
+    LLUIColor color_deprecated = getColorGroup("deprecated");
+    LLUIColor color_god_mode = getColorGroup("god-mode");
 
     LLKeywordToken::ETokenType token_type = LLKeywordToken::TT_UNKNOWN;
     // If a new token type is added here, it must also be added to the 'addToken' method
@@ -725,7 +725,7 @@ void LLKeywords::insertSegments(const LLWString& wtext, std::vector<LLTextSegmen
     insertSegment( seg_list, text_segment, text_len, style, editor);
 }
 
-void LLKeywords::insertSegment(std::vector<LLTextSegmentPtr>& seg_list, LLTextSegmentPtr new_segment, S32 text_len, const LLColor4 &defaultColor, LLTextEditor& editor )
+void LLKeywords::insertSegment(std::vector<LLTextSegmentPtr>& seg_list, LLTextSegmentPtr new_segment, S32 text_len, const LLUIColor& defaultColor, LLTextEditor& editor )
 {
     LLTextSegmentPtr last = seg_list.back();
     S32 new_seg_end = new_segment->getEnd();

--- a/indra/llui/llkeywords.h
+++ b/indra/llui/llkeywords.h
@@ -72,7 +72,7 @@ public:
         TT_TYPE                             // WORD
     } ETokenType;
 
-    LLKeywordToken( ETokenType type, const LLColor4& color, const LLWString& token, const LLWString& tool_tip, const LLWString& delimiter  )
+    LLKeywordToken( ETokenType type, const LLUIColor& color, const LLWString& token, const LLWString& tool_tip, const LLWString& delimiter  )
         :
         mType( type ),
         mToken( token ),
@@ -87,7 +87,7 @@ public:
     bool                isHead(const llwchar* s) const;
     bool                isTail(const llwchar* s) const;
     const LLWString&    getToken() const        { return mToken; }
-    const LLColor4&     getColor() const        { return mColor; }
+    const LLUIColor&     getColor() const        { return mColor; }
     ETokenType          getType()  const        { return mType; }
     const LLWString&    getToolTip() const      { return mToolTip; }
     const LLWString&    getDelimiter() const    { return mDelimiter; }
@@ -99,7 +99,7 @@ public:
 private:
     ETokenType  mType;
     LLWString   mToken;
-    LLColor4    mColor;
+    LLUIColor    mColor;
     LLWString   mToolTip;
     LLWString   mDelimiter;
 };
@@ -111,7 +111,7 @@ public:
     ~LLKeywords();
 
     void        clearLoaded() { mLoaded = false; }
-    LLColor4    getColorGroup(std::string_view key_in);
+    LLUIColor    getColorGroup(std::string_view key_in);
     bool        isLoaded() const    { return mLoaded; }
 
     void        findSegments(std::vector<LLTextSegmentPtr> *seg_list,
@@ -124,7 +124,7 @@ public:
     // Add the token as described
     void addToken(LLKeywordToken::ETokenType type,
                     const std::string& key,
-                    const LLColor4& color,
+                    const LLUIColor& color,
                     const std::string& tool_tip = LLStringUtil::null,
                     const std::string& delimiter = LLStringUtil::null);
 
@@ -153,7 +153,7 @@ public:
         bool mOwner;
 
 
-        LLColor4            mColor;
+        LLUIColor            mColor;
     };
 
     typedef std::map<WStringMapIndex, LLKeywordToken*> word_token_map_t;
@@ -161,7 +161,7 @@ public:
     keyword_iterator_t begin() const { return mWordTokenMap.begin(); }
     keyword_iterator_t end() const { return mWordTokenMap.end(); }
 
-    typedef std::map<WStringMapIndex, LLColor4> group_color_map_t;
+    typedef std::map<WStringMapIndex, LLUIColor> group_color_map_t;
     typedef group_color_map_t::const_iterator color_iterator_t;
     group_color_map_t   mColorGroupMap;
 
@@ -174,7 +174,7 @@ protected:
     void        insertSegment(std::vector<LLTextSegmentPtr>& seg_list,
                               LLTextSegmentPtr new_segment,
                               S32 text_len,
-                              const LLColor4 &defaultColor,
+                              const LLUIColor &defaultColor,
                               class LLTextEditor& editor);
     void        insertSegments(const LLWString& wtext,
                                std::vector<LLTextSegmentPtr>& seg_list,

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -224,12 +224,12 @@ public:
     void            setRevertOnEsc( bool b )        { mRevertOnEsc = b; }
     void            setKeystrokeOnEsc(bool b)       { mKeystrokeOnEsc = b; }
 
-    void setCursorColor(const LLColor4& c)          { mCursorColor = c; }
+    void setCursorColor(const LLUIColor& c)          { mCursorColor = c; }
     const LLColor4& getCursorColor() const          { return mCursorColor.get(); }
 
-    void setFgColor( const LLColor4& c )            { mFgColor = c; }
-    void setReadOnlyFgColor( const LLColor4& c )    { mReadOnlyFgColor = c; }
-    void setTentativeFgColor(const LLColor4& c)     { mTentativeFgColor = c; }
+    void setFgColor( const LLUIColor& c )            { mFgColor = c; }
+    void setReadOnlyFgColor( const LLUIColor& c )    { mReadOnlyFgColor = c; }
+    void setTentativeFgColor(const LLUIColor& c)     { mTentativeFgColor = c; }
 
     const LLColor4& getFgColor() const          { return mFgColor.get(); }
     const LLColor4& getReadOnlyFgColor() const  { return mReadOnlyFgColor.get(); }

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -204,7 +204,7 @@ public:
     void            setText(const LLStringExplicit &new_text);
 
     const std::string& getText() const override { return mText.getString(); }
-    LLWString       getWText() const    { return mText.getWString(); }
+    const LLWString&   getWText() const    { return mText.getWString(); }
     LLWString getConvertedText() const; // trimmed text with paragraphs converted to newlines
 
     S32             getLength() const   { return mText.length(); }

--- a/indra/llui/llmultisliderctrl.cpp
+++ b/indra/llui/llmultisliderctrl.cpp
@@ -440,7 +440,7 @@ void LLMultiSliderCtrl::setEnabled(bool b)
 
     if( mLabelBox )
     {
-        mLabelBox->setColor( b ? mTextEnabledColor.get() : mTextDisabledColor.get() );
+        mLabelBox->setColor( b ? mTextEnabledColor : mTextDisabledColor );
     }
 
     mMultiSlider->setEnabled( b );
@@ -452,7 +452,7 @@ void LLMultiSliderCtrl::setEnabled(bool b)
 
     if( mTextBox )
     {
-        mTextBox->setColor( b ? mTextEnabledColor.get() : mTextDisabledColor.get() );
+        mTextBox->setColor( b ? mTextEnabledColor : mTextDisabledColor );
     }
 }
 

--- a/indra/llui/llmultisliderctrl.h
+++ b/indra/llui/llmultisliderctrl.h
@@ -130,8 +130,8 @@ public:
     bool            canAddSliders() { return mMultiSlider->canAddSliders(); }
 
     void            setLabel(const std::string& label)              { if (mLabelBox) mLabelBox->setText(label); }
-    void            setLabelColor(const LLColor4& c)            { mTextEnabledColor = c; }
-    void            setDisabledLabelColor(const LLColor4& c)    { mTextDisabledColor = c; }
+    void            setLabelColor(const LLUIColor& c)            { mTextEnabledColor = c; }
+    void            setDisabledLabelColor(const LLUIColor& c)    { mTextDisabledColor = c; }
 
     boost::signals2::connection setSliderMouseDownCallback( const commit_signal_t::slot_type& cb );
     boost::signals2::connection setSliderMouseUpCallback( const commit_signal_t::slot_type& cb );

--- a/indra/llui/llpanel.cpp
+++ b/indra/llui/llpanel.cpp
@@ -490,8 +490,8 @@ void LLPanel::initFromParams(const LLPanel::Params& p)
 
     setBackgroundVisible(p.background_visible);
     setBackgroundOpaque(p.background_opaque);
-    setBackgroundColor(p.bg_opaque_color().get());
-    setTransparentColor(p.bg_alpha_color().get());
+    setBackgroundColor(p.bg_opaque_color);
+    setTransparentColor(p.bg_alpha_color);
     mBgOpaqueImage = p.bg_opaque_image();
     mBgAlphaImage = p.bg_alpha_image();
     mBgOpaqueImageOverlay = p.bg_opaque_image_overlay;
@@ -693,7 +693,7 @@ void LLPanel::childSetCommitCallback(std::string_view id, boost::function<void (
     }
 }
 
-void LLPanel::childSetColor(std::string_view id, const LLColor4& color)
+void LLPanel::childSetColor(std::string_view id, const LLUIColor& color)
 {
     LLUICtrl* child = findChild<LLUICtrl>(id);
     if (child)

--- a/indra/llui/llpanel.h
+++ b/indra/llui/llpanel.h
@@ -134,16 +134,16 @@ public:
     bool            hasBorder() const { return mBorder != NULL; }
     void            setBorderVisible( bool b );
 
-    void            setBackgroundColor( const LLColor4& color ) { mBgOpaqueColor = color; }
+    void            setBackgroundColor( const LLUIColor& color ) { mBgOpaqueColor = color; }
     const LLColor4& getBackgroundColor() const { return mBgOpaqueColor; }
-    void            setTransparentColor(const LLColor4& color) { mBgAlphaColor = color; }
+    void            setTransparentColor(const LLUIColor& color) { mBgAlphaColor = color; }
     const LLColor4& getTransparentColor() const { return mBgAlphaColor; }
     void            setBackgroundImage(LLUIImage* image) { mBgOpaqueImage = image; }
     void            setTransparentImage(LLUIImage* image) { mBgAlphaImage = image; }
     LLPointer<LLUIImage> getBackgroundImage() const { return mBgOpaqueImage; }
     LLPointer<LLUIImage> getTransparentImage() const { return mBgAlphaImage; }
-    LLColor4        getBackgroundImageOverlay() { return mBgOpaqueImageOverlay; }
-    LLColor4        getTransparentImageOverlay() { return mBgAlphaImageOverlay; }
+    const LLColor4&        getBackgroundImageOverlay() { return mBgOpaqueImageOverlay; }
+    const LLColor4&        getTransparentImageOverlay() { return mBgAlphaImageOverlay; }
     void            setBackgroundVisible( bool b )  { mBgVisible = b; }
     bool            isBackgroundVisible() const { return mBgVisible; }
     void            setBackgroundOpaque(bool b)     { mBgOpaque = b; }
@@ -192,7 +192,7 @@ public:
     // which takes a generic slot.  Or use mCommitCallbackRegistrar.add() with
     // a named callback and reference it in XML.
     void childSetCommitCallback(std::string_view id, boost::function<void (LLUICtrl*,void*)> cb, void* data);
-    void childSetColor(std::string_view id, const LLColor4& color);
+    void childSetColor(std::string_view id, const LLUIColor& color);
 
     LLCtrlSelectionInterface* childGetSelectionInterface(std::string_view id) const;
     LLCtrlListInterface* childGetListInterface(std::string_view id) const;

--- a/indra/llui/llscrolllistcell.cpp
+++ b/indra/llui/llscrolllistcell.cpp
@@ -465,7 +465,7 @@ LLScrollListCheck::LLScrollListCheck(const LLScrollListCell::Params& p)
         setWidth(rect.getWidth()); //check_box->getWidth();
     }
 
-    mCheckBox->setColor(p.color);
+    mCheckBox->setColor(p.color());
 }
 
 

--- a/indra/llui/llsearchablecontrol.h
+++ b/indra/llui/llsearchablecontrol.h
@@ -43,7 +43,7 @@ namespace ll
             virtual ~SearchableControl()
             { }
 
-            LLColor4 getHighlightColor( ) const
+            const LLColor4& getHighlightColor( ) const
             {
                 static LLUIColor highlight_color = LLUIColorTable::instance().getColor("SearchableControlHighlightColor", LLColor4::red);
                 return highlight_color.get();

--- a/indra/llui/llsliderctrl.cpp
+++ b/indra/llui/llsliderctrl.cpp
@@ -393,7 +393,7 @@ void LLSliderCtrl::setEnabled(bool b)
 
     if( mLabelBox )
     {
-        mLabelBox->setColor( b ? mTextEnabledColor.get() : mTextDisabledColor.get() );
+        mLabelBox->setColor( b ? mTextEnabledColor : mTextDisabledColor );
     }
 
     mSlider->setEnabled( b );
@@ -405,7 +405,7 @@ void LLSliderCtrl::setEnabled(bool b)
 
     if( mTextBox )
     {
-        mTextBox->setColor( b ? mTextEnabledColor.get() : mTextDisabledColor.get() );
+        mTextBox->setColor( b ? mTextEnabledColor : mTextDisabledColor );
     }
 }
 

--- a/indra/llui/llsliderctrl.h
+++ b/indra/llui/llsliderctrl.h
@@ -107,8 +107,8 @@ public:
     F32             getMaxValue() const { return mSlider->getMaxValue(); }
 
     void            setLabel(const LLStringExplicit& label)     { if (mLabelBox) mLabelBox->setText(label); }
-    void            setLabelColor(const LLColor4& c)            { mTextEnabledColor = c; }
-    void            setDisabledLabelColor(const LLColor4& c)    { mTextDisabledColor = c; }
+    void            setLabelColor(const LLUIColor& c)            { mTextEnabledColor = c; }
+    void            setDisabledLabelColor(const LLUIColor& c)    { mTextDisabledColor = c; }
 
     boost::signals2::connection setSliderMouseDownCallback( const commit_signal_t::slot_type& cb );
     boost::signals2::connection setSliderMouseUpCallback( const commit_signal_t::slot_type& cb );

--- a/indra/llui/llspinctrl.cpp
+++ b/indra/llui/llspinctrl.cpp
@@ -310,7 +310,7 @@ void LLSpinCtrl::updateLabelColor()
 {
     if( mLabelBox )
     {
-        mLabelBox->setColor( getEnabled() ? mTextEnabledColor.get() : mTextDisabledColor.get() );
+        mLabelBox->setColor( getEnabled() ? mTextEnabledColor : mTextDisabledColor );
     }
 }
 

--- a/indra/llui/llspinctrl.h
+++ b/indra/llui/llspinctrl.h
@@ -77,8 +77,8 @@ public:
     virtual void    setPrecision(S32 precision);
 
     void            setLabel(const LLStringExplicit& label);
-    void            setLabelColor(const LLColor4& c)            { mTextEnabledColor = c; updateLabelColor(); }
-    void            setDisabledLabelColor(const LLColor4& c)    { mTextDisabledColor = c; updateLabelColor();}
+    void            setLabelColor(const LLUIColor& c)            { mTextEnabledColor = c; updateLabelColor(); }
+    void            setDisabledLabelColor(const LLUIColor& c)    { mTextDisabledColor = c; updateLabelColor();}
     void            setAllowEdit(bool allow_edit);
 
     virtual void    onTabInto();

--- a/indra/llui/llstatgraph.cpp
+++ b/indra/llui/llstatgraph.cpp
@@ -100,8 +100,8 @@ void LLStatGraph::draw()
         it--;
     }
 
-    static LLColor4 default_color = LLUIColorTable::instance().getColor( "MenuDefaultBgColor" );
-    gGL.color4fv(default_color.mV);
+    static LLUIColor default_color = LLUIColorTable::instance().getColor( "MenuDefaultBgColor" );
+    gGL.color4fv(default_color.get().mV);
     gl_rect_2d(0, getRect().getHeight(), getRect().getWidth(), 0, true);
 
     gGL.color4fv(LLColor4::black.mV);

--- a/indra/llui/llstyle.cpp
+++ b/indra/llui/llstyle.cpp
@@ -33,11 +33,12 @@
 #include "llui.h"
 
 LLStyle::Params::Params()
-:   visible("visible", true),
+    : visible("visible", true),
     drop_shadow("drop_shadow", LLFontGL::NO_SHADOW),
     color("color", LLColor4::black),
     readonly_color("readonly_color", LLColor4::black),
     selected_color("selected_color", LLColor4::black),
+    alpha("alpha", 1.f),
     font("font", LLFontGL::getFontMonospace()),
     image("image"),
     link_href("href"),
@@ -54,7 +55,8 @@ LLStyle::LLStyle(const LLStyle::Params& p)
     mLink(p.link_href),
     mIsLink(p.is_link.isProvided() ? p.is_link : !p.link_href().empty()),
     mDropShadow(p.drop_shadow),
-    mImagep(p.image())
+    mImagep(p.image()),
+    mAlpha(p.alpha)
 {}
 
 void LLStyle::setFont(const LLFontGL* font)

--- a/indra/llui/llstyle.h
+++ b/indra/llui/llstyle.h
@@ -44,6 +44,7 @@ public:
         Optional<LLUIColor>             color,
                                         readonly_color,
                                         selected_color;
+        Optional<F32>                   alpha;
         Optional<const LLFontGL*>       font;
         Optional<LLUIImage*>            image;
         Optional<std::string>           link_href;
@@ -60,6 +61,9 @@ public:
 
     const LLUIColor& getSelectedColor() const { return mSelectedColor; }
     void setSelectedColor(const LLUIColor& color) { mSelectedColor = color; }
+
+    F32 getAlpha() const { return mAlpha; }
+    void setAlpha(F32 alpha) { mAlpha = alpha; }
 
     bool isVisible() const;
     void setVisible(bool is_visible);
@@ -89,7 +93,8 @@ public:
             && mFont == rhs.mFont
             && mLink == rhs.mLink
             && mImagep == rhs.mImagep
-            && mDropShadow == rhs.mDropShadow;
+            && mDropShadow == rhs.mDropShadow
+            && mAlpha == rhs.mAlpha;
     }
 
     bool operator!=(const LLStyle& rhs) const { return !(*this == rhs); }
@@ -98,18 +103,19 @@ public:
     LLFontGL::ShadowType        mDropShadow;
 
 protected:
-    ~LLStyle() { }
+    ~LLStyle() = default;
 
 private:
-    bool                mVisible;
+    std::string         mFontName;
+    std::string         mLink;
     LLUIColor           mColor;
     LLUIColor           mReadOnlyColor;
     LLUIColor           mSelectedColor;
-    std::string         mFontName;
     const LLFontGL*     mFont;
-    std::string         mLink;
-    bool                mIsLink;
     LLPointer<LLUIImage> mImagep;
+    F32                 mAlpha;
+    bool                mVisible;
+    bool                mIsLink;
 };
 
 typedef LLPointer<LLStyle> LLStyleSP;

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -2417,16 +2417,14 @@ void LLTextBase::appendAndHighlightTextImpl(const std::string &new_text, S32 hig
     {
         LLStyle::Params highlight_params(style_params);
 
-        LLSD pieces = LLTextParser::instance().parsePartialLineHighlights(new_text, highlight_params.color(), (LLTextParser::EHighlightPosition)highlight_part);
+        auto pieces = LLTextParser::instance().parsePartialLineHighlights(new_text, highlight_params.color, (LLTextParser::EHighlightPosition)highlight_part);
         for (S32 i = 0; i < pieces.size(); i++)
         {
-            LLSD color_llsd = pieces[i]["color"];
-            LLColor4 lcolor;
-            lcolor.setValue(color_llsd);
-            highlight_params.color = lcolor;
+            const auto& piece_pair = pieces[i];
+            highlight_params.color = piece_pair.second;
 
             LLWString wide_text;
-            wide_text = utf8str_to_wstring(pieces[i]["text"].asString());
+            wide_text = utf8str_to_wstring(piece_pair.first);
 
             S32 cur_length = getLength();
             LLStyleConstSP sp(new LLStyle(highlight_params));
@@ -3333,7 +3331,7 @@ F32 LLNormalTextSegment::drawClippedSegment(S32 seg_start, S32 seg_end, S32 sele
 
     const LLFontGL* font = mStyle->getFont();
 
-    LLColor4 color = (mEditor.getReadOnly() ? mStyle->getReadOnlyColor() : mStyle->getColor())  % alpha;
+    LLColor4 color = (mEditor.getReadOnly() ? mStyle->getReadOnlyColor() : mStyle->getColor())  % (alpha * mStyle->getAlpha());
 
     if( selection_start > seg_start )
     {

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1411,14 +1411,14 @@ void LLTextBase::draw()
 
 
 //virtual
-void LLTextBase::setColor( const LLColor4& c )
+void LLTextBase::setColor( const LLUIColor& c )
 {
     mFgColor = c;
     mStyleDirty = true;
 }
 
 //virtual
-void LLTextBase::setReadOnlyColor(const LLColor4 &c)
+void LLTextBase::setReadOnlyColor(const LLUIColor &c)
 {
     mReadOnlyFgColor = c;
     mStyleDirty = true;

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -2202,8 +2202,8 @@ static LLUIImagePtr image_from_icon_name(const std::string& icon_name)
 void LLTextBase::appendTextImpl(const std::string &new_text, const LLStyle::Params& input_params)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
-    LLStyle::Params style_params(input_params);
-    style_params.fillFrom(getStyleParams());
+    LLStyle::Params style_params(getStyleParams());
+    style_params.overwriteFrom(input_params);
 
     S32 part = (S32)LLTextParser::WHOLE;
     if (mParseHTML && !style_params.is_link) // Don't search for URLs inside a link segment (STORM-358).
@@ -3246,8 +3246,8 @@ F32 LLTextSegment::draw(S32 start, S32 end, S32 selection_start, S32 selection_e
 bool LLTextSegment::canEdit() const { return false; }
 void LLTextSegment::unlinkFromDocument(LLTextBase*) {}
 void LLTextSegment::linkToDocument(LLTextBase*) {}
-const LLColor4& LLTextSegment::getColor() const { return LLColor4::white; }
-//void LLTextSegment::setColor(const LLColor4 &color) {}
+const LLUIColor& LLTextSegment::getColor() const { static const LLUIColor white = LLUIColorTable::instance().getColor("White", LLColor4::white); return white; }
+//void LLTextSegment::setColor(const LLUIColor &color) {}
 LLStyleConstSP LLTextSegment::getStyle() const {static LLStyleConstSP sp(new LLStyle()); return sp; }
 void LLTextSegment::setStyle(LLStyleConstSP style) {}
 void LLTextSegment::setToken( LLKeywordToken* token ) {}
@@ -3293,7 +3293,7 @@ LLNormalTextSegment::LLNormalTextSegment( LLStyleConstSP style, S32 start, S32 e
     }
 }
 
-LLNormalTextSegment::LLNormalTextSegment( const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
+LLNormalTextSegment::LLNormalTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
 :   LLTextSegment(start, end),
     mToken(NULL),
     mEditor(editor)
@@ -3603,7 +3603,7 @@ LLLabelTextSegment::LLLabelTextSegment( LLStyleConstSP style, S32 start, S32 end
 {
 }
 
-LLLabelTextSegment::LLLabelTextSegment( const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
+LLLabelTextSegment::LLLabelTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
 :   LLNormalTextSegment(color, start, end, editor, is_visible)
 {
 }
@@ -3627,7 +3627,7 @@ LLEmojiTextSegment::LLEmojiTextSegment(LLStyleConstSP style, S32 start, S32 end,
 {
 }
 
-LLEmojiTextSegment::LLEmojiTextSegment(const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
+LLEmojiTextSegment::LLEmojiTextSegment(const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible)
     : LLNormalTextSegment(color, start, end, editor, is_visible)
 {
 }

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -584,9 +584,8 @@ void LLTextBase::drawCursor()
 
             if (LL_KIM_OVERWRITE == gKeyboard->getInsertMode() && !hasSelection() && text[mCursorPos] != '\n')
             {
-                LLColor4 text_color;
                 const LLFontGL* fontp;
-                text_color = segmentp->getColor();
+                const LLColor4& text_color = segmentp->getColor();
                 fontp = segmentp->getStyle()->getFont();
                 fontp->render(text, mCursorPos, cursor_rect,
                     LLColor4(1.f - text_color.mV[VRED], 1.f - text_color.mV[VGREEN], 1.f - text_color.mV[VBLUE], alpha),
@@ -1368,7 +1367,7 @@ void LLTextBase::draw()
         {
             bg_rect.intersectWith(text_rect);
         }
-        LLColor4 bg_color = mReadOnly
+        const LLColor4& bg_color = mReadOnly
                             ? mReadOnlyBgColor.get()
                             : hasFocus()
                                 ? mFocusBgColor.get()
@@ -1379,7 +1378,7 @@ void LLTextBase::draw()
     // Draw highlighted if needed
     if( ll::ui::SearchableControl::getHighlighted() )
     {
-        LLColor4 bg_color = ll::ui::SearchableControl::getHighlightColor();
+        const LLColor4& bg_color = ll::ui::SearchableControl::getHighlightColor();
         LLRect bg_rect = mVisibleTextRect;
         if( mScroller )
             bg_rect.intersectWith( text_rect );

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -372,8 +372,8 @@ public:
 
     // LLUICtrl interface
     /*virtual*/ bool        acceptsTextInput() const override { return !mReadOnly; }
-    /*virtual*/ void        setColor(const LLColor4& c) override;
-    virtual     void        setReadOnlyColor(const LLColor4 &c);
+    /*virtual*/ void        setColor(const LLUIColor& c) override;
+    virtual     void        setReadOnlyColor(const LLUIColor& c);
     /*virtual*/ void        onVisibilityChange(bool new_visibility) override;
 
     /*virtual*/ void        setValue(const LLSD& value) override;

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -84,8 +84,8 @@ public:
     virtual void                unlinkFromDocument(class LLTextBase* editor);
     virtual void                linkToDocument(class LLTextBase* editor);
 
-    virtual const LLColor4&     getColor() const;
-    //virtual void              setColor(const LLColor4 &color);
+    virtual const LLUIColor&     getColor() const;
+    //virtual void              setColor(const LLUIColor &color);
     virtual LLStyleConstSP      getStyle() const;
     virtual void                setStyle(LLStyleConstSP style);
     virtual void                setToken( LLKeywordToken* token );
@@ -125,7 +125,7 @@ class LLNormalTextSegment : public LLTextSegment
 {
 public:
     LLNormalTextSegment( LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor );
-    LLNormalTextSegment( const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
+    LLNormalTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
     virtual ~LLNormalTextSegment();
 
     /*virtual*/ bool                getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
@@ -133,7 +133,7 @@ public:
     /*virtual*/ S32                 getNumChars(S32 num_pixels, S32 segment_offset, S32 line_offset, S32 max_chars, S32 line_ind) const;
     /*virtual*/ F32                 draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
     /*virtual*/ bool                canEdit() const { return true; }
-    /*virtual*/ const LLColor4&     getColor() const                    { return mStyle->getColor(); }
+    /*virtual*/ const LLUIColor&     getColor() const                    { return mStyle->getColor(); }
     /*virtual*/ LLStyleConstSP      getStyle() const                    { return mStyle; }
     /*virtual*/ void                setStyle(LLStyleConstSP style)  { mStyle = style; }
     /*virtual*/ void                setToken( LLKeywordToken* token )   { mToken = token; }
@@ -170,7 +170,7 @@ class LLLabelTextSegment : public LLNormalTextSegment
 {
 public:
     LLLabelTextSegment( LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor );
-    LLLabelTextSegment( const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
+    LLLabelTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
 
 protected:
 
@@ -184,7 +184,7 @@ class LLEmojiTextSegment : public LLNormalTextSegment
 {
 public:
     LLEmojiTextSegment(LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor);
-    LLEmojiTextSegment(const LLColor4& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
+    LLEmojiTextSegment(const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
 
     bool canEdit() const override { return false; }
     bool handleToolTip(S32 x, S32 y, MASK mask) override;

--- a/indra/llui/lltextparser.h
+++ b/indra/llui/lltextparser.h
@@ -30,6 +30,7 @@
 
 #include "llsd.h"
 #include "llsingleton.h"
+#include "lluicolor.h"
 
 class LLUUID;
 class LLVector3d;
@@ -45,7 +46,9 @@ public:
     typedef enum e_highlight_position { WHOLE, START, MIDDLE, END } EHighlightPosition;
     typedef enum e_dialog_action { ACTION_NONE, ACTION_CLOSE, ACTION_ADD, ACTION_COPY, ACTION_UPDATE } EDialogAction;
 
-    LLSD parsePartialLineHighlights(const std::string &text,const LLColor4 &color, EHighlightPosition part=WHOLE, S32 index=0);
+    using parser_out_vec_t = std::vector<std::pair<std::string, LLUIColor>>;
+
+    parser_out_vec_t parsePartialLineHighlights(const std::string &text,const LLUIColor &color, EHighlightPosition part=WHOLE, S32 index=0);
     bool parseFullLineHighlights(const std::string &text, LLColor4 *color);
 
 private:

--- a/indra/llui/lluicolortable.cpp
+++ b/indra/llui/lluicolortable.cpp
@@ -198,7 +198,61 @@ LLUIColor LLUIColorTable::getColor(std::string_view name, const LLColor4& defaul
 // update user color, loaded colors are parsed on initialization
 void LLUIColorTable::setColor(std::string_view name, const LLColor4& color)
 {
-    setColor(name, color, mUserSetColors);
+    auto it = mUserSetColors.lower_bound(name);
+    if(it != mUserSetColors.end() && !(mUserSetColors.key_comp()(name, it->first)))
+    {
+        it->second = color;
+    }
+    else
+    {
+        string_color_map_t::iterator base_iter = mLoadedColors.find(name);
+        if (base_iter != mLoadedColors.end())
+        {
+            LLColor4 original_color = base_iter->second.get();
+            auto color_handle = mLoadedColors.extract(base_iter);
+            auto new_color_pair = mUserSetColors.insert(std::move(color_handle));
+            new_color_pair.position->second = color;
+            mLoadedColors.emplace(name, LLUIColor(original_color));
+        }
+        else
+        {
+            mUserSetColors.insert(it, std::make_pair(name, color));
+        }
+    }
+}
+
+bool LLUIColorTable::isDefault(std::string_view name) const
+{
+    string_color_map_t::const_iterator base_iter = mLoadedColors.find(name);
+    string_color_map_t::const_iterator user_iter = mUserSetColors.find(name);
+    if (base_iter != mLoadedColors.end())
+    {
+        if(user_iter != mUserSetColors.end())
+            return user_iter->second == base_iter->second;
+
+        return true;
+    }
+    else if (user_iter != mUserSetColors.end()) // user only color ???
+    {
+        return true;
+    }
+
+    return false;
+}
+
+void LLUIColorTable::resetToDefault(std::string_view name)
+{
+    string_color_map_t::iterator iter = mUserSetColors.find(name);
+
+    if (iter != mUserSetColors.end())
+    {
+        auto default_iter = mLoadedColors.find(name);
+
+        if (default_iter != mLoadedColors.end())
+        {
+            iter->second = default_iter->second.get();
+        }
+    }
 }
 
 bool LLUIColorTable::loadFromSettings()
@@ -223,18 +277,16 @@ void LLUIColorTable::saveUserSettings() const
 {
     Params params;
 
-    for(string_color_map_t::const_iterator it = mUserSetColors.begin();
-        it != mUserSetColors.end();
-        ++it)
+    for (const auto& color_pair : mUserSetColors)
     {
         // Compare user color value with the default value, skip if equal
-        string_color_map_t::const_iterator itd = mLoadedColors.find(it->first);
-        if(itd != mLoadedColors.end() && itd->second == it->second)
+        string_color_map_t::const_iterator itd = mLoadedColors.find(color_pair.first);
+        if(itd != mLoadedColors.end() && itd->second == color_pair.second)
             continue;
 
         ColorEntryParams color_entry;
-        color_entry.name = it->first;
-        color_entry.color.value = it->second;
+        color_entry.name = color_pair.first;
+        color_entry.color.value = color_pair.second;
 
         params.color_entries.add(color_entry);
     }

--- a/indra/llui/lluicolortable.h
+++ b/indra/llui/lluicolortable.h
@@ -83,11 +83,18 @@ public:
     // returns true if color_name exists in the table
     bool colorExists(std::string_view color_name) const;
 
+    bool isDefault(std::string_view color_name) const;
+
+    void resetToDefault(std::string_view color_name);
+
     // loads colors from settings files
     bool loadFromSettings();
 
     // saves colors specified by the user to the users skin directory
     void saveUserSettings() const;
+
+    const auto& getLoadedColors() { return mLoadedColors; }
+    const auto& getUserColors() { return mUserSetColors; }
 
 private:
     bool loadFromFilename(const std::string& filename, string_color_map_t& table);

--- a/indra/llui/lluictrl.cpp
+++ b/indra/llui/lluictrl.cpp
@@ -1023,7 +1023,7 @@ bool LLUICtrl::getTentative() const
 }
 
 // virtual
-void LLUICtrl::setColor(const LLColor4& color)
+void LLUICtrl::setColor(const LLUIColor& color)
 { }
 
 F32 LLUICtrl::getCurrentTransparency()

--- a/indra/llui/lluictrl.h
+++ b/indra/llui/lluictrl.h
@@ -216,7 +216,7 @@ public:
     // selected radio button, etc.).  Defaults to no-op.
     virtual void    clear();
 
-    virtual void    setColor(const LLColor4& color);
+    virtual void    setColor(const LLUIColor& color);
 
     // Ansariel: Changed to virtual. We might want to change the transparency ourself!
     virtual F32 getCurrentTransparency();

--- a/indra/llui/llviewborder.cpp
+++ b/indra/llui/llviewborder.cpp
@@ -73,14 +73,14 @@ LLViewBorder::LLViewBorder(const LLViewBorder::Params& p)
     mStyle(p.render_style)
 {}
 
-void LLViewBorder::setColors( const LLColor4& shadow_dark, const LLColor4& highlight_light )
+void LLViewBorder::setColors( const LLUIColor& shadow_dark, const LLUIColor& highlight_light )
 {
     mShadowDark = shadow_dark;
     mHighlightLight = highlight_light;
 }
 
-void LLViewBorder::setColorsExtended( const LLColor4& shadow_light, const LLColor4& shadow_dark,
-                               const LLColor4& highlight_light, const LLColor4& highlight_dark )
+void LLViewBorder::setColorsExtended( const LLUIColor& shadow_light, const LLUIColor& shadow_dark,
+                               const LLUIColor& highlight_light, const LLUIColor& highlight_dark )
 {
     mShadowDark = shadow_dark;
     mShadowLight = shadow_light;

--- a/indra/llui/llviewborder.h
+++ b/indra/llui/llviewborder.h
@@ -77,9 +77,9 @@ public:
     S32         getBorderWidth() const              { return mBorderWidth; }
     void        setBevel(EBevel bevel)              { mBevel = bevel; }
     EBevel      getBevel() const                    { return mBevel; }
-    void        setColors( const LLColor4& shadow_dark, const LLColor4& highlight_light );
-    void        setColorsExtended( const LLColor4& shadow_light, const LLColor4& shadow_dark,
-                                   const LLColor4& highlight_light, const LLColor4& highlight_dark );
+    void        setColors( const LLUIColor& shadow_dark, const LLUIColor& highlight_light );
+    void        setColorsExtended( const LLUIColor& shadow_light, const LLUIColor& shadow_dark,
+                                   const LLUIColor& highlight_light, const LLUIColor& highlight_dark );
     void        setTexture( const class LLUUID &image_id );
 
     LLColor4    getHighlightLight() {return mHighlightLight.get();}

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -286,6 +286,7 @@ set(viewer_SOURCE_FILES
     llfloaterscriptlimits.cpp
     llfloatersearch.cpp
     llfloatersellland.cpp
+    llfloatersettingscolor.cpp
     llfloatersettingsdebug.cpp
     llfloatersidepanelcontainer.cpp
     llfloatersnapshot.cpp
@@ -954,6 +955,7 @@ set(viewer_HEADER_FILES
     llfloaterscriptlimits.h
     llfloatersearch.h
     llfloatersellland.h
+    llfloatersettingscolor.h
     llfloatersettingsdebug.h
     llfloatersidepanelcontainer.h
     llfloatersnapshot.h

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -15773,6 +15773,17 @@
     <key>Value</key>
     <integer>0</integer>
   </map>
+  <key>ColorSettingsHideDefault</key>
+  <map>
+    <key>Comment</key>
+    <string>Show non-default settings only in Color Settings list</string>
+    <key>Persist</key>
+    <integer>0</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
   <key>DebugSettingsHideDefault</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -693,7 +693,7 @@ public:
             mNeedsTimeBox = false;
             user_name->setValue(mFrom);
             updateMinUserNameWidth();
-            LLColor4 sep_color = LLUIColorTable::instance().getColor("ChatTeleportSeparatorColor");
+            LLUIColor sep_color = LLUIColorTable::instance().getColor("ChatTeleportSeparatorColor");
             setTransparentColor(sep_color);
             mTimeBoxTextBox->setVisible(false);
         }
@@ -739,7 +739,7 @@ public:
                     std::string username = chat.mFromName.substr(username_start + 2);
                     username = username.substr(0, username.length() - 1);
                     LLStyle::Params style_params_name;
-                    LLColor4 userNameColor = LLUIColorTable::instance().getColor("EmphasisColor");
+                    LLUIColor userNameColor = LLUIColorTable::instance().getColor("EmphasisColor");
                     style_params_name.color(userNameColor);
                     style_params_name.font.name("SansSerifSmall");
                     style_params_name.font.style("NORMAL");
@@ -1037,7 +1037,7 @@ private:
             !av_name.isDisplayNameDefault())
         {
             LLStyle::Params style_params_name;
-            LLColor4 userNameColor = LLUIColorTable::instance().getColor("EmphasisColor");
+            LLUIColor userNameColor = LLUIColorTable::instance().getColor("EmphasisColor");
             style_params_name.color(userNameColor);
             style_params_name.font.name("SansSerifSmall");
             style_params_name.font.style("NORMAL");
@@ -1239,8 +1239,8 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
         mMoreChatPanel->reshape(mMoreChatPanel->getRect().getWidth(), height);
     }
 
-    LLColor4 txt_color = LLUIColorTable::instance().getColor("White");
-    LLColor4 name_color(txt_color);
+    LLUIColor txt_color = LLUIColorTable::instance().getColor("White");
+    LLUIColor name_color(txt_color);
 
     LLViewerChat::getChatColor(chat,txt_color);
     LLFontGL* fontp = LLViewerChat::getChatFont();
@@ -1317,7 +1317,7 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
         {
             if (!message_from_log)
             {
-                LLColor4 timestamp_color = LLUIColorTable::instance().getColor("ChatTimestampColor");
+                LLUIColor timestamp_color = LLUIColorTable::instance().getColor("ChatTimestampColor");
                 timestamp_style.color(timestamp_color);
                 timestamp_style.readonly_color(timestamp_color);
             }
@@ -1344,7 +1344,7 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
                 // set the link for the object name to be the objectim SLapp
                 // (don't let object names with hyperlinks override our objectim Url)
                 LLStyle::Params link_params(body_message_params);
-                LLColor4 link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
+                LLUIColor link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
                 link_params.color = link_color;
                 link_params.readonly_color = link_color;
                 link_params.is_link = true;

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -1239,10 +1239,11 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
         mMoreChatPanel->reshape(mMoreChatPanel->getRect().getWidth(), height);
     }
 
+    F32 alpha = 1.f;
     LLUIColor txt_color = LLUIColorTable::instance().getColor("White");
     LLUIColor name_color(txt_color);
+    LLViewerChat::getChatColor(chat, txt_color, alpha);
 
-    LLViewerChat::getChatColor(chat,txt_color);
     LLFontGL* fontp = LLViewerChat::getChatFont();
     std::string font_name = LLFontGL::nameFromFont(fontp);
     std::string font_size = LLFontGL::sizeFromFont(fontp);
@@ -1250,6 +1251,7 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
     LLStyle::Params body_message_params;
     body_message_params.color(txt_color);
     body_message_params.readonly_color(txt_color);
+    body_message_params.alpha(alpha);
     body_message_params.font.name(font_name);
     body_message_params.font.size(font_size);
     body_message_params.font.style(input_append_params.font.style);

--- a/indra/newview/llchatitemscontainerctrl.cpp
+++ b/indra/newview/llchatitemscontainerctrl.cpp
@@ -222,14 +222,9 @@ void LLFloaterIMNearbyChatToastPanel::init(LLSD& notification)
         if (mSourceType == CHAT_SOURCE_AGENT || mSourceType == CHAT_SOURCE_OBJECT)
         {
             LLStyle::Params style_params_name;
-
-            LLColor4 user_name_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
-            style_params_name.color(user_name_color);
-
-            std::string font_name = LLFontGL::nameFromFont(messageFont);
-            std::string font_style_size = LLFontGL::sizeFromFont(messageFont);
-            style_params_name.font.name(font_name);
-            style_params_name.font.size(font_style_size);
+            style_params_name.color = LLUIColorTable::instance().getColor("HTMLLinkColor");
+            style_params_name.font.name = LLFontGL::nameFromFont(messageFont);
+            style_params_name.font.size = LLFontGL::sizeFromFont(messageFont);
 
             style_params_name.link_href = notification["sender_slurl"].asString();
             style_params_name.is_link = true;

--- a/indra/newview/llchatitemscontainerctrl.cpp
+++ b/indra/newview/llchatitemscontainerctrl.cpp
@@ -134,8 +134,8 @@ void LLFloaterIMNearbyChatToastPanel::addMessage(LLSD& notification)
 
     std::string color_name = notification["text_color"].asString();
 
-    LLColor4 textColor = LLUIColorTable::instance().getColor(color_name);
-    textColor.mV[VALPHA] = (F32)notification["color_alpha"].asReal();
+    LLUIColor textColor = LLUIColorTable::instance().getColor(color_name);
+    F32 textAlpha = (F32)notification["color_alpha"].asReal();
 
     S32 font_size = notification["font_size"].asInteger();
 
@@ -152,6 +152,7 @@ void LLFloaterIMNearbyChatToastPanel::addMessage(LLSD& notification)
     {
         LLStyle::Params style_params;
         style_params.color(textColor);
+        style_params.alpha(textAlpha);
         std::string font_name = LLFontGL::nameFromFont(messageFont);
         std::string font_style_size = LLFontGL::sizeFromFont(messageFont);
         style_params.font.name(font_name);
@@ -190,8 +191,8 @@ void LLFloaterIMNearbyChatToastPanel::init(LLSD& notification)
 
     std::string color_name = notification["text_color"].asString();
 
-    LLColor4 textColor = LLUIColorTable::instance().getColor(color_name);
-    textColor.mV[VALPHA] = (F32)notification["color_alpha"].asReal();
+    LLUIColor textColor = LLUIColorTable::instance().getColor(color_name);
+    F32 textAlpha = (F32)notification["color_alpha"].asReal();
 
     S32 font_size = notification["font_size"].asInteger();
 
@@ -269,6 +270,7 @@ void LLFloaterIMNearbyChatToastPanel::init(LLSD& notification)
     {
         LLStyle::Params style_params;
         style_params.color(textColor);
+        style_params.alpha(textAlpha);
         std::string font_name = LLFontGL::nameFromFont(messageFont);
         std::string font_style_size = LLFontGL::sizeFromFont(messageFont);
         style_params.font.name(font_name);

--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -652,7 +652,7 @@ void LLConversationViewParticipant::draw()
     static LLUIColor sFlashBgColor = LLUIColorTable::instance().getColor("MenuItemFlashBgColor", DEFAULT_WHITE);
     static LLUIColor sFocusOutlineColor = LLUIColorTable::instance().getColor("InventoryFocusOutlineColor", DEFAULT_WHITE);
     static LLUIColor sMouseOverColor = LLUIColorTable::instance().getColor("InventoryMouseOverColor", DEFAULT_WHITE);
-    static LLUIColor sFriendColor = LLUIColorTable::instance().getColor("ConversationFriendColor");;
+    static LLUIColor sFriendColor = LLUIColorTable::instance().getColor("ConversationFriendColor");
 
     const bool show_context = (getRoot() ? getRoot()->getShowSelectionContext() : false);
 

--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -652,6 +652,7 @@ void LLConversationViewParticipant::draw()
     static LLUIColor sFlashBgColor = LLUIColorTable::instance().getColor("MenuItemFlashBgColor", DEFAULT_WHITE);
     static LLUIColor sFocusOutlineColor = LLUIColorTable::instance().getColor("InventoryFocusOutlineColor", DEFAULT_WHITE);
     static LLUIColor sMouseOverColor = LLUIColorTable::instance().getColor("InventoryMouseOverColor", DEFAULT_WHITE);
+    static LLUIColor sFriendColor = LLUIColorTable::instance().getColor("ConversationFriendColor");;
 
     const bool show_context = (getRoot() ? getRoot()->getShowSelectionContext() : false);
 
@@ -661,23 +662,23 @@ void LLConversationViewParticipant::draw()
     F32 y = (F32)getRect().getHeight() - font->getLineHeight() - (F32)mTextPad;
     F32 text_left = (F32)getLabelXPos();
 
-    LLColor4 color;
+    LLUIColor* color;
 
     LLLocalSpeakerMgr *speakerMgr = LLLocalSpeakerMgr::getInstance();
 
     if (speakerMgr && speakerMgr->isSpeakerToBeRemoved(mUUID))
     {
-        color = sFgDisabledColor;
+        color = &sFgDisabledColor;
     }
     else
     {
         if (LLAvatarActions::isFriend(mUUID))
         {
-            color = LLUIColorTable::instance().getColor("ConversationFriendColor");
+            color = &sFriendColor;
         }
         else
         {
-            color = mIsSelected ? sHighlightFgColor : sFgColor;
+            color = mIsSelected ? &sHighlightFgColor : &sFgColor;
         }
     }
 
@@ -688,7 +689,7 @@ void LLConversationViewParticipant::draw()
     }
 
     drawHighlight(show_context, mIsSelected, sHighlightBgColor, sFlashBgColor, sFocusOutlineColor, sMouseOverColor);
-    drawLabel(font, text_left, y, color, right_x);
+    drawLabel(font, text_left, y, color->get(), right_x);
 
     LLView::draw();
 }

--- a/indra/newview/llfloatercolorpicker.cpp
+++ b/indra/newview/llfloatercolorpicker.cpp
@@ -110,12 +110,6 @@ LLFloaterColorPicker::LLFloaterColorPicker (LLColorSwatchCtrl* swatch, bool show
 
     // create user interface for this picker
     createUI ();
-
-    if (!mCanApplyImmediately)
-    {
-        mApplyImmediateCheck->setEnabled(false);
-        mApplyImmediateCheck->set(false);
-    }
 }
 
 LLFloaterColorPicker::~LLFloaterColorPicker()
@@ -225,6 +219,12 @@ bool LLFloaterColorPicker::postBuild()
     mApplyImmediateCheck = getChild<LLCheckBoxCtrl>("apply_immediate");
     mApplyImmediateCheck->set(gSavedSettings.getBOOL("ApplyColorImmediately"));
     mApplyImmediateCheck->setCommitCallback(onImmediateCheck, this);
+
+    if (!mCanApplyImmediately)
+    {
+        mApplyImmediateCheck->setEnabled(false);
+        mApplyImmediateCheck->set(false);
+    }
 
     childSetCommitCallback("rspin", onTextCommit, (void*)this );
     childSetCommitCallback("gspin", onTextCommit, (void*)this );

--- a/indra/newview/llfloateremojipicker.cpp
+++ b/indra/newview/llfloateremojipicker.cpp
@@ -203,8 +203,7 @@ public:
         F32 centerY = 0.5f * clientHeight;
         drawIcon(centerX, centerY - 1, iconWidth);
 
-        static LLColor4 defaultColor(0.75f, 0.75f, 0.75f, 1.0f);
-        static LLUIColor textColor = LLUIColorTable::instance().getColor("MenuItemEnabledColor", defaultColor);
+        static LLUIColor textColor = LLUIColorTable::instance().getColor("MenuItemEnabledColor", LLColor4(0.75f, 0.75f, 0.75f, 1.0f));
         S32 max_pixels = clientWidth - iconWidth;
         drawName((F32)iconWidth, centerY, max_pixels, textColor.get());
     }
@@ -704,8 +703,7 @@ void LLFloaterEmojiPicker::fillEmojis(bool fromResize)
     LLPanel::Params icon_params;
     LLRect icon_rect(0, icon_size, icon_size, 0);
 
-    static LLColor4 default_color(0.75f, 0.75f, 0.75f, 1.0f);
-    LLColor4 bg_color = LLUIColorTable::instance().getColor("MenuItemHighlightBgColor", default_color);
+    static LLUIColor bg_color = LLUIColorTable::instance().getColor("MenuItemHighlightBgColor", LLColor4(0.75f, 0.75f, 0.75f, 1.0f));
 
     if (!mSelectedGroupIndex)
     {

--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -535,14 +535,13 @@ void LLFloaterIMNearbyChatHandler::processChat(const LLChat& chat_msg,
 
         if (gSavedSettings.getS32("ShowScriptErrorsLocation") == 1)// show error in window //("ScriptErrorsAsChat"))
         {
-
-            LLColor4 txt_color;
-
-            LLViewerChat::getChatColor(chat_msg,txt_color);
+            LLUIColor txt_color;
+            F32 alpha = 1.f;
+            LLViewerChat::getChatColor(chat_msg, txt_color, alpha);
 
             LLFloaterScriptDebug::addScriptLine(chat_msg.mText,
                                                 chat_msg.mFromName,
-                                                txt_color,
+                                                txt_color % alpha,
                                                 chat_msg.mFromID);
             return;
         }

--- a/indra/newview/llfloaterscriptedprefs.cpp
+++ b/indra/newview/llfloaterscriptedprefs.cpp
@@ -54,8 +54,6 @@ bool LLFloaterScriptEdPrefs::postBuild()
 void LLFloaterScriptEdPrefs::applyUIColor(LLUICtrl* ctrl, const LLSD& param)
 {
     LLUIColorTable::instance().setColor(param.asString(), LLColor4(ctrl->getValue()));
-    mEditor->initKeywords();
-    mEditor->loadKeywords();
 }
 
 void LLFloaterScriptEdPrefs::getUIColor(LLUICtrl* ctrl, const LLSD& param)

--- a/indra/newview/llfloatersettingscolor.cpp
+++ b/indra/newview/llfloatersettingscolor.cpp
@@ -1,0 +1,334 @@
+/**
+* @file llfloatersettingscolor.cpp
+* @brief Implementation of LLFloaterSettingsColor
+* @author Rye Cogtail<rye@alchemyviewer.org>
+*
+* $LicenseInfo:firstyear=2024&license=viewerlgpl$
+* Second Life Viewer Source Code
+* Copyright (C) 2024, Linden Research, Inc.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation;
+* version 2.1 of the License only.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*
+* Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+* $/LicenseInfo$
+*/
+
+#include "llviewerprecompiledheaders.h"
+
+#include "llfloatersettingscolor.h"
+
+#include "llfloater.h"
+#include "llfiltereditor.h"
+#include "lluictrlfactory.h"
+#include "llcombobox.h"
+#include "llspinctrl.h"
+#include "llcolorswatch.h"
+#include "llviewercontrol.h"
+#include "lltexteditor.h"
+
+
+LLFloaterSettingsColor::LLFloaterSettingsColor(const LLSD& key)
+:   LLFloater(key),
+    mSettingList(NULL)
+{
+    mCommitCallbackRegistrar.add("CommitSettings",  boost::bind(&LLFloaterSettingsColor::onCommitSettings, this));
+    mCommitCallbackRegistrar.add("ClickDefault",    boost::bind(&LLFloaterSettingsColor::onClickDefault, this));
+}
+
+LLFloaterSettingsColor::~LLFloaterSettingsColor()
+{}
+
+bool LLFloaterSettingsColor::postBuild()
+{
+    enableResizeCtrls(true, false, true);
+
+    mAlphaSpinner = getChild<LLSpinCtrl>("alpha_spinner");
+    mColorSwatch = getChild<LLColorSwatchCtrl>("color_swatch");
+
+    mDefaultButton = getChild<LLUICtrl>("default_btn");
+    mSettingNameText = getChild<LLTextBox>("color_name_txt");
+
+    getChild<LLFilterEditor>("filter_input")->setCommitCallback(boost::bind(&LLFloaterSettingsColor::setSearchFilter, this, _2));
+
+    mSettingList = getChild<LLScrollListCtrl>("setting_list");
+    mSettingList->setCommitOnSelectionChange(true);
+    mSettingList->setCommitCallback(boost::bind(&LLFloaterSettingsColor::onSettingSelect, this));
+
+    updateList();
+
+    gSavedSettings.getControl("ColorSettingsHideDefault")->getCommitSignal()->connect(boost::bind(&LLFloaterSettingsColor::updateList, this, false));
+
+    return LLFloater::postBuild();
+}
+
+void LLFloaterSettingsColor::draw()
+{
+    LLScrollListItem* first_selected = mSettingList->getFirstSelected();
+    if (first_selected)
+    {
+        if(auto cell = first_selected->getColumn(1))
+        {
+            updateControl(cell->getValue().asString());
+        }
+    }
+
+    LLFloater::draw();
+}
+
+void LLFloaterSettingsColor::onCommitSettings()
+{
+    LLScrollListItem* first_selected = mSettingList->getFirstSelected();
+    if (!first_selected)
+    {
+        return;
+    }
+    auto cell = first_selected->getColumn(1);
+
+    if (!cell)
+    {
+        return;
+    }
+
+    auto color_name = cell->getValue().asString();
+    if (color_name.empty())
+    {
+        return;
+    }
+
+    LLColor4 col4;
+    LLColor3 col3;
+    col3.setValue(mColorSwatch->getValue());
+    col4 = LLColor4(col3, (F32)mAlphaSpinner->getValue().asReal());
+    LLUIColorTable::instance().setColor(color_name, col4);
+
+    updateDefaultColumn(color_name);
+}
+
+// static
+void LLFloaterSettingsColor::onClickDefault()
+{
+    LLScrollListItem* first_selected = mSettingList->getFirstSelected();
+    if (first_selected)
+    {
+        auto cell = first_selected->getColumn(1);
+        if (cell)
+        {
+            auto name = cell->getValue().asString();
+            LLUIColorTable::instance().resetToDefault(name);
+            updateDefaultColumn(name);
+            updateControl(name);
+        }
+    }
+}
+
+// we've switched controls, or doing per-frame update, so update spinners, etc.
+void LLFloaterSettingsColor::updateControl(const std::string& color_name)
+{
+    hideUIControls();
+
+    if (!isSettingHidden(color_name))
+    {
+        mDefaultButton->setVisible(true);
+        mSettingNameText->setVisible(true);
+        mSettingNameText->setText(color_name);
+        mSettingNameText->setToolTip(color_name);
+
+        LLColor4 clr = LLUIColorTable::instance().getColor(color_name);
+        mColorSwatch->setVisible(true);
+        // only set if changed so color picker doesn't update
+        if (clr != LLColor4(mColorSwatch->getValue()))
+        {
+            mColorSwatch->setOriginal(clr);
+        }
+        mAlphaSpinner->setVisible(true);
+        mAlphaSpinner->setLabel(std::string("Alpha"));
+        if (!mAlphaSpinner->hasFocus())
+        {
+            mAlphaSpinner->setPrecision(3);
+            mAlphaSpinner->setMinValue(0.0);
+            mAlphaSpinner->setMaxValue(1.f);
+            mAlphaSpinner->setValue(clr.mV[VALPHA]);
+        }
+    }
+
+}
+
+void LLFloaterSettingsColor::updateList(bool skip_selection)
+{
+    std::string last_selected;
+    LLScrollListItem* item = mSettingList->getFirstSelected();
+    if (item)
+    {
+        LLScrollListCell* cell = item->getColumn(1);
+        if (cell)
+        {
+            last_selected = cell->getValue().asString();
+         }
+    }
+
+    mSettingList->deleteAllItems();
+
+    const auto& base_colors = LLUIColorTable::instance().getLoadedColors();
+    for (const auto& pair : base_colors)
+    {
+        const auto& name = pair.first;
+        if (matchesSearchFilter(name) && !isSettingHidden(name))
+        {
+            LLSD row;
+
+            row["columns"][0]["column"] = "changed_color";
+            row["columns"][0]["value"] = LLUIColorTable::instance().isDefault(name) ? "" : "*";
+
+            row["columns"][1]["column"] = "color";
+            row["columns"][1]["value"] = name;
+
+            LLScrollListItem* item = mSettingList->addElement(row, ADD_BOTTOM, nullptr);
+            if (!mSearchFilter.empty() && (last_selected == name) && !skip_selection)
+            {
+                std::string lower_name(name);
+                LLStringUtil::toLower(lower_name);
+                if (LLStringUtil::startsWith(lower_name, mSearchFilter))
+                {
+                    item->setSelected(true);
+                }
+            }
+        }
+    }
+
+    for (const auto& pair : LLUIColorTable::instance().getUserColors())
+    {
+        const auto& name = pair.first;
+        if (base_colors.find(name) == base_colors.end() && matchesSearchFilter(name) && !isSettingHidden(name))
+        {
+            LLSD row;
+
+            row["columns"][0]["column"] = "changed_color";
+            row["columns"][0]["value"] = LLUIColorTable::instance().isDefault(name) ? "" : "*";
+
+            row["columns"][1]["column"] = "color";
+            row["columns"][1]["value"] = name;
+
+            LLScrollListItem* item = mSettingList->addElement(row, ADD_BOTTOM, nullptr);
+            if (!mSearchFilter.empty() && (last_selected == name) && !skip_selection)
+            {
+                std::string lower_name(name);
+                LLStringUtil::toLower(lower_name);
+                if (LLStringUtil::startsWith(lower_name, mSearchFilter))
+                {
+                    item->setSelected(true);
+                }
+            }
+        }
+    }
+
+    mSettingList->updateSort();
+
+    if (!mSettingList->isEmpty())
+    {
+        if (mSettingList->hasSelectedItem())
+        {
+            mSettingList->scrollToShowSelected();
+        }
+        else if (!mSettingList->hasSelectedItem() && !mSearchFilter.empty() && !skip_selection)
+        {
+            if (!mSettingList->selectItemByPrefix(mSearchFilter, false, 1))
+            {
+                mSettingList->selectFirstItem();
+            }
+            mSettingList->scrollToShowSelected();
+        }
+    }
+    else
+    {
+        LLSD row;
+
+        row["columns"][0]["column"] = "changed_color";
+        row["columns"][0]["value"] = "";
+        row["columns"][1]["column"] = "color";
+        row["columns"][1]["value"] = "No matching colors.";
+
+        mSettingList->addElement(row);
+        hideUIControls();
+    }
+}
+
+void LLFloaterSettingsColor::onSettingSelect()
+{
+    LLScrollListItem* first_selected = mSettingList->getFirstSelected();
+    if (first_selected)
+    {
+        auto cell = first_selected->getColumn(1);
+        if (cell)
+        {
+            updateControl(cell->getValue().asString());
+        }
+    }
+}
+
+void LLFloaterSettingsColor::setSearchFilter(const std::string& filter)
+{
+    if(mSearchFilter == filter)
+        return;
+    mSearchFilter = filter;
+    LLStringUtil::toLower(mSearchFilter);
+    updateList();
+}
+
+bool LLFloaterSettingsColor::matchesSearchFilter(std::string setting_name)
+{
+    // If the search filter is empty, everything passes.
+    if (mSearchFilter.empty()) return true;
+
+    LLStringUtil::toLower(setting_name);
+    std::string::size_type match_name = setting_name.find(mSearchFilter);
+
+    return (std::string::npos != match_name);
+}
+
+bool LLFloaterSettingsColor::isSettingHidden(const std::string& color_name)
+{
+    static LLCachedControl<bool> hide_default(gSavedSettings, "ColorSettingsHideDefault", false);
+    return hide_default && LLUIColorTable::instance().isDefault(color_name);
+}
+
+void LLFloaterSettingsColor::updateDefaultColumn(const std::string& color_name)
+{
+    if (isSettingHidden(color_name))
+    {
+        hideUIControls();
+        updateList(true);
+        return;
+    }
+
+    LLScrollListItem* item = mSettingList->getFirstSelected();
+    if (item)
+    {
+        LLScrollListCell* cell = item->getColumn(0);
+        if (cell)
+        {
+            std::string is_default = LLUIColorTable::instance().isDefault(color_name) ? "" : "*";
+            cell->setValue(is_default);
+        }
+    }
+}
+
+void LLFloaterSettingsColor::hideUIControls()
+{
+    mColorSwatch->setVisible(false);
+    mAlphaSpinner->setVisible(false);
+    mDefaultButton->setVisible(false);
+    mSettingNameText->setVisible(false);
+}
+

--- a/indra/newview/llfloatersettingscolor.h
+++ b/indra/newview/llfloatersettingscolor.h
@@ -1,0 +1,81 @@
+/**
+* @file llfloatersettingscolor.h
+* @brief Header file for LLFloaterSettingsColor
+* @author Rye Cogtail<rye@alchemyviewer.org>
+*
+* $LicenseInfo:firstyear=2024&license=viewerlgpl$
+* Second Life Viewer Source Code
+* Copyright (C) 2024, Linden Research, Inc.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation;
+* version 2.1 of the License only.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*
+* Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+* $/LicenseInfo$
+*/
+
+#ifndef LLFLOATERCOLORSETTINGS_H
+#define LLFLOATERCOLORSETTINGS_H
+
+#include "llcontrol.h"
+#include "llfloater.h"
+
+class LLColorSwatchCtrl;
+class LLScrollListCtrl;
+class LLSpinCtrl;
+class LLTextBox;
+
+class LLFloaterSettingsColor final
+:   public LLFloater
+{
+    friend class LLFloaterReg;
+
+public:
+
+    bool postBuild() override;
+    void draw() override;
+
+    void updateControl(const std::string& color_name);
+
+    void onCommitSettings();
+    void onClickDefault();
+
+    bool matchesSearchFilter(std::string setting_name);
+    bool isSettingHidden(const std::string& color_name);
+
+private:
+    LLFloaterSettingsColor(const LLSD& key);
+    virtual ~LLFloaterSettingsColor();
+
+    void updateList(bool skip_selection = false);
+    void onSettingSelect();
+    void setSearchFilter(const std::string& filter);
+
+    void updateDefaultColumn(const std::string& color_name);
+    void hideUIControls();
+
+    LLScrollListCtrl* mSettingList;
+
+protected:
+    LLUICtrl*           mDefaultButton = nullptr;
+    LLTextBox*          mSettingNameText = nullptr;
+
+    LLSpinCtrl* mAlphaSpinner = nullptr;
+    LLColorSwatchCtrl* mColorSwatch = nullptr;
+
+    std::string mSearchFilter;
+};
+
+#endif //LLFLOATERCOLORSETTINGS_H
+

--- a/indra/newview/llhudnametag.cpp
+++ b/indra/newview/llhudnametag.cpp
@@ -279,8 +279,10 @@ void LLHUDNameTag::renderText(bool for_select)
     mOffsetY = lltrunc(mHeight * ((mVertAlignment == ALIGN_VERT_CENTER) ? 0.5f : 1.f));
 
     // *TODO: make this a per-text setting
-    LLColor4 bg_color = LLUIColorTable::instance().getColor("NameTagBackground");
-    bg_color.setAlpha(gSavedSettings.getF32("ChatBubbleOpacity") * alpha_factor);
+    static LLCachedControl<F32> bubble_opacity(gSavedSettings, "ChatBubbleOpacity");
+    static LLUIColor nametag_bg_color = LLUIColorTable::instance().getColor("NameTagBackground");
+    LLColor4 bg_color = nametag_bg_color;
+    bg_color.setAlpha(bubble_opacity * alpha_factor);
 
     // scale screen size of borders down
     //RN: for now, text on hud objects is never occluded
@@ -340,8 +342,7 @@ void LLHUDNameTag::renderText(bool for_select)
                 x_offset = -0.5f * mWidth + (HORIZONTAL_PADDING / 2.f);
             }
 
-            LLColor4 label_color(0.f, 0.f, 0.f, 1.f);
-            label_color.mV[VALPHA] = alpha_factor;
+            LLColor4 label_color(0.f, 0.f, 0.f, alpha_factor);
             hud_render_text(segment_iter->getText(), render_position, *fontp, segment_iter->mStyle, LLFontGL::NO_SHADOW, x_offset, y_offset, label_color, false);
         }
     }

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -138,8 +138,10 @@ void LLHUDText::renderText()
     mOffsetY = lltrunc(mHeight * ((mVertAlignment == ALIGN_VERT_CENTER) ? 0.5f : 1.f));
 
     // *TODO: make this a per-text setting
-    LLColor4 bg_color = LLUIColorTable::instance().getColor("ObjectBubbleColor");
-    bg_color.setAlpha(gSavedSettings.getF32("ChatBubbleOpacity") * alpha_factor);
+    static LLCachedControl<F32> bubble_opacity(gSavedSettings, "ChatBubbleOpacity");
+    static LLUIColor nametag_bg_color = LLUIColorTable::instance().getColor("ObjectBubbleColor");
+    LLColor4 bg_color = nametag_bg_color;
+    bg_color.setAlpha(bubble_opacity * alpha_factor);
 
     const S32 border_height = 16;
     const S32 border_width = 16;

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -2881,11 +2881,13 @@ void LLInventoryGalleryItem::draw()
         LLPanel::draw();
 
         // Draw border
-        LLUIColor border_color = LLUIColorTable::instance().getColor(mSelected ? "MenuItemHighlightBgColor" : "TextFgTentativeColor", LLColor4::white);
+        static LLUIColor menu_highlighted_color = LLUIColorTable::instance().getColor("MenuItemHighlightBgColor", LLColor4::white);;
+        static LLUIColor text_fg_tentative_color = LLUIColorTable::instance().getColor("TextFgTentativeColor", LLColor4::white);;
+        const LLColor4& border_color = mSelected ? menu_highlighted_color : text_fg_tentative_color;
         LLRect border = mThumbnailCtrl->getRect();
         border.mRight = border.mRight + 1;
         border.mTop = border.mTop + 1;
-        gl_rect_2d(border, border_color.get(), false);
+        gl_rect_2d(border, border_color, false);
     }
 }
 

--- a/indra/newview/llmanip.cpp
+++ b/indra/newview/llmanip.cpp
@@ -594,9 +594,9 @@ void LLManip::renderTickValue(const LLVector3& pos, F32 value, const std::string
 
 LLColor4 LLManip::setupSnapGuideRenderPass(S32 pass)
 {
-    static LLColor4 grid_color_fg = LLUIColorTable::instance().getColor("GridlineColor");
-    static LLColor4 grid_color_bg = LLUIColorTable::instance().getColor("GridlineBGColor");
-    static LLColor4 grid_color_shadow = LLUIColorTable::instance().getColor("GridlineShadowColor");
+    static LLUIColor grid_color_fg = LLUIColorTable::instance().getColor("GridlineColor");
+    static LLUIColor grid_color_bg = LLUIColorTable::instance().getColor("GridlineBGColor");
+    static LLUIColor grid_color_shadow = LLUIColorTable::instance().getColor("GridlineShadowColor");
 
     LLColor4 line_color;
     F32 line_alpha = gSavedSettings.getF32("GridOpacity");

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -1020,8 +1020,8 @@ void LLOutfitGalleryItem::setOutfitWorn(bool value)
     LLStringUtil::format_map_t worn_string_args;
     std::string worn_string = getString("worn_string", worn_string_args);
     LLUIColor text_color = LLUIColorTable::instance().getColor("White", LLColor4::white);
-    mOutfitWornText->setReadOnlyColor(text_color.get());
-    mOutfitNameText->setReadOnlyColor(text_color.get());
+    mOutfitWornText->setReadOnlyColor(text_color);
+    mOutfitNameText->setReadOnlyColor(text_color);
     mOutfitWornText->setFont(value ? LLFontGL::getFontSansSerifBold() : LLFontGL::getFontSansSerifSmall());
     mOutfitNameText->setFont(value ? LLFontGL::getFontSansSerifBold() : LLFontGL::getFontSansSerifSmall());
     mOutfitWornText->setValue(value ? worn_string : "");

--- a/indra/newview/llpanelpermissions.cpp
+++ b/indra/newview/llpanelpermissions.cpp
@@ -399,7 +399,7 @@ void LLPanelPermissions::refresh()
 
     // Style for creator and owner links (both group and agent)
     LLStyle::Params style_params;
-    LLColor4 link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
+    LLUIColor link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
     style_params.color = link_color;
     style_params.readonly_color = link_color;
     style_params.is_link = true; // link will be added later

--- a/indra/newview/llscripteditor.cpp
+++ b/indra/newview/llscripteditor.cpp
@@ -122,7 +122,7 @@ void LLScriptEditor::drawLineNumbers()
                 const LLWString ltext = utf8str_to_wstring(llformat("%d", line.mLineNum ));
                 bool is_cur_line = cursor_line == line.mLineNum;
                 const U8 style = is_cur_line ? LLFontGL::BOLD : LLFontGL::NORMAL;
-                const LLColor4 fg_color = is_cur_line ? mCursorColor : mReadOnlyFgColor;
+                const LLColor4& fg_color = is_cur_line ? mCursorColor : mReadOnlyFgColor;
                 getScriptFont()->render(
                                  ltext, // string to draw
                                  0, // begin offset

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -128,12 +128,12 @@ F32 LLSelectMgr::sHighlightAlpha = 0.f;
 F32 LLSelectMgr::sHighlightAlphaTest = 0.f;
 F32 LLSelectMgr::sHighlightUAnim = 0.f;
 F32 LLSelectMgr::sHighlightVAnim = 0.f;
-LLColor4 LLSelectMgr::sSilhouetteParentColor;
-LLColor4 LLSelectMgr::sSilhouetteChildColor;
-LLColor4 LLSelectMgr::sHighlightInspectColor;
-LLColor4 LLSelectMgr::sHighlightParentColor;
-LLColor4 LLSelectMgr::sHighlightChildColor;
-LLColor4 LLSelectMgr::sContextSilhouetteColor;
+LLUIColor LLSelectMgr::sSilhouetteParentColor;
+LLUIColor LLSelectMgr::sSilhouetteChildColor;
+LLUIColor LLSelectMgr::sHighlightInspectColor;
+LLUIColor LLSelectMgr::sHighlightParentColor;
+LLUIColor LLSelectMgr::sHighlightChildColor;
+LLUIColor LLSelectMgr::sContextSilhouetteColor;
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // struct LLDeRezInfo
@@ -6437,8 +6437,10 @@ void LLSelectMgr::renderSilhouettes(bool for_hud)
     bool wireframe_selection = (gFloaterTools && gFloaterTools->getVisible()) || LLSelectMgr::sRenderHiddenSelections;
     F32 fogCfx = (F32)llclamp((LLSelectMgr::getInstance()->getSelectionCenterGlobal() - gAgentCamera.getCameraPositionGlobal()).magVec() / (LLSelectMgr::getInstance()->getBBoxOfSelection().getExtentLocal().magVec() * 4), 0.0, 1.0);
 
-    static LLColor4 sParentColor = LLColor4(sSilhouetteParentColor[VRED], sSilhouetteParentColor[VGREEN], sSilhouetteParentColor[VBLUE], LLSelectMgr::sHighlightAlpha);
-    static LLColor4 sChildColor = LLColor4(sSilhouetteChildColor[VRED], sSilhouetteChildColor[VGREEN], sSilhouetteChildColor[VBLUE], LLSelectMgr::sHighlightAlpha);
+    LLColor4 sParentColor = sSilhouetteParentColor;
+    sParentColor.mV[VALPHA] = LLSelectMgr::sHighlightAlpha;
+    LLColor4 sChildColor = sSilhouetteChildColor;
+    sChildColor.mV[VALPHA] = LLSelectMgr::sHighlightAlpha;
 
     auto renderMeshSelection_f = [fogCfx, wireframe_selection](LLSelectNode* node, LLViewerObject* objectp, LLColor4 hlColor)
     {
@@ -8006,12 +8008,9 @@ S32 LLObjectSelection::getSelectedObjectRenderCost()
                    cost += object->getRenderCost(textures);
                    computed_objects.insert(object->getID());
 
-                   const_child_list_t children = object->getChildren();
-                   for (const_child_list_t::const_iterator child_iter = children.begin();
-                         child_iter != children.end();
-                         ++child_iter)
+                   const const_child_list_t& children = object->getChildren();
+                   for (LLViewerObject* child_obj : children)
                    {
-                       LLViewerObject* child_obj = *child_iter;
                        LLVOVolume *child = dynamic_cast<LLVOVolume*>( child_obj );
                        if (child)
                        {

--- a/indra/newview/llselectmgr.h
+++ b/indra/newview/llselectmgr.h
@@ -44,6 +44,7 @@
 #include "llcontrol.h"
 #include "llviewerobject.h" // LLObjectSelection::getSelectedTEValue template
 #include "llmaterial.h"
+#include "lluicolor.h"
 
 #include <deque>
 #include <boost/iterator/filter_iterator.hpp>
@@ -450,12 +451,12 @@ public:
     static F32                  sHighlightAlphaTest;
     static F32                  sHighlightUAnim;
     static F32                  sHighlightVAnim;
-    static LLColor4             sSilhouetteParentColor;
-    static LLColor4             sSilhouetteChildColor;
-    static LLColor4             sHighlightParentColor;
-    static LLColor4             sHighlightChildColor;
-    static LLColor4             sHighlightInspectColor;
-    static LLColor4             sContextSilhouetteColor;
+    static LLUIColor            sSilhouetteParentColor;
+    static LLUIColor            sSilhouetteChildColor;
+    static LLUIColor            sHighlightParentColor;
+    static LLUIColor            sHighlightChildColor;
+    static LLUIColor            sHighlightInspectColor;
+    static LLUIColor            sContextSilhouetteColor;
 
     LLCachedControl<bool>                   mHideSelectedObjects;
     LLCachedControl<bool>                   mRenderHighlightSelections;

--- a/indra/newview/llsidepaneliteminfo.cpp
+++ b/indra/newview/llsidepaneliteminfo.cpp
@@ -351,7 +351,7 @@ void LLSidepanelItemInfo::refreshFromItem(LLViewerInventoryItem* item)
 
     // Style for creator and owner links
     LLStyle::Params style_params;
-    LLColor4 link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
+    LLUIColor link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
     style_params.color = link_color;
     style_params.readonly_color = link_color;
     style_params.is_link = true; // link will be added later

--- a/indra/newview/llspeakers.cpp
+++ b/indra/newview/llspeakers.cpp
@@ -368,8 +368,8 @@ void LLSpeakerMgr::update(bool resort_ok)
         return;
     }
 
-    LLColor4 speaking_color = LLUIColorTable::instance().getColor("SpeakingColor");
-    LLColor4 overdriven_color = LLUIColorTable::instance().getColor("OverdrivenColor");
+    static const LLUIColor speaking_color = LLUIColorTable::instance().getColor("SpeakingColor");
+    static const LLUIColor overdriven_color = LLUIColorTable::instance().getColor("OverdrivenColor");
 
     if(resort_ok) // only allow list changes when user is not interacting with it
     {

--- a/indra/newview/lltoolbarview.cpp
+++ b/indra/newview/lltoolbarview.cpp
@@ -566,7 +566,7 @@ void LLToolBarView::draw()
     // Draw drop zones if drop of a tool is active
     if (isToolDragged())
     {
-        LLColor4 drop_color = LLUIColorTable::instance().getColor( "ToolbarDropZoneColor" );
+        static const LLUIColor drop_color = LLUIColorTable::instance().getColor( "ToolbarDropZoneColor" );
 
         for (S32 i = LLToolBarEnums::TOOLBAR_FIRST; i <= LLToolBarEnums::TOOLBAR_LAST; i++)
         {

--- a/indra/newview/llviewerchat.cpp
+++ b/indra/newview/llviewerchat.cpp
@@ -41,7 +41,7 @@
 LLViewerChat::font_change_signal_t LLViewerChat::sChatFontChangedSignal;
 
 //static
-void LLViewerChat::getChatColor(const LLChat& chat, LLColor4& r_color)
+void LLViewerChat::getChatColor(const LLChat& chat, LLUIColor& r_color, F32& r_color_alpha)
 {
     if(chat.mMuted)
     {
@@ -90,7 +90,7 @@ void LLViewerChat::getChatColor(const LLChat& chat, LLColor4& r_color)
                 }
                 break;
             default:
-                r_color.setToWhite();
+                r_color = LLUIColorTable::instance().getColor("White");
         }
 
         if (!chat.mPosAgent.isExactlyZero())
@@ -101,7 +101,11 @@ void LLViewerChat::getChatColor(const LLChat& chat, LLColor4& r_color)
             if (distance_squared > dist_near_chat * dist_near_chat)
             {
                 // diminish far-off chat
-                r_color.mV[VALPHA] = 0.8f;
+                r_color_alpha = 0.8f;
+            }
+            else
+            {
+                r_color_alpha = 1.0f;
             }
         }
     }

--- a/indra/newview/llviewerchat.h
+++ b/indra/newview/llviewerchat.h
@@ -29,15 +29,14 @@
 
 #include "llchat.h"
 #include "llfontgl.h"
-#include "v4color.h"
-
+#include "lluicolor.h"
 
 class LLViewerChat
 {
 public:
     typedef boost::signals2::signal<void (LLFontGL*)> font_change_signal_t;
 
-    static void getChatColor(const LLChat& chat, LLColor4& r_color);
+    static void getChatColor(const LLChat& chat, LLUIColor& r_color, F32& r_color_alpha);
     static void getChatColor(const LLChat& chat, std::string& r_color_name, F32& r_color_alpha);
     static LLFontGL* getChatFont();
     static S32 getChatFontSize();

--- a/indra/newview/llviewerfloaterreg.cpp
+++ b/indra/newview/llviewerfloaterreg.cpp
@@ -134,6 +134,7 @@
 #include "llfloaterscriptlimits.h"
 #include "llfloatersearch.h"
 #include "llfloatersellland.h"
+#include "llfloatersettingscolor.h"
 #include "llfloatersettingsdebug.h"
 #include "llfloatersidepanelcontainer.h"
 #include "llfloatersnapshot.h"
@@ -486,6 +487,7 @@ void LLViewerFloaterReg::registerFloaters()
     LLFloaterReg::add("script_limits", "floater_script_limits.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloaterScriptLimits>);
     LLFloaterReg::add("my_scripts", "floater_my_scripts.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloaterMyScripts>);
     LLFloaterReg::add("sell_land", "floater_sell_land.xml", &LLFloaterSellLand::buildFloater);
+    LLFloaterReg::add("settings_color", "floater_settings_color.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloaterSettingsColor>);
     LLFloaterReg::add("settings_debug", "floater_settings_debug.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloaterSettingsDebug>);
     LLFloaterReg::add("sound_devices", "floater_sound_devices.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloaterSoundDevices>);
     LLFloaterReg::add("stats", "floater_stats.xml", (LLFloaterBuildFunc)&LLFloaterReg::build<LLFloater>);

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -536,9 +536,7 @@ void init_menus()
     ///
     /// set up the colors
     ///
-    LLColor4 color;
-
-    LLColor4 context_menu_color = LLUIColorTable::instance().getColor("MenuPopupBgColor");
+    LLUIColor context_menu_color = LLUIColorTable::instance().getColor("MenuPopupBgColor");
 
     gMenuAvatarSelf->setBackgroundColor( context_menu_color );
     gMenuAvatarOther->setBackgroundColor( context_menu_color );
@@ -548,7 +546,7 @@ void init_menus()
 
     gMenuLand->setBackgroundColor( context_menu_color );
 
-    color = LLUIColorTable::instance().getColor( "MenuPopupBgColor" );
+    LLUIColor color = LLUIColorTable::instance().getColor( "MenuPopupBgColor" );
     gPopupMenuView->setBackgroundColor( color );
 
     // If we are not in production, use a different color to make it apparent.

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -1715,15 +1715,15 @@ void LLViewerObjectList::clearAllMapObjectsInRegion(LLViewerRegion* regionp)
 
 void LLViewerObjectList::renderObjectsForMap(LLNetMap &netmap)
 {
-    LLColor4 above_water_color = LLUIColorTable::instance().getColor( "NetMapOtherOwnAboveWater" );
-    LLColor4 below_water_color = LLUIColorTable::instance().getColor( "NetMapOtherOwnBelowWater" );
-    LLColor4 you_own_above_water_color =
+    static const LLUIColor above_water_color = LLUIColorTable::instance().getColor( "NetMapOtherOwnAboveWater" );
+    static const LLUIColor below_water_color = LLUIColorTable::instance().getColor( "NetMapOtherOwnBelowWater" );
+    static const LLUIColor you_own_above_water_color =
                         LLUIColorTable::instance().getColor( "NetMapYouOwnAboveWater" );
-    LLColor4 you_own_below_water_color =
+    static const LLUIColor you_own_below_water_color =
                         LLUIColorTable::instance().getColor( "NetMapYouOwnBelowWater" );
-    LLColor4 group_own_above_water_color =
+    static const LLUIColor group_own_above_water_color =
                         LLUIColorTable::instance().getColor( "NetMapGroupOwnAboveWater" );
-    LLColor4 group_own_below_water_color =
+    static const LLUIColor group_own_below_water_color =
                         LLUIColorTable::instance().getColor( "NetMapGroupOwnBelowWater" );
 
     F32 max_radius = gSavedSettings.getF32("MiniMapPrimMaxRadius");
@@ -1753,7 +1753,7 @@ void LLViewerObjectList::renderObjectsForMap(LLNetMap &netmap)
         // See DEV-17370 and DEV-29869/SNOW-79 for details.
         approx_radius = llmin(approx_radius, max_radius);
 
-        LLColor4U color = above_water_color;
+        LLColor4U color = above_water_color.get();
         if( objectp->permYouOwner() )
         {
             const F32 MIN_RADIUS_FOR_OWNED_OBJECTS = 2.f;
@@ -1766,29 +1766,29 @@ void LLViewerObjectList::renderObjectsForMap(LLNetMap &netmap)
             {
                 if ( objectp->permGroupOwner() )
                 {
-                    color = group_own_above_water_color;
+                    color = group_own_above_water_color.get();
                 }
                 else
                 {
-                color = you_own_above_water_color;
+                color = you_own_above_water_color.get();
             }
             }
             else
             {
                 if ( objectp->permGroupOwner() )
                 {
-                    color = group_own_below_water_color;
+                    color = group_own_below_water_color.get();
                 }
             else
             {
-                color = you_own_below_water_color;
+                color = you_own_below_water_color.get();
             }
         }
         }
         else
         if( pos.mdV[VZ] < water_height )
         {
-            color = below_water_color;
+            color = below_water_color.get();
         }
 
         netmap.renderScaledPointGlobal(

--- a/indra/newview/llviewerparceloverlay.cpp
+++ b/indra/newview/llviewerparceloverlay.cpp
@@ -53,6 +53,14 @@
 static const U8  OVERLAY_IMG_COMPONENTS = 4;
 static const F32 LINE_WIDTH = 0.0625f;
 
+bool LLViewerParcelOverlay::sColorSetInitialized = false;
+LLUIColor LLViewerParcelOverlay::sAvailColor;
+LLUIColor LLViewerParcelOverlay::sOwnedColor;
+LLUIColor LLViewerParcelOverlay::sGroupColor;
+LLUIColor LLViewerParcelOverlay::sSelfColor;
+LLUIColor LLViewerParcelOverlay::sForSaleColor;
+LLUIColor LLViewerParcelOverlay::sAuctionColor;
+
 LLViewerParcelOverlay::LLViewerParcelOverlay(LLViewerRegion* region, F32 region_width_meters)
 :   mRegion( region ),
     mParcelGridsPerEdge( S32( region_width_meters / PARCEL_GRID_STEP_METERS ) ),
@@ -60,6 +68,17 @@ LLViewerParcelOverlay::LLViewerParcelOverlay(LLViewerRegion* region, F32 region_
     mTimeSinceLastUpdate(),
     mOverlayTextureIdx(-1)
 {
+    if (!sColorSetInitialized)
+    {
+        sColorSetInitialized = true;
+        sAvailColor = LLUIColorTable::instance().getColor("PropertyColorAvail").get();
+        sOwnedColor = LLUIColorTable::instance().getColor("PropertyColorOther").get();
+        sGroupColor = LLUIColorTable::instance().getColor("PropertyColorGroup").get();
+        sSelfColor = LLUIColorTable::instance().getColor("PropertyColorSelf").get();
+        sForSaleColor = LLUIColorTable::instance().getColor("PropertyColorForSale").get();
+        sAuctionColor = LLUIColorTable::instance().getColor("PropertyColorAuction").get();
+    }
+
     // Create a texture to hold color information.
     // 4 components
     // Use mipmaps = false, clamped, NEAREST filter, for sharp edges
@@ -321,12 +340,12 @@ void LLViewerParcelOverlay::updateOverlayTexture()
         mOverlayTextureIdx = 0;
     }
 
-    const LLColor4U avail = LLUIColorTable::instance().getColor("PropertyColorAvail").get();
-    const LLColor4U owned = LLUIColorTable::instance().getColor("PropertyColorOther").get();
-    const LLColor4U group = LLUIColorTable::instance().getColor("PropertyColorGroup").get();
-    const LLColor4U self  = LLUIColorTable::instance().getColor("PropertyColorSelf").get();
-    const LLColor4U for_sale  = LLUIColorTable::instance().getColor("PropertyColorForSale").get();
-    const LLColor4U auction  = LLUIColorTable::instance().getColor("PropertyColorAuction").get();
+    const LLColor4U avail = sAvailColor.get();
+    const LLColor4U owned = sOwnedColor.get();
+    const LLColor4U group = sGroupColor.get();
+    const LLColor4U self  = sSelfColor.get();
+    const LLColor4U for_sale = sForSaleColor.get();
+    const LLColor4U auction = sAuctionColor.get();
 
     // Create the base texture.
     U8 *raw = mImageRaw->getData();
@@ -339,7 +358,7 @@ void LLViewerParcelOverlay::updateOverlayTexture()
     {
         U8 ownership = mOwnership[i];
 
-        F32 r,g,b,a;
+        U8 r,g,b,a;
 
         // Color stored in low three bits
         switch( ownership & 0x7 )
@@ -433,11 +452,11 @@ void LLViewerParcelOverlay::updatePropertyLines()
         return;
 
     LLColor4U colors[PARCEL_COLOR_MASK + 1];
-    colors[PARCEL_SELF] = LLUIColorTable::instance().getColor("PropertyColorSelf").get();
-    colors[PARCEL_OWNED] = LLUIColorTable::instance().getColor("PropertyColorOther").get();
-    colors[PARCEL_GROUP] = LLUIColorTable::instance().getColor("PropertyColorGroup").get();
-    colors[PARCEL_FOR_SALE] = LLUIColorTable::instance().getColor("PropertyColorForSale").get();
-    colors[PARCEL_AUCTION] = LLUIColorTable::instance().getColor("PropertyColorAuction").get();
+    colors[PARCEL_SELF] = sSelfColor.get();
+    colors[PARCEL_OWNED] = sOwnedColor.get();
+    colors[PARCEL_GROUP] = sGroupColor.get();
+    colors[PARCEL_FOR_SALE] = sForSaleColor.get();
+    colors[PARCEL_AUCTION] = sAuctionColor.get();
 
     mEdges.clear();
 

--- a/indra/newview/llviewerparceloverlay.h
+++ b/indra/newview/llviewerparceloverlay.h
@@ -35,6 +35,7 @@
 #include "lluuid.h"
 #include "llviewertexture.h"
 #include "llgl.h"
+#include "lluicolor.h"
 
 class LLViewerRegion;
 class LLVector3;
@@ -123,6 +124,14 @@ private:
     };
 
     std::vector<Edge> mEdges;
+
+    static bool sColorSetInitialized;
+    static LLUIColor sAvailColor;
+    static LLUIColor sOwnedColor;
+    static LLUIColor sGroupColor;
+    static LLUIColor sSelfColor;
+    static LLUIColor sForSaleColor;
+    static LLUIColor sAuctionColor;
 };
 
 #endif

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -222,15 +222,9 @@ public:
         image_rect.mTop = image_rect.mBottom + mImage->getHeight();
         mImage->draw(LLRect((S32)image_rect.mLeft, (S32)image_rect.mTop, (S32)image_rect.mRight, (S32)image_rect.mBottom));
 
-        LLColor4 color;
-        if (mEditor.getReadOnly())
-        {
-            color = LLUIColorTable::instance().getColor("TextEmbeddedItemReadOnlyColor");
-        }
-        else
-        {
-            color = LLUIColorTable::instance().getColor("TextEmbeddedItemColor");
-        }
+        static const LLUIColor embedded_item_readonly_col = LLUIColorTable::instance().getColor("TextEmbeddedItemReadOnlyColor");
+        static const LLUIColor embedded_item_col = LLUIColorTable::instance().getColor("TextEmbeddedItemColor");
+        const LLColor4& color = mEditor.getReadOnly() ? embedded_item_readonly_col : embedded_item_col;
 
         F32 right_x;
         mStyle->getFont()->render(mLabel, 0, image_rect.mRight + EMBEDDED_ITEM_LABEL_PADDING, draw_rect.mTop, color, LLFontGL::LEFT, LLFontGL::TOP, LLFontGL::UNDERLINE, LLFontGL::NO_SHADOW, static_cast<S32>(mLabel.length()), S32_MAX, &right_x);

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -2583,7 +2583,7 @@ void LLViewerWindow::setNormalControlsVisible( bool visible )
 void LLViewerWindow::setMenuBackgroundColor(bool god_mode, bool dev_grid)
 {
     LLSD args;
-    LLColor4 new_bg_color;
+    LLUIColor new_bg_color;
 
     // god more important than project, proj more important than grid
     if ( god_mode )

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -2190,7 +2190,7 @@ void LLViewerWindow::initWorldUI()
         gStatusBar->setFollows(FOLLOWS_LEFT | FOLLOWS_TOP | FOLLOWS_RIGHT);
         gStatusBar->setShape(status_bar_container->getLocalRect());
         // sync bg color with menu bar
-        gStatusBar->setBackgroundColor(gMenuBarView->getBackgroundColor().get());
+        gStatusBar->setBackgroundColor(gMenuBarView->getBackgroundColor());
         // add InBack so that gStatusBar won't be drawn over menu
         status_bar_container->addChildInBack(gStatusBar, 2/*tab order, after menu*/);
         status_bar_container->setVisible(true);
@@ -2199,7 +2199,7 @@ void LLViewerWindow::initWorldUI()
         LLView* nav_bar_container = getRootView()->getChild<LLView>("nav_bar_container");
 
         navbar->setShape(nav_bar_container->getLocalRect());
-        navbar->setBackgroundColor(gMenuBarView->getBackgroundColor().get());
+        navbar->setBackgroundColor(gMenuBarView->getBackgroundColor());
         nav_bar_container->addChild(navbar);
         nav_bar_container->setVisible(true);
     }

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -3531,7 +3531,9 @@ void LLVOAvatar::idleUpdateNameTagText(bool new_name)
         std::deque<LLChat>::iterator chat_iter = mChats.begin();
         mNameText->clearString();
 
-        LLColor4 new_chat = LLUIColorTable::instance().getColor( isSelf() ? "UserChatColor" : "AgentChatColor" );
+        static const LLUIColor user_chat_color = LLUIColorTable::instance().getColor("UserChatColor");
+        static const LLUIColor agent_chat_color = LLUIColorTable::instance().getColor("AgentChatColor");
+        const LLColor4& new_chat = isSelf() ? user_chat_color : agent_chat_color;
         LLColor4 normal_chat = lerp(new_chat, LLColor4(0.8f, 0.8f, 0.8f, 1.f), 0.7f);
         LLColor4 old_chat = lerp(normal_chat, LLColor4(0.6f, 0.6f, 0.6f, 1.f), 0.7f);
         if (mTyping && mChats.size() >= MAX_BUBBLE_CHAT_UTTERANCES)

--- a/indra/newview/skins/default/xui/en/floater_settings_color.xml
+++ b/indra/newview/skins/default/xui/en/floater_settings_color.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<floater
+    legacy_header_height="18"
+    can_minimize="false"
+    height="360"
+    min_height="367"
+    layout="topleft"
+    name="settings_color"
+    help_topic="settings_color"
+    title="COLOR SETTINGS"
+    reuse_instance="true"
+    can_resize="true"
+    min_width="550"
+    width="570">
+    <filter_editor
+        follows="left|top|right"
+        height="23"
+        layout="topleft"
+        left="10"
+        right="-10"
+        label="Enter search text"
+        max_length_chars="300"
+        name="filter_input"
+        text_pad_left="10"
+        top="30" />
+    <scroll_list
+        column_padding="0"
+        draw_heading="true"
+        draw_stripes="false"
+        heading_height="23"
+        height="266"
+        layout="topleft"
+        search_column="1"
+        sort_column="1"
+        left="10"
+        follows="left|top|bottom"
+        name="setting_list"
+        top_pad="2"
+        width="300">
+        <scroll_list.columns
+            name="changed_color"
+            relative_width="0.05" />
+        <scroll_list.columns
+            label="Color"
+            name="color" />
+    </scroll_list>
+    <text
+        type="string"
+        length="1"
+        follows="left|top"
+        height="16"
+        layout="topleft"
+        name="color_name_txt"
+        font="SansSerifSmallBold"
+        top_delta="8"
+        left_pad="10"
+        visible="true"
+        use_ellipses="true"
+        text_color="White"
+        width="240">
+        Color name
+    </text>
+    <color_swatch
+        top_pad="0"
+        left_delta="0"
+        follows="top|left"
+        can_apply_immediately="true"
+        height="180"
+        name="color_swatch"
+        visible="true"
+        layout="topleft"
+        width="240">
+        <color_swatch.commit_callback
+            function="CommitSettings" />
+    </color_swatch>
+    <spinner
+        height="20"
+        label="Alpha"
+        layout="topleft"
+        follows="top|left"
+        left_delta="0"
+        min_val="0"
+        max_val="1"
+        decimal_digits="3"
+        name="alpha_spinner"
+        top_pad="5"
+        visible="true"
+        width="120">
+        <spinner.commit_callback
+            function="CommitSettings" />
+    </spinner>
+    <button
+        height="22"
+        label="Reset to default"
+        follows="left|top"
+        layout="topleft"
+        left_delta="0"
+        name="default_btn"
+        visible="true"
+        top_pad="15"
+        width="150">
+        <button.commit_callback
+            function="ClickDefault" />
+    </button>
+    <check_box
+        control_name="ColorSettingsHideDefault"
+        height="16"
+        initial_value="true"
+        label="Show changed colors only"
+        layout="topleft"
+        top_pad="10"
+        left="10"
+        follows="left|bottom"
+        name="hide_default"
+        width="330">
+    </check_box>
+</floater>

--- a/indra/newview/skins/default/xui/en/menu_login.xml
+++ b/indra/newview/skins/default/xui/en/menu_login.xml
@@ -149,6 +149,13 @@
              function="Advanced.ShowDebugSettings"
              parameter="all" />
         </menu_item_call>
+        <menu_item_call
+         label="Show Color settings"
+         name="Color Settings">
+            <menu_item_call.on_click
+             function="Floater.Toggle"
+             parameter="settings_color" />
+        </menu_item_call>
         <menu_item_separator />
         <menu_item_call
          label="XUI Preview Tool"

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3830,6 +3830,13 @@ function="World.EnvPreset"
          name="XUI"
          tear_off="true">
             <menu_item_call
+             label="Show Color settings"
+             name="Color Settings">
+                <menu_item_call.on_click
+                 function="Floater.Toggle"
+                 parameter="settings_color" />
+            </menu_item_call>
+            <menu_item_call
                label="Reload Color Settings"
                name="Reload Color Settings">
               <menu_item_call.on_click


### PR DESCRIPTION
* Introduce a floater that can access LLUIColortable and update/reset color settings
* Fix chat colors not dynamically updating when changed in preferences
* Fix script editors not dynamically updating when changed in script editor preferences
* Introduce alpha parameter to LLStyle to allow setting text UI color alpha at runtime without breaking reference to color table
* Cache and optimize various color finds during draw
![secondlife-bin_PqC1iTCO8o](https://github.com/user-attachments/assets/f68ed401-9263-49d8-8a14-23bda101abe8)
![secondlife-bin_Oyci8svenn](https://github.com/user-attachments/assets/41b0be99-09e7-4f82-be39-bbd9974dc89b)
![secondlife-bin_yyQDD3WWFn](https://github.com/user-attachments/assets/223dd6db-b39b-49f4-8fdc-560dd2fd85a2)
