### PR TITLE
Callback button for groups was not being reenabled after hanging up on group call.

### DIFF
--- a/indra/newview/llfloaterimsessiontab.cpp
+++ b/indra/newview/llfloaterimsessiontab.cpp
@@ -450,7 +450,8 @@ void LLFloaterIMSessionTab::enableDisableCallBtn()
         else
         {
             // We allow to start call from this state only
-            if (mSession->mVoiceChannel->getState() == LLVoiceChannel::STATE_NO_CHANNEL_INFO &&
+            if (mSession->mVoiceChannel  &&
+                !mSession->mVoiceChannel->callStarted() &&
                 LLVoiceClient::instanceExists())
             {
                 LLVoiceClient* client = LLVoiceClient::getInstance();
@@ -494,10 +495,7 @@ void LLFloaterIMSessionTab::onCallButtonClicked()
     }
     else
     {
-        LLVoiceChannel::EState channel_state = mSession && mSession->mVoiceChannel ?
-            mSession->mVoiceChannel->getState() : LLVoiceChannel::STATE_NO_CHANNEL_INFO;
-        // We allow to start call from this state only
-        if (channel_state == LLVoiceChannel::STATE_NO_CHANNEL_INFO)
+        if (mSession->mVoiceChannel && !mSession->mVoiceChannel->callStarted())
         {
             gIMMgr->startCall(mSessionID);
         }

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -390,10 +390,10 @@ void notify_of_message(const LLSD& msg, bool is_dnd_msg)
                 }
                 else
                 {
-            LLAvatarNameCache::get(participant_id, boost::bind(&on_avatar_name_cache_toast, _1, _2, msg));
+                    LLAvatarNameCache::get(participant_id, boost::bind(&on_avatar_name_cache_toast, _1, _2, msg));
+                }
+            }
         }
-    }
-}
     }
     if (store_dnd_message)
     {
@@ -4178,11 +4178,16 @@ public:
         }
         if (input["body"]["info"].has("voice_channel_info"))
         {
+            // new voice channel info incoming, update and re-activate call
+            // if currently in a call.
             LLIMModel::LLIMSession* session = LLIMModel::getInstance()->findIMSession(session_id);
             if (session)
             {
-                session->initVoiceChannel(input["body"]["info"]["voice_channel_info"]);
-                session->mVoiceChannel->activate();
+                if (session->mVoiceChannel && session->mVoiceChannel->callStarted())
+                {
+                    session->initVoiceChannel(input["body"]["info"]["voice_channel_info"]);
+                    session->mVoiceChannel->activate();
+                }
             }
         }
     }


### PR DESCRIPTION
For #2532, callback button was remaining disabled after hanging up on a group call.

Also, fix https://github.com/secondlife/viewer-private/issues/283 where user was automatically added to a group call after the initiator of the group call hangs up and re-calls the group.

See those issues for repro steps.