### PR TITLE
Reenable Linux build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,9 +48,9 @@ jobs:
       matrix:
         runner: [windows-large, macos-12-xl]
         configuration: ${{ fromJSON(needs.setup.outputs.configurations) }}
-        # include:
-        # - runner: linux-large
-        #   configuration: ReleaseOS
+         include:
+         - runner: linux-large
+           configuration: ReleaseOS
     runs-on: ${{ matrix.runner }}
     outputs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}

--- a/indra/llcommon/llapr.h
+++ b/indra/llcommon/llapr.h
@@ -33,6 +33,7 @@
 #include <sys/param.h>  // Need PATH_MAX in APR headers...
 #endif
 
+#include <memory>
 #include <boost/noncopyable.hpp>
 #include "llwin32headerslean.h"
 #include "apr_thread_proc.h"

--- a/indra/llwindow/CMakeLists.txt
+++ b/indra/llwindow/CMakeLists.txt
@@ -58,6 +58,7 @@ set(llwindow_LINK_LIBRARIES
         ll::glext
         ll::uilibraries
         ll::SDL
+        ll::zlib-ng
         )
 
 # Libraries on which this library depends, needed for Linux builds

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -1409,7 +1409,6 @@ class Linux_x86_64_Manifest(LinuxManifest):
         with self.prefix(src=relpkgdir, dst="lib"):
             self.path("libapr-1.so*")
             self.path("libaprutil-1.so*")
-            self.path("libexpat.so.*")
             self.path_optional("libSDL*.so.*")
 
             self.path_optional("libjemalloc*.so")


### PR DESCRIPTION
- Make sure <memory> gets included for std::unique_ptr. This probably got included as a lucky accident by some other file before and then got refactored.
- Add zlib-ng ng as a dependency to llwindow. The new libpng16.a needs zlib (adler32). Strangely adding it directly to the dependencies of libpng did not work.
- libexpat.so* is gone due to latest package update, remove it from packaging
- Renable Linx build for GHA