### PR TITLE
Don't allow LLAttachmentsMgr to iterate COF items when there is no questionable links there

### DIFF
--- a/indra/newview/llattachmentsmgr.cpp
+++ b/indra/newview/llattachmentsmgr.cpp
@@ -465,7 +465,7 @@ bool LLAttachmentsMgr::isAttachmentStateComplete() const
 //
 void LLAttachmentsMgr::checkInvalidCOFLinks()
 {
-    if (!gInventory.isInventoryUsable())
+    if (!gInventory.isInventoryUsable() || mQuestionableCOFLinks.empty())
     {
         return;
     }


### PR DESCRIPTION
`checkInvalidCOFLinks()` was called every frame even if it's totally pointless, spending ~25 μs for COF iteration/checking.

![image](https://github.com/user-attachments/assets/ec9dc119-f815-455a-b7c6-1e95e8471edd)
