### PR TITLE
#2410 Combat 2.0 settings not reflected on heart icon

### DIFF
--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -7556,7 +7556,7 @@ Message from [NAME]:
    type="notify">
     <unique/>
 This land has damage enabled.
-You can be hurt here. If you die, you will be teleported to your home location.
+You can be hurt here. If you die, you might be teleported to your home location or to the spawn point.
   </notification>
 
   <notification


### PR DESCRIPTION
The notification message text is hardcoded in the viewer source code
It can't depend on the region settings stored on the server side

The bug description says:
> This text should likely be modified to reflect the change in Combat 2.0, either (simple fix) by removing the "you will be teleported to your home location." language, or (harder but better fix) returning the correct damage outcome for the region in question.

Implementing of the dependence between the icon notification text and the server-side option could cost too much
So we choose the first option (simple fix)