### PR TITLE
Fix various issues with snapshot upload fee calculation

### DIFF
--- a/indra/newview/llpanelsnapshot.cpp
+++ b/indra/newview/llpanelsnapshot.cpp
@@ -37,6 +37,7 @@
 
 // newview
 #include "llsidetraypanelcontainer.h"
+#include "llsnapshotlivepreview.h"
 #include "llviewercontrol.h" // gSavedSettings
 
 #include "llagentbenefits.h"
@@ -98,6 +99,17 @@ void LLPanelSnapshot::onOpen(const LLSD& key)
     if (old_format != new_format)
     {
         getParentByType<LLFloater>()->notify(LLSD().with("image-format-change", true));
+    }
+
+    // If resolution is set to "Current Window", force a snapshot update
+    // each time a snapshot panel is opened to determine the correct
+    // image size (and upload fee) depending on the snapshot type.
+    if (mSnapshotFloater && getChild<LLUICtrl>(getImageSizeComboName())->getValue().asString() == "[i0,i0]")
+    {
+        if (LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView())
+        {
+            preview->mForceUpdateSnapshot = true;
+        }
     }
 }
 

--- a/indra/newview/llpanelsnapshotinventory.cpp
+++ b/indra/newview/llpanelsnapshotinventory.cpp
@@ -42,77 +42,33 @@
 /**
  * The panel provides UI for saving snapshot as an inventory texture.
  */
-class LLPanelSnapshotInventoryBase
-    : public LLPanelSnapshot
-{
-    LOG_CLASS(LLPanelSnapshotInventoryBase);
-
-public:
-    LLPanelSnapshotInventoryBase();
-
-    /*virtual*/ bool postBuild();
-protected:
-    void onSend();
-    /*virtual*/ LLSnapshotModel::ESnapshotType getSnapshotType();
-};
-
 class LLPanelSnapshotInventory
-    : public LLPanelSnapshotInventoryBase
+    : public LLPanelSnapshot
 {
     LOG_CLASS(LLPanelSnapshotInventory);
 
 public:
     LLPanelSnapshotInventory();
-    /*virtual*/ bool postBuild();
-    /*virtual*/ void onOpen(const LLSD& key);
+    bool postBuild() override;
+    void onOpen(const LLSD& key) override;
 
     void onResolutionCommit(LLUICtrl* ctrl);
 
 private:
-    /*virtual*/ std::string getWidthSpinnerName() const     { return "inventory_snapshot_width"; }
-    /*virtual*/ std::string getHeightSpinnerName() const    { return "inventory_snapshot_height"; }
-    /*virtual*/ std::string getAspectRatioCBName() const    { return "inventory_keep_aspect_check"; }
-    /*virtual*/ std::string getImageSizeComboName() const   { return "texture_size_combo"; }
-    /*virtual*/ std::string getImageSizePanelName() const   { return LLStringUtil::null; }
-    /*virtual*/ void updateControls(const LLSD& info);
+    std::string getWidthSpinnerName() const override   { return "inventory_snapshot_width"; }
+    std::string getHeightSpinnerName() const override  { return "inventory_snapshot_height"; }
+    std::string getAspectRatioCBName() const override  { return "inventory_keep_aspect_check"; }
+    std::string getImageSizeComboName() const override { return "texture_size_combo"; }
+    std::string getImageSizePanelName() const override { return LLStringUtil::null; }
+    LLSnapshotModel::ESnapshotType getSnapshotType() override;
+    void updateControls(const LLSD& info) override;
 
-};
-
-class LLPanelOutfitSnapshotInventory
-    : public LLPanelSnapshotInventoryBase
-{
-    LOG_CLASS(LLPanelOutfitSnapshotInventory);
-
-public:
-    LLPanelOutfitSnapshotInventory();
-        /*virtual*/ bool postBuild();
-        /*virtual*/ void onOpen(const LLSD& key);
-
-private:
-    /*virtual*/ std::string getWidthSpinnerName() const     { return ""; }
-    /*virtual*/ std::string getHeightSpinnerName() const    { return ""; }
-    /*virtual*/ std::string getAspectRatioCBName() const    { return ""; }
-    /*virtual*/ std::string getImageSizeComboName() const   { return "texture_size_combo"; }
-    /*virtual*/ std::string getImageSizePanelName() const   { return LLStringUtil::null; }
-    /*virtual*/ void updateControls(const LLSD& info);
-
-    /*virtual*/ void cancel();
+    void onSend();
 };
 
 static LLPanelInjector<LLPanelSnapshotInventory> panel_class1("llpanelsnapshotinventory");
 
