### PR TITLE
Voice bars of self and as seen by others do not appear the same.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2983,7 +2983,9 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
                     // we got a 'power' update.
                     if (participant_obj.contains("p") && participant_obj["p"].is_number())
                     {
-                        participant->mLevel = (F32)participant_obj["p"].as_int64();
+                        // server sends up power as an integer which is level * 128 to save
+                        // character count.
+                        participant->mLevel = (F32)participant_obj["p"].as_int64()/128.0f;
                     }
 
                     if (participant_obj.contains("v") && participant_obj["v"].is_bool())


### PR DESCRIPTION
The voice server sends up the float power level of peers as an integer multiplied by 128, in order to save character count as the voice power level will likely be only 3 digits, instead of many for a full float.

The client was not taking this into account.

This is for issue: #1091.  See that issue for repro steps.