### PR TITLE
Fix for IM session name and icon.

### DIFF
--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -603,12 +603,13 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                         }
                     }
 
+                    std::string real_name;
+
                     if (!notice_name.empty())
                     {   // The simulator has injected some sort of notice into the conversation.
                         // findString will only replace the contents of buffer if the notice_id is found.
                         LLTrans::findString(buffer, notice_name, notice_args);
-                        name   = SYSTEM_FROM;
-                        from_id = LLUUID::null;
+                        real_name = SYSTEM_FROM;
                     }
 
                     gIMMgr->addMessage(session_id,
@@ -622,8 +623,9 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                         region_id,
                         position,
                         region_message,
-                        timestamp);
-
+                        timestamp,
+                        LLUUID::null,
+                        real_name);
                 }
                 else
                 {

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3143,9 +3143,16 @@ void LLIMMgr::addMessage(
     const LLUUID& region_id,
     const LLVector3& position,
     bool is_region_msg,
-    U32 timestamp) // May be zero
+    U32 timestamp,  // May be zero
+    LLUUID display_id,
+    std::string_view display_name)
 {
     LLUUID other_participant_id = target_id;
+    std::string message_display_name = (display_name.empty()) ? from : std::string(display_name);
+    if (display_id.isNull() && (display_name.empty()))
+    {
+        display_id = other_participant_id;
+    }
 
     LLUUID new_session_id = session_id;
     if (new_session_id.isNull())
@@ -3241,7 +3248,7 @@ void LLIMMgr::addMessage(
             }
 
             //Play sound for new conversations
-            if (!skip_message & !gAgent.isDoNotDisturb() && (gSavedSettings.getBOOL("PlaySoundNewConversation")))
+            if (!skip_message && !gAgent.isDoNotDisturb() && (gSavedSettings.getBOOL("PlaySoundNewConversation")))
             {
                 make_ui_sound("UISndNewIncomingIMSession");
             }
@@ -3255,7 +3262,7 @@ void LLIMMgr::addMessage(
 
     if (!LLMuteList::getInstance()->isMuted(other_participant_id, LLMute::flagTextChat) && !skip_message)
     {
-        LLIMModel::instance().addMessage(new_session_id, from, other_participant_id, msg, true, is_region_msg, timestamp);
+        LLIMModel::instance().addMessage(new_session_id, message_display_name, display_id, msg, true, is_region_msg, timestamp);
     }
 
     // Open conversation floater if offline messages are present

--- a/indra/newview/llimview.h
+++ b/indra/newview/llimview.h
@@ -368,7 +368,9 @@ public:
                     const LLUUID& region_id = LLUUID::null,
                     const LLVector3& position = LLVector3::zero,
                     bool is_region_msg = false,
-                    U32 timestamp = 0);
+                    U32 timestamp = 0,
+                    LLUUID display_id = LLUUID::null,
+                    std::string_view display_name = "");
 
     void addSystemMessage(const LLUUID& session_id, const std::string& message_name, const LLSD& args);
 


### PR DESCRIPTION
Adds optional parameters to addMessage which allow the function to override the icon and session name used for the chat while correctly naming and constructing the chat session. 