### PR TITLE
Expose LLVector4a in LLRender

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -271,7 +271,7 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
     const LLFontGlyphInfo* next_glyph = NULL;
 
     static constexpr S32 GLYPH_BATCH_SIZE = 30;
-    static thread_local LLVector3 vertices[GLYPH_BATCH_SIZE * 6];
+    static thread_local LLVector4a vertices[GLYPH_BATCH_SIZE * 6];
     static thread_local LLVector2 uvs[GLYPH_BATCH_SIZE * 6];
     static thread_local LLColor4U colors[GLYPH_BATCH_SIZE * 6];
 
@@ -1227,42 +1227,42 @@ LLFontGL &LLFontGL::operator=(const LLFontGL &source)
     return *this;
 }
 
-void LLFontGL::renderTriangle(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const
+void LLFontGL::renderTriangle(LLVector4a* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const
 {
     S32 index = 0;
 
-    vertex_out[index] = LLVector3(screen_rect.mRight, screen_rect.mTop, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mRight, uv_rect.mTop);
+    vertex_out[index].set(screen_rect.mRight, screen_rect.mTop, 0.f);
+    uv_out[index].set(uv_rect.mRight, uv_rect.mTop);
     colors_out[index] = color;
     index++;
 
-    vertex_out[index] = LLVector3(screen_rect.mLeft, screen_rect.mTop, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mLeft, uv_rect.mTop);
+    vertex_out[index].set(screen_rect.mLeft, screen_rect.mTop, 0.f);
+    uv_out[index].set(uv_rect.mLeft, uv_rect.mTop);
     colors_out[index] = color;
     index++;
 
-    vertex_out[index] = LLVector3(screen_rect.mLeft, screen_rect.mBottom, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mLeft, uv_rect.mBottom);
+    vertex_out[index].set(screen_rect.mLeft, screen_rect.mBottom, 0.f);
+    uv_out[index].set(uv_rect.mLeft, uv_rect.mBottom);
     colors_out[index] = color;
     index++;
 
 
-    vertex_out[index] = LLVector3(screen_rect.mRight, screen_rect.mTop, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mRight, uv_rect.mTop);
+    vertex_out[index].set(screen_rect.mRight, screen_rect.mTop, 0.f);
+    uv_out[index].set(uv_rect.mRight, uv_rect.mTop);
     colors_out[index] = color;
     index++;
 
-    vertex_out[index] = LLVector3(screen_rect.mLeft, screen_rect.mBottom, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mLeft, uv_rect.mBottom);
+    vertex_out[index].set(screen_rect.mLeft, screen_rect.mBottom, 0.f);
+    uv_out[index].set(uv_rect.mLeft, uv_rect.mBottom);
     colors_out[index] = color;
     index++;
 
-    vertex_out[index] = LLVector3(screen_rect.mRight, screen_rect.mBottom, 0.f);
-    uv_out[index] = LLVector2(uv_rect.mRight, uv_rect.mBottom);
+    vertex_out[index].set(screen_rect.mRight, screen_rect.mBottom, 0.f);
+    uv_out[index].set(uv_rect.mRight, uv_rect.mBottom);
     colors_out[index] = color;
 }
 
-void LLFontGL::drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, U8 style, ShadowType shadow, F32 drop_shadow_strength) const
+void LLFontGL::drawGlyph(S32& glyph_count, LLVector4a* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, U8 style, ShadowType shadow, F32 drop_shadow_strength) const
 {
     F32 slant_offset;
     slant_offset = ((style & ITALIC) ? ( -mFontFreetype->getAscenderHeight() * 0.2f) : 0.f);

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -238,8 +238,8 @@ private:
     LLFontDescriptor mFontDescriptor;
     LLPointer<LLFontFreetype> mFontFreetype;
 
-    void renderTriangle(LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const;
-    void drawGlyph(S32& glyph_count, LLVector3* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, U8 style, ShadowType shadow, F32 drop_shadow_fade) const;
+    void renderTriangle(LLVector4a* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, F32 slant_amt) const;
+    void drawGlyph(S32& glyph_count, LLVector4a* vertex_out, LLVector2* uv_out, LLColor4U* colors_out, const LLRectf& screen_rect, const LLRectf& uv_rect, const LLColor4U& color, U8 style, ShadowType shadow, F32 drop_shadow_fade) const;
 
     // Registry holds all instantiated fonts.
     static LLFontRegistry* sFontRegistry;

--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -1298,7 +1298,7 @@ void LLRender::pushUIMatrix()
 {
     if (mUIOffset.empty())
     {
-        mUIOffset.push_back(LLVector3(0,0,0));
+        mUIOffset.emplace_back(0.f,0.f,0.f);
     }
     else
     {
@@ -1307,7 +1307,7 @@ void LLRender::pushUIMatrix()
 
     if (mUIScale.empty())
     {
-        mUIScale.push_back(LLVector3(1,1,1));
+        mUIScale.emplace_back(1.f,1.f,1.f);
     }
     else
     {
@@ -1718,7 +1718,7 @@ LLVertexBuffer* LLRender::genBuffer(U32 attribute_mask, S32 count)
 
     vb->setBuffer();
 
-    vb->setPositionData((LLVector4a*)mVerticesp.get());
+    vb->setPositionData(mVerticesp.get());
 
     if (attribute_mask & LLVertexBuffer::MAP_TEXCOORD0)
     {
@@ -1774,12 +1774,12 @@ void LLRender::vertex3f(const GLfloat& x, const GLfloat& y, const GLfloat& z)
 
     if (mUIOffset.empty())
     {
-        mVerticesp[mCount] = LLVector3(x,y,z);
+        mVerticesp[mCount].set(x,y,z);
     }
     else
     {
         LLVector3 vert = (LLVector3(x,y,z)+mUIOffset.back()).scaledVec(mUIScale.back());
-        mVerticesp[mCount] = vert;
+        mVerticesp[mCount].set(vert.mV[VX], vert.mV[VY], vert.mV[VZ]);
     }
 
     mCount++;
@@ -1788,7 +1788,7 @@ void LLRender::vertex3f(const GLfloat& x, const GLfloat& y, const GLfloat& z)
     mTexcoordsp[mCount] = mTexcoordsp[mCount-1];
 }
 
-void LLRender::vertexBatchPreTransformed(LLVector3* verts, S32 vert_count)
+void LLRender::vertexBatchPreTransformed(LLVector4a* verts, S32 vert_count)
 {
     if (mCount + vert_count > 4094)
     {
@@ -1809,7 +1809,7 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, S32 vert_count)
         mVerticesp[mCount] = mVerticesp[mCount-1];
 }
 
-void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 vert_count)
+void LLRender::vertexBatchPreTransformed(LLVector4a* verts, LLVector2* uvs, S32 vert_count)
 {
     if (mCount + vert_count > 4094)
     {
@@ -1833,7 +1833,7 @@ void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 v
     }
 }
 
-void LLRender::vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U* colors, S32 vert_count)
+void LLRender::vertexBatchPreTransformed(LLVector4a* verts, LLVector2* uvs, LLColor4U* colors, S32 vert_count)
 {
     if (mCount + vert_count > 4094)
     {

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -449,9 +449,9 @@ public:
     void diffuseColor4ubv(const U8* c);
     void diffuseColor4ub(U8 r, U8 g, U8 b, U8 a);
 
-    void vertexBatchPreTransformed(LLVector3* verts, S32 vert_count);
-    void vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, S32 vert_count);
-    void vertexBatchPreTransformed(LLVector3* verts, LLVector2* uvs, LLColor4U*, S32 vert_count);
+    void vertexBatchPreTransformed(LLVector4a* verts, S32 vert_count);
+    void vertexBatchPreTransformed(LLVector4a* verts, LLVector2* uvs, S32 vert_count);
+    void vertexBatchPreTransformed(LLVector4a* verts, LLVector2* uvs, LLColor4U*, S32 vert_count);
 
     void setColorMask(bool writeColor, bool writeAlpha);
     void setColorMask(bool writeColorR, bool writeColorG, bool writeColorB, bool writeAlpha);
@@ -513,7 +513,7 @@ private:
     bool                mCurrColorMask[4];
 
     LLPointer<LLVertexBuffer>   mBuffer;
-    LLStrider<LLVector3>        mVerticesp;
+    LLStrider<LLVector4a>       mVerticesp;
     LLStrider<LLVector2>        mTexcoordsp;
     LLStrider<LLColor4U>        mColorsp;
     std::array<LLTexUnit, LL_NUM_TEXTURE_LAYERS> mTexUnits;

--- a/indra/llrender/llrender2dutils.cpp
+++ b/indra/llrender/llrender2dutils.cpp
@@ -446,15 +446,13 @@ void gl_draw_scaled_image_with_border(S32 x, S32 y, S32 width, S32 height, LLTex
                                 ui_translation.mV[VX] + width * ui_scale.mV[VX],
                                 ui_translation.mV[VY]);
 
-        LLGLSUIDefault gls_ui;
-
         gGL.getTexUnit(0)->bind(image, true);
 
         gGL.color4fv(color.mV);
 
         constexpr S32 NUM_VERTICES = 9 * 2 * 3; // 9 quads, 2 triangles per quad, 3 vertices per triangle
         static thread_local LLVector2 uv[NUM_VERTICES];
-        static thread_local LLVector3 pos[NUM_VERTICES];
+        static thread_local LLVector4a pos[NUM_VERTICES];
 
         S32 index = 0;
 
@@ -719,8 +717,6 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
         return;
     }
 
-    LLGLSUIDefault gls_ui;
-
     if(image != NULL)
     {
         gGL.getTexUnit(0)->bind(image, true);
@@ -735,8 +731,8 @@ void gl_draw_scaled_rotated_image(S32 x, S32 y, S32 width, S32 height, F32 degre
     if (degrees == 0.f)
     {
         constexpr S32 NUM_VERTICES = 2 * 3;
-        static thread_local LLVector2 uv[NUM_VERTICES];
-        static thread_local LLVector3 pos[NUM_VERTICES];
+        static thread_local LLVector2 uv[NUM_VERTICES +1];
+        static thread_local LLVector4a pos[NUM_VERTICES +1];
 
         gGL.begin(LLRender::TRIANGLES);
         {

--- a/indra/llui/llbadge.cpp
+++ b/indra/llui/llbadge.cpp
@@ -204,11 +204,11 @@ void renderBadgeBackground(F32 centerX, F32 centerY, F32 width, F32 height, cons
                         (F32)ll_round(x) + width,
                         (F32)ll_round(y) + height);
 
-    LLVector3 vertices[4];
-    vertices[0] = LLVector3(screen_rect.mLeft,  screen_rect.mTop,    1.0f);
-    vertices[1] = LLVector3(screen_rect.mRight, screen_rect.mTop,    1.0f);
-    vertices[2] = LLVector3(screen_rect.mLeft,  screen_rect.mBottom, 1.0f);
-    vertices[3] = LLVector3(screen_rect.mRight, screen_rect.mBottom, 1.0f);
+    LLVector4a vertices[4];
+    vertices[0].set(screen_rect.mLeft,  screen_rect.mTop,    1.0f);
+    vertices[1].set(screen_rect.mRight, screen_rect.mTop,    1.0f);
+    vertices[2].set(screen_rect.mLeft,  screen_rect.mBottom, 1.0f);
+    vertices[3].set(screen_rect.mRight, screen_rect.mBottom, 1.0f);
 
     gGL.begin(LLRender::TRIANGLE_STRIP);
     {

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -688,10 +688,10 @@ void LLViewerMedia::updateMedia(void *dummy_arg)
 
     static LLCachedControl<bool> inworld_media_enabled(gSavedSettings, "AudioStreamingMedia", true);
     static LLCachedControl<bool> inworld_audio_enabled(gSavedSettings, "AudioStreamingMusic", true);
-    U32 max_instances = gSavedSettings.getU32("PluginInstancesTotal");
-    U32 max_normal = gSavedSettings.getU32("PluginInstancesNormal");
-    U32 max_low = gSavedSettings.getU32("PluginInstancesLow");
-    F32 max_cpu = gSavedSettings.getF32("PluginInstancesCPULimit");
+    static LLCachedControl<U32> max_instances(gSavedSettings, "PluginInstancesTotal", 8);
+    static LLCachedControl<U32> max_normal(gSavedSettings, "PluginInstancesNormal", 2);
+    static LLCachedControl<U32> max_low(gSavedSettings, "PluginInstancesLow", 4);
+    static LLCachedControl<F32> max_cpu(gSavedSettings, "PluginInstancesCPULimit", 0.9);
     // Setting max_cpu to 0.0 disables CPU usage checking.
     bool check_cpu_usage = (max_cpu != 0.0f);
 
@@ -829,7 +829,8 @@ void LLViewerMedia::updateMedia(void *dummy_arg)
             }
             else
             {
-                if(gAudiop && LLViewerMedia::hasParcelAudio() && restore_parcel_audio && gSavedSettings.getBOOL("MediaTentativeAutoPlay"))
+                static LLCachedControl<bool> auto_play(gSavedSettings, "MediaTentativeAutoPlay", true);
+                if(gAudiop && LLViewerMedia::hasParcelAudio() && restore_parcel_audio && auto_play())
                 {
                     LLViewerAudio::getInstance()->startInternetStreamWithAutoFade(LLViewerMedia::getParcelAudioURL());
                     restore_parcel_audio = false;
@@ -880,7 +881,8 @@ void LLViewerMedia::updateMedia(void *dummy_arg)
         }
     }
 
-    if(gSavedSettings.getBOOL("MediaPerformanceManagerDebug"))
+    static LLCachedControl<bool> perf_debug(gSavedSettings, "MediaPerformanceManagerDebug", false);
+    if(perf_debug())
     {
         // Give impls the same ordering as the priority list
         // they're already in the right order for this.


### PR DESCRIPTION
1. Make sure we use LLVector4a's SSE logic instead of LLVector3's. The real strider is LLVector4a, but it's getting treated as if it is LLVector3.
2. Avoid using a bunch of allocators.
3. Some minor optimizations.