### PR TITLE
Fix sculpt discard level being discarded due to shadowing outer scope discard level

### DIFF
--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -1250,7 +1250,7 @@ void LLVOVolume::sculpt()
         if (!raw_image)
         {
             raw_image = mSculptTexture->getSavedRawImage();
-            S32 discard_level = mSculptTexture->getSavedRawImageLevel();
+            discard_level = mSculptTexture->getSavedRawImageLevel();
         }
 
         if (!raw_image)


### PR DESCRIPTION
This may fix #2024. Noticed this while fixing warnings.