### PR TITLE
viewer#2741 Don't reallocate buffer all the time

### DIFF
--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -51,6 +51,7 @@ extern LL_COMMON_API bool on_main_thread();
 
 //----------------------------------------------------------------------------
 const F32 MIN_TEXTURE_LIFETIME = 10.f;
+const F32 CONVERSION_SCRATCH_BUFFER_GL_VERSION = 3.29f;
 
 //which power of 2 is i?
 //assumes i is a power of 2 > 0
@@ -160,6 +161,7 @@ S32 LLImageGL::sMaxCategories = 1 ;
 bool LLImageGL::sSkipAnalyzeAlpha;
 U32  LLImageGL::sScratchPBO = 0;
 U32  LLImageGL::sScratchPBOSize = 0;
+U32* LLImageGL::sManualScratch = nullptr;
 
 
 //------------------------
@@ -262,6 +264,22 @@ void LLImageGL::initClass(LLWindow* window, S32 num_catagories, bool skip_analyz
     }
 }
 
+void LLImageGL::allocateConversionBuffer()
+{
+    if (gGLManager.mGLVersion < CONVERSION_SCRATCH_BUFFER_GL_VERSION)
+    {
+        try
+        {
+            sManualScratch = new U32[MAX_IMAGE_AREA];
+        }
+        catch (std::bad_alloc&)
+        {
+            LLError::LLUserWarningMsg::showOutOfMemory();
+            LL_ERRS() << "Failed to allocate sManualScratch" << LL_ENDL;
+        }
+    }
+}
+
 //static
 void LLImageGL::cleanupClass()
 {
@@ -273,6 +291,8 @@ void LLImageGL::cleanupClass()
         sScratchPBO = 0;
         sScratchPBOSize = 0;
     }
+
+    delete[] sManualScratch;
 }
 
 
@@ -1287,11 +1307,10 @@ void LLImageGL::deleteTextures(S32 numTextures, const U32 *textures)
 void LLImageGL::setManualImage(U32 target, S32 miplevel, S32 intformat, S32 width, S32 height, U32 pixformat, U32 pixtype, const void* pixels, bool allow_compression)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
