### PR TITLE
Shutdown crashes

### DIFF
--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -98,10 +98,7 @@ LLConversationViewSession::~LLConversationViewSession()
 
     if (mVoiceClientObserver)
     {
-        if (LLVoiceClient::instanceExists())
-        {
-            LLVoiceClient::getInstance()->removeObserver(mVoiceClientObserver);
-        }
+        LLVoiceClient::removeObserver(mVoiceClientObserver);
         delete mVoiceClientObserver;
     }
 
@@ -259,16 +256,15 @@ BOOL LLConversationViewSession::postBuild()
             icon->setVisible(true);
             mSpeakingIndicator->setSpeakerId(gAgentID, LLUUID::null, true);
             mIsInActiveVoiceChannel = true;
-            if(LLVoiceClient::instanceExists())
+
+            if (mVoiceClientObserver)
             {
-                if (mVoiceClientObserver)
-                {
-                    LLVoiceClient::getInstance()->removeObserver(mVoiceClientObserver);
-                    delete mVoiceClientObserver;
-                }
-                mVoiceClientObserver = new LLNearbyVoiceClientStatusObserver(this);
-                LLVoiceClient::getInstance()->addObserver(mVoiceClientObserver);
+                LLVoiceClient::removeObserver(mVoiceClientObserver);
+                delete mVoiceClientObserver;
             }
+            mVoiceClientObserver = new LLNearbyVoiceClientStatusObserver(this);
+            LLVoiceClient::addObserver(mVoiceClientObserver);
+
             break;
         }
         default:

