### PR TITLE
#2696 Viewer crashes on gestures : add checkbox 'Play all infinitely'

### DIFF
--- a/indra/newview/llfloatergesture.cpp
+++ b/indra/newview/llfloatergesture.cpp
@@ -36,6 +36,7 @@
 
 #include "llagent.h"
 #include "llappearancemgr.h"
+#include "llcheckboxctrl.h"
 #include "llclipboard.h"
 #include "llgesturemgr.h"
 #include "llkeyboard.h"
@@ -208,9 +209,12 @@ bool LLFloaterGesture::postBuild()
     getChild<LLUICtrl>("new_gesture_btn")->setCommitCallback(boost::bind(&LLFloaterGesture::onClickNew, this));
     getChild<LLButton>("del_btn")->setClickedCallback(boost::bind(&LLFloaterGesture::onDeleteSelected, this));
 
-    getChildView("play_btn")->setVisible( true);
-    getChildView("stop_btn")->setVisible( false);
+    getChildView("play_btn")->setVisible(true);
+    getChildView("stop_btn")->setVisible(false);
     setDefaultBtn("play_btn");
+
+    mPlayAllInfinitely = getChild<LLCheckBoxCtrl>("play_all_infinitely");
+
     mGestureFolderID = gInventory.findCategoryUUIDForType(LLFolderType::FT_GESTURE);
 
     uuid_vec_t folders;
@@ -237,6 +241,47 @@ bool LLFloaterGesture::postBuild()
     return true;
 }
 
+void LLFloaterGesture::draw()
+{
+    LLFloater::draw();
+
+    static LLCachedControl<bool> sQAMode(gSavedSettings, "QAMode", false);
+    if (!sQAMode)
+    {
+        mPlayAllInfinitely->setVisible(false);
+    }
+    else
+    {
+        if (!mPlayAllInfinitely->getVisible())
+        {
+            mPlayAllInfinitely->setValue(false);
+            mPlayAllInfinitely->setVisible(true);
+        }
+        else if (mPlayAllInfinitely->getValue().asBoolean())
+        {
+            static U8 frame_nr = 0;
+            if (++frame_nr > 3)
+            {
+                frame_nr = 0;
+            }
+            else if (frame_nr == 1)
+            {
+                onClickPlay();
+            }
+            else if (frame_nr == 3)
+            {
+                LLScrollListItem* prev_item = mGestureList->getFirstSelected();
+                mGestureList->selectNextItem();
+                LLScrollListItem* next_item = mGestureList->getFirstSelected();
+                if (next_item == prev_item)
+                {
+                    mGestureList->selectFirstItem();
+                }
+                mGestureList->scrollToShowSelected();
+            }
+        }
+    }
+}
 
 void LLFloaterGesture::refreshAll()
 {

--- a/indra/newview/llfloatergesture.h
+++ b/indra/newview/llfloatergesture.h
@@ -40,6 +40,7 @@ class LLView;
 class LLButton;
 class LLLineEditor;
 class LLComboBox;
+class LLCheckBoxCtrl;
 class LLViewerGesture;
 class LLGestureOptions;
 class LLScrollListCtrl;
@@ -57,20 +58,22 @@ public:
     virtual ~LLFloaterGesture();
 
     virtual bool postBuild();
-    virtual void done ();
+    virtual void draw();
+    virtual void done();
     void refreshAll();
     /**
      * @brief Add new scrolllistitem into gesture_list.
      * @param  item_id inventory id of gesture
      * @param  gesture can be NULL , if item was not loaded yet
      */
-    void addGesture(const LLUUID& item_id, LLMultiGesture* gesture, LLCtrlListInterface * list);
+    void addGesture(const LLUUID& item_id, LLMultiGesture* gesture, LLCtrlListInterface* list);
 
 protected:
     // Reads from the gesture manager's list of active gestures
     // and puts them in this list.
     void buildGestureList();
     void playGesture(LLUUID item_id);
+
 private:
     void addToCurrentOutFit();
     /**
@@ -102,7 +105,7 @@ private:
     LLUUID mSelectedID;
     LLUUID mGestureFolderID;
     LLScrollListCtrl* mGestureList;
-
+    LLCheckBoxCtrl* mPlayAllInfinitely;
     LLFloaterGestureObserver* mObserver;
 };
 

--- a/indra/newview/skins/default/xui/en/floater_gesture.xml
+++ b/indra/newview/skins/default/xui/en/floater_gesture.xml
@@ -12,7 +12,7 @@
  label="Places"
  layout="topleft"
  min_height="350"
- min_width="240"
+ min_width="313"
  width="313">
     <floater.string
      name="loading">
@@ -144,4 +144,11 @@
      name="stop_btn"
      top_delta="0"
      width="83" />
+    <check_box
+     name="play_all_infinitely"
+     label="Play all infinitely"
+     follows="bottom|right"
+     left_pad="5"
+     height="15"
+     width="100"/>
 </floater>


### PR DESCRIPTION
This checkbox is displayed at the bottom right corner of the GESTURES floater
It is visible only when the "Show Advanced Menu" option is ON
When this checkbox is checked, all gestures are being started in a cycle
This allows to reproduce the bug now and will allow to check for a regression in future (when the bug will be fixed)
![image](https://github.com/user-attachments/assets/8186015f-de2e-4a6e-bbca-c46872835a1c)![image](https://github.com/user-attachments/assets/e7b682af-e58f-42b8-bdf5-96fe08474540)




