### PR TITLE
viewer#2565 Optimize LLFolderViewItem::draw()

### DIFF
--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -429,165 +429,247 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTex
 
         gGL.color4fv(color.mV);
 
-        const S32 NUM_VERTICES = 9 * 4; // 9 quads
-        LLVector2 uv[NUM_VERTICES];
-        LLVector3 pos[NUM_VERTICES];
+        constexpr S32 NUM_VERTICES = 9 * 2 * 3; // 9 quads, 2 triangles per quad, 3 vertices per triangle
+        static thread_local LLVector2 uv[NUM_VERTICES];
+        static thread_local LLVector3 pos[NUM_VERTICES];
 
         S32 index = 0;
 
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
         {
-            // draw bottom left
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_outer_rect.mBottom, 0.f);
+            // draw bottom left triangles
+            // 1
+            uv[index].set(uv_outer_rect.mLeft, uv_outer_rect.mBottom);
+            pos[index].set(draw_outer_rect.mLeft, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_outer_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            // 2
+            uv[index].set(uv_outer_rect.mLeft, uv_outer_rect.mBottom);
+            pos[index].set(draw_outer_rect.mLeft, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            // draw bottom middle
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_outer_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_outer_rect.mBottom, 0.f);
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
+            // draw bottom middle triangles
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            // draw bottom right
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_outer_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_outer_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_outer_rect.mBottom, 0.f);
+            // 2
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            // draw left
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            // draw bottom right triangles
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_outer_rect.mBottom);
+            pos[index].set(draw_outer_rect.mRight, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_center_rect.mTop, 0.f);
+            // 2
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mBottom, 0.f);
             index++;
 
-            // draw middle
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            // draw left triangles
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            // draw right
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_center_rect.mBottom);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_center_rect.mBottom, 0.f);
+            // 2
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mTop, 0.f);
             index++;
 
-            // draw top left
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_center_rect.mTop, 0.f);
+            // draw middle triangles
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mLeft, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            // 2
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mBottom, 0.f);
             index++;
 
