### PR TITLE
Remove quads rendering mode entirely

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -271,9 +271,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
     const LLFontGlyphInfo* next_glyph = NULL;
 
     static constexpr S32 GLYPH_BATCH_SIZE = 30;
-    static thread_local LLVector3 vertices[GLYPH_BATCH_SIZE * 4];
-    static thread_local LLVector2 uvs[GLYPH_BATCH_SIZE * 4];
-    static thread_local LLColor4U colors[GLYPH_BATCH_SIZE * 4];
+    static thread_local LLVector3 vertices[GLYPH_BATCH_SIZE * 6];
+    static thread_local LLVector2 uvs[GLYPH_BATCH_SIZE * 6];
+    static thread_local LLColor4U colors[GLYPH_BATCH_SIZE * 6];
 
     LLColor4U text_color(color);
     // Preserve the transparency to render fading emojis in fading text (e.g.
@@ -305,9 +305,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
             // otherwise the queued glyphs will be taken from wrong textures.
             if (glyph_count > 0)
             {
-                gGL.begin(LLRender::QUADS);
+                gGL.begin(LLRender::TRIANGLES);
                 {
-                    gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+                    gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 6);
                 }
                 gGL.end();
                 glyph_count = 0;
@@ -338,9 +338,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
         if (glyph_count >= GLYPH_BATCH_SIZE)
         {
-            gGL.begin(LLRender::QUADS);
+            gGL.begin(LLRender::TRIANGLES);
             {
-                gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+                gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 6);
             }
             gGL.end();
 
@@ -376,9 +376,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
         cur_render_y = cur_y;
     }
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
-        gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 4);
+        gGL.vertexBatchPreTransformed(vertices, uvs, colors, glyph_count * 6);
     }
     gGL.end();
 
@@ -1227,7 +1227,7 @@ LLFontGL &LLFontGL::operator=(const LLFontGL &source)
     return *this;
 }
 
-void LLFontGL::renderQuad(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const
+void LLFontGL::renderTriangle(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const
 {
     S32 index = 0;
 
@@ -1238,6 +1238,17 @@ void LLFontGL::renderQuad(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* c
 
     vertex_out[index] = LLVector3(screen_rect.mLeft, screen_rect.mTop, 0.f);
     uv_out[index] = LLVector2(uv_rect.mLeft, uv_rect.mTop);
+    colors_out[index] = color;
+    index++;
+
+    vertex_out[index] = LLVector3(screen_rect.mLeft, screen_rect.mBottom, 0.f);
+    uv_out[index] = LLVector2(uv_rect.mLeft, uv_rect.mBottom);
+    colors_out[index] = color;
+    index++;
+
+
+    vertex_out[index] = LLVector3(screen_rect.mRight, screen_rect.mTop, 0.f);
+    uv_out[index] = LLVector2(uv_rect.mRight, uv_rect.mTop);
     colors_out[index] = color;
     index++;
 
@@ -1265,7 +1276,7 @@ void LLFontGL::drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_
             LLRectf screen_rect_offset = screen_rect;
 
             screen_rect_offset.translate((F32)(pass * BOLD_OFFSET), 0.f);
-            renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect_offset, uv_rect, color, slant_offset);
+            renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect_offset, uv_rect, color, slant_offset);
             glyph_count++;
         }
     }
@@ -1296,10 +1307,10 @@ void LLFontGL::drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_
                 break;
             }
 
-            renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect_offset, uv_rect, shadow_color, slant_offset);
+            renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect_offset, uv_rect, shadow_color, slant_offset);
             glyph_count++;
         }
-        renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect, uv_rect, color, slant_offset);
+        renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect, uv_rect, color, slant_offset);
         glyph_count++;
     }
     else if (shadow == DROP_SHADOW)
@@ -1308,14 +1319,14 @@ void LLFontGL::drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_
         shadow_color.mV[VALPHA] = U8(color.mV[VALPHA] * drop_shadow_strength);
         LLRectf screen_rect_shadow = screen_rect;
         screen_rect_shadow.translate(1.f, -1.f);
-        renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect_shadow, uv_rect, shadow_color, slant_offset);
+        renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect_shadow, uv_rect, shadow_color, slant_offset);
         glyph_count++;
-        renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect, uv_rect, color, slant_offset);
+        renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect, uv_rect, color, slant_offset);
         glyph_count++;
     }
     else // normal rendering
     {
-        renderQuad(&vertex_out[glyph_count * 4], &uv_out[glyph_count * 4], &colors_out[glyph_count * 4], screen_rect, uv_rect, color, slant_offset);
+        renderTriangle(&vertex_out[glyph_count * 6], &uv_out[glyph_count * 6], &colors_out[glyph_count * 6], screen_rect, uv_rect, color, slant_offset);
         glyph_count++;
     }
 }

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -238,7 +238,7 @@ private:
     LLFontDescriptor mFontDescriptor;
     LLPointer<LLFontFreetype> mFontFreetype;
 