-    std::unique_ptr<U32[]> scratch;
     if (LLRender::sGLCoreProfile)
     {
         LL_PROFILE_ZONE_SCOPED_CATEGORY_TEXTURE;
-        if (gGLManager.mGLVersion >= 3.29f)
+        if (gGLManager.mGLVersion >= CONVERSION_SCRATCH_BUFFER_GL_VERSION)
         {
             if (pixformat == GL_ALPHA)
             { //GL_ALPHA is deprecated, convert to RGBA
@@ -1323,27 +1342,15 @@ void LLImageGL::setManualImage(U32 target, S32 miplevel, S32 intformat, S32 widt
             { //GL_ALPHA is deprecated, convert to RGBA
                 if (pixels != nullptr)
                 {
-                    try
-                    {
-                        scratch.reset(new U32[width * height]);
-                    }
-                    catch (std::bad_alloc)
-                    {
-                        LLError::LLUserWarningMsg::showOutOfMemory();
-                        LL_ERRS() << "Failed to allocate " << (U32)(width * height * sizeof(U32))
-                            << " bytes for a manual image W" << width << " H" << height
-                            << " Pixformat: GL_ALPHA, pixtype: GL_UNSIGNED_BYTE" << LL_ENDL;
-                    }
-
                     U32 pixel_count = (U32)(width * height);
                     for (U32 i = 0; i < pixel_count; i++)
                     {
-                        U8* pix = (U8*)&scratch[i];
+                        U8* pix = (U8*)&sManualScratch[i];
                         pix[0] = pix[1] = pix[2] = 0;
                         pix[3] = ((U8*)pixels)[i];
                     }
 
-                    pixels = scratch.get();
+                    pixels = sManualScratch;
                 }
 
                 pixformat = GL_RGBA;
@@ -1354,30 +1361,18 @@ void LLImageGL::setManualImage(U32 target, S32 miplevel, S32 intformat, S32 widt
             { //GL_LUMINANCE_ALPHA is deprecated, convert to RGBA
                 if (pixels != nullptr)
                 {
-                    try
-                    {
-                        scratch.reset(new U32[width * height]);
-                    }
-                    catch (std::bad_alloc)
-                    {
-                        LLError::LLUserWarningMsg::showOutOfMemory();
-                        LL_ERRS() << "Failed to allocate " << (U32)(width * height * sizeof(U32))
-                            << " bytes for a manual image W" << width << " H" << height
-                            << " Pixformat: GL_LUMINANCE_ALPHA, pixtype: GL_UNSIGNED_BYTE" << LL_ENDL;
-                    }
-
                     U32 pixel_count = (U32)(width * height);
                     for (U32 i = 0; i < pixel_count; i++)
                     {
                         U8 lum = ((U8*)pixels)[i * 2 + 0];
                         U8 alpha = ((U8*)pixels)[i * 2 + 1];
 
-                        U8* pix = (U8*)&scratch[i];
+                        U8* pix = (U8*)&sManualScratch[i];
                         pix[0] = pix[1] = pix[2] = lum;
                         pix[3] = alpha;
                     }
 
-                    pixels = scratch.get();
+                    pixels = sManualScratch;
                 }
 
                 pixformat = GL_RGBA;
@@ -1388,29 +1383,17 @@ void LLImageGL::setManualImage(U32 target, S32 miplevel, S32 intformat, S32 widt
             { //GL_LUMINANCE_ALPHA is deprecated, convert to RGB
                 if (pixels != nullptr)
                 {
-                    try
-                    {
-                        scratch.reset(new U32[width * height]);
-                    }
-                    catch (std::bad_alloc)
-                    {
-                        LLError::LLUserWarningMsg::showOutOfMemory();
-                        LL_ERRS() << "Failed to allocate " << (U32)(width * height * sizeof(U32))
-                            << " bytes for a manual image W" << width << " H" << height
-                            << " Pixformat: GL_LUMINANCE, pixtype: GL_UNSIGNED_BYTE" << LL_ENDL;
-                    }
-
                     U32 pixel_count = (U32)(width * height);
                     for (U32 i = 0; i < pixel_count; i++)
                     {
                         U8 lum = ((U8*)pixels)[i];
 
-                        U8* pix = (U8*)&scratch[i];
+                        U8* pix = (U8*)&sManualScratch[i];
                         pix[0] = pix[1] = pix[2] = lum;
                         pix[3] = 255;
                     }
 
-                    pixels = scratch.get();
+                    pixels = sManualScratch;
                 }
                 pixformat = GL_RGBA;
                 intformat = GL_RGB8;

--- a/indra/llrender/llimagegl.h
+++ b/indra/llrender/llimagegl.h
@@ -298,6 +298,7 @@ public:
 
 public:
     static void initClass(LLWindow* window, S32 num_catagories, bool skip_analyze_alpha = false, bool thread_texture_loads = false, bool thread_media_updates = false);
+    static void allocateConversionBuffer();
     static void cleanupClass() ;
 
 private:
@@ -305,6 +306,7 @@ private:
     static bool sSkipAnalyzeAlpha;
     static U32 sScratchPBO;
     static U32 sScratchPBOSize;
+    static U32* sManualScratch;
 
     //the flag to allow to call readBackRaw(...).
     //can be removed if we do not use that function at all.

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1936,6 +1936,11 @@ LLViewerWindow::LLViewerWindow(const Params& p)
     }
 
     LLFontManager::initClass();
+
+    // fonts use an GL_UNSIGNED_BYTE image format,
+    // so they need convertion, init buffers if needed
+    LLImageGL::allocateConversionBuffer();
+
     // Init font system, load default fonts and generate basic glyphs
     // currently it takes aprox. 0.5 sec and we would load these fonts anyway
     // before login screen.


### PR DESCRIPTION
It doesn't look like scratch needs to be reallocated all the time, it gets deleted immediately after use and glTexImage2D copies content to target.

I have no idea how high fonts can go, but I assume 4096x4096 is more than enough.