### PR TITLE
viewer#2863 Notify of a missing material cap instead of applying locally

### DIFF
--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -3177,14 +3177,7 @@ void LLMaterialEditor::applyToSelection()
     {
         LL_WARNS("MaterialEditor") << "Not connected to materials capable region, missing ModifyMaterialParams cap" << LL_ENDL;
 
-        // Fallback local preview. Will be removed once override systems is finished and new cap is deployed everywhere.
-        LLPointer<LLFetchedGLTFMaterial> mat = new LLFetchedGLTFMaterial();
-        getGLTFMaterial(mat);
-        static const LLUUID placeholder("984e183e-7811-4b05-a502-d79c6f978a98");
-        gGLTFMaterialList.addMaterial(placeholder, mat);
-        LLRenderMaterialFunctor mat_func(placeholder);
-        LLObjectSelectionHandle selected_objects = LLSelectMgr::getInstance()->getSelection();
-        selected_objects->applyToTEs(&mat_func);
+        LLNotificationsUtil::add("MissingMaterialCaps");
     }
 }
 


### PR DESCRIPTION
Looks like an obsolete 'preview' code might be causing user to think a change has applied, yet it did not.