-    void renderQuad(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const;
+    void renderTriangle(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const;
     void drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, U8 style, ShadowType shadow, F32 drop_shadow_fade) const;
 
     // Registry holds all instantiated fonts.

--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -803,7 +803,6 @@ void LLLightState::setSpotDirection(const LLVector3& direction)
 LLRender::LLRender()
   : mDirty(false),
     mCount(0),
-    mQuadCycle(0),
     mMode(LLRender::TRIANGLES),
     mCurrTextureUnitIndex(0)
 {
@@ -1532,13 +1531,7 @@ void LLRender::begin(const GLuint& mode)
 {
     if (mode != mMode)
     {
-        if (mode == LLRender::QUADS)
-        {
-            mQuadCycle = 1;
-        }
-
-        if (mMode == LLRender::QUADS ||
-            mMode == LLRender::LINES ||
+        if (mMode == LLRender::LINES ||
             mMode == LLRender::TRIANGLES ||
             mMode == LLRender::POINTS)
         {
@@ -1561,8 +1554,7 @@ void LLRender::end()
         //IMM_ERRS << "GL begin and end called with no vertices specified." << LL_ENDL;
     }
 
-    if ((mMode != LLRender::QUADS &&
-        mMode != LLRender::LINES &&
+    if ((mMode != LLRender::LINES &&
         mMode != LLRender::TRIANGLES &&
         mMode != LLRender::POINTS) ||
         mCount > 2048)
@@ -1587,28 +1579,19 @@ void LLRender::flush()
         //store mCount in a local variable to avoid re-entrance (drawArrays may call flush)
         U32 count = mCount;
 
-            if (mMode == LLRender::QUADS && !sGLCoreProfile)
+        if (mMode == LLRender::TRIANGLES)
+        {
+            if (mCount%3 != 0)
             {
-                if (mCount%4 != 0)
-                {
-                count -= (mCount % 4);
-                LL_WARNS() << "Incomplete quad requested." << LL_ENDL;
-                }
+            count -= (mCount % 3);
+            LL_WARNS() << "Incomplete triangle requested." << LL_ENDL;
             }
+        }
 
-            if (mMode == LLRender::TRIANGLES)
+        if (mMode == LLRender::LINES)
+        {
+            if (mCount%2 != 0)
             {
-                if (mCount%3 != 0)
-                {
-                count -= (mCount % 3);
-                LL_WARNS() << "Incomplete triangle requested." << LL_ENDL;
-                }
-            }
-
-            if (mMode == LLRender::LINES)
-            {
-                if (mCount%2 != 0)
-                {
                 count -= (mCount % 2);
                 LL_WARNS() << "Incomplete line requested." << LL_ENDL;
             }
@@ -1758,16 +1741,7 @@ LLVertexBuffer* LLRender::genBuffer(U32 attribute_mask, S32 count)
 void LLRender::drawBuffer(LLVertexBuffer* vb, U32 mode, S32 count)
 {
     vb->setBuffer();
-
-    if (mode == LLRender::QUADS && sGLCoreProfile)
-    {
-        vb->drawArrays(LLRender::TRIANGLES, 0, count);
-        mQuadCycle = 1;
-    }
-    else
-    {
-        vb->drawArrays(mode, 0, count);
-    }
+    vb->drawArrays(mode, 0, count);
 }
 
 void LLRender::resetStriders(S32 count)
@@ -1788,7 +1762,6 @@ void LLRender::vertex3f(const GLfloat& x, const GLfloat& y, const GLfloat& z)
         {
             case LLRender::POINTS: flush(); break;
             case LLRender::TRIANGLES: if (mCount%3==0) flush(); break;
-            case LLRender::QUADS: if(mCount%4 == 0) flush(); break;
             case LLRender::LINES: if (mCount%2 == 0) flush(); break;
         }
     }
@@ -1809,25 +1782,6 @@ void LLRender::vertex3f(const GLfloat& x, const GLfloat& y, const GLfloat& z)
         mVerticesp[mCount] = vert;
     }
 
-    if (mMode == LLRender::QUADS && LLRender::sGLCoreProfile)
-    {
-        mQuadCycle++;
-        if (mQuadCycle == 4)
-        { //copy two vertices so fourth quad element will add a triangle
-            mQuadCycle = 0;
-
-            mCount++;
-            mVerticesp[mCount] = mVerticesp[mCount-3];
-            mColorsp[mCount] = mColorsp[mCount-3];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-3];
-
-            mCount++;
-            mVerticesp[mCount] = mVerticesp[mCount-2];
-            mColorsp[mCount] = mColorsp[mCount-2];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-2];
-        }
-    }
-
     mCount++;
     mVerticesp[mCount] = mVerticesp[mCount-1];
     mColorsp[mCount] = mColorsp[mCount-1];
@@ -1842,50 +1796,13 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, S32 vert_count)
         return;
     }
 
-    if (sGLCoreProfile && mMode == LLRender::QUADS)
-    { //quads are deprecated, convert to triangle list
-        S32 i = 0;
-
-        while (i < vert_count)
-        {
-            //read first three
-            mVerticesp[mCount++] = verts[i++];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount++] = verts[i++];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount++] = verts[i++];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            //copy two
-            mVerticesp[mCount++] = verts[i-3];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount++] = verts[i-1];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            //copy last one
-            mVerticesp[mCount++] = verts[i++];
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-        }
-    }
-    else
+    for (S32 i = 0; i < vert_count; i++)
     {
-        for (S32 i = 0; i < vert_count; i++)
-        {
-            mVerticesp[mCount] = verts[i];
+        mVerticesp[mCount] = verts[i];
 
-            mCount++;
-            mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-        }
+        mCount++;
+        mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
+        mColorsp[mCount] = mColorsp[mCount-1];
     }
 
     if( mCount > 0 ) // ND: Guard against crashes if mCount is zero, yes it can happen
@@ -1900,50 +1817,13 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 v
         return;
     }
 
-    if (sGLCoreProfile && mMode == LLRender::QUADS)
-    { //quads are deprecated, convert to triangle list
-        S32 i = 0;
-
-        while (i < vert_count)
-        {
-            //read first three
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount++] = uvs[i++];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount++] = uvs[i++];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount++] = uvs[i++];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            //copy last two
-            mVerticesp[mCount] = verts[i-3];
-            mTexcoordsp[mCount++] = uvs[i-3];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            mVerticesp[mCount] = verts[i-1];
-            mTexcoordsp[mCount++] = uvs[i-1];
-            mColorsp[mCount] = mColorsp[mCount-1];
-
-            //copy last one
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount++] = uvs[i++];
-            mColorsp[mCount] = mColorsp[mCount-1];
-        }
-    }
-    else
+    for (S32 i = 0; i < vert_count; i++)
     {
-        for (S32 i = 0; i < vert_count; i++)
-        {
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
+        mVerticesp[mCount] = verts[i];
+        mTexcoordsp[mCount] = uvs[i];
 
-            mCount++;
-            mColorsp[mCount] = mColorsp[mCount-1];
-        }
+        mCount++;
+        mColorsp[mCount] = mColorsp[mCount-1];
     }
 
     if (mCount > 0)
@@ -1961,51 +1841,13 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLCol
         return;
     }
 
-
-    if (sGLCoreProfile && mMode == LLRender::QUADS)
-    { //quads are deprecated, convert to triangle list
-        S32 i = 0;
-
-        while (i < vert_count)
-        {
-            //read first three
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
-            mColorsp[mCount++] = colors[i++];
-
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
-            mColorsp[mCount++] = colors[i++];
-
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
-            mColorsp[mCount++] = colors[i++];
-
-            //copy last two
-            mVerticesp[mCount] = verts[i-3];
-            mTexcoordsp[mCount] = uvs[i-3];
-            mColorsp[mCount++] = colors[i-3];
-
-            mVerticesp[mCount] = verts[i-1];
-            mTexcoordsp[mCount] = uvs[i-1];
-            mColorsp[mCount++] = colors[i-1];
-
-            //copy last one
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
-            mColorsp[mCount++] = colors[i++];
-        }
-    }
-    else
+    for (S32 i = 0; i < vert_count; i++)
     {
-        for (S32 i = 0; i < vert_count; i++)
-        {
-            mVerticesp[mCount] = verts[i];
-            mTexcoordsp[mCount] = uvs[i];
-            mColorsp[mCount] = colors[i];
+        mVerticesp[mCount] = verts[i];
+        mTexcoordsp[mCount] = uvs[i];
+        mColorsp[mCount] = colors[i];
 
-            mCount++;
-        }
+        mCount++;
     }
 
     if (mCount > 0)

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -319,7 +319,6 @@ public:
         POINTS,
         LINES,
         LINE_STRIP,
-        QUADS,
         LINE_LOOP,
         NUM_MODES
     };
@@ -508,7 +507,6 @@ private:
     LLColor4 mAmbientLightColor;
 
     bool            mDirty;
-    U32             mQuadCycle;
     U32             mCount;
     U32             mMode;
     U32             mCurrTextureUnitIndex;