--- a/indra/newview/llfloaterimsession.cpp
+++ b/indra/newview/llfloaterimsession.cpp
@@ -287,10 +287,8 @@ void LLFloaterIMSession::sendMsg(const std::string& msg)
 LLFloaterIMSession::~LLFloaterIMSession()
 {
     mVoiceChannelStateChangeConnection.disconnect();
-    if(LLVoiceClient::instanceExists())
-    {
-        LLVoiceClient::getInstance()->removeObserver(this);
-    }
+
+    LLVoiceClient::removeObserver(this);
 
     LLTransientFloaterMgr::getInstance()->removeControlView(LLTransientFloaterMgr::IM, this);
 
@@ -366,7 +364,7 @@ BOOL LLFloaterIMSession::postBuild()
 
     childSetAction("voice_call_btn", boost::bind(&LLFloaterIMSession::onCallButtonClicked, this));
 
-    LLVoiceClient::getInstance()->addObserver(this);
+    LLVoiceClient::addObserver(this);
 
     //*TODO if session is not initialized yet, add some sort of a warning message like "starting session...blablabla"
     //see LLFloaterIMPanel for how it is done (IB)
@@ -537,6 +535,7 @@ void LLFloaterIMSession::boundVoiceChannel()
     LLVoiceChannel* voice_channel = LLIMModel::getInstance()->getVoiceChannel(mSessionID);
     if(voice_channel)
     {
+        mVoiceChannelStateChangeConnection.disconnect();
         mVoiceChannelStateChangeConnection = voice_channel->setStateChangedCallback(
                 boost::bind(&LLFloaterIMSession::onVoiceChannelStateChanged, this, _1, _2));
 

--- a/indra/newview/llfloaterimsessiontab.cpp
+++ b/indra/newview/llfloaterimsessiontab.cpp
@@ -433,7 +433,7 @@ void LLFloaterIMSessionTab::draw()
 
 void LLFloaterIMSessionTab::enableDisableCallBtn()
 {
-    if (!LLApp::isExiting() && LLVoiceClient::instanceExists() && mVoiceButton)
+    if (LLVoiceClient::instanceExists() && mVoiceButton)
     {
         mVoiceButton->setEnabled(
             mSessionID.notNull()
@@ -544,6 +544,12 @@ void LLFloaterIMSessionTab::closeFloater(bool app_quitting)
 {
     LLFloaterEmojiPicker::saveState();
     super::closeFloater(app_quitting);
+}
+
+void LLFloaterIMSessionTab::deleteAllChildren()
+{
+    super::deleteAllChildren();
+    mVoiceButton = NULL;
 }
 
 std::string LLFloaterIMSessionTab::appendTime()

--- a/indra/newview/llfloaterimsessiontab.h
+++ b/indra/newview/llfloaterimsessiontab.h
@@ -82,6 +82,7 @@ public:
     /*virtual*/ void setVisible(BOOL visible);
     /*virtual*/ void setFocus(BOOL focus);
     /*virtual*/ void closeFloater(bool app_quitting = false);
+    /*virtual*/ void deleteAllChildren();
 
     // Handle the left hand participant list widgets
     void addConversationViewParticipant(LLConversationItem* item, bool update_view = true);

--- a/indra/newview/llpanelgroup.cpp
+++ b/indra/newview/llpanelgroup.cpp
@@ -98,10 +98,7 @@ LLPanelGroup::LLPanelGroup()
 LLPanelGroup::~LLPanelGroup()
 {
     LLGroupMgr::getInstance()->removeObserver(this);
-    if(LLVoiceClient::instanceExists())
-    {
-        LLVoiceClient::getInstance()->removeObserver(this);
-    }
+    LLVoiceClient::removeObserver(this);
 }
 
 void LLPanelGroup::onOpen(const LLSD& key)
@@ -194,7 +191,7 @@ BOOL LLPanelGroup::postBuild()
         mJoinText = panel_general->getChild<LLUICtrl>("join_cost_text");
     }
 
-    LLVoiceClient::getInstance()->addObserver(this);
+    LLVoiceClient::addObserver(this);
 
     return TRUE;
 }

--- a/indra/newview/llpanelpeople.cpp
+++ b/indra/newview/llpanelpeople.cpp
@@ -338,7 +338,7 @@ public:
         LLAvatarTracker::instance().addObserver(this);
 
         // For notification when SIP online status changes.
-        LLVoiceClient::getInstance()->addObserver(this);
+        LLVoiceClient::addObserver(this);
         mInvObserver = new LLInventoryFriendCardObserver(this);
     }
 
@@ -346,10 +346,7 @@ public:
     {
         // will be deleted by ~LLInventoryModel
         //delete mInvObserver;
-        if (LLVoiceClient::instanceExists())
-        {
-            LLVoiceClient::getInstance()->removeObserver(this);
-        }
+        LLVoiceClient::removeObserver(this);
         LLAvatarTracker::instance().removeObserver(this);
     }
 
@@ -577,10 +574,7 @@ LLPanelPeople::~LLPanelPeople()
     delete mFriendListUpdater;
     delete mRecentListUpdater;
 
-    if(LLVoiceClient::instanceExists())
-    {
-        LLVoiceClient::getInstance()->removeObserver(this);
-    }
+    LLVoiceClient::removeObserver(this);
 }
 
 void LLPanelPeople::onFriendsAccordionExpandedCollapsed(LLUICtrl* ctrl, const LLSD& param, LLAvatarList* avatar_list)
@@ -721,7 +715,7 @@ BOOL LLPanelPeople::postBuild()
     // Must go after setting commit callback and initializing all pointers to children.
     mTabContainer->selectTabByName(NEARBY_TAB_NAME);
 
-    LLVoiceClient::getInstance()->addObserver(this);
+    LLVoiceClient::addObserver(this);
 
     // call this method in case some list is empty and buttons can be in inconsistent state
     updateButtons();

--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -702,10 +702,7 @@ LLPanelProfileSecondLife::~LLPanelProfileSecondLife()
         LLAvatarTracker::instance().removeParticularFriendObserver(getAvatarId(), this);
     }
 
