### PR TITLE
Restore tonemapping to ACES with a slight mix towards linear and raise exposure limits

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9063,7 +9063,7 @@
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>1</real>
+    <real>1.5</real>
   </map>
   
   <key>RenderReflectionProbeDrawDistance</key>
@@ -9874,7 +9874,7 @@
         <key>Type</key>
         <string>F32</string>
         <key>Value</key>
-        <real>1.0</real>
+        <real>0.7</real>
     </map>
     <key>RenderTonemapType</key>
     <map>
@@ -9885,7 +9885,7 @@
         <key>Type</key>
         <string>U32</string>
         <key>Value</key>
-        <integer>0</integer>
+        <integer>1</integer>
     </map>
     <key>ReplaySession</key>
     <map>

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -337,7 +337,7 @@
     layout="topleft"
     left="30"
     min_val="0.5"
-    max_val="1.5"
+    max_val="4.0"
     name="RenderExposure"
     show_text="true"
     top_pad="14"


### PR DESCRIPTION
* Restores default tonemapping to ACES with a 30% mix towards linear
* Raises exposure limit to 4 in graphics preferences
* Raises default exposure multiplier to 1.5

#2719
Partial #2465