### PR TITLE
#2696 Viewer crashes on gestures : use setDimensions for mFullWidth/mFullHeight

### DIFF
--- a/indra/llrender/llgltexture.cpp
+++ b/indra/llrender/llgltexture.cpp
@@ -36,11 +36,9 @@ LLGLTexture::LLGLTexture(bool usemipmaps)
 LLGLTexture::LLGLTexture(const U32 width, const U32 height, const U8 components, bool usemipmaps)
 {
     init();
-    mFullWidth = width ;
-    mFullHeight = height ;
+    setDimensions(width, height);
     mUseMipMaps = usemipmaps;
-    mComponents = components ;
-    setTexelsPerImage();
+    mComponents = components;
 }
 
 LLGLTexture::LLGLTexture(const LLImageRaw* raw, bool usemipmaps)
@@ -49,10 +47,8 @@ LLGLTexture::LLGLTexture(const LLImageRaw* raw, bool usemipmaps)
     mUseMipMaps = usemipmaps ;
     // Create an empty image of the specified size and width
     mGLTexturep = new LLImageGL(raw, usemipmaps) ;
-    mFullWidth = mGLTexturep->getWidth();
-    mFullHeight = mGLTexturep->getHeight();
+    setDimensions(mGLTexturep->getWidth(), mGLTexturep->getHeight());
     mComponents = mGLTexturep->getComponents();
-    setTexelsPerImage();
 }
 
 LLGLTexture::~LLGLTexture()
@@ -130,7 +126,7 @@ void LLGLTexture::generateGLTexture()
 {
     if(mGLTexturep.isNull())
     {
-        mGLTexturep = new LLImageGL(mFullWidth, mFullHeight, mComponents, mUseMipMaps) ;
+        mGLTexturep = new LLImageGL(getFullWidth(), getFullHeight(), mComponents, mUseMipMaps) ;
     }
 }
 
@@ -159,10 +155,8 @@ bool LLGLTexture::createGLTexture(S32 discard_level, const LLImageRaw* imageraw,
 
     if(ret)
     {
-        mFullWidth = mGLTexturep->getCurrentWidth() ;
-        mFullHeight = mGLTexturep->getCurrentHeight() ;
-        mComponents = mGLTexturep->getComponents() ;
-        setTexelsPerImage();
+        setDimensions(mGLTexturep->getCurrentWidth(), mGLTexturep->getCurrentHeight());
+        mComponents = mGLTexturep->getComponents();
     }
 
     return ret ;
@@ -447,11 +441,11 @@ void LLGLTexture::destroyGLTexture()
     }
 }
 
-void LLGLTexture::setTexelsPerImage()
+void LLGLTexture::setDimensions(U32 width, U32 height)
 {
-    U32 fullwidth = llmin(mFullWidth,U32(MAX_IMAGE_SIZE_DEFAULT));
-    U32 fullheight = llmin(mFullHeight,U32(MAX_IMAGE_SIZE_DEFAULT));
-    mTexelsPerImage = (U32)fullwidth * fullheight;
+    mFullWidth = width;
+    mFullHeight = height;
+    mTexelsPerImage = llmin(width, MAX_IMAGE_SIZE_DEFAULT) * llmin(height, MAX_IMAGE_SIZE_DEFAULT);
 }
 
 static LLUUID sStubUUID;

