### PR TITLE
Enable /permissive- on MSVC for better standards conformance 

### DIFF
--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -85,6 +85,7 @@ if (WINDOWS)
           /Oy-
           /fp:fast
           /MP
+          /permissive-
       )
 
   # Nicky: x64 implies SSE2

--- a/indra/llappearance/llavatarappearancedefines.cpp
+++ b/indra/llappearance/llavatarappearancedefines.cpp
@@ -252,6 +252,7 @@ LLAvatarAppearanceDictionary::BakedEntry::BakedEntry(ETextureIndex tex_index,
         LLWearableType::EType t = (LLWearableType::EType)va_arg(argp,int);
         mWearables.push_back(t);
     }
+    va_end(argp);
 }
 
 ETextureIndex LLAvatarAppearanceDictionary::bakedToLocalTextureIndex(EBakedTextureIndex index) const

--- a/indra/llcommon/llallocator_heap_profile.cpp
+++ b/indra/llcommon/llallocator_heap_profile.cpp
@@ -28,13 +28,6 @@
 #include "linden_common.h"
 #include "llallocator_heap_profile.h"
 
-#if LL_MSVC
-// disable warning about boost::lexical_cast returning uninitialized data
-// when it fails to parse the string
-#pragma warning (disable:4701)
-#pragma warning (disable:4702)
-#endif
-
 #include <boost/algorithm/string/split.hpp>
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>

--- a/indra/llcommon/llevents.h
+++ b/indra/llcommon/llevents.h
@@ -38,16 +38,8 @@
 #include <vector>
 #include <deque>
 #include <functional>
-#if LL_WINDOWS
-    #pragma warning (push)
-    #pragma warning (disable : 4263) // boost::signals2::expired_slot::what() has const mismatch
-    #pragma warning (disable : 4264)
-#endif
-#include <boost/signals2.hpp>
-#if LL_WINDOWS
-    #pragma warning (pop)
-#endif
 
+#include <boost/signals2.hpp>
 #include <boost/bind.hpp>
 #include <boost/utility.hpp>        // noncopyable
 #include <boost/optional/optional.hpp>

