### PR TITLE
Put viewer's Lua functionality behind a feature flag, default off.

### DIFF
--- a/indra/llcommon/lldefs.h
+++ b/indra/llcommon/lldefs.h
@@ -28,6 +28,7 @@
 #define LL_LLDEFS_H
 
 #include "stdtypes.h"
+#include <cassert>
 #include <type_traits>
 
 // Often used array indices
@@ -169,6 +170,31 @@ constexpr U32   MAXADDRSTR      = 17;       // 123.567.901.345 = 15 chars + \0 +
 //   llclampb(a)     // clamps a to [0 .. 255]
 //
 
+// llless(d0, d1) safely compares d0 < d1 even if one is signed and the other
+// is unsigned. A simple (d0 < d1) expression converts the signed operand to
+// unsigned before comparing. If the signed operand is negative, that flips
+// the negative value to a huge positive value, producing the wrong answer!
+// llless() specifically addresses that case.
+template <typename T0, typename T1>
+inline bool llless(T0 d0, T1 d1)
+{
+    if constexpr (std::is_signed_v<T0> && ! std::is_signed_v<T1>)
+    {
+        // T0 signed, T1 unsigned: negative d0 is less than any unsigned d1
+        if (d0 < 0)
+            return true;
+    }
+    else if constexpr (! std::is_signed_v<T0> && std::is_signed_v<T1>)
+    {
+        // T0 unsigned, T1 signed: any unsigned d0 is greater than negative d1
+        if (d1 < 0)
+            return false;
+    }
+    // both T0 and T1 are signed, or both are unsigned, or both non-negative:
+    // straightforward comparison works
+    return d0 < d1;
+}
+
 // recursion tail
 template <typename T>
 inline auto llmax(T data)
@@ -180,7 +206,7 @@ template <typename T0, typename T1, typename... Ts>
 inline auto llmax(T0 d0, T1 d1, Ts... rest)
 {
     auto maxrest = llmax(d1, rest...);
-    return (d0 > maxrest)? d0 : maxrest;
+    return llless(maxrest, d0)? d0 : maxrest;
 }
 
 // recursion tail
@@ -194,12 +220,28 @@ template <typename T0, typename T1, typename... Ts>
 inline auto llmin(T0 d0, T1 d1, Ts... rest)
 {
     auto minrest = llmin(d1, rest...);
-    return (d0 < minrest) ? d0 : minrest;
+    return llless(d0, minrest) ? d0 : minrest;
 }
 
 template <typename A, typename MIN, typename MAX>
 inline A llclamp(A a, MIN minval, MAX maxval)
 {
+    // The only troublesome case is if A is unsigned and either minval or
+    // maxval is both signed and negative. Casting a negative number to
+    // unsigned flips it to a huge positive number, making this llclamp() call
+    // ineffective.
+    if constexpr (! std::is_signed_v<A>)
+    {
+        if constexpr (std::is_signed_v<MIN>)
+        {
+            assert(minval >= 0);
+        }
+        if constexpr (std::is_signed_v<MAX>)
+        {
+            assert(maxval >= 0);
+        }
+    }
+
     A aminval{ static_cast<A>(minval) }, amaxval{ static_cast<A>(maxval) };
     if ( a < aminval )
     {

--- a/indra/llcommon/lldefs.h
+++ b/indra/llcommon/lldefs.h
@@ -183,16 +183,23 @@ inline bool llless(T0 d0, T1 d1)
         // T0 signed, T1 unsigned: negative d0 is less than any unsigned d1
         if (d0 < 0)
             return true;
+        // both are non-negative: explicitly cast to avoid C4018
+        return std::make_unsigned_t<T0>(d0) < d1;
     }
     else if constexpr (! std::is_signed_v<T0> && std::is_signed_v<T1>)
     {
         // T0 unsigned, T1 signed: any unsigned d0 is greater than negative d1
         if (d1 < 0)
             return false;
+        // both are non-negative: explicitly cast to avoid C4018
+        return d0 < std::make_unsigned_t<T1>(d1);
     }
-    // both T0 and T1 are signed, or both are unsigned, or both non-negative:
-    // straightforward comparison works
-    return d0 < d1;
+    else
+    {
+        // both T0 and T1 are signed, or both are unsigned:
+        // straightforward comparison works
+        return d0 < d1;
+    }
 }
 
 // recursion tail

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -115,8 +115,11 @@ public:
     void check_interrupts_counter();
 
 private:
+    /*---------------------------- feature flag ----------------------------*/
+    bool mFeature{ false };
+    /*---------------------------- feature flag ----------------------------*/
     script_finished_fn mCallback;
-    lua_State* mState;
+    lua_State* mState{ nullptr };
     std::string mError;
     S32 mInterrupts{ 0 };
 };

