### PR TITLE
viewer#2529 Optimize updateGLVariablesForSettings

### DIFF
--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -141,6 +141,26 @@ void LLSettingsBase::lerpSettings(LLSettingsBase &other, F64 mix)
     loadValuesFromLLSD();
 }
 
+void LLSettingsBase::lerpVector2(LLVector2& a, const LLVector2& b, F32 mix)
+{
+    a.mV[0] = lerp(a.mV[0], b.mV[0], mix);
+    a.mV[1] = lerp(a.mV[1], b.mV[1], mix);
+}
+
+void LLSettingsBase::lerpVector3(LLVector3& a, const LLVector3& b, F32 mix)
+{
+    a.mV[0] = lerp(a.mV[0], b.mV[0], mix);
+    a.mV[1] = lerp(a.mV[1], b.mV[1], mix);
+    a.mV[2] = lerp(a.mV[2], b.mV[2], mix);
+}
+
+void LLSettingsBase::lerpColor(LLColor3& a, const LLColor3& b, F32 mix)
+{
+    a.mV[0] = lerp(a.mV[0], b.mV[0], mix);
+    a.mV[1] = lerp(a.mV[1], b.mV[1], mix);
+    a.mV[2] = lerp(a.mV[2], b.mV[2], mix);
+}
+
 LLSD LLSettingsBase::combineSDMaps(const LLSD &settings, const LLSD &other)
 {
     LLSD newSettings;
@@ -759,7 +779,7 @@ F64 LLSettingsBlender::setBlendFactor(const LLSettingsBase::BlendFactor& blendf_
 
     if (mTarget)
     {
-        mTarget->replaceSettings(mInitial->getSettings());
+        mTarget->replaceSettings(mInitial);
         mTarget->blend(mFinal, blendf);
     }
     else
@@ -774,7 +794,7 @@ void LLSettingsBlender::triggerComplete()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_ENVIRONMENT;
     if (mTarget)
-        mTarget->replaceSettings(mFinal->getSettings());
+        mTarget->replaceSettings(mFinal);
     LLSettingsBlender::ptr_t hold = shared_from_this();   // prevents this from deleting too soon
     mTarget->update();
     mOnFinished(shared_from_this());

--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -69,23 +69,21 @@ const U32 LLSettingsBase::Validator::VALIDATION_PARTIAL(0x01 << 0);
 LLSettingsBase::LLSettingsBase():
     mSettings(LLSD::emptyMap()),
     mDirty(true),
-    mLLSDDirty(false),
+    mLLSDDirty(true),
     mReplaced(false),
     mBlendedFactor(0.0),
     mSettingFlags(0)
 {
-    loadValuesFromLLSD();
 }
 
 LLSettingsBase::LLSettingsBase(const LLSD setting) :
     mSettings(setting),
-    mLLSDDirty(false),
+    mLLSDDirty(true),
     mDirty(true),
     mReplaced(false),
     mBlendedFactor(0.0),
     mSettingFlags(0)
 {
-    loadValuesFromLLSD();
 }
 
 //virtual
@@ -134,6 +132,7 @@ void LLSettingsBase::saveValuesIfNeeded()
 //=========================================================================
 void LLSettingsBase::lerpSettings(LLSettingsBase &other, F64 mix)
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_ENVIRONMENT;
     saveValuesIfNeeded();
     stringset_t skip = getSkipInterpolateKeys();
     stringset_t slerps = getSlerpKeys();
@@ -437,6 +436,7 @@ bool LLSettingsBase::validate()
 
     saveValuesIfNeeded();
     LLSD result = LLSettingsBase::settingValidation(mSettings, validations);
+    loadValuesFromLLSD();
 
     if (result["errors"].size() > 0)
     {

--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -69,25 +69,80 @@ const U32 LLSettingsBase::Validator::VALIDATION_PARTIAL(0x01 << 0);
 LLSettingsBase::LLSettingsBase():
     mSettings(LLSD::emptyMap()),
     mDirty(true),
-    mBlendedFactor(0.0)
+    mLLSDDirty(false),
+    mReplaced(false),
+    mBlendedFactor(0.0),
+    mSettingFlags(0)
 {
+    loadValuesFromLLSD();
 }
 
 LLSettingsBase::LLSettingsBase(const LLSD setting) :
     mSettings(setting),
+    mLLSDDirty(false),
     mDirty(true),
-    mBlendedFactor(0.0)
+    mReplaced(false),
+    mBlendedFactor(0.0),
+    mSettingFlags(0)
 {
+    loadValuesFromLLSD();
+}
+
+//virtual
+void LLSettingsBase::loadValuesFromLLSD()
+{
+    mLLSDDirty = false;
+
+    mAssetId = mSettings[SETTING_ASSETID].asUUID();
+    mSettingId = getValue(SETTING_ID).asUUID();
+    mSettingName = getValue(SETTING_NAME).asString();
+    if (mSettings.has(SETTING_FLAGS))
+    {
+        mSettingFlags = (U32)mSettings[SETTING_FLAGS].asInteger();
+    }
+    else
+    {
+        mSettingFlags = 0;
+    }
+}
+
+//virtual
+void LLSettingsBase::saveValuesToLLSD()
+{
+    mLLSDDirty = false;
+
+    mSettings[SETTING_NAME] = mSettingName;
+    if (mAssetId.isNull())
+    {
+        mSettings.erase(SETTING_ASSETID);
+    }
+    else
+    {
+        mSettings[SETTING_ASSETID] = mAssetId;
+    }
+    mSettings[SETTING_FLAGS] = LLSD::Integer(mSettingFlags);
+}
+
+void LLSettingsBase::saveValuesIfNeeded()
+{
+    if (mLLSDDirty)
+    {
+        saveValuesToLLSD();
+    }
 }
 
 //=========================================================================
-void LLSettingsBase::lerpSettings(const LLSettingsBase &other, F64 mix)
+void LLSettingsBase::lerpSettings(LLSettingsBase &other, F64 mix)
 {
-    mSettings = interpolateSDMap(mSettings, other.mSettings, other.getParameterMap(), mix);
+    saveValuesIfNeeded();
+    stringset_t skip = getSkipInterpolateKeys();
+    stringset_t slerps = getSlerpKeys();
+    mSettings = interpolateSDMap(mSettings, other.getSettings(), other.getParameterMap(), mix, skip, slerps);
     setDirtyFlag(true);
+    loadValuesFromLLSD();
 }
 
-LLSD LLSettingsBase::combineSDMaps(const LLSD &settings, const LLSD &other) const
+LLSD LLSettingsBase::combineSDMaps(const LLSD &settings, const LLSD &other)
 {
     LLSD newSettings;
 
@@ -161,12 +216,9 @@ LLSD LLSettingsBase::combineSDMaps(const LLSD &settings, const LLSD &other) cons
     return newSettings;
 }
 
-LLSD LLSettingsBase::interpolateSDMap(const LLSD &settings, const LLSD &other, const parammapping_t& defaults, F64 mix) const
+LLSD LLSettingsBase::interpolateSDMap(const LLSD &settings, const LLSD &other, const parammapping_t& defaults, F64 mix, const stringset_t& skip, const stringset_t& slerps)
 {
     LLSD newSettings;
-
-    stringset_t skip = getSkipInterpolateKeys();
-    stringset_t slerps = getSlerpKeys();
 
     llassert(mix >= 0.0f && mix <= 1.0f);
 
@@ -204,7 +256,7 @@ LLSD LLSettingsBase::interpolateSDMap(const LLSD &settings, const LLSD &other, c
             }
         }
 
-        newSettings[key_name] = interpolateSDValue(key_name, value, other_value, defaults, mix, slerps);
+        newSettings[key_name] = interpolateSDValue(key_name, value, other_value, defaults, mix, skip, slerps);
     }
 
     // Special handling cases
@@ -233,12 +285,12 @@ LLSD LLSettingsBase::interpolateSDMap(const LLSD &settings, const LLSD &other, c
         if (def_iter != defaults.end())
         {
             // Blend against default value
-            newSettings[key_name] = interpolateSDValue(key_name, def_iter->second.getDefaultValue(), (*it).second, defaults, mix, slerps);
+            newSettings[key_name] = interpolateSDValue(key_name, def_iter->second.getDefaultValue(), (*it).second, defaults, mix, skip, slerps);
         }
         else if ((*it).second.type() == LLSD::TypeMap)
         {
             // interpolate in case there are defaults inside (part of legacy)
-            newSettings[key_name] = interpolateSDValue(key_name, LLSDMap(), (*it).second, defaults, mix, slerps);
+            newSettings[key_name] = interpolateSDValue(key_name, LLSDMap(), (*it).second, defaults, mix, skip, slerps);
         }
         // else do nothing when no known defaults
         // TODO: Should I blend this out instead?
@@ -260,7 +312,7 @@ LLSD LLSettingsBase::interpolateSDMap(const LLSD &settings, const LLSD &other, c
     return newSettings;
 }
 
-LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD &value, const LLSD &other_value, const parammapping_t& defaults, BlendFactor mix, const stringset_t& slerps) const
+LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD &value, const LLSD &other_value, const parammapping_t& defaults, BlendFactor mix, const stringset_t& skip, const stringset_t& slerps)
 {
     LLSD new_value;
 
@@ -286,7 +338,7 @@ LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD 
             break;
         case LLSD::TypeMap:
             // deep copy.
-            new_value = interpolateSDMap(value, other_value, defaults, mix);
+            new_value = interpolateSDMap(value, other_value, defaults, mix, skip, slerps);
             break;
 
         case LLSD::TypeArray:
@@ -348,13 +400,15 @@ LLSettingsBase::stringset_t LLSettingsBase::getSkipInterpolateKeys() const
     return skipSet;
 }
 
-LLSD LLSettingsBase::getSettings() const
+LLSD& LLSettingsBase::getSettings()
 {
+    saveValuesIfNeeded();
     return mSettings;
 }
 
-LLSD LLSettingsBase::cloneSettings() const
+LLSD LLSettingsBase::cloneSettings()
 {
+    saveValuesIfNeeded();
     LLSD settings(combineSDMaps(getSettings(), LLSD()));
     if (U32 flags = getFlags())
     {
@@ -363,7 +417,7 @@ LLSD LLSettingsBase::cloneSettings() const
     return settings;
 }
 
-size_t LLSettingsBase::getHash() const
+size_t LLSettingsBase::getHash()
 {   // get a shallow copy of the LLSD filtering out values to not include in the hash
     LLSD hash_settings = llsd_shallow(getSettings(),
         LLSDMap(SETTING_NAME, false)(SETTING_ID, false)(SETTING_HASH, false)("*", true));
@@ -381,6 +435,7 @@ bool LLSettingsBase::validate()
         mSettings[SETTING_TYPE] = getSettingsType();
     }
 
+    saveValuesIfNeeded();
     LLSD result = LLSettingsBase::settingValidation(mSettings, validations);
 
     if (result["errors"].size() > 0)

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -110,71 +110,55 @@ public:
     virtual bool isVeryDirty() const { return mReplaced; }
     inline void setDirtyFlag(bool dirty) { mDirty = dirty; clearAssetId(); }
 
-    size_t getHash() const; // Hash will not include Name, ID or a previously stored Hash
+    size_t getHash(); // Hash will not include Name, ID or a previously stored Hash
 
     inline LLUUID getId() const
     {
-        return getValue(SETTING_ID).asUUID();
+        return mSettingId;
     }
 
     inline std::string getName() const
     {
-        return getValue(SETTING_NAME).asString();
+        return mSettingName;
     }
 
     inline void setName(std::string val)
     {
-        setValue(SETTING_NAME, val);
+        mSettingName = val;
+        setLLSDDirty();
     }
 
     inline LLUUID getAssetId() const
     {
-        if (mSettings.has(SETTING_ASSETID))
-            return mSettings[SETTING_ASSETID].asUUID();
-        return LLUUID();
+        return mAssetId;
     }
 
     inline U32 getFlags() const
     {
-        if (mSettings.has(SETTING_FLAGS))
-            return static_cast<U32>(mSettings[SETTING_FLAGS].asInteger());
-        return 0;
+        return mSettingFlags;
     }
 
     inline void setFlags(U32 value)
     {
-        setLLSD(SETTING_FLAGS, LLSD::Integer(value));
+        mSettingFlags = value;
+        setLLSDDirty();
     }
 
     inline bool getFlag(U32 flag) const
     {
-        if (mSettings.has(SETTING_FLAGS))
-            return ((U32)mSettings[SETTING_FLAGS].asInteger() & flag) == flag;
-        return false;
+        return (mSettingFlags & flag) == flag;
     }
 
     inline void setFlag(U32 flag)
     {
-        U32 flags((mSettings.has(SETTING_FLAGS)) ? (U32)mSettings[SETTING_FLAGS].asInteger() : 0);
-
-        flags |= flag;
-
-        if (flags)
-            mSettings[SETTING_FLAGS] = LLSD::Integer(flags);
-        else
-            mSettings.erase(SETTING_FLAGS);
+        mSettingFlags |= flag;
+        setLLSDDirty();
     }
 
     inline void clearFlag(U32 flag)
     {
-        U32 flags((mSettings.has(SETTING_FLAGS)) ? (U32)mSettings[SETTING_FLAGS].asInteger() : 0);
-
-        flags &= ~flag;
-
-        if (flags)
-            mSettings[SETTING_FLAGS] = LLSD::Integer(flags);
-        else
-            mSettings.erase(SETTING_FLAGS);
+        mSettingFlags &= ~flag;
+        setLLSDDirty();
     }
 
     virtual void replaceSettings(LLSD settings)
@@ -183,14 +167,31 @@ public:
         setDirtyFlag(true);
         mReplaced = true;
         mSettings = settings;
+        loadValuesFromLLSD();
     }
 
-    virtual LLSD getSettings() const;
+    void setSettings(LLSD settings)
+    {
+        setDirtyFlag(true);
+        mSettings = settings;
+        loadValuesFromLLSD();
+    }
+
+    // if you are using getSettings to edit them, call setSettings(settings),
+    // replaceSettings(settings) or loadValuesFromLLSD() afterwards
+    virtual LLSD& getSettings();
+    virtual void setLLSDDirty()
+    {
+        mLLSDDirty = true;
+        mDirty = true;
+        clearAssetId();
+    }
 
     //---------------------------------------------------------------------
     //
     inline void setLLSD(const std::string &name, const LLSD &value)
     {
+        saveValuesIfNeeded();
         mSettings[name] = value;
         mDirty = true;
         if (name != SETTING_ASSETID)
@@ -202,8 +203,9 @@ public:
         setLLSD(name, value);
     }
 
-    inline LLSD getValue(const std::string &name, const LLSD &deflt = LLSD()) const
+    inline LLSD getValue(const std::string &name, const LLSD &deflt = LLSD())
     {
+        saveValuesIfNeeded();
         if (!mSettings.has(name))
             return deflt;
         return mSettings[name];
@@ -259,11 +261,11 @@ public:
         (const_cast<LLSettingsBase *>(this))->updateSettings();
     }
 
-    virtual void    blend(const ptr_t &end, BlendFactor blendf) = 0;
+    virtual void    blend(ptr_t &end, BlendFactor blendf) = 0;
 
     virtual bool    validate();
 
-    virtual ptr_t   buildDerivedClone() const = 0;
+    virtual ptr_t   buildDerivedClone() = 0;
 
     class Validator
     {
@@ -310,17 +312,20 @@ public:
 
     inline void setAssetId(LLUUID value)
     {   // note that this skips setLLSD
-        mSettings[SETTING_ASSETID] = value;
+        mAssetId = value;
+        mLLSDDirty = true;
     }
 
     inline void clearAssetId()
     {
-        if (mSettings.has(SETTING_ASSETID))
-            mSettings.erase(SETTING_ASSETID);
+        mAssetId.setNull();
+        mLLSDDirty = true;
     }
 
     // Calculate any custom settings that may need to be cached.
     virtual void updateSettings() { mDirty = false; mReplaced = false; }
+    LLSD         cloneSettings();
+
 protected:
 
     LLSettingsBase();
@@ -331,7 +336,7 @@ protected:
     typedef std::set<std::string>   stringset_t;
 
     // combining settings objects. Customize for specific setting types
-    virtual void lerpSettings(const LLSettingsBase &other, BlendFactor mix);
+    virtual void lerpSettings(LLSettingsBase &other, BlendFactor mix);
 
     // combining settings maps where it can based on mix rate
     // @settings initial value (mix==0)
@@ -339,8 +344,8 @@ protected:
     // @defaults list of default values for legacy fields and (re)setting shaders
     // @mix from 0 to 1, ratio or rate of transition from initial 'settings' to 'other'
     // return interpolated and combined LLSD map
-    LLSD    interpolateSDMap(const LLSD &settings, const LLSD &other, const parammapping_t& defaults, BlendFactor mix) const;
-    LLSD    interpolateSDValue(const std::string& name, const LLSD &value, const LLSD &other, const parammapping_t& defaults, BlendFactor mix, const stringset_t& slerps) const;
+    static LLSD interpolateSDMap(const LLSD &settings, const LLSD &other, const parammapping_t& defaults, BlendFactor mix, const stringset_t& skip, const stringset_t& slerps);
+    static LLSD interpolateSDValue(const std::string& name, const LLSD &value, const LLSD &other, const parammapping_t& defaults, BlendFactor mix, const stringset_t& skip, const stringset_t& slerps);
 
     /// when lerping between settings, some may require special handling.
     /// Get a list of these key to be skipped by the default settings lerp.
@@ -353,32 +358,40 @@ protected:
 
     virtual validation_list_t getValidationList() const = 0;
 
-    // Apply any settings that need special handling.
-    virtual void applySpecial(void *, bool force = false) { };
+    // Apply settings.
+    virtual void applyToUniforms(void *) { };
+    virtual void applySpecial(void*, bool force = false) { };
 
     virtual parammapping_t getParameterMap() const { return parammapping_t(); }
-
-    LLSD        mSettings;
-
-    LLSD        cloneSettings() const;
 
     inline void setBlendFactor(BlendFactor blendfactor)
     {
         mBlendedFactor = blendfactor;
     }
 
-    void replaceWith(LLSettingsBase::ptr_t other)
+    virtual void replaceWith(LLSettingsBase::ptr_t other)
     {
         replaceSettings(other->cloneSettings());
         setBlendFactor(other->getBlendFactor());
     }
 
+    virtual void loadValuesFromLLSD();
+    virtual void saveValuesToLLSD();
+    void saveValuesIfNeeded();
+
+    LLUUID mAssetId;
+    LLUUID mSettingId;
+    std::string mSettingName;
+    U32 mSettingFlags;
+
 private:
+    bool        mLLSDDirty;
     bool        mDirty;
     bool        mReplaced; // super dirty!
 
-    LLSD        combineSDMaps(const LLSD &first, const LLSD &other) const;
+    static LLSD combineSDMaps(const LLSD &first, const LLSD &other);
 
+    LLSD        mSettings;
     BlendFactor mBlendedFactor;
 };
 

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -173,6 +173,18 @@ public:
         loadValuesFromLLSD();
     }
 
