### PR TITLE
Fixed md5 buffer in LLMD5::finalize not being correctly zero-initialized

### DIFF
--- a/indra/llcommon/llmd5.cpp
+++ b/indra/llcommon/llmd5.cpp
@@ -68,10 +68,6 @@ documentation and/or software.
 
  */
 
-
-
-
-
 #include "linden_common.h"
 
 #include "llmd5.h"
@@ -81,232 +77,203 @@ documentation and/or software.
 // how many bytes to grab at a time when checking files
 const int LLMD5::BLOCK_LEN = 4096;
 
-
 // LLMD5 simple initialization method
-
 LLMD5::LLMD5()
 {
-  init();
+    init();
 }
-
-
-
 
 // MD5 block update operation. Continues an MD5 message-digest
 // operation, processing another message block, and updating the
 // context.
+void LLMD5::update(const uint8_t* input, const size_t input_length)
+{
+    size_t input_index, buffer_index;
+    size_t buffer_space; // how much space is left in buffer
 
-void LLMD5::update (const uint8_t *input, const size_t input_length) {
+    if (finalized)
+    { // so we can't update!
+        std::cerr << "LLMD5::update:  Can't update a finalized digest!" << std::endl;
+        return;
+    }
 
-  size_t input_index, buffer_index;
-  size_t buffer_space;                // how much space is left in buffer
+    // Compute number of bytes mod 64
+    buffer_index = size_t((count >> 3) & 0x3F);
 
-  if (finalized){  // so we can't update!
-      std::cerr << "LLMD5::update:  Can't update a finalized digest!" << std::endl;
-    return;
-  }
+    // Update number of bits
+    count += input_length << 3;
 
-  // Compute number of bytes mod 64
-  buffer_index = size_t((count >> 3) & 0x3F);
+    buffer_space = 64 - buffer_index; // how much space is left in buffer
 
-  // Update number of bits
-  count += input_length << 3;
+    // now, transform each 64-byte piece of the input, bypassing the buffer
+    if (input == NULL || input_length == 0)
+    {
+        std::cerr << "LLMD5::update:  Invalid input!" << std::endl;
+        return;
+    }
 
-  buffer_space = 64 - buffer_index;  // how much space is left in buffer
+    // Transform as many times as possible.
+    if (input_length >= buffer_space) // ie. we have enough to fill the buffer
+    {
+        // fill the rest of the buffer and transform
+        memcpy(/* Flawfinder: ignore */
+               buffer + buffer_index,
+               input,
+               buffer_space);
+        transform(buffer);
 
-  // now, transform each 64-byte piece of the input, bypassing the buffer
-  if (input == NULL || input_length == 0){
-      std::cerr << "LLMD5::update:  Invalid input!" << std::endl;
-      return;
-  }
+        for (input_index = buffer_space; input_index + 63 < input_length; input_index += 64)
+            transform(input + input_index);
 
-  // Transform as many times as possible.
-  if (input_length >= buffer_space) { // ie. we have enough to fill the buffer
-    // fill the rest of the buffer and transform
-    memcpy( /* Flawfinder: ignore */
-        buffer + buffer_index,
-        input,
-        buffer_space);
-    transform (buffer);
+        buffer_index = 0; // so we can buffer remaining
+    }
+    else
+        input_index = 0; // so we can buffer the whole input
 
-    for (input_index = buffer_space; input_index + 63 < input_length;
-     input_index += 64)
-      transform (input+input_index);
-
-    buffer_index = 0;  // so we can buffer remaining
-  }
-  else
-    input_index=0;     // so we can buffer the whole input
-
-
-  // and here we do the buffering:
-  memcpy(buffer+buffer_index, input+input_index, input_length-input_index);     /* Flawfinder: ignore */
+    // and here we do the buffering:
+    memcpy(buffer + buffer_index, input + input_index, input_length - input_index); /* Flawfinder: ignore */
 }
-
-
 
 // MD5 update for files.
 // Like above, except that it works on files (and uses above as a primitive.)
+void LLMD5::update(FILE* file)
+{
+    unsigned char buffer[BLOCK_LEN]; /* Flawfinder: ignore */
+    int len;
 
-void LLMD5::update(FILE* file){
+    while ((len = (int)fread(buffer, 1, BLOCK_LEN, file)))
+        update(buffer, len);
 
-  unsigned char buffer[BLOCK_LEN];      /* Flawfinder: ignore */
-  int len;
-
-  while ( (len=(int)fread(buffer, 1, BLOCK_LEN, file)) )
-    update(buffer, len);
-
-  fclose (file);
-
+    fclose(file);
 }
 
 // MD5 update for istreams.
 // Like update for files; see above.
+void LLMD5::update(std::istream& stream)
+{
+    unsigned char buffer[BLOCK_LEN]; /* Flawfinder: ignore */
+    int len;
 
-void LLMD5::update(std::istream& stream){
-
-  unsigned char buffer[BLOCK_LEN];      /* Flawfinder: ignore */
-  int len;
-
-  while (stream.good()){
-    stream.read( (char*)buffer, BLOCK_LEN);     /* Flawfinder: ignore */        // note that return value of read is unusable.
-    len=(int)stream.gcount();
-    update(buffer, len);
-  }
-
+    while (stream.good())
+    {
+        stream.read((char*)buffer, BLOCK_LEN); /* Flawfinder: ignore */ // note that return value of read is unusable.
+        len = (int)stream.gcount();
+        update(buffer, len);
+    }
 }
 
-void  LLMD5::update(const std::string& s)
+void LLMD5::update(const std::string& s)
 {
-    update((unsigned char *)s.c_str(),s.length());
+    update((unsigned char*)s.c_str(), s.length());
 }
 
 // MD5 finalization. Ends an MD5 message-digest operation, writing the
 // the message digest and zeroizing the context.
-
-
-void LLMD5::finalize (){
-
-  unsigned char bits[8];        /* Flawfinder: ignore */
-  size_t index, padLen;
-  static uint8_t PADDING[64]={
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+void LLMD5::finalize()
+{
+    unsigned char bits[8]; /* Flawfinder: ignore */
+    size_t index, padLen;
+    static uint8_t PADDING[64] =
+    {
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
 
-  if (finalized){
-    std::cerr << "LLMD5::finalize:  Already finalized this digest!" << std::endl;
-    return;
-  }
+    if (finalized)
+    {
+        std::cerr << "LLMD5::finalize:  Already finalized this digest!" << std::endl;
+        return;
+    }
 
-  // Save number of bits.
-  // Treat count, a uint64_t, as uint32_t[2].
-  encode (bits, reinterpret_cast<uint32_t*>(&count), 8);
+    // Save number of bits.
+    // Treat count, a uint64_t, as uint32_t[2].
+    encode(bits, reinterpret_cast<uint32_t*>(&count), 8);
 
-  // Pad out to 56 mod 64.
-  index = size_t((count >> 3) & 0x3f);
-  padLen = (index < 56) ? (56 - index) : (120 - index);
-  update (PADDING, padLen);
+    // Pad out to 56 mod 64.
+    index  = size_t((count >> 3) & 0x3f);
+    padLen = (index < 56) ? (56 - index) : (120 - index);
+    update(PADDING, padLen);
 
-  // Append length (before padding)
-  update (bits, 8);
+    // Append length (before padding)
+    update(bits, 8);
 
-  // Store state in digest
-  encode (digest, state, 16);
+    // Store state in digest
+    encode(digest, state, 16);
 
-  // Zeroize sensitive information
-  memset (buffer, 0, sizeof(*buffer));
+    // Zeroize sensitive information
+    memset(buffer, 0, sizeof(buffer));
 
-  finalized=1;
-
+    finalized = true;
 }
 
-
-
-
-LLMD5::LLMD5(FILE *file){
-
-  init();  // must be called be all constructors
-  update(file);
-  finalize ();
+LLMD5::LLMD5(FILE* file)
+{
+    init(); // must be called be all constructors
+    update(file);
+    finalize();
 }
 
-
-
-
-LLMD5::LLMD5(std::istream& stream){
-
-  init();  // must called by all constructors
-  update (stream);
-  finalize();
+LLMD5::LLMD5(std::istream& stream)
+{
+    init(); // must called by all constructors
+    update(stream);
+    finalize();
 }
 
 // Digest a string of the format ("%s:%i" % (s, number))
-LLMD5::LLMD5(const unsigned char *string, const unsigned int number)
+LLMD5::LLMD5(const unsigned char* string, const unsigned int number)
 {
-    const char *colon = ":";
-    char tbuf[16];      /* Flawfinder: ignore */
+    const char* colon = ":";
+    char tbuf[16]; /* Flawfinder: ignore */
     init();
-    update(string, (U32)strlen((const char *) string));     /* Flawfinder: ignore */
-    update((const unsigned char *) colon, (U32)strlen(colon));      /* Flawfinder: ignore */
-    snprintf(tbuf, sizeof(tbuf), "%i", number); /* Flawfinder: ignore */
-    update((const unsigned char *) tbuf, (U32)strlen(tbuf));    /* Flawfinder: ignore */
+    update(string, (U32)strlen((const char*)string));        /* Flawfinder: ignore */
+    update((const unsigned char*)colon, (U32)strlen(colon)); /* Flawfinder: ignore */
+    snprintf(tbuf, sizeof(tbuf), "%i", number);              /* Flawfinder: ignore */
+    update((const unsigned char*)tbuf, (U32)strlen(tbuf));   /* Flawfinder: ignore */
     finalize();
 }
 
 // Digest a string
-LLMD5::LLMD5(const unsigned char *s)
+LLMD5::LLMD5(const unsigned char* s)
 {
     init();
-    update(s, (U32)strlen((const char *) s));       /* Flawfinder: ignore */
+    update(s, (U32)strlen((const char*)s)); /* Flawfinder: ignore */
     finalize();
 }
 
-void LLMD5::raw_digest(unsigned char *s) const
+void LLMD5::raw_digest(unsigned char* s) const
 {
     if (!finalized)
     {
-        std::cerr << "LLMD5::raw_digest:  Can't get digest if you haven't "<<
-            "finalized the digest!" << std::endl;
+        std::cerr << "LLMD5::raw_digest:  Can't get digest if you haven't "
+                  << "finalized the digest!" << std::endl;
         s[0] = '\0';
         return;
     }
 
-    memcpy(s, digest, 16);      /* Flawfinder: ignore */
-    return;
+    memcpy(s, digest, 16); /* Flawfinder: ignore */
 }
 
-
-
-void LLMD5::hex_digest(char *s) const
+void LLMD5::hex_digest(char* s) const
 {
-    int i;
-
     if (!finalized)
     {
-        std::cerr << "LLMD5::hex_digest:  Can't get digest if you haven't "<<
-          "finalized the digest!" <<std::endl;
+        std::cerr << "LLMD5::hex_digest:  Can't get digest if you haven't "
+                  << "finalized the digest!" << std::endl;
         s[0] = '\0';
         return;
     }
 
-    for (i=0; i<16; i++)
+    for (int i = 0; i < 16; i++)
     {
-        sprintf(s+i*2, "%02x", digest[i]);      /* Flawfinder: ignore */
+        sprintf(s + i * 2, "%02x", digest[i]); /* Flawfinder: ignore */
     }
 
-    s[32]='\0';
-
-    return;
+    s[32] = '\0';
 }
 
-
-
-
-
-
-std::ostream& operator<<(std::ostream &stream, LLMD5 context)
+std::ostream& operator<<(std::ostream& stream, const LLMD5& context)
 {
     char s[33];     /* Flawfinder: ignore */
     context.hex_digest(s);
@@ -320,7 +287,7 @@ bool operator==(const LLMD5& a, const LLMD5& b)
     unsigned char b_guts[16];
     a.raw_digest(a_guts);
     b.raw_digest(b_guts);
-    if (memcmp(a_guts,b_guts,16)==0)
+    if (memcmp(a_guts, b_guts, 16) == 0)
         return true;
     else
         return false;
@@ -328,30 +295,27 @@ bool operator==(const LLMD5& a, const LLMD5& b)
 
 bool operator!=(const LLMD5& a, const LLMD5& b)
 {
-    return !(a==b);
+    return !(a == b);
 }
 
 // PRIVATE METHODS:
+void LLMD5::init()
+{
+    finalized = false; // we just started!
 
-void LLMD5::init(){
-  finalized=0;  // we just started!
+    // Nothing counted, so count=0
+    count = 0;
 
-  // Nothing counted, so count=0
-  count = 0;
-
-  // Load magic initialization constants.
-  state[0] = 0x67452301;
-  state[1] = 0xefcdab89;
-  state[2] = 0x98badcfe;
-  state[3] = 0x10325476;
+    // Load magic initialization constants.
+    state[0] = 0x67452301;
+    state[1] = 0xefcdab89;
+    state[2] = 0x98badcfe;
+    state[3] = 0x10325476;
 }
-
-
 
 // Constants for MD5Transform routine.
 // Although we could use C++ style constants, defines are actually better,
 // since they let us easily evade scope clashes.
-
 #define S11 7
 #define S12 12
 #define S13 17
@@ -381,153 +345,144 @@ void LLMD5::init(){
 
 /* ROTATE_LEFT rotates x left n bits.
  */
-#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32-(n))))
+#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
 
 /* FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
 Rotation is separate from addition to prevent recomputation.
  */
-#define FF(a, b, c, d, x, s, ac) { \
- (a) += F ((b), (c), (d)) + (x) + (U32)(ac); \
- (a) = ROTATE_LEFT ((a), (s)); \
- (a) += (b); \
-  }
-#define GG(a, b, c, d, x, s, ac) { \
- (a) += G ((b), (c), (d)) + (x) + (U32)(ac); \
- (a) = ROTATE_LEFT ((a), (s)); \
- (a) += (b); \
-  }
-#define HH(a, b, c, d, x, s, ac) { \
- (a) += H ((b), (c), (d)) + (x) + (U32)(ac); \
- (a) = ROTATE_LEFT ((a), (s)); \
- (a) += (b); \
-  }
-#define II(a, b, c, d, x, s, ac) { \
- (a) += I ((b), (c), (d)) + (x) + (U32)(ac); \
- (a) = ROTATE_LEFT ((a), (s)); \
- (a) += (b); \
-  }
-
-
+#define FF(a, b, c, d, x, s, ac)                   \
+    {                                              \
+        (a) += F((b), (c), (d)) + (x) + (U32)(ac); \
+        (a) = ROTATE_LEFT((a), (s));               \
+        (a) += (b);                                \
+    }
+#define GG(a, b, c, d, x, s, ac)                   \
+    {                                              \
+        (a) += G((b), (c), (d)) + (x) + (U32)(ac); \
+        (a) = ROTATE_LEFT((a), (s));               \
+        (a) += (b);                                \
+    }
+#define HH(a, b, c, d, x, s, ac)                   \
+    {                                              \
+        (a) += H((b), (c), (d)) + (x) + (U32)(ac); \
+        (a) = ROTATE_LEFT((a), (s));               \
+        (a) += (b);                                \
+    }
+#define II(a, b, c, d, x, s, ac)                   \
+    {                                              \
+        (a) += I((b), (c), (d)) + (x) + (U32)(ac); \
+        (a) = ROTATE_LEFT((a), (s));               \
+        (a) += (b);                                \
+    }
 
 // LLMD5 basic transformation. Transforms state based on block.
-void LLMD5::transform (const U8 block[64]){
+void LLMD5::transform(const U8 block[64])
+{
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
-  uint32_t a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+    decode(x, block, 64);
 
-  decode (x, block, 64);
+    assert(!finalized); // not just a user error, since the method is private
 
-  assert(!finalized);  // not just a user error, since the method is private
+    /* Round 1 */
+    FF(a, b, c, d, x[0], S11, 0xd76aa478);  /* 1 */
+    FF(d, a, b, c, x[1], S12, 0xe8c7b756);  /* 2 */
+    FF(c, d, a, b, x[2], S13, 0x242070db);  /* 3 */
+    FF(b, c, d, a, x[3], S14, 0xc1bdceee);  /* 4 */
+    FF(a, b, c, d, x[4], S11, 0xf57c0faf);  /* 5 */
+    FF(d, a, b, c, x[5], S12, 0x4787c62a);  /* 6 */
+    FF(c, d, a, b, x[6], S13, 0xa8304613);  /* 7 */
+    FF(b, c, d, a, x[7], S14, 0xfd469501);  /* 8 */
+    FF(a, b, c, d, x[8], S11, 0x698098d8);  /* 9 */
+    FF(d, a, b, c, x[9], S12, 0x8b44f7af);  /* 10 */
+    FF(c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+    FF(b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+    FF(a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+    FF(d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+    FF(c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+    FF(b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
 
-  /* Round 1 */
-  FF (a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
-  FF (d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
-  FF (c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
-  FF (b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
-  FF (a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
-  FF (d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
-  FF (c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
-  FF (b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
-  FF (a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
-  FF (d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
-  FF (c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
-  FF (b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
-  FF (a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
-  FF (d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
-  FF (c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
-  FF (b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+    /* Round 2 */
+    GG(a, b, c, d, x[1], S21, 0xf61e2562);  /* 17 */
+    GG(d, a, b, c, x[6], S22, 0xc040b340);  /* 18 */
+    GG(c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+    GG(b, c, d, a, x[0], S24, 0xe9b6c7aa);  /* 20 */
+    GG(a, b, c, d, x[5], S21, 0xd62f105d);  /* 21 */
+    GG(d, a, b, c, x[10], S22, 0x2441453);  /* 22 */
+    GG(c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+    GG(b, c, d, a, x[4], S24, 0xe7d3fbc8);  /* 24 */
+    GG(a, b, c, d, x[9], S21, 0x21e1cde6);  /* 25 */
+    GG(d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+    GG(c, d, a, b, x[3], S23, 0xf4d50d87);  /* 27 */
+    GG(b, c, d, a, x[8], S24, 0x455a14ed);  /* 28 */
+    GG(a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+    GG(d, a, b, c, x[2], S22, 0xfcefa3f8);  /* 30 */
+    GG(c, d, a, b, x[7], S23, 0x676f02d9);  /* 31 */
+    GG(b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
 
- /* Round 2 */
-  GG (a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
-  GG (d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
-  GG (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
-  GG (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
-  GG (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
-  GG (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
-  GG (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
-  GG (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
-  GG (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
-  GG (d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
-  GG (c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
-  GG (b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
-  GG (a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
-  GG (d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
-  GG (c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
-  GG (b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+    /* Round 3 */
+    HH(a, b, c, d, x[5], S31, 0xfffa3942);  /* 33 */
+    HH(d, a, b, c, x[8], S32, 0x8771f681);  /* 34 */
+    HH(c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+    HH(b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+    HH(a, b, c, d, x[1], S31, 0xa4beea44);  /* 37 */
+    HH(d, a, b, c, x[4], S32, 0x4bdecfa9);  /* 38 */
+    HH(c, d, a, b, x[7], S33, 0xf6bb4b60);  /* 39 */
+    HH(b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+    HH(a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+    HH(d, a, b, c, x[0], S32, 0xeaa127fa);  /* 42 */
+    HH(c, d, a, b, x[3], S33, 0xd4ef3085);  /* 43 */
+    HH(b, c, d, a, x[6], S34, 0x4881d05);   /* 44 */
+    HH(a, b, c, d, x[9], S31, 0xd9d4d039);  /* 45 */
+    HH(d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+    HH(c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+    HH(b, c, d, a, x[2], S34, 0xc4ac5665);  /* 48 */
 
-  /* Round 3 */
-  HH (a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
-  HH (d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
-  HH (c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
-  HH (b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
-  HH (a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
-  HH (d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
-  HH (c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
-  HH (b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
-  HH (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
-  HH (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
-  HH (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
-  HH (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
-  HH (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
-  HH (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
-  HH (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
-  HH (b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
+    /* Round 4 */
+    II(a, b, c, d, x[0], S41, 0xf4292244);  /* 49 */
+    II(d, a, b, c, x[7], S42, 0x432aff97);  /* 50 */
+    II(c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+    II(b, c, d, a, x[5], S44, 0xfc93a039);  /* 52 */
+    II(a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+    II(d, a, b, c, x[3], S42, 0x8f0ccc92);  /* 54 */
+    II(c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+    II(b, c, d, a, x[1], S44, 0x85845dd1);  /* 56 */
+    II(a, b, c, d, x[8], S41, 0x6fa87e4f);  /* 57 */
+    II(d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+    II(c, d, a, b, x[6], S43, 0xa3014314);  /* 59 */
+    II(b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+    II(a, b, c, d, x[4], S41, 0xf7537e82);  /* 61 */
+    II(d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+    II(c, d, a, b, x[2], S43, 0x2ad7d2bb);  /* 63 */
+    II(b, c, d, a, x[9], S44, 0xeb86d391);  /* 64 */
 
-  /* Round 4 */
-  II (a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
-  II (d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
-  II (c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
-  II (b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
-  II (a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
-  II (d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
-  II (c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
-  II (b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
-  II (a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
-  II (d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
-  II (c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
-  II (b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
-  II (a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
-  II (d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
-  II (c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
-  II (b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
 
-  state[0] += a;
-  state[1] += b;
-  state[2] += c;
-  state[3] += d;
-
-  // Zeroize sensitive information.
-  memset ( (uint8_t *) x, 0, sizeof(x));
-
+    // Zeroize sensitive information.
+    memset(x, 0, sizeof(x));
 }
-
-
 
 // Encodes input (uint32_t) into output (unsigned char). Assumes len is
 // a multiple of 4.
-void LLMD5::encode (uint8_t *output, const uint32_t *input, const size_t len) {
-
-  size_t i, j;
-
-  for (i = 0, j = 0; j < len; i++, j += 4) {
-    output[j]   = (uint8_t)  (input[i] & 0xff);
-    output[j+1] = (uint8_t) ((input[i] >> 8) & 0xff);
-    output[j+2] = (uint8_t) ((input[i] >> 16) & 0xff);
-    output[j+3] = (uint8_t) ((input[i] >> 24) & 0xff);
-  }
+void LLMD5::encode(uint8_t* output, const uint32_t* input, const size_t len)
+{
+    for (size_t i = 0, j = 0; j < len; i++, j += 4)
+    {
+        output[j] = (uint8_t)(input[i] & 0xff);
+        output[j + 1] = (uint8_t)((input[i] >> 8) & 0xff);
+        output[j + 2] = (uint8_t)((input[i] >> 16) & 0xff);
+        output[j + 3] = (uint8_t)((input[i] >> 24) & 0xff);
+    }
 }
-
-
-
 
 // Decodes input (unsigned char) into output (uint32_t). Assumes len is
 // a multiple of 4.
-void LLMD5::decode (uint32_t *output, const uint8_t *input, const size_t len){
-
-  size_t i, j;
-
-  for (i = 0, j = 0; j < len; i++, j += 4)
-    output[i] = ((uint32_t)input[j]) | (((uint32_t)input[j+1]) << 8) |
-      (((uint32_t)input[j+2]) << 16) | (((uint32_t)input[j+3]) << 24);
+void LLMD5::decode(uint32_t* output, const uint8_t* input, const size_t len)
+{
+    for (size_t i = 0, j = 0; j < len; i++, j += 4)
+        output[i] = ((uint32_t)input[j]) | (((uint32_t)input[j+1]) << 8) |
+        (((uint32_t)input[j+2]) << 16) | (((uint32_t)input[j+3]) << 24);
 }
-
-

--- a/indra/llcommon/llmd5.h
+++ b/indra/llcommon/llmd5.h
@@ -67,59 +67,57 @@ documentation and/or software.
 
 */
 
-#include <cstdint>                  // uint32_t et al.
+#include <cstdint> // uint32_t et al.
 
 // use for the raw digest output
 const int MD5RAW_BYTES = 16;
 
 // use for outputting hex digests
-const int MD5HEX_STR_SIZE = 33;  // char hex[MD5HEX_STR_SIZE]; with null
+const int MD5HEX_STR_SIZE  = 33; // char hex[MD5HEX_STR_SIZE]; with null
 const int MD5HEX_STR_BYTES = 32; // message system fixed size
 
-class LL_COMMON_API LLMD5 {
-// how many bytes to grab at a time when checking files
-  static const int BLOCK_LEN;
+class LL_COMMON_API LLMD5
+{
+    // how many bytes to grab at a time when checking files
+    static const int BLOCK_LEN;
 
 public:
-// methods for controlled operation:
-  LLMD5              ();  // simple initializer
-  void  update     (const uint8_t *input, const size_t input_length);
-  void  update     (std::istream& stream);
-  void  update     (FILE *file);
-  void  update     (const std::string& str);
-  void  finalize   ();
+    // methods for controlled operation:
+    LLMD5(); // simple initializer
+    void update(const uint8_t* input, const size_t input_length);
+    void update(std::istream& stream);
+    void update(FILE* file);
+    void update(const std::string& str);
+    void finalize();
 
-// constructors for special circumstances.  All these constructors finalize
-// the MD5 context.
-  LLMD5              (const unsigned char *string); // digest string, finalize
-  LLMD5              (std::istream& stream);       // digest stream, finalize
-  LLMD5              (FILE *file);            // digest file, close, finalize
-  LLMD5              (const unsigned char *string, const unsigned int number);
+    // constructors for special circumstances.  All these constructors finalize
+    // the MD5 context.
+    LLMD5(const unsigned char* string); // digest string, finalize
+    LLMD5(std::istream& stream);        // digest stream, finalize
+    LLMD5(FILE* file);                  // digest file, close, finalize
+    LLMD5(const unsigned char* string, const unsigned int number);
 
-// methods to acquire finalized result
-  void              raw_digest(unsigned char *array) const; // provide 16-byte array for binary data
-  void              hex_digest(char *string) const;         // provide 33-byte array for ascii-hex string
+    // methods to acquire finalized result
+    void raw_digest(unsigned char* array) const; // provide 16-byte array for binary data
+    void hex_digest(char* string) const;         // provide 33-byte array for ascii-hex string
 
-  friend LL_COMMON_API std::ostream&   operator<< (std::ostream&, LLMD5 context);
+    friend LL_COMMON_API std::ostream& operator<<(std::ostream&, const LLMD5& context);
 
 private:
+    // next, the private data:
+    uint32_t state[4];
+    uint64_t count;      // number of *bits*, mod 2^64
+    uint8_t  buffer[64]; // input buffer
+    uint8_t  digest[16];
+    bool     finalized;
 
+    // last, the private methods, mostly static:
+    void init();                           // called by all constructors
+    void transform(const uint8_t* buffer); // does the real update work.  Note
+                                           // that length is implied to be 64.
 
-// next, the private data:
-  uint32_t state[4];
-  uint64_t count;     // number of *bits*, mod 2^64
-  uint8_t buffer[64];   // input buffer
-  uint8_t digest[16];
-  uint8_t finalized;
-
-// last, the private methods, mostly static:
-  void init             ();               // called by all constructors
-  void transform        (const uint8_t *buffer);  // does the real update work.  Note
-                                          // that length is implied to be 64.
-
-  static void encode    (uint8_t *dest, const uint32_t *src, const size_t length);
-  static void decode    (uint32_t *dest, const uint8_t *src, const size_t length);
-
+    static void encode(uint8_t* dest, const uint32_t* src, const size_t length);
+    static void decode(uint32_t* dest, const uint8_t* src, const size_t length);
 };
 
 LL_COMMON_API bool operator==(const LLMD5& a, const LLMD5& b);


### PR DESCRIPTION
Fixes the error mentioned in my issue posted here-
https://github.com/secondlife/viewer/issues/2500

Unless I am mistaken and it is intentional, the md5 buffer in the LLMD5::finalize function is being incorrectly zeroized and instead only the first byte is being zeroized.

Also went ahead and refactored the code so it more closely matches the styling of the rest of the codebase.