--- a/indra/llcommon/llfindlocale.cpp
+++ b/indra/llcommon/llfindlocale.cpp
@@ -185,7 +185,7 @@ canonise_fl(FL_Locale *l) {
 #define RML(pn,sn) MAKELANGID(LANG_##pn, SUBLANG_##sn)
 struct IDToCode {
   LANGID id;
-  char*  code;
+  const char*  code;
 };
 static const IDToCode both_to_code[] = {
   {ML(ENGLISH,US),           "en_US.ISO_8859-1"},

--- a/indra/llcommon/llsdjson.cpp
+++ b/indra/llcommon/llsdjson.cpp
@@ -35,16 +35,7 @@
 #include "llerror.h"
 #include "../llmath/llmath.h"
 
-#if LL_WINDOWS
-#pragma warning (push)
-#pragma warning (disable : 4702) // compiler thinks unreachable code
-#endif
 #include <boost/json/src.hpp>
-#if LL_WINDOWS
-#pragma warning (pop)
-#endif
-
-
 
 //=========================================================================
 LLSD LlsdFromJson(const boost::json::value& val)

--- a/indra/llcommon/llstacktrace.cpp
+++ b/indra/llcommon/llstacktrace.cpp
@@ -33,10 +33,7 @@
 #include <sstream>
 
 #include "llwin32headerslean.h"
-#pragma warning (push)
-#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
 #include <dbghelp.h>
-#pragma warning (pop)
 
 typedef USHORT NTAPI RtlCaptureStackBackTrace_Function(
     IN ULONG frames_to_skip,

--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -900,6 +900,11 @@ void HeapFree_deleter(void* ptr)
 
 } // anonymous namespace
 
+unsigned long windows_get_last_error()
+{
+    return GetLastError();
+}
+
 template<>
 std::wstring windows_message<std::wstring>(DWORD error)
 {

--- a/indra/llcommon/llstring.h
+++ b/indra/llcommon/llstring.h
@@ -46,7 +46,6 @@
 #endif
 
 #include <string.h>
-#include <boost/scoped_ptr.hpp>
 
 const char LL_UNKNOWN_CHAR = '?';
 class LLSD;
@@ -832,8 +831,10 @@ template<>
 LL_COMMON_API std::wstring windows_message<std::wstring>(unsigned long error);
 
 /// Get Windows message string, implicitly calling GetLastError()
+LL_COMMON_API unsigned long windows_get_last_error();
+
 template<typename STRING>
-STRING windows_message() { return windows_message<STRING>(GetLastError()); }
+STRING windows_message() { return windows_message<STRING>(windows_get_last_error()); }
 
 //@}
 

--- a/indra/llcommon/lluuid.cpp
+++ b/indra/llcommon/lluuid.cpp
@@ -31,6 +31,7 @@
 // ugh, this is ugly.  We need to straighten out our linking for this library
 #pragma comment(lib, "IPHLPAPI.lib")
 #include <iphlpapi.h>
+#include <nb30.h>
 #endif
 
 #include "llapp.h"

--- a/indra/llcommon/tests/commonmisc_test.cpp
+++ b/indra/llcommon/tests/commonmisc_test.cpp
@@ -46,12 +46,6 @@
 
 #include "../test/lltut.h"
 
-
-#if LL_WINDOWS
-// disable overflow warnings
-#pragma warning(disable: 4307)
-#endif
-
 namespace tut
 {
     struct sd_data

--- a/indra/llimage/llimagejpeg.h
+++ b/indra/llimage/llimagejpeg.h
@@ -31,7 +31,6 @@
 
 #include "llimage.h"
 
-#include "llwin32headerslean.h"
 extern "C" {
 #ifdef LL_USESYSTEMLIBS
 # include <jpeglib.h>

--- a/indra/llinventory/llinventorytype.cpp
+++ b/indra/llinventory/llinventorytype.cpp
@@ -53,6 +53,7 @@ struct InventoryEntry : public LLDictionaryEntry
             LLAssetType::EType t = (LLAssetType::EType)va_arg(argp,int);
             mAssetTypes.push_back(t);
         }
+        va_end(argp);
     }
 
     const std::string mHumanName;

--- a/indra/llmath/llsimdtypes.h
+++ b/indra/llmath/llsimdtypes.h
@@ -33,20 +33,6 @@
 
 typedef __m128  LLQuad;
 
-
-#if LL_WINDOWS
-#pragma warning(push)
-#pragma warning( disable : 4800 3 ) // Disable warning about casting int to bool for this class.
-#if defined(_MSC_VER) && (_MSC_VER < 1500)
-// VC++ 2005 is missing these intrinsics
-// __forceinline is MSVC specific and attempts to override compiler inlining judgment. This is so
-// even in debug builds this call is a NOP.
-__forceinline const __m128 _mm_castsi128_ps( const __m128i a ) { return reinterpret_cast<const __m128&>(a); }
-__forceinline const __m128i _mm_castps_si128( const __m128 a ) { return reinterpret_cast<const __m128i&>(a); }
-#endif // _MSC_VER
-
-#endif // LL_WINDOWS
-
 class LLBool32
 {
 public:
@@ -62,10 +48,6 @@ public:
 private:
     int m_bool{ 0 };
 };
-
-#if LL_WINDOWS
-#pragma warning(pop)
-#endif
 
 class LLSimdScalar
 {

--- a/indra/llmessage/llblowfishcipher.cpp
+++ b/indra/llmessage/llblowfishcipher.cpp
@@ -88,7 +88,7 @@ U32 LLBlowfishCipher::encrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len)
             src_len))
     {
         LL_WARNS() << "LLBlowfishCipher::encrypt EVP_EncryptUpdate failure" << LL_ENDL;
-        goto ERROR;
+        goto BF_ENCRYPT_ERROR;
     }
 
     // There may be some final data left to encrypt if the input is
@@ -96,14 +96,14 @@ U32 LLBlowfishCipher::encrypt(const U8* src, U32 src_len, U8* dst, U32 dst_len)
     if (!EVP_EncryptFinal_ex(context, (unsigned char*)(dst + output_len), &temp_len))
     {
         LL_WARNS() << "LLBlowfishCipher::encrypt EVP_EncryptFinal failure" << LL_ENDL;
-        goto ERROR;
+        goto BF_ENCRYPT_ERROR;
     }
     output_len += temp_len;
 
     EVP_CIPHER_CTX_free(context);
     return output_len;
 
-ERROR:
+BF_ENCRYPT_ERROR:
     EVP_CIPHER_CTX_free(context);
     return 0;
 }

