### PR TITLE
Enable C++20 standard

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        runner: [windows-large, macos-12-xl]
+        runner: [windows-large, macos-13-xl]
         configuration: ${{ fromJSON(needs.setup.outputs.configurations) }}
     runs-on: ${{ matrix.runner }}
     outputs:
@@ -64,7 +64,7 @@ jobs:
       # autobuild-package.xml.
       AUTOBUILD_VCS_INFO: "true"
       AUTOBUILD_VSVER: "170"
-      DEVELOPER_DIR: "/Applications/Xcode_14.0.1.app/Contents/Developer"
+      DEVELOPER_DIR: "/Applications/Xcode.app/Contents/Developer"
       # Ensure that Linden viewer builds engage Bugsplat.
       BUGSPLAT_DB: ${{ needs.setup.outputs.bugsplat_db }}
       build_coverity: false

--- a/indra/CMakeLists.txt
+++ b/indra/CMakeLists.txt
@@ -29,6 +29,11 @@ else()
   set( USE_AUTOBUILD_3P ON )
 endif()
 
+# Override C++ standard version defined in build-variables here until all branches
+# and 3rd party libraries can build with C++20
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include(Variables)
 include(BuildVersion)
 

--- a/indra/llcommon/classic_callback.h
+++ b/indra/llcommon/classic_callback.h
@@ -85,7 +85,7 @@ struct index_of<idx, sought, candidate>
  * // ClassicCallback already used it to locate the lambda instance.)
  * auto ccb{
  *     makeClassicCallback<callback_t>(
- *         [=](int n, const char* s, void*, double f){ ... }) };
+ *         [=, this](int n, const char* s, void*, double f){ ... }) };
  * oldAPI(ccb.get_callback(), ccb.get_userdata());
  * // If the passed callback is called before oldAPI() returns, we can now
  * // safely destroy ccb. If the callback might be called later, consider

--- a/indra/llcommon/llapp.cpp
+++ b/indra/llcommon/llapp.cpp
@@ -226,7 +226,7 @@ bool LLApp::parseCommandOptions(int argc, wchar_t** wargv)
         if(wargv[ii][0] != '-')
         {
             LL_INFOS() << "Did not find option identifier while parsing token: "
-                << wargv[ii] << LL_ENDL;
+                << (intptr_t)wargv[ii] << LL_ENDL;
             return false;
         }
         int offset = 1;

--- a/indra/llcommon/llmainthreadtask.h
+++ b/indra/llcommon/llmainthreadtask.h
@@ -89,10 +89,10 @@ private:
         }
         // Given arbitrary CALLABLE, which might be a lambda, how are we
         // supposed to obtain its signature for std::packaged_task? It seems
-        // redundant to have to add an argument list to engage result_of, then
+        // redundant to have to add an argument list to engage invoke_result_t, then
         // add the argument list again to complete the signature. At least we
         // only support a nullary CALLABLE.
-        std::packaged_task<typename std::result_of<CALLABLE()>::type()> mTask;
+        std::packaged_task<std::invoke_result_t<CALLABLE>()> mTask;
     };
 };
 

--- a/indra/llcommon/llpointer.h
+++ b/indra/llcommon/llpointer.h
@@ -418,6 +418,18 @@ private:
     bool mStayUnique;
 };
 
+// compare operators for C++20
+template<typename Type>
+bool operator!=(Type *lhs, const LLPointer<Type> &rhs)
+{
+    return (lhs != rhs.get());
+}
+
+template<typename Type>
+bool operator==(Type *lhs, const LLPointer<Type> &rhs)
+{
+    return (lhs == rhs.get());
+}
 
 // boost hash adapter
 template <class Type>

--- a/indra/llcommon/llpredicate.h
+++ b/indra/llcommon/llpredicate.h
@@ -154,7 +154,7 @@ namespace LLPredicate
             return (mRule && value).someSet();
         }
 
-        bool requires(const Value<ENUM> value) const
+        bool required(const Value<ENUM> value) const
         {
             return (mRule && value).someSet() && (!mRule && value).noneSet();
         }

--- a/indra/llcommon/llpredicate.h
+++ b/indra/llcommon/llpredicate.h
@@ -139,7 +139,7 @@ namespace LLPredicate
         Rule()
         {}
 
-        void require(ENUM e, bool match)
+        void mandate(ENUM e, bool match)
         {
             mRule.set(e, match);
         }
@@ -154,7 +154,7 @@ namespace LLPredicate
             return (mRule && value).someSet();
         }
 
-        bool required(const Value<ENUM> value) const
+        bool mandates(const Value<ENUM> value) const
         {
             return (mRule && value).someSet() && (!mRule && value).noneSet();
         }

