### PR TITLE
Reduce thread contention between main thread and asset fetch threads

### DIFF
--- a/indra/llcorehttp/httprequest.cpp
+++ b/indra/llcorehttp/httprequest.cpp
@@ -489,6 +489,7 @@ HttpStatus HttpRequest::createService()
         HttpRequestQueue::init();
         HttpRequestQueue * rq = HttpRequestQueue::instanceOf();
         HttpService::init(rq);
+        HTTPStats::createInstance();
         has_inited = true;
     }
 
@@ -502,6 +503,7 @@ HttpStatus HttpRequest::destroyService()
 
     if (has_inited)
     {
+        HTTPStats::deleteSingleton();
         HttpService::term();
         HttpRequestQueue::term();
         has_inited = false;

--- a/indra/llcorehttp/httpstats.h
+++ b/indra/llcorehttp/httpstats.h
@@ -35,12 +35,12 @@
 
 namespace LLCore
 {
-    class HTTPStats : public LLSingleton<HTTPStats>
+    class HTTPStats final : public LLSimpleton<HTTPStats>
     {
-        LLSINGLETON(HTTPStats);
-        virtual ~HTTPStats();
-
     public:
+        HTTPStats();
+        ~HTTPStats();
+
         void resetStats();
 
         typedef LLStatsAccumulator StatsAccumulator;

--- a/indra/llfilesystem/lldiskcache.h
+++ b/indra/llfilesystem/lldiskcache.h
@@ -104,16 +104,9 @@ class LLDiskCache :
          * so many things had to be pushed back there to accomodate it, that I
          * decided to move it here.  Still not sure that's completely right.
          */
-        const std::string metaDataToFilepath(const std::string id,
-                                             LLAssetType::EType at,
-                                             const std::string extra_info);
+        static const std::string metaDataToFilepath(const std::string& id,
+                                             LLAssetType::EType at);
 
-        /**
-         * Update the "last write time" of a file to "now". This must be called whenever a
-         * file in the cache is read (not written) so that the last time the file was
-         * accessed is up to date (This is used in the mechanism for purging the cache)
-         */
-        void updateFileAccessTime(const std::string file_path);
 
         /**
          * Purge the oldest items in the cache so that the combined size of all files
@@ -170,17 +163,7 @@ class LLDiskCache :
          * setting could potentially point it at a non-cache directory (for example,
          * the Windows System dir) with disastrous results.
          */
-        std::string mCacheDir;
-
-        /**
-         * The prefix inserted at the start of a cache file filename to
-         * help identify it as a cache file. It's probably not required
-         * (just the presence in the cache folder is enough) but I am
-         * paranoid about the cache folder being set to something bad
-         * like the users' OS system dir by mistake or maliciously and
-         * this will help to offset any damage if that happens.
-         */
-        std::string mCacheFilenamePrefix;
+        static std::string sCacheDir;
 
         /**
          * When enabled, displays additional debugging information in

--- a/indra/llfilesystem/llfilesystem.h
+++ b/indra/llfilesystem/llfilesystem.h
@@ -53,6 +53,13 @@ class LLFileSystem
         bool rename(const LLUUID& new_id, const LLAssetType::EType new_type);
         bool remove();
 
+        /**
+         * Update the "last write time" of a file to "now". This must be called whenever a
+         * file in the cache is read (not written) so that the last time the file was
+         * accessed is up to date (This is used in the mechanism for purging the cache)
+         */
+        void updateFileAccessTime(const std::string& file_path);
+
         static bool getExists(const LLUUID& file_id, const LLAssetType::EType file_type);
         static bool removeFile(const LLUUID& file_id, const LLAssetType::EType file_type, int suppress_error = 0);
         static bool renameFile(const LLUUID& old_file_id, const LLAssetType::EType old_file_type,

--- a/indra/llui/llspellcheck.cpp
+++ b/indra/llui/llspellcheck.cpp
@@ -42,19 +42,13 @@ static const std::string DICT_FILE_USER = "user_dictionaries.xml";
 LLSpellChecker::settings_change_signal_t LLSpellChecker::sSettingsChangeSignal;
 
 LLSpellChecker::LLSpellChecker()
-    : mHunspell(NULL)
 {
+    // Load initial dictionary information
+    refreshDictionaryMap();
 }
 
 LLSpellChecker::~LLSpellChecker()
 {
-    delete mHunspell;
-}
-
-void LLSpellChecker::initSingleton()
-{
-    // Load initial dictionary information
-    refreshDictionaryMap();
 }
 
 bool LLSpellChecker::checkSpelling(const std::string& word) const
@@ -300,8 +294,7 @@ void LLSpellChecker::initHunspell(const std::string& dict_language)
 {
     if (mHunspell)
     {
-        delete mHunspell;
-        mHunspell = NULL;
+        mHunspell.reset();
         mDictLanguage.clear();
         mDictFile.clear();
         mIgnoreList.clear();
@@ -322,11 +315,11 @@ void LLSpellChecker::initHunspell(const std::string& dict_language)
         const std::string filename_dic = dict_entry["name"].asString() + ".dic";
         if ( (gDirUtilp->fileExists(user_path + filename_aff)) && (gDirUtilp->fileExists(user_path + filename_dic)) )
         {
-            mHunspell = new Hunspell((user_path + filename_aff).c_str(), (user_path + filename_dic).c_str());
+            mHunspell = std::make_unique<Hunspell>((user_path + filename_aff).c_str(), (user_path + filename_dic).c_str());
         }
         else if ( (gDirUtilp->fileExists(app_path + filename_aff)) && (gDirUtilp->fileExists(app_path + filename_dic)) )
         {
-            mHunspell = new Hunspell((app_path + filename_aff).c_str(), (app_path + filename_dic).c_str());
+            mHunspell = std::make_unique<Hunspell>((app_path + filename_aff).c_str(), (app_path + filename_dic).c_str());
         }
         if (!mHunspell)
         {

--- a/indra/llui/llspellcheck.h
+++ b/indra/llui/llspellcheck.h
@@ -34,12 +34,12 @@
 
 class Hunspell;
 
-class LLSpellChecker : public LLSingleton<LLSpellChecker>
+class LLSpellChecker : public LLSimpleton<LLSpellChecker>
 {
-    LLSINGLETON(LLSpellChecker);
+public:
+    LLSpellChecker();
     ~LLSpellChecker();
 
-public:
     void addToCustomDictionary(const std::string& word);
     void addToIgnoreList(const std::string& word);
     bool checkSpelling(const std::string& word) const;
@@ -47,7 +47,6 @@ public:
 protected:
     void addToDictFile(const std::string& dict_path, const std::string& word);
     void initHunspell(const std::string& dict_language);
-    void initSingleton() override;
 
 public:
     typedef std::list<std::string> dict_list_t;
@@ -77,7 +76,7 @@ public:
     static boost::signals2::connection setSettingsChangeCallback(const settings_change_signal_t::slot_type& cb);
 
 protected:
-    Hunspell*   mHunspell;
+    std::unique_ptr<Hunspell>   mHunspell;
     std::string mDictLanguage;
     std::string mDictFile;
     dict_list_t mDictSecondary;

--- a/indra/llui/llui.cpp
+++ b/indra/llui/llui.cpp
@@ -54,6 +54,7 @@
 #include "llmenubutton.h"
 #include "llloadingindicator.h"
 #include "llwindow.h"
+#include "llspellcheck.h"
 
 // for registration
 #include "llfiltereditor.h"
@@ -157,6 +158,7 @@ mRootView(NULL),
 mHelpImpl(NULL)
 {
     LLRender2D::createInstance(image_provider);
+    LLSpellChecker::createInstance();
 
     if ((get_ptr_in_map(mSettingGroups, std::string("config")) == NULL) ||
         (get_ptr_in_map(mSettingGroups, std::string("floater")) == NULL) ||
@@ -198,6 +200,7 @@ mHelpImpl(NULL)
 
 LLUI::~LLUI()
 {
+    LLSpellChecker::deleteSingleton();
     LLRender2D::deleteSingleton();
 }
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -806,6 +806,20 @@ bool LLAppViewer::init()
         LLUIImageList::getInstance(),
         ui_audio_callback,
         deferred_ui_audio_callback);
+
+    if (gSavedSettings.getBOOL("SpellCheck"))
+    {
+        std::list<std::string> dict_list;
+        std::string dict_setting = gSavedSettings.getString("SpellCheckDictionary");
+        boost::split(dict_list, dict_setting, boost::is_any_of(std::string(",")));
+        if (!dict_list.empty())
+        {
+            LLSpellChecker::setUseSpellCheck(dict_list.front());
+            dict_list.pop_front();
+            LLSpellChecker::instance().setSecondaryDictionaries(dict_list);
+        }
+    }
+
     LL_INFOS("InitInfo") << "UI initialized." << LL_ENDL ;
 
     // NOW LLUI::getLanguage() should work. gDirUtilp must know the language
@@ -1611,7 +1625,7 @@ bool LLAppViewer::doFrame()
 
             {
                 LL_PROFILE_ZONE_NAMED_CATEGORY_APP("df gMeshRepo");
-            gMeshRepo.update() ;
+                gMeshRepo.update() ;
             }
 
             if(!total_work_pending) //pause texture fetching threads if nothing to process.
@@ -2797,19 +2811,6 @@ bool LLAppViewer::initConfiguration()
         // good because we haven't yet called LLUI::initClass().
         gDirUtilp->setSkinFolder(skinfolder->getValue().asString(),
                                  gSavedSettings.getString("Language"));
-    }
-
-    if (gSavedSettings.getBOOL("SpellCheck"))
-    {
-        std::list<std::string> dict_list;
-        std::string dict_setting = gSavedSettings.getString("SpellCheckDictionary");
-        boost::split(dict_list, dict_setting, boost::is_any_of(std::string(",")));
-        if (!dict_list.empty())
-        {
-            LLSpellChecker::setUseSpellCheck(dict_list.front());
-            dict_list.pop_front();
-            LLSpellChecker::instance().setSecondaryDictionaries(dict_list);
-        }
     }
 
     if (gNonInteractive)

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -1284,6 +1284,7 @@ bool LLAppViewer::init()
     //LLSimpleton creations
     LLEnvironment::createInstance();
     LLWorld::createInstance();
+    LLViewerStatsRecorder::createInstance();
     LLSelectMgr::createInstance();
     LLViewerCamera::createInstance();
     LL::GLTFSceneManager::createInstance();
@@ -2166,6 +2167,7 @@ bool LLAppViewer::cleanup()
     LL::GLTFSceneManager::deleteSingleton();
     LLEnvironment::deleteSingleton();
     LLSelectMgr::deleteSingleton();
+    LLViewerStatsRecorder::deleteSingleton();
     LLViewerEventRecorder::deleteSingleton();
     LLWorld::deleteSingleton();
     LLVoiceClient::deleteSingleton();

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1285,7 +1285,6 @@ bool idle_startup()
         //
         // Initialize classes w/graphics stuff.
         //
-        LLViewerStatsRecorder::instance(); // Since textures work in threads
         LLSurface::initClasses();
         display_startup();
 

--- a/indra/newview/llviewerstatsrecorder.cpp
+++ b/indra/newview/llviewerstatsrecorder.cpp
@@ -27,16 +27,13 @@
 #include "llviewerprecompiledheaders.h"
 #include "llviewerstatsrecorder.h"
 
-
 #include "llcontrol.h"
 #include "llfile.h"
+#include "llviewercontrol.h"
 #include "llviewerregion.h"
 #include "llviewerobject.h"
 #include "llworld.h"
 
-extern LLControlGroup  gSavedSettings;
-
-LLViewerStatsRecorder* LLViewerStatsRecorder::sInstance = NULL;
 LLViewerStatsRecorder::LLViewerStatsRecorder() :
     mStatsFile(NULL),
     mTimer(),
@@ -48,11 +45,6 @@ LLViewerStatsRecorder::LLViewerStatsRecorder() :
     mMaxDuration(300.f),
     mSkipSaveIfZeros(false)
 {
-    if (NULL != sInstance)
-    {
-        LL_ERRS() << "Attempted to create multiple instances of LLViewerStatsRecorder!" << LL_ENDL;
-    }
-    sInstance = this;
     clearStats();
 }
 

--- a/indra/newview/llviewerstatsrecorder.h
+++ b/indra/newview/llviewerstatsrecorder.h
@@ -38,13 +38,12 @@
 class LLMutex;
 class LLViewerObject;
 
-class LLViewerStatsRecorder : public LLSingleton<LLViewerStatsRecorder>
+class LLViewerStatsRecorder : public LLSimpleton<LLViewerStatsRecorder>
 {
-    LLSINGLETON(LLViewerStatsRecorder);
+public:
+    LLViewerStatsRecorder();
     LOG_CLASS(LLViewerStatsRecorder);
     ~LLViewerStatsRecorder();
-
- public:
     // Enable/disable stats recording.  This is broken down into two
     // flags so we can record stats without writing them to the log
     // file.  This is useful to analyzing updates for scene loading.
@@ -139,8 +138,6 @@ private:
     void writeToLog(F32 interval);
     void closeStatsFile();
     void makeStatsFileName();
-
-    static LLViewerStatsRecorder* sInstance;
 
     LLFILE *    mStatsFile;         // File to write data into
     std::string mStatsFileName;


### PR DESCRIPTION
Reduce thread contention between the main thread and all asset fetch threads due to frequent access to the singleton master dependency list by utilizing simpletons and statics.

Found while profiling:
![image](https://github.com/user-attachments/assets/320c7107-026b-489a-a48f-4219c5b05b87)
