### PR TITLE
viewer#2203 Crash at breakVoiceConnectionCoro

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -459,6 +459,7 @@ void LLWebRTCVoiceClient::voiceConnectionCoro()
             // Could help with voice updates making for smoother
             // voice when we're busy.
             llcoro::suspendUntilTimeout(UPDATE_THROTTLE_SECONDS);
+            if (sShuttingDown) return; // 'this' migh already be invalid
             bool voiceEnabled = mVoiceEnabled;
 
             if (!isAgentAvatarValid())
@@ -2186,47 +2187,47 @@ void LLVoiceWebRTCConnection::processIceUpdates()
 {
     mOutstandingRequests++;
     LLCoros::getInstance()->launch("LLVoiceWebRTCConnection::processIceUpdatesCoro",
-                                   boost::bind(&LLVoiceWebRTCConnection::processIceUpdatesCoro, this));
+                                   boost::bind(&LLVoiceWebRTCConnection::processIceUpdatesCoro, this->shared_from_this()));
 }
 
 // Ice candidates may be streamed in before or after the SDP offer is available (see below)
 // This function determines whether candidates are available to send to the Secondlife WebRTC
 // server via the simulator.  If so, and there are no more candidates, this code
 // will make the cap call to the server sending up the ICE candidates.
-void LLVoiceWebRTCConnection::processIceUpdatesCoro()
+void LLVoiceWebRTCConnection::processIceUpdatesCoro(connectionPtr_t connection)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOICE
 
-    if (mShutDown || LLWebRTCVoiceClient::isShuttingDown())
+    if (connection->mShutDown || LLWebRTCVoiceClient::isShuttingDown())
     {
-        mOutstandingRequests--;
+        connection->mOutstandingRequests--;
         return;
     }
 
     bool iceCompleted = false;
     LLSD body;
-    if (!mIceCandidates.empty() || mIceCompleted)
+    if (!connection->mIceCandidates.empty() || connection->mIceCompleted)
     {
-        LLViewerRegion *regionp = LLWorld::instance().getRegionFromID(mRegionID);
+        LLViewerRegion *regionp = LLWorld::instance().getRegionFromID(connection->mRegionID);
         if (!regionp || !regionp->capabilitiesReceived())
         {
             LL_DEBUGS("Voice") << "no capabilities for ice gathering; waiting " << LL_ENDL;
-            mOutstandingRequests--;
+            connection->mOutstandingRequests--;
             return;
         }
 
         std::string url = regionp->getCapability("VoiceSignalingRequest");
         if (url.empty())
         {
-            mOutstandingRequests--;
+            connection->mOutstandingRequests--;
             return;
         }
 
         LL_DEBUGS("Voice") << "region ready to complete voice signaling; url=" << url << LL_ENDL;
-        if (!mIceCandidates.empty())
+        if (!connection->mIceCandidates.empty())
         {
             LLSD candidates = LLSD::emptyArray();
-            for (auto &ice_candidate : mIceCandidates)
+            for (auto &ice_candidate : connection->mIceCandidates)
             {
                 LLSD body_candidate;
                 body_candidate["sdpMid"]        = ice_candidate.mSdpMid;
@@ -2235,18 +2236,18 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro()
                 candidates.append(body_candidate);
             }
             body["candidates"] = candidates;
-            mIceCandidates.clear();
+            connection->mIceCandidates.clear();
         }
-        else if (mIceCompleted)
+        else if (connection->mIceCompleted)
         {
             LLSD body_candidate;
             body_candidate["completed"] = true;
             body["candidate"]           = body_candidate;
-            iceCompleted                = mIceCompleted;
-            mIceCompleted               = false;
+            iceCompleted                = connection->mIceCompleted;
+            connection->mIceCompleted   = false;
         }
 
-        body["viewer_session"]    = mViewerSession;
+        body["viewer_session"]    = connection->mViewerSession;
         body["voice_server_type"] = WEBRTC_VOICE_SERVER_TYPE;
 
         LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t httpAdapter(
@@ -2261,7 +2262,7 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro()
 
         if (LLWebRTCVoiceClient::isShuttingDown())
         {
-            mOutstandingRequests--;
+            connection->mOutstandingRequests--;
             return;
         }
 
@@ -2271,10 +2272,10 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro()
         if (!status)
         {
             // couldn't trickle the candidates, so restart the session.
-            setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
+            connection->setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
         }
     }
-    mOutstandingRequests--;
+    connection->mOutstandingRequests--;
 }
 
 
@@ -2428,31 +2429,31 @@ void LLVoiceWebRTCConnection::sendData(const std::string &data)
 
 // Tell the simulator that we're shutting down a voice connection.
 // The simulator will pass this on to the Secondlife WebRTC server.
-void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
+void LLVoiceWebRTCConnection::breakVoiceConnectionCoro(connectionPtr_t connection)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOICE
 
     LL_DEBUGS("Voice") << "Disconnecting voice." << LL_ENDL;
-    if (mWebRTCDataInterface)
+    if (connection->mWebRTCDataInterface)
     {
-        mWebRTCDataInterface->unsetDataObserver(this);
-        mWebRTCDataInterface = nullptr;
+        connection->mWebRTCDataInterface->unsetDataObserver(connection.get());
+        connection->mWebRTCDataInterface = nullptr;
     }