-static LLPanelInjector<LLPanelOutfitSnapshotInventory> panel_class2("llpaneloutfitsnapshotinventory");
-
-LLPanelSnapshotInventoryBase::LLPanelSnapshotInventoryBase()
-{
-}
-
-bool LLPanelSnapshotInventoryBase::postBuild()
-{
-    return LLPanelSnapshot::postBuild();
-}
-
-LLSnapshotModel::ESnapshotType LLPanelSnapshotInventoryBase::getSnapshotType()
+LLSnapshotModel::ESnapshotType LLPanelSnapshotInventory::getSnapshotType()
 {
     return LLSnapshotModel::SNAPSHOT_TEXTURE;
 }
@@ -130,7 +86,7 @@ bool LLPanelSnapshotInventory::postBuild()
     getChild<LLSpinCtrl>(getHeightSpinnerName())->setAllowEdit(false);
 
     getChild<LLUICtrl>(getImageSizeComboName())->setCommitCallback(boost::bind(&LLPanelSnapshotInventory::onResolutionCommit, this, _1));
-    return LLPanelSnapshotInventoryBase::postBuild();
+    return LLPanelSnapshot::postBuild();
 }
 
 // virtual
@@ -153,7 +109,7 @@ void LLPanelSnapshotInventory::onResolutionCommit(LLUICtrl* ctrl)
     getChild<LLSpinCtrl>(getHeightSpinnerName())->setVisible(!current_window_selected);
 }
 
-void LLPanelSnapshotInventoryBase::onSend()
+void LLPanelSnapshotInventory::onSend()
 {
     S32 w = 0;
     S32 h = 0;
@@ -185,39 +141,5 @@ void LLPanelSnapshotInventoryBase::onSend()
         {
             mSnapshotFloater->inventorySaveFailed();
         }
-    }
-}
-
-LLPanelOutfitSnapshotInventory::LLPanelOutfitSnapshotInventory()
-{
-    mCommitCallbackRegistrar.add("Inventory.SaveOutfitPhoto", { boost::bind(&LLPanelOutfitSnapshotInventory::onSend, this), cb_info::UNTRUSTED_BLOCK });
-    mCommitCallbackRegistrar.add("Inventory.SaveOutfitCancel", { boost::bind(&LLPanelOutfitSnapshotInventory::cancel, this), cb_info::UNTRUSTED_BLOCK });
-}
-
-// virtual
-bool LLPanelOutfitSnapshotInventory::postBuild()
-{
-    return LLPanelSnapshotInventoryBase::postBuild();
-}
-
-// virtual
-void LLPanelOutfitSnapshotInventory::onOpen(const LLSD& key)
-{
-    getChild<LLUICtrl>("hint_lbl")->setTextArg("[UPLOAD_COST]", llformat("%d", LLAgentBenefitsMgr::current().getTextureUploadCost()));
-    LLPanelSnapshot::onOpen(key);
-}
-
-// virtual
-void LLPanelOutfitSnapshotInventory::updateControls(const LLSD& info)
-{
-    const bool have_snapshot = info.has("have-snapshot") ? info["have-snapshot"].asBoolean() : true;
-    getChild<LLUICtrl>("save_btn")->setEnabled(have_snapshot);
-}
-
-void LLPanelOutfitSnapshotInventory::cancel()
-{
-    if (mSnapshotFloater)
-    {
-        mSnapshotFloater->closeFloater();
     }
 }

--- a/indra/newview/llpanelsnapshotlocal.cpp
+++ b/indra/newview/llpanelsnapshotlocal.cpp
@@ -47,18 +47,18 @@ class LLPanelSnapshotLocal
 
 public:
     LLPanelSnapshotLocal();
-    /*virtual*/ bool postBuild();
-    /*virtual*/ void onOpen(const LLSD& key);
+    bool postBuild() override;
+    void onOpen(const LLSD& key) override;
 
 private:
