### PR TITLE
Cmake configure speed up and MSVC redist copy fix

### DIFF
--- a/indra/cmake/Copy3rdPartyLibs.cmake
+++ b/indra/cmake/Copy3rdPartyLibs.cmake
@@ -106,7 +106,8 @@ if(WINDOWS)
         else(ADDRESS_SIZE EQUAL 32)
             set(redist_find_path "$ENV{VCTOOLSREDISTDIR}x64\\Microsoft.VC${MSVC_TOOLSET_VER}.CRT")
         endif(ADDRESS_SIZE EQUAL 32)
-        get_filename_component(redist_path "${redist_find_path}" ABSOLUTE)
+        get_filename_component(redist_path_component "${redist_find_path}" ABSOLUTE)
+        set(redist_path ${redist_path_component} CACHE INTERNAL "MSVC Redist Path" FORCE)
         MESSAGE(STATUS "VC Runtime redist path: ${redist_path}")
     endif (MSVC_TOOLSET_VER AND DEFINED ENV{VCTOOLSREDISTDIR})
 
@@ -132,12 +133,11 @@ if(WINDOWS)
             msvcp${MSVC_VER}_2.dll
             msvcp${MSVC_VER}_atomic_wait.dll
             msvcp${MSVC_VER}_codecvt_ids.dll
-            msvcr${MSVC_VER}.dll
             vcruntime${MSVC_VER}.dll
             vcruntime${MSVC_VER}_1.dll
             vcruntime${MSVC_VER}_threads.dll
             )
-        if(redist_path AND EXISTS "${redist_path}/${release_msvc_file}")
+        if(DEFINED redist_path AND EXISTS "${redist_path}/${release_msvc_file}")
             MESSAGE(STATUS "Copying redist file from ${redist_path}/${release_msvc_file}")
             to_staging_dirs(
                 ${redist_path}

--- a/indra/cmake/Prebuilt.cmake
+++ b/indra/cmake/Prebuilt.cmake
@@ -43,6 +43,8 @@ macro (use_prebuilt_binary _binary)
         message(STATUS "Installing ${_binary}...")
         execute_process(COMMAND "${AUTOBUILD_EXECUTABLE}"
                 install
+                -A${ADDRESS_SIZE}
+                --skip-source-environment
                 --install-dir=${AUTOBUILD_INSTALL_DIR}
                 ${_binary}
                 WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
* Fixes issues where incorrect MSVC redist would be found when cmake was rerun automatically by IDE
* Remove msvcr from the MSVC redist copy as it has been long replaced by vcruntime and no longer exists
* Speed up autobuild prebuilt installation by skipping the sourcing of the extended autobuild environment for each prebuilt
* Explicitly pass ADDRESS_SIZE to autobuild install to allow running cmake directly outside of the autobuild wrapper

This decreased configure time from 67 to 31 seconds on my machine.