### PR TITLE
viewer-private#260 The 'Speak' button looks disabled during IM voice chat

### DIFF
--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3857,6 +3857,11 @@ bool LLIMMgr::startCall(const LLUUID& session_id, LLVoiceChannel::EDirection dir
     {
         voice_channel->setChannelInfo(voice_channel_info);
     }
+    else if (voice_channel->getState() < LLVoiceChannel::STATE_READY)
+    {
+        // restart if there wa an error or it was hang up
+        voice_channel->resetChannelInfo();
+    }
     voice_channel->setCallDirection(direction);
     voice_channel->activate();
     return true;

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -115,6 +115,12 @@ void LLVoiceChannel::setChannelInfo(const LLSD &channelInfo)
     }
 }
 
+void LLVoiceChannel::resetChannelInfo()
+{
+    mChannelInfo = LLSD();
+    mState = STATE_NO_CHANNEL_INFO;
+}
+
 void LLVoiceChannel::onChange(EStatusType type, const LLSD& channelInfo, bool proximal)
 {
     LL_DEBUGS("Voice") << "Incoming channel info: " << channelInfo << LL_ENDL;
@@ -913,6 +919,12 @@ void LLVoiceChannelP2P::setChannelInfo(const LLSD& channel_info)
     {
         activate();
     }
+}
+
+void LLVoiceChannelP2P::resetChannelInfo()
+{
+    mChannelInfo = LLVoiceClient::getInstance()->getP2PChannelInfoTemplate(mOtherUserID);
+    mState = STATE_NO_CHANNEL_INFO; // we have template, not full info
 }
 
 void LLVoiceChannelP2P::setState(EState state)

--- a/indra/newview/llvoicechannel.h
+++ b/indra/newview/llvoicechannel.h
@@ -72,7 +72,8 @@ public:
     virtual void handleError(EStatusType status);
     virtual void deactivate();
     virtual void activate();
-    virtual void setChannelInfo(const LLSD &channelInfo);
+    virtual void setChannelInfo(const LLSD& channelInfo);
+    virtual void resetChannelInfo();
     virtual void requestChannelInfo();
     virtual bool isActive() const;
     virtual bool callStarted() const;
@@ -189,6 +190,7 @@ class LLVoiceChannelP2P : public LLVoiceChannelGroup
     void requestChannelInfo() override;
     void deactivate() override;
     void setChannelInfo(const LLSD& channel_info) override;
+    void resetChannelInfo() override;
 
   protected:
     void setState(EState state) override;


### PR DESCRIPTION
p2p channels was reusing obsolete channel info which resulted in challe considered to be inactive due to handle mismatch