-    if (LLVoiceClient::instanceExists())
-    {
-        LLVoiceClient::getInstance()->removeObserver((LLVoiceClientStatusObserver*)this);
-    }
+    LLVoiceClient::removeObserver((LLVoiceClientStatusObserver*)this);
 
     if (mAvatarNameCacheConnection.connected())
     {

--- a/indra/newview/llspeakingindicatormanager.cpp
+++ b/indra/newview/llspeakingindicatormanager.cpp
@@ -182,7 +182,7 @@ void SpeakingIndicatorManager::unregisterSpeakingIndicator(const LLUUID& speaker
 SpeakingIndicatorManager::SpeakingIndicatorManager()
 {
     LLVoiceChannel::setCurrentVoiceChannelChangedCallback(boost::bind(&SpeakingIndicatorManager::sOnCurrentChannelChanged, this, _1));
-    LLVoiceClient::getInstance()->addObserver(this);
+    LLVoiceClient::addObserver(this);
 }
 
 SpeakingIndicatorManager::~SpeakingIndicatorManager()
@@ -193,10 +193,7 @@ void SpeakingIndicatorManager::cleanupSingleton()
 {
     // Don't use LLVoiceClient::getInstance() here without a check,
     // singleton MAY have already been destroyed.
-    if (LLVoiceClient::instanceExists())
-    {
-        LLVoiceClient::getInstance()->removeObserver(this);
-    }
+    LLVoiceClient::removeObserver(this);
 }
 
 void SpeakingIndicatorManager::sOnCurrentChannelChanged(const LLUUID& /*session_id*/)

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -1753,9 +1753,7 @@ LLPluginClassMedia* LLViewerMediaImpl::newSourceFromMediaType(std::string media_
             bool javascript_enabled = gSavedSettings.getBOOL("BrowserJavascriptEnabled");
             media_source->setJavascriptEnabled(javascript_enabled || clean_browser);
 
-            // collect 'web security disabled' (see Chrome --web-security-disabled) setting from prefs and send to embedded browser
-            bool web_security_disabled = gSavedSettings.getBOOL("BrowserWebSecurityDisabled");
-            media_source->setWebSecurityDisabled(web_security_disabled || clean_browser);
+            media_source->setWebSecurityDisabled(clean_browser);
 
             // collect setting indicates if local file access from file URLs is allowed from prefs and send to embedded browser
             bool file_access_from_file_urls = gSavedSettings.getBOOL("BrowserFileAccessFromFileUrls");

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -81,10 +81,7 @@ LLVoiceChannel::~LLVoiceChannel()
     {
         sCurrentVoiceChannel = NULL;
         // Must check instance exists here, the singleton MAY have already been destroyed.
-        if(LLVoiceClient::instanceExists())
-        {
-            LLVoiceClient::getInstance()->removeObserver(this);
-        }
+        LLVoiceClient::removeObserver(this);
     }
 
     sVoiceChannelMap.erase(mSessionID);
@@ -219,7 +216,7 @@ void LLVoiceChannel::deactivate()
             LLVoiceClient::getInstance()->setUserPTTState(false);
         }
     }
-    LLVoiceClient::getInstance()->removeObserver(this);
+    LLVoiceClient::removeObserver(this);
 
     if (sCurrentVoiceChannel == this)
     {
@@ -259,7 +256,7 @@ void LLVoiceChannel::activate()
         setState(STATE_CALL_STARTED);
     }
 
-    LLVoiceClient::getInstance()->addObserver(this);
+    LLVoiceClient::addObserver(this);
 
     //do not send earlier, channel should be initialized, should not be in STATE_NO_CHANNEL_INFO state
     sCurrentVoiceChannelChangedSignal(this->mSessionID);
@@ -751,7 +748,7 @@ void LLVoiceChannelProximal::deactivate()
     {
         setState(STATE_HUNG_UP);
     }
-    LLVoiceClient::getInstance()->removeObserver(this);
+    LLVoiceClient::removeObserver(this);
     LLVoiceClient::getInstance()->activateSpatialChannel(false);
 }
 

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -796,8 +796,14 @@ void LLVoiceClient::addObserver(LLVoiceClientStatusObserver* observer)
 
 void LLVoiceClient::removeObserver(LLVoiceClientStatusObserver* observer)
 {
-    LLVivoxVoiceClient::getInstance()->removeObserver(observer);
-    LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    if (LLVivoxVoiceClient::instanceExists())
+    {
+        LLVivoxVoiceClient::getInstance()->removeObserver(observer);
+    }
+    if (LLWebRTCVoiceClient::instanceExists())
+    {
+        LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    }
 }
 
 void LLVoiceClient::addObserver(LLFriendObserver* observer)
