### PR TITLE
Reduce build time on all three platforms and introduce linux tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,6 +138,9 @@ jobs:
             libxcursor-dev libxfixes-dev libgstreamer1.0-dev \
             libgstreamer-plugins-base1.0-dev ninja-build libxft-dev \
             llvm mold libpipewire-0.3-dev libdbus-1-dev
+          sudo locale-gen en_US.UTF-8
+          sudo locale-gen en_GB.UTF-8
+          sudo locale-gen fr_FR.UTF-8
 
       - name: Install windows dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -267,13 +267,6 @@ jobs:
           fi
           export PYTHON_COMMAND_NATIVE="$(native_path "$PYTHON_COMMAND")"
 
-          # Compile with clang, link with mold on linux.
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            export CC=clang
-            export CXX=clang++
-            export CMAKE_OPTIONS='-DLINK_WITH_MOLD=ON'
-          fi
-
           ./build.sh
 
           # Each artifact is downloaded as a distinct .zip file. Multiple jobs

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -3147,14 +3147,15 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>build</key>
               <map>
                 <key>command</key>
-                <string>xcodebuild</string>
+                <string>cmake</string>
                 <key>options</key>
                 <array>
-                  <string>-configuration</string>
+                  <string>--build</string>
+                  <string>.</string>
+                  <string>--config</string>
                   <string>RelWithDebInfo</string>
-                  <string>-project</string>
-                  <string>SecondLife.xcodeproj</string>
-                  <string>-parallelizeTargets</string>
+                  <string>--parallel</string>
+                  <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
               <key>default</key>
@@ -3175,14 +3176,15 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>build</key>
               <map>
                 <key>command</key>
-                <string>xcodebuild</string>
+                <string>cmake</string>
                 <key>options</key>
                 <array>
-                  <string>-configuration</string>
+                  <string>--build</string>
+                  <string>.</string>
+                  <string>--config</string>
                   <string>RelWithDebInfo</string>
-                  <string>-project</string>
-                  <string>SecondLife.xcodeproj</string>
-                  <string>-parallelizeTargets</string>
+                  <string>--parallel</string>
+                  <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
               <key>name</key>
@@ -3205,14 +3207,15 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>build</key>
               <map>
                 <key>command</key>
-                <string>xcodebuild</string>
+                <string>cmake</string>
                 <key>options</key>
                 <array>
-                  <string>-configuration</string>
+                  <string>--build</string>
+                  <string>.</string>
+                  <string>--config</string>
                   <string>Release</string>
-                  <string>-project</string>
-                  <string>SecondLife.xcodeproj</string>
-                  <string>-parallelizeTargets</string>
+                  <string>--parallel</string>
+                  <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
               <key>name</key>
@@ -3231,14 +3234,15 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
               <key>build</key>
               <map>
                 <key>command</key>
-                <string>xcodebuild</string>
+                <string>cmake</string>
                 <key>options</key>
                 <array>
-                  <string>-configuration</string>
+                  <string>--build</string>
+                  <string>.</string>
+                  <string>--config</string>
                   <string>Release</string>
-                  <string>-project</string>
-                  <string>SecondLife.xcodeproj</string>
-                  <string>-parallelizeTargets</string>
+                  <string>--parallel</string>
+                  <string>$AUTOBUILD_CPU_COUNT</string>
                 </array>
               </map>
               <key>name</key>

--- a/build.sh
+++ b/build.sh
@@ -201,17 +201,9 @@ pre_build()
     # honor autobuild_configure_parameters same as sling-buildscripts
     eval_autobuild_configure_parameters=$(eval $(echo echo $autobuild_configure_parameters))
 
-    # We build the viewer on Linux, but we haven't committed to support the
-    # Linux viewer. As of 2024-05-30, Linux build-time test infrastructure is
-    # not in place, so don't even bother running tests on Linux.
-    if [[ "$RUNNER_OS" == "Linux" ]]
-    then LL_TESTS=OFF
-    else LL_TESTS=ON
-    fi
-
     "$autobuild" configure --quiet -c $variant \
      ${eval_autobuild_configure_parameters:---} \
-     -DLL_TESTS:BOOL=$LL_TESTS \
+     -DLL_TESTS:BOOL=ON \
      -DPACKAGE:BOOL=ON \
      -DHAVOK:BOOL="$HAVOK" \
      -DRELEASE_CRASH_REPORTING:BOOL="$RELEASE_CRASH_REPORTING" \