--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -175,50 +175,70 @@ void gl_drop_shadow(S32 left, S32 top, S32 right, S32 bottom, const LLColor4 &st
     LLColor4 end_color = start_color;
     end_color.mV[VALPHA] = 0.f;
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
 
     // Right edge, CCW faces screen
     gGL.color4fv(start_color.mV);
-    gGL.vertex2i(right,     top-lines);
-    gGL.vertex2i(right,     bottom);
+    gGL.vertex2i(right, top - lines);
+    gGL.vertex2i(right, bottom);
     gGL.color4fv(end_color.mV);
-    gGL.vertex2i(right+lines, bottom);
-    gGL.vertex2i(right+lines, top-lines);
+    gGL.vertex2i(right + lines, bottom);
+    gGL.color4fv(start_color.mV);
+    gGL.vertex2i(right, top - lines);
+    gGL.color4fv(end_color.mV);
+    gGL.vertex2i(right + lines, bottom);
+    gGL.vertex2i(right + lines, top - lines);
 
     // Bottom edge, CCW faces screen
     gGL.color4fv(start_color.mV);
-    gGL.vertex2i(right,     bottom);
-    gGL.vertex2i(left+lines,    bottom);
+    gGL.vertex2i(right, bottom);
+    gGL.vertex2i(left + lines, bottom);
     gGL.color4fv(end_color.mV);
-    gGL.vertex2i(left+lines,    bottom-lines);
-    gGL.vertex2i(right,     bottom-lines);
+    gGL.vertex2i(left + lines, bottom - lines);
+    gGL.color4fv(start_color.mV);
+    gGL.vertex2i(right, bottom);
+    gGL.color4fv(end_color.mV);
+    gGL.vertex2i(left + lines, bottom - lines);
+    gGL.vertex2i(right, bottom - lines);
 
     // bottom left Corner
     gGL.color4fv(start_color.mV);
-    gGL.vertex2i(left+lines,    bottom);
+    gGL.vertex2i(left + lines, bottom);
     gGL.color4fv(end_color.mV);
-    gGL.vertex2i(left,      bottom);
+    gGL.vertex2i(left, bottom);
     // make the bottom left corner not sharp
-    gGL.vertex2i(left+1,        bottom-lines+1);
-    gGL.vertex2i(left+lines,    bottom-lines);
+    gGL.vertex2i(left + 1, bottom - lines + 1);
+    gGL.color4fv(start_color.mV);
+    gGL.vertex2i(left + lines, bottom);
+    gGL.color4fv(end_color.mV);
+    gGL.vertex2i(left + 1, bottom - lines + 1);
+    gGL.vertex2i(left + lines, bottom - lines);
 
     // bottom right corner
     gGL.color4fv(start_color.mV);
-    gGL.vertex2i(right,     bottom);
+    gGL.vertex2i(right, bottom);
     gGL.color4fv(end_color.mV);
-    gGL.vertex2i(right,     bottom-lines);
+    gGL.vertex2i(right, bottom - lines);
     // make the rightmost corner not sharp
-    gGL.vertex2i(right+lines-1, bottom-lines+1);
-    gGL.vertex2i(right+lines,   bottom);
+    gGL.vertex2i(right + lines - 1, bottom - lines + 1);
+    gGL.color4fv(start_color.mV);
+    gGL.vertex2i(right, bottom);
+    gGL.color4fv(end_color.mV);
+    gGL.vertex2i(right + lines - 1, bottom - lines + 1);
+    gGL.vertex2i(right + lines, bottom);
 
     // top right corner
     gGL.color4fv(start_color.mV);
-    gGL.vertex2i( right,            top-lines );
+    gGL.vertex2i(right, top - lines);
     gGL.color4fv(end_color.mV);
-    gGL.vertex2i( right+lines,  top-lines );
+    gGL.vertex2i(right + lines, top - lines);
     // make the corner not sharp
-    gGL.vertex2i( right+lines-1,    top-1 );
-    gGL.vertex2i( right,            top );
+    gGL.vertex2i(right + lines - 1, top - 1);
+    gGL.color4fv(start_color.mV);
+    gGL.vertex2i(right, top - lines);
+    gGL.color4fv(end_color.mV);
+    gGL.vertex2i(right + lines - 1, top - 1);
+    gGL.vertex2i(right, top);
 
     gGL.end();
     stop_glerror();

--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -633,15 +633,7 @@ void LLVertexBufferData::draw()
     gGL.loadMatrix(glm::value_ptr(mTexture0));
 
     mVB->setBuffer();
-
-    if (mMode == LLRender::QUADS && LLRender::sGLCoreProfile)
-    {
-        mVB->drawArrays(LLRender::TRIANGLES, 0, mCount);
-    }
-    else
-    {
-        mVB->drawArrays(mMode, 0, mCount);
-    }
+    mVB->drawArrays(mMode, 0, mCount);
 
     gGL.popMatrix();
     gGL.matrixMode(LLRender::MM_PROJECTION);
@@ -714,7 +706,6 @@ const U32 LLVertexBuffer::sGLMode[LLRender::NUM_MODES] =
     GL_POINTS,
     GL_LINES,
     GL_LINE_STRIP,
-    GL_QUADS,
     GL_LINE_LOOP,
 };
 

--- a/indra/llui/llbadge.cpp
+++ b/indra/llui/llbadge.cpp
@@ -205,12 +205,12 @@ void renderBadgeBackground(F32 centerX, F32 centerY, F32 width, F32 height, cons
                         (F32)ll_round(y) + height);
 
     LLVector3 vertices[4];
-    vertices[0] = LLVector3(screen_rect.mRight, screen_rect.mTop,    1.0f);
-    vertices[1] = LLVector3(screen_rect.mLeft,  screen_rect.mTop,    1.0f);
+    vertices[0] = LLVector3(screen_rect.mLeft,  screen_rect.mTop,    1.0f);
+    vertices[1] = LLVector3(screen_rect.mRight, screen_rect.mTop,    1.0f);
     vertices[2] = LLVector3(screen_rect.mLeft,  screen_rect.mBottom, 1.0f);
     vertices[3] = LLVector3(screen_rect.mRight, screen_rect.mBottom, 1.0f);
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLE_STRIP);
     {
         gGL.vertexBatchPreTransformed(vertices, 4);
     }

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -2275,36 +2275,28 @@ void LLFloater::drawConeToOwner(F32 &context_cone_opacity,
 
         gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
         LLGLEnable(GL_CULL_FACE);
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLE_STRIP);
         {
             gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
             gGL.vertex2i(owner_rect.mLeft, owner_rect.mTop);
+            gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
+            gGL.vertex2i(local_rect.mLeft, local_rect.mTop);
+            gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
             gGL.vertex2i(owner_rect.mRight, owner_rect.mTop);
             gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
             gGL.vertex2i(local_rect.mRight, local_rect.mTop);
-            gGL.vertex2i(local_rect.mLeft, local_rect.mTop);
-
+            gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
+            gGL.vertex2i(owner_rect.mRight, owner_rect.mBottom);
             gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
-            gGL.vertex2i(local_rect.mLeft, local_rect.mTop);
-            gGL.vertex2i(local_rect.mLeft, local_rect.mBottom);
+            gGL.vertex2i(local_rect.mRight, local_rect.mBottom);
             gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
             gGL.vertex2i(owner_rect.mLeft, owner_rect.mBottom);
+            gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
+            gGL.vertex2i(local_rect.mLeft, local_rect.mBottom);
+            gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
             gGL.vertex2i(owner_rect.mLeft, owner_rect.mTop);
-
             gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
-            gGL.vertex2i(local_rect.mRight, local_rect.mBottom);
-            gGL.vertex2i(local_rect.mRight, local_rect.mTop);
-            gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
-            gGL.vertex2i(owner_rect.mRight, owner_rect.mTop);
-            gGL.vertex2i(owner_rect.mRight, owner_rect.mBottom);
-
-
-            gGL.color4f(0.f, 0.f, 0.f, contex_cone_out_alpha * context_cone_opacity);
-            gGL.vertex2i(local_rect.mLeft, local_rect.mBottom);
-            gGL.vertex2i(local_rect.mRight, local_rect.mBottom);
-            gGL.color4f(0.f, 0.f, 0.f, contex_cone_in_alpha * context_cone_opacity);
-            gGL.vertex2i(owner_rect.mRight, owner_rect.mBottom);
-            gGL.vertex2i(owner_rect.mLeft, owner_rect.mBottom);
+            gGL.vertex2i(local_rect.mLeft, local_rect.mTop);
         }
         gGL.end();
     }