--- a/indra/llrender/llgltexture.h
+++ b/indra/llrender/llgltexture.h
@@ -40,11 +40,8 @@ class LLImageRaw;
 class LLGLTexture : public LLTexture
 {
 public:
-    enum
-    {
-        MAX_IMAGE_SIZE_DEFAULT = 2048,
-        INVALID_DISCARD_LEVEL = 0x7fff
-    };
+    static const U32 MAX_IMAGE_SIZE_DEFAULT = 2048;
+    static const U32 INVALID_DISCARD_LEVEL = 0x7fff;
 
     enum EBoostLevel
     {
@@ -104,6 +101,7 @@ public:
 
     S32 getFullWidth() const { return mFullWidth; }
     S32 getFullHeight() const { return mFullHeight; }
+    U32 getTexelsPerImage() const { return mTexelsPerImage; }
 
     void generateGLTexture() ;
     void destroyGLTexture() ;
@@ -176,28 +174,27 @@ private:
     void init();
 
 protected:
-    void setTexelsPerImage();
+    void setDimensions(U32 width, U32 height);
+    void setTexelsPerImage(U32 tpi) { mTexelsPerImage = tpi; }
 
 public:
     /*virtual*/ LLImageGL* getGLTexture() const ;
 
 protected:
     S32 mBoostLevel;                // enum describing priority level
-    U32 mFullWidth;
-    U32 mFullHeight;
     bool mUseMipMaps;
     S8  mComponents;
-    U32 mTexelsPerImage;            // Texels per image.
     mutable S8  mNeedsGLTexture;
 
     //GL texture
     LLPointer<LLImageGL> mGLTexturep ;
     S8 mDontDiscard;            // Keep full res version of this image (for UI, etc)
-
-protected:
     LLGLTextureState  mTextureState ;
 
-
+private:
+    U32 mFullWidth;
+    U32 mFullHeight;
+    U32 mTexelsPerImage;
 };
 
 #endif // LL_GL_TEXTURE_H

--- a/indra/newview/lldynamictexture.cpp
+++ b/indra/newview/lldynamictexture.cpp
@@ -95,7 +95,7 @@ void LLViewerDynamicTexture::generateGLTexture(LLGLint internal_format, LLGLenum
         LL_ERRS() << "Bad number of components in dynamic texture: " << mComponents << LL_ENDL;
     }
 
-    LLPointer<LLImageRaw> raw_image = new LLImageRaw(mFullWidth, mFullHeight, mComponents);
+    LLPointer<LLImageRaw> raw_image = new LLImageRaw(getFullWidth(), getFullHeight(), mComponents);
     if (internal_format >= 0)
     {
         setExplicitFormat(internal_format, primary_format, type_format, swap_bytes);
@@ -132,7 +132,7 @@ void LLViewerDynamicTexture::preRender(bool clear_depth)
     mCamera.setView(camera->getView());
     mCamera.setNear(camera->getNear());
 
-    glViewport(mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight);
+    glViewport(mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight());
     if (clear_depth)
     {
         glClear(GL_DEPTH_BUFFER_BIT);
@@ -160,7 +160,7 @@ void LLViewerDynamicTexture::postRender(bool success)
                 generateGLTexture() ;
             }
 
-            success = mGLTexturep->setSubImageFromFrameBuffer(0, 0, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight);
+            success = mGLTexturep->setSubImageFromFrameBuffer(0, 0, mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight());
         }
     }
 

--- a/indra/newview/lldynamictexture.h
+++ b/indra/newview/lldynamictexture.h
@@ -67,7 +67,7 @@ public:
     S32         getOriginX() const  { return mOrigin.mX; }
     S32         getOriginY() const  { return mOrigin.mY; }
 
-    S32         getSize()       { return mFullWidth * mFullHeight * mComponents; }
+    S32         getSize()       { return getFullWidth() * getFullHeight() * mComponents; }
 
     virtual bool needsRender() { return true; }
     virtual void preRender(bool clear_depth = true);

--- a/indra/newview/llfloaterbvhpreview.cpp
+++ b/indra/newview/llfloaterbvhpreview.cpp
@@ -1101,7 +1101,7 @@ bool    LLPreviewAnimation::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)getFullWidth(), 0.0f, (F32)getFullHeight(), -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -1113,7 +1113,7 @@ bool    LLPreviewAnimation::render()
     gGL.getTexUnit(0)->unbind(LLTexUnit::TT_TEXTURE);
     gGL.color4f(0.15f, 0.2f, 0.3f, 1.f);
 
