### PR TITLE
Update libexpat to 2.6.2 and libapr to 1.7.4

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -46,11 +46,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>dc4a38439f90325b406ec3f7cc4fa66edf0eeec8</string>
+              <string>058ffb9080ac03abd8ecd1f57fcc1160351c71ed</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.2-e935465/apr_suite-1.7.2-e935465-darwin64-e935465.tar.zst</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.4-r1/apr_suite-1.7.4-10278668642-darwin64-10278668642.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -60,9 +60,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>84a1a140f20b25d714949185e854d14b</string>
+              <string>272d97471f6ecf6e1eb4802f353d1f8c6f024eb3</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
               <key>url</key>
-              <string>http://automated-builds-secondlife-com.s3.amazonaws.com/ct2/4811/15302/apr_suite-1.4.5.504800-linux64-504800.tar.bz2</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.4-r1/apr_suite-1.7.4-10278668642-linux64-10278668642.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -72,11 +74,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>8233de9a11f323a03d569db1043ba5198176457b</string>
+              <string>587b0b61ecff2ac55cfbcb8e57a7b07c844a0069</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.2-e935465/apr_suite-1.7.2-e935465-windows64-e935465.tar.zst</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.4-r1/apr_suite-1.7.4-10278668642-windows64-10278668642.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -89,7 +91,7 @@
         <key>copyright</key>
         <string>Copyright © 2012 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.</string>
         <key>version</key>
-        <string>1.7.2-e935465</string>
+        <string>1.7.4-10278668642</string>
         <key>name</key>
         <string>apr_suite</string>
         <key>description</key>
@@ -524,11 +526,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>b85526ca80b6a7e73c7870285cf68d568f742095</string>
+              <string>bd61ec7787ea96d11f735afa5a6296ed175472b6</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-expat/releases/download/v2.1.1.1f36d02/expat-2.1.1.1f36d02-darwin64-1f36d02.tar.zst</string>
+              <string>https://github.com/secondlife/3p-expat/releases/download/v2.6.2-r4/expat-2.6.2-r4-darwin64-10278332617.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -538,11 +540,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>4cd82e2dec06ddff19e9b3dc0254f2593ec80452</string>
+              <string>acf891bda4125a92f6347e69f0e7867f32cebd20</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-expat/releases/download/v2.1.1.1f36d02/expat-2.1.1.1f36d02-linux64-1f36d02.tar.zst</string>
+              <string>https://github.com/secondlife/3p-expat/releases/download/v2.6.2-r4/expat-2.6.2-r4-linux64-10278332617.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -552,11 +554,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>47c01a89bc32c5740efe51be43e459ffd9b7cd34</string>
+              <string>1b9c198626fca0f30fb2770856e65767a9951683</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-expat/releases/download/v2.1.1.1f36d02/expat-2.1.1.1f36d02-windows64-1f36d02.tar.zst</string>
+              <string>https://github.com/secondlife/3p-expat/releases/download/v2.6.2-r4/expat-2.6.2-r4-windows64-10278332617.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -567,9 +569,9 @@
         <key>license_file</key>
         <string>LICENSES/expat.txt</string>
         <key>copyright</key>
-        <string>Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd and Clark Cooper - Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Expat maintainers.</string>
+        <string>Copyright (c) 1998-2000 Thai Open Source Software Center Ltd and Clark Cooper - Copyright (c) 2001-2022 Expat maintainers.</string>
         <key>version</key>
-        <string>2.1.1.1f36d02</string>
+        <string>2.6.2-r4</string>
         <key>name</key>
         <string>expat</string>
         <key>description</key>

--- a/indra/cmake/APR.cmake
+++ b/indra/cmake/APR.cmake
@@ -18,6 +18,7 @@ if (WINDOWS)
           ${ARCH_PREBUILT_DIRS_RELEASE}/${APR_selector}apr-1.lib
           ${ARCH_PREBUILT_DIRS_RELEASE}/${APR_selector}aprutil-1.lib
           )
+  target_compile_definitions( ll::apr INTERFACE APR_DECLARE_STATIC=1 APU_DECLARE_STATIC=1 API_DECLARE_STATIC=1)
 elseif (DARWIN)
   if (LLCOMMON_LINK_SHARED)
     set(APR_selector     "0.dylib")
@@ -28,16 +29,15 @@ elseif (DARWIN)
   endif (LLCOMMON_LINK_SHARED)
 
   target_link_libraries( ll::apr INTERFACE
-          libapr-1.${APR_selector}
-          libaprutil-1.${APRUTIL_selector}
+          ${ARCH_PREBUILT_DIRS_RELEASE}/libapr-1.${APR_selector}
+          ${ARCH_PREBUILT_DIRS_RELEASE}/libaprutil-1.${APR_selector}
           iconv
           )
-else (WINDOWS)
+else()
   target_link_libraries( ll::apr INTERFACE
-          apr-1
-          aprutil-1
-          uuid
+          ${ARCH_PREBUILT_DIRS_RELEASE}/libapr-1.a
+          ${ARCH_PREBUILT_DIRS_RELEASE}/libaprutil-1.a
           rt
           )
-endif (WINDOWS)
+endif ()
 target_include_directories( ll::apr SYSTEM INTERFACE  ${LIBS_PREBUILT_DIR}/include/apr-1 )