--- a/indra/llui/llstatbar.cpp
+++ b/indra/llui/llstatbar.cpp
@@ -460,7 +460,7 @@ void LLStatBar::draw()
                     max_value = 0.f;
 
                 gGL.color4f(1.f, 0.f, 0.f, 1.f);
-                gGL.begin( LLRender::QUADS );
+                gGL.begin(LLRender::TRIANGLES);
                 const S32 max_frame = llmin(num_frames, num_values);
                 U32 num_samples = 0;
                 for (S32 i = 1; i <= max_frame; i++)
@@ -498,6 +498,9 @@ void LLStatBar::draw()
                         gGL.vertex2f((F32)bar_rect.mRight - offset, max);
                         gGL.vertex2f((F32)bar_rect.mRight - offset, min);
                         gGL.vertex2f((F32)bar_rect.mRight - offset - 1, min);
+
+                        gGL.vertex2f((F32)bar_rect.mRight - offset, max);
+                        gGL.vertex2f((F32)bar_rect.mRight - offset - 1, min);
                         gGL.vertex2f((F32)bar_rect.mRight - offset - 1, max);
                     }
                     else
@@ -505,7 +508,10 @@ void LLStatBar::draw()
                         gGL.vertex2f(min, (F32)bar_rect.mBottom + offset + 1);
                         gGL.vertex2f(min, (F32)bar_rect.mBottom + offset);
                         gGL.vertex2f(max, (F32)bar_rect.mBottom + offset);
-                        gGL.vertex2f(max, (F32)bar_rect.mBottom + offset + 1 );
+
+                        gGL.vertex2f(min, (F32)bar_rect.mBottom + offset + 1);
+                        gGL.vertex2f(max, (F32)bar_rect.mBottom + offset);
+                        gGL.vertex2f(max, (F32)bar_rect.mBottom + offset + 1);
                     }
                 }
                 gGL.end();

--- a/indra/newview/llbox.cpp
+++ b/indra/newview/llbox.cpp
@@ -76,16 +76,23 @@ void LLBox::renderface(S32 which_face)
         {7, 4, 0, 3}
     };
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
+    {
         //gGL.normal3fv(&normals[which_face][0]);
-        gGL.texCoord2f(1,0);
-        gGL.vertex3fv(&mVertex[ faces[which_face][0] ][0]);
-        gGL.texCoord2f(1,1);
-        gGL.vertex3fv(&mVertex[ faces[which_face][1] ][0]);
-        gGL.texCoord2f(0,1);
-        gGL.vertex3fv(&mVertex[ faces[which_face][2] ][0]);
-        gGL.texCoord2f(0,0);
-        gGL.vertex3fv(&mVertex[ faces[which_face][3] ][0]);
+        gGL.texCoord2f(1.f, 0.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][0]][0]);
+        gGL.texCoord2f(1.f, 1.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][1]][0]);
+        gGL.texCoord2f(0.f, 1.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][2]][0]);
+
+        gGL.texCoord2f(1.f, 0.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][0]][0]);
+        gGL.texCoord2f(0.f, 1.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][2]][0]);
+        gGL.texCoord2f(0.f, 0.f);
+        gGL.vertex3fv(&mVertex[faces[which_face][3]][0]);
+    }
     gGL.end();
 }
 

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -406,12 +406,17 @@ void LLFloaterBvhPreview::draw()
 
         gGL.getTexUnit(0)->bind(mAnimPreview);
 
-        gGL.begin( LLRender::QUADS );
+        gGL.begin(LLRender::TRIANGLES);
         {
             gGL.texCoord2f(0.f, 1.f);
             gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
             gGL.texCoord2f(0.f, 0.f);
             gGL.vertex2i(PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+            gGL.texCoord2f(1.f, 0.f);
+            gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+
+            gGL.texCoord2f(0.f, 1.f);
+            gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
             gGL.texCoord2f(1.f, 0.f);
             gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
             gGL.texCoord2f(1.f, 1.f);

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -285,16 +285,21 @@ void LLFloaterImagePreview::draw()
             }
 
             gGL.color3f(1.f, 1.f, 1.f);
-            gGL.begin( LLRender::QUADS );
+            gGL.begin(LLRender::TRIANGLES);
             {
                 gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mTop);
-                gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
+                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
                 gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mBottom);
-                gGL.vertex2i(PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mBottom);
                 gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mBottom);
-                gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+
+                gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mTop);
+                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
+                gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mBottom);
+                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
                 gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mTop);
-                gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
+                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mTop);
             }
             gGL.end();
 
@@ -317,16 +322,21 @@ void LLFloaterImagePreview::draw()
                     gGL.getTexUnit(0)->bind(mAvatarPreview);
                 }
 
-                gGL.begin( LLRender::QUADS );
+                gGL.begin(LLRender::TRIANGLES);
                 {
                     gGL.texCoord2f(0.f, 1.f);
-                    gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
+                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
                     gGL.texCoord2f(0.f, 0.f);
-                    gGL.vertex2i(PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mBottom);
                     gGL.texCoord2f(1.f, 0.f);
-                    gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+
+                    gGL.texCoord2f(0.f, 1.f);
+                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
+                    gGL.texCoord2f(1.f, 0.f);
+                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
                     gGL.texCoord2f(1.f, 1.f);
-                    gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
+                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mTop);
                 }
                 gGL.end();
 

--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -782,16 +782,21 @@ void LLFloaterModelPreview::draw3dPreview()
 
     gGL.getTexUnit(0)->bind(mModelPreview);
 
-    gGL.begin( LLRender::QUADS );
+    gGL.begin(LLRender::TRIANGLES);
     {
         gGL.texCoord2f(0.f, 1.f);
-        gGL.vertex2i(mPreviewRect.mLeft+1, mPreviewRect.mTop-1);
+        gGL.vertex2i(mPreviewRect.mLeft + 1, mPreviewRect.mTop - 1);
         gGL.texCoord2f(0.f, 0.f);
-        gGL.vertex2i(mPreviewRect.mLeft+1, mPreviewRect.mBottom+1);
+        gGL.vertex2i(mPreviewRect.mLeft + 1, mPreviewRect.mBottom + 1);
         gGL.texCoord2f(1.f, 0.f);
-        gGL.vertex2i(mPreviewRect.mRight-1, mPreviewRect.mBottom+1);
+        gGL.vertex2i(mPreviewRect.mRight - 1, mPreviewRect.mBottom + 1);
+
+        gGL.texCoord2f(1.f, 0.f);
+        gGL.vertex2i(mPreviewRect.mRight - 1, mPreviewRect.mBottom + 1);
         gGL.texCoord2f(1.f, 1.f);
-        gGL.vertex2i(mPreviewRect.mRight-1, mPreviewRect.mTop-1);
+        gGL.vertex2i(mPreviewRect.mRight - 1, mPreviewRect.mTop - 1);
+        gGL.texCoord2f(0.f, 1.f);
+        gGL.vertex2i(mPreviewRect.mLeft + 1, mPreviewRect.mTop - 1);
     }
     gGL.end();
 

