### PR TITLE
viewer#2883 Regenerate font's matrix and depth instead of loading

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -404,7 +404,6 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
     {
         // recursively render ellipses at end of string
         // we've already reserved enough room
-        gGL.pushUIMatrix();
         static LLWString elipses_wstr(utf8string_to_wstring(std::string("...")));
         render(elipses_wstr,
                 0,
@@ -417,7 +416,6 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
                 right_x,
                 false,
                 use_color);
-        gGL.popUIMatrix();
     }
 
     gGL.popUIMatrix();

--- a/indra/llrender/llfontvertexbuffer.cpp
+++ b/indra/llrender/llfontvertexbuffer.cpp
@@ -213,6 +213,17 @@ void LLFontVertexBuffer::renderBuffers()
     gGL.flush(); // deliberately empty pending verts
     gGL.getTexUnit(0)->enable(LLTexUnit::TT_TEXTURE);
     gGL.pushUIMatrix();
+
+    gGL.loadUIIdentity();
+
+    // Depth translation, so that floating text appears 'in-world'
+    // and is correctly occluded.
+    gGL.translatef(0.f, 0.f, LLFontGL::sCurDepth);
+    gGL.setSceneBlendType(LLRender::BT_ALPHA);
+
+    // Note: ellipses should technically be covered by push/load/translate of their own
+    // but it's more complexity, values do not change, skipping doesn't appear to break
+    // anything, so we can skip that until it proves to cause issues.
     for (LLVertexBufferData& buffer : mBufferList)
     {
         buffer.draw();

--- a/indra/llrender/llfontvertexbuffer.cpp
+++ b/indra/llrender/llfontvertexbuffer.cpp
@@ -144,6 +144,8 @@ S32 LLFontVertexBuffer::render(
              || mLastShadow != shadow // ex: buttons change shadow state
              || mLastScaleX != LLFontGL::sScaleX
              || mLastScaleY != LLFontGL::sScaleY
+             || mLastVertDPI != LLFontGL::sVertDPI
+             || mLastHorizDPI != LLFontGL::sHorizDPI
              || mLastOrigin != LLFontGL::sCurOrigin)
     {
         genBuffers(fontp, text, begin_offset, x, y, color, halign, valign,
@@ -196,6 +198,8 @@ void LLFontVertexBuffer::genBuffers(
 
     mLastScaleX = LLFontGL::sScaleX;
     mLastScaleY = LLFontGL::sScaleY;
+    mLastVertDPI = LLFontGL::sVertDPI;
+    mLastHorizDPI = LLFontGL::sHorizDPI;
     mLastOrigin = LLFontGL::sCurOrigin;
 
     if (right_x)

--- a/indra/llrender/llfontvertexbuffer.h
+++ b/indra/llrender/llfontvertexbuffer.h
@@ -115,6 +115,8 @@ private:
     // LLFontGL's statics
     F32 mLastScaleX = 1.f;
     F32 mLastScaleY = 1.f;
+    F32 mLastVertDPI = 0.f;
+    F32 mLastHorizDPI = 0.f;
     LLCoordGL mLastOrigin;
 
     static bool sEnableBufferCollection;

--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -604,7 +604,7 @@ public:
 
 static LLVBOPool* sVBOPool = nullptr;
 
-void LLVertexBufferData::draw()
+void LLVertexBufferData::drawWithMatrix()
 {
     if (!mVB)
     {
@@ -640,6 +640,28 @@ void LLVertexBufferData::draw()
     gGL.popMatrix();
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.popMatrix();
+}
+
+void LLVertexBufferData::draw()
+{
+    if (!mVB)
+    {
+        llassert(false);
+        // Not supposed to happen, check buffer generation
+        return;
+    }
+
+    if (mTexName)
+    {
+        gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_TEXTURE, mTexName);
+    }
+    else
+    {
+        gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
+    }
+
+    mVB->setBuffer();
+    mVB->drawArrays(mMode, 0, mCount);
 }
 
 //============================================================================

--- a/indra/llrender/llvertexbuffer.h
+++ b/indra/llrender/llvertexbuffer.h
@@ -77,6 +77,7 @@ public:
         , mModelView(projection)
         , mTexture0(texture0)
     {}
+    void drawWithMatrix();
     void draw();
     LLPointer<LLVertexBuffer> mVB;
     U8 mMode;


### PR DESCRIPTION
To fix issues with nametags' depth and window resizes. Apparently matrix needs regular updates so it shouldn't be saved for nametags.