--- a/indra/cmake/Copy3rdPartyLibs.cmake
+++ b/indra/cmake/Copy3rdPartyLibs.cmake
@@ -54,10 +54,13 @@ if(WINDOWS)
     set(release_src_dir "${ARCH_PREBUILT_DIRS_RELEASE}")
     set(release_files
         openjp2.dll
-        libapr-1.dll
-        libaprutil-1.dll
         nghttp2.dll
         )
+
+    if(LLCOMMON_LINK_SHARED)
+        set(release_files ${release_files} libapr-1.dll)
+        set(release_files ${release_files} libaprutil-1.dll)
+    endif()
 
     # OpenSSL
     if(ADDRESS_SIZE EQUAL 64)
@@ -179,15 +182,19 @@ elseif(DARWIN)
        )
     set(release_src_dir "${ARCH_PREBUILT_DIRS_RELEASE}")
     set(release_files
-        libapr-1.0.dylib
-        libapr-1.dylib
-        libaprutil-1.0.dylib
-        libaprutil-1.dylib
-        ${EXPAT_COPY}
         libndofdev.dylib
         libnghttp2.dylib
         libnghttp2.14.dylib
        )
+
+    if(LLCOMMON_LINK_SHARED)
+        set(release_files ${release_files}
+            libapr-1.0.dylib
+            libapr-1.dylib
+            libaprutil-1.0.dylib
+            libaprutil-1.dylib
+            )
+    endif()
 
     if (TARGET ll::openal)
       list(APPEND release_files libalut.dylib libopenal.dylib)
@@ -224,8 +231,6 @@ elseif(LINUX)
 
      if( USE_AUTOBUILD_3P )
          list( APPEND release_files
-                 libapr-1.so.0
-                 libaprutil-1.so.0
                  libatk-1.0.so
                  libfreetype.so.6.6.2
                  libfreetype.so.6
@@ -237,6 +242,13 @@ elseif(LINUX)
                  libgmodule-2.0.so
                  libgobject-2.0.so
                  )
+
+        if(LLCOMMON_LINK_SHARED)
+            set(release_files ${release_files}
+                libapr-1.so.0
+                libaprutil-1.so.0
+                )
+        endif()
      endif()
 
 else(WINDOWS)

--- a/indra/cmake/EXPAT.cmake
+++ b/indra/cmake/EXPAT.cmake
@@ -7,14 +7,13 @@ add_library( ll::expat INTERFACE IMPORTED )
 use_system_binary(expat)
 use_prebuilt_binary(expat)
 if (WINDOWS)
-    target_link_libraries( ll::expat  INTERFACE libexpatMT )
-    set(EXPAT_COPY libexpatMT.dll)
-else (WINDOWS)
-    target_link_libraries( ll::expat INTERFACE expat )
-    if (DARWIN)
-        set(EXPAT_COPY libexpat.1.dylib libexpat.dylib)
-    else ()
-        set(EXPAT_COPY libexpat.so.1 libexpat.so)
-    endif ()
-endif (WINDOWS)
+    target_compile_definitions( ll::expat INTERFACE XML_STATIC=1)
+    target_link_libraries( ll::expat  INTERFACE
+            debug ${ARCH_PREBUILT_DIRS_DEBUG}/libexpatd.lib
+            optimized ${ARCH_PREBUILT_DIRS_RELEASE}/libexpat.lib)
+else ()
+    target_link_libraries( ll::expat  INTERFACE
+            debug ${ARCH_PREBUILT_DIRS_DEBUG}/libexpat.a
+            optimized ${ARCH_PREBUILT_DIRS_RELEASE}/libexpat.a)
+endif ()
 target_include_directories( ll::expat SYSTEM INTERFACE ${LIBS_PREBUILT_DIR}/include )

--- a/indra/llcorehttp/CMakeLists.txt
+++ b/indra/llcorehttp/CMakeLists.txt
@@ -155,8 +155,6 @@ if (DARWIN)
   # for portability. This operation is Darwin-specific. We can count on the
   # 'cp' command.
   set(copy_dylibs
-    libapr-1.0.dylib
-    libaprutil-1.0.dylib
     libnghttp2*.dylib
     ${EXPAT_COPY}
     )

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -1008,9 +1008,6 @@ class Darwin_x86_64_Manifest(ViewerManifest):
                 libfile_parent = self.get_dst_prefix()
                 dylibs=[]
                 for libfile in (
-                                "libapr-1.0.dylib",
-                                "libaprutil-1.0.dylib",
-                                "libexpat.1.dylib",
                                 # libnghttp2.dylib is a symlink to
                                 # libnghttp2.major.dylib, which is a symlink to
                                 # libnghttp2.version.dylib. Get all of them.
@@ -1315,14 +1312,7 @@ class Linux_i686_Manifest(LinuxManifest):
         debpkgdir = os.path.join(pkgdir, "lib", "debug")
 
         with self.prefix(src=relpkgdir, dst="lib"):
-            self.path("libapr-1.so")
-            self.path("libapr-1.so.0")
-            self.path("libapr-1.so.0.4.5")
-            self.path("libaprutil-1.so")
-            self.path("libaprutil-1.so.0")
-            self.path("libaprutil-1.so.0.4.1")
             self.path("libdb*.so")
-            self.path("libexpat.so.*")
             self.path("libuuid.so*")
             self.path("libSDL-1.2.so.*")
             self.path("libdirectfb-1.*.so.*")


### PR DESCRIPTION
This updates to use expat 2.6.2 and libapr 1.7.4 #1098 

* Security and stability improvements

