### PR TITLE
[WebRTC] Fixes to managing device start/stop playout/recording.

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -745,18 +745,6 @@
       </map>
       <key>glm</key>
       <map>
-        <key>canonical_repo</key>
-        <string>https://github.com/secondlife/3p-glm</string>
-        <key>copyright</key>
-        <string>Copyright (c) 2005 - G-Truc Creation</string>
-        <key>description</key>
-        <string>OpenGL Mathematics</string>
-        <key>license</key>
-        <string>MIT</string>
-        <key>license_file</key>
-        <string>LICENSES/glm_license.txt</string>
-        <key>name</key>
-        <string>glm</string>
         <key>platforms</key>
         <map>
           <key>common</key>
@@ -774,16 +762,28 @@
             <string>common</string>
           </map>
         </map>
-        <key>source_type</key>
-        <string>git</string>
+        <key>license</key>
+        <string>MIT</string>
+        <key>license_file</key>
+        <string>LICENSES/glm_license.txt</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2005 - G-Truc Creation</string>
+        <key>version</key>
+        <string>v1.0.1</string>
+        <key>name</key>
+        <string>glm</string>
         <key>vcs_branch</key>
         <string>refs/tags/v1.0.1-r1</string>
         <key>vcs_revision</key>
         <string>399cd5ba57a9267a560ce07e50a0f8c5fe3dc66f</string>
         <key>vcs_url</key>
         <string>git://github.com/secondlife/3p-glm.git</string>
-        <key>version</key>
-        <string>v1.0.1</string>
+        <key>canonical_repo</key>
+        <string>https://github.com/secondlife/3p-glm</string>
+        <key>description</key>
+        <string>OpenGL Mathematics</string>
+        <key>source_type</key>
+        <string>git</string>
       </map>
       <key>gstreamer</key>
       <map>
@@ -1418,14 +1418,6 @@
       </map>
       <key>llphysicsextensions_source</key>
       <map>
-        <key>copyright</key>
-        <string>Copyright (c) 2010, Linden Research, Inc.</string>
-        <key>license</key>
-        <string>internal</string>
-        <key>license_file</key>
-        <string>LICENSES/llphysicsextensions.txt</string>
-        <key>name</key>
-        <string>llphysicsextensions_source</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -1477,8 +1469,16 @@
             <string>windows64</string>
           </map>
         </map>
+        <key>license</key>
+        <string>internal</string>
+        <key>license_file</key>
+        <string>LICENSES/llphysicsextensions.txt</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2010, Linden Research, Inc.</string>
         <key>version</key>
         <string>1.0.b8b1f73</string>
+        <key>name</key>
+        <string>llphysicsextensions_source</string>
       </map>
       <key>llphysicsextensions_stub</key>
       <map>
@@ -2008,16 +2008,6 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
       </map>
       <key>openal</key>
       <map>
-        <key>copyright</key>
-        <string>Copyright (C) 1999-2007 by authors.</string>
-        <key>description</key>
-        <string>OpenAL Soft is a software implementation of the OpenAL 3D audio API.</string>
-        <key>license</key>
-        <string>LGPL2</string>
-        <key>license_file</key>
-        <string>LICENSES/openal-soft.txt</string>
-        <key>name</key>
-        <string>openal</string>
         <key>platforms</key>
         <map>
           <key>darwin64</key>
@@ -2063,8 +2053,18 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <string>windows64</string>
           </map>
         </map>
+        <key>license</key>
+        <string>LGPL2</string>
+        <key>license_file</key>
+        <string>LICENSES/openal-soft.txt</string>
+        <key>copyright</key>
+        <string>Copyright (C) 1999-2007 by authors.</string>
         <key>version</key>
         <string>1.23.1</string>
+        <key>name</key>
+        <string>openal</string>
+        <key>description</key>
+        <string>OpenAL Soft is a software implementation of the OpenAL 3D audio API.</string>
       </map>
       <key>openjpeg</key>
       <map>