@@ -808,8 +814,14 @@ void LLVoiceClient::addObserver(LLFriendObserver* observer)
 
 void LLVoiceClient::removeObserver(LLFriendObserver* observer)
 {
-    LLVivoxVoiceClient::getInstance()->removeObserver(observer);
-    LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    if (LLVivoxVoiceClient::instanceExists())
+    {
+        LLVivoxVoiceClient::getInstance()->removeObserver(observer);
+    }
+    if (LLWebRTCVoiceClient::instanceExists())
+    {
+        LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    }
 }
 
 void LLVoiceClient::addObserver(LLVoiceClientParticipantObserver* observer)
@@ -820,8 +832,14 @@ void LLVoiceClient::addObserver(LLVoiceClientParticipantObserver* observer)
 
 void LLVoiceClient::removeObserver(LLVoiceClientParticipantObserver* observer)
 {
-    LLVivoxVoiceClient::getInstance()->removeObserver(observer);
-    LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    if (LLVivoxVoiceClient::instanceExists())
+    {
+        LLVivoxVoiceClient::getInstance()->removeObserver(observer);
+    }
+    if (LLWebRTCVoiceClient::instanceExists())
+    {
+        LLWebRTCVoiceClient::getInstance()->removeObserver(observer);
+    }
 }
 
 std::string LLVoiceClient::sipURIFromID(const LLUUID &id) const

--- a/indra/newview/llvoiceclient.h
+++ b/indra/newview/llvoiceclient.h
@@ -482,12 +482,12 @@ public:
 
     void onRegionChanged();
 
-    void addObserver(LLVoiceClientStatusObserver* observer);
-    void removeObserver(LLVoiceClientStatusObserver* observer);
-    void addObserver(LLFriendObserver* observer);
-    void removeObserver(LLFriendObserver* observer);
-    void addObserver(LLVoiceClientParticipantObserver* observer);
-    void removeObserver(LLVoiceClientParticipantObserver* observer);
+    static void addObserver(LLVoiceClientStatusObserver* observer);
+    static void removeObserver(LLVoiceClientStatusObserver* observer);
+    static void addObserver(LLFriendObserver* observer);
+    static void removeObserver(LLFriendObserver* observer);
+    static void addObserver(LLVoiceClientParticipantObserver* observer);
+    static void removeObserver(LLVoiceClientParticipantObserver* observer);
 
     std::string sipURIFromID(const LLUUID &id) const;
     LLSD getP2PChannelInfoTemplate(const LLUUID& id) const;

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -70,6 +70,7 @@ class LLWebRTCVoiceClient : public LLSingleton<LLWebRTCVoiceClient>,
     virtual ~LLWebRTCVoiceClient();
 
 public:
+    void cleanupSingleton() override;
     /// @name LLVoiceModuleInterface virtual implementations
     ///  @see LLVoiceModuleInterface
     //@{
@@ -300,6 +301,7 @@ public:
         static void for_each(sessionFunc_t func);
 
         static void reapEmptySessions();
+        static void clearSessions();
 
         bool isEmpty() { return mWebRTCConnections.empty(); }
 
@@ -319,7 +321,7 @@ public:
         participantUUIDMap mParticipantsByUUID;
 
         static bool hasSession(const std::string &sessionID)
-        { return mSessions.find(sessionID) != mSessions.end(); }
+        { return sSessions.find(sessionID) != sSessions.end(); }
 
        bool mHangupOnLastLeave;  // notify observers after the session becomes empty.
        bool mNotifyOnFirstJoin;  // notify observers when the first peer joins.
@@ -330,7 +332,7 @@ public:
 
     private:
 
-        static std::map<std::string, ptr_t> mSessions;  // canonical list of outstanding sessions.
+        static std::map<std::string, ptr_t> sSessions;  // canonical list of outstanding sessions.
 
         static void for_eachPredicate(const std::pair<std::string,
                                       LLWebRTCVoiceClient::sessionState::wptr_t> &a,


### PR DESCRIPTION
1. Made removeObserver static because floater wasn't removed from observers. Voice singleton gets removed first, so made it call rtc/vivox singletons directly (probably better to just move observers into LLVoiceClient or get rid of those internal singletons, but this is a crash fix, not a refactoring change)

2. sessions survived for too long after singleton was destroyed and cleanup got issues, fixed by cleaning up along with the singleton. Also renamed it from mSessions to sSession.