### PR TITLE
viewer#3055 Fix texture fetch being stuck

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1555,8 +1555,8 @@ void LLViewerFetchedTexture::postCreateTexture()
     if (!needsToSaveRawImage())
     {
         mNeedsAux = false;
-        destroyRawImage();
     }
+    destroyRawImage(); // will save raw image if needed
 
     mNeedsCreateTexture = false;
 }


### PR DESCRIPTION
destroyRawImage() is the only function that calls saveRawImage(), not calling it results in fetcher thinking that it still needs data to do the saving and looping back to trying to fetch.