-    gl_rect_2d_simple( mFullWidth, mFullHeight );
+    gl_rect_2d_simple(getFullWidth(), getFullHeight());
 
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.popMatrix();
@@ -1137,8 +1137,8 @@ bool    LLPreviewAnimation::render()
         target_pos + (mCameraOffset  * av_rot) );                                           // point of interest
 
     camera->setViewNoBroadcast(LLViewerCamera::getInstance()->getDefaultFOV() / mCameraZoom);
-    camera->setAspect((F32) mFullWidth / (F32) mFullHeight);
-    camera->setPerspective(false, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight, false);
+    camera->setAspect((F32)getFullWidth() / (F32)getFullHeight());
+    camera->setPerspective(false, mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight(), false);
 
     //SJB: Animation is updated in LLVOAvatar::updateCharacter
 

--- a/indra/newview/llfloaterimagepreview.cpp
+++ b/indra/newview/llfloaterimagepreview.cpp
@@ -681,7 +681,7 @@ bool LLImagePreviewAvatar::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)getFullWidth(), 0.0f, (F32)getFullHeight(), -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -693,7 +693,7 @@ bool LLImagePreviewAvatar::render()
 
     gUIProgram.bind();
 
-    gl_rect_2d_simple( mFullWidth, mFullHeight );
+    gl_rect_2d_simple(getFullWidth(), getFullHeight());
 
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.popMatrix();
@@ -715,9 +715,9 @@ bool LLImagePreviewAvatar::render()
 
     stop_glerror();
 
-    LLViewerCamera::getInstance()->setAspect((F32)mFullWidth / mFullHeight);
+    LLViewerCamera::getInstance()->setAspect((F32)getFullWidth() / getFullHeight());
     LLViewerCamera::getInstance()->setView(LLViewerCamera::getInstance()->getDefaultFOV() / mCameraZoom);
-    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight, false);
+    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight(), false);
 
     LLVertexBuffer::unbind();
     avatarp->updateLOD();
@@ -885,7 +885,7 @@ bool LLImagePreviewSculpted::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)getFullWidth(), 0.0f, (F32)getFullHeight(), -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -895,7 +895,7 @@ bool LLImagePreviewSculpted::render()
 
     gUIProgram.bind();
 
-    gl_rect_2d_simple( mFullWidth, mFullHeight );
+    gl_rect_2d_simple(getFullWidth(), getFullHeight());
 
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.popMatrix();
@@ -918,9 +918,9 @@ bool LLImagePreviewSculpted::render()
 
     stop_glerror();
 
-    LLViewerCamera::getInstance()->setAspect((F32) mFullWidth / mFullHeight);
+    LLViewerCamera::getInstance()->setAspect((F32)getFullWidth() / getFullHeight());
     LLViewerCamera::getInstance()->setView(LLViewerCamera::getInstance()->getDefaultFOV() / mCameraZoom);
-    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight, false);
+    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight(), false);
 
     const LLVolumeFace &vf = mVolume->getVolumeFace(0);
     U32 num_indices = vf.mNumIndices;

--- a/indra/newview/llgltfmaterialpreviewmgr.cpp
+++ b/indra/newview/llgltfmaterialpreviewmgr.cpp
@@ -462,8 +462,8 @@ bool LLGLTFPreviewTexture::render()
     // Set up camera and viewport
     const LLVector3 origin(0.0, 0.0, 0.0);
     camera.lookAt(origin, object_position);
-    camera.setAspect((F32)(mFullHeight / mFullWidth));
-    const LLRect texture_rect(0, mFullHeight, mFullWidth, 0);
+    camera.setAspect((F32)getFullHeight() / getFullWidth());
+    const LLRect texture_rect(0, getFullHeight(), getFullWidth(), 0);
     camera.setPerspective(NOT_FOR_SELECTION, texture_rect.mLeft, texture_rect.mBottom, texture_rect.getWidth(), texture_rect.getHeight(), false, camera.getNear(), MAX_FAR_CLIP*2.f);
 
     // Generate sphere object on-the-fly. Discard afterwards. (Vertex buffer is

