### PR TITLE
Restore old error handling early out logic in LLAppViewer::init()

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -747,7 +747,9 @@ bool LLAppViewer::init()
     // inits from settings.xml and from strings.xml
     if (!initConfiguration())
     {
-        LL_ERRS("InitInfo") << "initConfiguration() failed." << LL_ENDL;
+        LL_WARNS("InitInfo") << "initConfiguration() failed." << LL_ENDL;
+        // quit immediately
+        return false;
     }
 
     LL_INFOS("InitInfo") << "Configuration initialized." << LL_ENDL ;
@@ -914,7 +916,9 @@ bool LLAppViewer::init()
     if (!initHardwareTest())
     {
         // Early out from user choice.
-        LL_ERRS("InitInfo") << "initHardwareTest() failed." << LL_ENDL;
+        LL_WARNS("InitInfo") << "initHardwareTest() failed." << LL_ENDL;
+        // quit immediately
+        return false;
     }
     LL_INFOS("InitInfo") << "Hardware test initialization done." << LL_ENDL ;
 
@@ -930,7 +934,9 @@ bool LLAppViewer::init()
     {
         std::string msg = LLTrans::getString("MBUnableToAccessFile");
         OSMessageBox(msg.c_str(), LLStringUtil::null, OSMB_OK);
-        LL_ERRS("InitInfo") << "Failed to init cache" << LL_ENDL;
+        LL_WARNS("InitInfo") << "Failed to init cache" << LL_ENDL;
+        // quit immediately
+        return false;
     }
     LL_INFOS("InitInfo") << "Cache initialization is done." << LL_ENDL ;
 
@@ -963,7 +969,9 @@ bool LLAppViewer::init()
     if (!gGLManager.mHasRequirements)
     {
         // Already handled with a MBVideoDrvErr
-        LL_ERRS("InitInfo") << "gGLManager.mHasRequirements is false." << LL_ENDL;
+        LL_WARNS("InitInfo") << "gGLManager.mHasRequirements is false." << LL_ENDL;
+        // quit immediately
+        return false;
     }
 
     // Without SSE2 support we will crash almost immediately, warn here.
@@ -973,7 +981,9 @@ bool LLAppViewer::init()
         // all hell breaks lose.
         std::string msg = LLNotifications::instance().getGlobalString("UnsupportedCPUSSE2");
         OSMessageBox(msg.c_str(), LLStringUtil::null, OSMB_OK);
-        LL_ERRS("InitInfo") << "SSE2 is not supported" << LL_ENDL;
+        LL_WARNS("InitInfo") << "SSE2 is not supported" << LL_ENDL;
+        // quit immediately
+        return false;
     }
 
     // alert the user if they are using unsupported hardware
@@ -3969,7 +3979,6 @@ void LLAppViewer::forceQuit()
     LLApp::setQuitting();
 }
 
-//TODO: remove
 void LLAppViewer::fastQuit(S32 error_code)
 {
     // finish pending transfers


### PR DESCRIPTION
fixes secondlife/viewer#2474