### PR TITLE
Don't enable vivox spatial when teleporting while in a webrtc conference/p2p/group call

### DIFF
--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -256,8 +256,8 @@ void LLVoiceClient::setSpatialVoiceModule(const std::string &voice_server_type)
         if (inProximalChannel())
         {
             mSpatialVoiceModule->processChannels(false);
+            module->processChannels(true);
         }
-        module->processChannels(true);
         mSpatialVoiceModule = module;
         mSpatialVoiceModule->updateSettings();
     }


### PR DESCRIPTION
Processing for vivox was being enabled when teleporting into a vivox region regardless as to whether the user was in a conference/p2p/group call, resulting in vivox spatial and webrtc conference/p2p/group simultaneously being active.

This fixes https://github.com/secondlife/viewer-private/issues/281.

Repro steps are in that issue.