### PR TITLE
Update calcDataSizeJ2C to stop undersized blocks

### DIFF
--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -281,7 +281,7 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 height = (h > 0) ? h : 2048;
     S32 max_dimension = llmax(width, height); // Find largest dimension
     S32 block_area = MAX_BLOCK_SIZE * MAX_BLOCK_SIZE; // Calculated initial block area from established max block size (currently 64)
-    block_area *= (max_dimension / MAX_BLOCK_SIZE / max_components); // Adjust initial block area by ratio of largest dimension to block size per component
+    block_area *= llmax((max_dimension / MAX_BLOCK_SIZE / max_components), 1); // Adjust initial block area by ratio of largest dimension to block size per component
     S32 totalbytes = (S32) (block_area * max_components * precision); // First block layer computed before loop without compression rate
     S32 block_layers = 1; // Start at layer 1 since first block layer is computed outside loop
     while (block_layers < 6) // Walk five layers for the five discards in JPEG2000


### PR DESCRIPTION
The initial block area for the pyramid walk should not be smaller than the max_block_size area so there needs to be an llmax to not allow multiplication below 1.

This was causing decode errors for complex small images (128x128 or smaller) on discards 1 and 2.

Tested on OpenJPEG 2.5. 

Should improve quality of decodes for affected cases in KDU but probably should be tested just in case.