--- a/indra/llcommon/llqueuedthread.cpp
+++ b/indra/llcommon/llqueuedthread.cpp
@@ -146,7 +146,7 @@ size_t LLQueuedThread::updateQueue(F32 max_time_ms)
         // schedule a call to threadedUpdate for every call to updateQueue
         if (!isQuitting())
         {
-            mRequestQueue.post([=]()
+            mRequestQueue.post([=, this]()
                 {
                     LL_PROFILE_ZONE_NAMED_CATEGORY_THREAD("qt - update");
                     mIdleThread = false;
@@ -461,10 +461,10 @@ void LLQueuedThread::processRequest(LLQueuedThread::QueuedRequest* req)
                 // while work is pending
                 bool ret = LL::WorkQueue::postMaybe(
                     mMainQueue,
-                    [=]()
+                    [=, this]()
                     {
                         LL_PROFILE_ZONE_NAMED("processRequest - retry");
-                        mRequestQueue.post([=]()
+                        mRequestQueue.post([=, this]()
                             {
                                 LL_PROFILE_ZONE_NAMED("processRequest - retry"); // <-- not redundant, track retry on both queues
                                 processRequest(req);
@@ -474,7 +474,7 @@ void LLQueuedThread::processRequest(LLQueuedThread::QueuedRequest* req)
 #else
                 using namespace std::chrono_literals;
                 auto retry_time = LL::WorkQueue::TimePoint::clock::now() + 16ms;
-                mRequestQueue.post([=]
+                mRequestQueue.post([=, this]
                     {
                         LL_PROFILE_ZONE_NAMED("processRequest - retry");
                         if (LL::WorkQueue::TimePoint::clock::now() < retry_time)

--- a/indra/llcorehttp/tests/test_httpoperation.hpp
+++ b/indra/llcorehttp/tests/test_httpoperation.hpp
@@ -92,7 +92,7 @@ namespace tut
         op->setReplyPath(LLCore::HttpOperation::HttpReplyQueuePtr_t(), h1);
 
         // Check ref count
-        ensure(op.unique() == 1);
+        ensure(op.use_count() == 1);
 
         // release the reference, releasing the operation but
         // not the handlers.

--- a/indra/llprimitive/llprimitive.cpp
+++ b/indra/llprimitive/llprimitive.cpp
@@ -804,7 +804,7 @@ bool LLPrimitive::setVolume(const LLVolumeParams &volume_params, const S32 detai
         }
 
         volumep = sVolumeManager->refVolume(volume_params, detail);
-        if (volumep == mVolumep)
+        if (mVolumep == volumep)
         {
             sVolumeManager->unrefVolume( volumep );  // LLVolumeMgr::refVolume() creates a reference, but we don't need a second one.
             return true;

--- a/indra/llprimitive/lltextureentry.cpp
+++ b/indra/llprimitive/lltextureentry.cpp
@@ -562,7 +562,7 @@ void LLTextureEntry::setGLTFMaterial(LLGLTFMaterial* material, bool local_origin
 S32 LLTextureEntry::setGLTFMaterialOverride(LLGLTFMaterial* mat)
 {
     llassert(mat == nullptr || getGLTFMaterial() != nullptr); // if override is not null, base material must not be null
-    if (mat == mGLTFMaterialOverrides)
+    if (mGLTFMaterialOverrides == mat)
     {
         return TEM_CHANGE_NONE;
     }

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -1667,7 +1667,7 @@ void LLImageGL::syncToMainThread(LLGLuint new_tex_name)
             glFlush();
             LL::WorkQueue::postMaybe(
                 mMainQueue,
-                [=, this]()
+                [=/*, this*/]()
                 {
                     LL_PROFILE_ZONE_NAMED("cglt - wait sync");
                     {

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -1667,7 +1667,7 @@ void LLImageGL::syncToMainThread(LLGLuint new_tex_name)
             glFlush();
             LL::WorkQueue::postMaybe(
                 mMainQueue,
-                [=]()
+                [=, this]()
                 {
                     LL_PROFILE_ZONE_NAMED("cglt - wait sync");
                     {
@@ -1685,7 +1685,7 @@ void LLImageGL::syncToMainThread(LLGLuint new_tex_name)
     ref();
     LL::WorkQueue::postMaybe(
         mMainQueue,
-        [=]()
+        [=, this]()
         {
             LL_PROFILE_ZONE_NAMED("cglt - delete callback");
             syncTexName(new_tex_name);

--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -162,7 +162,7 @@ GLWorkQueue::Work GLWorkQueue::pop()
 
         // Wait for a new element to become available or for the queue to close
         {
-            mCondition.wait(lock, [=] { return !mQueue.empty() || mClosed; });
+            mCondition.wait(lock, [=, this] { return !mQueue.empty() || mClosed; });
         }
     }
 

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -34,7 +34,7 @@
 #include "llpanel.h"
 #include "llcriticaldamp.h"
 #include "lliconctrl.h"
-#include "boost/foreach.hpp"
+#include <ranges>
 
 static const F32 MIN_FRACTIONAL_SIZE = 0.00001f;
 static const F32 MAX_FRACTIONAL_SIZE = 1.f;
@@ -834,7 +834,7 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
     LLLayoutPanel* other_resize_panel = NULL;
     LLLayoutPanel* following_panel = NULL;
 
-    BOOST_REVERSE_FOREACH(LLLayoutPanel* panelp, mPanels) // Should replace this when C++20 reverse view adaptor becomes available...
+    for (auto panelp : mPanels | std::views::reverse)
     {
         if (panelp->mAutoResize)
         {
@@ -992,7 +992,7 @@ void LLLayoutStack::reshape(S32 width, S32 height, bool called_from_parent)
 void LLLayoutStack::updateResizeBarLimits()
 {
     LLLayoutPanel* previous_visible_panelp{ nullptr };
-    BOOST_REVERSE_FOREACH(LLLayoutPanel* visible_panelp, mPanels) // Should replace this when C++20 reverse view adaptor becomes available...
+    for (auto visible_panelp : mPanels | std::views::reverse)
     {
         if (!visible_panelp->getVisible() || visible_panelp->mCollapsed)
         {

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -36,8 +36,8 @@
 #include "lliconctrl.h"
 #include <ranges>
 
-static const F32 MIN_FRACTIONAL_SIZE = 0.00001f;
-static const F32 MAX_FRACTIONAL_SIZE = 1.f;
+static constexpr F32 MIN_FRACTIONAL_SIZE = 0.00001f;
+static constexpr F32 MAX_FRACTIONAL_SIZE = 1.f;
 
 static LLDefaultChildRegistry::Register<LLLayoutStack> register_layout_stack("layout_stack");
 static LLLayoutStack::LayoutStackRegistry::Register<LLLayoutPanel> register_layout_panel("layout_panel");
@@ -831,12 +831,11 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
     F32 delta_auto_resize_headroom = 0.f;
     F32 old_auto_resize_headroom = 0.f;
 
-    LLLayoutPanel* other_resize_panel = NULL;
-    LLLayoutPanel* following_panel = NULL;
+    LLLayoutPanel* other_resize_panel = nullptr;
+    LLLayoutPanel* following_panel = nullptr;
 
-    for (auto it = mPanels.rbegin(); it != mPanels.rend(); ++it)
+    for (auto panelp : mPanels | std::views::reverse)
     {
-        auto* panelp = *it;
         if (panelp->mAutoResize)
         {
             old_auto_resize_headroom += (F32)(panelp->mTargetDim - panelp->getRelevantMinDim());
@@ -993,9 +992,8 @@ void LLLayoutStack::reshape(S32 width, S32 height, bool called_from_parent)
 void LLLayoutStack::updateResizeBarLimits()
 {
     LLLayoutPanel* previous_visible_panelp{ nullptr };
-    for (auto it = mPanels.rbegin(); it != mPanels.rend(); ++it)
+    for (auto visible_panelp : mPanels | std::views::reverse)
     {
-        auto* visible_panelp = *it;
         if (!visible_panelp->getVisible() || visible_panelp->mCollapsed)
         {
             visible_panelp->mResizeBar->setVisible(false);

--- a/indra/llui/lllayoutstack.cpp
+++ b/indra/llui/lllayoutstack.cpp
@@ -834,8 +834,9 @@ void LLLayoutStack::updatePanelRect( LLLayoutPanel* resized_panel, const LLRect&
     LLLayoutPanel* other_resize_panel = NULL;
     LLLayoutPanel* following_panel = NULL;
 
-    for (auto panelp : mPanels | std::views::reverse)
+    for (auto it = mPanels.rbegin(); it != mPanels.rend(); ++it)
     {
+        auto* panelp = *it;
         if (panelp->mAutoResize)
         {
             old_auto_resize_headroom += (F32)(panelp->mTargetDim - panelp->getRelevantMinDim());
@@ -992,8 +993,9 @@ void LLLayoutStack::reshape(S32 width, S32 height, bool called_from_parent)
 void LLLayoutStack::updateResizeBarLimits()
 {
     LLLayoutPanel* previous_visible_panelp{ nullptr };
-    for (auto visible_panelp : mPanels | std::views::reverse)
+    for (auto it = mPanels.rbegin(); it != mPanels.rend(); ++it)
     {
+        auto* visible_panelp = *it;
         if (!visible_panelp->getVisible() || visible_panelp->mCollapsed)
         {
             visible_panelp->mResizeBar->setVisible(false);

--- a/indra/llui/llviewereventrecorder.cpp
+++ b/indra/llui/llviewereventrecorder.cpp
@@ -261,7 +261,7 @@ void LLViewerEventRecorder::logKeyUnicodeEvent(llwchar uni_char) {
 
   event.insert("event",LLSD("keyDown"));
 
-  LL_DEBUGS()  << "[VITA] unicode key: " << uni_char   << LL_ENDL;
+  LL_DEBUGS()  << "[VITA] unicode key: " << (int)uni_char   << LL_ENDL;
   LL_DEBUGS()  << "[VITA] dumpxml " << LLSDXMLStreamer(event) << "\n" << LL_ENDL;
 
 

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -685,7 +685,7 @@ void LLWebRTCPeerConnectionImpl::init(LLWebRTCImpl * webrtc_impl)
 void LLWebRTCPeerConnectionImpl::terminate()
 {
     mWebRTCImpl->PostSignalingTask(
-        [=]()
+        [=, this]()
         {
             if (mPeerConnection)
             {

--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -1040,7 +1040,7 @@ F32 LLWindowMacOSX::getGamma()
         &greenGamma,
         &blueMin,
         &blueMax,
-        &blueGamma) == noErr)
+        &blueGamma) == kCGErrorSuccess)
     {
         // So many choices...
         // Let's just return the green channel gamma for now.
@@ -1091,7 +1091,7 @@ bool LLWindowMacOSX::setGamma(const F32 gamma)
         &greenGamma,
         &blueMin,
         &blueMax,
-        &blueGamma) != noErr)
+        &blueGamma) != kCGErrorSuccess)
     {
         return false;
     }
@@ -1106,7 +1106,7 @@ bool LLWindowMacOSX::setGamma(const F32 gamma)
         gamma,
         blueMin,
         blueMax,
-        gamma) != noErr)
+        gamma) != kCGErrorSuccess)
     {
         return false;
     }
@@ -1158,7 +1158,7 @@ bool LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
     newPosition.y = screen_pos.mY;
 
     CGSetLocalEventsSuppressionInterval(0.0);
-    if(CGWarpMouseCursorPosition(newPosition) == noErr)
+    if(CGWarpMouseCursorPosition(newPosition) == kCGErrorSuccess)
     {
         result = true;
     }

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -1013,7 +1013,7 @@ bool LLWindowWin32::maximize()
     bool success = false;
     if (!mWindowHandle) return success;
 
-    mWindowThread->post([=]
+    mWindowThread->post([=, this]
         {
             WINDOWPLACEMENT placement;
             placement.length = sizeof(WINDOWPLACEMENT);
@@ -1077,7 +1077,7 @@ bool LLWindowWin32::setSizeImpl(const LLCoordScreen size)
         return false;
     }
 
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             WINDOWPLACEMENT placement;
             placement.length = sizeof(WINDOWPLACEMENT);
@@ -1691,7 +1691,7 @@ const   S32   max_format  = (S32)num_formats - 1;
 
     // *HACK: Attempt to prevent startup crashes by deferring memory accounting
     // until after some graphics setup. See SL-20177. -Cosmic,2023-09-18
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
     {
         mWindowThread->glReady();
     });
@@ -1926,7 +1926,7 @@ void LLWindowWin32::moveWindow( const LLCoordScreen& position, const LLCoordScre
     // THIS CAUSES DEV-15484 and DEV-15949
     //ShowWindow(mWindowHandle, SW_RESTORE);
     // NOW we can call MoveWindow
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             MoveWindow(mWindowHandle, position.mX, position.mY, size.mX, size.mY, TRUE);
         });
@@ -1936,7 +1936,7 @@ void LLWindowWin32::setTitle(const std::string title)
 {
     // TODO: Do we need to use the wide string version of this call
     // to support non-ascii usernames (and region names?)
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             SetWindowTextA(mWindowHandle, title.c_str());
         });
@@ -1962,7 +1962,7 @@ bool LLWindowWin32::setCursorPosition(const LLCoordWindow position)
     mCallbacks->handleMouseMove(this, position.convert(), (MASK)0);
 
     // actually set the cursor position on the window thread
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             // actually set the OS cursor position
             SetCursorPos(screen_pos.mX, screen_pos.mY);
@@ -1999,7 +1999,7 @@ void LLWindowWin32::hideCursor()
 {
     ASSERT_MAIN_THREAD();
 
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             while (ShowCursor(FALSE) >= 0)
             {
@@ -2017,7 +2017,7 @@ void LLWindowWin32::showCursor()
 
     ASSERT_MAIN_THREAD();
 
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             // makes sure the cursor shows up
             while (ShowCursor(TRUE) < 0)
@@ -2141,7 +2141,7 @@ void LLWindowWin32::updateCursor()
     {
         mCurrentCursor = mNextCursor;
         auto nextCursor = mCursor[mNextCursor];
-        mWindowThread->post([=]()
+        mWindowThread->post([=, this]()
             {
                 SetCursor(nextCursor);
             });
@@ -3358,9 +3358,9 @@ bool LLWindowWin32::getClientRectInScreenSpace( RECT* rectp )
 
 void LLWindowWin32::flashIcon(F32 seconds)
 {
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
-            FLASHWINFO flash_info;
+            FLASHWINFO flash_info {};
 
             flash_info.cbSize = sizeof(FLASHWINFO);
             flash_info.hwnd = mWindowHandle;
@@ -3838,7 +3838,7 @@ void *LLWindowWin32::getPlatformWindow()
 
 void LLWindowWin32::bringToFront()
 {
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             BringWindowToTop(mWindowHandle);
         });
@@ -3847,7 +3847,7 @@ void LLWindowWin32::bringToFront()
 // set (OS) window focus back to the client
 void LLWindowWin32::focusClient()
 {
-    mWindowThread->post([=]()
+    mWindowThread->post([=, this]()
         {
             SetFocus(mWindowHandle);
         });
@@ -3885,7 +3885,7 @@ void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, bool b)
 
     if (sLanguageTextInputAllowed)
     {
-        mWindowThread->post([=]()
+        mWindowThread->post([=, this]()
         {
             // Allowing: Restore the previous IME status, so that the user has a feeling that the previous
             // text input continues naturally.  Be careful, however, the IME status is meaningful only during the user keeps
@@ -3901,7 +3901,7 @@ void LLWindowWin32::allowLanguageTextInput(LLPreeditor *preeditor, bool b)
     }
     else
     {
-        mWindowThread->post([=]()
+        mWindowThread->post([=, this]()
         {
             // Disallowing: Turn off the IME so that succeeding key events bypass IME and come to us directly.
             // However, do it after saving the current IME  status.  We need to restore the status when
@@ -4920,7 +4920,7 @@ void LLWindowWin32::updateWindowRect()
     if (GetWindowRect(mWindowHandle, &rect) &&
         GetClientRect(mWindowHandle, &client_rect))
     {
-        post([=]
+        post([=, this]
             {
                 mRect = rect;
                 mClientRect = client_rect;

--- a/indra/llxml/llxmlnode.cpp
+++ b/indra/llxml/llxmlnode.cpp
@@ -222,13 +222,13 @@ bool LLXMLNode::removeChild(LLXMLNode *target_child)
         LLXMLChildList::iterator children_itr = mChildren->map.find(target_child->mName);
         while (children_itr != mChildren->map.end())
         {
-            if (target_child == children_itr->second)
+            if (children_itr->second == target_child)
             {
-                if (target_child == mChildren->head)
+                if (mChildren->head == target_child)
                 {
                     mChildren->head = target_child->mNext;
                 }
-                if (target_child == mChildren->tail)
+                if (mChildren->tail == target_child)
                 {
                     mChildren->tail = target_child->mPrev;
                 }

--- a/indra/newview/gltfscenemanager.cpp
+++ b/indra/newview/gltfscenemanager.cpp
@@ -494,7 +494,7 @@ void GLTFSceneManager::update()
             LLNewBufferedResourceUploadInfo::uploadFinish_f finish = [this, buffer](LLUUID assetId, LLSD response)
             {
                 LLAppViewer::instance()->postToMainCoro(
-                    [=]()
+                    [=, this]()
                     {
                         if (mUploadingAsset)
                         {

--- a/indra/newview/lldeferredsounds.cpp
+++ b/indra/newview/lldeferredsounds.cpp
@@ -29,8 +29,6 @@
 
 #include "lldeferredsounds.h"
 
-#include "llaudioengine.h"
-
 void LLDeferredSounds::deferSound(SoundData& sound)
 {
     soundVector.push_back(sound);

--- a/indra/newview/lldeferredsounds.h
+++ b/indra/newview/lldeferredsounds.h
@@ -28,8 +28,7 @@
 #define LL_LLDEFERREDSOUNDS_H
 
 #include "llsingleton.h"
-
-struct SoundData;
+#include "llaudioengine.h"
 
 class LLDeferredSounds : public LLSingleton<LLDeferredSounds>
 {

--- a/indra/newview/lldrawable.cpp
+++ b/indra/newview/lldrawable.cpp
@@ -140,7 +140,7 @@ void LLDrawable::init(bool new_entry)
         llassert(!vo_entry->getGroup()); //not in the object cache octree.
     }
 
-    llassert(!vo_entry || vo_entry->getEntry() == mEntry);
+    llassert(!vo_entry || LLPointer<LLViewerOctreeEntry>(vo_entry->getEntry()) == mEntry);
 
     initVisible(sCurVisible - 2);//invisible for the current frame and the last frame.
 }

--- a/indra/newview/lldrawpool.cpp
+++ b/indra/newview/lldrawpool.cpp
@@ -415,7 +415,7 @@ void LLRenderPass::renderRiggedGroup(LLSpatialGroup* group, U32 type, bool textu
         LLDrawInfo* pparams = *k;
         if (pparams)
         {
-            if (lastAvatar != pparams->mAvatar || lastMeshId != pparams->mSkinInfo->mHash)
+            if (pparams->mAvatar != lastAvatar || pparams->mSkinInfo->mHash != lastMeshId)
             {
                 uploadMatrixPalette(*pparams);
                 lastAvatar = pparams->mAvatar;
@@ -477,7 +477,7 @@ void LLRenderPass::pushRiggedBatches(U32 type, bool texture, bool batch_textures
             LLDrawInfo* pparams = *i;
             LLCullResult::increment_iterator(i, end);
 
-            if (pparams->mAvatar.notNull() && (lastAvatar != pparams->mAvatar || lastMeshId != pparams->mSkinInfo->mHash))
+            if (pparams->mAvatar.notNull() && (pparams->mAvatar != lastAvatar || pparams->mSkinInfo->mHash != lastMeshId))
             {
                 uploadMatrixPalette(*pparams);
                 lastAvatar = pparams->mAvatar;
@@ -505,7 +505,7 @@ void LLRenderPass::pushUntexturedRiggedBatches(U32 type)
         LLDrawInfo* pparams = *i;
         LLCullResult::increment_iterator(i, end);
 
-        if (pparams->mAvatar.notNull() && (lastAvatar != pparams->mAvatar || lastMeshId != pparams->mSkinInfo->mHash))
+        if (pparams->mAvatar.notNull() && (pparams->mAvatar != lastAvatar || pparams->mSkinInfo->mHash != lastMeshId))
         {
             uploadMatrixPalette(*pparams);
             lastAvatar = pparams->mAvatar;
@@ -554,7 +554,7 @@ void LLRenderPass::pushRiggedMaskBatches(U32 type, bool texture, bool batch_text
             gGL.flush();
         }
 
-        if (lastAvatar != pparams->mAvatar || lastMeshId != pparams->mSkinInfo->mHash)
+        if (pparams->mAvatar != lastAvatar || pparams->mSkinInfo->mHash != lastMeshId)
         {
             uploadMatrixPalette(*pparams);
             lastAvatar = pparams->mAvatar;
@@ -838,7 +838,7 @@ void LLRenderPass::pushUntexturedRiggedGLTFBatches(U32 type)
 // static
 void LLRenderPass::pushRiggedGLTFBatch(LLDrawInfo& params, LLVOAvatar*& lastAvatar, U64& lastMeshId)
 {
-    if (params.mAvatar.notNull() && (lastAvatar != params.mAvatar || lastMeshId != params.mSkinInfo->mHash))
+    if (params.mAvatar.notNull() && (params.mAvatar != lastAvatar || params.mSkinInfo->mHash != lastMeshId))
     {
         uploadMatrixPalette(params);
         lastAvatar = params.mAvatar;
@@ -851,7 +851,7 @@ void LLRenderPass::pushRiggedGLTFBatch(LLDrawInfo& params, LLVOAvatar*& lastAvat
 // static
 void LLRenderPass::pushUntexturedRiggedGLTFBatch(LLDrawInfo& params, LLVOAvatar*& lastAvatar, U64& lastMeshId)
 {
-    if (params.mAvatar.notNull() && (lastAvatar != params.mAvatar || lastMeshId != params.mSkinInfo->mHash))
+    if (params.mAvatar.notNull() && (params.mAvatar != lastAvatar || params.mSkinInfo->mHash != lastMeshId))
     {
         uploadMatrixPalette(params);
         lastAvatar = params.mAvatar;

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -351,8 +351,8 @@ void LLDrawPoolAlpha::renderAlphaHighlight()
 
                     if (rigged)
                     {
-                        if (lastAvatar != params.mAvatar ||
-                            lastMeshId != params.mSkinInfo->mHash)
+                        if (params.mAvatar != lastAvatar ||
+                            params.mSkinInfo->mHash != lastMeshId)
                         {
                             if (!uploadMatrixPalette(params))
                             {
@@ -534,7 +534,7 @@ void LLDrawPoolAlpha::renderRiggedEmissives(std::vector<LLDrawInfo*>& emissives)
         LL_PROFILE_ZONE_NAMED_CATEGORY_DRAWPOOL("Emissives");
 
         bool tex_setup = TexSetup(draw, false);
-        if (lastAvatar != draw->mAvatar || lastMeshId != draw->mSkinInfo->mHash)
+        if (draw->mAvatar != lastAvatar || draw->mSkinInfo->mHash != lastMeshId)
         {
             if (!uploadMatrixPalette(*draw))
             { // failed to upload matrix palette, skip rendering
@@ -558,7 +558,7 @@ void LLDrawPoolAlpha::renderRiggedPbrEmissives(std::vector<LLDrawInfo*>& emissiv
 
     for (LLDrawInfo* draw : emissives)
     {
-        if (lastAvatar != draw->mAvatar || lastMeshId != draw->mSkinInfo->mHash)
+        if (draw->mAvatar != lastAvatar || draw->mSkinInfo->mHash != lastMeshId)
         {
             if (!uploadMatrixPalette(*draw))
             { // failed to upload matrix palette, skip rendering
@@ -770,7 +770,7 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
 
                     if (current_shader)
                     {
-                        current_shader->uniform4f(LLShaderMgr::SPECULAR_COLOR, spec_color.mV[0], spec_color.mV[1], spec_color.mV[2], spec_color.mV[3]);
+                        current_shader->uniform4f(LLShaderMgr::SPECULAR_COLOR, spec_color.mV[VRED], spec_color.mV[VGREEN], spec_color.mV[VBLUE], spec_color.mV[VALPHA]);
                         current_shader->uniform1f(LLShaderMgr::ENVIRONMENT_INTENSITY, env_intensity);
                         current_shader->uniform1f(LLShaderMgr::EMISSIVE_BRIGHTNESS, brightness);
                     }
@@ -778,8 +778,8 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
 
                 if (params.mAvatar != nullptr)
                 {
-                    if (lastAvatar != params.mAvatar ||
-                        lastMeshId != params.mSkinInfo->mHash ||
+                    if (params.mAvatar != lastAvatar ||
+                        params.mSkinInfo->mHash != lastMeshId||
                         lastAvatarShader != LLGLSLShader::sCurBoundShaderPtr)
                     {
                         if (!uploadMatrixPalette(params))

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -572,7 +572,7 @@ void LLDrawPoolBump::renderDeferred(S32 pass)
 
             if (rigged)
             {
-                if (avatar != params.mAvatar || skin != params.mSkinInfo->mHash)
+                if (params.mAvatar != avatar || params.mSkinInfo->mHash != skin)
                 {
                     uploadMatrixPalette(params);
                     avatar = params.mAvatar;
@@ -993,7 +993,7 @@ void LLDrawPoolBump::pushBumpBatches(U32 type)
         {
             if (mRigged)
             {
-                if (avatar != params.mAvatar || skin != params.mSkinInfo->mHash)
+                if (params.mAvatar != avatar || params.mSkinInfo->mHash != skin)
                 {
                     if (uploadMatrixPalette(params))
                     {

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -2123,7 +2123,7 @@ void LLEnvironment::coroRequestEnvironment(S32 parcel_id, LLEnvironment::environ
         LLSD environment = result[KEY_ENVIRONMENT];
         if (environment.isDefined() && apply)
         {
-            LLAppViewer::instance()->postToMainCoro([=, this]()
+            LLAppViewer::instance()->postToMainCoro([=/*, this*/]()
                 {
                     EnvironmentInfo::ptr_t envinfo = LLEnvironment::EnvironmentInfo::extract(environment);
                     apply(parcel_id, envinfo);

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -2123,7 +2123,7 @@ void LLEnvironment::coroRequestEnvironment(S32 parcel_id, LLEnvironment::environ
         LLSD environment = result[KEY_ENVIRONMENT];
         if (environment.isDefined() && apply)
         {
-            LLAppViewer::instance()->postToMainCoro([=]()
+            LLAppViewer::instance()->postToMainCoro([=, this]()
                 {
                     EnvironmentInfo::ptr_t envinfo = LLEnvironment::EnvironmentInfo::extract(environment);
                     apply(parcel_id, envinfo);

--- a/indra/newview/llhudeffectlookat.cpp
+++ b/indra/newview/llhudeffectlookat.cpp
@@ -412,7 +412,7 @@ bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *objec
     F32 current_time  = mTimer.getElapsedTimeF32();
 
     // type of lookat behavior or target object has changed
-    bool lookAtChanged = (target_type != mTargetType) || (object != mTargetObject);
+    bool lookAtChanged = (mTargetType != target_type) || (mTargetObject != object);
 
     // lookat position has moved a certain amount and we haven't just sent an update
     lookAtChanged = lookAtChanged || ((dist_vec_squared(position, mLastSentOffsetGlobal) > MIN_DELTAPOS_FOR_UPDATE_SQUARED) &&

--- a/indra/newview/llhudeffectpointat.cpp
+++ b/indra/newview/llhudeffectpointat.cpp
@@ -241,8 +241,7 @@ bool LLHUDEffectPointAt::setPointAt(EPointAtType target_type, LLViewerObject *ob
     F32 current_time  = mTimer.getElapsedTimeF32();
 
     // type of pointat behavior or target object has changed
-    bool targetTypeChanged = (target_type != mTargetType) ||
-        (object != mTargetObject);
+    bool targetTypeChanged = (mTargetType != target_type) || (mTargetObject != object);
 
     bool targetPosChanged = (dist_vec_squared(position, mLastSentOffsetGlobal) > MIN_DELTAPOS_FOR_UPDATE_SQUARED) &&
         ((current_time - mLastSendTime) > (1.f / MAX_SENDS_PER_SEC));

--- a/indra/newview/llhudeffecttrail.cpp
+++ b/indra/newview/llhudeffecttrail.cpp
@@ -252,7 +252,7 @@ void LLHUDEffectSpiral::triggerLocal()
 
 void LLHUDEffectSpiral::setTargetObject(LLViewerObject *objp)
 {
-    if (objp == mTargetObject)
+    if (mTargetObject == objp)
     {
         return;
     }

--- a/indra/newview/llhudobject.cpp
+++ b/indra/newview/llhudobject.cpp
@@ -85,7 +85,7 @@ F32 LLHUDObject::getDistance() const
 
 void LLHUDObject::setSourceObject(LLViewerObject* objectp)
 {
-    if (objectp == mSourceObject)
+    if (mSourceObject == objectp)
     {
         return;
     }
@@ -95,7 +95,7 @@ void LLHUDObject::setSourceObject(LLViewerObject* objectp)
 
 void LLHUDObject::setTargetObject(LLViewerObject* objectp)
 {
-    if (objectp == mTargetObject)
+    if (mTargetObject == objectp)
     {
         return;
     }

--- a/indra/newview/llkeyconflict.cpp
+++ b/indra/newview/llkeyconflict.cpp
@@ -165,7 +165,7 @@ bool LLKeyConflictHandler::registerControl(const std::string &control_name, U32 
         return false;
     }
     LLKeyData data(mouse, key, mask, ignore_mask);
-    if (type_data.mKeyBind.getKeyData(index) == data)
+    if (type_data.mKeyBind.getKeyData(index).operator==(data))
     {
         return true;
     }
@@ -650,7 +650,7 @@ void LLKeyConflictHandler::resetToDefault(const std::string &control_name, U32 i
     }
     LLKeyData data = getDefaultControl(control_name, index);
 
-    if (data != type_data.getKeyData(index))
+    if (data.operator!=(type_data.getKeyData(index)))
     {
         // reset controls that might have been switched to our current control
         removeConflicts(data, mControlsMap[control_name].mConflictMask);

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -546,8 +546,8 @@ LLViewerFetchedTexture* LLMeshUploadThread::FindViewerTexture(const LLImportMate
     return ppTex ? (*ppTex).get() : NULL;
 }
 
-volatile S32 LLMeshRepoThread::sActiveHeaderRequests = 0;
-volatile S32 LLMeshRepoThread::sActiveLODRequests = 0;
+S32 LLMeshRepoThread::sActiveHeaderRequests = 0;
+S32 LLMeshRepoThread::sActiveLODRequests = 0;
 U32 LLMeshRepoThread::sMaxConcurrentRequests = 1;
 S32 LLMeshRepoThread::sRequestLowWater = REQUEST2_LOW_WATER_MIN;
 S32 LLMeshRepoThread::sRequestHighWater = REQUEST2_HIGH_WATER_MIN;

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -255,8 +255,8 @@ class LLMeshRepoThread : public LLThread
 {
 public:
 
-    volatile static S32 sActiveHeaderRequests;
-    volatile static S32 sActiveLODRequests;
+    static S32 sActiveHeaderRequests;
+    static S32 sActiveLODRequests;
     static U32 sMaxConcurrentRequests;
     static S32 sRequestLowWater;
     static S32 sRequestHighWater;

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -438,6 +438,7 @@ void LLPanelEmojiComplete::updateConstraints()
 {
     mRenderRect = getLocalRect();
 
+    // Use cat face emoji as template to calculate width
     mEmojiWidth = (U16)(mIconFont->getWidthF32(reinterpret_cast<const char*>(u8"\U0001F431")) + mPadding * 2);
     if (mVertical)
     {

--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -438,7 +438,7 @@ void LLPanelEmojiComplete::updateConstraints()
 {
     mRenderRect = getLocalRect();
 
-    mEmojiWidth = (U16)(mIconFont->getWidthF32(u8"\U0001F431") + mPadding * 2);
+    mEmojiWidth = (U16)(mIconFont->getWidthF32(reinterpret_cast<const char*>(u8"\U0001F431")) + mPadding * 2);
     if (mVertical)
     {
         mEmojiHeight = mIconFont->getLineHeight() + mPadding * 2;

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -340,7 +340,7 @@ void LLReflectionMapManager::update()
             continue;
         }
 
-        if (probe != mDefaultProbe &&
+        if (mDefaultProbe != probe &&
             (!probe->isRelevant() || mPaused))
         { // skip irrelevant probes (or all non-default probes if paused)
             continue;
@@ -348,7 +348,7 @@ void LLReflectionMapManager::update()
 
         LLVector4a d;
 
-        if (probe != mDefaultProbe)
+        if (mDefaultProbe != probe)
         {
             if (probe->mViewerObject) //make sure probes track the viewer objects they are attached to
             {
@@ -684,7 +684,7 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
         mLightScale = max_local_light_ambiance / probe->getAmbiance();
     }
 
-    if (probe == mDefaultProbe)
+    if (mDefaultProbe == probe)
     {
         touch_default_probe(probe);
 
@@ -1071,7 +1071,7 @@ void LLReflectionMapManager::updateUniforms()
             break;
         }
 
-        if (refmap != mDefaultProbe)
+        if (mDefaultProbe != refmap)
         {
             // bucket search data
             // theory of operation:

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -606,7 +606,7 @@ void LLReflectionMapManager::deleteProbe(U32 i)
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;
     LLReflectionMap* probe = mProbes[i];
 
-    llassert(probe != mDefaultProbe);
+    llassert(probe != mDefaultProbe.get());
 
     if (probe->mCubeIndex != -1)
     { // mark the cube index used by this probe as being free

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -7790,7 +7790,7 @@ void LLObjectSelection::moveNodeToFront(LLSelectNode *nodep)
 void LLObjectSelection::removeNode(LLSelectNode *nodep)
 {
     mSelectNodeMap.erase(nodep->getObject());
-    if (nodep->getObject() == mPrimaryObject)
+    if (mPrimaryObject == nodep->getObject())
     {
         mPrimaryObject = NULL;
     }

--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -301,7 +301,7 @@ bool LLSpatialGroup::addObject(LLDrawable *drawablep)
     }
     {
         drawablep->setGroup(this);
-        setState(OBJECT_DIRTY | GEOM_DIRTY);
+        setState(static_cast<U32>(OBJECT_DIRTY) | static_cast<U32>(GEOM_DIRTY));
         setOcclusionState(LLSpatialGroup::DISCARD_QUERY, LLSpatialGroup::STATE_MODE_ALL_CAMERAS);
         gPipeline.markRebuild(this);
         if (drawablep->isSpatialBridge())
@@ -731,7 +731,7 @@ bool LLSpatialGroup::changeLOD()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_SPATIAL;
 
-    if (hasState(ALPHA_DIRTY | OBJECT_DIRTY))
+    if (hasState(static_cast<U32>(ALPHA_DIRTY) | static_cast<U32>(OBJECT_DIRTY)))
     {
         //a rebuild is going to happen, update distance and LoD
         return true;

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -47,7 +47,7 @@
 #include <unordered_map>
 
 #define SG_STATE_INHERIT_MASK (OCCLUDED)
-#define SG_INITIAL_STATE_MASK (DIRTY | GEOM_DIRTY)
+#define SG_INITIAL_STATE_MASK (static_cast<U32>(DIRTY) | static_cast<U32>(GEOM_DIRTY))
 
 class LLViewerOctreePartition;
 class LLSpatialPartition;

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -3524,7 +3524,7 @@ TFReqSendMetrics::doWork(LLTextureFetch * fetcher)
     //  return true;
 
     static volatile bool reporting_started(false);
-    static volatile S32 report_sequence(0);
+    static S32 report_sequence(0);
 
     // In mStatsSD, we have a copy we own of the LLSD representation
     // of the asset stats. Add some additional fields and ship it off.

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -2832,7 +2832,7 @@ bool LLTextureFetch::getRequestFinished(const LLUUID& id, S32& discard_level,
 bool LLTextureFetch::updateRequestPriority(const LLUUID& id, F32 priority)
 {
     LL_PROFILE_ZONE_SCOPED;
-    mRequestQueue.tryPost([=]()
+    mRequestQueue.tryPost([=, this]()
         {
             LLTextureFetchWorker* worker = getWorker(id);
             if (worker)

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -2902,14 +2902,14 @@ void LLViewerMediaImpl::update()
             media_tex->ref();
             main_queue->postTo(
                 mTexUpdateQueue, // Worker thread queue
-                [=]() // work done on update worker thread
+                [=, this]()       // work done on update worker thread
                 {
 #if LL_IMAGEGL_THREAD_CHECK
                     media_tex->getGLTexture()->mActiveThread = LLThread::currentID();
 #endif
                     doMediaTexUpdate(media_tex, data, data_width, data_height, x_pos, y_pos, width, height, true);
                 },
-                [=]() // callback to main thread
+                [=, this]()  // callback to main thread
                 {
 #if LL_IMAGEGL_THREAD_CHECK
                     media_tex->getGLTexture()->mActiveThread = LLThread::currentID();

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2451,7 +2451,7 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
     // copy features to lambda in case the region is deleted before the lambda is executed
     LLSD features = mSimulatorFeatures;
 
-    auto work = [=, this]()
+    auto work = [=/*, this*/]()
         {
             // if region has MaxTextureResolution, set max_texture_dimension settings, otherwise use default
             if (features.has("MaxTextureResolution"))

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -2451,7 +2451,7 @@ void LLViewerRegion::setSimulatorFeatures(const LLSD& sim_features)
     // copy features to lambda in case the region is deleted before the lambda is executed
     LLSD features = mSimulatorFeatures;
 
-    auto work = [=]()
+    auto work = [=, this]()
         {
             // if region has MaxTextureResolution, set max_texture_dimension settings, otherwise use default
             if (features.has("MaxTextureResolution"))

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -503,7 +503,7 @@ S32 LLEmbeddedItems::getIndexFromEmbeddedChar(llwchar wch)
     }
     else
     {
-        LL_WARNS() << "Embedded char " << wch << " not found, using 0" << LL_ENDL;
+        LL_WARNS() << "Embedded char " << (int)wch << " not found, using 0" << LL_ENDL;
         return 0;
     }
 }

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -725,12 +725,12 @@ bool LLViewerTexture::bindDefaultImage(S32 stage)
     if (stage < 0) return false;
 
     bool res = true;
-    if (LLViewerFetchedTexture::sDefaultImagep.notNull() && (this != LLViewerFetchedTexture::sDefaultImagep.get()))
+    if (LLViewerFetchedTexture::sDefaultImagep.notNull() && (LLViewerFetchedTexture::sDefaultImagep != this))
     {
         // use default if we've got it
         res = gGL.getTexUnit(stage)->bind(LLViewerFetchedTexture::sDefaultImagep);
     }
-    if (!res && LLViewerTexture::sNullImagep.notNull() && (this != LLViewerTexture::sNullImagep))
+    if (!res && LLViewerTexture::sNullImagep.notNull() && (LLViewerTexture::sNullImagep != this))
     {
         res = gGL.getTexUnit(stage)->bind(LLViewerTexture::sNullImagep);
     }

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1331,7 +1331,7 @@ LLWindowCallbacks::DragNDropResult LLViewerWindow::handleDragNDrop( LLWindow *wi
                                 // Check the whitelist, if there's media (otherwise just show it)
                                 if (te->getMediaData() == NULL || te->getMediaData()->checkCandidateUrl(url))
                                 {
-                                    if ( obj != mDragHoveredObject)
+                                    if (mDragHoveredObject != obj)
                                     {
                                         // Highlight the dragged object
                                         LLSelectMgr::getInstance()->unhighlightObjectOnly(mDragHoveredObject);

--- a/indra/newview/llvograss.cpp
+++ b/indra/newview/llvograss.cpp
@@ -596,7 +596,7 @@ U32 LLVOGrass::getPartitionType() const
 }
 
 LLGrassPartition::LLGrassPartition(LLViewerRegion* regionp)
-: LLSpatialPartition(LLDrawPoolAlpha::VERTEX_DATA_MASK | LLVertexBuffer::MAP_TEXTURE_INDEX, true, regionp)
+: LLSpatialPartition(static_cast<U32>(LLDrawPoolAlpha::VERTEX_DATA_MASK) | static_cast<U32>(LLVertexBuffer::MAP_TEXTURE_INDEX), true, regionp)
 {
     mDrawableType = LLPipeline::RENDER_TYPE_GRASS;
     mPartitionType = LLViewerRegion::PARTITION_GRASS;

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -6297,7 +6297,7 @@ void LLVivoxVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESta
 
         if (voice_status)
         {
-            LLAppViewer::instance()->postToMainCoro([=, this]() { LLFirstUse::speak(true); });
+            LLAppViewer::instance()->postToMainCoro([=/*, this*/]() { LLFirstUse::speak(true); });
         }
     }
 }

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -6297,7 +6297,7 @@ void LLVivoxVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESta
 
         if (voice_status)
         {
-            LLAppViewer::instance()->postToMainCoro([=]() { LLFirstUse::speak(true); });
+            LLAppViewer::instance()->postToMainCoro([=, this]() { LLFirstUse::speak(true); });
         }
     }
 }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -410,7 +410,7 @@ void LLWebRTCVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESt
 
         if (voice_status)
         {
-            LLAppViewer::instance()->postToMainCoro([=]() { LLFirstUse::speak(true); });
+            LLAppViewer::instance()->postToMainCoro([=, this]() { LLFirstUse::speak(true); });
         }
     }
 }
@@ -644,8 +644,7 @@ void LLWebRTCVoiceClient::OnDevicesChanged(const llwebrtc::LLWebRTCVoiceDeviceLi
                                            const llwebrtc::LLWebRTCVoiceDeviceList& capture_devices)
 {
 
-    LL::WorkQueue::postMaybe(mMainQueue,
-                             [=]
+    LL::WorkQueue::postMaybe(mMainQueue, [=, this]
         {
             OnDevicesChangedImpl(render_devices, capture_devices);
         });
@@ -2158,7 +2157,7 @@ LLVoiceWebRTCConnection::~LLVoiceWebRTCConnection()
 void LLVoiceWebRTCConnection::OnIceGatheringState(llwebrtc::LLWebRTCSignalingObserver::EIceGatheringState state)
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             LL_DEBUGS("Voice") << "Ice Gathering voice account. " << state << LL_ENDL;
 
             switch (state)
@@ -2181,7 +2180,7 @@ void LLVoiceWebRTCConnection::OnIceGatheringState(llwebrtc::LLWebRTCSignalingObs
 // callback from llwebrtc
 void LLVoiceWebRTCConnection::OnIceCandidate(const llwebrtc::LLWebRTCIceCandidate& candidate)
 {
-    LL::WorkQueue::postMaybe(mMainQueue, [=] { mIceCandidates.push_back(candidate); });
+    LL::WorkQueue::postMaybe(mMainQueue, [=, this] { mIceCandidates.push_back(candidate); });
 }
 
 void LLVoiceWebRTCConnection::processIceUpdates()
@@ -2298,7 +2297,7 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro(connectionPtr_t connection)
 void LLVoiceWebRTCConnection::OnOfferAvailable(const std::string &sdp)
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             if (mShutDown)
             {
                 return;
@@ -2325,7 +2324,7 @@ void LLVoiceWebRTCConnection::OnOfferAvailable(const std::string &sdp)
 void LLVoiceWebRTCConnection::OnAudioEstablished(llwebrtc::LLWebRTCAudioInterface* audio_interface)
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             if (mShutDown)
             {
                 return;
@@ -2347,7 +2346,7 @@ void LLVoiceWebRTCConnection::OnAudioEstablished(llwebrtc::LLWebRTCAudioInterfac
 void LLVoiceWebRTCConnection::OnRenegotiationNeeded()
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             LL_DEBUGS("Voice") << "Voice channel requires renegotiation." << LL_ENDL;
             if (!mShutDown)
             {
@@ -2361,7 +2360,7 @@ void LLVoiceWebRTCConnection::OnRenegotiationNeeded()
 void LLVoiceWebRTCConnection::OnPeerConnectionClosed()
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             LL_DEBUGS("Voice") << "Peer connection has closed." << LL_ENDL;
             if (mVoiceConnectionState == VOICE_STATE_WAIT_FOR_CLOSE)
             {
@@ -2795,7 +2794,7 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
 // llwebrtc callback
 void LLVoiceWebRTCConnection::OnDataReceived(const std::string& data, bool binary)
 {
-    LL::WorkQueue::postMaybe(mMainQueue, [=] { LLVoiceWebRTCConnection::OnDataReceivedImpl(data, binary); });
+    LL::WorkQueue::postMaybe(mMainQueue, [=, this] { LLVoiceWebRTCConnection::OnDataReceivedImpl(data, binary); });
 }
 
 //
@@ -2950,7 +2949,7 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
 void LLVoiceWebRTCConnection::OnDataChannelReady(llwebrtc::LLWebRTCDataInterface *data_interface)
 {
     LL::WorkQueue::postMaybe(mMainQueue,
-        [=] {
+        [=, this] {
             if (mShutDown)
             {
                 return;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -410,7 +410,7 @@ void LLWebRTCVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESt
 
         if (voice_status)
         {
-            LLAppViewer::instance()->postToMainCoro([=, this]() { LLFirstUse::speak(true); });
+            LLAppViewer::instance()->postToMainCoro([=/*, this*/]() { LLFirstUse::speak(true); });
         }
     }
 }

--- a/indra/newview/llvopartgroup.cpp
+++ b/indra/newview/llvopartgroup.cpp
@@ -702,7 +702,7 @@ U32 LLVOPartGroup::getPartitionType() const
 }
 
 LLParticlePartition::LLParticlePartition(LLViewerRegion* regionp)
-: LLSpatialPartition(LLDrawPoolAlpha::VERTEX_DATA_MASK | LLVertexBuffer::MAP_TEXTURE_INDEX, true, regionp)
+: LLSpatialPartition(static_cast<U32>(LLDrawPoolAlpha::VERTEX_DATA_MASK) | static_cast<U32>(LLVertexBuffer::MAP_TEXTURE_INDEX), true, regionp)
 {
     mRenderPass = LLRenderPass::PASS_ALPHA;
     mDrawableType = LLPipeline::RENDER_TYPE_PARTICLES;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -6645,7 +6645,7 @@ void LLPipeline::renderAlphaObjects(bool rigged)
                 LLGLSLShader::sCurBoundShaderPtr->uniform1i(LLShaderMgr::SUN_UP_FACTOR, sun_up);
                 LLGLSLShader::sCurBoundShaderPtr->uniform1f(LLShaderMgr::DEFERRED_SHADOW_TARGET_WIDTH, (float)target_width);
                 LLGLSLShader::sCurBoundShaderPtr->setMinimumAlpha(ALPHA_BLEND_CUTOFF);
-                if (lastAvatar != pparams->mAvatar || lastMeshId != pparams->mSkinInfo->mHash)
+                if (pparams->mAvatar != lastAvatar || pparams->mSkinInfo->mHash != lastMeshId)
                 {
                     mSimplePool->uploadMatrixPalette(*pparams);
                     lastAvatar = pparams->mAvatar;


### PR DESCRIPTION
The following issues had to be resolved in order to achieve C++20 compatibility:
* `std::result_of` has been deprecated since C++17 and was removed with C++20. Replaced with `std::invoke_result` and its respective helper `std::invoke_result_t`
* `requires` is a keyword as of C++20, so the method with the same name in `Rule` (llpredicate.h) has been renamed to `required` (also seems to be unused anyway)
* Implicit capture of `&(*this)` via value-capture-default ([=]) has been deprecated. Replaced affected cases with `[=, this]`
* Compiler gets very picky about (un)equal operations between `T*` and `LLPointer<T>`. Changed order of arguments so `LLPointer<T>` is on the left-hand side and `T*` on the right-hand side to use overloaded operators from LLPointer instead of having to call `LLPointer<T>::get()`
* `u8` character literal has type `char8_t` instead of `char` since C++20 - use `reinterpret_cast<const char*>` to cast to compatible type in LLPanelEmojiComplete::updateConstraints()
* `std::shared_ptr::unique()` has been removed in C++20 - replaced check in test_httpoperation.hpp with `std::shared_ptr::use_count()` since the test was basically wrong because of a copy-paste-error anyway
* Replace `BOOST_REVERSE_FOREACH` with reverse view range adaptor that became available with C++20