### PR TITLE
Fix some race conditions on webrtc connection shutdown.

### DIFF
--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -631,6 +631,11 @@ class LLVoiceWebRTCConnection :
         mShutDown = true;
     }
 
+    bool isShuttingDown()
+    {
+        return mShutDown;
+    }
+
     void OnVoiceConnectionRequestSuccess(const LLSD &body);
 
   protected:


### PR DESCRIPTION
In a few locations, there were cases where connection shutdown would stall, leaving the connection in place.  This was due to bad handling of the outstanding operations counter.

This is a fix for: https://github.com/secondlife/viewer-private/issues/278

To validate, follow the steps in that issue.