### PR TITLE
Larger font batch

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -270,10 +270,11 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
     const LLFontGlyphInfo* next_glyph = NULL;
 
-    const S32 GLYPH_BATCH_SIZE = 30;
-    LLVector3 vertices[GLYPH_BATCH_SIZE * 4];
-    LLVector2 uvs[GLYPH_BATCH_SIZE * 4];
-    LLColor4U colors[GLYPH_BATCH_SIZE * 4];
+    static constexpr S32 GLYPH_BATCH_SIZE = 512;
+    // probably doesn't need to be thread_local, but gGL is so better to be safe and consistent.
+    static thread_local LLVector3 vertices[GLYPH_BATCH_SIZE * 4];
+    static thread_local LLVector2 uvs[GLYPH_BATCH_SIZE * 4];
+    static thread_local LLColor4U colors[GLYPH_BATCH_SIZE * 4];
 
     LLColor4U text_color(color);
     // Preserve the transparency to render fading emojis in fading text (e.g.
@@ -307,7 +308,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
             {
                 gGL.begin(LLRender::QUADS);
                 {
-                    gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+                    gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4, true);
                 }
                 gGL.end();
                 glyph_count = 0;
@@ -340,7 +341,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
         {
             gGL.begin(LLRender::QUADS);
             {
-                gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+                gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4, true);
             }
             gGL.end();
 
@@ -378,7 +379,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
     gGL.begin(LLRender::QUADS);
     {
-        gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+        gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4, true);
     }
     gGL.end();
 

--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -1928,9 +1928,10 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 v
     }
 }
 
-void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U* colors, S32 vert_count)
+void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U* colors, S32 vert_count, bool for_flush)
 {
-    if (mCount + vert_count > 4094)
+    if (!for_flush // LLRender::flush() allocates dynaically
+        && mCount + vert_count > 4094) // preallocated 4096 in mBuffer
     {
         //  LL_WARNS() << "GL immediate mode overflow.  Some geometry not drawn." << LL_ENDL;
         return;

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -448,7 +448,7 @@ public:
 
     void vertexBatchPreTransformed(LLVector3* verts, S32 vert_count);
     void vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 vert_count);
-    void vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U*, S32 vert_count);
+    void vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U*, S32 vert_count, bool for_flush = false);
 
     void setColorMask(bool writeColor, bool writeAlpha);
     void setColorMask(bool writeColorR, bool writeColorG, bool writeColorB, bool writeAlpha);

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -775,6 +775,7 @@ void LLVOAvatarSelf::updateVisualParams()
 
 void LLVOAvatarSelf::writeWearablesToAvatar()
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_AVATAR;
     for (U32 type = 0; type < LLWearableType::WT_COUNT; type++)
     {
         LLWearable *wearable = gAgentWearables.getTopWearable((LLWearableType::EType)type);

--- a/indra/newview/llworld.cpp
+++ b/indra/newview/llworld.cpp
@@ -768,6 +768,7 @@ void LLWorld::updateParticles()
 
 void LLWorld::renderPropertyLines()
 {
+    LL_PROFILE_ZONE_SCOPED;
     for (region_list_t::iterator iter = mVisibleRegionList.begin();
          iter != mVisibleRegionList.end(); ++iter)
     {

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -4521,33 +4521,53 @@ void LLPipeline::renderDebug()
     }
 
     // Debug stuff.
-    for (LLWorld::region_list_t::const_iterator iter = LLWorld::getInstance()->getRegionList().begin();
-            iter != LLWorld::getInstance()->getRegionList().end(); ++iter)
+    if (gPipeline.hasRenderDebugMask(LLPipeline::RENDER_DEBUG_OCTREE |
+        LLPipeline::RENDER_DEBUG_OCCLUSION |
+        LLPipeline::RENDER_DEBUG_LIGHTS |
+        LLPipeline::RENDER_DEBUG_BATCH_SIZE |
+        LLPipeline::RENDER_DEBUG_UPDATE_TYPE |
+        LLPipeline::RENDER_DEBUG_BBOXES |
+        LLPipeline::RENDER_DEBUG_NORMALS |
+        LLPipeline::RENDER_DEBUG_POINTS |
+        LLPipeline::RENDER_DEBUG_TEXTURE_AREA |
+        LLPipeline::RENDER_DEBUG_TEXTURE_ANIM |
+        LLPipeline::RENDER_DEBUG_RAYCAST |
+        LLPipeline::RENDER_DEBUG_AVATAR_VOLUME |
+        LLPipeline::RENDER_DEBUG_AVATAR_JOINTS |
+        LLPipeline::RENDER_DEBUG_AGENT_TARGET |
+        LLPipeline::RENDER_DEBUG_SHADOW_FRUSTA |
+        LLPipeline::RENDER_DEBUG_TEXEL_DENSITY))
     {
-        LLViewerRegion* region = *iter;
-        for (U32 i = 0; i < LLViewerRegion::NUM_PARTITIONS; i++)
+        LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("partitions");
+
+        for (LLWorld::region_list_t::const_iterator iter = LLWorld::getInstance()->getRegionList().begin();
+            iter != LLWorld::getInstance()->getRegionList().end(); ++iter)
         {
-            LLSpatialPartition* part = region->getSpatialPartition(i);
-            if (part)
+            LLViewerRegion* region = *iter;
+            for (U32 i = 0; i < LLViewerRegion::NUM_PARTITIONS; i++)
             {
-                if ( (hud_only && (part->mDrawableType == RENDER_TYPE_HUD || part->mDrawableType == RENDER_TYPE_HUD_PARTICLES)) ||
-                     (!hud_only && hasRenderType(part->mDrawableType)) )
+                LLSpatialPartition* part = region->getSpatialPartition(i);
+                if (part)
                 {
-                    part->renderDebug();
+                    if ((hud_only && (part->mDrawableType == RENDER_TYPE_HUD || part->mDrawableType == RENDER_TYPE_HUD_PARTICLES)) ||
+                        (!hud_only && hasRenderType(part->mDrawableType)))
+                    {
+                        part->renderDebug();
+                    }
                 }
             }
         }
-    }
 
-    for (LLCullResult::bridge_iterator i = sCull->beginVisibleBridge(); i != sCull->endVisibleBridge(); ++i)
-    {
-        LLSpatialBridge* bridge = *i;
-        if (!bridge->isDead() && hasRenderType(bridge->mDrawableType))
+        for (LLCullResult::bridge_iterator i = sCull->beginVisibleBridge(); i != sCull->endVisibleBridge(); ++i)
         {
-            gGL.pushMatrix();
-            gGL.multMatrix((F32*)bridge->mDrawable->getRenderMatrix().mMatrix);
-            bridge->renderDebug();
-            gGL.popMatrix();
+            LLSpatialBridge* bridge = *i;
+            if (!bridge->isDead() && hasRenderType(bridge->mDrawableType))
+            {
+                gGL.pushMatrix();
+                gGL.multMatrix((F32*)bridge->mDrawable->getRenderMatrix().mMatrix);
+                bridge->renderDebug();
+                gGL.popMatrix();
+            }
         }
     }
 


### PR DESCRIPTION
1. Increased font batch size from 30 to 512 glyphs. This reduces buffer searches and allocations in flush().

Still WIP on moving buffers into viewes, but that likely won't cover everythings, so this change should be usefull regardless.

2. Noticed an inefficiency in renderDebug(), it was running over a huge list of bridges pointlesly. Performance gain is tiny (from 7-16μs to 1-5μs), but couldn't ignore it.