-            // draw top middle
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_outer_rect.mTop, 0.f);
+            // draw right triangles
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mLeft, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            // draw top right
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_center_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_center_rect.mTop, 0.f);
+            // 2
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mBottom);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mBottom, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_outer_rect.mRight, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_outer_rect.mRight, draw_outer_rect.mTop, 0.f);
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mTop, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_center_rect.mRight, uv_outer_rect.mTop);
-            pos[index] = LLVector3(draw_center_rect.mRight, draw_outer_rect.mTop, 0.f);
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            index++;
+
+            // draw top left triangles
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            // 2
+            uv[index].set(uv_outer_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mLeft, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_outer_rect.mLeft, uv_outer_rect.mTop);
+            pos[index].set(draw_outer_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            // draw top middle triangles
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            // 2
+            uv[index].set(uv_center_rect.mLeft, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mLeft, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mLeft, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            // draw top right triangles
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_outer_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_outer_rect.mRight, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_outer_rect.mRight, uv_outer_rect.mTop);
+            pos[index].set(draw_outer_rect.mRight, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            // 2
+            uv[index].set(uv_center_rect.mRight, uv_center_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_center_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_outer_rect.mRight, uv_outer_rect.mTop);
+            pos[index].set(draw_outer_rect.mRight, draw_outer_rect.mTop, 0.f);
+            index++;
+
+            uv[index].set(uv_center_rect.mRight, uv_outer_rect.mTop);
+            pos[index].set(draw_center_rect.mRight, draw_outer_rect.mTop, 0.f);
             index++;
 
             gGL.vertexBatchPreTransformed(pos, uv, NUM_VERTICES);
@@ -629,11 +711,11 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
 
     if (degrees == 0.f)
     {
-        const S32 NUM_VERTICES = 4; // 9 quads
-        LLVector2 uv[NUM_VERTICES];
-        LLVector3 pos[NUM_VERTICES];
+        constexpr S32 NUM_VERTICES = 2 * 3;
+        static thread_local LLVector2 uv[NUM_VERTICES];
+        static thread_local LLVector3 pos[NUM_VERTICES];
 
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
         {
             LLVector3 ui_scale = gGL.getUIScale();
             LLVector3 ui_translation = gGL.getUITranslation();
@@ -644,20 +726,28 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
             S32 scaled_width = ll_round(width * ui_scale.mV[VX]);
             S32 scaled_height = ll_round(height * ui_scale.mV[VY]);
 
-            uv[index] = LLVector2(uv_rect.mRight, uv_rect.mTop);
-            pos[index] = LLVector3(ui_translation.mV[VX] + scaled_width, ui_translation.mV[VY] + scaled_height, 0.f);
+            uv[index].set(uv_rect.mRight, uv_rect.mTop);
+            pos[index].set(ui_translation.mV[VX] + scaled_width, ui_translation.mV[VY] + scaled_height, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_rect.mLeft, uv_rect.mTop);
-            pos[index] = LLVector3(ui_translation.mV[VX], ui_translation.mV[VY] + scaled_height, 0.f);
+            uv[index].set(uv_rect.mLeft, uv_rect.mTop);
+            pos[index].set(ui_translation.mV[VX], ui_translation.mV[VY] + scaled_height, 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_rect.mLeft, uv_rect.mBottom);
-            pos[index] = LLVector3(ui_translation.mV[VX], ui_translation.mV[VY], 0.f);
+            uv[index].set(uv_rect.mLeft, uv_rect.mBottom);
+            pos[index].set(ui_translation.mV[VX], ui_translation.mV[VY], 0.f);
             index++;
 
-            uv[index] = LLVector2(uv_rect.mRight, uv_rect.mBottom);
-            pos[index] = LLVector3(ui_translation.mV[VX] + scaled_width, ui_translation.mV[VY], 0.f);
+            uv[index].set(uv_rect.mRight, uv_rect.mTop);
+            pos[index].set(ui_translation.mV[VX] + scaled_width, ui_translation.mV[VY] + scaled_height, 0.f);
+            index++;
+
+            uv[index].set(uv_rect.mLeft, uv_rect.mBottom);
+            pos[index].set(ui_translation.mV[VX], ui_translation.mV[VY], 0.f);
+            index++;
+
+            uv[index].set(uv_rect.mRight, uv_rect.mBottom);
+            pos[index].set(ui_translation.mV[VX] + scaled_width, ui_translation.mV[VY], 0.f);
             index++;
 
             gGL.vertexBatchPreTransformed(pos, uv, NUM_VERTICES);

--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -122,9 +122,12 @@ void gl_rect_2d(S32 left, S32 top, S32 right, S32 bottom, bool filled )
     // Counterclockwise quad will face the viewer
     if( filled )
     {
-        gGL.begin( LLRender::QUADS );
+        gGL.begin( LLRender::TRIANGLES );
             gGL.vertex2i(left, top);
             gGL.vertex2i(left, bottom);
+            gGL.vertex2i(right, bottom);
+
+            gGL.vertex2i(left, top);
             gGL.vertex2i(right, bottom);
             gGL.vertex2i(right, top);
         gGL.end();
@@ -777,7 +780,7 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
 
         gGL.color4fv(color.mV);
 
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
         {
             LLVector3 v;
 
@@ -792,6 +795,14 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
             v = LLVector3(-offset_x, -offset_y, 0.f) * quat;
             gGL.texCoord2f(uv_rect.mLeft, uv_rect.mBottom);
             gGL.vertex2f(v.mV[0], v.mV[1] );
+
+            v = LLVector3(offset_x, offset_y, 0.f) * quat;
+            gGL.texCoord2f(uv_rect.mRight, uv_rect.mTop);
+            gGL.vertex2f(v.mV[0], v.mV[1]);
+
+            v = LLVector3(-offset_x, -offset_y, 0.f) * quat;
+            gGL.texCoord2f(uv_rect.mLeft, uv_rect.mBottom);
+            gGL.vertex2f(v.mV[0], v.mV[1]);
 
             v = LLVector3(offset_x, -offset_y, 0.f) * quat;
             gGL.texCoord2f(uv_rect.mRight, uv_rect.mBottom);
@@ -1038,13 +1049,19 @@ void gl_washer_segment_2d(F32 outer_radius, F32 inner_radius, F32 start_radians,
 
 void gl_rect_2d_simple_tex( S32 width, S32 height )
 {
-    gGL.begin( LLRender::QUADS );
+    gGL.begin( LLRender::TRIANGLES );
 
         gGL.texCoord2f(1.f, 1.f);
         gGL.vertex2i(width, height);
 
         gGL.texCoord2f(0.f, 1.f);
         gGL.vertex2i(0, height);
+
+        gGL.texCoord2f(0.f, 0.f);
+        gGL.vertex2i(0, 0);
+
+        gGL.texCoord2f(1.f, 1.f);
+        gGL.vertex2i(width, height);
 
         gGL.texCoord2f(0.f, 0.f);
         gGL.vertex2i(0, 0);
@@ -1057,9 +1074,12 @@ void gl_rect_2d_simple_tex( S32 width, S32 height )
 
 void gl_rect_2d_simple( S32 width, S32 height )
 {
-    gGL.begin( LLRender::QUADS );
+    gGL.begin( LLRender::TRIANGLES );
         gGL.vertex2i(width, height);
         gGL.vertex2i(0, height);
+        gGL.vertex2i(0, 0);
+
+        gGL.vertex2i(width, height);
         gGL.vertex2i(0, 0);
         gGL.vertex2i(width, 0);
     gGL.end();
@@ -1101,7 +1121,7 @@ void gl_segmented_rect_2d_tex(const S32 left,
     LLVector2 width_vec((F32)width, 0.f);
     LLVector2 height_vec(0.f, (F32)height);
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         // draw bottom left
         gGL.texCoord2f(0.f, 0.f);
@@ -1109,6 +1129,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
 
         gGL.texCoord2f(border_uv_scale.mV[VX], 0.f);
         gGL.vertex2fv(border_width_left.mV);
+
+        gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+        gGL.vertex2fv((border_width_left + border_height_bottom).mV);
+
+        gGL.texCoord2f(0.f, 0.f);
+        gGL.vertex2f(0.f, 0.f);
 
         gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
         gGL.vertex2fv((border_width_left + border_height_bottom).mV);
@@ -1126,6 +1152,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
         gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec - border_width_right + border_height_bottom).mV);
 
+        gGL.texCoord2f(border_uv_scale.mV[VX], 0.f);
+        gGL.vertex2fv(border_width_left.mV);
+
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec - border_width_right + border_height_bottom).mV);
+
         gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
         gGL.vertex2fv((border_width_left + border_height_bottom).mV);
 
@@ -1135,6 +1167,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
 
         gGL.texCoord2f(1.f, 0.f);
         gGL.vertex2fv(width_vec.mV);
+
+        gGL.texCoord2f(1.f, border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec + border_height_bottom).mV);
+
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 0.f);
+        gGL.vertex2fv((width_vec - border_width_right).mV);
 
         gGL.texCoord2f(1.f, border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec + border_height_bottom).mV);
@@ -1152,6 +1190,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
         gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((border_width_left + height_vec - border_height_top).mV);
 
+        gGL.texCoord2f(0.f, border_uv_scale.mV[VY]);
+        gGL.vertex2fv(border_height_bottom.mV);
+
+        gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((border_width_left + height_vec - border_height_top).mV);
+
         gGL.texCoord2f(0.f, 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((height_vec - border_height_top).mV);
 
@@ -1161,6 +1205,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
 
         gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec - border_width_right + border_height_bottom).mV);
+
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec - border_width_right + height_vec - border_height_top).mV);
+
+        gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+        gGL.vertex2fv((border_width_left + border_height_bottom).mV);
 
         gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec - border_width_right + height_vec - border_height_top).mV);
