### PR TITLE
secondlife/viewer#2421: Do not calculate and store silhouette edges for nearly every geometric prim with a corner

### DIFF
--- a/indra/llmath/llvolume.h
+++ b/indra/llmath/llvolume.h
@@ -918,6 +918,15 @@ public:
     // Get a reference to the octree, which may be null
     const LLVolumeOctree* getOctree() const;
 
+    // Part of silhouette generation (used by selection outlines)
+    // Populates the provided edge array with numbers corresponding to
+    // *partial* logic of whether a particular index should be rendered
+    // as a silhouette edge. -1 indicates the index should be rendered as a
+    // silhouette edge. See generateSilhouetteVertices for the full logic.
+    // Silhouette edges can only be generated for some types of prims. If a
+    // silhouette edge cannot be generated, the edge array will be left empty.
+    void generateSilhouetteEdge(const LLVolume* volume, std::vector<S32>& edge) const;
+
     enum
     {
         SINGLE_MASK =   0x0001,
@@ -962,8 +971,6 @@ public:
     // are two triangles {0, 2, 3} and {1, 2, 4} with values being
     // indexes for mPositions/mNormals/mTexCoords
     U16* mIndices;
-
-    std::vector<S32>    mEdge;
 
     //list of skin weights for rigged volumes
     // format is mWeights[vertex_index].mV[influence] = <joint_index>.<weight>
@@ -1113,9 +1120,9 @@ private:
 
 public:
     virtual void setMeshAssetLoaded(bool loaded);
-    virtual bool isMeshAssetLoaded();
+    virtual bool isMeshAssetLoaded() const;
     virtual void setMeshAssetUnavaliable(bool unavaliable);
-    virtual bool isMeshAssetUnavaliable();
+    virtual bool isMeshAssetUnavaliable() const;
 
  protected:
     bool mUnique;


### PR DESCRIPTION
Removes `LLVolumeFace::mEdge` in favor of calculating the "edge" array on-demand in `LLSelectMgr::generateSilhouette`.

Most of the contents of the "edge" array are used only for ifdef'd out debugging code - seems like low-hanging fruit for code removal, assuming we don't need that anymore.