### PR TITLE
temporary workaround for #2870: disable SDL2 on mac

### DIFF
--- a/indra/llwindow/llgamecontrol.cpp
+++ b/indra/llwindow/llgamecontrol.cpp
@@ -1530,6 +1530,9 @@ void LLGameControl::init(const std::string& gamecontrollerdb_path,
     llassert(saveObject);
     llassert(updateUI);
 
+#ifndef LL_DARWIN
+    // SDL2 is temporarily disabled on Mac, so this needs to be a no-op on that platform
+
     int result = SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_SENSOR);
     if (result < 0)
     {
@@ -1555,6 +1558,7 @@ void LLGameControl::init(const std::string& gamecontrollerdb_path,
             LL_INFOS("SDL2") << "Total " << count << " mappings added from " << gamecontrollerdb_path << LL_ENDL;
         }
     }
+#endif // LL_DARWIN
 
     g_gameControl = LLGameControl::getInstance();
 
@@ -1614,6 +1618,9 @@ void LLGameControl::clearAllStates()
 // static
 void LLGameControl::processEvents(bool app_has_focus)
 {
+#ifndef LL_DARWIN
+    // SDL2 is temporarily disabled on Mac, so this needs to be a no-op on that platform
+
     // This method used by non-linux platforms which only use SDL for GameController input
     SDL_Event event;
     if (!app_has_focus)
@@ -1631,6 +1638,7 @@ void LLGameControl::processEvents(bool app_has_focus)
     {
         handleEvent(event, app_has_focus);
     }
+#endif // LL_DARWIN
 }
 
 void LLGameControl::handleEvent(const SDL_Event& event, bool app_has_focus)

--- a/indra/llwindow/llwindow.cpp
+++ b/indra/llwindow/llwindow.cpp
@@ -416,7 +416,11 @@ LLWindow* LLWindowManager::createWindow(
 
     if (use_gl)
     {
+#ifndef LL_DARWIN
+        // SDL2 is temporarily disabled on Mac
         init_sdl();
+#endif
+
 #if LL_WINDOWS
         new_window = new LLWindowWin32(callbacks,
             title, name, x, y, width, height, flags,


### PR DESCRIPTION
**SDL2** has a builtin pipeline that uses Cocoa’s NSTextInputClient protocol, and the input submitted during the `SDL_PollEvent()` call.  Meanwhile we have our own hookup to NSTextInputClient, hence the Mac viewer now gets two events for almost every keystroke.

The proper solution probably requires us to hack our SDL2 on Mac to remove the automatic text input of that library, however in the meantime we offer this **workaround**: disable SDL2 for DARWIN builds.  This means we won't have access to game controllers through SDL2, however that isn't necessarily terrible because AFAICT most game controllers don't work on the Mac operating system: only a small handful of game controllers are supported because "Apple knows best".