### PR TITLE
#2884 fix for stalls caused by coro suspend

### DIFF
--- a/indra/llcommon/llcoros.cpp
+++ b/indra/llcommon/llcoros.cpp
@@ -472,7 +472,7 @@ LLBoundListener LLCoros::getStopListener(const std::string& caller,
     // This overload responds to viewer shutdown and to killreq(consumer).
     return LLEventPumps::instance().obtain("LLCoros")
         .listen(
-            LLEventPump::inventName(caller),
+            caller,
             [consumer, cleanup](const LLSD& event)
             {
                 auto status{ event["status"].asString() };

--- a/indra/llcommon/lleventcoro.cpp
+++ b/indra/llcommon/lleventcoro.cpp
@@ -168,7 +168,7 @@ postAndSuspendSetup(const std::string& callerName,
     // notice the pending LLApp status first.
     LLBoundListener stopper(
         LLCoros::getStopListener(
-            listenerName,
+            LLEventPump::ANONYMOUS,
             LLCoros::instance().getName(),
             [&promise, listenerName](const LLSD& status)
             {

--- a/indra/llcommon/lualistener.cpp
+++ b/indra/llcommon/lualistener.cpp
@@ -40,7 +40,7 @@ LuaListener::LuaListener(lua_State* L):
     // Listen for shutdown events.
     mShutdownConnection(
         LLCoros::getStopListener(
-            "LuaState",
+            LLEventPump::ANONYMOUS,
             mCoroName,
             [this](const LLSD&)
             {


### PR DESCRIPTION
Reverted one change introduced in https://github.com/secondlife/viewer/commit/c78be38a6a4211f06876bc80b3f19f89a5f936e0

This changeset also fixes the issue with stalls after running multiple Lua scripts with `sleep` inside a loop - https://github.com/secondlife/viewer/issues/2917