### PR TITLE
Linux: Remove APR from Linux-Symbolgrabber

### DIFF
--- a/indra/media_plugins/base/media_plugin_base.h
+++ b/indra/media_plugins/base/media_plugin_base.h
@@ -38,7 +38,7 @@ struct SymbolToGrab
 {
     bool mRequired;
     char const *mName;
-    apr_dso_handle_sym_t *mPPFunc;
+    void **mPPFunc;
 };
 
 class SymbolGrabber
@@ -52,8 +52,7 @@ private:
     std::vector< SymbolToGrab > gSymbolsToGrab;
 
     bool sSymsGrabbed = false;
-    apr_pool_t *sSymDSOMemoryPool = nullptr;
-    std::vector<apr_dso_handle_t *> sLoadedLibraries;
+    std::vector<void *> sLoadedLibraries;
 };
 
 extern SymbolGrabber gSymbolGrabber;
@@ -63,7 +62,7 @@ extern SymbolGrabber gSymbolGrabber;
 #define LL_GRAB_SYM(SYMBOL_GRABBER, REQUIRED, SYMBOL_NAME, RETURN, ...) \
     RETURN (*ll##SYMBOL_NAME)(__VA_ARGS__) = nullptr; \
     size_t gRegistered##SYMBOL_NAME = SYMBOL_GRABBER.registerSymbol( \
-        { REQUIRED, #SYMBOL_NAME , (apr_dso_handle_sym_t*)&ll##SYMBOL_NAME} \
+        { REQUIRED, #SYMBOL_NAME , (void**)&ll##SYMBOL_NAME} \
     );
 
 #endif


### PR DESCRIPTION
dlopen and dlsym are well…suited for and let us avoid the need to deal with the pecularities of APR.

This fixes a problem after the latest  updates of APR and WebRTC where APR sometimes would crash when trying to load the DSOs and resolve symbols (or sometimes even when creating the apr pool).

