### PR TITLE
#2445 revive old LLERROR_CRASH implementation

### DIFF
--- a/indra/llcommon/llerror.cpp
+++ b/indra/llcommon/llerror.cpp
@@ -1641,19 +1641,3 @@ namespace LLError
         sLocalizedOutOfMemoryWarning = message;
     }
 }
-
-void crashdriver(void (*callback)(int*))
-{
-    // The LLERROR_CRASH macro used to have inline code of the form:
-    //int* make_me_crash = NULL;
-    //*make_me_crash = 0;
-
-    // But compilers are getting smart enough to recognize that, so we must
-    // assign to an address supplied by a separate source file. We could do
-    // the assignment here in crashdriver() -- but then BugSplat would group
-    // all LL_ERRS() crashes as the fault of this one function, instead of
-    // identifying the specific LL_ERRS() source line. So instead, do the
-    // assignment in a lambda in the caller's source. We just provide the
-    // nullptr target.
-    callback(nullptr);
-}

--- a/indra/llcommon/llerror.h
+++ b/indra/llcommon/llerror.h
@@ -408,9 +408,11 @@ typedef LLError::NoClassInfo _LL_CLASS_TO_LOG;
 #define LL_NEWLINE '\n'
 
 // Use this only in LL_ERRS or in a place that LL_ERRS may not be used
-#define LLERROR_CRASH                                   \
-{                                                       \
-    crashdriver([](int* ptr){ *ptr = 0; exit(*ptr); }); \
+#define LLERROR_CRASH                                \
+{                                                    \
+    int* make_me_crash = (int*)0xDEADBEEFDEADBEEFUL; \
+    *make_me_crash = 0;                              \
+    exit(*make_me_crash);                            \
 }
 
 #define LL_ENDL                                         \
@@ -511,8 +513,5 @@ LL_ENDL;
 LL_DEBUGS("SomeTag") performs the locking and map-searching ONCE, then caches
 the result in a static variable.
 */
-
-// used by LLERROR_CRASH
-void crashdriver(void (*)(int*));
 
 #endif // LL_LLERROR_H


### PR DESCRIPTION
this removes the indirect crashdriver() method of crashing in LL_ERRS and restores the old method of dereferencing a bad pointer except using 0xDEADBEEFDEADBEEF instead of NULL, which by experience seems better supported by modern compilers for the time being

should fix secondlife/viewer#2445