@@ -1178,6 +1228,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
         gGL.texCoord2f(1.f, 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec + height_vec - border_height_top).mV);
 
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec - border_width_right + border_height_bottom).mV);
+
+        gGL.texCoord2f(1.f, 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec + height_vec - border_height_top).mV);
+
         gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec - border_width_right + height_vec - border_height_top).mV);
 
@@ -1187,6 +1243,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
 
         gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((border_width_left + height_vec - border_height_top).mV);
+
+        gGL.texCoord2f(border_uv_scale.mV[VX], 1.f);
+        gGL.vertex2fv((border_width_left + height_vec).mV);
+
+        gGL.texCoord2f(0.f, 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((height_vec - border_height_top).mV);
 
         gGL.texCoord2f(border_uv_scale.mV[VX], 1.f);
         gGL.vertex2fv((border_width_left + height_vec).mV);
@@ -1204,6 +1266,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
         gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f);
         gGL.vertex2fv((width_vec - border_width_right + height_vec).mV);
 
+        gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((border_width_left + height_vec - border_height_top).mV);
+
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f);
+        gGL.vertex2fv((width_vec - border_width_right + height_vec).mV);
+
         gGL.texCoord2f(border_uv_scale.mV[VX], 1.f);
         gGL.vertex2fv((border_width_left + height_vec).mV);
 
