### PR TITLE
Fix GLTF Load Crash

### DIFF
--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -1050,7 +1050,7 @@ void LLGLSLShader::bind()
 
     gGL.flush();
 
-    if (sCurBoundShader != mProgramObject)  // Don't re-bind current shader
+    if (this && sCurBoundShader != mProgramObject)  // Don't re-bind current shader
     {
         if (sCurBoundShaderPtr)
         {
@@ -1064,7 +1064,7 @@ void LLGLSLShader::bind()
         LLVertexBuffer::setupClientArrays(mAttributeMask);
     }
 
-    if (mUniformsDirty)
+    if (this && mUniformsDirty)
     {
         LLShaderMgr::instance()->updateShaderUniforms(this);
         mUniformsDirty = false;

--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -1050,7 +1050,7 @@ void LLGLSLShader::bind()
 
     gGL.flush();
 
-    if (this && sCurBoundShader != mProgramObject)  // Don't re-bind current shader
+    if (sCurBoundShader != mProgramObject)  // Don't re-bind current shader
     {
         if (sCurBoundShaderPtr)
         {
@@ -1064,7 +1064,7 @@ void LLGLSLShader::bind()
         LLVertexBuffer::setupClientArrays(mAttributeMask);
     }
 
-    if (this && mUniformsDirty)
+    if (mUniformsDirty)
     {
         LLShaderMgr::instance()->updateShaderUniforms(this);
         mUniformsDirty = false;

--- a/indra/newview/gltfscenemanager.cpp
+++ b/indra/newview/gltfscenemanager.cpp
@@ -655,14 +655,14 @@ void GLTFSceneManager::render(Asset& asset, U8 variant)
 
             if (!shader_bound)
             { // don't bind the shader until we know we have somthing to render
-                if (opaque)
-                {
-                    gGLTFPBRMetallicRoughnessProgram.bind(variant);
-                }
-                else
-                { // alpha shaders need all the shadow map setup etc
-                    gPipeline.bindDeferredShader(gGLTFPBRMetallicRoughnessProgram.mGLTFVariants[variant]);
-                }
+                //if (opaque)
+                //{
+                //    gGLTFPBRMetallicRoughnessProgram.bind(variant);
+                //}
+                //else
+                //{ // alpha shaders need all the shadow map setup etc
+                //    gPipeline.bindDeferredShader(gGLTFPBRMetallicRoughnessProgram.mGLTFVariants[variant]);
+                //}
 
                 if (!rigged)
                 {


### PR DESCRIPTION
For some reason, shader is null at some point in the Develop -> GLTF -> Load process, so this needs to be qualified to avoid assigning a nullptr to sCurBoundShaderPtr.

Probably a bad idea to allow this, anyway.