--- a/indra/llcommon/tests/llcond_test.cpp
+++ b/indra/llcommon/tests/llcond_test.cpp
@@ -19,6 +19,7 @@
 // other Linden headers
 #include "../test/lltut.h"
 #include "llcoros.h"
+#include "lldefs.h"                 // llless()
 
 /*****************************************************************************
 *   TUT
@@ -63,5 +64,79 @@ namespace tut
         ensure_equals(cond.get(), 1);
         cond.set_all(2);
         cond.wait_equal(3);
+    }
+
+    template <typename T0, typename T1>
+    struct compare
+    {
+        const char* desc;
+        T0 lhs;
+        T1 rhs;
+        bool expect;
+
+        void test() const
+        {
+            // fails
+//          ensure_equals(desc, (lhs <  rhs), expect);
+            ensure_equals(desc, llless(lhs, rhs), expect);
+        }
+    };
+
+    template<> template<>
+    void object::test<3>()
+    {
+        set_test_name("comparison");
+        // Try to construct signed and unsigned variables such that the
+        // compiler can't optimize away the code to compare at runtime.
+        std::istringstream input("-1 10 20 10 20");
+        int minus1, s10, s20;
+        input >> minus1 >> s10 >> s20;
+        unsigned u10, u20;
+        input >> u10 >> u20;
+        ensure_equals("minus1 wrong", minus1, -1);
+        ensure_equals("s10 wrong", s10, 10);
+        ensure_equals("s20 wrong", s20, 20);
+        ensure_equals("u10 wrong", u10, 10);
+        ensure_equals("u20 wrong", u20, 20);
+        // signed < signed should always work!
+        compare<int, int> ss[] =
+            { {"minus1 < s10", minus1, s10, true},
+              {"s10 < s10", s10, s10, false},
+              {"s20 < s10", s20, s20, false}
+            };
+        for (const auto& cmp : ss)
+        {
+            cmp.test();
+        }
+        // unsigned < unsigned should always work!
+        compare<unsigned, unsigned> uu[] =
+            { {"u10 < u20", u10, u20, true},
+              {"u20 < u20", u20, u20, false},
+              {"u20 < u10", u20, u10, false}
+            };
+        for (const auto& cmp : uu)
+        {
+            cmp.test();
+        }
+        // signed < unsigned ??
+        compare<int, unsigned> su[] =
+            { {"minus1 < u10", minus1, u10, true},
+              {"s10 < u10", s10, u10, false},
+              {"s20 < u10", s20, u10, false}
+            };
+        for (const auto& cmp : su)
+        {
+            cmp.test();
+        }
+        // unsigned < signed ??
+        compare<unsigned, int> us[] =
+            { {"u10 < minus1", u10, minus1, false},
+              {"u10 < s10", u10, s10, false},
+              {"u10 < s20", u10, s20, true}
+            };
+        for (const auto& cmp : us)
+        {
+            cmp.test();
+        }
     }
 } // namespace tut

--- a/indra/llmeshoptimizer/llmeshoptimizer.cpp
+++ b/indra/llmeshoptimizer/llmeshoptimizer.cpp
@@ -57,7 +57,7 @@ void LLMeshOptimizer::generateShadowIndexBufferU32(U32 *destination,
     S32 index = 0;
     if (vertex_positions)
     {
-        streams[index].data = (const float*)vertex_positions;
+        streams[index].data = vertex_positions->getF32ptr();
         // Despite being LLVector4a, only x, y and z are in use
         streams[index].size = sizeof(F32) * 3;
         streams[index].stride = sizeof(F32) * 4;
@@ -65,14 +65,14 @@ void LLMeshOptimizer::generateShadowIndexBufferU32(U32 *destination,
     }
     if (normals)
     {
-        streams[index].data = (const float*)normals;
+        streams[index].data = normals->getF32ptr();
         streams[index].size = sizeof(F32) * 3;
         streams[index].stride = sizeof(F32) * 4;
         index++;
     }
     if (text_coords)
     {
-        streams[index].data = (const float*)text_coords;
+        streams[index].data = text_coords->mV;
         streams[index].size = sizeof(F32) * 2;
         streams[index].stride = sizeof(F32) * 2;
         index++;
@@ -108,21 +108,21 @@ void LLMeshOptimizer::generateShadowIndexBufferU16(U16 *destination,
     S32 index = 0;
     if (vertex_positions)
     {
-        streams[index].data = (const float*)vertex_positions;
+        streams[index].data = vertex_positions->getF32ptr();
         streams[index].size = sizeof(F32) * 3;
         streams[index].stride = sizeof(F32) * 4;
         index++;
     }
     if (normals)
     {
-        streams[index].data = (const float*)normals;
+        streams[index].data = normals->getF32ptr();
         streams[index].size = sizeof(F32) * 3;
         streams[index].stride = sizeof(F32) * 4;
         index++;
     }
     if (text_coords)
     {
-        streams[index].data = (const float*)text_coords;
+        streams[index].data = text_coords->mV;
         streams[index].size = sizeof(F32) * 2;
         streams[index].stride = sizeof(F32) * 2;
         index++;
@@ -162,9 +162,9 @@ size_t LLMeshOptimizer::generateRemapMultiU32(
     U64 vertex_count)
 {
     meshopt_Stream streams[] = {
-       {(const float*)vertex_positions, sizeof(F32) * 3, sizeof(F32) * 4},
-       {(const float*)normals, sizeof(F32) * 3, sizeof(F32) * 4},
-       {(const float*)text_coords, sizeof(F32) * 2, sizeof(F32) * 2},
+       {vertex_positions->getF32ptr(), sizeof(F32) * 3, sizeof(F32) * 4},
+       {normals->getF32ptr(), sizeof(F32) * 3, sizeof(F32) * 4},
+       {text_coords->mV, sizeof(F32) * 2, sizeof(F32) * 2},
     };
 
     // Remap can function without indices,
@@ -236,7 +236,7 @@ void LLMeshOptimizer::remapPositionsBuffer(LLVector4a * destination_vertices,
     U64 vertex_count,
     const unsigned int* remap)
 {
-    meshopt_remapVertexBuffer((float*)destination_vertices, (const float*)vertex_positions, vertex_count, sizeof(LLVector4a), remap);
+    meshopt_remapVertexBuffer(destination_vertices->getF32ptr(), vertex_positions->getF32ptr(), vertex_count, sizeof(LLVector4a), remap);
 }
 
 void LLMeshOptimizer::remapNormalsBuffer(LLVector4a * destination_normalss,
@@ -244,7 +244,7 @@ void LLMeshOptimizer::remapNormalsBuffer(LLVector4a * destination_normalss,
     U64 mormals_count,
     const unsigned int* remap)
 {
-    meshopt_remapVertexBuffer((float*)destination_normalss, (const float*)normals, mormals_count, sizeof(LLVector4a), remap);
+    meshopt_remapVertexBuffer(destination_normalss->getF32ptr(), normals->getF32ptr(), mormals_count, sizeof(LLVector4a), remap);
 }
 
 void LLMeshOptimizer::remapUVBuffer(LLVector2 * destination_uvs,
@@ -252,7 +252,7 @@ void LLMeshOptimizer::remapUVBuffer(LLVector2 * destination_uvs,
     U64 uv_count,
     const unsigned int* remap)
 {
-    meshopt_remapVertexBuffer((float*)destination_uvs, (const float*)uv_positions, uv_count, sizeof(LLVector2), remap);
+    meshopt_remapVertexBuffer(destination_uvs->mV, uv_positions->mV, uv_count, sizeof(LLVector2), remap);
 }
 
 //static
@@ -273,7 +273,7 @@ U64 LLMeshOptimizer::simplifyU32(U32 *destination,
         return meshopt_simplifySloppy<unsigned int>(destination,
             indices,
             index_count,
-            (const float*)vertex_positions,
+            vertex_positions->getF32ptr(),
             vertex_count,
             vertex_positions_stride,
             target_index_count,
@@ -286,7 +286,7 @@ U64 LLMeshOptimizer::simplifyU32(U32 *destination,
         return meshopt_simplify<unsigned int>(destination,
             indices,
             index_count,
-            (const float*)vertex_positions,
+            vertex_positions->getF32ptr(),
             vertex_count,
             vertex_positions_stride,
             target_index_count,
@@ -315,7 +315,7 @@ U64 LLMeshOptimizer::simplify(U16 *destination,
         return meshopt_simplifySloppy<unsigned short>(destination,
             indices,
             index_count,
-            (const float*)vertex_positions,
+            vertex_positions->getF32ptr(),
             vertex_count,
             vertex_positions_stride,
             target_index_count,
@@ -328,7 +328,7 @@ U64 LLMeshOptimizer::simplify(U16 *destination,
         return meshopt_simplify<unsigned short>(destination,
             indices,
             index_count,
-            (const float*)vertex_positions,
+            vertex_positions->getF32ptr(),
             vertex_count,
             vertex_positions_stride,
             target_index_count,

--- a/indra/llui/llmenugl.cpp
+++ b/indra/llui/llmenugl.cpp
@@ -2625,7 +2625,9 @@ void LLMenuGL::insert( S32 position, LLView * ctrl, bool arrange /*= true*/ )
 {
     LLMenuItemGL * item = dynamic_cast<LLMenuItemGL *>(ctrl);
 
-    if (NULL == item || position < 0 || position >= mItems.size())
+    // If position == size(), std::advance() will return end() -- which is
+    // okay, because insert(end()) is the same as append().
+    if (NULL == item || position < 0 || position > mItems.size())
     {
         return;
     }

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -3999,6 +3999,17 @@
         <string>scripts/lua</string>
       </array>
     </map>
+    <key>LuaFeature</key>
+    <map>
+      <key>Comment</key>
+      <string>Enable viewer's Lua script engine.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>LuaRequirePath</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/scripts/lua/auto/menus.lua
+++ b/indra/newview/scripts/lua/auto/menus.lua
@@ -1,0 +1,51 @@
+-- Inject Lua-related menus into the top menu structure. Run this as a Lua
+-- script so that turning off the Lua feature also disables these menus.
+
+-- Under Develop -> Consoles, want to present the equivalent of:
+-- <menu_item_separator/>
+-- <menu_item_check
+--     label="LUA Debug Console"
+--     name="LUA Debug Console">
+--   <menu_item_check.on_check
+--       function="Floater.Visible"
+--       parameter="lua_debug" />
+--   <menu_item_check.on_click
+--       function="Floater.Toggle"
+--       parameter="lua_debug" />
+-- </menu_item_check>
+-- <menu_item_check
+--     label="LUA Scripts Info"
+--     name="LUA Scripts">
+--   <menu_item_check.on_check
+--       function="Floater.Visible"
+--       parameter="lua_scripts" />
+--   <menu_item_check.on_click
+--       function="Floater.Toggle"
+--       parameter="lua_scripts" />
+-- </menu_item_check>
+
+local startup = require 'startup'
+local UI = require 'UI'
+
+-- Don't mess with the viewer's menu structure until we've logged in.
+startup.wait('STATE_STARTED')
+
+-- Add LUA Debug Console to Develop->Consoles
+local pos = 9
+UI.addMenuSeparator{
+    parent_menu='Consoles', pos=pos,
+}
+pos += 1
+UI.addMenuItem{
+    parent_menu='Consoles', pos=pos,
+    name='lua_debug', label='LUA Debug Console',
+    func='Floater.ToggleOrBringToFront', param='lua_debug',
+}
+pos += 1
+
+-- Add LUA Scripts Info to Develop->Consoles
+UI.addMenuItem{
+    parent_menu='Consoles', pos=pos,
+    name='lua_scripts', label='LUA Scripts Info',
+    func='Floater.ToggleOrBringToFront', param='lua_scripts',
+}

--- a/indra/newview/scripts/lua/require/UI.lua
+++ b/indra/newview/scripts/lua/require/UI.lua
@@ -170,13 +170,13 @@ end
 
 -- see UI.callables() for valid values of 'func'
 function UI.addMenuItem(...)
-    local args = mapargs('name,label,parent_menu,func,param', ...)
+    local args = mapargs('name,label,parent_menu,func,param,pos', ...)
     args.op = 'addMenuItem'
     return leap.request('UI', args)
 end
 
 function UI.addMenuSeparator(...)
-    local args = mapargs('parent_menu', ...)
+    local args = mapargs('parent_menu,pos', ...)
     args.op = 'addMenuSeparator'
     return leap.request('UI', args)
 end

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2565,27 +2565,6 @@ function="World.EnvPreset"
                parameter="scene monitor" />
             </menu_item_check>
             <menu_item_separator/>
-            <menu_item_check
-         label="LUA Debug Console"
-         name="LUA Debug Console">
-            <menu_item_check.on_check
-             function="Floater.Visible"
-             parameter="lua_debug" />
-            <menu_item_check.on_click
-             function="Floater.Toggle"
-             parameter="lua_debug" />
-        </menu_item_check>
-            <menu_item_check
-            label="LUA Scripts Info"
-            name="LUA Scripts">
-            <menu_item_check.on_check
-             function="Floater.Visible"
-             parameter="lua_scripts" />
-            <menu_item_check.on_click
-             function="Floater.Toggle"
-             parameter="lua_scripts" />
-            </menu_item_check>
-            <menu_item_separator/>
 
             <menu_item_call
              label="Region Info to Debug Console"

--- a/indra/newview/tests/cppfeatures_test.cpp
+++ b/indra/newview/tests/cppfeatures_test.cpp
@@ -283,7 +283,7 @@ void cpp_features_test_object_t::test<8>()
     ensure("init member inline 1", ii.mFoo==10);
 
     InitInlineWithConstructor iici;
-    ensure("init member inline 2", iici.mFoo=10);
+    ensure("init member inline 2", iici.mFoo==10);
     ensure("init member inline 3", iici.mBar==25);
 }
 


### PR DESCRIPTION
When disabled, the Lua machinery simply returns an error message.

Remove Lua floaters from the default menu structure, but add a Lua autorun script to dynamically re-add them if Lua is enabled.