### PR TITLE
Restore currently entered text in chat entry textbox after going through history with Ctrl-PgUp/PgDown

### DIFF
--- a/indra/llui/llchatentry.cpp
+++ b/indra/llui/llchatentry.cpp
@@ -45,7 +45,8 @@ LLChatEntry::LLChatEntry(const Params& p)
     mExpandLinesCount(p.expand_lines_count),
     mPrevLinesCount(0),
     mSingleLineMode(false),
-    mPrevExpandedLineCount(S32_MAX)
+    mPrevExpandedLineCount(S32_MAX),
+    mCurrentInput("")
 {
     // Initialize current history line iterator
     mCurrentHistoryLine = mLineHistory.begin();
@@ -189,6 +190,7 @@ bool LLChatEntry::handleSpecialKey(const KEY key, const MASK mask)
         {
             needsReflow();
         }
+        mCurrentInput = "";
         break;
 
     case KEY_UP:
@@ -196,6 +198,11 @@ bool LLChatEntry::handleSpecialKey(const KEY key, const MASK mask)
         {
             if (!mLineHistory.empty() && mCurrentHistoryLine > mLineHistory.begin())
             {
+                if (mCurrentHistoryLine == mLineHistory.end())
+                {
+                    mCurrentInput = getText();
+                }
+
                 setText(*(--mCurrentHistoryLine));
                 endOfDoc();
             }
@@ -210,16 +217,15 @@ bool LLChatEntry::handleSpecialKey(const KEY key, const MASK mask)
     case KEY_DOWN:
         if (mHasHistory && MASK_CONTROL == mask)
         {
-            if (!mLineHistory.empty() && mCurrentHistoryLine < (mLineHistory.end() - 1) )
+            if (!mLineHistory.empty() && mCurrentHistoryLine < (mLineHistory.end() - 1))
             {
                 setText(*(++mCurrentHistoryLine));
                 endOfDoc();
             }
-            else if (!mLineHistory.empty() && mCurrentHistoryLine == (mLineHistory.end() - 1) )
+            else if (!mLineHistory.empty() && mCurrentHistoryLine == (mLineHistory.end() - 1))
             {
                 mCurrentHistoryLine++;
-                std::string empty("");
-                setText(empty);
+                setText(mCurrentInput);
                 needsReflow();
                 endOfDoc();
             }

--- a/indra/llui/llchatentry.h
+++ b/indra/llui/llchatentry.h
@@ -101,6 +101,8 @@ private:
     S32                                 mExpandLinesCount;
     S32                                 mPrevLinesCount;
     S32                                 mPrevExpandedLineCount;
+
+    std::string                         mCurrentInput;
 };
 
 #endif /* LLCHATENTRY_H_ */


### PR DESCRIPTION
This changes a rather inconvenient annoyance in the chat entry textbox. Say you entered several messages and started typing a new message into the chat entry textbox, you then decide to scroll through the history with Ctrl-PgUp/PgDown and then return to the actual input, everything you entered is gone and you have to enter it again. This change will restore the current input from before scrolling through the history.

Sounds complicated, therefor I made videos showing the difference.

Old behavior: https://gyazo.com/f6222fb2ec2a2885e000f8f5f7f71286
New behavior: https://gyazo.com/2069706990534b771e859573f8bb7840