### PR TITLE
Fix copy&paste error in llfloaterimagepreview.cpp

### DIFF
--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -288,18 +288,18 @@ void LLFloaterImagePreview::draw()
             gGL.begin(LLRender::TRIANGLES);
             {
                 gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mTop);
-                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
+                gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
                 gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mBottom);
-                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mBottom);
+                gGL.vertex2i(PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
                 gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mBottom);
-                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+                gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
 
-                gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mTop);
-                gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
                 gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mBottom);
-                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+                gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                gGL.texCoord2f(mPreviewImageRect.mLeft, mPreviewImageRect.mTop);
+                gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
                 gGL.texCoord2f(mPreviewImageRect.mRight, mPreviewImageRect.mTop);
-                gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mTop);
+                gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
             }
             gGL.end();
 
@@ -325,18 +325,18 @@ void LLFloaterImagePreview::draw()
                 gGL.begin(LLRender::TRIANGLES);
                 {
                     gGL.texCoord2f(0.f, 1.f);
-                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
+                    gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
                     gGL.texCoord2f(0.f, 0.f);
-                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mBottom);
+                    gGL.vertex2i(PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
                     gGL.texCoord2f(1.f, 0.f);
-                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+                    gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
 
-                    gGL.texCoord2f(0.f, 1.f);
-                    gGL.vertex2i(mPreviewRect.mLeft, mPreviewRect.mTop);
                     gGL.texCoord2f(1.f, 0.f);
-                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mBottom);
+                    gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_HPAD + PREF_BUTTON_HEIGHT + PREVIEW_HPAD);
+                    gGL.texCoord2f(0.f, 1.f);
+                    gGL.vertex2i(PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
                     gGL.texCoord2f(1.f, 1.f);
-                    gGL.vertex2i(mPreviewRect.mRight, mPreviewRect.mTop);
+                    gGL.vertex2i(r.getWidth() - PREVIEW_HPAD, PREVIEW_TEXTURE_HEIGHT + PREVIEW_VPAD);
                 }
                 gGL.end();
 


### PR DESCRIPTION
Follow-up to #2593 : Restore image preview rendering based on original values - there were some changes in Firestorm that superseeded the original change, which I missed while adding the changes to the LL viewer.