@@ -1213,6 +1281,12 @@ void gl_segmented_rect_2d_tex(const S32 left,
 
         gGL.texCoord2f(1.f, 1.f - border_uv_scale.mV[VY]);
         gGL.vertex2fv((width_vec + height_vec - border_height_top).mV);
+
+        gGL.texCoord2f(1.f, 1.f);
+        gGL.vertex2fv((width_vec + height_vec).mV);
+
+        gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+        gGL.vertex2fv((width_vec - border_width_right + height_vec - border_height_top).mV);
 
         gGL.texCoord2f(1.f, 1.f);
         gGL.vertex2fv((width_vec + height_vec).mV);
@@ -1271,7 +1345,7 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
     LLVector2 x_min;
     LLVector2 x_max;
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         if (start_fragment < middle_start)
         {
@@ -1290,6 +1364,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(u_max, border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + border_height_bottom).mV);
 
+            gGL.texCoord2f(u_min, 0.f);
+            gGL.vertex2fv(x_min.mV);
+
+            gGL.texCoord2f(u_max, border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + border_height_bottom).mV);
+
             gGL.texCoord2f(u_min, border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + border_height_bottom).mV);
 
@@ -1303,6 +1383,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
 
+            gGL.texCoord2f(u_min, border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + border_height_bottom).mV);
+
+            gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
             gGL.texCoord2f(u_min, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
@@ -1312,6 +1398,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
 
             gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
+            gGL.texCoord2f(u_max, 1.f);
+            gGL.vertex2fv((x_max + height_vec).mV);
+
+            gGL.texCoord2f(u_min, 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
             gGL.texCoord2f(u_max, 1.f);
             gGL.vertex2fv((x_max + height_vec).mV);
@@ -1335,6 +1427,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + border_height_bottom).mV);
 
+            gGL.texCoord2f(border_uv_scale.mV[VX], 0.f);
+            gGL.vertex2fv(x_min.mV);
+
+            gGL.texCoord2f(1.f - border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + border_height_bottom).mV);
+
             gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + border_height_bottom).mV);
 
@@ -1348,6 +1446,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
 
+            gGL.texCoord2f(border_uv_scale.mV[VX], border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + border_height_bottom).mV);
+
+            gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
             gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
@@ -1357,6 +1461,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
 
             gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
+            gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f);
+            gGL.vertex2fv((x_max + height_vec).mV);
+
+            gGL.texCoord2f(border_uv_scale.mV[VX], 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
             gGL.texCoord2f(1.f - border_uv_scale.mV[VX], 1.f);
             gGL.vertex2fv((x_max + height_vec).mV);
@@ -1382,6 +1492,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(u_max, border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + border_height_bottom).mV);
 
+            gGL.texCoord2f(u_min, 0.f);
+            gGL.vertex2fv((x_min).mV);
+
+            gGL.texCoord2f(u_max, border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + border_height_bottom).mV);
+
             gGL.texCoord2f(u_min, border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + border_height_bottom).mV);
 
@@ -1395,6 +1511,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
             gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
 