+    virtual void replaceSettings(const ptr_t& other)
+    {
+        mBlendedFactor = 0.0;
+        setDirtyFlag(true);
+        mReplaced = true;
+        mSettingFlags = other->getFlags();
+        mSettingName = other->getName();
+        mSettingId = other->getId();
+        mAssetId = other->getAssetId();
+        setLLSDDirty();
+    }
+
     void setSettings(LLSD settings)
     {
         setDirtyFlag(true);
@@ -327,6 +339,10 @@ public:
     virtual void updateSettings() { mDirty = false; mReplaced = false; }
     LLSD         cloneSettings();
 
+    static void lerpVector2(LLVector2& a, const LLVector2& b, F32 mix);
+    static void lerpVector3(LLVector3& a, const LLVector3& b, F32 mix);
+    static void lerpColor(LLColor3& a, const LLColor3& b, F32 mix);
+
 protected:
 
     LLSettingsBase();
@@ -370,9 +386,9 @@ protected:
         mBlendedFactor = blendfactor;
     }
 
-    virtual void replaceWith(LLSettingsBase::ptr_t other)
+    virtual void replaceWith(const LLSettingsBase::ptr_t other)
     {
-        replaceSettings(other->cloneSettings());
+        replaceSettings(other);
         setBlendFactor(other->getBlendFactor());
     }
 

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -109,6 +109,7 @@ public:
     virtual bool isDirty() const { return mDirty; }
     virtual bool isVeryDirty() const { return mReplaced; }
     inline void setDirtyFlag(bool dirty) { mDirty = dirty; clearAssetId(); }