-    mWebRTCAudioInterface   = nullptr;
-    LLViewerRegion *regionp = LLWorld::instance().getRegionFromID(mRegionID);
+    connection->mWebRTCAudioInterface   = nullptr;
+    LLViewerRegion *regionp = LLWorld::instance().getRegionFromID(connection->mRegionID);
     if (!regionp || !regionp->capabilitiesReceived())
     {
         LL_DEBUGS("Voice") << "no capabilities for voice provisioning; waiting " << LL_ENDL;
-        setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
-        mOutstandingRequests--;
+        connection->setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
+        connection->mOutstandingRequests--;
         return;
     }
 
     std::string url = regionp->getCapability("ProvisionVoiceAccountRequest");
     if (url.empty())
     {
-        setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
-        mOutstandingRequests--;
+        connection->setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
+        connection->mOutstandingRequests--;
         return;
     }
 
@@ -2461,7 +2462,7 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
     LLVoiceWebRTCStats::getInstance()->provisionAttemptStart();
     LLSD body;
     body["logout"]         = TRUE;
-    body["viewer_session"] = mViewerSession;
+    body["viewer_session"] = connection->mViewerSession;
     body["voice_server_type"] = WEBRTC_VOICE_SERVER_TYPE;
 
     LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t httpAdapter(
@@ -2472,15 +2473,15 @@ void LLVoiceWebRTCConnection::breakVoiceConnectionCoro()
 
     httpOpts->setWantHeaders(true);
 
-    mOutstandingRequests++;
+    connection->mOutstandingRequests++;
 
     // tell the server to shut down the connection as a courtesy.
     // shutdownConnection will drop the WebRTC connection which will
     // also shut things down.
     LLSD result = httpAdapter->postAndSuspend(httpRequest, url, body, httpOpts);
 
-    mOutstandingRequests--;
-    setVoiceConnectionState(VOICE_STATE_SESSION_EXIT);
+    connection->mOutstandingRequests--;
+    connection->setVoiceConnectionState(VOICE_STATE_SESSION_EXIT);
 }
 
 // Tell the simulator to tell the Secondlife WebRTC server that we want a voice
@@ -2664,7 +2665,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
             // VOICE_STATE_SESSION_ESTABLISHED via a callback on a webrtc thread.
             setVoiceConnectionState(VOICE_STATE_CONNECTION_WAIT);
             LLCoros::getInstance()->launch("LLVoiceWebRTCConnection::requestVoiceConnectionCoro",
-                                           boost::bind(&LLVoiceWebRTCConnection::requestVoiceConnectionCoro, this));
+                                           boost::bind(&LLVoiceWebRTCConnection::requestVoiceConnectionCoro, this->shared_from_this()));
             break;
 
         case VOICE_STATE_CONNECTION_WAIT:
@@ -2744,7 +2745,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
         case VOICE_STATE_DISCONNECT:
             setVoiceConnectionState(VOICE_STATE_WAIT_FOR_EXIT);
             LLCoros::instance().launch("LLVoiceWebRTCConnection::breakVoiceConnectionCoro",
-                                       boost::bind(&LLVoiceWebRTCConnection::breakVoiceConnectionCoro, this));
+                                       boost::bind(&LLVoiceWebRTCConnection::breakVoiceConnectionCoro, this->shared_from_this()));
             break;
 
         case VOICE_STATE_WAIT_FOR_EXIT:

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -576,7 +576,8 @@ class LLVoiceWebRTCStats : public LLSingleton<LLVoiceWebRTCStats>
 
 class LLVoiceWebRTCConnection :
     public llwebrtc::LLWebRTCSignalingObserver,
-    public llwebrtc::LLWebRTCDataObserver
+    public llwebrtc::LLWebRTCDataObserver,
+    public boost::enable_shared_from_this<LLVoiceWebRTCConnection>
 {
   public:
     LLVoiceWebRTCConnection(const LLUUID &regionID, const std::string &channelID);
@@ -610,7 +611,7 @@ class LLVoiceWebRTCConnection :
 
     void processIceUpdates();
 
-    void processIceUpdatesCoro();
+    static void processIceUpdatesCoro(connectionPtr_t connection);
 
     virtual void setMuteMic(bool muted);
     virtual void setSpeakerVolume(F32 volume);
@@ -677,9 +678,9 @@ class LLVoiceWebRTCConnection :
     }
 
     virtual void requestVoiceConnection() = 0;
-    void requestVoiceConnectionCoro() { requestVoiceConnection(); }
+    static void requestVoiceConnectionCoro(connectionPtr_t connection) { connection->requestVoiceConnection(); }
 
-    void breakVoiceConnectionCoro();
+    static void breakVoiceConnectionCoro(connectionPtr_t connection);
 
     LLVoiceClientStatusObserver::EStatusType mCurrentStatus;
 


### PR DESCRIPTION
Bar webrtc's coroutines from necromancy.

Coroutines (at least our implementation) routinely outlive their caller, make them static where possible and shore up where not.