### PR TITLE
viewer#3001 Fix doubletap run

### DIFF
--- a/indra/newview/llviewerinput.cpp
+++ b/indra/newview/llviewerinput.cpp
@@ -158,6 +158,9 @@ static void agent_handle_doubletap_run(EKeystate s, LLAgent::EDoubleTapRunMode m
 
 static void agent_push_forwardbackward( EKeystate s, S32 direction, LLAgent::EDoubleTapRunMode mode )
 {
+    agent_handle_doubletap_run(s, mode);
+    if (KEYSTATE_UP == s) return;
+
     F32 time = gKeyboard->getCurKeyElapsedTime();
     S32 frame_count = ll_round(gKeyboard->getCurKeyElapsedFrameCount());
 


### PR DESCRIPTION
This code was removed in https://github.com/secondlife/viewer/commit/ed6ecca2a45e52d9be1d91107b9643b5ecdfb8bf, but is needed for doubletap run to work.

I don't see agent_push_forward, agent_push_forwardbackward, nor "push_forward" being used anywhere in that commit.