### PR TITLE
Restore option to change location of existing pick

### DIFF
--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -801,7 +801,7 @@ void LLPanelProfilePick::onClickSave()
     {
         mParcelCallbackConnection.disconnect();
     }
-    if (mLocationChanged) 
+    if (mLocationChanged)
     {
         onClickSetLocation();
     }

--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -246,6 +246,8 @@ void LLPanelProfilePicks::onClickNewBtn()
         select_tab(true).
         label(pick_panel->getPickName()));
     updateButtons();
+
+    pick_panel->addLocationChangedCallbacks();
 }
 
 void LLPanelProfilePicks::onClickDelete()
@@ -571,10 +573,12 @@ void LLPanelProfilePick::setAvatarId(const LLUUID& avatar_id)
     {
         mPickName->setEnabled(true);
         mPickDescription->setEnabled(true);
+        mSetCurrentLocationButton->setVisible(true);
     }
     else
     {
         mSnapshotCtrl->setEnabled(false);
+        mSetCurrentLocationButton->setVisible(false);
     }
 }
 
@@ -585,6 +589,7 @@ bool LLPanelProfilePick::postBuild()
     mSaveButton = getChild<LLButton>("save_changes_btn");
     mCreateButton = getChild<LLButton>("create_changes_btn");
     mCancelButton = getChild<LLButton>("cancel_changes_btn");
+    mSetCurrentLocationButton = getChild<LLButton>("set_to_curr_location_btn");
 
     mSnapshotCtrl = getChild<LLTextureCtrl>("pick_snapshot");
     mSnapshotCtrl->setCommitCallback(boost::bind(&LLPanelProfilePick::onSnapshotChanged, this));
@@ -597,6 +602,7 @@ bool LLPanelProfilePick::postBuild()
     mSaveButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickSave, this));
     mCreateButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickSave, this));
     mCancelButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickCancel, this));
+    mSetCurrentLocationButton->setCommitCallback(boost::bind(&LLPanelProfilePick::onClickSetLocation, this));
 
     mPickName->setKeystrokeCallback(boost::bind(&LLPanelProfilePick::onPickChanged, this, _1), NULL);
     mPickName->setEnabled(false);
@@ -759,6 +765,32 @@ bool LLPanelProfilePick::isDirty() const
     return false;
 }
 
+void LLPanelProfilePick::onClickSetLocation()
+{
+    // Save location for later use.
+    setPosGlobal(gAgent.getPositionGlobal());
+
+    std::string parcel_name, region_name;
+
+    LLParcel* parcel = LLViewerParcelMgr::getInstance()->getAgentParcel();
+    if (parcel)
+    {
+        mParcelId = parcel->getID();
+        parcel_name = parcel->getName();
+    }
+
+    LLViewerRegion* region = gAgent.getRegion();
+    if (region)
+    {
+        region_name = region->getName();
+    }
+
+    setPickLocation(createLocationText(getLocationNotice(), parcel_name, region_name, getPosGlobal()));
+
+    mLocationChanged = true;
+    enableSaveButton(true);
+}
+
 void LLPanelProfilePick::onClickSave()
 {
     if (mRegionCallbackConnection.connected())
@@ -768,6 +800,10 @@ void LLPanelProfilePick::onClickSave()
     if (mParcelCallbackConnection.connected())
     {
         mParcelCallbackConnection.disconnect();
+    }
+    if (mLocationChanged) 
+    {
+        onClickSetLocation();
     }
     sendUpdate();
 
@@ -814,6 +850,12 @@ void LLPanelProfilePick::processParcelInfo(const LLParcelData& parcel_data)
     {
         LLRemoteParcelInfoProcessor::getInstance()->removeObserver(mParcelId, this);
     }
+}
+
+void LLPanelProfilePick::addLocationChangedCallbacks()
+{
+    mRegionCallbackConnection = gAgent.addRegionChangedCallback([this]() { onClickSetLocation(); });
+    mParcelCallbackConnection = gAgent.addParcelChangedCallback([this]() { onClickSetLocation(); });
 }
 
 void LLPanelProfilePick::sendUpdate()

--- a/indra/newview/llpanelprofilepicks.h
+++ b/indra/newview/llpanelprofilepicks.h
@@ -138,6 +138,8 @@ public:
     void setParcelID(const LLUUID& parcel_id) override { mParcelId = parcel_id; }
     void setErrorStatus(S32 status, const std::string& reason) override {};
 
+    void addLocationChangedCallbacks();
+
   protected:
 
     /**
@@ -200,6 +202,11 @@ public:
     void resetDirty() override;
 
     /**
+     * Callback for "Set Location" button click
+     */
+    void onClickSetLocation();
+
+    /**
      * Callback for "Save" and "Create" button click
      */
     void onClickSave();
@@ -221,6 +228,7 @@ protected:
     LLTextureCtrl*      mSnapshotCtrl;
     LLLineEditor*       mPickName;
     LLTextEditor*       mPickDescription;
+    LLButton*           mSetCurrentLocationButton;
     LLButton*           mSaveButton;
     LLButton*           mCreateButton;
     LLButton*           mCancelButton;
@@ -236,7 +244,7 @@ protected:
 
     bool mLocationChanged;
     bool mNewPick;
-    bool                mIsEditing;
+    bool mIsEditing;
 
     void onDescriptionFocusReceived();
 };

--- a/indra/newview/skins/default/xui/en/panel_profile_pick.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_pick.xml
@@ -200,6 +200,26 @@
 
         <layout_panel
          follows="all"
+         layout="bottomleft"
+         left_pad="2"
+         name="set_to_curr_location_btn_lp"
+         auto_resize="false"
+         width="100">
+          <button
+           name="set_to_curr_location_btn"
+           label="Set Location"
+           tool_tip="Set to Current Location"
+           left="0"
+           top="0"
+           height="23"
+           width="100"
+           follows="left|top"
+           layout="topleft"
+          />
+        </layout_panel>
+
+        <layout_panel
+         follows="all"
          layout="topleft"
          name="util_resizer_right"
          auto_resize="true"


### PR DESCRIPTION
Here, have a quick fix for #2614 : Restore functionality to update the location of an existing pick by returning the original code that was removed in a2d75995d17c596ca57d9c9a092cbf45d335d90c because the button went missing.