+            gGL.texCoord2f(u_min, border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + border_height_bottom).mV);
+
+            gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
             gGL.texCoord2f(u_min, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
@@ -1404,6 +1526,12 @@ void gl_segmented_rect_2d_fragment_tex(const LLRect& rect,
 
             gGL.texCoord2f(u_max, 1.f - border_uv_scale.mV[VY]);
             gGL.vertex2fv((x_max + height_vec - border_height_top).mV);
+
+            gGL.texCoord2f(u_max, 1.f);
+            gGL.vertex2fv((x_max + height_vec).mV);
+
+            gGL.texCoord2f(u_min, 1.f - border_uv_scale.mV[VY]);
+            gGL.vertex2fv((x_min + height_vec - border_height_top).mV);
 
             gGL.texCoord2f(u_max, 1.f);
             gGL.vertex2fv((x_max + height_vec).mV);
@@ -1422,7 +1550,7 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         // draw bottom left
         gGL.texCoord2f(clip_rect.mLeft, clip_rect.mBottom);
@@ -1430,6 +1558,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 
         gGL.texCoord2f(center_uv_rect.mLeft, clip_rect.mBottom);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mBottom * height_vec).mV);
+
+        gGL.texCoord2f(clip_rect.mLeft, clip_rect.mBottom);
+        gGL.vertex3f(0.f, 0.f, 0.f);
 
         gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mBottom);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mBottom * height_vec).mV);
@@ -1447,6 +1581,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
         gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mBottom);
         gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mBottom * height_vec).mV);
 
+        gGL.texCoord2f(center_uv_rect.mLeft, clip_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mLeft * width_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mBottom * height_vec).mV);
+
         gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mBottom);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mBottom * height_vec).mV);
 
@@ -1456,6 +1596,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 
         gGL.texCoord2f(clip_rect.mRight, clip_rect.mBottom);
         gGL.vertex3fv(width_vec.mV);
+
+        gGL.texCoord2f(clip_rect.mRight, center_uv_rect.mBottom);
+        gGL.vertex3fv((width_vec + center_draw_rect.mBottom * height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mRight, clip_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mRight * width_vec).mV);
 
         gGL.texCoord2f(clip_rect.mRight, center_uv_rect.mBottom);
         gGL.vertex3fv((width_vec + center_draw_rect.mBottom * height_vec).mV);
@@ -1473,6 +1619,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
         gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mTop * height_vec).mV);
 
+        gGL.texCoord2f(clip_rect.mLeft, center_uv_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mBottom * height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mTop * height_vec).mV);
+
         gGL.texCoord2f(clip_rect.mLeft, center_uv_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mTop * height_vec).mV);
 
@@ -1482,6 +1634,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 
         gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mBottom);
         gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mBottom * height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mTop * height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mLeft * width_vec + center_draw_rect.mBottom * height_vec).mV);
 
         gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mTop * height_vec).mV);
@@ -1499,6 +1657,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
         gGL.texCoord2f(clip_rect.mRight, center_uv_rect.mTop);
         gGL.vertex3fv((width_vec + center_draw_rect.mTop * height_vec).mV);
 
+        gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mBottom);
+        gGL.vertex3fv((center_draw_rect.mRight* width_vec + center_draw_rect.mBottom * height_vec).mV);
+
+        gGL.texCoord2f(clip_rect.mRight, center_uv_rect.mTop);
+        gGL.vertex3fv((width_vec + center_draw_rect.mTop * height_vec).mV);
+
         gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mRight * width_vec + center_draw_rect.mTop * height_vec).mV);
 
@@ -1511,6 +1675,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 
         gGL.texCoord2f(center_uv_rect.mLeft, clip_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec + height_vec).mV);
+
+        gGL.texCoord2f(clip_rect.mLeft, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mTop* height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mLeft* width_vec + center_draw_rect.mTop * height_vec).mV);
 
         gGL.texCoord2f(clip_rect.mLeft, clip_rect.mTop);
         gGL.vertex3fv((height_vec).mV);
@@ -1525,6 +1695,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
         gGL.texCoord2f(center_uv_rect.mRight, clip_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mRight * width_vec + height_vec).mV);
 
+        gGL.texCoord2f(center_uv_rect.mLeft, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mLeft* width_vec + center_draw_rect.mTop * height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mRight* width_vec + center_draw_rect.mTop * height_vec).mV);
+
         gGL.texCoord2f(center_uv_rect.mLeft, clip_rect.mTop);
         gGL.vertex3fv((center_draw_rect.mLeft * width_vec + height_vec).mV);
 
