### PR TITLE
Clean up llpointer.h per previous discussions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,7 @@ jobs:
           continue-on-error: true
           configuration: ReleaseOS
     runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.continue-on-error }}
     outputs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,6 @@ jobs:
           continue-on-error: true
           configuration: ReleaseOS
     runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.continue-on-error }}
     outputs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
       viewer_version: ${{ steps.build.outputs.viewer_version }}
@@ -156,6 +155,7 @@ jobs:
         env:
           AUTOBUILD_VCS_BRANCH: ${{ steps.which-branch.outputs.branch }}
           RUNNER_OS: ${{ runner.os }}
+        continue-on-error: ${{ matrix.continue-on-error }}
         run: |
           # set up things the viewer's build.sh script expects
           set -x

--- a/indra/llappearance/lltexlayerparams.h
+++ b/indra/llappearance/lltexlayerparams.h
@@ -30,6 +30,7 @@
 #include "llpointer.h"
 #include "v4color.h"
 #include "llviewervisualparam.h"
+#include <atomic>
 
 class LLAvatarAppearance;
 class LLImageRaw;

--- a/indra/llcommon/CMakeLists.txt
+++ b/indra/llcommon/CMakeLists.txt
@@ -70,6 +70,7 @@ set(llcommon_SOURCE_FILES
     llmetrics.cpp
     llmortician.cpp
     llmutex.cpp
+    llpointer.cpp
     llpredicate.cpp
     llprocess.cpp
     llprocessor.cpp

--- a/indra/llcommon/llerror.h
+++ b/indra/llcommon/llerror.h
@@ -239,17 +239,12 @@ namespace LLError
 
         ~CallSite();
 
-#ifdef LL_LIBRARY_INCLUDE
-        bool shouldLog();
-#else // LL_LIBRARY_INCLUDE
         bool shouldLog()
         {
             return mCached
                     ? mShouldLog
                     : Log::shouldLog(*this);
         }
-            // this member function needs to be in-line for efficiency
-#endif // LL_LIBRARY_INCLUDE
 
         void invalidate();
 

--- a/indra/llcommon/llpointer.cpp
+++ b/indra/llcommon/llpointer.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file   llpointer.cpp
+ * @author Nat Goodspeed
+ * @date   2024-09-26
+ * @brief  Implementation for llpointer.
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Copyright (c) 2024, Linden Research, Inc.
+ * $/LicenseInfo$
+ */
+
+// Precompiled header
+#include "linden_common.h"
+// associated header
+#include "llpointer.h"
+// STL headers
+// std headers
+// external library headers
+// other Linden headers
+#include "llerror.h"
+
+void LLPointerBase::wild_dtor(std::string_view msg)
+{
+//  LL_WARNS() << msg << LL_ENDL;
+    llassert_msg(false, msg);
+}

--- a/indra/llcommon/llpointer.h
+++ b/indra/llcommon/llpointer.h
@@ -189,10 +189,6 @@ public:
     }
 
 protected:
-#ifdef LL_LIBRARY_INCLUDE
-    void ref();
-    void unref();
-#else
     void ref()
     {
         if (mPointer)
@@ -215,7 +211,6 @@ protected:
             }
         }
     }
-#endif // LL_LIBRARY_INCLUDE
 
 protected:
     Type*   mPointer;