--- a/indra/newview/lltoolmorph.cpp
+++ b/indra/newview/lltoolmorph.cpp
@@ -189,7 +189,7 @@ bool LLVisualParamHint::render()
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.pushMatrix();
     gGL.loadIdentity();
-    gGL.ortho(0.0f, (F32)mFullWidth, 0.0f, (F32)mFullHeight, -1.0f, 1.0f);
+    gGL.ortho(0.0f, (F32)getFullWidth(), 0.0f, (F32)getFullHeight(), -1.0f, 1.0f);
 
     gGL.matrixMode(LLRender::MM_MODELVIEW);
     gGL.pushMatrix();
@@ -199,7 +199,7 @@ bool LLVisualParamHint::render()
 
     LLGLSUIDefault gls_ui;
     //LLGLState::verify(true);
-    mBackgroundp->draw(0, 0, mFullWidth, mFullHeight);
+    mBackgroundp->draw(0, 0, getFullWidth(), getFullHeight());
 
     gGL.matrixMode(LLRender::MM_PROJECTION);
     gGL.popMatrix();
@@ -238,13 +238,13 @@ bool LLVisualParamHint::render()
 
     gGL.flush();
 
-    LLViewerCamera::getInstance()->setAspect((F32)mFullWidth / (F32)mFullHeight);
+    LLViewerCamera::getInstance()->setAspect((F32)getFullWidth() / (F32)getFullHeight());
     LLViewerCamera::getInstance()->setOriginAndLookAt(
         camera_pos,         // camera
         LLVector3::z_axis,  // up
         target_pos );       // point of interest
 
-    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, mFullWidth, mFullHeight, false);
+    LLViewerCamera::getInstance()->setPerspective(false, mOrigin.mX, mOrigin.mY, getFullWidth(), getFullHeight(), false);
 
     if (gAgentAvatarp->mDrawable.notNull())
     {
@@ -288,18 +288,18 @@ void LLVisualParamHint::draw(F32 alpha)
     gGL.begin(LLRender::TRIANGLES);
     {
         gGL.texCoord2i(0, 1);
-        gGL.vertex2i(0, mFullHeight);
+        gGL.vertex2i(0, getFullHeight());
         gGL.texCoord2i(0, 0);
         gGL.vertex2i(0, 0);
         gGL.texCoord2i(1, 0);
-        gGL.vertex2i(mFullWidth, 0);
+        gGL.vertex2i(getFullWidth(), 0);
 
         gGL.texCoord2i(0, 1);
-        gGL.vertex2i(0, mFullHeight);
+        gGL.vertex2i(0, getFullHeight());
         gGL.texCoord2i(1, 0);
-        gGL.vertex2i(mFullWidth, 0);
+        gGL.vertex2i(getFullWidth(), 0);
         gGL.texCoord2i(1, 1);
-        gGL.vertex2i(mFullWidth, mFullHeight);
+        gGL.vertex2i(getFullWidth(), getFullHeight());
     }
     gGL.end();
 

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -148,8 +148,6 @@ public:
 
     LLFrameTimer* getLastReferencedTimer() { return &mLastReferencedTimer; }
 
-    S32 getFullWidth() const { return mFullWidth; }
-    S32 getFullHeight() const { return mFullHeight; }
     /*virtual*/ void setKnownDrawSize(S32 width, S32 height);
 
     virtual void addFace(U32 channel, LLFace* facep) ;


### PR DESCRIPTION
The fields mFullWidth and mFullHeight are being always changed together
The field mTexelsPerImage should be recalculated after these fields are changed
It looks more OOP to make all these fields private and modify them in a function