### PR TITLE
Ignore VmallocTotal from /proc/meminfo

### DIFF
--- a/indra/cmake/Linking.cmake
+++ b/indra/cmake/Linking.cmake
@@ -7,6 +7,7 @@ set(ARCH_PREBUILT_DIRS ${AUTOBUILD_INSTALL_DIR}/lib)
 set(ARCH_PREBUILT_DIRS_PLUGINS ${AUTOBUILD_INSTALL_DIR}/plugins)
 set(ARCH_PREBUILT_DIRS_RELEASE ${AUTOBUILD_INSTALL_DIR}/lib/release)
 set(ARCH_PREBUILT_DIRS_DEBUG ${AUTOBUILD_INSTALL_DIR}/lib/debug)
+
 if (WINDOWS OR DARWIN )
   # Kludge for older cmake versions, 3.20+ is needed to use a genex in add_custom_command( OUTPUT <var> ... )
   # Using this will work okay-ish, as Debug is not supported anyway. But for property multi config and also

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -1107,6 +1107,14 @@ LLSD LLMemoryInfo::loadStatsMap()
                 LLSD::String key(matched[1].first, matched[1].second);
                 LLSD::String value_str(matched[2].first, matched[2].second);
                 LLSD::Integer value(0);
+
+                // Skip over VmallocTotal. It's just a fixed and huge number on (modern) systems. "34359738367 kB"
+                // https://unix.stackexchange.com/questions/700724/why-is-vmalloctotal-34359738367-kb
+                // If not skipped converting it to a LLSD::integer (32 bit) will fail and spam the logs (this function
+                // is called quite frequently).
+                if( key == "VmallocTotal")
+                    continue;
+
                 try
                 {
                     value = boost::lexical_cast<LLSD::Integer>(value_str);


### PR DESCRIPTION
Ignore VmallocTotal as it's fixed, huge Number.
Not ignoring it will cause a lot of log spam due to conversion/parse errors.
