### PR TITLE
Add Support HTTP Multiplexing

### DIFF
--- a/indra/llcorehttp/_httplibcurl.cpp
+++ b/indra/llcorehttp/_httplibcurl.cpp
@@ -487,7 +487,7 @@ void HttpLibcurl::policyUpdated(unsigned int policy_class)
         policy.stallPolicy(policy_class, false);
         mDirtyPolicy[policy_class] = false;
 
-        if (options.mPipelining > 1)
+        if (options.mPipelining)
         {
             // We'll try to do pipelining on this multihandle
             check_curl_multi_setopt(multi_handle,

--- a/indra/llcorehttp/_httplibcurl.cpp
+++ b/indra/llcorehttp/_httplibcurl.cpp
@@ -493,7 +493,7 @@ void HttpLibcurl::policyUpdated(unsigned int policy_class)
             LL_INFOS("HttpLibcurl") << "HTTP Pipelining Enable." << LL_ENDL;
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_PIPELINING,
-                                     1L);
+                                     CURLPIPE_MULTIPLEX | CURLPIPE_HTTP1);
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_MAX_PIPELINE_LENGTH,
                                      long(options.mPipelining));
@@ -509,7 +509,7 @@ void HttpLibcurl::policyUpdated(unsigned int policy_class)
             LL_INFOS("HttpLibcurl") << "HTTP Pipelining Disable." << LL_ENDL;
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_PIPELINING,
-                                     0L);
+                                     CURLPIPE_NOTHING);
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_MAX_HOST_CONNECTIONS,
                                      0L);

--- a/indra/llcorehttp/_httplibcurl.cpp
+++ b/indra/llcorehttp/_httplibcurl.cpp
@@ -490,6 +490,7 @@ void HttpLibcurl::policyUpdated(unsigned int policy_class)
         if (options.mPipelining)
         {
             // We'll try to do pipelining on this multihandle
+            LL_INFOS("HttpLibcurl") << "HTTP Pipelining Enable." << LL_ENDL;
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_PIPELINING,
                                      1L);
@@ -505,6 +506,7 @@ void HttpLibcurl::policyUpdated(unsigned int policy_class)
         }
         else
         {
+            LL_INFOS("HttpLibcurl") << "HTTP Pipelining Disable." << LL_ENDL;
             check_curl_multi_setopt(multi_handle,
                                      CURLMOPT_PIPELINING,
                                      0L);


### PR DESCRIPTION
Enables HTTP/2 Multiplexing.
If this doesn't work, it will use HTTP pipelining.