--- a/indra/newview/llglsandbox.cpp
+++ b/indra/newview/llglsandbox.cpp
@@ -338,28 +338,19 @@ void LLViewerParcelMgr::renderRect(const LLVector3d &west_south_bottom_global,
     gGL.end();
 
     gGL.color4f(1.f, 1.f, 0.f, 0.2f);
-    gGL.begin(LLRender::QUADS);
-
-    gGL.vertex3f(west, north, nw_bottom);
-    gGL.vertex3f(west, north, nw_top);
-    gGL.vertex3f(east, north, ne_top);
-    gGL.vertex3f(east, north, ne_bottom);
-
-    gGL.vertex3f(east, north, ne_bottom);
-    gGL.vertex3f(east, north, ne_top);
-    gGL.vertex3f(east, south, se_top);
-    gGL.vertex3f(east, south, se_bottom);
-
-    gGL.vertex3f(east, south, se_bottom);
-    gGL.vertex3f(east, south, se_top);
-    gGL.vertex3f(west, south, sw_top);
-    gGL.vertex3f(west, south, sw_bottom);
-
-    gGL.vertex3f(west, south, sw_bottom);
-    gGL.vertex3f(west, south, sw_top);
-    gGL.vertex3f(west, north, nw_top);
-    gGL.vertex3f(west, north, nw_bottom);
-
+    gGL.begin(LLRender::TRIANGLE_STRIP);
+    {
+        gGL.vertex3f(west, north, nw_bottom);
+        gGL.vertex3f(west, north, nw_top);
+        gGL.vertex3f(east, north, ne_bottom);
+        gGL.vertex3f(east, north, ne_top);
+        gGL.vertex3f(east, south, se_bottom);
+        gGL.vertex3f(east, south, se_top);
+        gGL.vertex3f(west, south, sw_top);
+        gGL.vertex3f(west, south, sw_bottom);
+        gGL.vertex3f(west, north, nw_top);
+        gGL.vertex3f(west, north, nw_bottom);
+    }
     gGL.end();
 
     LLUI::setLineWidth(1.f);
@@ -493,6 +484,10 @@ void LLViewerParcelMgr::renderOneSegment(F32 x1, F32 y1, F32 x2, F32 y2, F32 hei
 
         gGL.vertex3f(x2, y2, z2);
 
+        gGL.vertex3f(x1, y1, z);
+
+        gGL.vertex3f(x2, y2, z2);
+
         z = z2+height;
         gGL.vertex3f(x2, y2, z);
     }
@@ -523,18 +518,24 @@ void LLViewerParcelMgr::renderOneSegment(F32 x1, F32 y1, F32 x2, F32 y2, F32 hei
         }
 
 
-        gGL.texCoord2f(tex_coord1*0.5f+0.5f, z1*0.5f);
+        gGL.texCoord2f(tex_coord1 * 0.5f + 0.5f, z1 * 0.5f);
         gGL.vertex3f(x1, y1, z1);
 
-        gGL.texCoord2f(tex_coord2*0.5f+0.5f, z2*0.5f);
+        gGL.texCoord2f(tex_coord2 * 0.5f + 0.5f, z2 * 0.5f);
         gGL.vertex3f(x2, y2, z2);
 
         // top edge stairsteps
-        z = llmax(z2+height, z1+height);
-        gGL.texCoord2f(tex_coord2*0.5f+0.5f, z*0.5f);
+        z = llmax(z2 + height, z1 + height);
+        gGL.texCoord2f(tex_coord2 * 0.5f + 0.5f, z * 0.5f);
         gGL.vertex3f(x2, y2, z);
 
-        gGL.texCoord2f(tex_coord1*0.5f+0.5f, z*0.5f);
+        gGL.texCoord2f(tex_coord1 * 0.5f + 0.5f, z1 * 0.5f);
+        gGL.vertex3f(x1, y1, z1);
+
+        gGL.texCoord2f(tex_coord2 * 0.5f + 0.5f, z * 0.5f);
+        gGL.vertex3f(x2, y2, z);
+
+        gGL.texCoord2f(tex_coord1 * 0.5f + 0.5f, z * 0.5f);
         gGL.vertex3f(x1, y1, z);
     }
 }
@@ -575,7 +576,7 @@ void LLViewerParcelMgr::renderHighlightSegments(const U8* segments, LLViewerRegi
                 if (!has_segments)
                 {
                     has_segments = true;
-                    gGL.begin(LLRender::QUADS);
+                    gGL.begin(LLRender::TRIANGLES);
                 }
                 renderOneSegment(x1, y1, x2, y2, PARCEL_POST_HEIGHT, SOUTH_MASK, regionp);
             }
@@ -591,7 +592,7 @@ void LLViewerParcelMgr::renderHighlightSegments(const U8* segments, LLViewerRegi
                 if (!has_segments)
                 {
                     has_segments = true;
-                    gGL.begin(LLRender::QUADS);
+                    gGL.begin(LLRender::TRIANGLES);
                 }
                 renderOneSegment(x1, y1, x2, y2, PARCEL_POST_HEIGHT, WEST_MASK, regionp);
             }
@@ -647,7 +648,7 @@ void LLViewerParcelMgr::renderCollisionSegments(U8* segments, bool use_pass, LLV
         gGL.getTexUnit(0)->bind(mBlockedImage);
     }
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
 
     for (y = 0; y < STRIDE; y++)
     {

--- a/indra/newview/llhudeffectblob.cpp
+++ b/indra/newview/llhudeffectblob.cpp
@@ -78,16 +78,23 @@ void LLHUDEffectBlob::render()
         LLVector3 u_scale = pixel_right * (F32)mPixelSize;
         LLVector3 v_scale = pixel_up * (F32)mPixelSize;
 
-        { gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
+        {
             gGL.texCoord2f(0.f, 1.f);
             gGL.vertex3fv((v_scale - u_scale).mV);
             gGL.texCoord2f(0.f, 0.f);
             gGL.vertex3fv((-v_scale - u_scale).mV);
             gGL.texCoord2f(1.f, 0.f);
             gGL.vertex3fv((-v_scale + u_scale).mV);
+
+            gGL.texCoord2f(0.f, 1.f);
+            gGL.vertex3fv((v_scale - u_scale).mV);
+            gGL.texCoord2f(1.f, 0.f);
+            gGL.vertex3fv((-v_scale + u_scale).mV);
             gGL.texCoord2f(1.f, 1.f);
             gGL.vertex3fv((v_scale + u_scale).mV);
-        } gGL.end();
+        }
+        gGL.end();
 
     } gGL.popMatrix();
 }

--- a/indra/newview/llhudicon.cpp
+++ b/indra/newview/llhudicon.cpp
@@ -152,12 +152,17 @@ void LLHUDIcon::render()
         gGL.getTexUnit(0)->bind(mImagep);
     }
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         gGL.texCoord2f(0.f, 1.f);
         gGL.vertex3fv(upper_left.mV);
         gGL.texCoord2f(0.f, 0.f);
         gGL.vertex3fv(lower_left.mV);
+        gGL.texCoord2f(1.f, 0.f);
+        gGL.vertex3fv(lower_right.mV);
+
+        gGL.texCoord2f(0.f, 1.f);
+        gGL.vertex3fv(upper_left.mV);
         gGL.texCoord2f(1.f, 0.f);
         gGL.vertex3fv(lower_right.mV);
         gGL.texCoord2f(1.f, 1.f);

