### PR TITLE
Fix avatar lod corruption issue 

### DIFF
--- a/indra/newview/lldrawable.cpp
+++ b/indra/newview/lldrawable.cpp
@@ -1603,7 +1603,7 @@ void LLSpatialBridge::updateDistance(LLCamera& camera_in, bool force_update)
         for (LLViewerObject* child : mDrawable->getVObj()->getChildren())
         {
             LLDrawable* drawable = child->mDrawable;
-            if (drawable && !drawable->isDead() && drawable->isAvatar())
+            if (drawable && !drawable->isDead() && !drawable->isAvatar())
             {
                 drawable->updateDistance(camera, force_update);
             }


### PR DESCRIPTION
Fix avatar lod getting stuck/corrupted from https://github.com/secondlife/viewer/pull/2238 where the isAvatar check was mistakenly inverted