### PR TITLE
viewer#2363 Region Day Offset error with Time of Day

### DIFF
--- a/indra/newview/llpanelenvironment.cpp
+++ b/indra/newview/llpanelenvironment.cpp
@@ -296,7 +296,7 @@ void LLPanelEnvironmentInfo::refresh()
     F32Hours dayoffset(mCurrentEnvironment->mDayOffset);
 
     if (dayoffset.value() > 12.0f)
-        dayoffset -= F32Hours(24.0);
+        dayoffset -= daylength;
 
     mSliderDayLength->setValue(daylength.value());
     mSliderDayOffset->setValue(dayoffset.value());
@@ -723,6 +723,11 @@ void LLPanelEnvironmentInfo::onSldDayLengthChanged(F32 value)
         F32Hours daylength(value);
 
         mCurrentEnvironment->mDayLength = daylength;
+        F32 offset = (F32)mSliderDayOffset->getValue().asReal();
+        if (offset <= 0.0f)
+        {
+            onSldDayOffsetChanged(offset);
+        }
         setDirtyFlag(DIRTY_FLAG_DAYLENGTH);
 
         udpateApparentTimeOfDay();
@@ -736,7 +741,8 @@ void LLPanelEnvironmentInfo::onSldDayOffsetChanged(F32 value)
         F32Hours dayoffset(value);
 
         if (dayoffset.value() <= 0.0f)
-            dayoffset += F32Hours(24.0);
+            // if day cycle is 5 hours long, we want -1h offset to result in 4h
+            dayoffset += mCurrentEnvironment->mDayLength;
 
         mCurrentEnvironment->mDayOffset = dayoffset;
         setDirtyFlag(DIRTY_FLAG_DAYOFFSET);
@@ -929,7 +935,7 @@ void LLPanelEnvironmentInfo::udpateApparentTimeOfDay()
 {
     static const F32 SECONDSINDAY(24.0 * 60.0 * 60.0);
 
-    if ((!mCurrentEnvironment) || (mCurrentEnvironment->mDayLength.value() < 1.0) || (mCurrentEnvironment->mDayOffset.value() < 1.0))
+    if ((!mCurrentEnvironment) || (mCurrentEnvironment->mDayLength.value() < 1.0))
     {
         mLabelApparentTime->setVisible(false);
         return;


### PR DESCRIPTION
When we have a 23h day cycle and 23h offset, doing a 24h flip will result in -1h. Flip by day length instead so that 23h-23h will result in 0h.

This has a negative side effect of values not being saved exactly as users specified them, so a -1h offset will turn to 4h on next load with a 5h long day. But it is nature of a day to 'loop', so I decided there is no point to translate -1 into 14 or something like that just to be able to indicate that it needs to be with a '-' sign.