--- a/indra/newview/lljoystickbutton.cpp
+++ b/indra/newview/lljoystickbutton.cpp
@@ -637,18 +637,24 @@ void LLJoystickCameraRotate::drawRotatedImage( LLPointer<LLUIImage> image, S32 r
 
     gGL.color4fv(UI_VERTEX_COLOR.mV);
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
-        gGL.texCoord2fv( uv[ (rotations + 0) % 4]);
-        gGL.vertex2i(width, height );
+        gGL.texCoord2fv(uv[(rotations + 0) % 4]);
+        gGL.vertex2i(width, height);
 
-        gGL.texCoord2fv( uv[ (rotations + 1) % 4]);
-        gGL.vertex2i(0, height );
+        gGL.texCoord2fv(uv[(rotations + 1) % 4]);
+        gGL.vertex2i(0, height);
 
-        gGL.texCoord2fv( uv[ (rotations + 2) % 4]);
+        gGL.texCoord2fv(uv[(rotations + 2) % 4]);
         gGL.vertex2i(0, 0);
 
-        gGL.texCoord2fv( uv[ (rotations + 3) % 4]);
+        gGL.texCoord2fv(uv[(rotations + 0) % 4]);
+        gGL.vertex2i(width, height);
+
+        gGL.texCoord2fv(uv[(rotations + 2) % 4]);
+        gGL.vertex2i(0, 0);
+
+        gGL.texCoord2fv(uv[(rotations + 3) % 4]);
         gGL.vertex2i(width, 0);
     }
     gGL.end();
@@ -909,7 +915,7 @@ void LLJoystickQuaternion::drawRotatedImage(LLPointer<LLUIImage> image, S32 rota
 
     gGL.color4fv(UI_VERTEX_COLOR.mV);
 
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         gGL.texCoord2fv(uv[(rotations + 0) % 4]);
         gGL.vertex2i(width, height);
@@ -919,6 +925,12 @@ void LLJoystickQuaternion::drawRotatedImage(LLPointer<LLUIImage> image, S32 rota
 
         gGL.texCoord2fv(uv[(rotations + 2) % 4]);
         gGL.vertex2i(0, 0);
+
+        gGL.texCoord2fv(uv[(rotations + 0) % 4]);
+        gGL.vertex2i(width, height);
+
+        gGL.texCoord2fv(uv[(rotations + 1) % 4]);
+        gGL.vertex2i(0, height);
 
         gGL.texCoord2fv(uv[(rotations + 3) % 4]);
         gGL.vertex2i(width, 0);

--- a/indra/newview/llmanipscale.cpp
+++ b/indra/newview/llmanipscale.cpp
@@ -618,43 +618,22 @@ void LLManipScale::renderFaces( const LLBBox& bbox )
     {
         gGL.color4fv( default_normal_color.mV );
         LLGLDepthTest gls_depth(GL_FALSE);
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLE_STRIP);
         {
-            // Face 0
-            gGL.vertex3f(min.mV[VX], max.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], min.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], min.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], max.mV[VY], max.mV[VZ]);
-
-            // Face 1
-            gGL.vertex3f(max.mV[VX], min.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], min.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], max.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], max.mV[VY], max.mV[VZ]);
-
-            // Face 2
             gGL.vertex3f(min.mV[VX], max.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], max.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], max.mV[VY], max.mV[VZ]);
             gGL.vertex3f(max.mV[VX], max.mV[VY], min.mV[VZ]);
-
-            // Face 3
-            gGL.vertex3f(min.mV[VX], max.mV[VY], max.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], max.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], min.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], min.mV[VY], max.mV[VZ]);
-
-            // Face 4
-            gGL.vertex3f(min.mV[VX], min.mV[VY], max.mV[VZ]);
             gGL.vertex3f(min.mV[VX], min.mV[VY], min.mV[VZ]);
             gGL.vertex3f(max.mV[VX], min.mV[VY], min.mV[VZ]);
             gGL.vertex3f(max.mV[VX], min.mV[VY], max.mV[VZ]);
-
-            // Face 5
-            gGL.vertex3f(min.mV[VX], min.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(min.mV[VX], max.mV[VY], min.mV[VZ]);
             gGL.vertex3f(max.mV[VX], max.mV[VY], min.mV[VZ]);
-            gGL.vertex3f(max.mV[VX], min.mV[VY], min.mV[VZ]);
+            gGL.vertex3f(max.mV[VX], max.mV[VY], max.mV[VZ]);
+            gGL.vertex3f(min.mV[VX], max.mV[VY], min.mV[VZ]);
+            gGL.vertex3f(min.mV[VX], max.mV[VY], max.mV[VZ]);
+            gGL.vertex3f(min.mV[VX], min.mV[VY], min.mV[VZ]);
+            gGL.vertex3f(min.mV[VX], min.mV[VY], max.mV[VZ]);
+            gGL.vertex3f(max.mV[VX], min.mV[VY], max.mV[VZ]);
+            gGL.vertex3f(min.mV[VX], max.mV[VY], max.mV[VZ]);
+            gGL.vertex3f(max.mV[VX], max.mV[VY], max.mV[VZ]);
         }
         gGL.end();
     }

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -843,7 +843,7 @@ void LLMediaCtrl::draw()
             calcOffsetsAndSize(&x_offset, &y_offset, &width, &height);
 
             // draw the browser
