### PR TITLE
Bump contributor-assistant to v2.6.1

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: secondlife-3p/contributor-assistant@v2
+        uses: secondlife-3p/contributor-assistant@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.SHARED_CLA_TOKEN }}


### PR DESCRIPTION
This should suppress a warning ("The following actions use a deprecated Node.js"). 