@@ -2793,11 +2793,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>194b4f5957c9f003c46e61a434e23a7c3d1180d6</string>
+              <string>f8a58d9b5d18810189c5b09ca5c5d7227346ac8d</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.70-debug/webrtc-m114.5735.08.70-debug.10377605436-darwin64-10377605436.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72/webrtc-m114.5735.08.72.10447328796-darwin64-10447328796.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2807,11 +2807,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>38e0c7d30b4c40eb04e60ab199440b847cc7c6cf</string>
+              <string>0037f70b29f6c85eb7ee2f030f466d774793bf41</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.70-debug/webrtc-m114.5735.08.70-debug.10377605436-linux64-10377605436.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72/webrtc-m114.5735.08.72.10447328796-linux64-10447328796.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2821,11 +2821,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>053fb5c873df9192e34cddcf2db1c5fdcff76ba1</string>
+              <string>744ca0f034f73a10fc40182f6c099a5952cb42a6</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.70-debug/webrtc-m114.5735.08.70-debug.10377605436-windows64-10377605436.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72/webrtc-m114.5735.08.72.10447328796-windows64-10447328796.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2838,7 +2838,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.70-debug.10377605436</string>
+        <string>m114.5735.08.72.10447328796</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2793,11 +2793,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>cbf9fae6cdc6983456eec601a596ce27c961f05f</string>
+              <string>3570b6442d472cd97bad8622c2ec2571d72218a0</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-debug/webrtc-m114.5735.08.72-debug.10438479298-darwin64-10438479298.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-test/webrtc-m114.5735.08.72-test.10444682919-darwin64-10444682919.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2807,11 +2807,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>8a874c6bd96cdcce8b6fe744f235dc60f1bb4279</string>
+              <string>eadf6aa99313940ded11801d42c11375669f1628</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-debug/webrtc-m114.5735.08.72-debug.10438479298-linux64-10438479298.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-test/webrtc-m114.5735.08.72-test.10444682919-linux64-10444682919.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2821,11 +2821,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>379e29faa67a826729179f7228146e2812a6088a</string>
+              <string>0081fd35290adbc8e66dd366535fb6cd8a966f1e</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-debug/webrtc-m114.5735.08.72-debug.10438479298-windows64-10438479298.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.72-test/webrtc-m114.5735.08.72-test.10444682919-windows64-10444682919.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2838,7 +2838,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.72-debug.10438479298</string>
+        <string>m114.5735.08.72-test.10444682919</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/llwebrtc/CMakeLists.txt
+++ b/indra/llwebrtc/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library (llwebrtc SHARED ${llwebrtc_SOURCE_FILES})
 set_target_properties(llwebrtc PROPERTIES PUBLIC_HEADER llwebrtc.h)
 
 if (WINDOWS)
+    cmake_policy(SET CMP0091 NEW)
     set_target_properties(llwebrtc
         PROPERTIES
         LINK_FLAGS "/debug /LARGEADDRESSAWARE"
@@ -42,7 +43,10 @@ if (WINDOWS)
                                        wmcodecdspuuid
                                        msdmo
                                        strmiids
-                                       iphlpapi)
+                                       iphlpapi
+                                       libcmt)
+    # as the webrtc libraries are release, build this binary as release as well.
+    target_compile_options(llwebrtc PRIVATE "/MT")
     if (USE_BUGSPLAT)
         set_target_properties(llwebrtc PROPERTIES PDB_OUTPUT_DIRECTORY "${SYMBOLS_STAGING_DIR}")
     endif (USE_BUGSPLAT)

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -278,6 +278,8 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     // enables/disables capture via the capture device
     void setRecording(bool recording);
 
+    void setPlayout(bool playing);
+
   protected:
     LLWebRTCLogSink*                                           mLogSink;
 


### PR DESCRIPTION
Fix 1:
Fixes prevent attempting to start playout/recording before the devices are set up, to prevent restarting playout/recording, to prevent attempts to stop when not playing/recording, and so on...

This should address the case where audio device changes can cause an assert.  It should also address the case where audio was unnecessarily played or transmitted when connecting.

Fix 2:
When voice is disabled, the audio devices are not set up to play/record so there should be no disruption of bluetooth music from other apps.

Fix 3:
When a device transitions from two channels to one channel playout, then back to two, the audio stream now returns back to two channels.  i.e. when bluetooth goes out of hands-free mode, spatial audio returns.  (https://github.com/secondlife/viewer-private/issues/267) 

Fix 4:
Don't initialize or use audio devices when voice is disabled, allowing the viewer to be used even if there are bad device drivers or such.
(https://github.com/secondlife/viewer/issues/2259)

Fix 5:
Use release builds of the webrtc libraries, which don't included a lot of the debug-only asserts that were causing crashes.  This is okay, as the debug-only asserts typically assert in code where there is sufficient error handling to recover or otherwise proceed without crashing.  The non-debug asserts are not removed, however, so truly fatal errors will result in crash logging.
Also, symbols are still produced for these release builds of webrtc.
(https://github.com/secondlife/viewer/issues/2321)

Test Plan:
1) start the viewer with an audio device (maybe a bluetooth device) in use.
2) Log in to webrtc1.
3) Use the device to speak.
4) Disable/remove the device (either via the OS sound subsystem, or by simply turning off the bluetooth device.)
5) Voice should default back to any other available devices.

Also:
1) Use a bluetooth audio device for both input and output.
2) Play some audio from your favorite MP3 player  (just to get a secondary source)
3) Start the viewer, and log in to webrtc1.
4) Observe the audio from your MP3 doesn't revert to mono.
5) Press "talk"
6) Observe the audio from the MP3 source does revert to mono.
7) Log out, start the viewer, and disable voice from the preferences panel before logging in.
8) Log in.
9) Observe the MP3 audio does not revert to mono.

And:
1) With a bluetooth headset, log in to webrtc1 (user A)
2) With a separate viewer, log in to webrtc1 and generate audio.  (user B)
3) Move user A away from user B sufficiently to get spatial audio (try spinning after moving away)
4) Talk with user A - observe that spatial audio for user A goes to mono (it's a bluetooth thing.)
5) Un-talk user A - observe that spatial audio returns for user A.