-    /*virtual*/ std::string getWidthSpinnerName() const     { return "local_snapshot_width"; }
-    /*virtual*/ std::string getHeightSpinnerName() const    { return "local_snapshot_height"; }
-    /*virtual*/ std::string getAspectRatioCBName() const    { return "local_keep_aspect_check"; }
-    /*virtual*/ std::string getImageSizeComboName() const   { return "local_size_combo"; }
-    /*virtual*/ std::string getImageSizePanelName() const   { return "local_image_size_lp"; }
-    /*virtual*/ LLSnapshotModel::ESnapshotFormat getImageFormat() const;
-    /*virtual*/ LLSnapshotModel::ESnapshotType getSnapshotType();
-    /*virtual*/ void updateControls(const LLSD& info);
+    std::string getWidthSpinnerName() const  override  { return "local_snapshot_width"; }
+    std::string getHeightSpinnerName() const override  { return "local_snapshot_height"; }
+    std::string getAspectRatioCBName() const override  { return "local_keep_aspect_check"; }
+    std::string getImageSizeComboName() const override { return "local_size_combo"; }
+    std::string getImageSizePanelName() const override { return "local_image_size_lp"; }
+    LLSnapshotModel::ESnapshotFormat getImageFormat() const override;
+    LLSnapshotModel::ESnapshotType getSnapshotType() override;
+    void updateControls(const LLSD& info) override;
 
     S32 mLocalFormat;
 

--- a/indra/newview/llpanelsnapshotoptions.cpp
+++ b/indra/newview/llpanelsnapshotoptions.cpp
@@ -30,11 +30,7 @@
 #include "llsidetraypanelcontainer.h"
 
 #include "llfloatersnapshot.h" // FIXME: create a snapshot model
-#include "llsnapshotlivepreview.h"
 #include "llfloaterreg.h"
-
-#include "llagentbenefits.h"
-
 
 /**
  * Provides several ways to save a snapshot.
@@ -46,12 +42,9 @@ class LLPanelSnapshotOptions
 
 public:
     LLPanelSnapshotOptions();
-    ~LLPanelSnapshotOptions();
     bool postBuild() override;
-    void onOpen(const LLSD& key) override;
 
 private:
-    void updateUploadCost();
     void openPanel(const std::string& panel_name);
     void onSaveToProfile();
     void onSaveToEmail();
@@ -71,39 +64,11 @@ LLPanelSnapshotOptions::LLPanelSnapshotOptions()
     mCommitCallbackRegistrar.add("Snapshot.SaveToComputer",     { boost::bind(&LLPanelSnapshotOptions::onSaveToComputer,  this) });
 }
 
-LLPanelSnapshotOptions::~LLPanelSnapshotOptions()
-{
-}
-
 // virtual
 bool LLPanelSnapshotOptions::postBuild()
 {
     mSnapshotFloater = getParentByType<LLFloaterSnapshotBase>();
     return LLPanel::postBuild();
-}
-
-// virtual
-void LLPanelSnapshotOptions::onOpen(const LLSD& key)
-{
-    updateUploadCost();
-}
-
-void LLPanelSnapshotOptions::updateUploadCost()
-{
-    S32 w = 0;
-    S32 h = 0;
-
-    if( mSnapshotFloater )
-    {
-        LLSnapshotLivePreview* preview = mSnapshotFloater->getPreviewView();
-        if( preview )
-        {
-            preview->getSize(w, h);
-        }
-    }
-
-    S32 upload_cost = LLAgentBenefitsMgr::current().getTextureUploadCost(w, h);
-    getChild<LLUICtrl>("save_to_inventory_btn")->setLabelArg("[AMOUNT]", llformat("%d", upload_cost));
 }
 
 void LLPanelSnapshotOptions::openPanel(const std::string& panel_name)

--- a/indra/newview/llpanelsnapshotoptions.cpp
+++ b/indra/newview/llpanelsnapshotoptions.cpp
@@ -47,8 +47,8 @@ class LLPanelSnapshotOptions
 public:
     LLPanelSnapshotOptions();
     ~LLPanelSnapshotOptions();
-    /*virtual*/ bool postBuild();
-    /*virtual*/ void onOpen(const LLSD& key);
+    bool postBuild() override;
+    void onOpen(const LLSD& key) override;
 
 private:
     void updateUploadCost();

