### PR TITLE
Fix macOS locale not being set due to missing locale strings

### DIFF
--- a/indra/newview/skins/default/xui/da/language_settings.xml
+++ b/indra/newview/skins/default/xui/da/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">danish</string>
 	<string name="MacLocale">da_DK.UTF-8</string>
+	<string name="macOSLocale">da_DK.UTF-8</string>
 	<string name="DarwinLocale">da_DK.UTF-8</string>
 	<string name="LinuxLocale">da_DK.UTF-8</string>
 	

--- a/indra/newview/skins/default/xui/de/language_settings.xml
+++ b/indra/newview/skins/default/xui/de/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">german</string>
 	<string name="MacLocale">de_DE.UTF-8</string>
+	<string name="macOSLocale">de_DE.UTF-8</string>
 	<string name="DarwinLocale">de_DE.UTF-8</string>
 	<string name="LinuxLocale">de_DE.UTF-8</string>
 	

--- a/indra/newview/skins/default/xui/en/language_settings.xml
+++ b/indra/newview/skins/default/xui/en/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">english</string>
 	<string name="MacLocale">C</string>
+	<string name="macOSLocale">C</string>
 	<string name="DarwinLocale">C</string>
 	<string name="LinuxLocale">C</string>
   

--- a/indra/newview/skins/default/xui/es/language_settings.xml
+++ b/indra/newview/skins/default/xui/es/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">spanish</string>
 	<string name="MacLocale">es_ES.UTF-8</string>
+	<string name="macOSLocale">es_ES.UTF-8</string>
 	<string name="DarwinLocale">es_ES.UTF-8</string>
 	<string name="LinuxLocale">es_ES.UTF-8</string>
 	

--- a/indra/newview/skins/default/xui/fr/language_settings.xml
+++ b/indra/newview/skins/default/xui/fr/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">french</string>
 	<string name="MacLocale">fr_FR.UTF-8</string>
+	<string name="macOSLocale">fr_FR.UTF-8</string>
 	<string name="DarwinLocale">fr_FR.UTF-8</string>
 	<string name="LinuxLocale">fr_FR.UTF-8</string>
 	

--- a/indra/newview/skins/default/xui/it/language_settings.xml
+++ b/indra/newview/skins/default/xui/it/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">italian</string>
 	<string name="MacLocale">it_IT.UTF-8</string>
+	<string name="macOSLocale">it_IT.UTF-8</string>
 	<string name="DarwinLocale">it_IT.UTF-8</string>
 	<string name="LinuxLocale">it_IT.UTF-8</string>
 	

--- a/indra/newview/skins/default/xui/ja/language_settings.xml
+++ b/indra/newview/skins/default/xui/ja/language_settings.xml
@@ -6,6 +6,9 @@
 	<string name="MacLocale">
 		ja_JP.UTF-8
 	</string>
+	<string name="macOSLocale">
+		ja_JP.UTF-8
+	</string>
 	<string name="DarwinLocale">
 		ja_JP.UTF-8
 	</string>

--- a/indra/newview/skins/default/xui/pl/language_settings.xml
+++ b/indra/newview/skins/default/xui/pl/language_settings.xml
@@ -2,6 +2,7 @@
 <strings>
 	<string name="MicrosoftLocale">polish</string>
 	<string name="MacLocale">pl_PL.UTF-8</string>
+	<string name="macOSLocale">pl_PL.UTF-8</string>
 	<string name="DarwinLocale">pl_PL.UTF-8</string>
 	<string name="LinuxLocale">pl_PL.UTF-8</string>
 	<string name="TimeHour">hour,datetime,slt</string>

--- a/indra/newview/skins/default/xui/pt/language_settings.xml
+++ b/indra/newview/skins/default/xui/pt/language_settings.xml
@@ -5,6 +5,7 @@
 	<!-- Locale Information -->
 	<string name="MicrosoftLocale">portuguese</string>
 	<string name="MacLocale">pt_PT.UTF-8</string>
+	<string name="macOSLocale">pt_PT.UTF-8</string>
 	<string name="DarwinLocale">pt_PT.UTF-8</string>
 	<string name="LinuxLocale">pt_PT.UTF-8</string>
 	


### PR DESCRIPTION
This fixes the macOS locale not being set correctly due to OS string changes that were not propagated to UI xml