### PR TITLE
Fix pink flash when window is resized

### DIFF
--- a/indra/llui/llflatlistview.h
+++ b/indra/llui/llflatlistview.h
@@ -126,7 +126,7 @@ public:
     /** Returns full rect of child panel */
     const LLRect& getItemsRect() const;
 
-    LLRect getRequiredRect() const { return getItemsRect(); }
+    LLRect getRequiredRect() { return getItemsRect(); }
 
     /** Returns distance between items */
     const S32 getItemsPad() const { return mItemPad; }

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -8342,7 +8342,9 @@ void LLPipeline::renderDeferredLighting()
             unbindDeferredShader(gDeferredBlurLightProgram);
         }
         screen_target->bindTarget();
-        screen_target->invalidate(GL_COLOR_BUFFER_BIT);
+        // clear color buffer here - zeroing alpha (glow) is important or it will accumulate against sky
+        glClearColor(0, 0, 0, 0);
+        screen_target->clear(GL_COLOR_BUFFER_BIT);
 
         if (RenderDeferredAtmospheric)
         {  // apply sunlight contribution


### PR DESCRIPTION
Fix a magenta flashing that appeared with 6ebd6494a75d9b3d34e45655d79d0027fbba3898 by restoring clearing of the deferred screen target