### PR TITLE
Use pre-installed NSIS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,10 +120,6 @@ jobs:
             ${{ runner.os }}-64-${{ matrix.configuration }}-
             ${{ runner.os }}-64-
 
-      - name: Install windows dependencies
-        if: runner.os == 'Windows'
-        run: choco install nsis-unicode
-
       - name: Determine source branch
         id: which-branch
         uses: secondlife/viewer-build-util/which-branch@v2

--- a/indra/newview/installers/windows/installer_template.nsi
+++ b/indra/newview/installers/windows/installer_template.nsi
@@ -32,6 +32,7 @@ SetCompressor /solid lzma	# Compress whole installer as one block
 SetDatablockOptimize off	# Only saves us 0.1%, not worth it
 XPStyle on                  # Add an XP manifest to the installer
 RequestExecutionLevel admin	# For when we write to Program Files
+Unicode true                # Enable unicode support
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Project flags


### PR DESCRIPTION
Use the [pre-installed version](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) of NSIS (v3.10) that comes with windows-2022 runners.