--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -35,7 +35,7 @@ add_compile_definitions(BOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # Force enable SSE2 instructions in GLM per the manual
 # https://github.com/g-truc/glm/blob/master/manual.md#section2_10
-add_compile_definitions(GLM_FORCE_DEFAULT_ALIGNED_GENTYPES=1 GLM_FORCE_SSE2=1)
+add_compile_definitions(GLM_FORCE_DEFAULT_ALIGNED_GENTYPES=1 GLM_FORCE_SSE2=1 GLM_ENABLE_EXPERIMENTAL=1)
 
 # Configure crash reporting
 set(RELEASE_CRASH_REPORTING OFF CACHE BOOL "Enable use of crash reporting in release builds")
@@ -47,6 +47,11 @@ endif()
 
 if(NON_RELEASE_CRASH_REPORTING)
   add_compile_definitions( LL_SEND_CRASH_REPORTS=1)
+endif()
+
+set(USE_LTO OFF CACHE BOOL "Enable Link Time Optimization")
+if(USE_LTO)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Don't bother with a MinSizeRel or Debug builds.
@@ -102,7 +107,7 @@ if (WINDOWS)
 
   #ND: When using something like buildcache (https://github.com/mbitsnbites/buildcache)
   # to make those wrappers work /Zi must be changed to /Z7, as /Zi due to it's nature is not compatible with caching
-  if( ${CMAKE_CXX_COMPILER_LAUNCHER} MATCHES ".*cache.*")
+  if(${CMAKE_CXX_COMPILER_LAUNCHER} MATCHES ".*cache.*")
     add_compile_options( /Z7 )
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")

--- a/indra/cmake/Copy3rdPartyLibs.cmake
+++ b/indra/cmake/Copy3rdPartyLibs.cmake
@@ -200,7 +200,6 @@ elseif(LINUX)
         libortp.so
         libvivoxoal.so.1
         libvivoxsdk.so
-        libSDL2.so
         )
     set(slvoice_files SLVoice)
 
