### PR TITLE
secondlife/viewer#2768: Fix for PBR texture animations sometimes not starting 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: indent-with-spaces
         files: \.(cpp|c|h|inl|py|glsl|cmake)$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-xml
       - id: mixed-line-ending

--- a/indra/newview/llface.cpp
+++ b/indra/newview/llface.cpp
@@ -1557,7 +1557,7 @@ bool LLFace::getGeometryVolume(const LLVolume& volume,
             }
 
             U8 texgen = getTextureEntry()->getTexGen();
-            if (rebuild_tcoord && texgen != LLTextureEntry::TEX_GEN_DEFAULT)
+            if (texgen != LLTextureEntry::TEX_GEN_DEFAULT)
             { //planar texgen needs binormals
                 mVObjp->getVolume()->genTangents(face_index);
             }

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -123,7 +123,7 @@ public:
 
     std::vector<LLPointer<LLViewerTexture> > mTextureList;
 
-    LLUUID mMaterialID; // id of LLGLTFMaterial or LLMaterial applied to this draw info
+    LLUUID mMaterialHash; // hash of LLGLTFMaterial or LLMaterial applied to this draw info
 
     U32 mShaderMask = 0;
     F32  mEnvIntensity = 0.f;
@@ -272,8 +272,7 @@ public:
         IN_IMAGE_QUEUE          = (ALPHA_DIRTY << 1),
         IMAGE_DIRTY             = (IN_IMAGE_QUEUE << 1),
         MESH_DIRTY              = (IMAGE_DIRTY << 1),
-        NEW_DRAWINFO            = (MESH_DIRTY << 1),
-        IN_BUILD_Q1             = (NEW_DRAWINFO << 1),
+        IN_BUILD_Q1             = (MESH_DIRTY << 1),
         IN_BUILD_Q2             = (IN_BUILD_Q1 << 1),
         STATE_MASK              = 0x0000FFFF,
     } eSpatialState;

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -9897,7 +9897,6 @@ void initialize_menus()
     view_listener_t::addMenu(new LLAdvancedClickGLTFEdit(), "Advanced.ClickGLTFEdit", cb_info::UNTRUSTED_BLOCK);
     view_listener_t::addMenu(new LLAdvancedClickResizeWindow(), "Advanced.ClickResizeWindow", cb_info::UNTRUSTED_BLOCK);
     view_listener_t::addMenu(new LLAdvancedPurgeShaderCache(), "Advanced.ClearShaderCache", cb_info::UNTRUSTED_BLOCK);
-    view_listener_t::addMenu(new LLAdvancedRebuildTerrain(), "Advanced.RebuildTerrain", cb_info::UNTRUSTED_BLOCK);
 
     #ifdef TOGGLE_HACKED_GODLIKE_VIEWER
     view_listener_t::addMenu(new LLAdvancedHandleToggleHackedGodmode(), "Advanced.HandleToggleHackedGodmode");
@@ -9915,10 +9914,10 @@ void initialize_menus()
     view_listener_t::addMenu(new LLAdvancedResetInterestLists(), "Advanced.ResetInterestLists");
 
     // Develop > Terrain
