### PR TITLE
Various minor crash and correctness fixes

### DIFF
--- a/indra/llmessage/llpartdata.cpp
+++ b/indra/llmessage/llpartdata.cpp
@@ -331,7 +331,7 @@ bool LLPartSysData::isNullPS(const S32 block_num)
 
     S32 size;
     // Check size of block
-    size = gMessageSystem->getSize("ObjectData", block_num, "PSBlock");
+    size = gMessageSystem->getSizeFast(_PREHASH_ObjectData, block_num, _PREHASH_PSBlock);
 
     if (!size)
     {
@@ -344,7 +344,7 @@ bool LLPartSysData::isNullPS(const S32 block_num)
         return true;
     }
 
-    gMessageSystem->getBinaryData("ObjectData", "PSBlock", ps_data_block, size, block_num, PS_MAX_DATA_BLOCK_SIZE);
+    gMessageSystem->getBinaryDataFast(_PREHASH_ObjectData, _PREHASH_PSBlock, ps_data_block, size, block_num, PS_MAX_DATA_BLOCK_SIZE);
 
     LLDataPackerBinaryBuffer dp(ps_data_block, size);
     if (size > PS_LEGACY_DATA_BLOCK_SIZE)
@@ -373,7 +373,7 @@ bool LLPartSysData::unpackBlock(const S32 block_num)
     U8 ps_data_block[PS_MAX_DATA_BLOCK_SIZE];
 
     // Check size of block
-    S32 size = gMessageSystem->getSize("ObjectData", block_num, "PSBlock");
+    S32 size = gMessageSystem->getSizeFast(_PREHASH_ObjectData, block_num, _PREHASH_PSBlock);
 
     if (size > PS_MAX_DATA_BLOCK_SIZE)
     {
@@ -382,7 +382,7 @@ bool LLPartSysData::unpackBlock(const S32 block_num)
     }
 
     // Get from message
-    gMessageSystem->getBinaryData("ObjectData", "PSBlock", ps_data_block, size, block_num, PS_MAX_DATA_BLOCK_SIZE);
+    gMessageSystem->getBinaryDataFast(_PREHASH_ObjectData, _PREHASH_PSBlock, ps_data_block, size, block_num, PS_MAX_DATA_BLOCK_SIZE);
 
     LLDataPackerBinaryBuffer dp(ps_data_block, size);
 

--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -2750,7 +2750,7 @@ void LLGLUserClipPlane::setPlane(F32 a, F32 b, F32 c, F32 d)
     if(cplane[2] < 0)
         cplane *= -1;
 
-    glm::mat4 suffix;
+    glm::mat4 suffix = glm::identity<glm::mat4>();
     suffix = glm::row(suffix, 2, cplane);
     glm::mat4 newP = suffix * P;
     gGL.matrixMode(LLRender::MM_PROJECTION);

--- a/indra/llui/llfloater.cpp
+++ b/indra/llui/llfloater.cpp
@@ -247,6 +247,7 @@ LLFloater::LLFloater(const LLSD& key, const LLFloater::Params& p)
     mTitle(p.title),
     mShortTitle(p.short_title),
     mSingleInstance(p.single_instance),
+    mIsReuseInitialized(p.reuse_instance.isProvided()),
     mReuseInstance(p.reuse_instance.isProvided() ? p.reuse_instance : p.single_instance), // reuse single-instance floaters by default
     mKey(key),
     mCanTearOff(p.can_tear_off),
@@ -3350,6 +3351,7 @@ void LLFloater::initFromParams(const LLFloater::Params& p)
     mHeaderHeight = p.header_height;
     mLegacyHeaderHeight = p.legacy_header_height;
     mSingleInstance = p.single_instance;
+    mIsReuseInitialized = p.reuse_instance.isProvided();
     mReuseInstance = p.reuse_instance.isProvided() ? p.reuse_instance : p.single_instance;
 
     mDefaultRelativeX = p.rel_x;

