### PR TITLE
secondlife/viewer#3104: Fix outfit gallery pictures sometimes not loading. Remove texture resolution restriction.

### DIFF
--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -55,8 +55,15 @@
 
 static LLPanelInjector<LLOutfitGallery> t_outfit_gallery("outfit_gallery");
 
-#define MAX_OUTFIT_PHOTO_WIDTH 256
-#define MAX_OUTFIT_PHOTO_HEIGHT 256
+// The maximum resolution at which to load the outfit photo. If the given
+// texture has a higher resolution, tell the texture streaming system to
+// only load the resolution needed. An in-world object may request to load
+// the texture at a higher resolution, but that won't affect textures
+// loaded with LLViewerTexture::FETCHED_TEXTURE. (see
+// LLOutfitGalleryItem::setImageAssetId and also
+// LLViewerTexture::LOD_TEXTURE)
+#define MAX_OUTFIT_PHOTO_LOAD_WIDTH 256
+#define MAX_OUTFIT_PHOTO_LOAD_HEIGHT 256
 
 const S32 GALLERY_ITEMS_PER_ROW_MIN = 2;
 
@@ -979,28 +986,18 @@ void LLOutfitGalleryItem::draw()
     border.mRight = border.mRight + 1;
     gl_rect_2d(border, border_color, false);
 
-    // If the floater is focused, don't apply its alpha to the texture (STORM-677).
-    const F32 alpha = getTransparencyType() == TT_ACTIVE ? 1.0f : getCurrentTransparency();
     if (mTexturep)
     {
-        if (mImageUpdatePending && mTexturep->getDiscardLevel() >= 0)
-        {
-            mImageUpdatePending = false;
-            if (mTexturep->getOriginalWidth() > MAX_OUTFIT_PHOTO_WIDTH || mTexturep->getOriginalHeight() > MAX_OUTFIT_PHOTO_HEIGHT)
-            {
-                setDefaultImage();
-            }
-        }
-        else
-        {
-            LLRect interior = border;
-            interior.stretch(-1);
+        LLRect interior = border;
+        interior.stretch(-1);
 
-            gl_draw_scaled_image(interior.mLeft - 1, interior.mBottom, interior.getWidth(), interior.getHeight(), mTexturep, UI_VERTEX_COLOR % alpha);
+        // Pump the priority
+        const F32 stats = (F32)llmin(interior.getWidth() * interior.getHeight(), MAX_OUTFIT_PHOTO_LOAD_WIDTH * MAX_OUTFIT_PHOTO_LOAD_HEIGHT);
+        mTexturep->addTextureStats(stats);
 
-            // Pump the priority
-            mTexturep->addTextureStats((F32)(interior.getWidth() * interior.getHeight()));
-        }
+        // If the floater is focused, don't apply its alpha to the texture (STORM-677).
+        const F32 alpha = getTransparencyType() == TT_ACTIVE ? 1.0f : getCurrentTransparency();
+        gl_draw_scaled_image(interior.mLeft - 1, interior.mBottom, interior.getWidth(), interior.getHeight(), mTexturep, UI_VERTEX_COLOR % alpha);
     }
 
 }
@@ -1129,13 +1126,17 @@ bool LLOutfitGalleryItem::openOutfitsContent()
 bool LLOutfitGalleryItem::setImageAssetId(LLUUID image_asset_id)
 {
     LLPointer<LLViewerFetchedTexture> texture = LLViewerTextureManager::getFetchedTexture(image_asset_id, FTT_DEFAULT, MIPMAP_YES, LLGLTexture::BOOST_NONE, LLViewerTexture::FETCHED_TEXTURE);
-    if (texture && texture->getOriginalWidth() <= MAX_OUTFIT_PHOTO_WIDTH && texture->getOriginalHeight() <= MAX_OUTFIT_PHOTO_HEIGHT)
+    if (texture)
     {
         mImageAssetId = image_asset_id;
         mTexturep = texture;
+        // *TODO: There was previously logic which attempted to toggle
+        // visibility of the preview icon based on certain conditions,
+        // however these conditions either did not make sense or were not
+        // applicable due to texture streaming. Maybe we should only hide
+        // the preview icon if the texture has at least one mip loaded.
         mPreviewIcon->setVisible(false);
         mDefaultImage = false;
-        mImageUpdatePending = (texture->getDiscardLevel() == -1);
         return true;
     }
     return false;
@@ -1152,7 +1153,6 @@ void LLOutfitGalleryItem::setDefaultImage()
     mImageAssetId.setNull();
     mPreviewIcon->setVisible(true);
     mDefaultImage = true;
-    mImageUpdatePending = false;
 }
 
 LLContextMenu* LLOutfitGalleryContextMenu::createMenu()

--- a/indra/newview/lloutfitgallery.cpp
+++ b/indra/newview/lloutfitgallery.cpp
@@ -1128,7 +1128,7 @@ bool LLOutfitGalleryItem::openOutfitsContent()
 
 bool LLOutfitGalleryItem::setImageAssetId(LLUUID image_asset_id)
 {
-    LLPointer<LLViewerFetchedTexture> texture = LLViewerTextureManager::getFetchedTexture(image_asset_id, FTT_DEFAULT, MIPMAP_YES, LLGLTexture::BOOST_NONE, LLViewerTexture::LOD_TEXTURE);
+    LLPointer<LLViewerFetchedTexture> texture = LLViewerTextureManager::getFetchedTexture(image_asset_id, FTT_DEFAULT, MIPMAP_YES, LLGLTexture::BOOST_NONE, LLViewerTexture::FETCHED_TEXTURE);
     if (texture && texture->getOriginalWidth() <= MAX_OUTFIT_PHOTO_WIDTH && texture->getOriginalHeight() <= MAX_OUTFIT_PHOTO_HEIGHT)
     {
         mImageAssetId = image_asset_id;

--- a/indra/newview/lloutfitgallery.h
+++ b/indra/newview/lloutfitgallery.h
@@ -266,7 +266,6 @@ private:
     bool     mSelected;
     bool     mWorn;
     bool     mDefaultImage;
-    bool     mImageUpdatePending;
     bool     mHidden;
     std::string mOutfitName;
 };


### PR DESCRIPTION
I have decided against the more common pattern of using texture boosting in this case. As mentioned in the ticket, outfits floater and texture loading need further follow-up. However, that work can be deferred.