### PR TITLE
Don't keep updating snapshot preview when the floater is closed

### DIFF
--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -1297,7 +1297,8 @@ bool LLFloaterSnapshotBase::ImplBase::updatePreviewList(bool initialized)
 
 void LLFloaterSnapshotBase::ImplBase::updateLivePreview()
 {
-    if (ImplBase::updatePreviewList(true) && mFloater)
+    // don't update preview for hidden floater
+    if (mFloater && mFloater->isInVisibleChain() && ImplBase::updatePreviewList(true))
     {
         LL_DEBUGS() << "changed" << LL_ENDL;
         updateControls(mFloater);


### PR DESCRIPTION
Closing 'Snapshot' floater didn't stop `updateLivePreview()` calls, which were still triggered each frame. It's pointless, even though quite cheap (~7μs). Let's get rid of it.
![image](https://github.com/user-attachments/assets/8f0a9ba0-80cd-496b-a7a3-8055dd93726b)

Also update slow getters to LLCachedControl.