### PR TITLE
Use libdecor for SDL

### DIFF
--- a/indra/llwindow/llsdl.cpp
+++ b/indra/llwindow/llsdl.cpp
@@ -56,6 +56,7 @@ void init_sdl()
     std::initializer_list<std::tuple< char const*, char const * > > hintList =
             {
                     {SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR,"0"},
+                    {SDL_HINT_VIDEO_WAYLAND_PREFER_LIBDECOR,"1"},
                     {SDL_HINT_VIDEODRIVER,"wayland,x11"},
                     {SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH,"1"},
                     {SDL_HINT_IME_INTERNAL_EDITING,"1"}

--- a/indra/newview/linux_tools/wrapper.sh
+++ b/indra/newview/linux_tools/wrapper.sh
@@ -52,9 +52,10 @@ if [ "$XMODIFIERS" = "" ]; then
 fi
 
 ## If you are using wayland environment, use wayland instead of xwayland.
-if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-    export SDL_VIDEODRIVER="wayland"
-fi
+## Do not default to wayland until SDL compatibility issues are resolved.
+#if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+#    export SDL_VIDEODRIVER="wayland"
+#fi
 
 ## Nothing worth editing below this line.
 ##-------------------------------------------------------------------

--- a/indra/newview/linux_tools/wrapper.sh
+++ b/indra/newview/linux_tools/wrapper.sh
@@ -51,6 +51,11 @@ if [ "$XMODIFIERS" = "" ]; then
     export XMODIFIERS="@im=fcitx"
 fi
 
+## If you are using wayland environment, use wayland instead of xwayland.
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    export SDL_VIDEODRIVER="wayland"
+fi
+
 ## Nothing worth editing below this line.
 ##-------------------------------------------------------------------
 


### PR DESCRIPTION
Enables native support for the Wayland desktop environment.

Extract only the commits you need from #2749 .

Related Issues : https://github.com/secondlife/viewer/issues/1442 [Linux] Add Native Support for Wayland

- [x] Compile viewer
- [x] Allows you to launch the viewer.
- [x] Use libdecor for GNOME