### PR TITLE
Fix for #2237: intermittent Lua data stack overflow.

### DIFF
--- a/indra/llcommon/lua_function.cpp
+++ b/indra/llcommon/lua_function.cpp
@@ -1056,7 +1056,10 @@ LuaStackDelta::LuaStackDelta(lua_State* L, const std::string& where, int delta):
 LuaStackDelta::~LuaStackDelta()
 {
     auto depth{ lua_gettop(L) };
-    if (mDepth + mDelta != depth)
+    // If we're unwinding the stack due to an exception, then of course we
+    // can't expect the logic in the block containing this LuaStackDelta
+    // instance to keep its contract wrt the Lua data stack.
+    if (std::uncaught_exceptions() == 0 && mDepth + mDelta != depth)
     {
         LL_ERRS("Lua") << mWhere << ": Lua stack went from " << mDepth << " to " << depth;
         if (mDelta)

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -65,6 +65,9 @@ namespace lluau
     void check_interrupts_counter(lua_State* L);
 } // namespace lluau
 
+// must be a macro because __FUNCTION__ is context-sensitive
+#define lluau_checkstack(L, n) luaL_checkstack((L), (n), __FUNCTION__)
+
 std::string lua_tostdstring(lua_State* L, int index);
 void lua_pushstdstring(lua_State* L, const std::string& str);
 LLSD lua_tollsd(lua_State* L, int index);
@@ -294,7 +297,7 @@ auto lua_to<void*>(lua_State* L, int index)
 template <typename T>
 auto lua_getfieldv(lua_State* L, int index, const char* k)
 {
-    luaL_checkstack(L, 1, nullptr);
+    lluau_checkstack(L, 1);
     lua_getfield(L, index, k);
     LuaPopper pop(L, 1);
     return lua_to<T>(L, -1);
@@ -304,7 +307,7 @@ auto lua_getfieldv(lua_State* L, int index, const char* k)
 template <typename T>
 auto lua_setfieldv(lua_State* L, int index, const char* k, const T& value)
 {
-    luaL_checkstack(L, 1, nullptr);
+    lluau_checkstack(L, 1);
     lua_push(L, value);
     lua_setfield(L, index, k);
 }
@@ -313,7 +316,7 @@ auto lua_setfieldv(lua_State* L, int index, const char* k, const T& value)
 template <typename T>
 auto lua_rawgetfield(lua_State* L, int index, const std::string_view& k)
 {
-    luaL_checkstack(L, 1, nullptr);
+    lluau_checkstack(L, 1);
     lua_pushlstring(L, k.data(), k.length());
     lua_rawget(L, index);
     LuaPopper pop(L, 1);
@@ -324,7 +327,7 @@ auto lua_rawgetfield(lua_State* L, int index, const std::string_view& k)
 template <typename T>
 void lua_rawsetfield(lua_State* L, int index, const std::string_view& k, const T& value)
 {
-    luaL_checkstack(L, 2, nullptr);
+    lluau_checkstack(L, 2);
     lua_pushlstring(L, k.data(), k.length());
     lua_push(L, value);
     lua_rawset(L, index);
@@ -430,7 +433,7 @@ DistinctInt TypeTag<T>::value;
 template <class T, typename... ARGS>
 void lua_emplace(lua_State* L, ARGS&&... args)
 {
-    luaL_checkstack(L, 1, nullptr);
+    lluau_checkstack(L, 1);
     int tag{ TypeTag<T>::value };
     if (! lua_getuserdatadtor(L, tag))
     {

--- a/indra/llcommon/scope_exit.h
+++ b/indra/llcommon/scope_exit.h
@@ -1,0 +1,34 @@
+/**
+ * @file   scope_exit.h
+ * @author Nat Goodspeed
+ * @date   2024-08-15
+ * @brief  Cheap imitation of std::experimental::scope_exit
+ * 
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Copyright (c) 2024, Linden Research, Inc.
+ * $/LicenseInfo$
+ */
+
+#if ! defined(LL_SCOPE_EXIT_H)
+#define LL_SCOPE_EXIT_H
+
+#include <functional>
+
+namespace LL
+{
+
+class scope_exit
+{
+public:
+    scope_exit(const std::function<void()>& func): mFunc(func) {}
+    scope_exit(const scope_exit&) = delete;
+    scope_exit& operator=(const scope_exit&) = delete;
+    ~scope_exit() { mFunc(); }
+
+private:
+    std::function<void()> mFunc;
+};
+
+} // namespace LL
+
+#endif /* ! defined(LL_SCOPE_EXIT_H) */

--- a/indra/llcommon/tempset.h
+++ b/indra/llcommon/tempset.h
@@ -35,7 +35,7 @@ public:
 
 private:
     VAR& mVar;
-    VALUE mOldValue;
+    VAR mOldValue;
 };
 
 #endif /* ! defined(LL_TEMPSET_H) */

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -57,7 +57,7 @@ lua_function(sleep, "sleep(seconds): pause the running coroutine")
     F32 seconds = lua_tonumber(L, -1);
     lua_pop(L, 1);
     llcoro::suspendUntilTimeout(seconds);
-    lluau::set_interrupts_counter(L, 0);
+    LuaState::getParent(L).set_interrupts_counter(0);
     return 0;
 };
 
@@ -162,7 +162,7 @@ lua_function(get_event_next,
     const auto& [pump, data]{ listener.getNext() };
     lua_pushstdstring(L, pump);
     lua_pushllsd(L, data);
-    lluau::set_interrupts_counter(L, 0);
+    LuaState::getParent(L).set_interrupts_counter(0);
     return 2;
 }
 

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -66,7 +66,7 @@ std::string lua_print_msg(lua_State* L, const std::string_view& level)
 {
     // On top of existing Lua arguments, we're going to push tostring() and
     // duplicate each existing stack entry so we can stringize each one.
-    luaL_checkstack(L, 2, nullptr);
+    lluau_checkstack(L, 2);
     luaL_where(L, 1);
     // start with the 'where' info at the top of the stack
     std::ostringstream out;
@@ -139,7 +139,7 @@ lua_function(get_event_pumps,
              "Events posted to replypump are queued for get_event_next().\n"
              "post_on(commandpump, ...) to engage LLEventAPI operations (see helpleap()).")
 {
-    luaL_checkstack(L, 2, nullptr);
+    lluau_checkstack(L, 2);
     auto& listener{ LuaState::obtainListener(L) };
     // return the reply pump name and the command pump name on caller's lua_State
     lua_pushstdstring(L, listener.getReplyName());
@@ -153,7 +153,7 @@ lua_function(get_event_next,
              "is returned by get_event_pumps(). Blocks the calling chunk until an\n"
              "event becomes available.")
 {
-    luaL_checkstack(L, 2, nullptr);
+    lluau_checkstack(L, 2);
     auto& listener{ LuaState::obtainListener(L) };
     const auto& [pump, data]{ listener.getNext() };
     lua_pushstdstring(L, pump);

--- a/indra/newview/llluamanager.cpp
+++ b/indra/newview/llluamanager.cpp
@@ -53,6 +53,7 @@ std::map<std::string, std::string> LLLUAmanager::sScriptNames;
 
 lua_function(sleep, "sleep(seconds): pause the running coroutine")
 {
+    lua_checkdelta(L, -1);
     F32 seconds = lua_tonumber(L, -1);
     lua_pop(L, 1);
     llcoro::suspendUntilTimeout(seconds);
@@ -125,6 +126,7 @@ lua_function(print_warning, "print_warning(args...): WARNING level logging")
 
 lua_function(post_on, "post_on(pumpname, data): post specified data to specified LLEventPump")
 {
+    lua_checkdelta(L, -2);
     std::string pumpname{ lua_tostdstring(L, 1) };
     LLSD data{ lua_tollsd(L, 2) };
     lua_pop(L, 2);
@@ -139,6 +141,7 @@ lua_function(get_event_pumps,
              "Events posted to replypump are queued for get_event_next().\n"
              "post_on(commandpump, ...) to engage LLEventAPI operations (see helpleap()).")
 {
+    lua_checkdelta(L, 2);
     lluau_checkstack(L, 2);
     auto& listener{ LuaState::obtainListener(L) };
     // return the reply pump name and the command pump name on caller's lua_State
@@ -153,6 +156,7 @@ lua_function(get_event_next,
              "is returned by get_event_pumps(). Blocks the calling chunk until an\n"
              "event becomes available.")
 {
+    lua_checkdelta(L, 2);
     lluau_checkstack(L, 2);
     auto& listener{ LuaState::obtainListener(L) };
     const auto& [pump, data]{ listener.getNext() };
@@ -271,6 +275,7 @@ std::string read_file(const std::string &name)
 
 lua_function(require, "require(module_name) : load module_name.lua from known places")
 {
+    lua_checkdelta(L);
     std::string name = lua_tostdstring(L, 1);
     lua_pop(L, 1);
 

--- a/indra/newview/scripts/lua/require/timers.lua
+++ b/indra/newview/scripts/lua/require/timers.lua
@@ -34,35 +34,53 @@ function timers.Timer:new(delay, callback, iterate)
 
     callback = callback or function() obj:tick() end
 
-    local first = true
+    local calls = 0
     if iterate then
+        -- With iterative timers, beware of running a timer callback which
+        -- performs async actions lasting longer than the timer interval. The
+        -- lengthy callback suspends, allowing leap to retrieve the next
+        -- event, which is a timer tick. leap calls a new instance of the
+        -- callback, even though the previous callback call is still
+        -- suspended... etc. 'in_callback' defends against that recursive
+        -- case. Rather than re-enter the suspended callback, drop the
+        -- too-soon timer event. (We could count the too-soon timer events and
+        -- iterate calling the callback, but it's a bathtub problem: the
+        -- callback could end up getting farther and farther behind.)
+        local in_callback = false
         obj.id = leap.eventstream(
             'Timers',
             {op='scheduleEvery', every=delay},
             function (event)
                 local reqid = event.reqid
-                if first then
-                    first = false
+                calls += 1
+                if calls == 1 then
                     dbg('timer(%s) first callback', reqid)
                     -- discard the first (immediate) response: don't call callback
                     return nil
                 else
-                    dbg('timer(%s) nth callback', reqid)
-                    return callback(event)
+                    if in_callback then
+                        dbg('dropping timer(%s) callback %d', reqid, calls)
+                    else
+                        dbg('timer(%s) callback %d', reqid, calls)
+                        in_callback = true
+                        local ret = callback(event)
+                        in_callback = false
+                        return ret
+                    end
                 end
             end
         ).reqid
-    else
+    else                        -- (not iterate)
         obj.id = leap.eventstream(
             'Timers',
             {op='scheduleAfter', after=delay},
             function (event)
+                calls += 1
                 -- Arrange to return nil the first time, true the second. This
                 -- callback is called immediately with the response to
                 -- 'scheduleAfter', and if we immediately returned true, we'd
                 -- be done, and the subsequent timer event would be discarded.
-                if first then
-                    first = false
+                if calls == 1 then
                     -- Caller doesn't expect an immediate callback.
                     return nil
                 else


### PR DESCRIPTION
Use a static `unordered_map` to allow a function receiving `(lua_State* L)` to
look up the `LuaState` instance managing that `lua_State`. We've thought about
this from time to time already. `LuaState`'s constructor creates the map entry;
its destructor removes it; the new static `getParent(lua_State* L)` method
performs the lookup.

Migrate `lluau::set_interrupts_counter()` and `check_interrupts_counter()` into
`LuaState` member functions. Add a new `mInterrupts` counter for them.

Importantly, `LuaState::check_interrupts_counter()`, which is indirectly called
by a `lua_callbacks().interrupt` function, no longer performs any Lua stack
operations. Empirically, it seems the Lua engine is capable of interrupting
itself at a moment when re-entry confuses it.

Change previous `lluau::set_interrupts_counter(L, 0)` calls to
`LuaState::getParent(L).set_interrupts_counter(0)`.

Also add `LuaStackDelta` class, and a `lua_checkdelta()` helper macro, to verify
that the Lua data stack depth on exit from a block differs from the depth on
entry by exactly the expected amount. Sprinkle `lua_checkdelta()` macros in
likely places.