### PR TITLE
Skip windows symbol upload if there was no Release config build.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -354,6 +354,7 @@ jobs:
       BUGSPLAT_USER: ${{ secrets.BUGSPLAT_USER }}
       BUGSPLAT_PASS: ${{ secrets.BUGSPLAT_PASS }}
     needs: build
+    if: needs.build.outputs.configuration == 'Release'
     runs-on: ubuntu-latest
     steps:
       - name: Download viewer exe


### PR DESCRIPTION
see example failure here: https://github.com/secondlife/viewer/actions/runs/10353344352