--- a/indra/newview/llpanelsnapshotpostcard.cpp
+++ b/indra/newview/llpanelsnapshotpostcard.cpp
@@ -56,18 +56,18 @@ class LLPanelSnapshotPostcard
 
 public:
     LLPanelSnapshotPostcard();
-    /*virtual*/ bool postBuild();
-    /*virtual*/ void onOpen(const LLSD& key);
+    bool postBuild() override;
+    void onOpen(const LLSD& key) override;
 
 private:
-    /*virtual*/ std::string getWidthSpinnerName() const     { return "postcard_snapshot_width"; }
-    /*virtual*/ std::string getHeightSpinnerName() const    { return "postcard_snapshot_height"; }
-    /*virtual*/ std::string getAspectRatioCBName() const    { return "postcard_keep_aspect_check"; }
-    /*virtual*/ std::string getImageSizeComboName() const   { return "postcard_size_combo"; }
-    /*virtual*/ std::string getImageSizePanelName() const   { return "postcard_image_size_lp"; }
-    /*virtual*/ LLSnapshotModel::ESnapshotFormat getImageFormat() const { return LLSnapshotModel::SNAPSHOT_FORMAT_JPEG; }
-    /*virtual*/ LLSnapshotModel::ESnapshotType getSnapshotType();
-    /*virtual*/ void updateControls(const LLSD& info);
+    std::string getWidthSpinnerName() const override   { return "postcard_snapshot_width"; }
+    std::string getHeightSpinnerName() const override  { return "postcard_snapshot_height"; }
+    std::string getAspectRatioCBName() const override  { return "postcard_keep_aspect_check"; }
+    std::string getImageSizeComboName() const override { return "postcard_size_combo"; }
+    std::string getImageSizePanelName() const override { return "postcard_image_size_lp"; }
+    LLSnapshotModel::ESnapshotFormat getImageFormat() const override { return LLSnapshotModel::SNAPSHOT_FORMAT_JPEG; }
+    LLSnapshotModel::ESnapshotType getSnapshotType() override;
+    void updateControls(const LLSD& info) override;
 
     bool missingSubjMsgAlertCallback(const LLSD& notification, const LLSD& response);
     static void sendPostcardFinished(LLSD result);

--- a/indra/newview/llpanelsnapshotprofile.cpp
+++ b/indra/newview/llpanelsnapshotprofile.cpp
@@ -49,17 +49,17 @@ class LLPanelSnapshotProfile
 public:
     LLPanelSnapshotProfile();
 
-    /*virtual*/ bool postBuild();
-    /*virtual*/ void onOpen(const LLSD& key);
+    bool postBuild() override;
+    void onOpen(const LLSD& key) override;
 
 private:
-    /*virtual*/ std::string getWidthSpinnerName() const     { return "profile_snapshot_width"; }
-    /*virtual*/ std::string getHeightSpinnerName() const    { return "profile_snapshot_height"; }
-    /*virtual*/ std::string getAspectRatioCBName() const    { return "profile_keep_aspect_check"; }
-    /*virtual*/ std::string getImageSizeComboName() const   { return "profile_size_combo"; }
-    /*virtual*/ std::string getImageSizePanelName() const   { return "profile_image_size_lp"; }
-    /*virtual*/ LLSnapshotModel::ESnapshotFormat getImageFormat() const { return LLSnapshotModel::SNAPSHOT_FORMAT_PNG; }
-    /*virtual*/ void updateControls(const LLSD& info);
+    std::string getWidthSpinnerName() const override   { return "profile_snapshot_width"; }
+    std::string getHeightSpinnerName() const override  { return "profile_snapshot_height"; }
+    std::string getAspectRatioCBName() const override  { return "profile_keep_aspect_check"; }
+    std::string getImageSizeComboName() const override { return "profile_size_combo"; }
+    std::string getImageSizePanelName() const override { return "profile_image_size_lp"; }
+    LLSnapshotModel::ESnapshotFormat getImageFormat() const override { return LLSnapshotModel::SNAPSHOT_FORMAT_PNG; }
+    void updateControls(const LLSD& info) override;
 
     void onSend();
 };

