### PR TITLE
Attempt at fix for secondlife/viewer#2745 mac crash when app is in background

### DIFF
--- a/indra/llcommon/llprocessor.cpp
+++ b/indra/llcommon/llprocessor.cpp
@@ -692,7 +692,8 @@ private:
         memset(cpu_vendor, 0, len);
         sysctlbyname("machdep.cpu.vendor", (void*)cpu_vendor, &len, NULL, 0);
         cpu_vendor[0x1f] = 0;
-        setInfo(eVendor, cpu_vendor);
+        // M series CPUs don't provide this field so if empty, just fall back to Apple.
+        setInfo(eVendor, (cpu_vendor[0] != '\0') ? cpu_vendor : "Apple");
 
         setInfo(eStepping, getSysctlInt("machdep.cpu.stepping"));
         setInfo(eModel, getSysctlInt("machdep.cpu.model"));

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -1,4 +1,4 @@
-version 62
+version 63
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -68,8 +68,8 @@ RenderFSAASamples			1	3
 RenderMaxTextureIndex		1	16
 RenderGLContextCoreProfile         1   1
 RenderGLMultiThreadedTextures      1   0
-RenderGLMultiThreadedMedia         1   1
-RenderAppleUseMultGL        1   1
+RenderGLMultiThreadedMedia         1   0
+RenderAppleUseMultGL        1   0
 RenderReflectionsEnabled    1   1
 RenderReflectionProbeDetail	1	2
 RenderScreenSpaceReflections 1  1
@@ -408,8 +408,8 @@ RenderFSAASamples			1	0
 
 // AppleGPU and NonAppleGPU can be thought of as Apple silicon vs Intel Mac
 list AppleGPU
-RenderGLMultiThreadedMedia  1   1
-RenderAppleUseMultGL        1   1
+RenderGLMultiThreadedMedia  1   0
+RenderAppleUseMultGL        1   0
 
 list NonAppleGPU
 RenderGLMultiThreadedMedia  1   0


### PR DESCRIPTION
once again disable RenderAppleUseMultGL and RenderGLMultiThreadedMedia
also added a tiny fix for missing processor vendor in crash reports