### PR TITLE
[WebRTC] allow quad channel microphones/inputs

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2909,11 +2909,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>baabb11f324be350253b1fb58cf262c1aa19fa70</string>
+              <string>f4f4f05a4eaa14efc17a51b4d3f43b0834fec2a2</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-darwin64-10190042668.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.68-debug/webrtc-m114.5735.08.68-debug.10356186505-darwin64-10356186505.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2923,11 +2923,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>a13776c8f99f8975665be66ff8b51a80ba46c718</string>
+              <string>1419766891f2d3a70e3231bf8fed874ad8e4dcac</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-linux64-10190042668.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.68-debug/webrtc-m114.5735.08.68-debug.10356186505-linux64-10356186505.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2937,11 +2937,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>965ef5d65a14191a52ee9ec6a9a8a1d2ce3f2ffb</string>
+              <string>1f4cb5cbffdcb846de012d336cdbbc74ec5b2919</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.67-debug/webrtc-m114.5735.08.67-debug.10190042668-windows64-10190042668.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.68-debug/webrtc-m114.5735.08.68-debug.10356186505-windows64-10356186505.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2954,7 +2954,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.67-debug.10190042668</string>
+        <string>m114.5735.08.68-debug.10356186505</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>


### PR DESCRIPTION
bugsplat crash: https://github.com/secondlife/viewer-private/issues/257

In the debug version of WebRTC, it makes an explicit check that the number of channels for an input device is between 1 and 2.  The release version allows more, and should downmix if 1 channel is asked for.

This fix bumps up the max channels allowed to 8.