-    view_listener_t::addMenu(new LLAdvancedRebuildTerrain(), "Advanced.RebuildTerrain");
-    view_listener_t::addMenu(new LLAdvancedTerrainCreateLocalPaintMap(), "Advanced.TerrainCreateLocalPaintMap");
-    view_listener_t::addMenu(new LLAdvancedTerrainEditLocalPaintMap(), "Advanced.TerrainEditLocalPaintMap");
-    view_listener_t::addMenu(new LLAdvancedTerrainDeleteLocalPaintMap(), "Advanced.TerrainDeleteLocalPaintMap");
+    view_listener_t::addMenu(new LLAdvancedRebuildTerrain(), "Advanced.RebuildTerrain", cb_info::UNTRUSTED_BLOCK);
+    view_listener_t::addMenu(new LLAdvancedTerrainCreateLocalPaintMap(), "Advanced.TerrainCreateLocalPaintMap", cb_info::UNTRUSTED_BLOCK);
+    view_listener_t::addMenu(new LLAdvancedTerrainEditLocalPaintMap(), "Advanced.TerrainEditLocalPaintMap", cb_info::UNTRUSTED_BLOCK);
+    view_listener_t::addMenu(new LLAdvancedTerrainDeleteLocalPaintMap(), "Advanced.TerrainDeleteLocalPaintMap", cb_info::UNTRUSTED_BLOCK);
 
     // Advanced > UI
     registrar.add("Advanced.WebBrowserTest", boost::bind(&handle_web_browser_test, _2));  // sigh! this one opens the MEDIA browser

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5431,7 +5431,7 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
         info->mEnd - draw_vec[idx]->mStart + facep->getGeomCount() <= (U32) gGLManager.mGLMaxVertexRange &&
         info->mCount + facep->getIndicesCount() <= (U32) gGLManager.mGLMaxIndexRange &&
 #endif
-        info->mMaterialID == mat_id &&
+        info->mMaterialHash == mat_id &&
         info->mFullbright == fullbright &&
         info->mBump == bump &&
         (!mat || (info->mShiny == shiny)) && // need to break batches when a material is shared, but legacy settings are different
@@ -5490,11 +5490,11 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
         if (gltf_mat)
         {
             // just remember the material ID, render pools will reference the GLTF material
-            draw_info->mMaterialID = mat_id;
+            draw_info->mMaterialHash = mat_id;
         }
         else if (mat)
         {
-            draw_info->mMaterialID = mat_id;
+            draw_info->mMaterialHash = mat_id;
 
             // We have a material.  Update our draw info accordingly.
 
@@ -5526,10 +5526,10 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
             }
         }
 
-        // if (type == LLRenderPass::PASS_ALPHA) // always populate the draw_info ptr
-        { //for alpha sorting
-            facep->setDrawInfo(draw_info);
-        }
+        // This backpointer is used by alpha sorting and avatar attachment
+        // accounting.
+        // To be safe, always populate the draw_info ptr.
+        facep->setDrawInfo(draw_info);
 
         if (index < FACE_DO_NOT_BATCH_TEXTURES)
         { //initialize texture list for texture batching
@@ -6151,7 +6151,7 @@ void LLVolumeGeometryManager::rebuildMesh(LLSpatialGroup* group)
                 LLVertexBuffer::flushBuffers();
             }
 
-            group->clearState(LLSpatialGroup::MESH_DIRTY | LLSpatialGroup::NEW_DRAWINFO);
+            group->clearState(LLSpatialGroup::MESH_DIRTY);
         }
     }
 }

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -3520,11 +3520,6 @@ void LLPipeline::postSort(LLCamera &camera)
             continue;
         }
 
-        if (group->hasState(LLSpatialGroup::NEW_DRAWINFO) && group->hasState(LLSpatialGroup::GEOM_DIRTY) && !gCubeSnapshot)
-        {  // no way this group is going to be drawable without a rebuild
-            group->rebuildGeom();
-        }
-
         for (LLSpatialGroup::draw_map_t::iterator j = group->mDrawMap.begin(); j != group->mDrawMap.end(); ++j)
         {
             LLSpatialGroup::drawmap_elem_t &src_vec = j->second;


### PR DESCRIPTION
Follow-up to https://github.com/secondlife/viewer/pull/2971 .

This fixes another case where PBR texture animations did not play, if the PBR base material does not contain textures but the GLTF material overrides do. The GLTF material overrides were arriving sufficiently late such that the texture virtual size was calculated to be 0, which prevented the texture matrix from being copied over to the `LLDrawInfo`. Since the contents of the overrides cannot be predicted in advance, a rebuild is required.