### PR TITLE
#2553 about sl crash locale init

### DIFF
--- a/indra/llcommon/llerror.cpp
+++ b/indra/llcommon/llerror.cpp
@@ -110,7 +110,7 @@ namespace {
         virtual void recordMessage(LLError::ELevel level,
                                     const std::string& message) override
         {
-            LL_PROFILE_ZONE_SCOPED_CATEGORY_LOGGING
+            LL_PROFILE_ZONE_SCOPED_CATEGORY_LOGGING;
             int syslogPriority = LOG_CRIT;
             switch (level) {
                 case LLError::LEVEL_DEBUG:  syslogPriority = LOG_DEBUG; break;

--- a/indra/llcommon/llstring.cpp
+++ b/indra/llcommon/llstring.cpp
@@ -1410,6 +1410,14 @@ bool LLStringUtil::simpleReplacement(std::string &replacement, std::string token
 template<>
 void LLStringUtil::setLocale(std::string inLocale)
 {
+    if(startsWith(inLocale, "MissingString"))
+    {
+        // it seems this hasn't been working for some time, and I'm not sure how it is intentded to
+        // properly discover the correct locale.  early out now to avoid failures later in
+        // formatNumber()
+        LL_WARNS() << "Failed attempting to set invalid locale: " << inLocale << LL_ENDL;
+        return;
+    }
     sLocale = inLocale;
 };
 


### PR DESCRIPTION
Attempted fix for mac crash when showing About Second Life.
secondlife/viewer#2553

The app is crashing in the debugger with an unhandled exception issued from LLStringUtil::formatNumber() when attempting to imbue the locale.  This makes no sense since the call to construct the locale is directly wrapped in a try/catch block that should be handling it.  The bugsplat call stack looks slightly different and fails in some Cocoa array allocation handling when terminating due to the uncaught exception.

Nonetheless this whole situation can be avoided by not attempting to set invalid locales such as `MissingString(macosLocale)`.  I have not yet discovered why we are attempting to look up locale names in strings.xml which have not been there for some time.