### PR TITLE
Added missing comma in a list. Fixed loop with too small a loop variable.

### DIFF
--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -852,7 +852,7 @@ void LLImagePreviewSculpted::setPreviewTarget(LLImageRaw* imagep, F32 distance)
     }
 
     // build indices
-    for (U16 i = 0; i < num_indices; i++)
+    for (U32 i = 0; i < num_indices; i++)
     {
         *(index_strider++) = vf.mIndices[i];
     }

--- a/indra/newview/llviewerfloaterreg.cpp
+++ b/indra/newview/llviewerfloaterreg.cpp
@@ -242,7 +242,7 @@ public:
                 "avatar_picker",
                 "camera",
                 "camera_presets",
-                "change_item_thumbnail"
+                "change_item_thumbnail",
                 "classified",
                 "add_landmark",
                 "delete_pref_preset",


### PR DESCRIPTION
The build indices loop in LLImagePreviewSculpted::setPreviewTarget had the loop variable set as a U16 when it should be a U32.
The blacklist_untrusted list in LLFloaterOpenHandler::canHandleUntrusted is missing a comma for one of the entries.