### PR TITLE
#2408 The long covenant with emojis significantly slows down FPS

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -2368,6 +2368,34 @@ S32 LLTextBase::removeFirstLine()
     return 0;
 }
 
+// virtual
+void LLTextBase::copyContents(const LLTextBase* source)
+{
+    llassert(source);
+    if (!source)
+        return;
+
+    beforeValueChange();
+    deselect();
+
+    mSegments.clear();
+    for (const LLTextSegmentPtr& segp : source->mSegments)
+    {
+        mSegments.emplace(segp->clone(*this));
+    }
+
+    mLineInfoList.clear();
+    for (const line_info& li : mLineInfoList)
+    {
+        mLineInfoList.push_back(line_info(li));
+    }
+
+    getViewModel()->setDisplay(source->getViewModel()->getDisplay());
+
+    onValueChange(0, getLength());
+    needsReflow();
+}
+
 void LLTextBase::appendLineBreakSegment(const LLStyle::Params& style_params)
 {
     segment_vec_t segments;
@@ -3233,6 +3261,24 @@ boost::signals2::connection LLTextBase::setIsObjectBlockedCallback(const is_bloc
 LLTextSegment::~LLTextSegment()
 {}
 
+// static
+LLStyleSP LLTextSegment::cloneStyle(LLTextBase& target, const LLStyle* source)
+{
+    // Take most params from target
+    LLStyle::Params params = target.getStyleParams();
+    LLStyle* style = new LLStyle(params);
+
+    // Take some params from source
+    style->setLinkHREF(source->getLinkHREF());
+    if (source->isImage())
+    {
+        style->setImage(source->getImage()->getName());
+    }
+
+    return style;
+}
+
+
 bool LLTextSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const { width = 0; height = 0; return false; }
 bool LLTextSegment::getDimensions(S32 first_char, S32 num_chars, S32& width, S32& height) const
 {
@@ -3574,6 +3620,13 @@ void LLNormalTextSegment::setToolTip(const std::string& tooltip)
     mTooltip = tooltip;
 }
 
+// virtual
+LLTextSegmentPtr LLNormalTextSegment::clone(LLTextBase& target) const
+{
+    LLStyleConstSP sp(cloneStyle(target, mStyle));
+    return new LLNormalTextSegment(sp, mStart, mEnd, target);
+}
+
 bool LLNormalTextSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
 {
     height = 0;
@@ -3701,6 +3754,13 @@ LLLabelTextSegment::LLLabelTextSegment( const LLUIColor& color, S32 start, S32 e
 {
 }
 
+// virtual
+LLTextSegmentPtr LLLabelTextSegment::clone(LLTextBase& target) const
+{
+    LLStyleConstSP sp(cloneStyle(target, mStyle));
+    return new LLLabelTextSegment(sp, mStart, mEnd, target);
+}
+
 /*virtual*/
 const LLWString& LLLabelTextSegment::getWText() const
 {
@@ -3725,6 +3785,13 @@ LLEmojiTextSegment::LLEmojiTextSegment(const LLUIColor& color, S32 start, S32 en
 {
 }
 
+// virtual
+LLTextSegmentPtr LLEmojiTextSegment::clone(LLTextBase& target) const
+{
+    LLStyleConstSP sp(cloneStyle(target, mStyle));
+    return new LLEmojiTextSegment(sp, mStart, mEnd, target);
+}
+
 bool LLEmojiTextSegment::handleToolTip(S32 x, S32 y, MASK mask)
 {
     if (mTooltip.empty())
@@ -3747,6 +3814,14 @@ LLOnHoverChangeableTextSegment::LLOnHoverChangeableTextSegment( LLStyleConstSP s
       LLNormalTextSegment(normal_style, start, end, editor),
       mHoveredStyle(style),
       mNormalStyle(normal_style){}
+
+// virtual
+LLTextSegmentPtr LLOnHoverChangeableTextSegment::clone(LLTextBase& target) const
+{
+    LLStyleConstSP hsp(cloneStyle(target, mHoveredStyle));
+    LLStyleConstSP nsp(cloneStyle(target, mNormalStyle));
+    return new LLOnHoverChangeableTextSegment(hsp, nsp, mStart, mEnd, target);
+}
 
 /*virtual*/
 F32 LLOnHoverChangeableTextSegment::draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect)
@@ -3785,6 +3860,13 @@ LLInlineViewSegment::LLInlineViewSegment(const Params& p, S32 start, S32 end)
 LLInlineViewSegment::~LLInlineViewSegment()
 {
     mView->die();
+}
+
+// virtual
+LLTextSegmentPtr LLInlineViewSegment::clone(LLTextBase& target) const
+{
+    llassert_always_msg(false, "NOT SUPPORTED");
+    return nullptr;
 }
 
 bool LLInlineViewSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
@@ -3874,6 +3956,14 @@ LLLineBreakTextSegment::LLLineBreakTextSegment(LLStyleConstSP style,S32 pos):LLT
 LLLineBreakTextSegment::~LLLineBreakTextSegment()
 {
 }
+
+// virtual
+LLTextSegmentPtr LLLineBreakTextSegment::clone(LLTextBase& target) const
+{
+    LLLineBreakTextSegment* copy = new LLLineBreakTextSegment(mStart);
+    copy->mFontHeight = mFontHeight;
+    return copy;
+}
 bool LLLineBreakTextSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
 {
     width = 0;
@@ -3901,8 +3991,16 @@ LLImageTextSegment::~LLImageTextSegment()
 {
 }
 
+// virtual
+LLTextSegmentPtr LLImageTextSegment::clone(LLTextBase& target) const
+{
+    LLStyleConstSP sp(cloneStyle(target, mStyle));
+    return new LLImageTextSegment(sp, mStart, target);
+}
+
 static const S32 IMAGE_HPAD = 3;
 
+// virtual
 bool LLImageTextSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
 {
     width = 0;

--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -45,6 +45,7 @@
 class LLScrollContainer;
 class LLContextMenu;
 class LLUrlMatch;
+class LLTextBase;
 
 ///
 /// A text segment is used to specify a subsection of a text string
@@ -62,6 +63,9 @@ public:
         mEnd(end)
     {}
     virtual ~LLTextSegment();
+    virtual LLTextSegmentPtr clone(LLTextBase& terget) const { return new LLTextSegment(mStart, mEnd); }
+    static LLStyleSP cloneStyle(LLTextBase& target, const LLStyle* source);
+
     bool                        getDimensions(S32 first_char, S32 num_chars, S32& width, S32& height) const;
 
     virtual bool                getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
@@ -128,6 +132,7 @@ public:
     LLNormalTextSegment( LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor );
     LLNormalTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
     virtual ~LLNormalTextSegment();
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
 
     /*virtual*/ bool                getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
     /*virtual*/ S32                 getOffset(S32 segment_local_x_coord, S32 start_offset, S32 num_chars, bool round) const;
@@ -180,6 +185,7 @@ class LLLabelTextSegment : public LLNormalTextSegment
 public:
     LLLabelTextSegment( LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor );
     LLLabelTextSegment( const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
 
 protected:
 
@@ -194,6 +200,7 @@ class LLEmojiTextSegment : public LLNormalTextSegment
 public:
     LLEmojiTextSegment(LLStyleConstSP style, S32 start, S32 end, LLTextBase& editor);
     LLEmojiTextSegment(const LLUIColor& color, S32 start, S32 end, LLTextBase& editor, bool is_visible = true);
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const override;
 
     bool canEdit() const override { return false; }
     bool handleToolTip(S32 x, S32 y, MASK mask) override;
@@ -204,6 +211,7 @@ class LLOnHoverChangeableTextSegment : public LLNormalTextSegment
 {
 public:
     LLOnHoverChangeableTextSegment( LLStyleConstSP style, LLStyleConstSP normal_style, S32 start, S32 end, LLTextBase& editor );
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
     /*virtual*/ F32 draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
     /*virtual*/ bool handleHover(S32 x, S32 y, MASK mask);
 protected:
@@ -218,6 +226,7 @@ class LLIndexSegment : public LLTextSegment
 {
 public:
     LLIndexSegment() : LLTextSegment(0, 0) {}
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const { return new LLIndexSegment(); }
 };
 
 class LLInlineViewSegment : public LLTextSegment
@@ -235,6 +244,8 @@ public:
 
     LLInlineViewSegment(const Params& p, S32 start, S32 end);
     ~LLInlineViewSegment();
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
+
     /*virtual*/ bool        getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
     /*virtual*/ S32         getNumChars(S32 num_pixels, S32 segment_offset, S32 line_offset, S32 max_chars, S32 line_ind) const;
     /*virtual*/ void        updateLayout(const class LLTextBase& editor);
@@ -259,6 +270,7 @@ public:
     LLLineBreakTextSegment(LLStyleConstSP style,S32 pos);
     LLLineBreakTextSegment(S32 pos);
     ~LLLineBreakTextSegment();
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
     /*virtual*/ bool        getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
     S32         getNumChars(S32 num_pixels, S32 segment_offset, S32 line_offset, S32 max_chars, S32 line_ind) const;
     F32         draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
@@ -272,6 +284,8 @@ class LLImageTextSegment : public LLTextSegment
 public:
     LLImageTextSegment(LLStyleConstSP style,S32 pos,class LLTextBase& editor);
     ~LLImageTextSegment();
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const;
+
     /*virtual*/ bool        getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const;
     S32         getNumChars(S32 num_pixels, S32 segment_offset, S32 char_offset, S32 max_chars, S32 line_ind) const;
     F32         draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
@@ -510,6 +524,7 @@ public:
 
     const LLFontGL*         getFont() const override { return mFont; }
 
+    virtual void            copyContents(const LLTextBase* source);
     virtual void            appendLineBreakSegment(const LLStyle::Params& style_params);
     virtual void            appendImageSegment(const LLStyle::Params& style_params);
     virtual void            appendWidget(const LLInlineViewSegment::Params& params, const std::string& text, bool allow_undo);

--- a/indra/newview/llchatmsgbox.cpp
+++ b/indra/newview/llchatmsgbox.cpp
@@ -41,6 +41,16 @@ public:
         mEditor(NULL)
     {}
 
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const
+    {
+        ChatSeparator* copy = new ChatSeparator(mStart, mEnd);
+        if (mEditor)
+        {
+            copy->mEditor = &target;
+        }
+        return copy;
+    }
+
     /*virtual*/ void linkToDocument(class LLTextBase* editor)
     {
         mEditor = editor;

--- a/indra/newview/llexpandabletextbox.cpp
+++ b/indra/newview/llexpandabletextbox.cpp
@@ -44,6 +44,14 @@ public:
         mExpanderLabel(utf8str_to_wstring(more_text))
     {}
 
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const
+    {
+        LLStyleSP sp(cloneStyle(target, mStyle));
+        LLExpanderSegment* copy = new LLExpanderSegment(sp, mStart, mEnd, LLStringUtil::null, target);
+        copy->mExpanderLabel = mExpanderLabel;
+        return copy;
+    }
+
     /*virtual*/ bool    getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
     {
         // more label always spans width of text box

--- a/indra/newview/llfloaterbuyland.cpp
+++ b/indra/newview/llfloaterbuyland.cpp
@@ -163,6 +163,7 @@ public:
     void updateParcelInfo();
     void updateCovenantInfo();
     static void onChangeAgreeCovenant(LLUICtrl* ctrl, void* user_data);
+    void updateFloaterCovenant(const LLTextBase* source, const LLUUID &asset_id);
     void updateFloaterCovenantText(const std::string& string, const LLUUID &asset_id);
     void updateFloaterEstateName(const std::string& name);
     void updateFloaterLastModified(const std::string& text);
@@ -201,6 +202,8 @@ public:
 
     void onVisibilityChanged ( const LLSD& new_visibility );
 
+private:
+    void onCovenantTextUpdated(const LLUUID& asset_id);
 };
 
 // static
@@ -218,6 +221,15 @@ void LLFloaterBuyLand::buyLand(
     {
         ui->setForGroup(is_for_group);
         ui->setParcel(region, parcel);
+    }
+}
+
+// static
+void LLFloaterBuyLand::updateCovenant(const LLTextBase* source, const LLUUID& asset_id)
+{
+    if (LLFloaterBuyLandUI* floater = LLFloaterReg::findTypedInstance<LLFloaterBuyLandUI>("buy_land"))
+    {
+        floater->updateFloaterCovenant(source, asset_id);
     }
 }
 
@@ -560,11 +572,24 @@ void LLFloaterBuyLandUI::onChangeAgreeCovenant(LLUICtrl* ctrl, void* user_data)
     }
 }
 
+void LLFloaterBuyLandUI::updateFloaterCovenant(const LLTextBase* source, const LLUUID& asset_id)
+{
+    LLViewerTextEditor* editor = getChild<LLViewerTextEditor>("covenant_editor");
+    editor->copyContents(source);
+
+    onCovenantTextUpdated(asset_id);
+}
+
 void LLFloaterBuyLandUI::updateFloaterCovenantText(const std::string &string, const LLUUID& asset_id)
 {
     LLViewerTextEditor* editor = getChild<LLViewerTextEditor>("covenant_editor");
     editor->setText(string);
 
+    onCovenantTextUpdated(asset_id);
+}
+
+void LLFloaterBuyLandUI::onCovenantTextUpdated(const LLUUID& asset_id)
+{
     LLCheckBoxCtrl* check = getChild<LLCheckBoxCtrl>("agree_covenant");
     LLTextBox* box = getChild<LLTextBox>("covenant_text");
     if (asset_id.isNull())

--- a/indra/newview/llfloaterbuyland.h
+++ b/indra/newview/llfloaterbuyland.h
@@ -27,6 +27,7 @@
 #ifndef LL_LLFLOATERBUYLAND_H
 #define LL_LLFLOATERBUYLAND_H
 
+class LLTextBase;
 class LLFloater;
 class LLViewerRegion;
 class LLParcelSelection;
@@ -37,6 +38,7 @@ public:
     static void buyLand(LLViewerRegion* region,
                         LLSafeHandle<LLParcelSelection> parcel,
                         bool is_for_group);
+    static void updateCovenant(const LLTextBase* source, const LLUUID& asset_id);
     static void updateCovenantText(const std::string& string, const LLUUID& asset_id);
     static void updateEstateName(const std::string& name);
     static void updateLastModified(const std::string& text);

--- a/indra/newview/llfloaterland.cpp
+++ b/indra/newview/llfloaterland.cpp
@@ -3124,6 +3124,16 @@ void LLPanelLandCovenant::refresh()
 }
 
 // static
+void LLPanelLandCovenant::updateCovenant(const LLTextBase* source)
+{
+    if (LLPanelLandCovenant* self = LLFloaterLand::getCurrentPanelLandCovenant())
+    {
+        LLViewerTextEditor* editor = self->getChild<LLViewerTextEditor>("covenant_editor");
+        editor->copyContents(source);
+    }
+}
+
+// static
 void LLPanelLandCovenant::updateCovenantText(const std::string &string)
 {
     LLPanelLandCovenant* self = LLFloaterLand::getCurrentPanelLandCovenant();

--- a/indra/newview/llfloaterland.h
+++ b/indra/newview/llfloaterland.h
@@ -50,6 +50,7 @@ class LLRadioGroup;
 class LLParcelSelectionObserver;
 class LLSpinCtrl;
 class LLTabContainer;
+class LLTextBase;
 class LLTextBox;
 class LLTextEditor;
 class LLTextureCtrl;
@@ -416,6 +417,7 @@ public:
     virtual ~LLPanelLandCovenant();
     virtual bool postBuild();
     void refresh();
+    static void updateCovenant(const LLTextBase* source);
     static void updateCovenantText(const std::string& string);
     static void updateEstateName(const std::string& name);
     static void updateLastModified(const std::string& text);

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -2820,6 +2820,16 @@ void LLPanelEstateCovenant::setEstateName(const std::string& name)
 }
 
 // static
+void LLPanelEstateCovenant::updateCovenant(const LLTextBase* source, const LLUUID& asset_id)
+{
+    if (LLPanelEstateCovenant* panelp = LLFloaterRegionInfo::getPanelCovenant())
+    {
+        panelp->mEditor->copyContents(source);
+        panelp->setCovenantID(asset_id);
+    }
+}
+
+// static
 void LLPanelEstateCovenant::updateCovenantText(const std::string& string, const LLUUID& asset_id)
 {
     LLPanelEstateCovenant* panelp = LLFloaterRegionInfo::getPanelCovenant();

--- a/indra/newview/llfloaterregioninfo.h
+++ b/indra/newview/llfloaterregioninfo.h
@@ -382,6 +382,7 @@ public:
                                void* user_data, S32 status, LLExtStat ext_status);
 
     // Accessor functions
+    static void updateCovenant(const LLTextBase* source, const LLUUID& asset_id);
     static void updateCovenantText(const std::string& string, const LLUUID& asset_id);
     static void updateEstateName(const std::string& name);
     static void updateLastModified(const std::string& text);

--- a/indra/newview/llpanelplaceprofile.cpp
+++ b/indra/newview/llpanelplaceprofile.cpp
@@ -629,6 +629,11 @@ void LLPanelPlaceProfile::updateCovenantText(const std::string &text)
     mCovenantText->setText(text);
 }
 
+void LLPanelPlaceProfile::updateCovenant(const LLTextBase* source)
+{
+    mCovenantText->copyContents(source);
+}
+
 void LLPanelPlaceProfile::onForSaleBannerClick()
 {
     LLViewerParcelMgr* mgr = LLViewerParcelMgr::getInstance();

--- a/indra/newview/llpanelplaceprofile.h
+++ b/indra/newview/llpanelplaceprofile.h
@@ -31,6 +31,7 @@
 
 class LLAccordionCtrl;
 class LLIconCtrl;
+class LLTextBase;
 class LLTextEditor;
 
 class LLPanelPlaceProfile : public LLPanelPlaceInfo
@@ -60,6 +61,7 @@ public:
     void updateEstateName(const std::string& name);
     void updateEstateOwnerName(const std::string& name);
     void updateCovenantText(const std::string &text);
+    void updateCovenant(const LLTextBase* source);
 
 private:
     void onForSaleBannerClick();

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -6739,7 +6739,8 @@ void onCovenantLoadComplete(const LLUUID& asset_uuid,
 {
     LL_DEBUGS("Messaging") << "onCovenantLoadComplete()" << LL_ENDL;
     std::string covenant_text;
-    if(0 == status)
+    std::unique_ptr<LLViewerTextEditor> editorp;
+    if (0 == status)
     {
         LLFileSystem file(asset_uuid, type, LLFileSystem::READ);
 
@@ -6760,13 +6761,13 @@ void onCovenantLoadComplete(const LLUUID& asset_uuid,
             {
                 LL_WARNS("Messaging") << "Problem importing estate covenant." << LL_ENDL;
                 covenant_text = "Problem importing estate covenant.";
+                delete editor;
             }
             else
             {
                 // Version 0 (just text, doesn't include version number)
-                covenant_text = editor->getText();
+                editorp.reset(editor); // Use covenant from editorp;
             }
-            delete editor;
         }
         else
         {
@@ -6792,17 +6793,32 @@ void onCovenantLoadComplete(const LLUUID& asset_uuid,
 
         LL_WARNS("Messaging") << "Problem loading notecard: " << status << LL_ENDL;
     }
-    LLPanelEstateCovenant::updateCovenantText(covenant_text, asset_uuid);
-    LLPanelLandCovenant::updateCovenantText(covenant_text);
-    LLFloaterBuyLand::updateCovenantText(covenant_text, asset_uuid);
 
-    LLPanelPlaceProfile* panel = LLFloaterSidePanelContainer::getPanel<LLPanelPlaceProfile>("places", "panel_place_profile");
-    if (panel)
+    if (editorp)
     {
-        panel->updateCovenantText(covenant_text);
+        LLPanelEstateCovenant::updateCovenant(editorp.get(), asset_uuid);
+        LLPanelLandCovenant::updateCovenant(editorp.get());
+        LLFloaterBuyLand::updateCovenant(editorp.get(), asset_uuid);
+    }
+    else
+    {
+        LLPanelEstateCovenant::updateCovenantText(covenant_text, asset_uuid);
+        LLPanelLandCovenant::updateCovenantText(covenant_text);
+        LLFloaterBuyLand::updateCovenantText(covenant_text, asset_uuid);
+    }
+
+    if (LLPanelPlaceProfile* panel = LLFloaterSidePanelContainer::getPanel<LLPanelPlaceProfile>("places", "panel_place_profile"))
+    {
+        if (editorp)
+        {
+            panel->updateCovenant(editorp.get());
+        }
+        else
+        {
+            panel->updateCovenantText(covenant_text);
+        }
     }
 }
-
 
 void process_feature_disabled_message(LLMessageSystem* msg, void**)
 {

--- a/indra/newview/llviewertexteditor.cpp
+++ b/indra/newview/llviewertexteditor.cpp
@@ -179,6 +179,16 @@ public:
         mToolTip = inv_item->getName() + '\n' + inv_item->getDescription();
     }
 
+    /*virtual*/ LLTextSegmentPtr clone(LLTextBase& target) const
+    {
+        LLTextEditor* editor = dynamic_cast<LLTextEditor*>(&target);
+        llassert(editor);
+        if (!editor)
+            return nullptr;
+
+        return new LLEmbeddedItemSegment(mStart, mImage, mItem, *editor);
+    }
+
     /*virtual*/ bool getDimensionsF32(S32 first_char, S32 num_chars, F32& width, S32& height) const
     {
         if (num_chars == 0)


### PR DESCRIPTION
When the covenant is loaded, it is being parsed 4 times
This operation takes much time for splitting the text on segments
Each line of the text is at least a segment, and each line break is a segment

The provided example contains almost 6000 lines of text with emoji
On my PC it takes 20+ seconds to show the covenant (4 times of 5+ sec.)

The proposed change decreases this delay 4 times, because the parsing is being done only once,
and then the contents of the 1st text editor is being copied to other text editors as is