@@ -214,7 +213,8 @@ elseif(LINUX)
     set(release_src_dir "${ARCH_PREBUILT_DIRS_RELEASE}")
     # *FIX - figure out what to do with duplicate libalut.so here -brad
     set(release_files
-       )
+        libSDL2-2.0.so.0
+        )
 
      if( USE_AUTOBUILD_3P )
          list( APPEND release_files

--- a/indra/llcorehttp/tests/llcorehttp_test.cpp
+++ b/indra/llcorehttp/tests/llcorehttp_test.cpp
@@ -41,13 +41,7 @@
 #include "test_httpstatus.hpp"
 #include "test_refcounted.hpp"
 #include "test_httpoperation.hpp"
-// As of 2019-06-28, test_httprequest.hpp consistently crashes on Mac Release
-// builds for reasons not yet diagnosed.
-// On Linux too, this is likely to badly handling (p)thread creation and not waiting
-// for threads to properly shutdown
-#if LL_WINDOWS
 #include "test_httprequest.hpp"
-#endif
 
 #include "test_httpheaders.hpp"
 #include "test_httprequestqueue.hpp"
@@ -55,9 +49,6 @@
 
 #include "llproxy.h"
 #include "llcleanup.h"
-
-void ssl_thread_id_callback(CRYPTO_THREADID*);
-void ssl_locking_callback(int mode, int type, const char * file, int line);
 
 #if 0   // lltut provides main and runner
 
@@ -83,26 +74,9 @@ int main()
 
 #endif // 0
 
-int ssl_mutex_count(0);
-LLCoreInt::HttpMutex ** ssl_mutex_list = NULL;
-
 void init_curl()
 {
     curl_global_init(CURL_GLOBAL_ALL);
-
-    ssl_mutex_count = CRYPTO_num_locks();
-    if (ssl_mutex_count > 0)
-    {
-        ssl_mutex_list = new LLCoreInt::HttpMutex * [ssl_mutex_count];
-
-        for (int i(0); i < ssl_mutex_count; ++i)
-        {
-            ssl_mutex_list[i] = new LLCoreInt::HttpMutex;
-        }
-
-        CRYPTO_set_locking_callback(ssl_locking_callback);
-        CRYPTO_THREADID_set_callback(ssl_thread_id_callback);
-    }
 
     LLProxy::getInstance();
 }
@@ -111,39 +85,6 @@ void init_curl()
 void term_curl()
 {
     SUBSYSTEM_CLEANUP(LLProxy);
-
-    CRYPTO_set_locking_callback(NULL);
-    for (int i(0); i < ssl_mutex_count; ++i)
-    {
-        delete ssl_mutex_list[i];
-    }
-    delete [] ssl_mutex_list;
-}
-
-
-void ssl_thread_id_callback(CRYPTO_THREADID* pthreadid)
-{
-#if defined(WIN32)
-    CRYPTO_THREADID_set_pointer(pthreadid, GetCurrentThread());
-#else
-    CRYPTO_THREADID_set_pointer(pthreadid, pthread_self());
-#endif
-}
-
-
-void ssl_locking_callback(int mode, int type, const char * /* file */, int /* line */)
-{
-    if (type >= 0 && type < ssl_mutex_count)
-    {
-        if (mode & CRYPTO_LOCK)
-        {
-            ssl_mutex_list[type]->lock();
-        }
-        else
-        {
-            ssl_mutex_list[type]->unlock();
-        }
-    }
 }
 
 

--- a/indra/llcorehttp/tests/test_httprequest.hpp
+++ b/indra/llcorehttp/tests/test_httprequest.hpp
@@ -454,6 +454,10 @@ void HttpRequestTestObjectType::test<4>()
 template <> template <>
 void HttpRequestTestObjectType::test<5>()
 {
+#ifndef LL_WINDOWS
+    skip("Skip due to issues with testing thread cancellation");
+#endif
+
     ScopedCurlInit ready;
 
     set_test_name("HttpRequest Spin (soft) + NoOp + hard termination");
@@ -517,6 +521,9 @@ void HttpRequestTestObjectType::test<5>()
 template <> template <>
 void HttpRequestTestObjectType::test<6>()
 {
+#ifndef LL_WINDOWS
+    skip("Skip due to issues with testing thread cancellation");
+#endif
     ScopedCurlInit ready;
 
     set_test_name("HttpRequest Spin + NoOp + hard termination");
@@ -2737,13 +2744,6 @@ void HttpRequestTestObjectType::test<22>()
 
     set_test_name("BUG-2295");
 
-#if LL_WINDOWS && ADDRESS_SIZE == 64
-    // teamcity win64 builds freeze on this test, if you figure out the cause, please fix it
-    if (getenv("TEAMCITY_PROJECT_NAME"))
-    {
-        skip("BUG-2295 - partial load on W64 causes freeze");
-    }
-#endif
     // Handler can be stack-allocated *if* there are no dangling
     // references to it after completion of this method.
     // Create before memory record as the string copy will bump numbers.
@@ -2779,7 +2779,7 @@ void HttpRequestTestObjectType::test<22>()
         for (int i(0); i < test_count; ++i)
         {
             char buffer[128];
-            sprintf(buffer, "/bug2295/%d/", i);
+            snprintf(buffer, sizeof(buffer), "/bug2295/%d/", i);
             HttpHandle handle = req->requestGetByteRange(HttpRequest::DEFAULT_POLICY_ID,
                                                          url_base + buffer,
                                                          0,
@@ -2810,7 +2810,7 @@ void HttpRequestTestObjectType::test<22>()
         for (int i(0); i < test2_count; ++i)
         {
             char buffer[128];
-            sprintf(buffer, "/bug2295/00000012/%d/", i);
+            snprintf(buffer, sizeof(buffer), "/bug2295/00000012/%d/", i);
             HttpHandle handle = req->requestGetByteRange(HttpRequest::DEFAULT_POLICY_ID,
                                                          url_base + buffer,
                                                          0,
@@ -2841,7 +2841,7 @@ void HttpRequestTestObjectType::test<22>()
         for (int i(0); i < test3_count; ++i)
         {
             char buffer[128];
-            sprintf(buffer, "/bug2295/inv_cont_range/%d/", i);
+            snprintf(buffer, sizeof(buffer), "/bug2295/inv_cont_range/%d/", i);
             HttpHandle handle = req->requestGetByteRange(HttpRequest::DEFAULT_POLICY_ID,
                                                          url_base + buffer,
                                                          0,
@@ -2916,14 +2916,6 @@ void HttpRequestTestObjectType::test<23>()
     ScopedCurlInit ready;
 
     set_test_name("HttpRequest GET 503s with 'Retry-After'");
-
-#if LL_WINDOWS && ADDRESS_SIZE == 64
-    // teamcity win64 builds freeze on this test, if you figure out the cause, please fix it
-    if (getenv("TEAMCITY_PROJECT_NAME"))
-    {
-        skip("llcorehttp 503-with-retry test hangs on Windows 64");
-    }
-#endif
 
     // This tests mainly that the code doesn't fall over if
     // various well- and mis-formed Retry-After headers are

--- a/indra/llcorehttp/tests/test_llcorehttp_peer.py
+++ b/indra/llcorehttp/tests/test_llcorehttp_peer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """\
-@file   test_llsdmessage_peer.py
+@file   test_llcorehttp_peer.py
 @author Nat Goodspeed
 @date   2008-10-09
 @brief  This script asynchronously runs the executable (with args) specified on

--- a/indra/llcorehttp/tests/test_refcounted.hpp
+++ b/indra/llcorehttp/tests/test_refcounted.hpp
@@ -28,8 +28,6 @@
 
 #include "_refcounted.h"
 
-// disable all of this because it's hanging win64 builds?
-#if ! (LL_WINDOWS && ADDRESS_SIZE == 64)
 using namespace LLCoreInt;
 
 namespace tut
@@ -122,5 +120,4 @@ namespace tut
         ensure(rc->getRefCount() == RefCounted::NOT_REF_COUNTED);
     }
 }
-#endif  // disabling on Win64
 #endif  // TEST_LLCOREINT_REF_COUNTED_H_

--- a/indra/llmath/llmatrix3a.cpp
+++ b/indra/llmath/llmatrix3a.cpp
@@ -24,6 +24,8 @@
  * $/LicenseInfo$
  */
 
+#include "linden_common.h"
+
 #include "llmath.h"
 
 static LL_ALIGN_16(const F32 M_IDENT_3A[12]) =

--- a/indra/llmath/llmatrix4a.cpp
+++ b/indra/llmath/llmatrix4a.cpp
@@ -24,6 +24,8 @@
 * $/LicenseInfo$
 */
 
+#include "linden_common.h"
+
 #include "llmath.h"
 #include "llmatrix4a.h"
 

--- a/indra/llmath/llrigginginfo.cpp
+++ b/indra/llmath/llrigginginfo.cpp
@@ -24,6 +24,8 @@
 * $/LicenseInfo$
 */
 
+#include "linden_common.h"
+
 #include "llmath.h"
 #include "llrigginginfo.h"
 

--- a/indra/llmath/llvector4a.cpp
+++ b/indra/llmath/llvector4a.cpp
@@ -24,6 +24,8 @@
  * $/LicenseInfo$
  */
 
+#include "linden_common.h"
+
 #include "llmemory.h"
 #include "llmath.h"
 #include "llquantize.h"

--- a/indra/llmath/llvolumeoctree.cpp
+++ b/indra/llmath/llvolumeoctree.cpp
@@ -24,6 +24,8 @@
  * $/LicenseInfo$
  */
 
+#include "linden_common.h"
+
 #include "llvolumeoctree.h"
 #include "llvector4a.h"
 

--- a/indra/llmath/v3colorutil.h
+++ b/indra/llmath/v3colorutil.h
@@ -28,6 +28,7 @@
 #define LL_V3COLORUTIL_H
 
 #include "v3color.h"
+#include "v4color.h"
 
 inline LLColor3 componentDiv(const LLColor3& left, const LLColor3& right)
 {

--- a/indra/llui/CMakeLists.txt
+++ b/indra/llui/CMakeLists.txt
@@ -283,10 +283,8 @@ if(LL_TESTS)
       )
   set_property( SOURCE ${llui_TEST_SOURCE_FILES} PROPERTY LL_TEST_ADDITIONAL_LIBRARIES ${test_libs})
   LL_ADD_PROJECT_UNIT_TESTS(llui "${llui_TEST_SOURCE_FILES}")
-  # INTEGRATION TESTS
 
-  if(NOT LINUX)
-      set(test_libs llui llmessage llcorehttp llxml llrender llcommon ll::hunspell ll::SDL2)
-    LL_ADD_INTEGRATION_TEST(llurlentry llurlentry.cpp "${test_libs}")
-  endif(NOT LINUX)
+  # INTEGRATION TESTS
+  set(test_libs llui llmessage llcorehttp llxml llrender llcommon ll::hunspell ll::SDL2)
+  LL_ADD_INTEGRATION_TEST(llurlentry llurlentry.cpp "${test_libs}")
 endif(LL_TESTS)

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -23,7 +23,7 @@
 * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
 * $/LicenseInfo$
 */
-#include "../newview/llviewerprecompiledheaders.h"
+#include "linden_common.h"
 
 #include "llflashtimer.h"
 

--- a/indra/llui/llui.h
+++ b/indra/llui/llui.h
@@ -31,8 +31,6 @@
 #include "llrect.h"
 #include "llcoord.h"
 #include "llcontrol.h"
-#include "llcoord.h"
-#include "llcontrol.h"
 #include "llinitparam.h"
 #include "llregistry.h"
 #include "llrender2dutils.h"

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1456,6 +1456,7 @@ if (DARWIN)
   set_source_files_properties(
     llappdelegate-objc.mm
     PROPERTIES
+    SKIP_PRECOMPILE_HEADERS TRUE
     COMPILE_DEFINITIONS "${VIEWER_CHANNEL_VERSION_DEFINES}"
     # BugsplatMac is a module, imported with @import. That language feature
     # demands these -f switches.

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1439,6 +1439,18 @@ if (DARWIN)
   LIST(APPEND viewer_SOURCE_FILES llfilepicker_mac.mm)
   LIST(APPEND viewer_HEADER_FILES llfilepicker_mac.h)
 
+  set_source_files_properties(
+    llappviewermacosx-objc.mm
+    PROPERTIES
+    SKIP_PRECOMPILE_HEADERS TRUE
+  )
+
+  set_source_files_properties(
+    llfilepicker_mac.mm
+    PROPERTIES
+    SKIP_PRECOMPILE_HEADERS TRUE
+  )
+
   # This should be compiled with the viewer.
   LIST(APPEND viewer_SOURCE_FILES llappdelegate-objc.mm)
   set_source_files_properties(
@@ -1734,6 +1746,10 @@ list(APPEND EVENT_HOST_SCRIPTS ${EVENT_HOST_SCRIPT_GLOB_LIST})
 set(PACKAGE ON CACHE BOOL
     "Add a package target that builds an installer package.")
 
+if(USE_PRECOMPILED_HEADERS)
+  target_precompile_headers( ${VIEWER_BINARY_NAME} PRIVATE llviewerprecompiledheaders.h )
+endif(USE_PRECOMPILED_HEADERS)
+
 if (WINDOWS)
     set_target_properties(${VIEWER_BINARY_NAME}
         PROPERTIES
@@ -1743,10 +1759,6 @@ if (WINDOWS)
         LINK_FLAGS_RELEASE "/FORCE:MULTIPLE /MAP\"secondlife-bin.MAP\" /OPT:REF /LARGEADDRESSAWARE"
         )
     target_compile_options(${VIEWER_BINARY_NAME} PRIVATE /bigobj)
-
-    if(USE_PRECOMPILED_HEADERS)
-       target_precompile_headers( ${VIEWER_BINARY_NAME} PRIVATE llviewerprecompiledheaders.h )
-    endif(USE_PRECOMPILED_HEADERS)
 
     # If adding a file to viewer_manifest.py in the WindowsManifest.construct() method, be sure to add the dependency
     # here.

--- a/indra/newview/gltf/common.h
+++ b/indra/newview/gltf/common.h
@@ -26,8 +26,6 @@
  * $/LicenseInfo$
  */
 
-#define GLM_ENABLE_EXPERIMENTAL 1
-
 #include "glm/vec2.hpp"
 #include "glm/vec3.hpp"
 #include "glm/vec4.hpp"

--- a/indra/newview/llinventoryitemslist.cpp
+++ b/indra/newview/llinventoryitemslist.cpp
@@ -99,7 +99,7 @@ void LLInventoryItemsList::updateSelection()
 
     for(std::vector<LLSD>::const_iterator cur_id_it = cur.begin(); cur_id_it != cur.end() && !mSelectTheseIDs.empty(); ++cur_id_it)
     {
-        uuid_vec_t::iterator select_ids_it = std::find(mSelectTheseIDs.begin(), mSelectTheseIDs.end(), *cur_id_it);
+        uuid_vec_t::iterator select_ids_it = std::find(mSelectTheseIDs.begin(), mSelectTheseIDs.end(), cur_id_it->asUUID());
         if(select_ids_it != mSelectTheseIDs.end())
         {
             selectItemByUUID(*select_ids_it);

--- a/indra/newview/llviewerprecompiledheaders.h
+++ b/indra/newview/llviewerprecompiledheaders.h
@@ -29,22 +29,28 @@
 #ifndef LL_LLVIEWERPRECOMPILEDHEADERS_H
 #define LL_LLVIEWERPRECOMPILEDHEADERS_H
 
-#include "llwin32headers.h"
-
 // This file MUST be the first one included by each .cpp file
 // in viewer.
 // It is used to precompile headers for improved build speed.
 
 #include "linden_common.h"
 
+#include "llwin32headers.h"
+
 #include <algorithm>
 #include <deque>
 #include <functional>
+#include <list>
 #include <map>
 #include <set>
 #include <vector>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 
 // Library headers from llcommon project:
+#include "apply.h"
+#include "function_types.h"
 #include "indra_constants.h"
 #include "llinitparam.h"
 #include "llapp.h"
@@ -54,8 +60,10 @@
 #include "llerror.h"
 #include "llfasttimer.h"
 #include "llframetimer.h"
+#include "llinstancetracker.h"
 #include "llpointer.h"
 #include "llprocessor.h"
+#include "llrand.h"
 #include "llrefcount.h"
 #include "llsafehandle.h"
 #include "llsd.h"
@@ -65,11 +73,13 @@
 #include "llstring.h"
 #include "llsys.h"
 #include "lltimer.h"
+#include "lluuid.h"
 #include "stdtypes.h"
 #include "u64.h"
 
 // Library includes from llmath project
 #include "llmath.h"
+#include "llbbox.h"
 #include "llbboxlocal.h"
 #include "llcamera.h"
 #include "llcoord.h"
@@ -77,9 +87,7 @@
 #include "llcrc.h"
 #include "llplane.h"
 #include "llquantize.h"
-#include "llrand.h"
 #include "llrect.h"
-#include "lluuid.h"
 #include "m3math.h"
 #include "m4math.h"
 #include "llquaternion.h"
@@ -91,11 +99,42 @@
 #include "v4coloru.h"
 #include "v4math.h"
 #include "xform.h"
+#include "llvector4a.h"
+#include "llmatrix4a.h"
+#include "lloctree.h"
+#include "llvolume.h"
 
+// Library includes from llfilesystem project
 #include "lldir.h"
 
 // Library includes from llmessage project
+#include "llassetstorage.h"
+#include "llavatarnamecache.h"
 #include "llcachename.h"
+#include "llcorehttputil.h"
 
+// Library includes from llrender project
+#include "llgl.h"
+#include "llrender.h"
+
+// Library includes from llrender project
+#include "llcharacter.h"
+
+// Library includes from llui project
+#include "llnotifications.h"
+#include "llpanel.h"
+#include "llfloater.h"
+
+#include <boost/function.hpp>
+#include <boost/signals2.hpp>
+#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/json.hpp>
+
+#include "glm/glm.hpp"
+#include "glm/gtc/type_ptr.hpp"
+#include "glm/ext/quaternion_float.hpp"
+#include "glm/gtx/quaternion.hpp"
+#include "glm/gtx/matrix_decompose.hpp"
 
 #endif

--- a/indra/test/lltut.h
+++ b/indra/test/lltut.h
@@ -128,7 +128,7 @@ namespace tut
 
     inline void ensure_memory_matches(const void* actual, U32 actual_len, const void* expected,U32 expected_len)
     {
-        ensure_memory_matches(NULL, actual, actual_len, expected, expected_len);
+        ensure_memory_matches("", actual, actual_len, expected, expected_len);
     }
 
     template <class T,class Q>


### PR DESCRIPTION
* Enable precompiled header for mac and linux builds
* Improves build times on platforms by tweaking the precompiled header(6-8 minutes off mac GHA)
* Fixes various tests disabled on non-windows platforms or otherwise(llcorehttp requests, llurlentry, llkdu)
* Fix test builds on linux and enable in GHA
* Changes Linux GHA builds to use GCC for better C++20 compat