### PR TITLE
mute icons were not showing during group call when user was muted

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2993,10 +2993,9 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
                         participant->mIsSpeaking = participant_obj["v"].as_bool();
                     }
 
-                    if (participant_obj.contains("v") && participant_obj["m"].is_bool())
+                    if (participant_obj.contains("m") && participant_obj["m"].is_bool())
                     {
                         participant->mIsModeratorMuted = participant_obj["m"].as_bool();
-                        ;
                     }
                 }
             }


### PR DESCRIPTION
This fixes: https://github.com/secondlife/viewer-private/issues/285

When processing messages from the voice server, the volume and not the mute status was being checked with respect to retrieving the mute status.

See issue for repro steps.