### PR TITLE
Reduce MAX_AGENT_UPDATES_PER_SECOND

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3211,7 +3211,7 @@ void send_agent_update(bool force_send, bool send_reliable)
                         last_camera_at;
 
     // compute sec_since_last_send
-    constexpr F64 MAX_AGENT_UPDATES_PER_SECOND = 125.0; // Value derived experimentally to avoid Input Delays with latest PBR-Capable Viewers when viewer FPS is highly volatile.
+    constexpr F64 MAX_AGENT_UPDATES_PER_SECOND = 20.0; // Value derived experimentally to avoid Input Delays with latest PBR-Capable Viewers when viewer FPS is highly volatile.
     constexpr F64 MIN_AGENT_UPDATES_PER_SECOND = 1.0; // keep-alive rate
     constexpr F64 MIN_AGENT_UPDATE_PERIOD = 1.0 / MAX_AGENT_UPDATES_PER_SECOND;
     constexpr F64 MAX_AGENT_UPDATE_PERIOD = 1.0 / MIN_AGENT_UPDATES_PER_SECOND;

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3211,7 +3211,7 @@ void send_agent_update(bool force_send, bool send_reliable)
                         last_camera_at;
 
     // compute sec_since_last_send
-    constexpr F64 MAX_AGENT_UPDATES_PER_SECOND = 20.0; // Value derived experimentally to avoid Input Delays with latest PBR-Capable Viewers when viewer FPS is highly volatile.
+    constexpr F64 MAX_AGENT_UPDATES_PER_SECOND = 45.0; // Match server tick rate
     constexpr F64 MIN_AGENT_UPDATES_PER_SECOND = 1.0; // keep-alive rate
     constexpr F64 MIN_AGENT_UPDATE_PERIOD = 1.0 / MAX_AGENT_UPDATES_PER_SECOND;
     constexpr F64 MAX_AGENT_UPDATE_PERIOD = 1.0 / MIN_AGENT_UPDATES_PER_SECOND;


### PR DESCRIPTION
This number has historically been 10.

Back in June, Beq raised it to 125 in this commit https://github.com/secondlife/viewer/commit/2e836ab06f934038394b46e9c861312c0441b657.

Their commit to the Firestorm repository makes a reference to a 25 number that I assume is the sim's tick rate. https://github.com/FirestormViewer/phoenix-firestorm/commit/beea955388333103972609f2809c221156ced499

I believe this change lead to several networking issues, including the increase in avatar outfit issues reported by users as the change was rolled out in updates to the community.

Regardless of this being the case, this update rate is absurdly high. In popular fast-paced shooter games, 60 updates a second is typical and 120 in highly competitive environments. Meanwhile, more leisurely-paced gaming platforms like Roblox is 30 and Minecraft is 20.

Pinging stakeholders or those in past discussions on the issue: @beqjanus @vldevel