### PR TITLE
Add LL::ResultSet subclass VectorResultSet for the simple case.

### DIFF
--- a/indra/llcommon/resultset.cpp
+++ b/indra/llcommon/resultset.cpp
@@ -61,20 +61,6 @@ LLSD ResultSet::getSlice(int index, int count) const
     return getSliceStart(index, count).first;
 }
 
-/*==========================================================================*|
-LLSD ResultSet::getSingle(int index) const
-{
-    if (0 <= index && index < getLength())
-    {
-        return getSingle_(index);
-    }
-    else
-    {
-        return {};
-    }
-}
-|*==========================================================================*/
-
 ResultSet::ResultSet(const std::string& name):
     mName(name)
 {

--- a/indra/llcommon/resultset.h
+++ b/indra/llcommon/resultset.h
@@ -17,6 +17,7 @@
 #include "llsd.h"
 #include <iosfwd>                   // std::ostream
 #include <utility>                  // std::pair
+#include <vector>
 
 namespace LL
 {
@@ -41,17 +42,27 @@ struct ResultSet: public LLIntTracker<ResultSet>
     LLSD getSlice(int index, int count) const;
     // Like getSlice(), but also return adjusted start position.
     std::pair<LLSD, int> getSliceStart(int index, int count) const;
-/*==========================================================================*|
-    // Retrieve LLSD corresponding to a single entry from the result set,
-    // with index validation.
-    LLSD getSingle(int index) const;
-|*==========================================================================*/
 
     /*---------------- the rest is solely for debug logging ----------------*/
     std::string mName;
 
     ResultSet(const std::string& name);
     virtual ~ResultSet();
+};
+
+// VectorResultSet is for the simple case of a ResultSet managing a single
+// std::vector<T>.
+template <typename T>
+struct VectorResultSet: public ResultSet
+{
+    using super = VectorResultSet<T>;
+
+    VectorResultSet(const std::string& name): ResultSet(name) {}
+    int getLength() const override { return narrow(mVector.size()); }
+    LLSD getSingle(int index) const override { return getSingleFrom(mVector[index]); }
+    virtual LLSD getSingleFrom(const T&) const = 0;
+
+    std::vector<T> mVector;
 };
 
 } // namespace LL

--- a/indra/newview/llagentlistener.cpp
+++ b/indra/newview/llagentlistener.cpp
@@ -729,15 +729,11 @@ void LLAgentListener::getID(LLSD const& event_data)
     Response response(llsd::map("id", gAgentID), event_data);
 }
 
-struct AvResultSet : public LL::ResultSet
+struct AvResultSet : public LL::VectorResultSet<LLVOAvatar*>
 {
-    AvResultSet() : LL::ResultSet("nearby_avatars") {}
-    std::vector<LLVOAvatar*> mAvatars;
-
-    int getLength() const override { return narrow(mAvatars.size()); }
-    LLSD getSingle(int index) const override
+    AvResultSet() : super("nearby_avatars") {}
+    LLSD getSingleFrom(LLVOAvatar* const& av) const override
     {
-        auto av = mAvatars[index];
         LLAvatarName av_name;
         LLAvatarNameCache::get(av->getID(), &av_name);
         LLVector3 region_pos = av->getCharacterPosition();
@@ -749,15 +745,11 @@ struct AvResultSet : public LL::ResultSet
     }
 };
 
-struct ObjResultSet : public LL::ResultSet
+struct ObjResultSet : public LL::VectorResultSet<LLViewerObject*>
 {
-    ObjResultSet() : LL::ResultSet("nearby_objects") {}
-    std::vector<LLViewerObject*> mObjects;
-
-    int getLength() const override { return narrow(mObjects.size()); }
-    LLSD getSingle(int index) const override
+    ObjResultSet() : super("nearby_objects") {}
+    LLSD getSingleFrom(LLViewerObject* const& obj) const override
     {
-        auto obj = mObjects[index];
         return llsd::map("id", obj->getID(),
                          "global_pos", ll_sd_from_vector3d(obj->getPositionGlobal()),
                          "region_pos", ll_sd_from_vector3(obj->getPositionRegion()),
@@ -791,7 +783,7 @@ void LLAgentListener::getNearbyAvatarsList(LLSD const& event_data)
         {
             if ((dist_vec_squared(avatar->getPositionGlobal(), agent_pos) <= radius))
             {
-                avresult->mAvatars.push_back(avatar);
+                avresult->mVector.push_back(avatar);
             }
         }
     }
@@ -813,7 +805,7 @@ void LLAgentListener::getNearbyObjectsList(LLSD const& event_data)
         {
             if ((dist_vec_squared(object->getPositionGlobal(), agent_pos) <= radius))
             {
-                objresult->mObjects.push_back(object);
+                objresult->mVector.push_back(object);
             }
         }
     }


### PR DESCRIPTION
Update existing simple LL::ResultSet subclasses.