### PR TITLE
#2257 BugSplat Crash #1503682: SecondLifeViewer!LLFloaterIMSessionTab::enableDisableCallBtn(438)

### DIFF
--- a/indra/newview/llfloaterimsessiontab.cpp
+++ b/indra/newview/llfloaterimsessiontab.cpp
@@ -433,7 +433,7 @@ void LLFloaterIMSessionTab::draw()
 
 void LLFloaterIMSessionTab::enableDisableCallBtn()
 {
-    if (LLVoiceClient::instanceExists() && mVoiceButton)
+    if (!LLApp::isExiting() && LLVoiceClient::instanceExists() && mVoiceButton)
     {
         mVoiceButton->setEnabled(
             mSessionID.notNull()


### PR DESCRIPTION
Crash was reported at 08-10-2024 11:03:52 PM GMT+2 (2 seconds after the user quit request)
The floater was closed and partially destroyed

SecondLife.log
```
2024-08-10T21:03:50Z INFO # newview/llappviewer.cpp(4051) LLAppViewer::userQuit : User requested quit
2024-08-10T21:03:50Z INFO # newview/llappviewer.cpp(3988) LLAppViewer::requestQuit : requestQuit
2024-08-10T21:03:50Z WARNING # newview/llhudmanager.cpp(82) LLHUDManager::sendEffects : Trying to send dead effect!
2024-08-10T21:03:50Z INFO # llui/llfloater.cpp(708) LLFloater::closeFloater : Closing floater panel_im
2024-08-10T21:03:50Z INFO #IMVIEW# newview/llimview.cpp(3477) LLIMMgr::removeSession : LLIMMgr::removeSession, session removed, session id = 66b41b72-df96-f462-95f9-b32f7e491a40
2024-08-10T21:03:50Z INFO # llui/llfloater.cpp(708) LLFloater::closeFloater : Closing floater panel_im
2024-08-10T21:03:50Z INFO #IMVIEW# newview/llimview.cpp(3477) LLIMMgr::removeSession : LLIMMgr::removeSession, session removed, session id = 805bbdd3-ac52-0d56-8efd-785ac29ec395
2024-08-10T21:03:50Z INFO # llui/llfloater.cpp(708) LLFloater::closeFloater : Closing floater panel_im
2024-08-10T21:03:50Z INFO #IMVIEW# newview/llimview.cpp(3477) LLIMMgr::removeSession : LLIMMgr::removeSession, session removed, session id = 9a1eb3cd-0a46-0922-33c8-ba0334055708
2024-08-10T21:03:50Z INFO # llui/llfloater.cpp(708) LLFloater::closeFloater : Closing floater panel_im
2024-08-10T21:03:50Z INFO #IMVIEW# newview/llimview.cpp(3477) LLIMMgr::removeSession : LLIMMgr::removeSession, session removed, session id = bf6ba9fb-7f41-03f6-3772-876fca7b8a32
2024-08-10T21:03:50Z INFO # llui/llfloater.cpp(708) LLFloater::closeFloater : Closing floater floater_im_box
```

See https://app.bugsplat.com/v2/crash?database=SecondLife_Viewer_2018&id=1503682#attachments