### PR TITLE
#2482 Low end NVIDIA compatibility pass

### DIFF
--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -1038,6 +1038,7 @@ void LLGLManager::initWGL()
         GLH_EXT_NAME(wglGetGPUIDsAMD) = (PFNWGLGETGPUIDSAMDPROC)GLH_EXT_GET_PROC_ADDRESS("wglGetGPUIDsAMD");
         GLH_EXT_NAME(wglGetGPUInfoAMD) = (PFNWGLGETGPUINFOAMDPROC)GLH_EXT_GET_PROC_ADDRESS("wglGetGPUInfoAMD");
     }
+    mHasNVXGpuMemoryInfo = ExtensionExists("GL_NVX_gpu_memory_info", gGLHExts.mSysExts);
 
     if (ExtensionExists("WGL_EXT_swap_control", gGLHExts.mSysExts))
     {
@@ -1203,6 +1204,17 @@ bool LLGLManager::initGL()
         if (mVRAM != 0)
         {
             LL_WARNS("RenderInit") << "VRAM Detected (AMDAssociations):" << mVRAM << LL_ENDL;
+        }
+    }
+    else if (mHasNVXGpuMemoryInfo)
+    {
+        GLint mem_kb = 0;
+        glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &mem_kb);
+        mVRAM = mem_kb / 1024;
+
+        if (mVRAM != 0)
+        {
+            LL_WARNS("RenderInit") << "VRAM Detected (NVXGpuMemoryInfo):" << mVRAM << LL_ENDL;
         }
     }
 #endif

--- a/indra/llrender/llgl.h
+++ b/indra/llrender/llgl.h
@@ -97,6 +97,7 @@ public:
 
     // Vendor-specific extensions
     bool mHasAMDAssociations = false;
+    bool mHasNVXGpuMemoryInfo = false;
 
     bool mIsAMD;
     bool mIsNVIDIA;

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -1,4 +1,4 @@
-version 62
+version 63
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -200,7 +200,7 @@ RenderFlexTimeFactor		1	1.0
 RenderGlowResolutionPow		1	9
 RenderMaxPartCount			1	4096
 RenderLocalLightCount		1	1024
-RenderTransparentWater      1   1
+RenderTransparentWater      1   0
 RenderTerrainDetail			1	1
 RenderTerrainLODFactor		1	2.0
 RenderTerrainPBRDetail      1   0

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -1,4 +1,4 @@
-version 59
+version 60
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -131,7 +131,7 @@ RenderTerrainDetail			1	1
 RenderTerrainLODFactor		1	1.0
 RenderTerrainPBRDetail      1   -1
 RenderTerrainPBRPlanarSampleCount 1   1
-RenderTransparentWater		1	1
+RenderTransparentWater		1	0
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
@@ -166,7 +166,7 @@ RenderTerrainDetail			1	1
 RenderTerrainLODFactor		1	2.0
 RenderTerrainPBRDetail      1   0
 RenderTerrainPBRPlanarSampleCount 1   1
-RenderTransparentWater		1	1
+RenderTransparentWater		1	0
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
@@ -201,7 +201,7 @@ RenderTerrainDetail			1	1
 RenderTerrainLODFactor		1	2.0
 RenderTerrainPBRDetail      1   0
 RenderTerrainPBRPlanarSampleCount 1   1
-RenderTransparentWater		1	1
+RenderTransparentWater		1	0
 RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0