--- a/indra/newview/skins/default/xui/de/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/de/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		<combo_box.item label="Klein (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Mittel (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Groß (512x512)" name="Large(512x512)"/>
-		<combo_box.item label="Aktuelles Fenster (512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Aktuelles Fenster" name="CurrentWindow"/>
 		<combo_box.item label="Benutzerdefiniert" name="Custom"/>
 	</combo_box>
 	<spinner label="Breite x Höhe" name="inventory_snapshot_width"/>

--- a/indra/newview/skins/default/xui/de/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/de/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Auf Datenträger speichern" name="save_to_computer_btn"/>
-	<button label="In Inventar speichern ([AMOUNT] L$)" name="save_to_inventory_btn"/>
+	<button label="In Inventar speichern" name="save_to_inventory_btn"/>
 	<button label="Im Profil-Feed teilen" name="save_to_profile_btn"/>
 	<button label="Auf Facebook teilen" name="send_to_facebook_btn"/>
 	<button label="Auf Twitter teilen" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
@@ -60,7 +60,7 @@
          name="Large(512x512)"
          value="[i512,i512]" />
         <combo_box.item
-         label="Current Window(512x512)"
+         label="Current Window"
          name="CurrentWindow"
          value="[i0,i0]" />
         <combo_box.item
@@ -119,6 +119,8 @@
      type="string"
      word_wrap="true">
         To save your image as a texture select one of the square formats.
+
+Upload cost: L$[UPLOAD_COST]
     </text>
     <button
      follows="right|bottom"

--- a/indra/newview/skins/default/xui/en/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/en/panel_snapshot_options.xml
@@ -31,7 +31,7 @@
    image_overlay_alignment="left"
    image_top_pad="-1"
    imgoverlay_label_space="10"
-   label="Save to Inventory (L$[AMOUNT])"
+   label="Save to Inventory"
    layout="topleft"
    left_delta="0"
    name="save_to_inventory_btn"

--- a/indra/newview/skins/default/xui/es/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/es/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		Guardar una imagen en el inventario cuesta [UPLOAD_COST] L$. Para guardar una imagen como una textura, selecciona uno de los formatos cuadrados.
 	</text>
 	<combo_box label="Resolución" name="texture_size_combo">
-		<combo_box.item label="Ventana actual (512 × 512)" name="CurrentWindow"/>
+		<combo_box.item label="Ventana actual" name="CurrentWindow"/>
 		<combo_box.item label="Pequeña (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Mediana (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Grande (512x512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/es/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/es/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Guardar en disco" name="save_to_computer_btn"/>
-	<button label="Guardar en inventario (L$[AMOUNT])" name="save_to_inventory_btn"/>
+	<button label="Guardar en inventario" name="save_to_inventory_btn"/>
 	<button label="Compartir en los comentarios de Mi perfil" name="save_to_profile_btn"/>
 	<button label="Compartir en Facebook" name="send_to_facebook_btn"/>
 	<button label="Compartir en Twitter" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/fr/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/fr/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		L&apos;enregistrement d&apos;une image dans l&apos;inventaire coûte [UPLOAD_COST] L$. Pour enregistrer votre image sous forme de texture, sélectionnez un format carré.
 	</text>
 	<combo_box label="Résolution" name="texture_size_combo">
-		<combo_box.item label="Fenêtre actuelle (512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Fenêtre actuelle" name="CurrentWindow"/>
 		<combo_box.item label="Petite (128 x 128)" name="Small(128x128)"/>
 		<combo_box.item label="Moyenne (256 x 256)" name="Medium(256x256)"/>
 		<combo_box.item label="Grande (512 x 512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/fr/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/fr/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Enreg. sur le disque" name="save_to_computer_btn"/>
-	<button label="Enreg. dans l&apos;inventaire ([AMOUNT] L$)" name="save_to_inventory_btn"/>
+	<button label="Enreg. dans l&apos;inventaire" name="save_to_inventory_btn"/>
 	<button label="Partager sur le flux de profil" name="save_to_profile_btn"/>
 	<button label="Partager sur Facebook" name="send_to_facebook_btn"/>
 	<button label="Partager sur Twitter" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/it/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/it/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		Salvare un&apos;immagine nell&apos;inventario costa L$[UPLOAD_COST]. Per salvare l&apos;immagine come texture, selezionare uno dei formati quadrati.
 	</text>
 	<combo_box label="Risoluzione" name="texture_size_combo">
