### PR TITLE
Replace boost::shared_ptr with std in voice classes

### DIFF
--- a/indra/llcommon/llerrorcontrol.h
+++ b/indra/llcommon/llerrorcontrol.h
@@ -198,7 +198,7 @@ namespace LLError
     };
 
     /**
-     * @NOTE: addRecorder() and removeRecorder() uses the boost::shared_ptr to allow for shared ownership
+     * @NOTE: addRecorder() and removeRecorder() uses the std::shared_ptr to allow for shared ownership
      * while still ensuring that the allocated memory is eventually freed
      */
     LL_COMMON_API void addRecorder(RecorderPtr);

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -28,7 +28,6 @@
 #include "llsettingsdaycycle.h"
 #include "llerror.h"
 #include <algorithm>
-#include <boost/make_shared.hpp>
 #include "lltrace.h"
 #include "llfasttimer.h"
 #include "v3colorutil.h"

--- a/indra/llinventory/llsettingswater.cpp
+++ b/indra/llinventory/llsettingswater.cpp
@@ -27,7 +27,6 @@
 
 #include "llsettingswater.h"
 #include <algorithm>
-#include <boost/make_shared.hpp>
 #include "lltrace.h"
 #include "llfasttimer.h"
 #include "v3colorutil.h"

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -54,8 +54,6 @@
 
 #include "llregioninfomodel.h"
 
-#include <boost/make_shared.hpp>
-
 #include "llatmosphere.h"
 #include "llagent.h"
 #include "roles_constants.h"

--- a/indra/newview/lleventpoll.cpp
+++ b/indra/newview/lleventpoll.cpp
@@ -40,8 +40,6 @@
 #include "llcorehttputil.h"
 #include "lleventfilter.h"
 