--- a/indra/newview/llglsandbox.cpp
+++ b/indra/newview/llglsandbox.cpp
@@ -1075,6 +1075,9 @@ F32 gpu_benchmark()
             return -1.f;
         }
         LLImageGL::setManualImage(GL_TEXTURE_2D, 0, GL_RGBA, res,res,GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        // disable mipmaps and use point filtering to cause cache misses
+        gGL.getTexUnit(0)->setHasMipMaps(false);
+        gGL.getTexUnit(0)->setTextureFilteringOption(LLTexUnit::TFO_POINT);
 
         if (alloc_timer.getElapsedTimeF32() > time_limit)
         {
@@ -1191,7 +1194,8 @@ F32 gpu_benchmark()
     F32 seconds = ms/1000.f;
 
     F64 samples_drawn = (F64)gBenchmarkProgram.mSamplesDrawn;
-    F32 samples_sec = (F32)((samples_drawn/1000000000.0)/seconds);
+    F64 gpixels_drawn = samples_drawn / 1000000000.0;
+    F32 samples_sec = (F32)(gpixels_drawn/seconds);
     gbps = samples_sec*4;  // 4 bytes per sample
 
     LL_INFOS("Benchmark") << "Memory bandwidth is " << llformat("%.3f", gbps) << " GB/sec according to ARB_timer_query, total time " << seconds << " seconds" << LL_ENDL;

--- a/indra/newview/llviewerstats.cpp
+++ b/indra/newview/llviewerstats.cpp
@@ -597,6 +597,9 @@ void send_viewer_stats(bool include_preferences)
         agent["run_time"] = run_time;
     }
 
+    // report time the viewer has spent in the foreground
+    agent["foreground_time"] = gForegroundTime.getElapsedTimeF32();
+
     // send fps only for time app spends in foreground
     agent["fps"] = (F32)gForegroundFrameCount / gForegroundTime.getElapsedTimeF32();
     agent["version"] = LLVersionInfo::instance().getChannelAndVersion();

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -511,33 +511,20 @@ void LLViewerTexture::updateClass()
 
     F32 over_pct = (used - target) / target;
 
-    bool is_low = over_pct > 0.f;
+    bool is_sys_low = isSystemMemoryLow();
+    bool is_low = is_sys_low || over_pct > 0.f;
 
     if (isSystemMemoryLow())
     {
-        is_low = true;
-        // System RAM is low -> ramp up discard bias over time to free memory
-        if (sEvaluationTimer.getElapsedTimeF32() > MEMORY_CHECK_WAIT_TIME)
-        {
-            static LLCachedControl<F32> low_mem_min_discard_increment(gSavedSettings, "RenderLowMemMinDiscardIncrement", .1f);
-            sDesiredDiscardBias += (F32) low_mem_min_discard_increment * (F32) gFrameIntervalSeconds;
-            sEvaluationTimer.reset();
-        }
-    }
-    else
-    {
-        sDesiredDiscardBias = llmax(sDesiredDiscardBias, 1.f + over_pct);
-
-        if (sDesiredDiscardBias > 1.f && over_pct < 0.f)
-        {
-            sDesiredDiscardBias -= gFrameIntervalSeconds * 0.01f;
-        }
+        is_sys_low = true;
     }
 
     static bool was_low = false;
+    static bool was_sys_low = false;
+
     if (is_low && !was_low)
     {
-        LL_WARNS() << "Low system memory detected, emergency downrezzing off screen textures" << LL_ENDL;
+        // slam to 1.5 bias the moment we hit low memory (discards off screen textures immediately
         sDesiredDiscardBias = llmax(sDesiredDiscardBias, 1.5f);
 
         for (auto& image : gTextureList)
@@ -547,7 +534,29 @@ void LLViewerTexture::updateClass()
     }
 
     was_low = is_low;
+    was_sys_low = is_sys_low;
 
+    if (is_low)
+    {
+        // ramp up discard bias over time to free memory
+        if (sEvaluationTimer.getElapsedTimeF32() > MEMORY_CHECK_WAIT_TIME)
+        {
+            static LLCachedControl<F32> low_mem_min_discard_increment(gSavedSettings, "RenderLowMemMinDiscardIncrement", .1f);
+            sDesiredDiscardBias += (F32)low_mem_min_discard_increment * (F32)gFrameIntervalSeconds;
+            sEvaluationTimer.reset();
+        }
+    }
+    else
+    {
+        // don't execute above until the slam to 1.5 has a chance to take effect
+        sEvaluationTimer.reset();
+
+        // lower discard bias over time when free memory is available
+        if (sDesiredDiscardBias > 1.f && over_pct < 0.f)
+        {
+            sDesiredDiscardBias -= gFrameIntervalSeconds * 0.01f;
+        }
+    }
 
     // set to max discard bias if the window has been backgrounded for a while
     static bool was_backgrounded = false;

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -514,22 +514,21 @@ void LLViewerTexture::updateClass()
     bool is_sys_low = isSystemMemoryLow();
     bool is_low = is_sys_low || over_pct > 0.f;
 
-    if (isSystemMemoryLow())
-    {
-        is_sys_low = true;
-    }
-
     static bool was_low = false;
     static bool was_sys_low = false;
 
     if (is_low && !was_low)
     {
-        // slam to 1.5 bias the moment we hit low memory (discards off screen textures immediately
+        // slam to 1.5 bias the moment we hit low memory (discards off screen textures immediately)
         sDesiredDiscardBias = llmax(sDesiredDiscardBias, 1.5f);
 
-        for (auto& image : gTextureList)
-        {
-            gTextureList.updateImageDecodePriority(image, false /*will modify gTextureList otherwise!*/);
+        if (is_sys_low)
+        { // if we're low on system memory, emergency purge off screen textures to avoid a death spiral
+            LL_WARNS() << "Low system memory detected, emergency downrezzing off screen textures" << LL_ENDL;
+            for (auto& image : gTextureList)
+            {
+                gTextureList.updateImageDecodePriority(image, false /*will modify gTextureList otherwise!*/);
+            }
         }
     }
 

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -949,7 +949,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
       // this is an alternative to decaying mMaxVirtualSize over time
       // that keeps textures from continously downrezzing and uprezzing in the background
 
-        if (LLViewerTexture::sDesiredDiscardBias > 2.f ||
+        if (LLViewerTexture::sDesiredDiscardBias > 1.5f ||
             (!on_screen && LLViewerTexture::sDesiredDiscardBias > 1.f))
         {
             imagep->mMaxVirtualSize = 0.f;


### PR DESCRIPTION
- Use GL_NVX_gpu_memory_info when available
- Disable transparent water on Mid+ and lower
- Adjust GPU benchmark to better tell the truth
- Texture bias tune up