### PR TITLE
Interim fix for particles no longer rezzing properly after "blur fix".

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -938,9 +938,9 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                 onFace = true;
                 F32 radius;
                 F32 cos_angle_to_view_dir;
-                bool in_frustum = face->calcPixelArea(cos_angle_to_view_dir, radius);
                 static LLCachedControl<F32> bias_unimportant_threshold(gSavedSettings, "TextureBiasUnimportantFactor", 0.25f);
                 F32 vsize = face->getPixelArea();
+                bool in_frustum = face->calcPixelArea(cos_angle_to_view_dir, radius);
 
                 // Scale desired texture resolution higher or lower depending on texture scale
                 //


### PR DESCRIPTION
There are other changes that may make this "fix" unnecessary, in any case, this fix is probably not the ideal fix at all (see below), posting the PR to cover the interim issue of the bug I inadvertently introduced.
In a previous PR, I noted:

Note this change moves the calcPixelArea() call to the top BEFORE we user getPixelArea(). Either that call is entirely redundant (i.e. if calc was called earlier in the frame) or we were using the stale pixelArea (one frame behind). If the former is true then it might be faster to just do an AABB frustum check.

It turns out that by moving the calcPixelArea to the "correct place", we break the rezzing of particles which are then being downsampled as a result. Moving this back to the "incorrect" location undoes the immediate effect but this whole scenario may need to be re-examined.

See https://github.com/FirestormViewer/phoenix-firestorm/commit/ff891ca38d1a8d84bc1676020f6ac1272964e81e#commitcomment-144921537 for more discussion


