### PR TITLE
Fix race condition that was preventing "Voice Call" menu from reliably calling.

### DIFF
--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -242,10 +242,7 @@ static void on_avatar_name_cache_start_call(const LLUUID& agent_id,
 {
     std::string name = av_name.getDisplayName();
     LLUUID session_id = gIMMgr->addSession(name, IM_NOTHING_SPECIAL, agent_id, LLSD());
-    if (session_id != LLUUID::null)
-    {
-        gIMMgr->startCall(session_id);
-    }
+    gIMMgr->autoStartCallOnStartup(session_id);
     make_ui_sound("UISndStartIM");
 }
 


### PR DESCRIPTION
The code attempted to do a call to a session immediately after a call that launched a coroutine to set up a session.  Sometimes, the coroutine executed in time, sometimes not.

The fix is to set a flag to start a call after the session has been created on the server.

Test Plan:
* Close all active chat sessions.
* Select 'Voice Call' in the context menu of a nearby avatar.
* Validate popup appears for that nearby avatar requesting to start/ignore/go to im.
* Select 'start'
* Validate the call completes.