### PR TITLE
Fix loose mGalleryPanel in LLInventoryGallery

### DIFF
--- a/indra/newview/llfloaterimnearbychathandler.cpp
+++ b/indra/newview/llfloaterimnearbychathandler.cpp
@@ -152,7 +152,6 @@ protected:
     toast_list_t m_toast_pool;
 
     bool    mStopProcessing;
-    bool    mChannelRect;
 };
 
 

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -147,8 +147,6 @@ const LLInventoryGallery::Params& LLInventoryGallery::getDefaultParams()
 bool LLInventoryGallery::postBuild()
 {
     mScrollPanel = getChild<LLScrollContainer>("gallery_scroll_panel");
-    LLPanel::Params params = LLPanel::getDefaultParams();
-    mGalleryPanel = LLUICtrlFactory::create<LLPanel>(params);
     mMessageTextBox = getChild<LLTextBox>("empty_txt");
     mInventoryGalleryMenu = new LLInventoryGalleryContextMenu(this);
     mRootGalleryMenu = new LLInventoryGalleryContextMenu(this);

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -109,8 +109,6 @@ bool LLOutfitGallery::postBuild()
 {
     bool rv = LLOutfitListBase::postBuild();
     mScrollPanel = getChild<LLScrollContainer>("gallery_scroll_panel");
-    LLPanel::Params params = LLPanel::getDefaultParams(); // Don't parse XML when creating dummy LLPanel
-    mGalleryPanel = LLUICtrlFactory::create<LLPanel>(params);
     mMessageTextBox = getChild<LLTextBox>("no_outfits_txt");
     mOutfitGalleryMenu = new LLOutfitGalleryContextMenu(this);
     return rv;


### PR DESCRIPTION
LLInventoryGallery::buildGalleryPanel does the creation, not postBuild() same for LLOutfitGallery. Either don't create mGalleryPanel or remove it before creating again.