### PR TITLE
Introduce Khronos Neutral tonemapper as new default tonemapper

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9832,6 +9832,28 @@
         <key>Value</key>
         <real>0.4</real>
     </map>
+    <key>RenderTonemapMix</key>
+    <map>
+        <key>Comment</key>
+        <string>Mix between linear and tonemapped colors (0.0(Linear) - 1.0(Tonemapped)</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>1.0</real>
+    </map>
+    <key>RenderTonemapType</key>
+    <map>
+        <key>Comment</key>
+        <string>What tonemapper to use: 0 = Khronos Neutral, 1 = ACES</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>U32</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>ReplaySession</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredGammaCorrect.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredGammaCorrect.glsl
@@ -29,9 +29,7 @@ out vec4 frag_color;
 
 uniform sampler2D diffuseRect;
 
-uniform float exposure;
 uniform float gamma;
-uniform float aces_mix;
 uniform vec2 screen_res;
 in vec2 vary_fragcoord;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -7087,10 +7087,16 @@ void LLPipeline::tonemap(LLRenderTarget* src, LLRenderTarget* dst)
         F32 e = llclamp(exposure(), 0.5f, 4.f);
 
         static LLStaticHashedString s_exposure("exposure");
-        static LLStaticHashedString aces_mix("aces_mix");
+        static LLStaticHashedString tonemap_mix("tonemap_mix");
+        static LLStaticHashedString tonemap_type("tonemap_type");
 
         shader.uniform1f(s_exposure, e);
-        shader.uniform1f(aces_mix, gEXRImage.notNull() ? 0.f : 0.3f);
+
+        static LLCachedControl<U32> tonemap_type_setting(gSavedSettings, "RenderTonemapType", 0U);
+        shader.uniform1i(tonemap_type, tonemap_type_setting);
+
+        static LLCachedControl<F32> tonemap_mix_setting(gSavedSettings, "RenderTonemapMix", 1.f);
+        shader.uniform1f(tonemap_mix, tonemap_mix_setting);
 
         mScreenTriangleVB->setBuffer();
         mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);


### PR DESCRIPTION
* Add Khronos Neutral to tonemapping shader as new default
* Add debug settings to control tonemapper used and mix between the clamped untonemapped and tonemapped image

#2464 