### PR TITLE
viewer#2999 Fix debug text flicker

### DIFF
--- a/indra/newview/llhudnametag.cpp
+++ b/indra/newview/llhudnametag.cpp
@@ -291,15 +291,6 @@ void LLHUDNameTag::renderText()
     LLVector3 render_position = mPositionAgent
             + (x_pixel_vec * screen_offset.mV[VX])
             + (y_pixel_vec * screen_offset.mV[VY]);
-    bool reset_buffers = false;
-    const F32 treshold = 0.000001f;
-    if (abs(mLastRenderPosition.mV[VX] - render_position.mV[VX]) > treshold
-        || abs(mLastRenderPosition.mV[VY] - render_position.mV[VY]) > treshold
-        || abs(mLastRenderPosition.mV[VZ] - render_position.mV[VZ]) > treshold)
-    {
-        reset_buffers = true;
-        mLastRenderPosition = render_position;
-    }
 
     LLGLDepthTest gls_depth(GL_TRUE, GL_FALSE);
     LLRect screen_rect;
@@ -323,11 +314,6 @@ void LLHUDNameTag::renderText()
         for(std::vector<LLHUDTextSegment>::iterator segment_iter = mLabelSegments.begin();
             segment_iter != mLabelSegments.end(); ++segment_iter )
         {
-            if (reset_buffers)
-            {
-                segment_iter->mFontBufferLabel.reset();
-            }
-
             // Label segments use default font
             const LLFontGL* fontp = (segment_iter->mStyle == LLFontGL::BOLD) ? mBoldFontp : mFontp;
             y_offset -= fontp->getLineHeight();
@@ -365,11 +351,6 @@ void LLHUDNameTag::renderText()
         for (std::vector<LLHUDTextSegment>::iterator segment_iter = mTextSegments.begin() + start_segment;
              segment_iter != mTextSegments.end(); ++segment_iter )
         {
-            if (reset_buffers)
-            {
-                segment_iter->mFontBufferText.reset();
-            }
-
             const LLFontGL* fontp = segment_iter->mFont;
             y_offset -= fontp->getLineHeight();
             y_offset -= LINE_PADDING;

--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -185,15 +185,6 @@ void LLHUDText::renderText()
     LLVector3 render_position = mPositionAgent
             + (x_pixel_vec * screen_offset.mV[VX])
             + (y_pixel_vec * screen_offset.mV[VY]);
-    bool reset_buffers = false;
-    const F32 treshold = 0.000001f;
-    if (abs(mLastRenderPosition.mV[VX] - render_position.mV[VX]) > treshold
-        || abs(mLastRenderPosition.mV[VY] - render_position.mV[VY]) > treshold
-        || abs(mLastRenderPosition.mV[VZ] - render_position.mV[VZ]) > treshold)
-    {
-        reset_buffers = true;
-        mLastRenderPosition = render_position;
-    }
 
     F32 y_offset = (F32)mOffsetY;
 
@@ -217,11 +208,6 @@ void LLHUDText::renderText()
         for (std::vector<LLHUDTextSegment>::iterator segment_iter = mTextSegments.begin() + start_segment;
              segment_iter != mTextSegments.end(); ++segment_iter )
         {
-            if (reset_buffers)
-            {
-                segment_iter->mFontBufferText.reset();
-            }
-
             const LLFontGL* fontp = segment_iter->mFont;
             y_offset -= fontp->getLineHeight() - 1; // correction factor to match legacy font metrics
 

--- a/indra/newview/llhudtext.h
+++ b/indra/newview/llhudtext.h
@@ -67,7 +67,6 @@ protected:
         LLColor4                mColor;
         LLFontGL::StyleFlags    mStyle;
         const LLFontGL*         mFont;
-        LLFontVertexBuffer      mFontBuffer;
         LLFontVertexBuffer      mFontBufferText;
     private:
         LLWString               mText;


### PR DESCRIPTION
Initially this code was responsible for refreshing nametags, but now buffer tracks position updates by itself, so code causes excessive refreshes.