### PR TITLE
Fix hang when incoming p2p or group calls throw up dialog.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -556,7 +556,6 @@ void LLWebRTCVoiceClient::voiceConnectionCoro()
                         return;
                     }
                     sessionState::processSessionStates();
-                    //sessionState::processSessionStates();
                     if (mProcessChannels && voiceEnabled && !mHidden)
                     {
                         sendPositionUpdate(false);

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -549,13 +549,20 @@ void LLWebRTCVoiceClient::voiceConnectionCoro()
                     updatePosition();
                 }
             }
-
-            sessionState::processSessionStates();
-            if (mProcessChannels && voiceEnabled && !mHidden)
-            {
-                sendPositionUpdate(false);
-                updateOwnVolume();
-            }
+            LL::WorkQueue::postMaybe(mMainQueue,
+                [=] {
+                    if  (sShuttingDown)
+                    {
+                        return;
+                    }
+                    sessionState::processSessionStates();
+                    //sessionState::processSessionStates();
+                    if (mProcessChannels && voiceEnabled && !mHidden)
+                    {
+                        sendPositionUpdate(false);
+                        updateOwnVolume();
+                    }
+            });
         }
     }
     catch (const LLCoros::Stop&)
@@ -2221,6 +2228,7 @@ void LLVoiceWebRTCConnection::OnIceCandidate(const llwebrtc::LLWebRTCIceCandidat
 void LLVoiceWebRTCConnection::processIceUpdates()
 {
     mOutstandingRequests++;
+
     LLCoros::getInstance()->launch("LLVoiceWebRTCConnection::processIceUpdatesCoro",
                                    boost::bind(&LLVoiceWebRTCConnection::processIceUpdatesCoro, this->shared_from_this()));
 }


### PR DESCRIPTION
Fix for https://github.com/secondlife/viewer/issues/2346

There were changes in atlasaurus that resulted in a hang for incoming p2p and group calls which throw up dialogs.  The changes revolved around mutex, coroutines, job queues, and such.
The fix was to do any processing that may result in callbacks from the webrtc code in a queued job instead of a coroutine.