### PR TITLE
Fix names in group chat sometimes showing as "Loading..." and never resolve

### DIFF
--- a/indra/llui/llurlentry.cpp
+++ b/indra/llui/llurlentry.cpp
@@ -600,15 +600,15 @@ void LLUrlEntryAgent::callObservers(const std::string &id,
 void LLUrlEntryAgent::onAvatarNameCache(const LLUUID& id,
                                         const LLAvatarName& av_name)
 {
-    avatar_name_cache_connection_map_t::iterator it = mAvatarNameCacheConnections.find(id);
-    if (it != mAvatarNameCacheConnections.end())
+    auto range = mAvatarNameCacheConnections.equal_range(id);
+    for (avatar_name_cache_connection_map_t::iterator it = range.first; it != range.second; ++it)
     {
         if (it->second.connected())
         {
             it->second.disconnect();
         }
-        mAvatarNameCacheConnections.erase(it);
     }
+    mAvatarNameCacheConnections.erase(range.first, range.second);
 
     std::string label = av_name.getCompleteName();
 
@@ -695,16 +695,7 @@ std::string LLUrlEntryAgent::getLabel(const std::string &url, const LLUrlLabelCa
     }
     else
     {
-        avatar_name_cache_connection_map_t::iterator it = mAvatarNameCacheConnections.find(agent_id);
-        if (it != mAvatarNameCacheConnections.end())
-        {
-            if (it->second.connected())
-            {
-                it->second.disconnect();
-            }
-            mAvatarNameCacheConnections.erase(it);
-        }
-        mAvatarNameCacheConnections[agent_id] = LLAvatarNameCache::get(agent_id, boost::bind(&LLUrlEntryAgent::onAvatarNameCache, this, _1, _2));
+        mAvatarNameCacheConnections.emplace(agent_id, LLAvatarNameCache::get(agent_id, boost::bind(&LLUrlEntryAgent::onAvatarNameCache, this, _1, _2)));
 
         addObserver(agent_id_string, url, cb);
         return LLTrans::getString("LoadingData");
@@ -770,17 +761,17 @@ LLUrlEntryAgentName::LLUrlEntryAgentName()
 {}
 
 void LLUrlEntryAgentName::onAvatarNameCache(const LLUUID& id,
-                                        const LLAvatarName& av_name)
+                                            const LLAvatarName& av_name)
 {
-    avatar_name_cache_connection_map_t::iterator it = mAvatarNameCacheConnections.find(id);
-    if (it != mAvatarNameCacheConnections.end())
+    auto range = mAvatarNameCacheConnections.equal_range(id);
+    for (avatar_name_cache_connection_map_t::iterator it = range.first; it != range.second; ++it)
     {
         if (it->second.connected())
         {
             it->second.disconnect();
         }
-        mAvatarNameCacheConnections.erase(it);
     }
+    mAvatarNameCacheConnections.erase(range.first, range.second);
 
     std::string label = getName(av_name);
     // received the agent name from the server - tell our observers
@@ -815,16 +806,7 @@ std::string LLUrlEntryAgentName::getLabel(const std::string &url, const LLUrlLab
     }
     else
     {
-        avatar_name_cache_connection_map_t::iterator it = mAvatarNameCacheConnections.find(agent_id);
-        if (it != mAvatarNameCacheConnections.end())
-        {
-            if (it->second.connected())
-            {
-                it->second.disconnect();
-            }
-            mAvatarNameCacheConnections.erase(it);
-        }
-        mAvatarNameCacheConnections[agent_id] = LLAvatarNameCache::get(agent_id, boost::bind(&LLUrlEntryAgentName::onAvatarNameCache, this, _1, _2));
+        mAvatarNameCacheConnections.emplace(agent_id, LLAvatarNameCache::get(agent_id, boost::bind(&LLUrlEntryAgentName::onAvatarNameCache, this, _1, _2)));
 
         addObserver(agent_id_string, url, cb);
         return LLTrans::getString("LoadingData");

--- a/indra/llui/llurlentry.h
+++ b/indra/llui/llurlentry.h
@@ -232,7 +232,7 @@ protected:
 private:
     void onAvatarNameCache(const LLUUID& id, const LLAvatarName& av_name);
 
-    typedef std::map<LLUUID, boost::signals2::connection> avatar_name_cache_connection_map_t;
+    typedef std::multimap<LLUUID, boost::signals2::connection> avatar_name_cache_connection_map_t;
     avatar_name_cache_connection_map_t mAvatarNameCacheConnections;
 };
 
@@ -264,7 +264,7 @@ protected:
 private:
     void onAvatarNameCache(const LLUUID& id, const LLAvatarName& av_name);
 
-    typedef std::map<LLUUID, boost::signals2::connection> avatar_name_cache_connection_map_t;
+    typedef std::multimap<LLUUID, boost::signals2::connection> avatar_name_cache_connection_map_t;
     avatar_name_cache_connection_map_t mAvatarNameCacheConnections;
 };
 


### PR DESCRIPTION
Finally available in the official viewer thanks to a special request from @RyeMutt : Fix the 10+ year old bug where names in group chat sometimes/often get stuck as "Loading..." and never resolve (BUG-3829 / MAINT-3118). Also see https://jira.firestormviewer.org/browse/FIRE-11330 for a description of the bug. 😄 