### PR TITLE
Restore LUA debug consoles in viewer menu and tie visibility to feature flag

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -2583,6 +2583,37 @@ function="World.EnvPreset"
                parameter="scene monitor" />
             </menu_item_check>
             <menu_item_separator/>
+            <menu_item_check
+               label="LUA Debug Console"
+               name="LUA Debug Console">
+              <menu_item_check.on_check
+               function="Floater.Visible"
+               parameter="lua_debug" />
+              <menu_item_check.on_click
+               function="Floater.Toggle"
+               parameter="lua_debug" />
+              <menu_item_check.on_visible
+               function="CheckControl"
+               parameter="LuaFeature" />
+            </menu_item_check>
+            <menu_item_check
+               label="LUA Scripts Info"
+               name="LUA Scripts">
+              <menu_item_check.on_check
+               function="Floater.Visible"
+               parameter="lua_scripts" />
+              <menu_item_check.on_click
+               function="Floater.Toggle"
+               parameter="lua_scripts" />
+              <menu_item_check.on_visible
+               function="CheckControl"
+               parameter="LuaFeature" />
+            </menu_item_check>
+            <menu_item_separator>
+              <menu_item_separator.on_visible
+               function="CheckControl"
+               parameter="LuaFeature"/>
+            </menu_item_separator>
 
             <menu_item_call
              label="Region Info to Debug Console"


### PR DESCRIPTION
@nat-goodspeed Instead of removing the LUA consoles from to viewer menu so they might get forgotten and lost forever, I added them back and instead tied their visibility to the corresponding feature flag.