### PR TITLE
2590 mac intel and radeon pro 5300m horrible fps 2

### DIFF
--- a/indra/llrender/llvertexbuffer.cpp
+++ b/indra/llrender/llvertexbuffer.cpp
@@ -272,11 +272,13 @@ static GLuint gen_buffer()
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_VERTEX("gen buffer");
         sIndex = pool_size;
+#if !LL_DARWIN
         if (!gGLManager.mIsAMD)
         {
             glGenBuffers(pool_size, sNamePool);
         }
         else
+#endif
         { // work around for AMD driver bug
             for (U32 i = 0; i < pool_size; ++i)
             {
@@ -942,6 +944,10 @@ void LLVertexBuffer::drawArrays(U32 mode, U32 first, U32 count) const
 void LLVertexBuffer::initClass(LLWindow* window)
 {
     llassert(sVBOPool == nullptr);
+
+    LL_INFOS() << "VBO Pooling Disabled" << LL_ENDL;
+    sVBOPool = new LLAppleVBOPool();
+
     if (gGLManager.mIsApple)
     {
         LL_INFOS() << "VBO Pooling Disabled" << LL_ENDL;

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7836,7 +7836,7 @@
         <key>Type</key>
         <string>U32</string>
         <key>Value</key>
-        <integer>1</integer>
+        <integer>0</integer>
     </map>
     <key>RenderDebugTextureBind</key>
     <map>
@@ -16037,6 +16037,17 @@
     <string>Boolean</string>
     <key>Value</key>
     <integer>0</integer>
+  </map>
+  <key>RenderHDREnabled</key>
+  <map>
+    <key>Comment</key>
+    <string>Enable HDR rendering.</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
   </map>
 </map>
 </llsd>

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarF.glsl
@@ -36,6 +36,7 @@ in vec2 vary_texcoord0;
 in vec3 vary_position;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 void main()
 {
@@ -51,7 +52,7 @@ void main()
     frag_data[0] = vec4(diff.rgb, 0.0);
     frag_data[1] = vec4(0,0,0,0);
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/bumpF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/bumpF.glsl
@@ -40,6 +40,8 @@ in vec2 vary_texcoord0;
 in vec3 vary_position;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 void main()
 {
     mirrorClip(vary_position);
@@ -62,6 +64,6 @@ void main()
         frag_data[1] = vertex_color.aaaa; // spec
         //frag_data[1] = vec4(vec3(vertex_color.a), vertex_color.a+(1.0-vertex_color.a)*vertex_color.a); // spec - from former class3 - maybe better, but not so well tested
         vec3 nvn = normalize(tnorm);
-        frag_data[2] = vec4(nvn, GBUFFER_FLAG_HAS_ATMOS);
+        frag_data[2] = encodeNormal(nvn, GBUFFER_FLAG_HAS_ATMOS);
         frag_data[3] = vec4(vertex_color.a, 0, 0, 0);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/deferredUtil.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/deferredUtil.glsl
@@ -75,6 +75,9 @@ const float ONE_OVER_PI = 0.3183098861;
 vec3 srgb_to_linear(vec3 cs);
 vec3 atmosFragLightingLinear(vec3 light, vec3 additive, vec3 atten);
 
+vec4 decodeNormal(vec4 norm);
+
+
 float calcLegacyDistanceAttenuation(float distance, float falloff)
 {
     float dist_atten = 1.0 - clamp((distance + falloff)/(1.0 + falloff), 0.0, 1.0);
@@ -145,8 +148,7 @@ vec2 getScreenCoordinate(vec2 screenpos)
 
 vec4 getNorm(vec2 screenpos)
 {
-    vec4 norm = texture(normalMap, screenpos.xy);
-    norm.xyz = normalize(norm.xyz);
+    vec4 norm = decodeNormal(texture(normalMap, screenpos.xy));
     return norm;
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskF.glsl
@@ -39,6 +39,8 @@ in vec2 vary_texcoord0;
 
 void mirrorClip(vec3 pos);
 
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 void main()
 {
     mirrorClip(vary_position);
@@ -53,7 +55,7 @@ void main()
     frag_data[0] = vec4(col.rgb, 0.0);
     frag_data[1] = vec4(0,0,0,0); // spec
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskIndexedF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskIndexedF.glsl
@@ -36,6 +36,7 @@ in vec4 vertex_color;
 in vec2 vary_texcoord0;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 void main()
 {
@@ -51,6 +52,6 @@ void main()
     frag_data[0] = vec4(col.rgb, 0.0);
     frag_data[1] = vec4(0,0,0,0);
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskNoColorF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/diffuseAlphaMaskNoColorF.glsl
@@ -33,6 +33,7 @@ uniform sampler2D diffuseMap;
 
 in vec3 vary_normal;
 in vec2 vary_texcoord0;
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 void main()
 {
@@ -46,7 +47,7 @@ void main()
     frag_data[0] = vec4(col.rgb, 0.0);
     frag_data[1] = vec4(0,0,0,0); // spec
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/diffuseF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/diffuseF.glsl
@@ -35,6 +35,7 @@ in vec2 vary_texcoord0;
 in vec3 vary_position;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 void main()
 {
@@ -42,9 +43,8 @@ void main()
     vec3 col = vertex_color.rgb * texture(diffuseMap, vary_texcoord0.xy).rgb;
     frag_data[0] = vec4(col, 0.0);
     frag_data[1] = vertex_color.aaaa; // spec
-    //frag_data[1] = vec4(vec3(vertex_color.a), vertex_color.a+(1.0-vertex_color.a)*vertex_color.a); // spec - from former class3 - maybe better, but not so well tested
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(vertex_color.a, 0, 0, 0);
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/diffuseIndexedF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/diffuseIndexedF.glsl
@@ -33,6 +33,8 @@ in vec2 vary_texcoord0;
 in vec3 vary_position;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 vec3 linear_to_srgb(vec3 c);
 
 void main()
@@ -46,6 +48,6 @@ void main()
     frag_data[0] = vec4(col, 0.0);
     frag_data[1] = vec4(spec, vertex_color.a); // spec
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(vertex_color.a, 0, 0, 0);
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/globalF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/globalF.glsl
@@ -43,3 +43,15 @@ void mirrorClip(vec3 pos)
     }
 }
 
+vec4 encodeNormal(vec3 norm, float gbuffer_flag)
+{
+    return vec4(norm * 0.5 + 0.5, gbuffer_flag);
+}
+
+vec4 decodeNormal(vec4 norm)
+{
+    norm.xyz = norm.xyz * 2.0 - 1.0;
+    return norm;
+}
+
+

--- a/indra/newview/app_settings/shaders/class1/deferred/impostorF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/impostorF.glsl
@@ -38,6 +38,8 @@ in vec2 vary_texcoord0;
 
 vec3 linear_to_srgb(vec3 c);
 
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 void main()
 {
     vec4 col = texture(diffuseMap, vary_texcoord0.xy);

--- a/indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl
@@ -61,6 +61,7 @@ uniform vec4 clipPlane;
 uniform float clipSign;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 uniform mat3 normal_matrix;
 
@@ -113,7 +114,7 @@ void main()
     // See: C++: addDeferredAttachments(), GLSL: softenLightF
     frag_data[0] = max(vec4(col, 0.0), vec4(0));                                                   // Diffuse
     frag_data[1] = max(vec4(spec.rgb,0.0), vec4(0));                                    // PBR linear packed Occlusion, Roughness, Metal.
-    frag_data[2] = vec4(tnorm, GBUFFER_FLAG_HAS_PBR); // normal, environment intensity, flags
+    frag_data[2] = encodeNormal(tnorm, GBUFFER_FLAG_HAS_PBR); // normal, environment intensity, flags
     frag_data[3] = max(vec4(emissive,0), vec4(0));                                                // PBR sRGB Emissive
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/pbrterrainF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbrterrainF.glsl
@@ -162,6 +162,7 @@ in vec4[2] vary_coords;
 #endif
 
 void mirrorClip(vec3 position);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 float terrain_mix(TerrainMix tm, vec4 tms4);
 
@@ -429,7 +430,7 @@ void main()
 #endif
     frag_data[0] = max(vec4(pbr_mix.col.xyz, 0.0), vec4(0));                                                   // Diffuse
     frag_data[1] = max(vec4(mix_orm.rgb, base_color_factor_alpha), vec4(0));                                    // PBR linear packed Occlusion, Roughness, Metal.
-    frag_data[2] = vec4(tnorm, GBUFFER_FLAG_HAS_PBR); // normal, flags
+    frag_data[2] = encodeNormal(tnorm, GBUFFER_FLAG_HAS_PBR); // normal, flags
     frag_data[3] = max(vec4(mix_emissive,0), vec4(0));                                                // PBR sRGB Emissive
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/terrainF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/terrainF.glsl
@@ -39,6 +39,7 @@ in vec4 vary_texcoord0;
 in vec4 vary_texcoord1;
 
 void mirrorClip(vec3 position);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 void main()
 {
@@ -60,7 +61,7 @@ void main()
     frag_data[0] = max(outColor, vec4(0));
     frag_data[1] = vec4(0.0,0.0,0.0,-1.0);
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }
 

--- a/indra/newview/app_settings/shaders/class1/deferred/treeF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/treeF.glsl
@@ -37,6 +37,8 @@ in vec3 vary_position;
 uniform float minimum_alpha;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 void main()
 {
     mirrorClip(vary_position);
@@ -49,6 +51,6 @@ void main()
     frag_data[0] = vec4(vertex_color.rgb*col.rgb, 0.0);
     frag_data[1] = vec4(0,0,0,0);
     vec3 nvn = normalize(vary_normal);
-    frag_data[2] = vec4(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
+    frag_data[2] = encodeNormal(nvn.xyz, GBUFFER_FLAG_HAS_ATMOS);
     frag_data[3] = vec4(0);
 }

--- a/indra/newview/app_settings/shaders/class1/gltf/pbrmetallicroughnessF.glsl
+++ b/indra/newview/app_settings/shaders/class1/gltf/pbrmetallicroughnessF.glsl
@@ -64,6 +64,8 @@ in vec2 base_color_uv;
 in vec2 emissive_uv;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
+
 vec3 linear_to_srgb(vec3 c);
 vec3 srgb_to_linear(vec3 c);
 // ==================================
@@ -241,7 +243,7 @@ void main()
 #else
     frag_data[0] = max(vec4(basecolor.rgb, 0.0), vec4(0));
     frag_data[1] = max(vec4(orm.rgb,0.0), vec4(0));
-    frag_data[2] = vec4(norm, GBUFFER_FLAG_HAS_PBR);
+    frag_data[2] = encodeNormal(norm, GBUFFER_FLAG_HAS_PBR);
     frag_data[3] = max(vec4(emissive,0), vec4(0));
 #endif
 #endif

--- a/indra/newview/app_settings/shaders/class3/deferred/materialF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/materialF.glsl
@@ -51,6 +51,7 @@ uniform mat3 normal_matrix;
 in vec3 vary_position;
 
 void mirrorClip(vec3 pos);
+vec4 encodeNormal(vec3 norm, float gbuffer_flag);
 
 #if (DIFFUSE_ALPHA_MODE == DIFFUSE_ALPHA_MODE_BLEND)
 
@@ -414,7 +415,7 @@ void main()
 
     frag_data[0] = max(vec4(diffcol.rgb, emissive), vec4(0));        // gbuffer is sRGB for legacy materials
     frag_data[1] = max(vec4(spec.rgb, glossiness), vec4(0));           // XYZ = Specular color. W = Specular exponent.
-    frag_data[2] = vec4(norm, flag);   // XY = Normal.  Z = Env. intensity. W = 1 skip atmos (mask off fog)
+    frag_data[2] = encodeNormal(norm, flag);   // XY = Normal.  Z = Env. intensity. W = 1 skip atmos (mask off fog)
     frag_data[3] = vec4(env, 0, 0, 0);
 
 #endif

--- a/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/softenLightF.glsl
@@ -27,6 +27,8 @@
 
 out vec4 frag_color;
 
+vec4 decodeNormal(vec4 norm);
+
 uniform sampler2D diffuseRect;
 uniform sampler2D specularRect;
 uniform sampler2D emissiveRect; // PBR linear packed Occlusion, Roughness, Metal. See: pbropaqueF.glsl

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -79,7 +79,7 @@ RenderHeroProbeResolution	1	2048
 RenderHeroProbeDistance		1	16
 RenderHeroProbeUpdateRate	1	6
 RenderHeroProbeConservativeUpdateMultiplier 1 16
-RenderDownScaleMethod       1   1
+RenderDownScaleMethod       1   0
 RenderCASSharpness          1   1
 RenderExposure				1   4
 RenderTonemapType			1   1

--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -463,6 +463,11 @@ void LLReflectionMapManager::update()
 
 LLReflectionMap* LLReflectionMapManager::addProbe(LLSpatialGroup* group)
 {
+    if (gGLManager.mGLVersion < 4.05f)
+    {
+        return nullptr;
+    }
+
     LLReflectionMap* probe = new LLReflectionMap();
     probe->mGroup = group;
 

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -1303,12 +1303,15 @@ void LLViewerRegion::updateReflectionProbes(bool full_update)
                 mReflectionMaps[idx] = gPipeline.mReflectionMapManager.addProbe();
             }
 
-            LLVector3 probe_origin = LLVector3(x, y, llmax(water_height, mImpl->mLandp->resolveHeightRegion(x, y)));
-            probe_origin.mV[2] += hover_height;
-            probe_origin += origin;
+            if (mReflectionMaps[idx])
+            {
+                LLVector3 probe_origin = LLVector3(x, y, llmax(water_height, mImpl->mLandp->resolveHeightRegion(x, y)));
+                probe_origin.mV[2] += hover_height;
+                probe_origin += origin;
 
-            mReflectionMaps[idx]->mOrigin.load3(probe_origin.mV);
-            mReflectionMaps[idx]->mRadius = probe_radius;
+                mReflectionMaps[idx]->mOrigin.load3(probe_origin.mV);
+                mReflectionMaps[idx]->mRadius = probe_radius;
+            }
         }
     }
 }

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -2493,7 +2493,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         }
     }
 
-    if (success)
+    if (success && gGLManager.mGLVersion > 4.05f)
     {
         gCASProgram.mName = "Contrast Adaptive Sharpening Shader";
         gCASProgram.mFeatures.hasSrgb = true;

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -546,7 +546,9 @@ void LLViewerTexture::updateClass()
         if (sEvaluationTimer.getElapsedTimeF32() > MEMORY_CHECK_WAIT_TIME)
         {
             static LLCachedControl<F32> low_mem_min_discard_increment(gSavedSettings, "RenderLowMemMinDiscardIncrement", .1f);
-            sDesiredDiscardBias += (F32) low_mem_min_discard_increment * (F32) gFrameIntervalSeconds;
+
+            F32 increment = low_mem_min_discard_increment + llmax(over_pct, 0.f);
+            sDesiredDiscardBias += increment * gFrameIntervalSeconds;
         }
     }
     else

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -607,7 +607,7 @@ void LLViewerTexture::updateClass()
                 last_desired_discard_bias = sDesiredDiscardBias;
                 was_backgrounded = true;
             }
-            sDesiredDiscardBias = 4.f;
+            sDesiredDiscardBias = 5.f;
         }
     }
     else
@@ -621,7 +621,7 @@ void LLViewerTexture::updateClass()
         }
     }
 
-    sDesiredDiscardBias = llclamp(sDesiredDiscardBias, 1.f, 4.f);
+    sDesiredDiscardBias = llclamp(sDesiredDiscardBias, 1.f, 5.f);
 
     LLViewerTexture::sFreezeImageUpdates = false;
 }

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -410,6 +410,8 @@ public:
 
     /*virtual*/bool  isActiveFetching() override; //is actively in fetching by the fetching pipeline.
 
+    virtual bool scaleDown() { return false; };
+
     bool mCreatePending = false;    // if true, this is in gTextureList.mCreateTextureList
     mutable bool mDownScalePending = false; // if true, this is in gTextureList.mDownScaleQueue
 
@@ -532,7 +534,7 @@ public:
     /*virtual*/ void processTextureStats();
     bool isUpdateFrozen() ;
 
-    bool scaleDown();
+    bool scaleDown() override;
 
 private:
     void init(bool firstinit) ;

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -529,9 +529,9 @@ public:
     LLViewerLODTexture(const LLUUID& id, FTType f_type, const LLHost& host = LLHost(), bool usemipmaps = true);
     LLViewerLODTexture(const std::string& url, FTType f_type, const LLUUID& id, bool usemipmaps = true);
 
-    /*virtual*/ S8 getType() const;
+    S8 getType() const override;
     // Process image stats to determine priority/quality requirements.
-    /*virtual*/ void processTextureStats();
+    void processTextureStats() override;
     bool isUpdateFrozen() ;
 
     bool scaleDown() override;

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1054,6 +1054,9 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
 
     if (!mDownScaleQueue.empty() && gPipeline.mDownResMap.isComplete())
     {
+        LLGLDisable blend(GL_BLEND);
+        gGL.setColorMask(true, true);
+
         // just in case we downres textures, bind downresmap and copy program
         gPipeline.mDownResMap.bindTarget();
         gCopyProgram.bind();
@@ -1094,7 +1097,9 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
     // do at least 5 and make sure we don't get too far behind even if it violates
     // the time limit.  Textures pending creation have a copy of their texture data
     // in system memory, so we don't want to let them pile up.
-    S32 min_count = (S32) mCreateTextureList.size() / 20 + 5;
+    //S32 min_count = (S32) mCreateTextureList.size() / 20 + 5;
+
+    create_timer.reset();
 
     while (!mCreateTextureList.empty())
     {
@@ -1105,7 +1110,7 @@ F32 LLViewerTextureList::updateImagesCreateTextures(F32 max_time)
         imagep->mCreatePending = false;
         mCreateTextureList.pop();
 
-        if (create_timer.getElapsedTimeF32() > max_time && --min_count <= 0)
+        if (create_timer.getElapsedTimeF32() > max_time) // && --min_count <= 0)
         {
             break;
         }


### PR DESCRIPTION
Address some performance issues on Intel Mac and fix some texture corruption when using FBOs for downscaling.

Allows AMD Apple GPUs  to batch-allocate VBO names.
Fixes compatibility with OpenGL < 4.1.
Increases maximum texture bias to 5 from 4.
Increases texture bias more quickly when memory pressure is very high.
Fix FBO driven texture downscaling performance and occasional texture corruption from GL_BLEND being enabled during downscaling.
Makes FBO downscaling the default method.
Introduce experimental feature -- RenderHDREnabled -- that will optionally disable HDR rendering.