-#include "boost/make_shared.hpp"
-
 namespace LLEventPolling
 {
 namespace Details

--- a/indra/newview/llfloatereditenvironmentbase.cpp
+++ b/indra/newview/llfloatereditenvironmentbase.cpp
@@ -28,8 +28,6 @@
 
 #include "llfloatereditenvironmentbase.h"
 
-#include <boost/make_shared.hpp>
-
 // libs
 #include "llnotifications.h"
 #include "llnotificationsutil.h"

--- a/indra/newview/llfloaterfixedenvironment.cpp
+++ b/indra/newview/llfloaterfixedenvironment.cpp
@@ -28,8 +28,6 @@
 
 #include "llfloaterfixedenvironment.h"
 
-#include <boost/make_shared.hpp>
-
 // libs
 #include "llbutton.h"
 #include "llnotifications.h"

--- a/indra/newview/lloutputmonitorctrl.cpp
+++ b/indra/newview/lloutputmonitorctrl.cpp
@@ -126,29 +126,31 @@ void LLOutputMonitorCtrl::draw()
     const F32 LEVEL_1 = LLVoiceClient::OVERDRIVEN_POWER_LEVEL * 2.f / 3.f;
     const F32 LEVEL_2 = LLVoiceClient::OVERDRIVEN_POWER_LEVEL;
 
+    LLVoiceClient* vocie_client = LLVoiceClient::getInstance();
+
     if (getVisible() && mAutoUpdate && !getIsMuted() && mSpeakerId.notNull())
     {
-        setPower(LLVoiceClient::getInstance()->getCurrentPower(mSpeakerId));
+        setPower(vocie_client->getCurrentPower(mSpeakerId));
         if(mIsAgentControl)
         {
-            setIsTalking(LLVoiceClient::getInstance()->getUserPTTState());
+            setIsTalking(vocie_client->getUserPTTState());
         }
         else
         {
-            setIsTalking(LLVoiceClient::getInstance()->getIsSpeaking(mSpeakerId));
+            setIsTalking(vocie_client->getIsSpeaking(mSpeakerId));
         }
     }
 
     if ((mPower == 0.f && !mIsTalking) && mShowParticipantsSpeaking)
     {
         std::set<LLUUID> participant_uuids;
-        LLVoiceClient::instance().getParticipantList(participant_uuids);
+        vocie_client->getParticipantList(participant_uuids);
         std::set<LLUUID>::const_iterator part_it = participant_uuids.begin();
 
         F32 power = 0;
         for (; part_it != participant_uuids.end(); ++part_it)
         {
-            power = LLVoiceClient::instance().getCurrentPower(*part_it);
+            power = vocie_client->getCurrentPower(*part_it);
             if (power)
             {
                 mPower = power;

--- a/indra/newview/llsculptidsize.cpp
+++ b/indra/newview/llsculptidsize.cpp
@@ -29,8 +29,6 @@
 #include "llvovolume.h"
 #include "lldrawable.h"
 #include "llvoavatar.h"
-//boost
-#include "boost/make_shared.hpp"
 
 //...........
 

--- a/indra/newview/llselectmgr.h
+++ b/indra/newview/llselectmgr.h
@@ -48,7 +48,6 @@
 #include <deque>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/signals2.hpp>
-#include <boost/make_shared.hpp>    // boost::make_shared
 
 class LLMessageSystem;
 class LLViewerTexture;

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -33,7 +33,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <boost/make_shared.hpp>
 #include "lltrace.h"
 #include "llfasttimer.h"
 #include "v3colorutil.h"

--- a/indra/newview/llspeakers.cpp
+++ b/indra/newview/llspeakers.cpp
@@ -377,16 +377,17 @@ void LLSpeakerMgr::update(BOOL resort_ok)
     }
 
     // update status of all current speakers
-    BOOL voice_channel_active = (!mVoiceChannel && LLVoiceClient::getInstance()->inProximalChannel()) || (mVoiceChannel && mVoiceChannel->isActive());
+    LLVoiceClient* voice_client = LLVoiceClient::getInstance();
+    bool voice_channel_active = (!mVoiceChannel && voice_client->inProximalChannel()) || (mVoiceChannel && mVoiceChannel->isActive());
     for (speaker_map_t::iterator speaker_it = mSpeakers.begin(); speaker_it != mSpeakers.end(); speaker_it++)
     {
         LLUUID speaker_id = speaker_it->first;
         LLSpeaker* speakerp = speaker_it->second;
 
-        if (voice_channel_active && LLVoiceClient::getInstance()->getVoiceEnabled(speaker_id))
+        if (voice_channel_active && voice_client->getVoiceEnabled(speaker_id))
         {
-            speakerp->mSpeechVolume = LLVoiceClient::getInstance()->getCurrentPower(speaker_id);
-            BOOL moderator_muted_voice = LLVoiceClient::getInstance()->getIsModeratorMuted(speaker_id);
+            speakerp->mSpeechVolume = voice_client->getCurrentPower(speaker_id);
+            BOOL moderator_muted_voice = voice_client->getIsModeratorMuted(speaker_id);
             if (moderator_muted_voice != speakerp->mModeratorMutedVoice)
             {
                 speakerp->mModeratorMutedVoice = moderator_muted_voice;
@@ -394,11 +395,11 @@ void LLSpeakerMgr::update(BOOL resort_ok)
                 speakerp->fireEvent(new LLSpeakerVoiceModerationEvent(speakerp));
             }
 
-            if (LLVoiceClient::getInstance()->getOnMuteList(speaker_id) || speakerp->mModeratorMutedVoice)
+            if (voice_client->getOnMuteList(speaker_id) || speakerp->mModeratorMutedVoice)
             {
                 speakerp->mStatus = LLSpeaker::STATUS_MUTED;
             }
-            else if (LLVoiceClient::getInstance()->getIsSpeaking(speaker_id))
+            else if (voice_client->getIsSpeaking(speaker_id))
             {
                 // reset inactivity expiration
                 if (speakerp->mStatus != LLSpeaker::STATUS_SPEAKING)
@@ -481,17 +482,18 @@ void LLSpeakerMgr::update(BOOL resort_ok)
 void LLSpeakerMgr::updateSpeakerList()
 {
     // Are we bound to the currently active voice channel?
-    if ((!mVoiceChannel && LLVoiceClient::getInstance()->inProximalChannel()) || (mVoiceChannel && mVoiceChannel->isActive()))
+    LLVoiceClient* vocie_client = LLVoiceClient::getInstance();
+    if ((!mVoiceChannel && vocie_client->inProximalChannel()) || (mVoiceChannel && mVoiceChannel->isActive()))
     {
         std::set<LLUUID> participants;
-        LLVoiceClient::getInstance()->getParticipantList(participants);
+        vocie_client->getParticipantList(participants);
         // If we are, add all voice client participants to our list of known speakers
         for (std::set<LLUUID>::iterator participant_it = participants.begin(); participant_it != participants.end(); ++participant_it)
         {
                 setSpeaker(*participant_it,
-                           LLVoiceClient::getInstance()->getDisplayName(*participant_it),
+                    vocie_client->getDisplayName(*participant_it),
                            LLSpeaker::STATUS_VOICE_ACTIVE,
-                           (LLVoiceClient::getInstance()->isParticipantAvatar(*participant_it)?LLSpeaker::SPEAKER_AGENT:LLSpeaker::SPEAKER_EXTERNAL));
+                           (vocie_client->isParticipantAvatar(*participant_it)?LLSpeaker::SPEAKER_AGENT:LLSpeaker::SPEAKER_EXTERNAL));
         }
     }
     else if (mVoiceChannel)

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -187,13 +187,13 @@ void LLVoiceChannel::handleError(EStatusType type)
     setState(STATE_ERROR);
 }
 
-BOOL LLVoiceChannel::isActive()
+bool LLVoiceChannel::isActive() const
 {
     // only considered active when currently bound channel matches what our channel
     return callStarted() && LLVoiceClient::getInstance()->isCurrentChannel(mChannelInfo);
 }
 
-BOOL LLVoiceChannel::callStarted()
+bool LLVoiceChannel::callStarted() const
 {
     return mState >= STATE_CALL_STARTED;
 }
@@ -662,7 +662,7 @@ LLVoiceChannelProximal::LLVoiceChannelProximal() :
 {
 }
 
-BOOL LLVoiceChannelProximal::isActive()
+bool LLVoiceChannelProximal::isActive() const
 {
     return callStarted() && LLVoiceClient::getInstance()->inProximalChannel();
 }

--- a/indra/newview/llvoicechannel.h
+++ b/indra/newview/llvoicechannel.h
@@ -74,8 +74,8 @@ public:
     virtual void activate();
     virtual void setChannelInfo(const LLSD &channelInfo);
     virtual void requestChannelInfo();
-    virtual BOOL isActive();
-    virtual BOOL callStarted();
+    virtual bool isActive() const;
+    virtual bool callStarted() const;
 
     // Session name is a UI label used for feedback about which person,
     // group, or phone number you are talking to
@@ -170,7 +170,7 @@ class LLVoiceChannelProximal : public LLVoiceChannel, public LLSingleton<LLVoice
     void onChange(EStatusType status, const LLSD &channelInfo, bool proximal) override;
     void handleStatusChange(EStatusType status) override;
     void handleError(EStatusType status) override;
-    BOOL isActive() override;
+    bool isActive() const override;
     void activate() override;
     void deactivate() override;
 };

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -408,13 +408,13 @@ const LLVoiceDeviceList& LLVoiceClient::getRenderDevices()
 //--------------------------------------------------
 // participants
 
-void LLVoiceClient::getParticipantList(std::set<LLUUID> &participants)
+void LLVoiceClient::getParticipantList(std::set<LLUUID> &participants) const
 {
     LLWebRTCVoiceClient::getInstance()->getParticipantList(participants);
     LLVivoxVoiceClient::getInstance()->getParticipantList(participants);
 }
 
-bool LLVoiceClient::isParticipant(const LLUUID &speaker_id)
+bool LLVoiceClient::isParticipant(const LLUUID &speaker_id) const
 {
     return LLWebRTCVoiceClient::getInstance()->isParticipant(speaker_id) ||
            LLVivoxVoiceClient::getInstance()->isParticipant(speaker_id);
@@ -718,12 +718,12 @@ void LLVoiceClient::toggleUserPTTState(void)
 //-------------------------------------------
 // nearby speaker accessors
 
-BOOL LLVoiceClient::getVoiceEnabled(const LLUUID& id)
+bool LLVoiceClient::getVoiceEnabled(const LLUUID& id) const
 {
-    return isParticipant(id) ? TRUE : FALSE;
+    return isParticipant(id);
 }
 
-std::string LLVoiceClient::getDisplayName(const LLUUID& id)
+std::string LLVoiceClient::getDisplayName(const LLUUID& id) const
 {
     std::string result = LLWebRTCVoiceClient::getInstance()->getDisplayName(id);
     if (result.empty())

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -133,7 +133,7 @@ class LLVoiceP2PIncomingCallInterface
     virtual void declineInvite() = 0;
 };
 
-typedef boost::shared_ptr<LLVoiceP2PIncomingCallInterface> LLVoiceP2PIncomingCallInterfacePtr;
+typedef std::shared_ptr<LLVoiceP2PIncomingCallInterface> LLVoiceP2PIncomingCallInterfacePtr;
 
 //////////////////////////////////
 /// @class LLVoiceModuleInterface

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -452,8 +452,8 @@ public:
 
     /////////////////////////////
     // Accessors for data related to nearby speakers
-    BOOL getVoiceEnabled(const LLUUID& id);     // true if we've received data for this avatar
-    std::string getDisplayName(const LLUUID& id);
+    bool getVoiceEnabled(const LLUUID& id) const;     // true if we've received data for this avatar
+    std::string getDisplayName(const LLUUID& id) const;
     BOOL isOnlineSIP(const LLUUID &id);
     BOOL isParticipantAvatar(const LLUUID &id);
     BOOL getIsSpeaking(const LLUUID& id);
@@ -463,8 +463,8 @@ public:
     F32 getUserVolume(const LLUUID& id);
 
     /////////////////////////////
-    void getParticipantList(std::set<LLUUID> &participants);
-    bool isParticipant(const LLUUID& speaker_id);
+    void getParticipantList(std::set<LLUUID> &participants) const;
+    bool isParticipant(const LLUUID& speaker_id) const;
 
     //////////////////////////
     /// @name text chat

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -4973,7 +4973,7 @@ void LLVivoxVoiceClient::hangup() { leaveChannel(); }
 
 LLVoiceP2PIncomingCallInterfacePtr LLVivoxVoiceClient::getIncomingCallInterface(const LLSD &voice_call_info)
 {
-    return boost::make_shared<LLVivoxVoiceP2PIncomingCall>(voice_call_info);
+    return std::make_shared<LLVivoxVoiceP2PIncomingCall>(voice_call_info);
 }
 
 bool LLVivoxVoiceClient::answerInvite(const std::string &sessionHandle)

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -1964,8 +1964,8 @@ bool LLWebRTCVoiceClient::estateSessionState::processConnectionStates()
 
         for (auto &connection : mWebRTCConnections)
         {
-            boost::shared_ptr<LLVoiceWebRTCSpatialConnection> spatialConnection =
-                boost::static_pointer_cast<LLVoiceWebRTCSpatialConnection>(connection);
+            std::shared_ptr<LLVoiceWebRTCSpatialConnection> spatialConnection =
+                std::static_pointer_cast<LLVoiceWebRTCSpatialConnection>(connection);
 
             LLUUID regionID = spatialConnection.get()->getRegionID();
 

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -1253,7 +1253,7 @@ void LLWebRTCVoiceClient::sessionState::removeParticipant(const LLWebRTCVoiceCli
                 LLWebRTCVoiceClient::getInstance()->notifyParticipantObservers();
             }
         }
-        if (mHangupOnLastLeave && (participantID != gAgentID) && (mParticipantsByUUID.size() <= 1))
+        if (mHangupOnLastLeave && (participantID != gAgentID) && (mParticipantsByUUID.size() <= 1) && LLWebRTCVoiceClient::instanceExists())
         {
             LLWebRTCVoiceClient::getInstance()->notifyStatusObservers(LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL);
         }

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -55,7 +55,7 @@ class LLWebRTCProtocolParser;
 
 class LLAvatarName;
 class LLVoiceWebRTCConnection;
-typedef boost::shared_ptr<LLVoiceWebRTCConnection> connectionPtr_t;
+typedef std::shared_ptr<LLVoiceWebRTCConnection> connectionPtr_t;
 
 extern const std::string WEBRTC_VOICE_SERVER_TYPE;
 
@@ -252,7 +252,7 @@ public:
         bool mIsModeratorMuted;
         LLUUID mRegion;
     };
-    typedef boost::shared_ptr<participantState> participantStatePtr_t;
+    typedef std::shared_ptr<participantState> participantStatePtr_t;
 
     participantStatePtr_t findParticipantByID(const std::string &channelID, const LLUUID &id);
     participantStatePtr_t addParticipantByID(const std::string& channelID, const LLUUID &id, const LLUUID& region);
@@ -265,10 +265,10 @@ public:
     class sessionState
     {
     public:
-        typedef boost::shared_ptr<sessionState> ptr_t;
-        typedef boost::weak_ptr<sessionState> wptr_t;
+        typedef std::shared_ptr<sessionState> ptr_t;
+        typedef std::weak_ptr<sessionState> wptr_t;
 
-        typedef boost::function<void(const ptr_t &)> sessionFunc_t;
+        typedef std::function<void(const ptr_t &)> sessionFunc_t;
 
         static void addSession(const std::string &channelID, ptr_t& session);
         virtual ~sessionState();
@@ -336,7 +336,7 @@ public:
                                       sessionFunc_t func);
     };
 
-    typedef boost::shared_ptr<sessionState> sessionStatePtr_t;
+    typedef std::shared_ptr<sessionState> sessionStatePtr_t;
     typedef std::map<std::string, sessionStatePtr_t> sessionMap;
 
     class estateSessionState : public sessionState
@@ -577,7 +577,7 @@ class LLVoiceWebRTCStats : public LLSingleton<LLVoiceWebRTCStats>
 class LLVoiceWebRTCConnection :
     public llwebrtc::LLWebRTCSignalingObserver,
     public llwebrtc::LLWebRTCDataObserver,
-    public boost::enable_shared_from_this<LLVoiceWebRTCConnection>
+    public std::enable_shared_from_this<LLVoiceWebRTCConnection>
 {
   public:
     LLVoiceWebRTCConnection(const LLUUID &regionID, const std::string &channelID);


### PR DESCRIPTION
Three comits:
 - Replace boost::shared_ptr with std in voice classes
 - Minimized some getInstance() calls on draw and idle
 - fixed a crash on exit