### PR TITLE
[WebRTC] After transition through WebRTC -> Vivox -> WebRTC regions, voice dot is on but no voice is transmitted.

### DIFF
--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -281,10 +281,8 @@ void LLVoiceClient::setNonSpatialVoiceModule(const std::string &voice_server_typ
 
 void LLVoiceClient::setHidden(bool hidden)
 {
-    if (mSpatialVoiceModule)
-    {
-        mSpatialVoiceModule->setHidden(hidden);
-    }
+    LLWebRTCVoiceClient::getInstance()->setHidden(hidden);
+    LLVivoxVoiceClient::getInstance()->setHidden(hidden);
 }
 
 void LLVoiceClient::terminate()

--- a/indra/newview/llvoicevivox.h
+++ b/indra/newview/llvoicevivox.h
@@ -89,6 +89,8 @@ public:
     // Returns true if vivox has successfully logged in and is not in error state
     bool isVoiceWorking() const override;
 
+    void setHidden(bool hidden) override;  // virtual
+
     /////////////////////
     /// @name Tuning
     //@{
@@ -760,7 +762,6 @@ private:
     LLSD getAudioSessionChannelInfo();
     std::string getAudioSessionHandle();
 
-    void setHidden(bool hidden) override; //virtual
     void sendPositionAndVolumeUpdate(void);
 
     void sendCaptureAndRenderDevices();

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -88,6 +88,7 @@ public:
     std::string sipURIFromID(const LLUUID &id) const override;
     LLSD getP2PChannelInfoTemplate(const LLUUID& id) const override;
 
+    void setHidden(bool hidden) override;  // virtual
 
     ///////////////////
     /// @name Logging
@@ -479,8 +480,6 @@ private:
     bool inEstateChannel();
 
     LLSD getAudioSessionChannelInfo();
-
-    void setHidden(bool hidden) override; //virtual
 
     void enforceTether();
 


### PR DESCRIPTION
#2074 

When teleporting, the viewer 'hides' voice, effectively disabling it, until the teleport has completed.  It does this by instructing the voice module to hide and then unhide.

The problem was, it would instruct one voice module for one voice server type to hide, and then after teleport, it would instruct the other voice module for the other voice server type to unhide, resulting in one voice module being hidden.

When the user transitions back to a region with the initial voice module, it's hidden, hence voice doesn't work.

The solution is to hide/unhide both voice modules.