### PR TITLE
[WebRTC] Voice dot not always visible after crossing region boundaries.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2150,20 +2150,9 @@ LLVoiceWebRTCConnection::LLVoiceWebRTCConnection(const LLUUID &regionID, const s
     mOutstandingRequests(0),
     mChannelID(channelID),
     mRegionID(regionID),
-    mPrimary(false),
+    mPrimary(true),
     mRetryWaitPeriod(0)
 {
-    if (isSpatial())
-    {
-        if (gAgent.getRegion())
-        {
-            mPrimary = (regionID == gAgent.getRegion()->getRegionID());
-        }
-    }
-    else
-    {
-        mPrimary = true;
-    }
 
     // retries wait a short period...randomize it so
     // all clients don't try to reconnect at once.
@@ -3065,6 +3054,10 @@ LLVoiceWebRTCSpatialConnection::LLVoiceWebRTCSpatialConnection(const LLUUID &reg
     LLVoiceWebRTCConnection(regionID, channelID),
     mParcelLocalID(parcelLocalID)
 {
+    if (gAgent.getRegion())
+    {
+        mPrimary = (regionID == gAgent.getRegion()->getRegionID());
+    }
 }
 
 LLVoiceWebRTCSpatialConnection::~LLVoiceWebRTCSpatialConnection()

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -622,7 +622,7 @@ class LLVoiceWebRTCConnection :
 
     bool connectionStateMachine();
 
-    virtual bool isSpatial() = 0;
+    virtual bool isSpatial() { return false; }
 
     LLUUID getRegionID() { return mRegionID; }
 
@@ -686,6 +686,7 @@ class LLVoiceWebRTCConnection :
     LLVoiceClientStatusObserver::EStatusType mCurrentStatus;
 
     LLUUID mRegionID;
+    bool   mPrimary;
     LLUUID mViewerSession;
     std::string mChannelID;
 


### PR DESCRIPTION
For issue #2064
The connection to the voice server was not upgraded/downgraded to primary/secondary when crossing region boundaries, so the server sent the wrong value and the viewer chose not to display a voice dot.