@@ -1534,6 +1710,12 @@ void gl_segmented_rect_3d_tex(const LLRectf& clip_rect, const LLRectf& center_uv
 
         gGL.texCoord2f(clip_rect.mRight, center_uv_rect.mTop);
         gGL.vertex3fv((width_vec + center_draw_rect.mTop * height_vec).mV);
+
+        gGL.texCoord2f(clip_rect.mRight, clip_rect.mTop);
+        gGL.vertex3fv((width_vec + height_vec).mV);
+
+        gGL.texCoord2f(center_uv_rect.mRight, center_uv_rect.mTop);
+        gGL.vertex3fv((center_draw_rect.mRight* width_vec + center_draw_rect.mTop * height_vec).mV);
 
         gGL.texCoord2f(clip_rect.mRight, clip_rect.mTop);
         gGL.vertex3fv((width_vec + height_vec).mV);

--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -1649,7 +1649,7 @@ void LLFolderView::scrollToShowItem(LLFolderViewItem* item, const LLRect& constr
     {
         LLRect local_rect = item->getLocalRect();
         S32 icon_height = mIcon.isNull() ? 0 : mIcon->getHeight();
-        S32 label_height = getLabelFontForStyle(mLabelStyle)->getLineHeight();
+        S32 label_height = getLabelFont()->getLineHeight();
         // when navigating with keyboard, only move top of opened folder on screen, otherwise show whole folder
         S32 max_height_to_show = item->isOpen() && mScrollContainer->hasFocus() ? (llmax( icon_height, label_height ) + item->getIconPad()) : local_rect.getHeight();
 

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -135,7 +135,6 @@ protected:
     LLUIColor                   mFontHighlightColor;
 
     // For now assuming all colors are the same in derived classes.
-    static bool                 sColorSetInitialized;
     static LLUIColor            sFgColor;
     static LLUIColor            sFgDisabledColor;
     static LLUIColor            sHighlightBgColor;
@@ -158,6 +157,7 @@ protected:
     virtual void setFlashState(bool) { }
 
     static LLFontGL* getLabelFontForStyle(U8 style);
+    const LLFontGL* getLabelFont();
 
     bool                        mIsSelected;
 
@@ -297,7 +297,7 @@ public:
 
     //  virtual void handleDropped();
     virtual void draw();
-    void drawOpenFolderArrow(const Params& default_params, const LLUIColor& fg_color);
+    void drawOpenFolderArrow();
     void drawHighlight(bool showContent, bool hasKeyboardFocus, const LLUIColor& selectColor, const LLUIColor& flashColor, const LLUIColor& outlineColor, const LLUIColor& mouseOverColor);
     void drawLabel(const LLFontGL* font, const F32 x, const F32 y, const LLColor4& color, F32 &right_x);
     virtual bool handleDragAndDrop(S32 x, S32 y, MASK mask, bool drop,
@@ -308,9 +308,14 @@ public:
 
 private:
     static std::map<U8, LLFontGL*> sFonts; // map of styles to fonts
+    static S32 sTopPad;
+    static LLUIImagePtr sFolderArrowImg;
+    static LLUIImagePtr sSelectionImg;
+    static LLFontGL* sSuffixFont;
 
     LLFontVertexBuffer mLabelFontBuffer;
     LLFontVertexBuffer mSuffixFontBuffer;
+    LLFontGL* pLabelFont{nullptr};
 };
 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -313,7 +313,7 @@ void LLConversationViewSession::draw()
     {
         // update the rotation angle of open folder arrow
         updateLabelRotation();
-        drawOpenFolderArrow(default_params, sFgColor);
+        drawOpenFolderArrow();
     }
     LLView::draw();
 }


### PR DESCRIPTION
3 commits:

1. viewer#2565 sliglty optimizes draw() (shaves 2μs out of 9)
2. Converted image drawing from deprecated quads to triangles, my hope was that it would make things a bit faster since there will no longer be a need to convert  
3. Cover rest of the file