--- a/indra/llcommon/owning_ptr.h
+++ b/indra/llcommon/owning_ptr.h
@@ -1,0 +1,71 @@
+/**
+ * @file   owning_ptr.h
+ * @author Nat Goodspeed
+ * @date   2024-09-27
+ * @brief  owning_ptr<T> is like std::unique_ptr<T>, but easier to integrate
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Copyright (c) 2024, Linden Research, Inc.
+ * $/LicenseInfo$
+ */
+
+#if ! defined(LL_OWNING_PTR_H)
+#define LL_OWNING_PTR_H
+
+#include <functional>
+#include <memory>
+
+/**
+ * owning_ptr<T> adapts std::unique_ptr<T> to make it easier to adopt into
+ * older code using dumb pointers.
+ *
+ * Consider a class Outer with a member Thing* mThing. After the constructor,
+ * each time a method wants to assign to mThing, it must test for nullptr and
+ * destroy the previous Thing instance. During Outer's lifetime, mThing is
+ * passed to legacy domain-specific functions accepting plain Thing*. Finally
+ * the destructor must again test for nullptr and destroy the remaining Thing
+ * instance.
+ *
+ * Multiply that by several different Outer members of different types,
+ * possibly with different domain-specific destructor functions.
+ *
+ * Dropping std::unique_ptr<Thing> into Outer is cumbersome for a several
+ * reasons. First, if Thing requires a domain-specific destructor function,
+ * the unique_ptr declaration of mThing must explicitly state the type of that
+ * function (as a function pointer, for a typical legacy function). Second,
+ * every Thing* assignment to mThing must be changed to mThing.reset(). Third,
+ * every time we call a legacy domain-specific function, we must pass
+ * mThing.get().
+ *
+ * owning_ptr<T> is designed to drop into a situation like this. The domain-
+ * specific destructor function, if any, is passed to its constructor; it need
+ * not be encoded into the pointer type. owning_ptr<T> supports plain pointer
+ * assignment, internally calling std::unique_ptr<T>::reset(). It also
+ * supports implicit conversion to plain T*, to pass the owned pointer to
+ * legacy domain-specific functions.
+ *
+ * Obviously owning_ptr<T> must not be used in situations where ownership of
+ * the referenced object is passed on to another pointer: use std::unique_ptr
+ * for that. Similarly, it is not for shared ownership. It simplifies lifetime
+ * management for classes that currently store (and explicitly destroy) plain
+ * T* pointers.
+ */
+template <typename T>
+class owning_ptr
+{
+    using deleter = std::function<void(T*)>;
+public:
+    owning_ptr(T* p=nullptr, const deleter& d=std::default_delete<T>()):
+        mPtr(p, d)
+    {}
+    void reset(T* p=nullptr) { mPtr.reset(p); }
+    owning_ptr& operator=(T* p) { mPtr.reset(p); return *this; }
+    operator T*() const { return mPtr.get(); }
+    T& operator*() const { return *mPtr; }
+    T* operator->() const { return mPtr.operator->(); }
+
+private:
+    std::unique_ptr<T, std::function<void(T*)>> mPtr;
+};
+
+#endif /* ! defined(LL_OWNING_PTR_H) */

--- a/indra/llcommon/owning_ptr.h
+++ b/indra/llcommon/owning_ptr.h
@@ -65,7 +65,7 @@ public:
     T* operator->() const { return mPtr.operator->(); }
 
 private:
-    std::unique_ptr<T, std::function<void(T*)>> mPtr;
+    std::unique_ptr<T, deleter> mPtr;
 };
 
 #endif /* ! defined(LL_OWNING_PTR_H) */

--- a/indra/llimage/llimage.h
+++ b/indra/llimage/llimage.h
@@ -27,10 +27,11 @@
 #ifndef LL_LLIMAGE_H
 #define LL_LLIMAGE_H
 
-#include "lluuid.h"
-#include "llstring.h"
+#include "llmutex.h"
 #include "llpointer.h"
+#include "llstring.h"
 #include "lltrace.h"
+#include "lluuid.h"
 
 constexpr S32 MIN_IMAGE_MIP =  2; // 4x4, only used for expand/contract power of 2
 constexpr S32 MAX_IMAGE_MIP = 12; // 4096x4096

--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -417,7 +417,7 @@ public:
             parameters.irreversible = 1;
         }
 
-        comment_text = { comment_text_in? comment_text_in : "no comment" };
+        comment_text.assign(comment_text_in? comment_text_in : "no comment");
 
         // Because comment_text is a member declared before parameters,
         // it will outlive parameters, so we can safely store in parameters a

--- a/indra/llmath/llvolumemgr.cpp
+++ b/indra/llmath/llvolumemgr.cpp
@@ -25,6 +25,7 @@
 
 #include "linden_common.h"
 
+#include "llmutex.h"
 #include "llvolumemgr.h"
 #include "llvolume.h"
 

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -94,6 +94,7 @@
 #include "llinitparam.h"
 #include "llinstancetracker.h"
 #include "llmortician.h"
+#include "llmutex.h"
 #include "llnotificationptr.h"
 #include "llpointer.h"
 #include "llrefcount.h"

--- a/indra/newview/llwatchdog.cpp
+++ b/indra/newview/llwatchdog.cpp
@@ -27,6 +27,7 @@
 
 #include "llviewerprecompiledheaders.h"
 #include "llwatchdog.h"
+#include "llmutex.h"
 #include "llthread.h"
 
 constexpr U32 WATCHDOG_SLEEP_TIME_USEC = 1000000U;


### PR DESCRIPTION
Migrate ~LLPointer()'s peculiar warning case to llpointer.cpp.
This allows removing #include "llerror.h" from llpointer.h.
Also remove #include "llmutex.h" as a heavy way to get
<boost/functional/hash.hpp>.

That requires adding #include "llmutex.h" to llimage.h, llnotifications.h,
llwatchdog.cpp and llvolumemgr.cpp, which were inheriting it from llpointer.h.

Also automate memory management in JPEG2KEncode and JPEG2KDecode.