-		<combo_box.item label="Finestra corrente (512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Finestra corrente" name="CurrentWindow"/>
 		<combo_box.item label="Piccola (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Media (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Grande (512x512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/it/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/it/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Salva sul disco" name="save_to_computer_btn"/>
-	<button label="Salva nell&apos;inventario (L$[AMOUNT])" name="save_to_inventory_btn"/>
+	<button label="Salva nell&apos;inventario" name="save_to_inventory_btn"/>
 	<button label="Condividi sul feed del profilo" name="save_to_profile_btn"/>
 	<button label="Condividi su Facebook" name="send_to_facebook_btn"/>
 	<button label="Condividi su Twitter" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/ja/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/ja/panel_snapshot_inventory.xml
@@ -6,7 +6,7 @@
 	</text>
 	<view_border name="hr"/>
 	<combo_box label="解像度" name="texture_size_combo">
-		<combo_box.item label="現在のウィンドウ (512✕512)" name="CurrentWindow"/>
+		<combo_box.item label="現在のウィンドウ" name="CurrentWindow"/>
 		<combo_box.item label="小（128✕128）" name="Small(128x128)"/>
 		<combo_box.item label="中（256✕256）" name="Medium(256x256)"/>
 		<combo_box.item label="大（512✕512）" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/ja/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/ja/panel_snapshot_inventory.xml
@@ -16,7 +16,7 @@
 	<spinner label="" name="inventory_snapshot_height"/>
 	<check_box label="縦横比の固定" name="inventory_keep_aspect_check"/>
 	<text name="hint_lbl">
-		画像をテクスチャとして保存する場合は、いずれかの正方形を選択してください。
+		画像をインベントリに保存するには L$[UPLOAD_COST] の費用がかかります。画像をテクスチャとして保存するには平方形式の 1 つを選択してください。
 	</text>
 	<button label="キャンセル" name="cancel_btn"/>
 	<button label="保存" name="save_btn"/>

--- a/indra/newview/skins/default/xui/ja/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/ja/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="ディスクに保存" name="save_to_computer_btn"/>
-	<button label="インベントリに保存（L$ [AMOUNT]）" name="save_to_inventory_btn"/>
+	<button label="インベントリに保存" name="save_to_inventory_btn"/>
 	<button label="プロフィールフィードで共有する" name="save_to_profile_btn"/>
 	<button label="メールで送信" name="save_to_email_btn"/>
 	<text name="fee_hint_lbl">

--- a/indra/newview/skins/default/xui/pl/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/pl/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <panel name="panel_snapshot_options">
 	<button label="Zapisz na dysku twardym" name="save_to_computer_btn" />
-	<button label="Zapisz do Szafy ([AMOUNT]L$)" name="save_to_inventory_btn" />
+	<button label="Zapisz do Szafy" name="save_to_inventory_btn" />
 	<button label="Wyślij na mój Kanał" name="save_to_profile_btn" />
 	<button label="Załaduj na Facebook" name="send_to_facebook_btn" />
 	<button label="Załaduj na Twitter" name="send_to_twitter_btn" />

--- a/indra/newview/skins/default/xui/pt/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/pt/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		Salvar uma imagem em seu inventário custa L$[UPLOAD_COST]. Para salvar sua imagem como uma textura, selecione um dos formatos quadrados.
 	</text>
 	<combo_box label="Resolução" name="texture_size_combo">
-		<combo_box.item label="Janela ativa (512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Janela ativa" name="CurrentWindow"/>
 		<combo_box.item label="Pequeno (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Médio (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Grande (512x512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/pt/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/pt/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Salvar no disco" name="save_to_computer_btn"/>
-	<button label="Salvar em inventário (L$[AMOUNT])" name="save_to_inventory_btn"/>
+	<button label="Salvar em inventário" name="save_to_inventory_btn"/>
 	<button label="Compartilhar no feed do perfil" name="save_to_profile_btn"/>
 	<button label="Compartilhar no Facebook" name="send_to_facebook_btn"/>
 	<button label="Compartilhar no Twitter" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/ru/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/ru/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		Сохранение изображения в инвентаре стоит L$[UPLOAD_COST]. Чтобы сохранить его как текстуру, выберите один из квадратных форматов.
 	</text>
 	<combo_box label="Размер" name="texture_size_combo">
