### PR TITLE
Restore default exposure to 1 and add exposure and tonemapping featuretable entries

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9063,7 +9063,7 @@
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>1.5</real>
+    <real>1.0</real>
   </map>
   
   <key>RenderReflectionProbeDrawDistance</key>

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -1,4 +1,4 @@
-version 63
+version 64
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -81,7 +81,9 @@ RenderHeroProbeUpdateRate	1	6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderDownScaleMethod       1   1
 RenderCASSharpness          1   1
-
+RenderExposure				1   4
+RenderTonemapType			1   1
+RenderTonemapMix			1   1
 
 //
 // Low Graphics Settings
@@ -119,6 +121,9 @@ RenderHeroProbeDistance		1	4
 RenderHeroProbeUpdateRate	1	6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Low Graphics Settings
@@ -156,6 +161,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Graphics Settings (standard)
@@ -193,6 +201,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium High Graphics Settings
@@ -230,6 +241,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Graphics Settings (SSAO + sun shadows)
@@ -267,6 +281,9 @@ RenderHeroProbeDistance		1	8
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
 RenderCASSharpness          1   0.4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Ultra Graphics Settings (deferred + SSAO + all shadows)
@@ -304,6 +321,9 @@ RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
 RenderCASSharpness          1   0.4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -341,6 +361,9 @@ RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
 RenderCASSharpness          1   0.4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Class Unknown Hardware (unknown)

--- a/indra/newview/featuretable_linux.txt
+++ b/indra/newview/featuretable_linux.txt
@@ -1,4 +1,4 @@
-version 29
+version 30
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -103,7 +103,9 @@ RenderHeroProbeResolution	1	256
 RenderHeroProbeDistance		1	4
 RenderHeroProbeUpdateRate	1   6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
-
+RenderExposure				1   4
+RenderTonemapType			1   1
+RenderTonemapMix			1   1
 
 //
 // Low Graphics Settings
@@ -139,6 +141,9 @@ RenderHeroProbeResolution	1	256
 RenderHeroProbeDistance		1	4
 RenderHeroProbeUpdateRate	1   6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Low Graphics Settings
@@ -173,6 +178,9 @@ RenderHeroProbeResolution	1	256
 RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Graphics Settings (standard)
@@ -207,6 +215,9 @@ RenderHeroProbeResolution	1	512
 RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium High Graphics Settings (deferred enabled)
@@ -241,6 +252,9 @@ RenderHeroProbeResolution	1	512
 RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Graphics Settings (deferred + SSAO)
@@ -275,6 +289,9 @@ RenderHeroProbeResolution	1	512
 RenderHeroProbeDistance		1	8
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Ultra Graphics Settings (deferred + SSAO + shadows)
@@ -309,6 +326,9 @@ RenderHeroProbeResolution	1	512
 RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -342,6 +362,9 @@ RenderHeroProbeResolution	1	1024
 RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Class Unknown Hardware (unknown)

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -1,4 +1,4 @@
-version 61
+version 62
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -80,6 +80,9 @@ RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   1
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   1
 
 //
 // Low Graphics Settings
@@ -117,6 +120,9 @@ RenderHeroProbeDistance		1	4
 RenderHeroProbeUpdateRate	1   6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Low Graphics Settings
@@ -154,6 +160,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium Graphics Settings (standard)
@@ -191,6 +200,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	3
 RenderHeroProbeConservativeUpdateMultiplier 1 16
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Medium High Graphics Settings
@@ -228,6 +240,9 @@ RenderHeroProbeDistance		1	6
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Graphics Settings (SSAO + sun shadows)
@@ -265,6 +280,9 @@ RenderHeroProbeDistance		1	8
 RenderHeroProbeUpdateRate	1	2
 RenderHeroProbeConservativeUpdateMultiplier 1 8
 RenderCASSharpness          1   0
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // High Ultra Graphics Settings (SSAO + all shadows)
@@ -302,6 +320,9 @@ RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
 RenderCASSharpness          1   0.4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -339,6 +360,9 @@ RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	1
 RenderHeroProbeConservativeUpdateMultiplier 1 4
 RenderCASSharpness          1   0.4
+RenderExposure				1   1
+RenderTonemapType			1   1
+RenderTonemapMix			1   0.7
 
 //
 // Class Unknown Hardware (unknown)


### PR DESCRIPTION
* Restore default exposure level to 1.0
* Add featuretable entries for tonemapping and exposure to correctly reset defaults

#2913
#2916