### PR TITLE
Fix calling LLFloaterPreference::setPanelVisibility resulting in selecting the 1st tab

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1988,7 +1988,9 @@ void LLFloaterPreference::setPanelVisibility(const LLSD& name, bool visible)
     LLPanel * panel = tab_containerp->getPanelByName(name.asStringRef());
     if (NULL != panel)
     {
+        auto current_tab = tab_containerp->getCurrentPanel();
         tab_containerp->setTabVisibility(panel, visible);
+        tab_containerp->selectTabPanel(current_tab);
     }
 }
 


### PR DESCRIPTION
I'm not quite sure if there currently is a way to reproduce this in the LL viewer, but if changing any graphics settings will trigger this method being called and changing the selected tab to the first one in the list.