### PR TITLE
Fix local resetting of skeleton

### DIFF
--- a/indra/newview/llhudeffectresetskeleton.cpp
+++ b/indra/newview/llhudeffectresetskeleton.cpp
@@ -194,7 +194,8 @@ void LLHUDEffectResetSkeleton::update()
     if (mTargetObject->isAvatar())
     {
         // Only the owner of a avatar can reset their skeleton like this
-        if (mSourceObject->getID() == mTargetObject->getID())
+        // Also allow reset if we created the effect (Local resetting)
+        if (mSourceObject->getID() == mTargetObject->getID() || getOriginatedHere())
         {
             LLVOAvatar* avatar = mTargetObject->asAvatar();
             avatar->resetSkeleton(mResetAnimations);


### PR DESCRIPTION
Not entirely sure if this is the right repo to push this to, but there is a bug that forbids resetting of the skeleton locally. This adds a check to verify if the source object is the target object *OR* if the effect was created locally.