### PR TITLE
Fix issue with improper reporting as to whether voice is working.

### DIFF
--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -5011,8 +5011,7 @@ bool LLVivoxVoiceClient::isVoiceWorking() const
     //Added stateSessionTerminated state to avoid problems with call in parcels with disabled voice (EXT-4758)
     // Condition with joining spatial num was added to take into account possible problems with connection to voice
     // server(EXT-4313). See bug descriptions and comments for MAX_NORMAL_JOINING_SPATIAL_NUM for more info.
-    return (mSpatialJoiningNum < MAX_NORMAL_JOINING_SPATIAL_NUM) && mIsProcessingChannels;
-//  return (mSpatialJoiningNum < MAX_NORMAL_JOINING_SPATIAL_NUM) && (stateLoggedIn <= mState) && (mState <= stateSessionTerminated);
+    return (mSpatialJoiningNum < MAX_NORMAL_JOINING_SPATIAL_NUM) && mIsLoggedIn;
 }
 
 // Returns true if the indicated participant in the current audio session is really an SL avatar.

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -420,7 +420,7 @@ void LLWebRTCVoiceClient::notifyStatusObservers(LLVoiceClientStatusObserver::ESt
         status != LLVoiceClientStatusObserver::STATUS_LEFT_CHANNEL &&
         status != LLVoiceClientStatusObserver::STATUS_VOICE_DISABLED)
     {
-        bool voice_status = LLVoiceClient::getInstance()->voiceEnabled() && LLVoiceClient::getInstance()->isVoiceWorking();
+        bool voice_status = LLVoiceClient::getInstance()->voiceEnabled() && mIsProcessingChannels;
 
         gAgent.setVoiceConnected(voice_status);
 
@@ -1335,7 +1335,10 @@ bool LLWebRTCVoiceClient::startAdHocSession(const LLSD& channelInfo, bool notify
 
 bool LLWebRTCVoiceClient::isVoiceWorking() const
 {
-    return mIsProcessingChannels;
+    // webrtc is working if the coroutine is active in the case of
+    // webrtc. WebRTC doesn't need to connect to a secondary process
+    // or a login server to become active.
+    return mIsCoroutineActive;
 }
 
 // Returns true if calling back the session URI after the session has closed is possible.


### PR DESCRIPTION
This fixes https://github.com/secondlife/viewer-private/issues/286, an issue where the 'call button' sometimes got greyed out when it shouldn't have been.

Vivox is now 'working' (and the call button can be enabled) when it's logged in. WebRTC is 'working' (and the call button can be enabled) when the coroutine is active.