+    inline void setReplaced() { mReplaced = true; }
 
     size_t getHash(); // Hash will not include Name, ID or a previously stored Hash
 

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -125,6 +125,7 @@ public:
     inline void setName(std::string val)
     {
         mSettingName = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -141,6 +142,7 @@ public:
     inline void setFlags(U32 value)
     {
         mSettingFlags = value;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -183,8 +185,6 @@ public:
     virtual void setLLSDDirty()
     {
         mLLSDDirty = true;
-        mDirty = true;
-        clearAssetId();
     }
 
     //---------------------------------------------------------------------

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -128,6 +128,7 @@ LLSettingsDay::LLSettingsDay(const LLSD &data) :
     mDaySettings(LLSD::emptyMap())
 {
     mDayTracks.resize(TRACK_MAX);
+    loadValuesFromLLSD();
 }
 
 LLSettingsDay::LLSettingsDay() :
@@ -136,6 +137,7 @@ LLSettingsDay::LLSettingsDay() :
     mDaySettings(LLSD::emptyMap())
 {
     mDayTracks.resize(TRACK_MAX);
+    replaceSettings(defaults());
 }
 
 //=========================================================================

--- a/indra/llinventory/llsettingsdaycycle.cpp
+++ b/indra/llinventory/llsettingsdaycycle.cpp
@@ -124,33 +124,40 @@ static const F32 DEFAULT_MULTISLIDER_INCREMENT(0.005f);
 //=========================================================================
 LLSettingsDay::LLSettingsDay(const LLSD &data) :
     LLSettingsBase(data),
-    mInitialized(false)
+    mInitialized(false),
+    mDaySettings(LLSD::emptyMap())
 {
     mDayTracks.resize(TRACK_MAX);
 }
 
 LLSettingsDay::LLSettingsDay() :
     LLSettingsBase(),
-    mInitialized(false)
+    mInitialized(false),
+    mDaySettings(LLSD::emptyMap())
 {
     mDayTracks.resize(TRACK_MAX);
 }
 
 //=========================================================================
-LLSD LLSettingsDay::getSettings() const
+LLSD& LLSettingsDay::getSettings()
 {
-    LLSD settings(LLSD::emptyMap());
+    if (!mDaySettings.emptyMap())
+    {
+        return mDaySettings;
+    }
+    mDaySettings = LLSD::emptyMap();
+    LLSD& settings = LLSettingsBase::getSettings();
 
-    if (mSettings.has(SETTING_NAME))
-        settings[SETTING_NAME] = mSettings[SETTING_NAME];
+    if (settings.has(SETTING_NAME))
+        mDaySettings[SETTING_NAME] = settings[SETTING_NAME];
 
-    if (mSettings.has(SETTING_ID))
-        settings[SETTING_ID] = mSettings[SETTING_ID];
+    if (settings.has(SETTING_ID))
+        mDaySettings[SETTING_ID] = settings[SETTING_ID];
 
-    if (mSettings.has(SETTING_ASSETID))
-        settings[SETTING_ASSETID] = mSettings[SETTING_ASSETID];
+    if (settings.has(SETTING_ASSETID))
+        mDaySettings[SETTING_ASSETID] = settings[SETTING_ASSETID];
 
-    settings[SETTING_TYPE] = getSettingsType();
+    mDaySettings[SETTING_TYPE] = getSettingsType();
 
     std::map<std::string, LLSettingsBase::ptr_t> in_use;
 
@@ -174,7 +181,7 @@ LLSD LLSettingsDay::getSettings() const
         }
         tracks.append(trackout);
     }
-    settings[SETTING_TRACKS] = tracks;
+    mDaySettings[SETTING_TRACKS] = tracks;
 
     LLSD frames(LLSD::emptyMap());
     for (std::map<std::string, LLSettingsBase::ptr_t>::iterator itFrame = in_use.begin(); itFrame != in_use.end(); ++itFrame)
@@ -184,9 +191,15 @@ LLSD LLSettingsDay::getSettings() const
 
         frames[(*itFrame).first] = framesettings;
     }
-    settings[SETTING_FRAMES] = frames;
+    mDaySettings[SETTING_FRAMES] = frames;
 
-    return settings;
+    return mDaySettings;
+}
+
+void LLSettingsDay::setLLSDDirty()
+{
+    mDaySettings = LLSD::emptyMap();
+    LLSettingsBase::setLLSDDirty();
 }
 
 bool LLSettingsDay::initialize(bool validate_frames)
@@ -392,6 +405,8 @@ bool LLSettingsDay::initialize(bool validate_frames)
         mSettings[SETTING_ASSETID] = assetid;
     }
 
+    loadValuesFromLLSD();
+
     mInitialized = true;
     return true;
 }
@@ -449,7 +464,7 @@ LLSD LLSettingsDay::defaults()
     return dfltsetting;
 }
 
-void LLSettingsDay::blend(const LLSettingsBase::ptr_t &other, F64 mix)
+void LLSettingsDay::blend(LLSettingsBase::ptr_t &other, F64 mix)
 {
     LL_ERRS("DAYCYCLE") << "Day cycles are not blendable!" << LL_ENDL;
 }

--- a/indra/llinventory/llsettingsdaycycle.h
+++ b/indra/llinventory/llsettingsdaycycle.h
@@ -81,9 +81,10 @@ public:
 
     bool                        initialize(bool validate_frames = false);
 
-    virtual ptr_t               buildClone() const = 0;
-    virtual ptr_t               buildDeepCloneAndUncompress() const = 0;
-    virtual LLSD                getSettings() const SETTINGS_OVERRIDE;
+    virtual ptr_t               buildClone() = 0;
+    virtual ptr_t               buildDeepCloneAndUncompress() = 0;
+    virtual LLSD&               getSettings() SETTINGS_OVERRIDE;
+    virtual void                setLLSDDirty() override;
     virtual LLSettingsType::type_e  getSettingsTypeValue() const SETTINGS_OVERRIDE { return LLSettingsType::ST_DAYCYCLE; }
 
 
@@ -91,7 +92,7 @@ public:
     virtual std::string         getSettingsType() const SETTINGS_OVERRIDE { return std::string("daycycle"); }
 
     // Settings status
-    virtual void                blend(const LLSettingsBase::ptr_t &other, F64 mix) SETTINGS_OVERRIDE;
+    virtual void                blend(LLSettingsBase::ptr_t &other, F64 mix) SETTINGS_OVERRIDE;
 
     static LLSD                 defaults();
 
@@ -127,7 +128,7 @@ public:
     virtual validation_list_t   getValidationList() const SETTINGS_OVERRIDE;
     static validation_list_t    validationList();
 