-            gGL.begin( LLRender::QUADS );
+            gGL.begin(LLRender::TRIANGLES);
             if (! media_plugin->getTextureCoordsOpenGL())
             {
                 // render using web browser reported width and height, instead of trying to invert GL scale
@@ -855,6 +855,12 @@ void LLMediaCtrl::draw()
 
                 gGL.texCoord2f( 0.f, max_v );
                 gGL.vertex2i( x_offset, y_offset );
+
+                gGL.texCoord2f(max_u, 0.f);
+                gGL.vertex2i(x_offset + width, y_offset + height);
+
+                gGL.texCoord2f(0.f, max_v);
+                gGL.vertex2i(x_offset, y_offset);
 
                 gGL.texCoord2f( max_u, max_v );
                 gGL.vertex2i( x_offset + width, y_offset );
@@ -870,6 +876,12 @@ void LLMediaCtrl::draw()
 
                 gGL.texCoord2f( 0.f, 0.f );
                 gGL.vertex2i( x_offset, y_offset );
+
+                gGL.texCoord2f(max_u, max_v);
+                gGL.vertex2i(x_offset + width, y_offset + height);
+
+                gGL.texCoord2f(0.f, 0.f);
+                gGL.vertex2i(x_offset, y_offset);
 
                 gGL.texCoord2f( max_u, 0.f );
                 gGL.vertex2i( x_offset + width, y_offset );

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -298,15 +298,22 @@ void LLNetMap::draw()
 
             // Draw using texture.
             gGL.getTexUnit(0)->bind(regionp->getLand().getSTexture());
-            gGL.begin(LLRender::QUADS);
+            gGL.begin(LLRender::TRIANGLES);
+            {
                 gGL.texCoord2f(0.f, 1.f);
                 gGL.vertex2f(left, top);
                 gGL.texCoord2f(0.f, 0.f);
                 gGL.vertex2f(left, bottom);
                 gGL.texCoord2f(1.f, 0.f);
                 gGL.vertex2f(right, bottom);
+
+                gGL.texCoord2f(0.f, 1.f);
+                gGL.vertex2f(left, top);
+                gGL.texCoord2f(1.f, 0.f);
+                gGL.vertex2f(right, bottom);
                 gGL.texCoord2f(1.f, 1.f);
                 gGL.vertex2f(right, top);
+            }
             gGL.end();
 
             gGL.flush();
@@ -347,15 +354,22 @@ void LLNetMap::draw()
         F32 image_half_width = 0.5f*mObjectMapPixels;
         F32 image_half_height = 0.5f*mObjectMapPixels;
 
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
+        {
             gGL.texCoord2f(0.f, 1.f);
             gGL.vertex2f(map_center_agent.mV[VX] - image_half_width, image_half_height + map_center_agent.mV[VY]);
             gGL.texCoord2f(0.f, 0.f);
             gGL.vertex2f(map_center_agent.mV[VX] - image_half_width, map_center_agent.mV[VY] - image_half_height);
             gGL.texCoord2f(1.f, 0.f);
             gGL.vertex2f(image_half_width + map_center_agent.mV[VX], map_center_agent.mV[VY] - image_half_height);
+
+            gGL.texCoord2f(0.f, 1.f);
+            gGL.vertex2f(map_center_agent.mV[VX] - image_half_width, image_half_height + map_center_agent.mV[VY]);
+            gGL.texCoord2f(1.f, 0.f);
+            gGL.vertex2f(image_half_width + map_center_agent.mV[VX], map_center_agent.mV[VY] - image_half_height);
             gGL.texCoord2f(1.f, 1.f);
             gGL.vertex2f(image_half_width + map_center_agent.mV[VX], image_half_height + map_center_agent.mV[VY]);
+        }
         gGL.end();
 
         for (LLWorld::region_list_t::const_iterator iter = LLWorld::getInstance()->getRegionList().begin();

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -295,13 +295,20 @@ void LLSnapshotLivePreview::draw()
         gGL.pushMatrix();
         {
             gGL.translatef((F32)rect.mLeft, (F32)rect.mBottom + TOP_PANEL_HEIGHT, 0.f);
-            gGL.begin(LLRender::QUADS);
+            gGL.begin(LLRender::TRIANGLES);
             {
                 gGL.texCoord2f(uv_width, uv_height);
-                gGL.vertex2i(rect.getWidth(), rect.getHeight() );
+                gGL.vertex2i(rect.getWidth(), rect.getHeight());
 
                 gGL.texCoord2f(0.f, uv_height);
-                gGL.vertex2i(0, rect.getHeight() );
+                gGL.vertex2i(0, rect.getHeight());
+
+                gGL.texCoord2f(0.f, 0.f);
+                gGL.vertex2i(0, 0);
+
+
+                gGL.texCoord2f(uv_width, uv_height);
+                gGL.vertex2i(rect.getWidth(), rect.getHeight());
 
                 gGL.texCoord2f(0.f, 0.f);
                 gGL.vertex2i(0, 0);
@@ -357,11 +364,16 @@ void LLSnapshotLivePreview::draw()
                 S32 y2 = gViewerWindow->getWindowHeightScaled() + TOP_PANEL_HEIGHT;
 
                 gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
-                gGL.begin(LLRender::QUADS);
+                gGL.begin(LLRender::TRIANGLES);
                 {
                     gGL.color4f(1.f, 1.f, 1.f, 0.f);
                     gGL.vertex2i(x1, y1);
                     gGL.vertex2i(x1 + gViewerWindow->getWindowWidthScaled(), y2);
+                    gGL.color4f(1.f, 1.f, 1.f, SHINE_OPACITY);
+                    gGL.vertex2i(x2 + gViewerWindow->getWindowWidthScaled(), y2);
+
+                    gGL.color4f(1.f, 1.f, 1.f, 0.f);
+                    gGL.vertex2i(x1, y1);
                     gGL.color4f(1.f, 1.f, 1.f, SHINE_OPACITY);
                     gGL.vertex2i(x2 + gViewerWindow->getWindowWidthScaled(), y2);
                     gGL.vertex2i(x2, y1);
@@ -369,6 +381,11 @@ void LLSnapshotLivePreview::draw()
                     gGL.color4f(1.f, 1.f, 1.f, SHINE_OPACITY);
                     gGL.vertex2i(x2, y1);
                     gGL.vertex2i(x2 + gViewerWindow->getWindowWidthScaled(), y2);
+                    gGL.color4f(1.f, 1.f, 1.f, 0.f);
+                    gGL.vertex2i(x3 + gViewerWindow->getWindowWidthScaled(), y2);
+
+                    gGL.color4f(1.f, 1.f, 1.f, SHINE_OPACITY);
+                    gGL.vertex2i(x2, y1);
                     gGL.color4f(1.f, 1.f, 1.f, 0.f);
                     gGL.vertex2i(x3 + gViewerWindow->getWindowWidthScaled(), y2);
                     gGL.vertex2i(x3, y1);
@@ -406,13 +423,19 @@ void LLSnapshotLivePreview::draw()
                 LLRect& rect = mImageRect[old_image_index];
                 gGL.translatef((F32)rect.mLeft, (F32)rect.mBottom - ll_round(getRect().getHeight() * 2.f * (fall_interp * fall_interp)), 0.f);
                 gGL.rotatef(-45.f * fall_interp, 0.f, 0.f, 1.f);
-                gGL.begin(LLRender::QUADS);
+                gGL.begin(LLRender::TRIANGLES);
                 {
                     gGL.texCoord2f(uv_width, uv_height);
-                    gGL.vertex2i(rect.getWidth(), rect.getHeight() );
+                    gGL.vertex2i(rect.getWidth(), rect.getHeight());
 
                     gGL.texCoord2f(0.f, uv_height);
-                    gGL.vertex2i(0, rect.getHeight() );
+                    gGL.vertex2i(0, rect.getHeight());
+
+                    gGL.texCoord2f(0.f, 0.f);
+                    gGL.vertex2i(0, 0);
+
+                    gGL.texCoord2f(uv_width, uv_height);
+                    gGL.vertex2i(rect.getWidth(), rect.getHeight());
 
                     gGL.texCoord2f(0.f, 0.f);
                     gGL.vertex2i(0, 0);

--- a/indra/newview/lltoolmorph.cpp
+++ b/indra/newview/lltoolmorph.cpp
@@ -285,12 +285,17 @@ void LLVisualParamHint::draw(F32 alpha)
     gGL.color4f(1.f, 1.f, 1.f, alpha);
 
     LLGLSUIDefault gls_ui;
-    gGL.begin(LLRender::QUADS);
+    gGL.begin(LLRender::TRIANGLES);
     {
         gGL.texCoord2i(0, 1);
         gGL.vertex2i(0, mFullHeight);
         gGL.texCoord2i(0, 0);
         gGL.vertex2i(0, 0);
+        gGL.texCoord2i(1, 0);
+        gGL.vertex2i(mFullWidth, 0);
+
+        gGL.texCoord2i(0, 1);
+        gGL.vertex2i(0, mFullHeight);
         gGL.texCoord2i(1, 0);
         gGL.vertex2i(mFullWidth, 0);
         gGL.texCoord2i(1, 1);

--- a/indra/newview/llviewerjointattachment.cpp
+++ b/indra/newview/llviewerjointattachment.cpp
@@ -86,13 +86,17 @@ U32 LLViewerJointAttachment::drawShape( F32 pixelArea, bool first_pass, bool is_
         LLGLDisable cull_face(GL_CULL_FACE);
 
         gGL.color4f(1.f, 1.f, 1.f, 1.f);
-        gGL.begin(LLRender::QUADS);
+        gGL.begin(LLRender::TRIANGLES);
         {
             gGL.vertex3f(-0.1f, 0.1f, 0.f);
             gGL.vertex3f(-0.1f, -0.1f, 0.f);
             gGL.vertex3f(0.1f, -0.1f, 0.f);
+
+            gGL.vertex3f(-0.1f, 0.1f, 0.f);
+            gGL.vertex3f(0.1f, -0.1f, 0.f);
             gGL.vertex3f(0.1f, 0.1f, 0.f);
-        }gGL.end();
+        }
+        gGL.end();
     }
     return 0;
 }

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -5424,14 +5424,6 @@ U32 LLVOAvatar::renderImpostor(LLColor4U color, S32 diffuse_channel)
         gGL.setSceneBlendType(LLRender::BT_ADD);
         gGL.getTexUnit(diffuse_channel)->unbind(LLTexUnit::TT_TEXTURE);
 
-        // gGL.begin(LLRender::QUADS);
-        // gGL.vertex3fv((pos+left-up).mV);
-        // gGL.vertex3fv((pos-left-up).mV);
-        // gGL.vertex3fv((pos-left+up).mV);
-        // gGL.vertex3fv((pos+left+up).mV);
-        // gGL.end();
-
-
         gGL.begin(LLRender::LINES);
         gGL.color4f(1.f,1.f,1.f,1.f);
         F32 thickness = llmax(F32(5.0f-5.0f*(gFrameTimeSeconds-mLastImpostorUpdateFrameTime)),1.0f);
@@ -5452,15 +5444,22 @@ U32 LLVOAvatar::renderImpostor(LLColor4U color, S32 diffuse_channel)
 
     gGL.color4ubv(color.mV);
     gGL.getTexUnit(diffuse_channel)->bind(&mImpostor);
-    gGL.begin(LLRender::QUADS);
-    gGL.texCoord2f(0,0);
-    gGL.vertex3fv((pos+left-up).mV);
-    gGL.texCoord2f(1,0);
-    gGL.vertex3fv((pos-left-up).mV);
-    gGL.texCoord2f(1,1);
-    gGL.vertex3fv((pos-left+up).mV);
-    gGL.texCoord2f(0,1);
-    gGL.vertex3fv((pos+left+up).mV);
+    gGL.begin(LLRender::TRIANGLES);
+    {
+        gGL.texCoord2f(0.f, 0.f);
+        gGL.vertex3fv((pos + left - up).mV);
+        gGL.texCoord2f(1.f, 0.f);
+        gGL.vertex3fv((pos - left - up).mV);
+        gGL.texCoord2f(1.f, 1.f);
+        gGL.vertex3fv((pos - left + up).mV);
+
+        gGL.texCoord2f(0.f, 0.f);
+        gGL.vertex3fv((pos + left - up).mV);
+        gGL.texCoord2f(1.f, 1.f);
+        gGL.vertex3fv((pos - left + up).mV);
+        gGL.texCoord2f(0.f, 1.f);
+        gGL.vertex3fv((pos + left + up).mV);
+    }
     gGL.end();
     gGL.flush();
     }

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -462,11 +462,16 @@ void LLWorldMapView::draw()
             gGL.color4f(0.2f, 0.0f, 0.0f, 0.4f);
 
             gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
-            gGL.begin(LLRender::QUADS);
+            gGL.begin(LLRender::TRIANGLES);
+            {
                 gGL.vertex2f(left, top);
                 gGL.vertex2f(left, bottom);
                 gGL.vertex2f(right, bottom);
+
+                gGL.vertex2f(left, top);
+                gGL.vertex2f(right, bottom);
                 gGL.vertex2f(right, top);
+            }
             gGL.end();
         }
         else if (show_for_sale && (level <= DRAW_LANDFORSALE_THRESHOLD))
@@ -483,15 +488,22 @@ void LLWorldMapView::draw()
                 {
                     gGL.getTexUnit(0)->bind(overlayimage);
                     gGL.color4f(1.f, 1.f, 1.f, 1.f);
-                    gGL.begin(LLRender::QUADS);
+                    gGL.begin(LLRender::TRIANGLES);
+                    {
                         gGL.texCoord2f(0.f, 1.f);
                         gGL.vertex3f(left, top, -0.5f);
                         gGL.texCoord2f(0.f, 0.f);
                         gGL.vertex3f(left, bottom, -0.5f);
                         gGL.texCoord2f(1.f, 0.f);
                         gGL.vertex3f(right, bottom, -0.5f);
+
+                        gGL.texCoord2f(0.f, 1.f);
+                        gGL.vertex3f(left, top, -0.5f);
+                        gGL.texCoord2f(1.f, 0.f);
+                        gGL.vertex3f(right, bottom, -0.5f);
                         gGL.texCoord2f(1.f, 1.f);
                         gGL.vertex3f(right, top, -0.5f);
+                    }
                     gGL.end();
                 }
             }
@@ -737,15 +749,22 @@ bool LLWorldMapView::drawMipmapLevel(S32 width, S32 height, S32 level, bool load
 
                     gGL.color4f(1.f, 1.0f, 1.0f, 1.0f);
 
-                    gGL.begin(LLRender::QUADS);
+                    gGL.begin(LLRender::TRIANGLES);
+                    {
                         gGL.texCoord2f(0.f, 1.f);
                         gGL.vertex3f(left, top, 0.f);
                         gGL.texCoord2f(0.f, 0.f);
                         gGL.vertex3f(left, bottom, 0.f);
                         gGL.texCoord2f(1.f, 0.f);
                         gGL.vertex3f(right, bottom, 0.f);
+
+                        gGL.texCoord2f(0.f, 1.f);
+                        gGL.vertex3f(left, top, 0.f);
+                        gGL.texCoord2f(1.f, 0.f);
+                        gGL.vertex3f(right, bottom, 0.f);
                         gGL.texCoord2f(1.f, 1.f);
                         gGL.vertex3f(right, top, 0.f);
+                    }
                     gGL.end();
 #if DEBUG_DRAW_TILE
                     drawTileOutline(level, top, left, bottom, right);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -10897,11 +10897,16 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
             gGL.diffuseColor4fv(LLColor4::pink.mV );
         }
 
-        gGL.begin(LLRender::QUADS);
-        gGL.vertex3f(-1, -1, clip_plane);
-        gGL.vertex3f(1, -1, clip_plane);
-        gGL.vertex3f(1, 1, clip_plane);
-        gGL.vertex3f(-1, 1, clip_plane);
+        gGL.begin(LLRender::TRIANGLES);
+        {
+            gGL.vertex3f(-1.f, -1.f, clip_plane);
+            gGL.vertex3f(1.f, -1.f, clip_plane);
+            gGL.vertex3f(1.f, 1.f, clip_plane);
+
+            gGL.vertex3f(-1.f, -1.f, clip_plane);
+            gGL.vertex3f(1.f, 1.f, clip_plane);
+            gGL.vertex3f(-1.f, 1.f, clip_plane);
+        }
         gGL.end();
         gGL.flush();
 


### PR DESCRIPTION
Quads had to go, so I guided them out. 👋 

This is taken from my [changes made to Firestorm](https://github.com/FirestormViewer/phoenix-firestorm/commit/0c4c1b59685ff99b93e220a03e79ba2b9df0bbfc) over 7 years ago and unless I made some copy&paste error, this should run just fine.