### PR TITLE
Fix issue where sometimes connections would be restarted instead of closed.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -3045,7 +3045,9 @@ void LLVoiceWebRTCConnection::OnDataChannelReady(llwebrtc::LLWebRTCDataInterface
                 return;
             }
 
-            if (data_interface)
+            // OnDataChannelReady may be called multiple times in a single connection attempt
+            // so don't double-set the observer.
+            if (!mWebRTCDataInterface && data_interface)
             {
                 mWebRTCDataInterface = data_interface;
                 mWebRTCDataInterface->setDataObserver(this);

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -691,7 +691,7 @@ class LLVoiceWebRTCConnection :
     virtual void requestVoiceConnection() = 0;
     static void requestVoiceConnectionCoro(connectionPtr_t connection) { connection->requestVoiceConnection(); }
 
-    static void breakVoiceConnectionCoro(connectionPtr_t connection);
+    static void breakVoiceConnection(connectionPtr_t connection);
 
     LLVoiceClientStatusObserver::EStatusType mCurrentStatus;
 

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -691,7 +691,7 @@ class LLVoiceWebRTCConnection :
     virtual void requestVoiceConnection() = 0;
     static void requestVoiceConnectionCoro(connectionPtr_t connection) { connection->requestVoiceConnection(); }
 
-    static void breakVoiceConnection(connectionPtr_t connection);
+    static void breakVoiceConnectionCoro(connectionPtr_t connection);
 
     LLVoiceClientStatusObserver::EStatusType mCurrentStatus;
 


### PR DESCRIPTION
When a connection was closed and caps weren't available, the connection would be restarted instead.  This could result in multiple active connections to the channel, resulting in an echo effect.

And, webrtc sometimes notifies that the data channel is open multiple times, which was resulting in multiple observers being created.