### PR TITLE
Reduce 'World map' floater draw time

### DIFF
--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -1773,8 +1773,8 @@ void LLFloaterWorldMap::onCommitSearchResult()
     }
     LLStringUtil::toLower(sim_name);
 
-    std::map<U64, LLSimInfo*>::const_iterator it;
-    for (it = LLWorldMap::getInstance()->getRegionMap().begin(); it != LLWorldMap::getInstance()->getRegionMap().end(); ++it)
+    LLWorldMap::sim_info_map_t::const_iterator end = LLWorldMap::instance().getRegionMap().end();
+    for (LLWorldMap::sim_info_map_t::const_iterator it = LLWorldMap::getInstance()->getRegionMap().begin(); it != end; ++it)
     {
         LLSimInfo* info = it->second;
 

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -186,6 +186,7 @@ LLWorldMapView::LLWorldMapView() :
     mMouseDownY(0),
     mSelectIDStart(0),
     mMapScale(0.f),
+    mMapRatio(0.5),
     mTargetMapScale(0.f),
     mMapIterpTime(MAP_ITERP_TIME_CONSTANT)
 {
@@ -285,7 +286,9 @@ void LLWorldMapView::setScale(F32 scale, bool snap)
         {
             mMapScale = 0.1f;
         }
+        mMapRatio = mMapScale / REGION_WIDTH_METERS;
         mMapIterpTime = MAP_ITERP_TIME_CONSTANT;
+
         F32 ratio = (scale / old_scale);
         mPanX *= ratio;
         mPanY *= ratio;
@@ -359,6 +362,7 @@ bool is_agent_in_region(LLViewerRegion* region, LLSimInfo* info)
 
 void LLWorldMapView::draw()
 {
+    LL_PROFILE_ZONE_SCOPED;
     static LLUIColor map_track_color = LLUIColorTable::instance().getColor("MapTrackColor", LLColor4::white);
 
     LLTextureView::clearDebugImages();
@@ -412,8 +416,9 @@ void LLWorldMapView::draw()
     drawMipmap(width, height);
 
     // Draw per sim overlayed information (names, mature, offline...)
-    for (LLWorldMap::sim_info_map_t::const_iterator it = LLWorldMap::getInstance()->getRegionMap().begin();
-         it != LLWorldMap::getInstance()->getRegionMap().end(); ++it)
+    static LLCachedControl<bool> show_for_sale(gSavedSettings, "MapShowLandForSale");
+    LLWorldMap::sim_info_map_t::const_iterator end = LLWorldMap::instance().getRegionMap().end();
+    for (LLWorldMap::sim_info_map_t::const_iterator it = LLWorldMap::getInstance()->getRegionMap().begin(); it != end; ++it)
     {
         U64 handle = it->first;
         LLSimInfo* info = it->second;
@@ -422,8 +427,8 @@ void LLWorldMapView::draw()
 
         // Find x and y position relative to camera's center.
         LLVector3d rel_region_pos = origin_global - camera_global;
-        F32 relative_x = (F32)(rel_region_pos.mdV[0] / REGION_WIDTH_METERS) * mMapScale;
-        F32 relative_y = (F32)(rel_region_pos.mdV[1] / REGION_WIDTH_METERS) * mMapScale;
+        F32 relative_x = (F32)(rel_region_pos.mdV[0] * mMapRatio);
+        F32 relative_y = (F32)(rel_region_pos.mdV[1] * mMapRatio);
 
         // Coordinates of the sim in pixels in the UI panel
         // When the view isn't panned, 0,0 = center of rectangle
@@ -464,7 +469,7 @@ void LLWorldMapView::draw()
                 gGL.vertex2f(right, top);
             gGL.end();
         }
-        else if (gSavedSettings.getBOOL("MapShowLandForSale") && (level <= DRAW_LANDFORSALE_THRESHOLD))
+        else if (show_for_sale && (level <= DRAW_LANDFORSALE_THRESHOLD))
         {
             // Draw the overlay image "Land for Sale / Land for Auction"
             LLViewerFetchedTexture* overlayimage = info->getLandForSaleImage();
@@ -500,7 +505,6 @@ void LLWorldMapView::draw()
         // Draw the region name in the lower left corner
         if (mMapScale >= DRAW_TEXT_THRESHOLD)
         {
-            LLFontGL* font = LLFontGL::getFont(LLFontDescriptor("SansSerif", "Small", LLFontGL::BOLD));
             std::string mesg;
             if (info->isDown())
             {
@@ -512,7 +516,7 @@ void LLWorldMapView::draw()
             }
             if (!mesg.empty())
             {
-                font->renderUTF8(
+                LLFontGL::getFontSansSerifSmallBold()->renderUTF8(
                     mesg, 0,
                     (F32)llfloor(left + 3), (F32)llfloor(bottom + 2),
                     LLColor4::white,
@@ -525,13 +529,19 @@ void LLWorldMapView::draw()
         }
     }
 
+    static LLCachedControl<bool> show_infohubs(gSavedSettings, "MapShowInfohubs");
+    static LLCachedControl<bool> show_telehubs(gSavedSettings, "MapShowTelehubs");
+    static LLCachedControl<bool> show_events(gSavedSettings, "MapShowEvents");
+    static LLCachedControl<bool> show_mature_events(gSavedSettings, "ShowMatureEvents");
+    static LLCachedControl<bool> show_adult_events(gSavedSettings, "ShowAdultEvents");
+
     // Draw item infos if we're not zoomed out too much and there's something to draw
-    if ((level <= DRAW_SIMINFO_THRESHOLD) && (gSavedSettings.getBOOL("MapShowInfohubs") ||
-                                              gSavedSettings.getBOOL("MapShowTelehubs") ||
-                                              gSavedSettings.getBOOL("MapShowLandForSale") ||
-                                              gSavedSettings.getBOOL("MapShowEvents") ||
-                                              gSavedSettings.getBOOL("ShowMatureEvents") ||
-                                              gSavedSettings.getBOOL("ShowAdultEvents")))
+    if ((level <= DRAW_SIMINFO_THRESHOLD) && (show_infohubs ||
+                                              show_telehubs ||
+                                              show_for_sale ||
+                                              show_events ||
+                                              show_mature_events ||
+                                              show_adult_events))
     {
         drawItems();
     }
@@ -828,11 +838,12 @@ void LLWorldMapView::drawImageStack(const LLVector3d& global_pos, LLUIImagePtr i
 
 void LLWorldMapView::drawItems()
 {
-    bool mature_enabled = gAgent.canAccessMature();
-    bool adult_enabled = gAgent.canAccessAdult();
-
-    bool show_mature = mature_enabled && gSavedSettings.getBOOL("ShowMatureEvents");
-    bool show_adult = adult_enabled && gSavedSettings.getBOOL("ShowAdultEvents");
+    static LLCachedControl<bool> show_infohubs(gSavedSettings, "MapShowInfohubs");
+    static LLCachedControl<bool> show_telehubs(gSavedSettings, "MapShowTelehubs");
+    static LLCachedControl<bool> show_events(gSavedSettings, "MapShowEvents");
+    static LLCachedControl<bool> show_mature_events(gSavedSettings, "ShowMatureEvents");
+    static LLCachedControl<bool> show_adult_events(gSavedSettings, "ShowAdultEvents");
+    static LLCachedControl<bool> show_for_sale(gSavedSettings, "MapShowLandForSale");
 
     for (handle_list_t::iterator iter = mVisibleRegions.begin(); iter != mVisibleRegions.end(); ++iter)
     {
@@ -843,17 +854,17 @@ void LLWorldMapView::drawItems()
             continue;
         }
         // Infohubs
-        if (gSavedSettings.getBOOL("MapShowInfohubs"))
+        if (show_infohubs)
         {
             drawGenericItems(info->getInfoHub(), sInfohubImage);
         }
         // Telehubs
-        if (gSavedSettings.getBOOL("MapShowTelehubs"))
+        if (show_telehubs)
         {
             drawGenericItems(info->getTeleHub(), sTelehubImage);
         }
         // Land for sale
-        if (gSavedSettings.getBOOL("MapShowLandForSale"))
+        if (show_for_sale)
         {
             drawGenericItems(info->getLandForSale(), sForSaleImage);
             // for 1.23, we're showing normal land and adult land in the same UI; you don't
@@ -865,17 +876,17 @@ void LLWorldMapView::drawItems()
             }
         }
         // PG Events
-        if (gSavedSettings.getBOOL("MapShowEvents"))
+        if (show_events)
         {
             drawGenericItems(info->getPGEvent(), sEventImage);
         }
         // Mature Events
-        if (show_mature)
+        if (show_mature_events && gAgent.canAccessMature())
         {
             drawGenericItems(info->getMatureEvent(), sEventMatureImage);
         }
         // Adult Events
-        if (show_adult)
+        if (show_adult_events && gAgent.canAccessAdult())
         {
             drawGenericItems(info->getAdultEvent(), sEventAdultImage);
         }
@@ -910,14 +921,12 @@ void LLWorldMapView::drawAgents()
 void LLWorldMapView::drawFrustum()
 {
     // Draw frustum
-    F32 meters_to_pixels = mMapScale/ REGION_WIDTH_METERS;
-
     F32 horiz_fov = LLViewerCamera::getInstance()->getView() * LLViewerCamera::getInstance()->getAspect();
     F32 far_clip_meters = LLViewerCamera::getInstance()->getFar();
-    F32 far_clip_pixels = far_clip_meters * meters_to_pixels;
+    F32 far_clip_pixels = far_clip_meters * mMapRatio;
 
     F32 half_width_meters = far_clip_meters * tan( horiz_fov / 2 );
-    F32 half_width_pixels = half_width_meters * meters_to_pixels;
+    F32 half_width_pixels = half_width_meters * mMapRatio;
 
     // Compute the frustum coordinates. Take the UI scale into account.
     F32 ctr_x = ((getLocalRect().getWidth() * 0.5f + mPanX)  * LLUI::getScaleFactor().mV[VX]);
@@ -978,8 +987,8 @@ LLVector3 LLWorldMapView::globalPosToView( const LLVector3d& global_pos )
     LLVector3 pos_local;
     pos_local.setVec(relative_pos_global);  // convert to floats from doubles
 
-    pos_local.mV[VX] *= mMapScale / REGION_WIDTH_METERS;
-    pos_local.mV[VY] *= mMapScale / REGION_WIDTH_METERS;
+    pos_local.mV[VX] *= mMapRatio;
+    pos_local.mV[VY] *= mMapRatio;
     // leave Z component in meters
 
 

--- a/indra/newview/llworldmapview.h
+++ b/indra/newview/llworldmapview.h
@@ -210,6 +210,7 @@ private:
 
     F32 mMapScale;
     F32 mTargetMapScale;
+    F32 mMapRatio;
     static F32 sMapScaleSetting;
     static LLVector2 sZoomPivot;
     static LLFrameTimer sZoomTimer;


### PR DESCRIPTION
'World map' floater draw time is reduced by approx. 750μs when observing a cluster of 4 PE regions.