-    virtual LLSettingsBase::ptr_t buildDerivedClone() const SETTINGS_OVERRIDE { return buildClone(); }
+    virtual LLSettingsBase::ptr_t buildDerivedClone() SETTINGS_OVERRIDE { return buildClone(); }
 
     LLSettingsBase::TrackPosition getUpperBoundFrame(S32 track, const LLSettingsBase::TrackPosition& keyframe);
     LLSettingsBase::TrackPosition getLowerBoundFrame(S32 track, const LLSettingsBase::TrackPosition& keyframe);
@@ -143,6 +144,7 @@ protected:
 
 private:
     CycleList_t                 mDayTracks;
+    LLSD                        mDaySettings;
 
     LLSettingsBase::Seconds     mLastUpdateTime;
 

--- a/indra/llinventory/llsettingssky.cpp
+++ b/indra/llinventory/llsettingssky.cpp
@@ -433,7 +433,80 @@ void LLSettingsSky::replaceSettings(LLSD settings)
     mNextHaloTextureId.setNull();
 }
 
-void LLSettingsSky::replaceWithSky(LLSettingsSky::ptr_t pother)
+void LLSettingsSky::replaceSettings(const LLSettingsBase::ptr_t& other_sky)
+{
+    LLSettingsBase::replaceSettings(other_sky);
+
+    llassert(getSettingsType() == other_sky->getSettingsType());
+
+    LLSettingsSky::ptr_t other = PTR_NAMESPACE::dynamic_pointer_cast<LLSettingsSky>(other_sky);
+
+    mCanAutoAdjust = other->mCanAutoAdjust;
+    mReflectionProbeAmbiance = other->mReflectionProbeAmbiance;
+
+    mSunScale = other->mSunScale;
+    mSunRotation = other->mSunRotation;
+    mSunlightColor = other->mSunlightColor;
+    mStarBrightness = other->mStarBrightness;
+    mMoonBrightness = other->mMoonBrightness;
+    mMoonScale = other->mMoonScale;
+    mMoonRotation = other->mMoonRotation;
+    mMaxY = other->mMaxY;
+    mGlow = other->mGlow;
+    mGamma = other->mGamma;
+    mCloudVariance = other->mCloudVariance;
+    mCloudShadow = other->mCloudShadow;
+    mScrollRate = other->mScrollRate;
+    mCloudScale = other->mCloudScale;
+    mCloudPosDensity1 = other->mCloudPosDensity1;
+    mCloudPosDensity2 = other->mCloudPosDensity2;
+    mCloudColor = other->mCloudColor;
+
+    mAbsorptionConfigs = other->mAbsorptionConfigs;
+    mMieConfigs = other->mMieConfigs;
+    mRayleighConfigs = other->mRayleighConfigs;
+
+    mSunArcRadians = other->mSunArcRadians;
+    mSkyTopRadius = other->mSkyTopRadius;
+    mSkyBottomRadius = other->mSkyBottomRadius;
+    mSkyMoistureLevel = other->mSkyMoistureLevel;
+    mSkyDropletRadius = other->mSkyDropletRadius;
+    mSkyIceLevel = other->mSkyIceLevel;
+    mPlanetRadius = other->mPlanetRadius;
+
+    mHasLegacyHaze = other->mHasLegacyHaze;
+    mDistanceMultiplier = other->mDistanceMultiplier;
+    mDensityMultiplier = other->mDensityMultiplier;
+    mHazeHorizon = other->mHazeHorizon;
+    mHazeDensity = other->mHazeDensity;
+    mBlueHorizon = other->mBlueHorizon;
+    mBlueDensity = other->mBlueDensity;
+    mAmbientColor = other->mAmbientColor;
+
+    mLegacyDistanceMultiplier = other->mLegacyDistanceMultiplier;
+    mLegacyDensityMultiplier = other->mLegacyDensityMultiplier;
+    mLegacyHazeHorizon = other->mLegacyHazeHorizon;
+    mLegacyHazeDensity = other->mLegacyHazeDensity;
+    mLegacyBlueHorizon = other->mLegacyBlueHorizon;
+    mLegacyBlueDensity = other->mLegacyBlueDensity;
+    mLegacyAmbientColor = other->mLegacyAmbientColor;
+
+    mSunTextureId = other->mSunTextureId;
+    mMoonTextureId = other->mMoonTextureId;
+    mCloudTextureId = other->mCloudTextureId;
+    mHaloTextureId = other->mHaloTextureId;
+    mRainbowTextureId = other->mRainbowTextureId;
+    mBloomTextureId = other->mBloomTextureId;
+
+    mNextSunTextureId.setNull();
+    mNextMoonTextureId.setNull();
+    mNextCloudTextureId.setNull();
+    mNextBloomTextureId.setNull();
+    mNextRainbowTextureId.setNull();
+    mNextHaloTextureId.setNull();
+}
+
+void LLSettingsSky::replaceWithSky(const LLSettingsSky::ptr_t& pother)
 {
     replaceWith(pother);
 
@@ -445,41 +518,28 @@ void LLSettingsSky::replaceWithSky(LLSettingsSky::ptr_t pother)
     mNextHaloTextureId = pother->mNextHaloTextureId;
 }
 
-void lerp_vector2(LLVector2& a, const LLVector2& b, F32 mix)
-{
-    a.mV[0] = lerp(a.mV[0], b.mV[0], mix);
-    a.mV[1] = lerp(a.mV[1], b.mV[1], mix);
-}
-
-void lerp_color(LLColor3 &a, const LLColor3 &b, F32 mix)
-{
-    a.mV[0] = lerp(a.mV[0], b.mV[0], mix);
-    a.mV[1] = lerp(a.mV[1], b.mV[1], mix);
-    a.mV[2] = lerp(a.mV[2], b.mV[2], mix);
-}
-
 bool lerp_legacy_color(LLColor3& a, bool& a_has_legacy, const LLColor3& b, bool b_has_legacy, const LLColor3& def, F32 mix)
 {
     if (b_has_legacy)
     {
         if (a_has_legacy)
         {
-            lerp_color(a, b, mix);
+            LLSettingsBase::lerpColor(a, b, mix);
         }
         else
         {
             a = def;
-            lerp_color(a, b, mix);
+            LLSettingsBase::lerpColor(a, b, mix);
             a_has_legacy = true;
         }
     }
     else if (a_has_legacy)
     {
-        lerp_color(a, def, mix);
+        LLSettingsBase::lerpColor(a, def, mix);
     }
     else
     {
-        lerp_color(a, b, mix);
+        LLSettingsBase::lerpColor(a, b, mix);
     }
     return a_has_legacy;
 }
