### PR TITLE
#2388 Texture downrezzing tune up.

### DIFF
--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -2212,13 +2212,6 @@ bool LLFace::calcPixelArea(F32& cos_angle_to_view_dir, F32& radius)
 
     F32 dist = lookAt.getLength3().getF32();
     dist = llmax(dist-size.getLength3().getF32(), 0.001f);
-    //ramp down distance for nearby objects
-    if (dist < 16.f)
-    {
-        dist /= 16.f;
-        dist *= dist;
-        dist *= 16.f;
-    }
 
     lookAt.normalize3fast() ;
 

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -548,7 +548,37 @@ void LLViewerTexture::updateClass()
 
     was_low = is_low;
 
-    sDesiredDiscardBias = llclamp(sDesiredDiscardBias, 1.f, 3.f);
+
+    // set to max discard bias if the window has been backgrounded for a while
+    static bool was_backgrounded = false;
+    static LLFrameTimer backgrounded_timer;
+
+    bool in_background = (gViewerWindow && !gViewerWindow->getWindow()->getVisible()) || !gFocusMgr.getAppHasFocus();
+
+    if (in_background)
+    {
+        if (backgrounded_timer.getElapsedTimeF32() > 10.f)
+        {
+            if (!was_backgrounded)
+            {
+                LL_INFOS() << "Viewer is backgrounded, freeing up video memory." << LL_ENDL;
+            }
+            was_backgrounded = true;
+            sDesiredDiscardBias = 4.f;
+        }
+    }
+    else
+    {
+        backgrounded_timer.reset();
+        if (was_backgrounded)
+        { // if the viewer was backgrounded
+            LL_INFOS() << "Viewer is no longer backgrounded, resuming normal texture usage." << LL_ENDL;
+            was_backgrounded = false;
+            sDesiredDiscardBias = 1.f;
+        }
+    }
+
+    sDesiredDiscardBias = llclamp(sDesiredDiscardBias, 1.f, 4.f);
 
     LLViewerTexture::sFreezeImageUpdates = false;
 }

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -146,6 +146,8 @@ public:
 
     virtual F32  getMaxVirtualSize() ;
 
+    LLFrameTimer* getLastReferencedTimer() { return &mLastReferencedTimer; }
+
     S32 getFullWidth() const { return mFullWidth; }
     S32 getFullHeight() const { return mFullHeight; }
     /*virtual*/ void setKnownDrawSize(S32 width, S32 height);
@@ -195,6 +197,7 @@ protected:
     mutable F32 mMaxVirtualSize = 0.f;  // The largest virtual size of the image, in pixels - how much data to we need?
     mutable S32  mMaxVirtualSizeResetCounter;
     mutable S32  mMaxVirtualSizeResetInterval;
+    LLFrameTimer mLastReferencedTimer;
 
     ll_face_list_t    mFaceList[LLRender::NUM_TEXTURE_CHANNELS]; //reverse pointer pointing to the faces using this image as texture
     U32               mNumFaces[LLRender::NUM_TEXTURE_CHANNELS];
@@ -571,10 +574,7 @@ public:
     /*virtual*/ void addFace(U32 ch, LLFace* facep) ;
     /*virtual*/ void removeFace(U32 ch, LLFace* facep) ;
 
-    /*virtual*/ F32  getMaxVirtualSize() ;
-
-    // get the timer that tracks the last time reinit was called
-    LLFrameTimer* getLastReferencedTimer() { return &mLastReferencedTimer; }
+    /*virtual*/ F32  getMaxVirtualSize();
 
 private:
     void switchTexture(U32 ch, LLFace* facep) ;
@@ -595,9 +595,6 @@ private:
     LLViewerMediaImpl* mMediaImplp ;
     bool mIsPlaying ;
     U32  mUpdateVirtualSizeTime ;
-
-    // tracks last time reinit was called
-    LLFrameTimer mLastReferencedTimer;
 
 public:
     static void updateClass() ;


### PR DESCRIPTION
- Hold onto unreferenced textures for 30 seconds.
- Don't downres unless memory is low
- Downres when viewer is backgrounded.