### PR TITLE
Fix a bunch of XUI errors

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1237,11 +1237,6 @@ void LLFloaterPreference::buildPopupLists()
 
 void LLFloaterPreference::refreshEnabledState()
 {
-    LLCheckBoxCtrl* ctrl_pbr = getChild<LLCheckBoxCtrl>("UsePBRShaders");
-
-    //PBR
-    ctrl_pbr->setEnabled(true);
-
     // Cannot have floater active until caps have been received
     getChild<LLButton>("default_creation_permissions")->setEnabled(LLStartUp::getStartupState() >= STATE_STARTED);
 

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
@@ -153,7 +153,6 @@ void LLFloaterPreferenceGraphicsAdvanced::refresh()
     updateSliderText(getChild<LLSliderCtrl>("TerrainMeshDetail",    true), getChild<LLTextBox>("TerrainMeshDetailText",     true));
     updateSliderText(getChild<LLSliderCtrl>("RenderPostProcess",    true), getChild<LLTextBox>("PostProcessText",           true));
     updateSliderText(getChild<LLSliderCtrl>("SkyMeshDetail",        true), getChild<LLTextBox>("SkyMeshDetailText",         true));
-    updateSliderText(getChild<LLSliderCtrl>("TerrainDetail",        true), getChild<LLTextBox>("TerrainDetailText",         true));
     LLAvatarComplexityControls::setIndirectControls();
     setMaxNonImpostorsText(
         gSavedSettings.getU32("RenderAvatarMaxNonImpostors"),
@@ -268,10 +267,6 @@ void LLFloaterPreferenceGraphicsAdvanced::setMaxNonImpostorsText(U32 value, LLTe
 
 void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 {
-    LLComboBox* ctrl_reflections   = getChild<LLComboBox>("Reflections");
-    LLTextBox* reflections_text = getChild<LLTextBox>("ReflectionsText");
-    LLCheckBoxCtrl* ctrl_wind_light    = getChild<LLCheckBoxCtrl>("WindLightUseAtmosShaders");
-    LLCheckBoxCtrl* ctrl_deferred = getChild<LLCheckBoxCtrl>("UseLightShaders");
     LLComboBox* ctrl_shadows = getChild<LLComboBox>("ShadowDetail");
     LLTextBox* shadows_text = getChild<LLTextBox>("RenderShadowDetailText");
     LLCheckBoxCtrl* ctrl_ssao = getChild<LLCheckBoxCtrl>("UseSSAO");
@@ -282,9 +277,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
     // disabled windlight
     if (!LLFeatureManager::getInstance()->isFeatureAvailable("WindLightUseAtmosShaders"))
     {
-        ctrl_wind_light->setEnabled(false);
-        ctrl_wind_light->setValue(false);
-
         sky->setEnabled(false);
         sky_text->setEnabled(false);
 
@@ -298,9 +290,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 
         ctrl_dof->setEnabled(false);
         ctrl_dof->setValue(false);
-
-        ctrl_deferred->setEnabled(false);
-        ctrl_deferred->setValue(false);
     }
 
     // disabled deferred
@@ -315,9 +304,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 
         ctrl_dof->setEnabled(false);
         ctrl_dof->setValue(false);
-
-        ctrl_deferred->setEnabled(false);
-        ctrl_deferred->setValue(false);
     }
 
     // disabled deferred SSAO
@@ -338,51 +324,13 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 
 void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledState()
 {
-    LLComboBox* ctrl_reflections = getChild<LLComboBox>("Reflections");
-    LLTextBox* reflections_text = getChild<LLTextBox>("ReflectionsText");
-
-    // Reflections
-    bool reflections = LLCubeMap::sUseCubeMaps;
-    ctrl_reflections->setEnabled(reflections);
-    reflections_text->setEnabled(reflections);
-
-    // Bump & Shiny
-    LLCheckBoxCtrl* bumpshiny_ctrl = getChild<LLCheckBoxCtrl>("BumpShiny");
-    bool bumpshiny = LLCubeMap::sUseCubeMaps && LLFeatureManager::getInstance()->isFeatureAvailable("RenderObjectBump");
-    bumpshiny_ctrl->setEnabled(bumpshiny);
-
-    // Vertex Shaders, Global Shader Enable
-    // SL-12594 Basic shaders are always enabled. DJH TODO clean up now-orphaned state handling code
-    LLSliderCtrl* terrain_detail = getChild<LLSliderCtrl>("TerrainDetail");   // can be linked with control var
-    LLTextBox* terrain_text = getChild<LLTextBox>("TerrainDetailText");
-
-    terrain_detail->setEnabled(false);
-    terrain_text->setEnabled(false);
-
     // WindLight
-    //LLCheckBoxCtrl* ctrl_wind_light = getChild<LLCheckBoxCtrl>("WindLightUseAtmosShaders");
-    //ctrl_wind_light->setEnabled(true);
     LLSliderCtrl* sky = getChild<LLSliderCtrl>("SkyMeshDetail");
     LLTextBox* sky_text = getChild<LLTextBox>("SkyMeshDetailText");
     sky->setEnabled(true);
     sky_text->setEnabled(true);
 
     bool enabled = true;
-#if 0 // deferred always on now
-    //Deferred/SSAO/Shadows
-    LLCheckBoxCtrl* ctrl_deferred = getChild<LLCheckBoxCtrl>("UseLightShaders");
-
-    enabled = LLFeatureManager::getInstance()->isFeatureAvailable("RenderDeferred") &&
-        bumpshiny_ctrl && bumpshiny_ctrl->get() &&
-        ctrl_wind_light->get();
-
-    ctrl_deferred->setEnabled(enabled);
-#endif
-
-    LLCheckBoxCtrl* ctrl_pbr = getChild<LLCheckBoxCtrl>("UsePBRShaders");
-
-    //PBR
-    ctrl_pbr->setEnabled(true);
 
     LLCheckBoxCtrl* ctrl_ssao = getChild<LLCheckBoxCtrl>("UseSSAO");
     LLCheckBoxCtrl* ctrl_dof = getChild<LLCheckBoxCtrl>("UseDoF");
@@ -414,11 +362,6 @@ void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledState()
         getChildView("texture compression")->setEnabled(false);
     }
 
-    // if no windlight shaders, turn off nighttime brightness, gamma, and fog distance
-    LLUICtrl* gamma_ctrl = getChild<LLUICtrl>("gamma");
-    gamma_ctrl->setEnabled(!gPipeline.canUseWindLightShaders());
-    getChildView("(brightness, lower is brighter)")->setEnabled(!gPipeline.canUseWindLightShaders());
-    getChildView("fog")->setEnabled(!gPipeline.canUseWindLightShaders());
     getChildView("antialiasing restart")->setVisible(!LLFeatureManager::getInstance()->isFeatureAvailable("RenderDeferred"));
 
     // now turn off any features that are unavailable

--- a/indra/newview/llfloatersidepanelcontainer.cpp
+++ b/indra/newview/llfloatersidepanelcontainer.cpp
@@ -56,7 +56,7 @@ LLFloaterSidePanelContainer::~LLFloaterSidePanelContainer()
 bool LLFloaterSidePanelContainer::postBuild()
 {
     mMainPanel = getChild<LLPanel>(sMainPanelName);
-    return TRUE;
+    return true;
 }
 
 void LLFloaterSidePanelContainer::onOpen(const LLSD& key)

--- a/indra/newview/skins/default/xui/en/floater_fast_timers.xml
+++ b/indra/newview/skins/default/xui/en/floater_fast_timers.xml
@@ -73,7 +73,9 @@
         name="scroll_vert"
         orientation="vertical"
         step_size="16"
+        doc_pos="0"
         doc_size="3000"
+        page_size="0"
           />
     </layout_panel>
     <layout_panel name="timers_panel"

--- a/indra/newview/skins/default/xui/en/panel_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_login.xml
@@ -145,7 +145,6 @@
     control_name="RememberPassword"
     follows="left|top"
     font="SansSerifMedium"
-    text_color="EmphasisColor"
     height="24"
     left="408"
     bottom_delta="0"

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -313,7 +313,6 @@
   <color_swatch
    can_apply_immediately="true"
    color="0 0 0 1"
-   control_name="NameTagBackground"
    follows="left|top"
    height="24"
    label_height="0"

--- a/indra/newview/skins/default/xui/en/widgets/slider_bar.xml
+++ b/indra/newview/skins/default/xui/en/widgets/slider_bar.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <!--All horizontal sliders are configured to have no highlighted track. See EXT-5939. -->
 <slider_bar follows="left|top"
-            track_color="SliderTrackColor"
             thumb_outline_color="SliderThumbOutlineColor"
             thumb_center_color="SliderThumbCenterColor"
             thumb_image="SliderThumb_Off"


### PR DESCRIPTION
```
2024-08-19T14:11:13Z WARNING # llcommon/llinitparam.cpp(217) LLInitParam::BaseBlock::validateBlock : Invalid param "doc_pos"
2024-08-19T14:11:13Z WARNING # llui/lluictrlfactory.h(217) LLUICtrlFactory::createWidgetImpl : E:\\SecondLifeTest\\skins\\default\\xui\\en\\floater_fast_timers.xml: Invalid parameter block for class LLScrollbar
2024-08-19T14:11:17Z WARNING # llcommon/llinitparam.cpp(103) LLInitParam::Parser::parserWarning : Failed to parse parameter "text_color.":	E:\\SecondLifeTest\\skins\\default\\xui\\en\\panel_login.xml(144)
2024-08-19T14:11:20Z WARNING # llcommon/llinitparam.cpp(103) LLInitParam::Parser::parserWarning : Failed to parse parameter "track_color.":	E:\\SecondLifeTest\\skins\\default\\xui\\en\\widgets\\slider_bar.xml(3)
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLTextBox named "TerrainDetailText" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLSliderCtrl named "TerrainDetail" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLComboBox named "Reflections" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLTextBox named "ReflectionsText" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLCheckBoxCtrl named "BumpShiny" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLCheckBoxCtrl named "UsePBRShaders" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLUICtrl named "gamma" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLView named "(brightness, lower is brighter)" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLView named "fog" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLCheckBoxCtrl named "WindLightUseAtmosShaders" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLCheckBoxCtrl named "UseLightShaders" in prefs_graphics_advanced
2024-08-19T14:11:20Z WARNING # llui/lluictrl.cpp(557) LLUICtrl::setControlName : Failed to assign control variable to background: control NameTagBackground does not exist.
2024-08-19T14:11:21Z WARNING # llui/llview.h(722) LLView::getChild : Making dummy class LLCheckBoxCtrl named "UsePBRShaders" in Preferences
```