@@ -517,26 +577,6 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
     LLSettingsSky::ptr_t other = PTR_NAMESPACE::dynamic_pointer_cast<LLSettingsSky>(end);
     if (other)
     {
-        if (other->mHasLegacyHaze)
-        {
-            if (!mHasLegacyHaze || !mLegacyAmbientColor)
-            {
-                // Special case since SETTING_AMBIENT is both in outer and legacy maps,
-                // we prioritize legacy one
-                setAmbientColor(other->getAmbientColor());
-                mLegacyAmbientColor = true;
-                mHasLegacyHaze = true;
-            }
-        }
-        else
-        {
-            if (mLegacyAmbientColor)
-            {
-                // Special case due to ambient's duality
-                mLegacyAmbientColor = false;
-            }
-        }
-
         LLUUID cloud_noise_id = getCloudNoiseTextureId();
         LLUUID cloud_noise_id_next = other->getCloudNoiseTextureId();
         if (!cloud_noise_id.isNull() && cloud_noise_id_next.isNull())
@@ -565,8 +605,8 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
 
         mSunRotation = slerp((F32)blendf, mSunRotation, other->mSunRotation);
         mMoonRotation = slerp((F32)blendf, mMoonRotation, other->mMoonRotation);
-        lerp_color(mSunlightColor, other->mSunlightColor, (F32)blendf);
-        lerp_color(mGlow, other->mGlow, (F32)blendf);
+        lerpColor(mSunlightColor, other->mSunlightColor, (F32)blendf);
+        lerpColor(mGlow, other->mGlow, (F32)blendf);
         mReflectionProbeAmbiance = lerp(mReflectionProbeAmbiance, other->mReflectionProbeAmbiance, (F32)blendf);
         mSunScale = lerp(mSunScale, other->mSunScale, (F32)blendf);
         mStarBrightness = lerp(mStarBrightness, other->mStarBrightness, (F32)blendf);
@@ -577,17 +617,10 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
         mCloudVariance = lerp(mCloudVariance, other->mCloudVariance, (F32)blendf);
         mCloudShadow = lerp(mCloudShadow, other->mCloudShadow, (F32)blendf);
         mCloudScale = lerp(mCloudScale, other->mCloudScale, (F32)blendf);
-        lerp_vector2(mScrollRate, other->mScrollRate, (F32)blendf);
-        lerp_color(mCloudPosDensity1, other->mCloudPosDensity1, (F32)blendf);
-        lerp_color(mCloudPosDensity2, other->mCloudPosDensity2, (F32)blendf);
-        lerp_color(mCloudColor, other->mCloudColor, (F32)blendf);
-
-        parammapping_t defaults = other->getParameterMap();
-        stringset_t skip = getSkipInterpolateKeys();
-        stringset_t slerps = getSlerpKeys();
-        mAbsorptionConfigs = interpolateSDMap(mAbsorptionConfigs, other->mAbsorptionConfigs, defaults, blendf, skip, slerps);
-        mMieConfigs = interpolateSDMap(mMieConfigs, other->mMieConfigs, defaults, blendf, skip, slerps);
-        mRayleighConfigs = interpolateSDMap(mRayleighConfigs, other->mRayleighConfigs, defaults, blendf, skip, slerps);
+        lerpVector2(mScrollRate, other->mScrollRate, (F32)blendf);
+        lerpColor(mCloudPosDensity1, other->mCloudPosDensity1, (F32)blendf);
+        lerpColor(mCloudPosDensity2, other->mCloudPosDensity2, (F32)blendf);
+        lerpColor(mCloudColor, other->mCloudColor, (F32)blendf);
 
         mSunArcRadians = lerp(mSunArcRadians, other->mSunArcRadians, (F32)blendf);
         mSkyTopRadius = lerp(mSkyTopRadius, other->mSkyTopRadius, (F32)blendf);
@@ -597,6 +630,28 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
         mSkyIceLevel = lerp(mSkyIceLevel, other->mSkyIceLevel, (F32)blendf);
         mPlanetRadius = lerp(mPlanetRadius, other->mPlanetRadius, (F32)blendf);
 
+        // Legacy settings
+
+        if (other->mHasLegacyHaze)
+        {
+            if (!mHasLegacyHaze || !mLegacyAmbientColor)
+            {
+                // Special case since SETTING_AMBIENT is both in outer and legacy maps,
+                // we prioritize legacy one
+                setAmbientColor(other->getAmbientColor());
+                mLegacyAmbientColor = true;
+                mHasLegacyHaze = true;
+            }
+        }
+        else
+        {
+            if (mLegacyAmbientColor)
+            {
+                // Special case due to ambient's duality
+                mLegacyAmbientColor = false;
+            }
+        }
+
         mHasLegacyHaze |= lerp_legacy_float(mHazeHorizon, mLegacyHazeHorizon, other->mHazeHorizon, other->mLegacyHazeHorizon, 0.19f, (F32)blendf);
         mHasLegacyHaze |= lerp_legacy_float(mHazeDensity, mLegacyHazeDensity, other->mHazeDensity, other->mLegacyHazeDensity, 0.7f, (F32)blendf);
         mHasLegacyHaze |= lerp_legacy_float(mDistanceMultiplier, mLegacyDistanceMultiplier, other->mDistanceMultiplier, other->mLegacyDistanceMultiplier, 0.8f, (F32)blendf);
@@ -604,60 +659,16 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
         mHasLegacyHaze |= lerp_legacy_color(mBlueHorizon, mLegacyBlueHorizon, other->mBlueHorizon, other->mLegacyBlueHorizon, LLColor3(0.4954f, 0.4954f, 0.6399f), (F32)blendf);
         mHasLegacyHaze |= lerp_legacy_color(mBlueDensity, mLegacyBlueDensity, other->mBlueDensity, other->mLegacyBlueDensity, LLColor3(0.2447f, 0.4487f, 0.7599f), (F32)blendf);
 
+        parammapping_t defaults = other->getParameterMap();
+        stringset_t skip = getSkipInterpolateKeys();
+        stringset_t slerps = getSlerpKeys();
+        mAbsorptionConfigs = interpolateSDMap(mAbsorptionConfigs, other->mAbsorptionConfigs, defaults, blendf, skip, slerps);
+        mMieConfigs = interpolateSDMap(mMieConfigs, other->mMieConfigs, defaults, blendf, skip, slerps);
+        mRayleighConfigs = interpolateSDMap(mRayleighConfigs, other->mRayleighConfigs, defaults, blendf, skip, slerps);
+
         setDirtyFlag(true);
         setReplaced();
         setLLSDDirty();
-
-        /////// validation
-        /*
-        LLSD blenddata = interpolateSDMap(settings, other_settings, other->getParameterMap(), blendf, skip, slerps);
-        blenddata[SETTING_CLOUD_SHADOW] = LLSD::Real(mCloudShadow);
-
-        LLSettingsSky::ptr_t sky_p = buildClone();
-        sky_p->replaceSettings(blenddata);
-        sky_p->loadValuesFromLLSD();
-        llassert(sky_p->getSettingsType() == getSettingsType());
-        llassert(sky_p->getSunRotation() == getSunRotation());
-        llassert(sky_p->getMoonRotation() == getMoonRotation());
-        llassert(sky_p->getSunTextureId() == getSunTextureId());
-        llassert(sky_p->getMoonTextureId() == getMoonTextureId());
-        llassert(sky_p->getCloudNoiseTextureId() == getCloudNoiseTextureId());
-        llassert(sky_p->getBloomTextureId() == getBloomTextureId());
-        llassert(sky_p->getRainbowTextureId() == getRainbowTextureId());
-        llassert(sky_p->getHaloTextureId() == getHaloTextureId());
-        llassert(sky_p->getCloudColor() == getCloudColor());
-        llassert(sky_p->getCloudPosDensity1() == getCloudPosDensity1());
-        llassert(sky_p->getCloudPosDensity2() == getCloudPosDensity2());
-        llassert(sky_p->getCloudScale() == getCloudScale());
-        llassert(sky_p->getCloudScrollRate() == getCloudScrollRate());
-        llassert(sky_p->getCloudShadow() == getCloudShadow());
-        llassert(sky_p->getCloudVariance() == getCloudVariance());
-        llassert(sky_p->getDomeOffset() == getDomeOffset());
-        llassert(sky_p->getDomeRadius() == getDomeRadius());
-        llassert(sky_p->getGamma() == getGamma());
-        llassert(sky_p->getStarBrightness() == getStarBrightness());
-        llassert(sky_p->getSunlightColor() == getSunlightColor());
-        llassert(sky_p->getSunScale() == getSunScale());
-        llassert(sky_p->getSunArcRadians() == getSunArcRadians());
-        llassert(sky_p->getSunlightColor() == getSunlightColor());
-        llassert(sky_p->getGlow() == getGlow());
-        llassert(sky_p->getReflectionProbeAmbiance() == getReflectionProbeAmbiance());
-        llassert(sky_p->getStarBrightness() == getStarBrightness());
-        llassert(sky_p->getMoonBrightness() == getMoonBrightness());
-        llassert(sky_p->getMoonScale() == getMoonScale());
-        llassert(sky_p->getMaxY() == getMaxY());
-        llassert(sky_p->getSkyTopRadius() == getSkyTopRadius());
-        llassert(sky_p->getSkyBottomRadius() == getSkyBottomRadius());
-        llassert(sky_p->getSkyMoistureLevel() == getSkyMoistureLevel());
-        llassert(sky_p->getSkyDropletRadius() == getSkyDropletRadius());
-        llassert(sky_p->getSkyIceLevel() == getSkyIceLevel());
-        llassert(sky_p->getPlanetRadius() == getPlanetRadius());
-        llassert(sky_p->getHazeHorizon() == getHazeHorizon());
-        llassert(sky_p->getHazeDensity() == getHazeDensity());
-        llassert(sky_p->getDistanceMultiplier() == getDistanceMultiplier());
-        llassert(sky_p->getDensityMultiplier() == getDensityMultiplier());
-        llassert(sky_p->getBlueHorizon() == getBlueHorizon());
-        llassert(sky_p->getBlueDensity() == getBlueDensity());*/
 
         mNextSunTextureId = other->getSunTextureId();
         mNextMoonTextureId = other->getMoonTextureId();

--- a/indra/llinventory/llsettingssky.h
+++ b/indra/llinventory/llsettingssky.h
@@ -121,8 +121,9 @@ public:
     virtual void blend(LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
 
     virtual void replaceSettings(LLSD settings) SETTINGS_OVERRIDE;
+    virtual void replaceSettings(const LLSettingsBase::ptr_t& other_sky) override;
 
-    void replaceWithSky(LLSettingsSky::ptr_t pother);
+    void replaceWithSky(const LLSettingsSky::ptr_t& pother);
     static LLSD defaults(const LLSettingsBase::TrackPosition& position = 0.0f);
 
     void loadValuesFromLLSD() override;

--- a/indra/llinventory/llsettingssky.h
+++ b/indra/llinventory/llsettingssky.h
@@ -365,21 +365,21 @@ protected:
     LLUUID      mNextHaloTextureId;
 
     bool mCanAutoAdjust;
+    LLQuaternion mSunRotation;
+    LLQuaternion mMoonRotation;
+    LLColor3 mSunlightColor;
+    LLColor3 mGlow;
     F32 mReflectionProbeAmbiance;
     F32 mSunScale;
-    LLQuaternion mSunRotation;
-    LLColor3 mSunlightColor;
     F32 mStarBrightness;
     F32 mMoonBrightness;
     F32 mMoonScale;
-    LLQuaternion mMoonRotation;
     F32 mMaxY;
-    LLColor3 mGlow;
     F32 mGamma;
     F32 mCloudVariance;
     F32 mCloudShadow;
-    LLVector2 mScrollRate;
     F32 mCloudScale;
+    LLVector2 mScrollRate;
     LLColor3 mCloudPosDensity1;
     LLColor3 mCloudPosDensity2;
     LLColor3 mCloudColor;

--- a/indra/llinventory/llsettingssky.h
+++ b/indra/llinventory/llsettingssky.h
@@ -402,6 +402,7 @@ protected:
     LLColor3 mBlueDensity;
     LLColor3 mAmbientColor;
 
+    bool mHasLegacyHaze;
     bool mLegacyHazeHorizon;
     bool mLegacyHazeDensity;
     bool mLegacyDistanceMultiplier;

--- a/indra/llinventory/llsettingssky.h
+++ b/indra/llinventory/llsettingssky.h
@@ -111,19 +111,22 @@ public:
     LLSettingsSky(const LLSD &data);
     virtual ~LLSettingsSky() { };
 
-    virtual ptr_t   buildClone() const = 0;
+    virtual ptr_t   buildClone() = 0;
 
     //---------------------------------------------------------------------
     virtual std::string getSettingsType() const SETTINGS_OVERRIDE { return std::string("sky"); }
     virtual LLSettingsType::type_e getSettingsTypeValue() const SETTINGS_OVERRIDE { return LLSettingsType::ST_SKY; }
 
     // Settings status
-    virtual void blend(const LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
+    virtual void blend(LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
 
     virtual void replaceSettings(LLSD settings) SETTINGS_OVERRIDE;
 
     void replaceWithSky(LLSettingsSky::ptr_t pother);
     static LLSD defaults(const LLSettingsBase::TrackPosition& position = 0.0f);
+
+    void loadValuesFromLLSD() override;
+    void saveValuesToLLSD() override;
 
     F32 getPlanetRadius() const;
     F32 getSkyBottomRadius() const;
@@ -306,7 +309,7 @@ public:
     LLColor3 getSunlightColorClamped() const;
     LLColor3 getAmbientColorClamped() const;
 
-    virtual LLSettingsBase::ptr_t buildDerivedClone() const SETTINGS_OVERRIDE { return buildClone(); }
+    virtual LLSettingsBase::ptr_t buildDerivedClone() SETTINGS_OVERRIDE { return buildClone(); }
 
     static LLUUID GetDefaultAssetId();
     static LLUUID GetDefaultSunTextureId();
@@ -348,6 +351,12 @@ protected:
     virtual stringset_t getSlerpKeys() const SETTINGS_OVERRIDE;
     virtual stringset_t getSkipInterpolateKeys() const SETTINGS_OVERRIDE;
 
+    LLUUID      mSunTextureId;
+    LLUUID      mMoonTextureId;
+    LLUUID      mCloudTextureId;
+    LLUUID      mBloomTextureId;
+    LLUUID      mRainbowTextureId;
+    LLUUID      mHaloTextureId;
     LLUUID      mNextSunTextureId;
     LLUUID      mNextMoonTextureId;
     LLUUID      mNextCloudTextureId;
@@ -355,17 +364,63 @@ protected:
     LLUUID      mNextRainbowTextureId;
     LLUUID      mNextHaloTextureId;
 
+    bool mCanAutoAdjust;
+    F32 mReflectionProbeAmbiance;
+    F32 mSunScale;
+    LLQuaternion mSunRotation;
+    LLColor3 mSunlightColor;
+    F32 mStarBrightness;
+    F32 mMoonBrightness;
+    F32 mMoonScale;
+    LLQuaternion mMoonRotation;
+    F32 mMaxY;
+    LLColor3 mGlow;
+    F32 mGamma;
+    F32 mCloudVariance;
+    F32 mCloudShadow;
+    LLVector2 mScrollRate;
+    F32 mCloudScale;
+    LLColor3 mCloudPosDensity1;
+    LLColor3 mCloudPosDensity2;
+    LLColor3 mCloudColor;
+    LLSD mAbsorptionConfigs;
+    LLSD mMieConfigs;
+    LLSD mRayleighConfigs;
+    F32 mSunArcRadians;
+    F32 mSkyTopRadius;
+    F32 mSkyBottomRadius;
+    F32 mSkyMoistureLevel;
+    F32 mSkyDropletRadius;
+    F32 mSkyIceLevel;
+    F32 mPlanetRadius;
+
+    F32 mHazeHorizon;
+    F32 mHazeDensity;
+    F32 mDistanceMultiplier;
+    F32 mDensityMultiplier;
+    LLColor3 mBlueHorizon;
+    LLColor3 mBlueDensity;
+    LLColor3 mAmbientColor;
+
+    bool mLegacyHazeHorizon;
+    bool mLegacyHazeDensity;
+    bool mLegacyDistanceMultiplier;
+    bool mLegacyDensityMultiplier;
+    bool mLegacyBlueHorizon;
+    bool mLegacyBlueDensity;
+    bool mLegacyAmbientColor;
+
 private:
     static LLSD rayleighConfigDefault();
     static LLSD absorptionConfigDefault();
     static LLSD mieConfigDefault();
 
-    LLColor3 getColor(const std::string& key, const LLColor3& default_value) const;
-    F32      getFloat(const std::string& key, F32 default_value) const;
+    LLColor3 getColor(const std::string& key, const LLColor3& default_value);
+    F32      getFloat(const std::string& key, F32 default_value);
 
     void        calculateHeavenlyBodyPositions() const;
     void        calculateLightSettings() const;
-    void        clampColor(LLColor3& color, F32 gamma, const F32 scale = 1.0f) const;
+    static void clampColor(LLColor3& color, F32 gamma, const F32 scale = 1.0f);
 
     mutable LLVector3   mSunDirection;
     mutable LLVector3   mMoonDirection;

--- a/indra/llinventory/llsettingswater.cpp
+++ b/indra/llinventory/llsettingswater.cpp
@@ -70,12 +70,14 @@ LLSettingsWater::LLSettingsWater(const LLSD &data) :
     LLSettingsBase(data),
     mNextNormalMapID()
 {
+    loadValuesFromLLSD();
 }
 
 LLSettingsWater::LLSettingsWater() :
     LLSettingsBase(),
     mNextNormalMapID()
 {
+    replaceSettings(defaults());
 }
 
 //=========================================================================
@@ -229,6 +231,7 @@ LLSD LLSettingsWater::translateLegacySettings(LLSD legacy)
 
 void LLSettingsWater::blend(LLSettingsBase::ptr_t &end, F64 blendf)
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_ENVIRONMENT;
     LLSettingsWater::ptr_t other = PTR_NAMESPACE::static_pointer_cast<LLSettingsWater>(end);
     if (other)
     {

--- a/indra/llinventory/llsettingswater.h
+++ b/indra/llinventory/llsettingswater.h
@@ -55,151 +55,167 @@ public:
     LLSettingsWater(const LLSD &data);
     virtual ~LLSettingsWater() { };
 
-    virtual ptr_t   buildClone() const = 0;
+    virtual ptr_t   buildClone() = 0;
 
     //---------------------------------------------------------------------
     virtual std::string     getSettingsType() const SETTINGS_OVERRIDE { return std::string("water"); }
     virtual LLSettingsType::type_e  getSettingsTypeValue() const SETTINGS_OVERRIDE { return LLSettingsType::ST_WATER; }
 
     // Settings status
-    virtual void blend(const LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
+    virtual void blend(LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
 
     virtual void replaceSettings(LLSD settings) SETTINGS_OVERRIDE;
     void replaceWithWater(LLSettingsWater::ptr_t other);
 
     static LLSD defaults(const LLSettingsBase::TrackPosition& position = 0.0f);
 
+    void loadValuesFromLLSD() override;
+    void saveValuesToLLSD() override;
+
     //---------------------------------------------------------------------
     F32 getBlurMultiplier() const
     {
-        return (F32)mSettings[SETTING_BLUR_MULTIPLIER].asReal();
+        return mBlurMultiplier;
     }
 
     void setBlurMultiplier(F32 val)
     {
-        setValue(SETTING_BLUR_MULTIPLIER, val);
+        mBlurMultiplier = val;
+        setLLSDDirty();
     }
 
     LLColor3 getWaterFogColor() const
     {
-        return LLColor3(mSettings[SETTING_FOG_COLOR]);
+        return mWaterFogColor;
     }
 
     void setWaterFogColor(LLColor3 val)
     {
-        setValue(SETTING_FOG_COLOR, val);
+        mWaterFogColor = val;
+        setLLSDDirty();
     }
 
     F32 getWaterFogDensity() const
     {
-        return (F32)mSettings[SETTING_FOG_DENSITY].asReal();
+        return mWaterFogDensity;
     }
 
     F32 getModifiedWaterFogDensity(bool underwater) const;
 
     void setWaterFogDensity(F32 val)
     {
-        setValue(SETTING_FOG_DENSITY, val);
+        mWaterFogDensity = val;
+        setLLSDDirty();
     }
 
     F32 getFogMod() const
     {
-        return (F32)mSettings[SETTING_FOG_MOD].asReal();
+        return mFogMod;
     }
 
     void setFogMod(F32 val)
     {
-        setValue(SETTING_FOG_MOD, val);
+        mFogMod = val;
+        setLLSDDirty();
     }
 
     F32 getFresnelOffset() const
     {
-        return (F32)mSettings[SETTING_FRESNEL_OFFSET].asReal();
+        return mFresnelOffset;
     }
 
     void setFresnelOffset(F32 val)
     {
-        setValue(SETTING_FRESNEL_OFFSET, val);
+        mFresnelOffset = val;
+        setLLSDDirty();
     }
 
     F32 getFresnelScale() const
     {
-        return (F32)mSettings[SETTING_FRESNEL_SCALE].asReal();
+        return mFresnelScale;
     }
 
     void setFresnelScale(F32 val)
     {
-        setValue(SETTING_FRESNEL_SCALE, val);
+        mFresnelScale = val;
+        setLLSDDirty();
     }
 
     LLUUID getTransparentTextureID() const
     {
-        return mSettings[SETTING_TRANSPARENT_TEXTURE].asUUID();
+        return mTransparentTextureID;
     }
 
     void setTransparentTextureID(LLUUID val)
     {
-        setValue(SETTING_TRANSPARENT_TEXTURE, val);
+        mTransparentTextureID = val;
+        setLLSDDirty();
     }
 
     LLUUID getNormalMapID() const
     {
-        return mSettings[SETTING_NORMAL_MAP].asUUID();
+        return mNormalMapID;
     }
 
     void setNormalMapID(LLUUID val)
     {
-        setValue(SETTING_NORMAL_MAP, val);
+        mNormalMapID = val;
+        setLLSDDirty();
     }
 
     LLVector3 getNormalScale() const
     {
-        return LLVector3(mSettings[SETTING_NORMAL_SCALE]);
+        return mNormalScale;
     }
 
     void setNormalScale(LLVector3 val)
     {
-        setValue(SETTING_NORMAL_SCALE, val);
+        mNormalScale = val;
+        setLLSDDirty();
     }
 
     F32 getScaleAbove() const
     {
-        return (F32)mSettings[SETTING_SCALE_ABOVE].asReal();
+        return mScaleAbove;
     }
 
     void setScaleAbove(F32 val)
     {
-        setValue(SETTING_SCALE_ABOVE, val);
+        mScaleAbove = val;
+        setLLSDDirty();
     }
 
     F32 getScaleBelow() const
     {
-        return (F32)mSettings[SETTING_SCALE_BELOW].asReal();
+        return mScaleBelow;
     }
 
     void setScaleBelow(F32 val)
     {
-        setValue(SETTING_SCALE_BELOW, val);
+        mScaleBelow = val;
+        setLLSDDirty();
     }
 
     LLVector2 getWave1Dir() const
     {
-        return LLVector2(mSettings[SETTING_WAVE1_DIR]);
+        return mWave1Dir;
     }
 
     void setWave1Dir(LLVector2 val)
     {
-        setValue(SETTING_WAVE1_DIR, val);
+        mWave1Dir = val;
+        setLLSDDirty();
     }
 
     LLVector2 getWave2Dir() const
     {
-        return LLVector2(mSettings[SETTING_WAVE2_DIR]);
+        return mWave2Dir;
     }
 
     void setWave2Dir(LLVector2 val)
     {
-        setValue(SETTING_WAVE2_DIR, val);
+        mWave2Dir = val;
+        setLLSDDirty();
     }
 
     //-------------------------------------------
@@ -218,7 +234,7 @@ public:
 
     static LLSD         translateLegacySettings(LLSD legacy);
 
-    virtual LLSettingsBase::ptr_t buildDerivedClone() const SETTINGS_OVERRIDE { return buildClone(); }
+    virtual LLSettingsBase::ptr_t buildDerivedClone() SETTINGS_OVERRIDE { return buildClone(); }
 
     static LLUUID GetDefaultAssetId();
     static LLUUID GetDefaultWaterNormalAssetId();
@@ -241,9 +257,22 @@ protected:
 
     LLSettingsWater();
 
+    LLUUID    mTransparentTextureID;
+    LLUUID    mNormalMapID;
     LLUUID    mNextTransparentTextureID;
     LLUUID    mNextNormalMapID;
 
+    F32 mBlurMultiplier;
+    LLColor3 mWaterFogColor;
+    F32 mWaterFogDensity;
+    F32 mFogMod;
+    F32 mFresnelOffset;
+    F32 mFresnelScale;
+    LLVector3 mNormalScale;
+    F32 mScaleAbove;
+    F32 mScaleBelow;
+    LLVector2 mWave1Dir;
+    LLVector2 mWave2Dir;
 };
 
 #endif

--- a/indra/llinventory/llsettingswater.h
+++ b/indra/llinventory/llsettingswater.h
@@ -81,6 +81,7 @@ public:
     void setBlurMultiplier(F32 val)
     {
         mBlurMultiplier = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -92,6 +93,7 @@ public:
     void setWaterFogColor(LLColor3 val)
     {
         mWaterFogColor = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -105,6 +107,7 @@ public:
     void setWaterFogDensity(F32 val)
     {
         mWaterFogDensity = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -116,6 +119,7 @@ public:
     void setFogMod(F32 val)
     {
         mFogMod = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -127,6 +131,7 @@ public:
     void setFresnelOffset(F32 val)
     {
         mFresnelOffset = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -138,6 +143,7 @@ public:
     void setFresnelScale(F32 val)
     {
         mFresnelScale = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -149,6 +155,7 @@ public:
     void setTransparentTextureID(LLUUID val)
     {
         mTransparentTextureID = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -160,6 +167,7 @@ public:
     void setNormalMapID(LLUUID val)
     {
         mNormalMapID = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -171,6 +179,7 @@ public:
     void setNormalScale(LLVector3 val)
     {
         mNormalScale = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -182,6 +191,7 @@ public:
     void setScaleAbove(F32 val)
     {
         mScaleAbove = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -193,6 +203,7 @@ public:
     void setScaleBelow(F32 val)
     {
         mScaleBelow = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -204,6 +215,7 @@ public:
     void setWave1Dir(LLVector2 val)
     {
         mWave1Dir = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 
@@ -215,6 +227,7 @@ public:
     void setWave2Dir(LLVector2 val)
     {
         mWave2Dir = val;
+        setDirtyFlag(true);
         setLLSDDirty();
     }
 

--- a/indra/llinventory/llsettingswater.h
+++ b/indra/llinventory/llsettingswater.h
@@ -65,7 +65,8 @@ public:
     virtual void blend(LLSettingsBase::ptr_t &end, F64 blendf) SETTINGS_OVERRIDE;
 
     virtual void replaceSettings(LLSD settings) SETTINGS_OVERRIDE;
-    void replaceWithWater(LLSettingsWater::ptr_t other);
+    virtual void replaceSettings(const LLSettingsBase::ptr_t& other_water) override;
+    void replaceWithWater(const LLSettingsWater::ptr_t& other);
 
     static LLSD defaults(const LLSettingsBase::TrackPosition& position = 0.0f);
 

--- a/indra/newview/llenvironment.cpp
+++ b/indra/newview/llenvironment.cpp
@@ -453,11 +453,11 @@ namespace
 
         void applyInjections(LLSettingsBase::Seconds delta)
         {
-            this->mSettings = this->mSource->getSettings();
+            LLSD settings = this->mSource->cloneSettings();
 
             for (auto ito = mOverrideValues.beginMap(); ito != mOverrideValues.endMap(); ++ito)
             {
-                this->mSettings[(*ito).first] = (*ito).second;
+                settings[(*ito).first] = (*ito).second;
             }
 
             const LLSettingsBase::stringset_t &slerps = this->getSlerpKeys();
@@ -469,7 +469,7 @@ namespace
             {
                 std::string key_name = (*it)->mKeyName;
 
-                LLSD value = this->mSettings[key_name];
+                LLSD value = settings[key_name];
                 LLSD target = (*it)->mValue;
 
                 if ((*it)->mFirstTime)
@@ -485,11 +485,11 @@ namespace
                     {
                         mOverrideValues[key_name] = target;
                         mOverrideExps[key_name] = (*it)->mExperience;
-                        this->mSettings[key_name] = target;
+                        settings[key_name] = target;
                     }
                     else
                     {
-                        this->mSettings.erase(key_name);
+                        settings.erase(key_name);
                     }
                 }
                 else if (specials.find(key_name) != specials.end())
@@ -500,8 +500,8 @@ namespace
                 {
                     if (!(*it)->mBlendIn)
                         mix = 1.0 - mix;
-                    (*it)->mLastValue = this->interpolateSDValue(key_name, value, target, this->getParameterMap(), mix, slerps);
-                    this->mSettings[key_name] = (*it)->mLastValue;
+                    (*it)->mLastValue = this->interpolateSDValue(key_name, value, target, this->getParameterMap(), mix, skips, slerps);
+                    settings[key_name] = (*it)->mLastValue;
                 }
             }
 
@@ -520,7 +520,7 @@ namespace
             {
                 mInjections.erase(mInjections.begin(), mInjections.end());
             }
-
+            this->setSettings(settings);
         }
 
         bool hasInjections() const
@@ -685,7 +685,8 @@ namespace
             if (!injection->mBlendIn)
                 mix = 1.0 - mix;
             stringset_t dummy;
-            F64 value = this->mSettings[injection->mKeyName].asReal();
+            LLSD settings = this->cloneSettings();
+            F64 value = settings[injection->mKeyName].asReal();
             if (this->getCloudNoiseTextureId().isNull())
             {
                 value = 0; // there was no texture so start from zero coverage
@@ -695,7 +696,8 @@ namespace
             // with different transitions, don't ignore it
             F64 result = lerp((F32)value, (F32)injection->mValue.asReal(), (F32)mix);
             injection->mLastValue = LLSD::Real(result);
-            this->mSettings[injection->mKeyName] = injection->mLastValue;
+            settings[injection->mKeyName] = injection->mLastValue;
+            this->setSettings(settings);
         }
 
         // Unfortunately I don't have a per texture blend factor.  We'll just pick the one that is furthest along.
@@ -1740,90 +1742,9 @@ void LLEnvironment::updateGLVariablesForSettings(LLShaderUniforms* uniforms, con
     {
         uniforms[i].clear();
     }
-
-    LLShaderUniforms* shader = &uniforms[LLGLSLShader::SG_ANY];
-    //_WARNS("RIDER") << "----------------------------------------------------------------" << LL_ENDL;
-    LLSettingsBase::parammapping_t params = psetting->getParameterMap();
-    for (auto &it: params)
-    {
-        LLSD value;
-        // legacy first since it contains ambient color and we prioritize value from legacy, see getAmbientColor()
-        if (psetting->mSettings.has(LLSettingsSky::SETTING_LEGACY_HAZE) && psetting->mSettings[LLSettingsSky::SETTING_LEGACY_HAZE].has(it.first))
-        {
-            value = psetting->mSettings[LLSettingsSky::SETTING_LEGACY_HAZE][it.first];
-        }
-        else if (psetting->mSettings.has(it.first))
-        {
-            value = psetting->mSettings[it.first];
-        }
-        else
-        {
-            // We need to reset shaders, use defaults
-            value = it.second.getDefaultValue();
-        }
-
-        LLSD::Type setting_type = value.type();
-        stop_glerror();
-        switch (setting_type)
-        {
-        case LLSD::TypeInteger:
-            shader->uniform1i(it.second.getShaderKey(), value.asInteger());
-            //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << value << LL_ENDL;
-            break;
-        case LLSD::TypeReal:
-            shader->uniform1f(it.second.getShaderKey(), (F32)value.asReal());
-            //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << value << LL_ENDL;
-            break;
-
-        case LLSD::TypeBoolean:
-            shader->uniform1i(it.second.getShaderKey(), value.asBoolean() ? 1 : 0);
-            //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << value << LL_ENDL;
-            break;
-
-        case LLSD::TypeArray:
-        {
-            LLVector4 vect4(value);
-            // always identify as a radiance pass if desaturating irradiance is disabled
-            static LLCachedControl<bool> desaturate_irradiance(gSavedSettings, "RenderDesaturateIrradiance", true);
-
-            if (desaturate_irradiance && gCubeSnapshot && !gPipeline.mReflectionMapManager.isRadiancePass())
-            { // maximize and remove tinting if this is an irradiance map render pass and the parameter feeds into the sky background color
-                auto max_vec = [](LLVector4 col)
-                {
-                    LLColor3 color(col);
-                    F32 h, s, l;
-                    color.calcHSL(&h, &s, &l);
-
-                    col.mV[0] = col.mV[1] = col.mV[2] = l;
-                    return col;
-                };
-
-                switch (it.second.getShaderKey())
-                {
-                case LLShaderMgr::BLUE_HORIZON:
-                case LLShaderMgr::BLUE_DENSITY:
-                    vect4 = max_vec(vect4);
-                        break;
-                }
-            }
-
-            //_WARNS("RIDER") << "pushing '" << (*it).first << "' as " << vect4 << LL_ENDL;
-            shader->uniform3fv(it.second.getShaderKey(), LLVector3(vect4.mV) );
-            break;
-        }
-
-        //  case LLSD::TypeMap:
-        //  case LLSD::TypeString:
-        //  case LLSD::TypeUUID:
-        //  case LLSD::TypeURI:
-        //  case LLSD::TypeBinary:
-        //  case LLSD::TypeDate:
-        default:
-            break;
-        }
-    }
     //_WARNS("RIDER") << "----------------------------------------------------------------" << LL_ENDL;
 
+    psetting->applyToUniforms(uniforms);
     psetting->applySpecial(uniforms);
 }
 

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -724,7 +724,6 @@ inline void draw_real(LLShaderUniforms* shader, F32 value, S32 shader_key)
 void LLSettingsVOSky::applyToUniforms(void* ptarget)
 {
     LLShaderUniforms* shader = &((LLShaderUniforms*)ptarget)[LLGLSLShader::SG_ANY];
-    LLSD &settings = getSettings();
 
     draw_color(shader, getAmbientColor(), LLShaderMgr::AMBIENT);
     draw_color(shader, getBlueDensity(), LLShaderMgr::BLUE_DENSITY);

--- a/indra/newview/llsettingsvo.h
+++ b/indra/newview/llsettingsvo.h
@@ -94,7 +94,7 @@ public:
 
     static ptr_t buildFromLegacyPreset(const std::string &name, const LLSD &oldsettings, LLSD &messages);
     static ptr_t    buildDefaultSky();
-    virtual ptr_t   buildClone() const SETTINGS_OVERRIDE;
+    virtual ptr_t   buildClone() SETTINGS_OVERRIDE;
 
     static ptr_t buildFromLegacyPresetFile(const std::string &name, const std::string &path, LLSD &messages);
 
@@ -110,6 +110,7 @@ protected:
 
     virtual void    updateSettings() override;
 
+    virtual void    applyToUniforms(void*) override;
     virtual void    applySpecial(void *, bool) override;
 
     virtual parammapping_t getParameterMap() const override;
@@ -128,7 +129,7 @@ public:
 
     static ptr_t buildFromLegacyPreset(const std::string &name, const LLSD &oldsettings, LLSD &messages);
     static ptr_t    buildDefaultWater();
-    virtual ptr_t   buildClone() const SETTINGS_OVERRIDE;
+    virtual ptr_t   buildClone() SETTINGS_OVERRIDE;
 
     static ptr_t buildFromLegacyPresetFile(const std::string &name, const std::string &path, LLSD &messages);
 
@@ -138,6 +139,7 @@ protected:
     LLSettingsVOWater();
 
     virtual void    updateSettings() override;
+    virtual void    applyToUniforms(void*) override;
     virtual void    applySpecial(void *, bool) override;
 
     virtual parammapping_t getParameterMap() const override;
@@ -167,8 +169,8 @@ public:
     static ptr_t    buildDefaultDayCycle();
     static ptr_t    buildFromEnvironmentMessage(LLSD settings);
     static void     buildFromOtherSetting(LLSettingsBase::ptr_t settings, asset_built_fn cb);
-    virtual ptr_t   buildClone() const SETTINGS_OVERRIDE;
-    virtual ptr_t   buildDeepCloneAndUncompress() const SETTINGS_OVERRIDE;
+    virtual ptr_t   buildClone() SETTINGS_OVERRIDE;
+    virtual ptr_t   buildDeepCloneAndUncompress() SETTINGS_OVERRIDE;
 
     static LLSD     convertToLegacy(const ptr_t &);
 

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -3888,7 +3888,9 @@ void LLViewerWindow::updateKeyboardFocus()
     LLUICtrl* cur_focus = dynamic_cast<LLUICtrl*>(gFocusMgr.getKeyboardFocus());
     if (cur_focus)
     {
-        if (!cur_focus->isInVisibleChain() || !cur_focus->isInEnabledChain())
+        bool is_in_visible_chain = cur_focus->isInVisibleChain();
+        bool is_in_enabled_chain = cur_focus->isInEnabledChain();
+        if (!is_in_visible_chain || !is_in_enabled_chain)
         {
             // don't release focus, just reassign so that if being given
             // to a sibling won't call onFocusLost on all the ancestors
@@ -3899,11 +3901,19 @@ void LLViewerWindow::updateKeyboardFocus()
             bool new_focus_found = false;
             while(parent)
             {
+                if (!is_in_visible_chain)
+                {
+                    is_in_visible_chain = parent->isInVisibleChain();
+                }
+                if (!is_in_enabled_chain)
+                {
+                    is_in_enabled_chain = parent->isInEnabledChain();
+                }
                 if (parent->isCtrl()
                     && (parent->hasTabStop() || parent == focus_root)
                     && !parent->getIsChrome()
-                    && parent->isInVisibleChain()
-                    && parent->isInEnabledChain())
+                    && is_in_visible_chain
+                    && is_in_enabled_chain)
                 {
                     if (!parent->focusFirstItem())
                     {


### PR DESCRIPTION
1. Optimize updateGLVariablesForSettings by removing LLSD operations
2. Optimize LLSettingsSky::blend by removing LLSD operations
3. Optimize LLSettingsWater::blend by removing LLSD operations
4. Small update for updateKeyboardFocus. If child is in visible/enabled tree, parent is too.

These commits avoid checking LLSD and now functions access values directly (which also has a benefit of being easier to debug), this cuts out 100-150μs per frame.