--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -24,10 +24,8 @@
  * $/LicenseInfo$
  */
 
-#if LL_MSVC
-#pragma warning (disable : 4263)
-#pragma warning (disable : 4264)
-#endif
+#include "linden_common.h"
+
 #include "dae.h"
 #include "dom/domAsset.h"
 #include "dom/domBind_material.h"
@@ -48,10 +46,6 @@
 #include "dom/domScale.h"
 #include "dom/domTranslate.h"
 #include "dom/domVisual_scene.h"
-#if LL_MSVC
-#pragma warning (default : 4263)
-#pragma warning (default : 4264)
-#endif
 
 #include "lldaeloader.h"
 #include "llsdserialize.h"

--- a/indra/llprimitive/tests/llmediaentry_test.cpp
+++ b/indra/llprimitive/tests/llmediaentry_test.cpp
@@ -26,14 +26,9 @@
 
 #include "linden_common.h"
 #include "lltut.h"
-#if LL_WINDOWS
-#pragma warning (push)
-#pragma warning (disable : 4702) // boost::lexical_cast generates this warning
-#endif
+
 #include <boost/lexical_cast.hpp>
-#if LL_WINDOWS
-#pragma warning (pop)
-#endif
+
 #include "llstring.h"
 #include "llsdutil.h"
 #include "llsdserialize.h"

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -1059,7 +1059,7 @@ LLSD LLDXHardware::getDisplayInfo()
 
         // Dump the string as an int into the structure
         char *stopstring;
-        ret["VRAM"] = (LLSD::Integer)strtol(ram_str.c_str(), &stopstring, 10);
+        ret["VRAM"] = LLSD::Integer(strtol(ram_str.c_str(), &stopstring, 10));
         std::string device_name = get_string(device_containerp, L"szDescription");
         ret["DeviceName"] = device_name;
         std::string device_driver=  get_string(device_containerp, L"szDriverVersion");

--- a/indra/llwindow/lldxhardware.cpp
+++ b/indra/llwindow/lldxhardware.cpp
@@ -441,7 +441,7 @@ std::string LLDXHardware::getDriverVersionWMI(EGPUVendor vendor)
     return mDriverVersion;
 }
 
