### PR TITLE
Fix thread-unsafe usage of LLPointer and LLMeshSkinInfo

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -864,7 +864,7 @@ LLMeshRepoThread::~LLMeshRepoThread()
 
     while (!mSkinInfoQ.empty())
     {
-        delete mSkinInfoQ.front();
+        llassert(mSkinInfoQ.front()->getNumRefs() == 1);
         mSkinInfoQ.pop_front();
     }
 
@@ -2058,13 +2058,15 @@ bool LLMeshRepoThread::skinInfoReceived(const LLUUID& mesh_id, U8* data, S32 dat
             LLSkinningUtil::initJointNums(info, gAgentAvatarp);
         }
 
-        // remember the skin info in the background thread so we can use it
+        // copy the skin info for the background thread so we can use it
         // to calculate per-joint bounding boxes when volumes are loaded
-        mSkinMap[mesh_id] = info;
+        mSkinMap[mesh_id] = new LLMeshSkinInfo(*info);
 
         {
+            // Move the LLPointer in to the skin info queue to avoid reference
+            // count modification after we leave the lock
             LLMutexLock lock(mMutex);
-            mSkinInfoQ.push_back(info);
+            mSkinInfoQ.emplace_back(std::move(info));
         }
     }
 


### PR DESCRIPTION
Fixes the cross-thread usage of LLPointer<LLMeshSkinInfo> by creating a copy of the data and moving the LLPointer into callback queue while under lock.

This crash can occur during shutdown or at runtime when the mSkinMap is dead culled.

#2755 