-		<combo_box.item label="Текущее окно (512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Текущее окно" name="CurrentWindow"/>
 		<combo_box.item label="Маленький (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Средний (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Большой (512x512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/ru/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/ru/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Сохранить на диске" name="save_to_computer_btn"/>
-	<button label="Сохранить в инвентаре (L$[AMOUNT])" name="save_to_inventory_btn"/>
+	<button label="Сохранить в инвентаре" name="save_to_inventory_btn"/>
 	<button label="Поделиться в профиле" name="save_to_profile_btn"/>
 	<button label="Поделиться в Facebook" name="send_to_facebook_btn"/>
 	<button label="Поделиться в Twitter" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/tr/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/tr/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		Bir görüntüyü envanterinize kaydetmenin maliyeti L$[UPLOAD_COST] olur. Görüntünüzü bir doku olarak kaydetmek için kare formatlardan birini seçin.
 	</text>
 	<combo_box label="Çözünürlük" name="texture_size_combo">
-		<combo_box.item label="Mevcut Pencere(512x512)" name="CurrentWindow"/>
+		<combo_box.item label="Mevcut Pencere" name="CurrentWindow"/>
 		<combo_box.item label="Küçük (128x128)" name="Small(128x128)"/>
 		<combo_box.item label="Orta (256x256)" name="Medium(256x256)"/>
 		<combo_box.item label="Büyük (512x512)" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/tr/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/tr/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="Diske Kaydet" name="save_to_computer_btn"/>
-	<button label="Envantere Kaydet (L$[AMOUNT])" name="save_to_inventory_btn"/>
+	<button label="Envantere Kaydet" name="save_to_inventory_btn"/>
 	<button label="Profil Akışında Paylaş" name="save_to_profile_btn"/>
 	<button label="Facebook&apos;ta Paylaş" name="send_to_facebook_btn"/>
 	<button label="Twitter&apos;da Paylaş" name="send_to_twitter_btn"/>

--- a/indra/newview/skins/default/xui/zh/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/zh/panel_snapshot_inventory.xml
@@ -7,7 +7,7 @@
 		將圖像儲存到收納區的費用為 L$[UPLOAD_COST]。 若要將圖像存為材質，請選擇一個正方格式。
 	</text>
 	<combo_box label="解析度" name="texture_size_combo">
-		<combo_box.item label="目前視窗(512x512)" name="CurrentWindow"/>
+		<combo_box.item label="目前視窗" name="CurrentWindow"/>
 		<combo_box.item label="小（128x128）" name="Small(128x128)"/>
 		<combo_box.item label="中（256x256）" name="Medium(256x256)"/>
 		<combo_box.item label="大（512x512）" name="Large(512x512)"/>

--- a/indra/newview/skins/default/xui/zh/panel_snapshot_options.xml
+++ b/indra/newview/skins/default/xui/zh/panel_snapshot_options.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel name="panel_snapshot_options">
 	<button label="儲存到硬碟" name="save_to_computer_btn"/>
-	<button label="儲存到收納區（L$[AMOUNT]）" name="save_to_inventory_btn"/>
+	<button label="儲存到收納區" name="save_to_inventory_btn"/>
 	<button label="分享至檔案訊息發佈" name="save_to_profile_btn"/>
 	<button label="分享到臉書" name="send_to_facebook_btn"/>
 	<button label="分享到推特" name="send_to_twitter_btn"/>


### PR DESCRIPTION
* Removed orphaned LLPanelOutfitSnapshotInventory
* Calculation of upload in snapshot to inventory panel for insufficient funds was based on preview image size instead of encoded image size, resulting in upload fees of L$50 for textures <= 1024x1024 pixels
* Calculation on the options button had the same issue plus additionally was using referring to the previously used snapshot type which isn't necessarily the same as snapshot to inventory. Removed the upload fee from the button.
* Added back display of calculated upload fee on the snapshot to inventory panel itself. The fee is updated if the image size changes to always display the correct upload fee.