-void get_wstring(IDxDiagContainer* containerp, WCHAR* wszPropName, WCHAR* wszPropValue, int outputSize)
+void get_wstring(IDxDiagContainer* containerp, const WCHAR* wszPropName, WCHAR* wszPropValue, int outputSize)
 {
     HRESULT hr;
     VARIANT var;
@@ -472,7 +472,7 @@ void get_wstring(IDxDiagContainer* containerp, WCHAR* wszPropName, WCHAR* wszPro
     VariantClear( &var );
 }
 
-std::string get_string(IDxDiagContainer *containerp, WCHAR *wszPropName)
+std::string get_string(IDxDiagContainer *containerp, const WCHAR *wszPropName)
 {
     WCHAR wszPropValue[256];
     get_wstring(containerp, wszPropName, wszPropValue, 256);
@@ -1059,7 +1059,7 @@ LLSD LLDXHardware::getDisplayInfo()
 
         // Dump the string as an int into the structure
         char *stopstring;
-        ret["VRAM"] = strtol(ram_str.c_str(), &stopstring, 10);
+        ret["VRAM"] = (LLSD::Integer)strtol(ram_str.c_str(), &stopstring, 10);
         std::string device_name = get_string(device_containerp, L"szDescription");
         ret["DeviceName"] = device_name;
         std::string device_driver=  get_string(device_containerp, L"szDriverVersion");

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -805,8 +805,8 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
             size_t name_len = strlen(display_device.DeviceName  );
             size_t desc_len = strlen(display_device.DeviceString);
 
-            CHAR *name = name_len ? display_device.DeviceName   : "???";
-            CHAR *desc = desc_len ? display_device.DeviceString : "???";
+            const CHAR *name = name_len ? display_device.DeviceName   : "???";
+            const CHAR *desc = desc_len ? display_device.DeviceString : "???";
 
             sprintf(text, "Display Device %d: %s, %s", display_index, name, desc);
             LL_INFOS("Window") << text << LL_ENDL;

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -36,32 +36,8 @@
 
 #include <vector>
 
-// *NOTE: boost::visit_each<> generates warning 4675 on .net 2003
-// Disable the warning for the boost includes.
-#if LL_WINDOWS
-# if (_MSC_VER >= 1300 && _MSC_VER < 1400)
-#   pragma warning(push)
-#   pragma warning( disable : 4675 )
-# endif
-#endif
-
 #include <boost/bind.hpp>
-
-#if LL_WINDOWS
-    #pragma warning (push)
-    #pragma warning (disable : 4263) // boost::signals2::expired_slot::what() has const mismatch
-    #pragma warning (disable : 4264)
-#endif
 #include <boost/signals2.hpp>
-#if LL_WINDOWS
-    #pragma warning (pop)
-#endif
-
-#if LL_WINDOWS
-# if (_MSC_VER >= 1300 && _MSC_VER < 1400)
-#   pragma warning(pop)
-# endif
-#endif
 
 class LLVector3;
 class LLVector3d;

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -66,11 +66,6 @@
 
 #include "llavatarpropertiesprocessor.h"
 
-#if LL_MSVC
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
-
 namespace
 {
     const S32   BAKE_RETRY_MAX_COUNT = 5;

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -269,11 +269,6 @@ using namespace LL;
 #include "glib.h"
 #endif // (LL_LINUX) && LL_GTK
 
-#if LL_MSVC
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
-
 static LLAppViewerListener sAppViewerListener(LLAppViewer::instance);
 
 ////// Windows-specific includes to the bottom - nasty defines in these pollute the preprocessor

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -28,25 +28,11 @@
 #include "llcommandlineparser.h"
 #include "llexception.h"
 
-// *NOTE: The boost::lexical_cast generates
-// the warning C4701(local used with out assignment) in VC7.1.
-// Disable the warning for the boost includes.
-#if _MSC_VER
-#   pragma warning(push)
-#   pragma warning( disable : 4701 )
-#else
-// NOTE: For the other platforms?
-#endif
-
 #include <boost/program_options.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/bind.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/assign/list_of.hpp>
-
-#if _MSC_VER
-#   pragma warning(pop)
-#endif
 
 #include "llsdserialize.h"
 #include "llerror.h"

--- a/indra/newview/llgroupmgr.cpp
+++ b/indra/newview/llgroupmgr.cpp
@@ -55,18 +55,7 @@
 #include "llcorehttputil.h"
 #include "lluiusage.h"
 
-
-#if LL_MSVC
-#pragma warning(push)
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
-
 #include <boost/lexical_cast.hpp>
-
-#if LL_MSVC
-#pragma warning(pop)   // Restore all warnings to the previous state
-#endif
 
 const U32 MAX_CACHED_GROUPS = 20;
 

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -58,10 +58,6 @@
 #include "llworld.h"
 
 #include "boost/lexical_cast.hpp"
-#if LL_MSVC
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
 
 extern void on_new_message(const LLSD& msg);
 

--- a/indra/newview/lllogchat.cpp
+++ b/indra/newview/lllogchat.cpp
@@ -42,19 +42,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/regex.hpp>
-
-#if LL_MSVC
-#pragma warning(push)
-// disable warning about boost::lexical_cast unreachable code
-// when it fails to parse the string
-#pragma warning (disable:4702)
-#endif
-
 #include <boost/date_time/gregorian/gregorian.hpp>
-#if LL_MSVC
-#pragma warning(pop)   // Restore all warnings to the previous state
-#endif
-
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/local_time_adjustor.hpp>
 

--- a/indra/newview/llmediadataclient.cpp
+++ b/indra/newview/llmediadataclient.cpp
@@ -29,11 +29,6 @@
 #include "llmediadataclient.h"
 #include "llviewercontrol.h"
 
-#if LL_MSVC
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
-
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 

--- a/indra/newview/llsecapi.h
+++ b/indra/newview/llsecapi.h
@@ -35,6 +35,7 @@
 #include "llexception.h"
 
 #ifdef LL_WINDOWS
+#pragma warning (push)
 #pragma warning(disable:4250)
 #endif // LL_WINDOWS
 
@@ -549,5 +550,8 @@ void registerSecHandler(const std::string& handler_type,
 
 extern LLPointer<LLSecAPIHandler> gSecAPIHandler;
 
+#ifdef LL_WINDOWS
+#pragma warning (pop)
+#endif // LL_WINDOWS
 
 #endif // LL_SECAPI_H

--- a/indra/newview/llsechandler_basic.h
+++ b/indra/newview/llsechandler_basic.h
@@ -28,6 +28,11 @@
 #ifndef LLSECHANDLER_BASIC
 #define LLSECHANDLER_BASIC
 
+#ifdef LL_WINDOWS
+#pragma warning (push)
+#pragma warning(disable:4250)
+#endif // LL_WINDOWS
+
 #include "llsecapi.h"
 #include <vector>
 #include <openssl/x509.h>
@@ -345,6 +350,10 @@ protected:
 };
 
 bool valueCompareLLSD(const LLSD& lhs, const LLSD& rhs);
+
+#ifdef LL_WINDOWS
+#pragma warning (pop)
+#endif // LL_WINDOWS
 
 #endif // LLSECHANDLER_BASIC
 

--- a/indra/newview/llviewerjoystick.cpp
+++ b/indra/newview/llviewerjoystick.cpp
@@ -195,7 +195,7 @@ BOOL CALLBACK di8_devices_callback(LPCDIDEVICEINSTANCE device_instance_ptr, LPVO
                 LLSD::Binary data; //just an std::vector
                 data.resize(size);
                 memcpy(&data[0], &device_instance_ptr->guidInstance /*POD _GUID*/, size);
-                LLViewerJoystick::getInstance()->initDevice((void*)&device, product_name, LLSD(data));
+                LLViewerJoystick::getInstance()->initDevice(&device, product_name, LLSD(data));
                 return DIENUM_STOP;
             }
         }

--- a/indra/newview/llviewerjoystick.cpp
+++ b/indra/newview/llviewerjoystick.cpp
@@ -195,7 +195,7 @@ BOOL CALLBACK di8_devices_callback(LPCDIDEVICEINSTANCE device_instance_ptr, LPVO
                 LLSD::Binary data; //just an std::vector
                 data.resize(size);
                 memcpy(&data[0], &device_instance_ptr->guidInstance /*POD _GUID*/, size);
-                LLViewerJoystick::getInstance()->initDevice(&device, product_name, LLSD(data));
+                LLViewerJoystick::getInstance()->initDevice((void*)&device, product_name, LLSD(data));
                 return DIENUM_STOP;
             }
         }
@@ -524,7 +524,7 @@ void LLViewerJoystick::initDevice(LLSD &guid)
 #endif
 }
 
