### PR TITLE
Auto-scaling amortisation of dynamic BB calcs

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1874,6 +1874,28 @@
     <key>Value</key>
     <real>64.0</real>
   </map>
+  <key>AvatarExtentRefreshPeriodBatch</key>
+  <map>
+    <key>Comment</key>
+    <string>how many frames do we spread over by default when refreshing extents (default is 4)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>4</integer>
+  </map>
+  <key>AvatarExtentRefreshMaxPerBatch</key>
+  <map>
+    <key>Comment</key>
+    <string>how many avatars do we want to handle in total per batch (default is 5)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>5</integer>
+  </map>
   <key>DebugAvatarAppearanceMessage</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -889,6 +889,7 @@ void LLViewerObjectList::update(LLAgent &agent)
     static std::vector<LLViewerObject*> idle_list;
 
     U32 idle_count = 0;
+    mNumAvatars = 0;
 
     {
         for (std::vector<LLPointer<LLViewerObject> >::iterator active_iter = mActiveObjects.begin();
@@ -906,6 +907,10 @@ void LLViewerObjectList::update(LLAgent &agent)
                     idle_list[idle_count] = objectp;
                 }
                 ++idle_count;
+                if (objectp->isAvatar())
+                {
+                    mNumAvatars++;
+                }
             }
             else
             {   // There shouldn't be any NULL pointers in the list, but they have caused

--- a/indra/newview/llviewerobjectlist.h
+++ b/indra/newview/llviewerobjectlist.h
@@ -145,6 +145,7 @@ public:
 
     S32 getOrphanParentCount() const { return (S32) mOrphanParents.size(); }
     S32 getOrphanCount() const { return mNumOrphans; }
+    S32 getAvatarCount() const { return mNumAvatars; }
     void orphanize(LLViewerObject *childp, U32 parent_id, U32 ip, U32 port);
     void findOrphans(LLViewerObject* objectp, U32 ip, U32 port);
 
@@ -191,6 +192,7 @@ protected:
     std::vector<U64>    mOrphanParents; // LocalID/ip,port of orphaned objects
     std::vector<OrphanInfo> mOrphanChildren;    // UUID's of orphaned objects
     S32 mNumOrphans;
+    S32 mNumAvatars;
 
     typedef std::vector<LLPointer<LLViewerObject> > vobj_list_t;
 

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2663,7 +2663,7 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
     {
         // Update extent if necessary.
         // if the frame counnter + the first byte of the UUID % upd_freq = 0 then update the extent.
-        mNeedsExtentUpdate = ((thisFrame + mID.mData[0]) % upd_freq == 0);        
+        mNeedsExtentUpdate = ((thisFrame + mID.mData[0]) % upd_freq == 0);
     }
 
     LLScopedContextString str("avatar_idle_update " + getFullname());

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2640,6 +2640,16 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
     if (thisFrame - lastRecalibrationFrame >= upd_freq)
     {
         // Only update at the start of a cycle. .
+        // update frequency = ((Num_Avatars -1 / NumberPerPeriod) + 1 ) * Periodicity
+        // Given NumberPerPeriod = 5 and Periodicity = 4
+        // | NumAvatars  | frequency |
+        // +-------------+-----------+
+        // |      1      |     4     |
+        // |      2      |     4     |
+        // |      5      |     4     |
+        // |     10      |     8     |
+        // |     25      |     20    |
+
         upd_freq = (((gObjectList.getAvatarCount() - 1) / refreshMaxPerPeriod) + 1)*refreshPeriod;
         lastRecalibrationFrame = thisFrame;
     }
@@ -2651,6 +2661,8 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
     }
     else
     {
+        // Update extent if necessary.
+        // if the frame counnter + the first byte of the UUID % upd_freq = 0 then update the extent.
         mNeedsExtentUpdate = ((thisFrame + mID.mData[0]) % upd_freq == 0);        
     }
 


### PR DESCRIPTION
Contributing code that has been in use in TPVs (FS and Alchemy, maybe others) for a number of years.

Limits the overhead of the dynamic BB calcs to
AvatarExtentRefreshMaxPerBatch per AvatarExtentRefreshPeriodBatch frames
default is 5 avatar per 4 frames. Thus a busy region with 25 avatars would
take 20 frames to refresh the all the BBs, keeping the per frame impact within a reasonable time quanta