--- a/indra/newview/llflexibleobject.cpp
+++ b/indra/newview/llflexibleobject.cpp
@@ -151,7 +151,6 @@ void LLVolumeImplFlexible::remapSections(LLFlexibleObjectSection *source, S32 so
 {
     S32 num_output_sections = 1<<dest_sections;
     LLVector3 scale = mVO->mDrawable->getScale();
-    F32 source_section_length = scale.mV[VZ] / (F32)(1<<source_sections);
     F32 section_length = scale.mV[VZ] / (F32)num_output_sections;
     if (source_sections == -1)
     {
@@ -183,6 +182,7 @@ void LLVolumeImplFlexible::remapSections(LLFlexibleObjectSection *source, S32 so
         // Iterate from right to left since it may be an in-place computation
         S32 step_shift = dest_sections-source_sections;
         S32 num_steps = 1<<step_shift;
+        F32 source_section_length = scale.mV[VZ] / (F32)(1<<source_sections);
         for (S32 section=num_output_sections-num_steps; section>=0; section -= num_steps)
         {
             LLFlexibleObjectSection *last_source_section = &source[section>>step_shift];

--- a/indra/newview/llinventorygallery.cpp
+++ b/indra/newview/llinventorygallery.cpp
@@ -2777,6 +2777,7 @@ static LLDefaultChildRegistry::Register<LLInventoryGalleryItem> r("inventory_gal
 LLInventoryGalleryItem::LLInventoryGalleryItem(const Params& p)
     : LLPanel(p),
     mSelected(false),
+    mWorn(false),
     mDefaultImage(true),
     mItemName(""),
     mWornSuffix(""),

--- a/indra/newview/lllocationinputctrl.h
+++ b/indra/newview/lllocationinputctrl.h
@@ -206,7 +206,7 @@ private:
     std::string mEditLandmarkTooltip;
     // this field holds a human-readable form of the location string, it is needed to be able to compare copy-pated value and real location
     std::string mHumanReadableLocation;
-    bool isHumanReadableLocationVisible;
+    bool isHumanReadableLocationVisible = true;
     std::string mMaturityHelpTopic;
 };
 

--- a/indra/newview/llmediactrl.cpp
+++ b/indra/newview/llmediactrl.cpp
@@ -1022,10 +1022,6 @@ void LLMediaCtrl::handleMediaEvent(LLPluginClassMedia* self, EMediaEvent event)
         case MEDIA_EVENT_NAVIGATE_COMPLETE:
         {
             LL_DEBUGS("Media") <<  "Media event:  MEDIA_EVENT_NAVIGATE_COMPLETE, result string is: " << self->getNavigateResultString() << LL_ENDL;
-            if(mHidingInitialLoad)
-            {
-                mHidingInitialLoad = false;
-            }
         };
         break;
 

--- a/indra/newview/llmediactrl.h
+++ b/indra/newview/llmediactrl.h
@@ -201,7 +201,6 @@ public:
                 mStretchToFill,
                 mMaintainAspectRatio,
                 mHideLoading,
-                mHidingInitialLoad,
                 mClearCache,
                 mHoverTextChanged,
                 mDecoupleTextureSize,

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -3565,7 +3565,7 @@ bool LLModelPreview::render()
                         LLPhysicsDecomp* decomp = gMeshRepo.mDecompThread;
                         if (decomp)
                         {
-                            LLMutexLock(decomp->mMutex);
+                            LLMutexLock lock(decomp->mMutex);
 
                             LLModel::Decomposition& physics = model->mPhysics;
 
@@ -3686,7 +3686,7 @@ bool LLModelPreview::render()
                             LLPhysicsDecomp* decomp = gMeshRepo.mDecompThread;
                             if (decomp)
                             {
-                                LLMutexLock(decomp->mMutex);
+                                LLMutexLock lock(decomp->mMutex);
 
                                 LLModel::Decomposition& physics = model->mPhysics;
 

--- a/indra/newview/llnetmap.cpp
+++ b/indra/newview/llnetmap.cpp
@@ -96,6 +96,7 @@ LLNetMap::LLNetMap (const Params & p)
     mPopupWorldPos(0.f, 0.f, 0.f),
     mMouseDown(0, 0),
     mPanning(false),
+    mCentering(false),
     mUpdateNow(false),
     mObjectImageCenterGlobal( gAgentCamera.getCameraPositionGlobal() ),
     mObjectRawImagep(),

--- a/indra/newview/llscrollingpanelparam.h
+++ b/indra/newview/llscrollingpanelparam.h
@@ -81,7 +81,6 @@ public:
 protected:
     LLTimer             mMouseDownTimer;    // timer for how long mouse has been held down on a hint.
     F32                 mLastHeldTime;
-    bool mAllowModify;
 
     LLButton* mLessBtn;
     LLButton* mMoreBtn;

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -985,7 +985,10 @@ bool LLViewerShaderMgr::loadShadersWater()
         return loadShadersWater();
     }
 
-    LLWorld::getInstance()->updateWaterObjects();
+    if (LLWorld::instanceExists())
+    {
+        LLWorld::getInstance()->updateWaterObjects();
+    }
 
     return true;
 }

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1422,6 +1422,11 @@ bool LLViewerTextureList::createUploadFile(LLPointer<LLImageRaw> raw_image,
         raw_image->getComponents());
 
     LLPointer<LLImageJ2C> compressedImage = LLViewerTextureList::convertToUploadFile(scale_image, max_image_dimentions);
+    if (compressedImage.isNull())
+    {
+        LL_INFOS() << "Couldn't convert to j2c, file : " << out_filename << LL_ENDL;
+        return false;
+    }
     if (compressedImage->getWidth() < min_image_dimentions || compressedImage->getHeight() < min_image_dimentions)
     {
         std::string reason = llformat("Images below %d x %d pixels are not allowed. Actual size: %d x %dpx",
@@ -1430,12 +1435,6 @@ bool LLViewerTextureList::createUploadFile(LLPointer<LLImageRaw> raw_image,
                                       compressedImage->getWidth(),
                                       compressedImage->getHeight());
         compressedImage->setLastError(reason);
-        return false;
-    }
-    if (compressedImage.isNull())
-    {
-        compressedImage->setLastError("Couldn't convert the image to jpeg2000.");
-        LL_INFOS() << "Couldn't convert to j2c, file : " << out_filename << LL_ENDL;
         return false;
     }
     if (!compressedImage->save(out_filename))

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -268,9 +268,6 @@ static const F32 MIN_DISPLAY_SCALE = 0.75f;
 
 static const char KEY_MOUSELOOK = 'M';
 
-static LLCachedControl<std::string> sSnapshotBaseName(LLCachedControl<std::string>(gSavedPerAccountSettings, "SnapshotBaseName", "Snapshot"));
-static LLCachedControl<std::string> sSnapshotDir(LLCachedControl<std::string>(gSavedPerAccountSettings, "SnapshotBaseDir", ""));
-
 LLTrace::SampleStatHandle<> LLViewerWindow::sMouseVelocityStat("Mouse Velocity");
 
 
@@ -2012,6 +2009,7 @@ LLViewerWindow::LLViewerWindow(const Params& p)
 
 std::string LLViewerWindow::getLastSnapshotDir()
 {
+    static LLCachedControl<std::string> sSnapshotDir(gSavedPerAccountSettings, "SnapshotBaseDir", "");
     return sSnapshotDir;
 }
 
@@ -3782,7 +3780,7 @@ void LLViewerWindow::updateLayout()
 {
     LLToolMgr* tool_mgr = LLToolMgr::getInstance();
     LLTool* tool = tool_mgr->getCurrentTool();
-    LLCachedControl<bool> freeze_time(gSavedSettings, "FreezeTime");
+    static LLCachedControl<bool> freeze_time(gSavedSettings, "FreezeTime");
     if (gFloaterTools != NULL
         && tool != NULL
         && tool != gToolNull
@@ -4711,6 +4709,7 @@ void LLViewerWindow::saveImageNumbered(LLImageFormatted *image, bool force_picke
     // Get a base file location if needed.
     if (force_picker || !isSnapshotLocSet())
     {
+        static LLCachedControl<std::string> sSnapshotBaseName(gSavedPerAccountSettings, "SnapshotBaseName", "Snapshot");
         std::string proposed_name(sSnapshotBaseName);
 
         // getSaveFile will append an appropriate extension to the proposed name, based on the ESaveFilter constant passed in.
@@ -4756,6 +4755,9 @@ void LLViewerWindow::onSelectionFailure(const snapshot_saved_signal_t::slot_type
 
 void LLViewerWindow::saveImageLocal(LLImageFormatted *image, const snapshot_saved_signal_t::slot_type& success_cb, const snapshot_saved_signal_t::slot_type& failure_cb)
 {
+    static LLCachedControl<std::string> sSnapshotBaseName(gSavedPerAccountSettings, "SnapshotBaseName", "Snapshot");
+    static LLCachedControl<std::string> sSnapshotDir(gSavedPerAccountSettings, "SnapshotBaseDir", "");
+
     std::string lastSnapshotDir = LLViewerWindow::getLastSnapshotDir();
     if (lastSnapshotDir.empty())
     {
@@ -4907,8 +4909,8 @@ void LLViewerWindow::playSnapshotAnimAndSound()
 
 bool LLViewerWindow::isSnapshotLocSet() const
 {
-    std::string snapshot_dir = sSnapshotDir;
-    return !snapshot_dir.empty();
+    static LLCachedControl<std::string> sSnapshotDir(gSavedPerAccountSettings, "SnapshotBaseDir", "");
+    return !sSnapshotDir().empty();
 }
 
 void LLViewerWindow::resetSnapshotLoc() const

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -687,7 +687,6 @@ LLVOAvatar::LLVOAvatar(const LLUUID& id,
     mVisualComplexity(VISUAL_COMPLEXITY_UNKNOWN),
     mLoadedCallbacksPaused(false),
     mLoadedCallbackTextures(0),
-    mRenderUnloadedAvatar(LLCachedControl<bool>(gSavedSettings, "RenderUnloadedAvatar", false)),
     mLastRezzedStatus(-1),
     mIsEditingAppearance(false),
     mUseLocalAppearance(false),
@@ -8523,7 +8522,8 @@ bool LLVOAvatar::processFullyLoadedChange(bool loading)
 
 bool LLVOAvatar::isFullyLoaded() const
 {
-    return (mRenderUnloadedAvatar || mFullyLoaded);
+    static LLCachedControl<bool> render_unloaded_avatars(gSavedSettings, "RenderUnloadedAvatar", false);
+    return (render_unloaded_avatars || mFullyLoaded);
 }
 
 bool LLVOAvatar::isTooComplex() const

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -668,8 +668,6 @@ private:
     LLVector3   mLastAnimExtents[2];
     LLVector3   mLastAnimBasePos;
 
-    LLCachedControl<bool> mRenderUnloadedAvatar;
-
     //--------------------------------------------------------------------
     // Wind rippling in clothes
     //--------------------------------------------------------------------

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -1012,7 +1012,7 @@ public:
     void            startTyping() { mTyping = true; mTypingTimer.reset(); }
     void            stopTyping() { mTyping = false; }
 private:
-    bool            mVisibleChat;
+    bool            mVisibleChat = false;
 
     //--------------------------------------------------------------------
     // Lip synch morphs
@@ -1194,7 +1194,7 @@ public:
     static F32          sGreyUpdateTime; // Last time stats were updated (to prevent multiple updates per frame)
 protected:
     S32                 getUnbakedPixelAreaRank();
-    bool                mHasGrey;
+    bool                mHasGrey = false;
 private:
     F32                 mMinPixelArea;
     F32                 mMaxPixelArea;


### PR DESCRIPTION
Found via Undefined Behavior sanitizer
* Fixes LLCachedControl being constructed in global scope
* Fixes an LLMutexLock in LLModelPreview that was immediately destroyed
* Fixes a tiny hotspot in particle load
* Fixes potential nullptr deref during image upload
* Fixes various class members being used without initialization