-bool LLViewerJoystick::initDevice(void * preffered_device /*LPDIRECTINPUTDEVICE8*/, std::string &name, LLSD &guid)
+bool LLViewerJoystick::initDevice(void * preffered_device /*LPDIRECTINPUTDEVICE8*/, const std::string &name, const LLSD &guid)
 {
 #if LIB_NDOF
     mLastDeviceUUID = guid;

--- a/indra/newview/llviewerjoystick.h
+++ b/indra/newview/llviewerjoystick.h
@@ -56,7 +56,7 @@ public:
     void init(bool autoenable);
     void initDevice(LLSD &guid);
     bool initDevice(void * preffered_device /*LPDIRECTINPUTDEVICE8*/);
-    bool initDevice(void * preffered_device /*LPDIRECTINPUTDEVICE8*/, std::string &name, LLSD &guid);
+    bool initDevice(void * preffered_device /*LPDIRECTINPUTDEVICE8*/, const std::string &name, const LLSD &guid);
     void terminate();
 
     void updateStatus();

--- a/indra/newview/llviewerprecompiledheaders.h
+++ b/indra/newview/llviewerprecompiledheaders.h
@@ -37,11 +37,6 @@
 
 #include "linden_common.h"
 
-// Work around stupid Microsoft STL warning
-#ifdef LL_WINDOWS
-#pragma warning (disable : 4702) // warning C4702: unreachable code
-#endif
-
 #include <algorithm>
 #include <deque>
 #include <functional>

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -24,12 +24,6 @@
  * $/LicenseInfo$
  */
 
-#if LL_MSVC
-// disable warning about boost::lexical_cast returning uninitialized data
-// when it fails to parse the string
-#pragma warning (disable:4701)
-#endif
-
 #include "llviewerprecompiledheaders.h"
 
 #include "llvoavatarself.h"
@@ -68,11 +62,6 @@
 #include "llcallstack.h"
 #include "llcorehttputil.h"
 #include "lluiusage.h"
-
-#if LL_MSVC
-// disable boost::lexical_cast warning
-#pragma warning (disable:4702)
-#endif
 
 #include <boost/lexical_cast.hpp>
 

--- a/indra/newview/llwindebug.h
+++ b/indra/newview/llwindebug.h
@@ -30,10 +30,7 @@
 #include "stdtypes.h"
 #include "llwin32headerslean.h"
 
-#pragma warning (push)
-#pragma warning (disable:4091) // a microsoft header has warnings. Very nice.
 #include <dbghelp.h>
-#pragma warning (pop)
 
 class LLWinDebug:
     public LLSingleton<LLWinDebug>

--- a/indra/test/test.cpp
+++ b/indra/test/test.cpp
@@ -53,16 +53,8 @@
 #   include "ctype_workaround.h"
 #endif
 
-#if LL_MSVC
-#pragma warning (push)
-#pragma warning (disable : 4702) // warning C4702: unreachable code
-#endif
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
-#if LL_MSVC
-#pragma warning (pop)
-#endif
-
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>

--- a/indra/viewer_components/login/lllogin.cpp
+++ b/indra/viewer_components/login/lllogin.cpp
@@ -28,13 +28,6 @@
 #include "llsd.h"
 #include "llsdutil.h"
 
-/*==========================================================================*|
-#ifdef LL_WINDOWS
-    // non-virtual destructor warning, boost::statechart does this intentionally.
-    #pragma warning (disable : 4265)
-#endif
-|*==========================================================================*/
-
 #include "lllogin.h"
 
 #include <boost/bind.hpp>


### PR DESCRIPTION
- Enables stricter C++ standards compliance more in line with clang and GCC.
- Clean up warning suppressions left over from old library or MSVC versions

https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170