### PR TITLE
Add support for CEF 120 and newer

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -518,11 +518,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>4124c79d8b0e319877ffa4c12581d5c1318b4d93</string>
+              <string>f8cb1640c4f607eb7083967ed31a2a66615cde5a</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.14.0-r3/dullahan-1.14.0.202408091639_118.4.1_g3dd6078_chromium-118.0.5993.54-windows64-10322607516.tar.zst</string>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.15.0-CEF_131.2.3/dullahan-1.15.0.202411191656_131.2.4_gb7543e4_chromium-131.0.6778.70-windows64-11917847734.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -1266,6 +1266,66 @@
         <string>libpng</string>
         <key>description</key>
         <string>PNG Reference library</string>
+      </map>
+      <key>libsqlite3</key>
+      <map>
+        <key>platforms</key>
+        <map>
+          <key>darwin64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>9028291522269a1449bb2a0a677499f976173f5d</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>http://sldev.free.fr/libraries/libsqlite3-3.47.0-darwin64-20241112.tar.bz2</string>
+            </map>
+            <key>name</key>
+            <string>darwin64</string>
+          </map>
+          <key>linux64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>b91bd334427b788ba369212cc47172cfd322deb2</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>http://sldev.free.fr/libraries/libsqlite3-3.47.0-linux64-20241112.tar.bz2</string>
+            </map>
+            <key>name</key>
+            <string>linux64</string>
+          </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>0c8851c3f7a3c636bf8e63bc44dadff39bd147a7</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>http://sldev.free.fr/libraries/libsqlite3-3.47.0-windows64-20241112.tar.bz2</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
+        </map>
+        <key>license</key>
+        <string>NONE</string>
+        <key>license_file</key>
+        <string>include/sqlite3.h</string>
+        <key>copyright</key>
+        <string>Public domain</string>
+        <key>version</key>
+        <string>3.47.0</string>
+        <key>name</key>
+        <string>libsqlite3</string>
+        <key>description</key>
+        <string>Public domain SQL library</string>
       </map>
       <key>libuuid</key>
       <map>

--- a/indra/cmake/CMakeLists.txt
+++ b/indra/cmake/CMakeLists.txt
@@ -54,6 +54,7 @@ set(cmake_SOURCE_FILES
         PulseAudio.cmake
         Python.cmake
         SDL2.cmake
+        SQLite3.cmake
         TemplateCheck.cmake
         TinyEXR.cmake
         TinyGLTF.cmake

--- a/indra/cmake/SQLite3.cmake
+++ b/indra/cmake/SQLite3.cmake
@@ -1,0 +1,20 @@
+# -*- cmake -*-
+if (SQLite3_CMAKE_INCLUDED)
+  return()
+endif (SQLite3_CMAKE_INCLUDED)
+set (SQLite3_CMAKE_INCLUDED TRUE)
+
+include(Prebuilt)
+
+use_prebuilt_binary(libsqlite3)
+
+set(SQLite3_INCLUDE_DIRS ${LIBS_PREBUILT_DIR}/include)
+if (LINUX)
+  set(SQLite3_LIBRARIES ${ARCH_PREBUILT_DIRS_RELEASE}/libsqlite3.a)
+elseif (WINDOWS)
+  set(SQLite3_LIBRARIES ${ARCH_PREBUILT_DIRS_RELEASE}/sqlite3.lib)
+elseif (DARWIN)
+  set(SQLite3_LIBRARIES ${ARCH_PREBUILT_DIRS_RELEASE}/libsqlite3.a)
+endif (LINUX)
+
+include_directories(SYSTEM SQLite3_INCLUDE_DIRS)

--- a/indra/llcommon/llfile.cpp
+++ b/indra/llcommon/llfile.cpp
@@ -338,6 +338,12 @@ int LLFile::stat(const std::string& filename, llstat* filestatus)
     return warnif("stat", filename, rc, ENOENT);
 }
 
+bool LLFile::exists(const std::string& filename)
+{
+    llstat st;
+    return stat(filename, &st) == 0;
+}
+
 bool LLFile::isdir(const std::string& filename)
 {
     llstat st;

--- a/indra/llcommon/llfile.h
+++ b/indra/llcommon/llfile.h
@@ -80,6 +80,7 @@ public:
     static  bool    copy(const std::string& from, const std::string& to);
 
     static  int     stat(const std::string& filename,llstat*    file_status);
+    static  bool    exists(const std::string& filename);
     static  bool    isdir(const std::string&    filename);
     static  bool    isfile(const std::string&   filename);
     static  LLFILE *    _Fiopen(const std::string& filename,

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -187,6 +187,7 @@ S32 LLDir::deleteFilesInDir(const std::string &dirname, const std::string &mask)
     return count;
 }
 
+//static
 U32 LLDir::deleteDirAndContents(const std::string& dir_name)
 {
     //Removes the directory and its contents.  Returns number of files deleted.

--- a/indra/llfilesystem/lldir.h
+++ b/indra/llfilesystem/lldir.h
@@ -68,7 +68,7 @@ class LLDir
         const std::string& app_read_only_data_dir = "") = 0;
 
     virtual S32 deleteFilesInDir(const std::string &dirname, const std::string &mask);
-    U32 deleteDirAndContents(const std::string& dir_name);
+    static U32 deleteDirAndContents(const std::string& dir_name);
     std::vector<std::string> getFilesInDir(const std::string &dirname);
 // pure virtual functions
     virtual std::string getCurPath() = 0;

--- a/indra/llplugin/llpluginclassmedia.cpp
+++ b/indra/llplugin/llpluginclassmedia.cpp
@@ -1228,6 +1228,15 @@ void LLPluginClassMedia::receivePluginMessage(const LLPluginMessage &message)
             mDebugMessageText = message.getValue("message_text");
             mDebugMessageLevel = message.getValue("message_level");
             mediaEvent(LLPluginClassMediaOwner::MEDIA_EVENT_DEBUG_MESSAGE);
+            if (mDebugMessageLevel == "info")
+            {
+                LL_INFOS("Plugin") << mDebugMessageText << LL_ENDL;
+            }
+            else if (mDebugMessageLevel == "warn" ||
+                     mDebugMessageLevel == "warning")
+            {
+                LL_WARNS("Plugin") << mDebugMessageText << LL_ENDL;
+            }
         }
         else if (message_name == "tooltip_text")
         {

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -11,15 +11,18 @@ include(PluginAPI)
 
 include(CEFPlugin)
 include(GLIB)
+include(SQLite3)
 
 ### media_plugin_cef
 
 set(media_plugin_cef_SOURCE_FILES
     media_plugin_cef.cpp
+    hbcookiesmerger.cpp
     )
 
 set(media_plugin_cef_HEADER_FILES
     volume_catcher.h
+    hbcookiesmerger.h
     )
 
 # Select which VolumeCatcher implementation to use
@@ -76,6 +79,7 @@ add_library(media_plugin_cef
 #)
 
 target_link_libraries(media_plugin_cef
+        ${SQLite3_LIBRARIES}
         media_plugin_base
         ll::cef
         ll::glib_headers

--- a/indra/media_plugins/cef/hbcookiesmerger.cpp
+++ b/indra/media_plugins/cef/hbcookiesmerger.cpp
@@ -1,0 +1,394 @@
+/**
+ * @file hbcookiesmerger.cpp
+ * @brief A CEF cookies database merger.
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Henri Beauchamp.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#include "linden_common.h"
+
+#include "sqlite3.h"
+
+#include "hbcookiesmerger.h"
+
+// These defines might need to be changed with future CEF versions, should
+// their "Cookies" database scheme change; in the latter case, make sure to
+// check for the fields type (currently, HOST_FIELD and COOKIE_FIELD are UTF-8
+// strings while DATE_FIELD is a 64 bits integer).
+#define COOKIES_TABLE "cookies"
+#define HOST_FIELD "host_key"
+#define COOKIE_FIELD "name"
+#define DATE_FIELD "last_update_utc"
+
+HBCookiesMerger::HBCookiesMerger(const std::string& source_db,
+                                 const std::string& dest_db,
+                                 const std::string& debug_log)
+:   mSrcFileName(source_db),
+    mDstFileName(dest_db),
+    mLogFileName(debug_log),
+    mSrcDb(nullptr),
+    mDstDb(nullptr),
+    mLogStream(nullptr)
+{
+}
+
+HBCookiesMerger::~HBCookiesMerger()
+{
+    // Do not log on destruction: the latter could happen after the consumer
+    // used that same log file, and file pointers would disagree then...
+    if (mLogStream)
+    {
+        delete mLogStream;
+    }
+    close();
+}
+
+void HBCookiesMerger::close()
+{
+    if (mDstDb)
+    {
+        sqlite3_close(mDstDb);
+        if (mLogStream)
+        {
+            *mLogStream << "Closing destination database." << std::endl;
+        }
+        mDstDb = nullptr;
+    }
+    if (mSrcDb)
+    {
+        if (mLogStream)
+        {
+            *mLogStream << "Closing source database." << std::endl;
+        }
+        sqlite3_close(mSrcDb);
+        mSrcDb = nullptr;
+    }
+}
+
+bool HBCookiesMerger::hasError(sqlite3* db, int result)
+{
+    if (result == SQLITE_OK || result == SQLITE_DONE)
+    {
+        mErrMsg.clear();
+        return false;
+    }
+    mErrMsg.assign(sqlite3_errmsg(db));
+    if (mLogStream)
+    {
+        *mLogStream << std::endl << "SQLite error: " << mErrMsg << std::endl;
+    }
+    return true;
+}
+
+std::set<std::string> HBCookiesMerger::getTables()
+{
+    // Get all tables excepted internal SQLite ones
+    static const char* sql =
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';";
+
+    std::set<std::string> tables;
+
+    sqlite3_stmt* stmt = nullptr;
+    if (!hasError(mSrcDb, sqlite3_prepare_v2(mSrcDb, sql, -1, &stmt, 0)))
+    {
+        int result;
+        while ((result = sqlite3_step(stmt)) == SQLITE_ROW)
+        {
+            tables.emplace((const char*)sqlite3_column_text(stmt, 0));
+        }
+        sqlite3_finalize(stmt);
+    }
+
+    return tables;
+}
+
+static void bind_row_values(sqlite3_stmt* src, sqlite3_stmt* dst, int columns)
+{
+    for (int i = 0; i < columns; ++i)
+    {
+        switch (sqlite3_column_type(src, i))
+        {
+            case SQLITE_INTEGER:
+                sqlite3_bind_int64(dst, i + 1, sqlite3_column_int64(src, i));
+                break;
+
+            case SQLITE_FLOAT:
+                sqlite3_bind_double(dst, i + 1, sqlite3_column_double(src, i));
+                break;
+
+            case SQLITE_TEXT:
+                sqlite3_bind_text(dst, i + 1,
+                                  (const char*)sqlite3_column_text(src, i),
+                                  -1, SQLITE_STATIC);
+                break;
+
+            case SQLITE_BLOB:
+                sqlite3_bind_blob(dst, i + 1, sqlite3_column_blob(src, i),
+                                  sqlite3_column_bytes(src, i), SQLITE_STATIC);
+                break;
+
+            case SQLITE_NULL:
+                sqlite3_bind_null(dst, i + 1);
+
+            default:        // Should never happen. Just do not care.
+                break;
+        }
+    }
+}
+
+bool HBCookiesMerger::mergeTable(const std::string& table)
+{
+    if (hasError(mDstDb,
+                 sqlite3_exec(mDstDb, "BEGIN TRANSACTION;", nullptr, nullptr,
+                              nullptr)))
+    {
+        return false;
+    }
+
+    std::string sql = "SELECT * FROM " + table;
+    sqlite3_stmt* read_stmt = nullptr;
+    if (hasError(mSrcDb,
+                 sqlite3_prepare_v2(mSrcDb, sql.c_str(), -1, &read_stmt, 0)))
+    {
+        return false;
+    }
+    int columns = sqlite3_column_count(read_stmt);
+
+    int host_field_index = -1;
+    int cookie_field_index = -1;
+    int date_field_index = -1;
+    std::string replace_sql = "INSERT OR REPLACE INTO " + table + " VALUES (";
+    for (int i = 0; i < columns; ++i)
+    {
+        replace_sql += "?";
+        if (i < columns - 1)
+        {
+            replace_sql += ",";
+        }
+        // Find the columns numbers for the cookies site (host_key), name and
+        // last update time stamp.
+        const char* cname = (const char*)sqlite3_column_name(read_stmt, i);
+        if (strcmp(cname, HOST_FIELD) == 0)
+        {
+            host_field_index = i;
+        }
+        else if (strcmp(cname, COOKIE_FIELD) == 0)
+        {
+            cookie_field_index = i;
+        }
+        else if (strcmp(cname, DATE_FIELD) == 0)
+        {
+            date_field_index = i;
+        }
+    }
+    replace_sql += ")";
+
+    if (host_field_index == -1 || cookie_field_index == -1 ||
+        date_field_index == -1)
+    {
+        mErrMsg = "Missing column in the cookies table.";
+        sqlite3_finalize(read_stmt);
+        return false;
+    }
+
+    std::string check_sql = "SELECT " DATE_FIELD " FROM " + table +
+                            " WHERE " HOST_FIELD " = ? AND " COOKIE_FIELD
+                            " = ?";
+    sqlite3_stmt* check_stmt = nullptr;
+    int result;
+    while ((result = sqlite3_step(read_stmt)) == SQLITE_ROW)
+    {
+        // For each row in the source table, grab the 'HOST_FIELD and cookie
+        // COOKIE_FIELD strings (which should identify each unique cookie), as
+        // well as the DATE_FIELD timestamp.
+        const char* host_key =
+            (const char*)sqlite3_column_text(read_stmt, host_field_index);
+        const char* name =
+            (const char*)sqlite3_column_text(read_stmt, cookie_field_index);
+        auto last_update_utc = sqlite3_column_int64(read_stmt,
+                                                    date_field_index);
+        if (mLogStream)
+        {
+            *mLogStream << "Cookie: " << host_key << " / " << name
+                        << " - Last updated: " << last_update_utc;
+        }
+
+        // Check if the cookie already exists in the destination database
+        if (check_stmt)
+        {
+            sqlite3_reset(check_stmt);    // Reset for next check
+        }
+        if (hasError(mDstDb,
+                     sqlite3_prepare_v2(mDstDb, check_sql.c_str(), -1,
+                                        &check_stmt, 0)))
+        {
+            sqlite3_finalize(read_stmt);
+            return false;
+        }
+
+        sqlite3_bind_text(check_stmt, 1, host_key, -1, SQLITE_STATIC);
+        sqlite3_bind_text(check_stmt, 2, name, -1, SQLITE_STATIC);
+        result = sqlite3_step(check_stmt);
+        if (result == SQLITE_DONE)
+        {
+            // The cookie does not exists in destination table: insert it.
+            if (mLogStream)
+            {
+                *mLogStream << " - Cookie does not exist: inserting it.";
+            }
+        }
+        else if (result == SQLITE_ROW)
+        {
+            // The cookie is already in destination table: see if it needs to
+            // be updated, based on last update timestamp.
+            if (last_update_utc <= sqlite3_column_int64(check_stmt, 0))
+            {
+                if (mLogStream)
+                {
+                    *mLogStream << " - Cookie is up to date." << std::endl;
+                }
+                continue;
+            }
+            if (mLogStream)
+            {
+                *mLogStream << " - Cookie needs updating.";
+            }
+        }
+        else
+        {
+            if (mLogStream)
+            {
+                *mLogStream << std::endl;
+            }
+            // Nothing to do.
+            continue;
+        }
+
+        // Insert or replace the cookie
+        sqlite3_stmt* replace_stmt = nullptr;
+        if (hasError(mDstDb,
+                     sqlite3_prepare_v2(mDstDb, replace_sql.c_str(), -1,
+                                        &replace_stmt, 0)))
+        {
+            sqlite3_finalize(check_stmt);
+            sqlite3_finalize(read_stmt);
+            return false;
+        }
+        bind_row_values(read_stmt, replace_stmt, columns);
+        if (hasError(mDstDb, sqlite3_step(replace_stmt)))
+        {
+            sqlite3_finalize(replace_stmt);
+            sqlite3_finalize(check_stmt);
+            sqlite3_finalize(read_stmt);
+            return false;
+        }
+        sqlite3_finalize(replace_stmt);
+        if (mLogStream)
+        {
+            *mLogStream << " - Cookie updated." << std::endl;
+        }
+    }
+
+    if (check_stmt)
+    {
+        sqlite3_finalize(check_stmt);
+    }
+    sqlite3_finalize(read_stmt);
+
+    if (mLogStream)
+    {
+        *mLogStream << "Cookies merged." << std::endl;
+    }
+
+    if (hasError(mDstDb,
+                 sqlite3_exec(mDstDb, "COMMIT;", nullptr, nullptr, nullptr)))
+    {
+        return false;
+    }
+    return true;
+}
+
+bool HBCookiesMerger::merge()
+{
+    mErrMsg.clear();
+
+    if (!mLogFileName.empty())
+    {
+        mLogStream = new llofstream(mLogFileName,
+                                    std::ios::out | std::ios::app);
+    }
+    if (mLogStream)
+    {
+        *mLogStream << "Merging cookies database '" << mSrcFileName
+                    << "' into database '" << mDstFileName << '"' << std::endl;
+    }
+    int result = sqlite3_open(mSrcFileName.c_str(), &mSrcDb);
+    if (result != SQLITE_OK)
+    {
+        mErrMsg = "Failed to open source database '" + mSrcFileName +
+                  "' with error: " + std::string(sqlite3_errstr(result));
+        if (mLogStream)
+        {
+            *mLogStream << mErrMsg << std::endl;
+            delete mLogStream;
+            mLogStream = nullptr;
+        }
+        return false;
+    }
+    result = sqlite3_open(mDstFileName.c_str(), &mDstDb);
+    if (result != SQLITE_OK)
+    {
+        mErrMsg = "Failed to open source database '" + mDstFileName +
+                  "' with error: " + std::string(sqlite3_errstr(result));
+        if (mLogStream)
+        {
+            *mLogStream << mErrMsg << std::endl;
+            delete mLogStream;
+            mLogStream = nullptr;
+        }
+        close();
+        return false;
+    }
+
+    std::set<std::string> tables = getTables();
+    if (!tables.count(COOKIES_TABLE))
+    {
+        mErrMsg = "No '" COOKIES_TABLE "' table in database: " + mSrcFileName;
+        if (mLogStream)
+        {
+            *mLogStream << mErrMsg << std::endl;
+            delete mLogStream;
+            mLogStream = nullptr;
+        }
+        close();
+        return false;
+    }
+
+    bool success = mergeTable(COOKIES_TABLE);
+    close();
+    if (mLogStream)
+    {
+        delete mLogStream;
+        mLogStream = nullptr;
+    }
+    return success;
+}

--- a/indra/media_plugins/cef/hbcookiesmerger.h
+++ b/indra/media_plugins/cef/hbcookiesmerger.h
@@ -1,0 +1,65 @@
+/**
+ * @file hbcookiesmerger.h
+ * @brief A CEF cookies database merger.
+ *
+ * $LicenseInfo:firstyear=2024&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2024, Henri Beauchamp.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+#ifndef HB_HBCOOKIESMERGER_H
+#define HB_HBCOOKIESMERGER_H
+
+#include <set>
+
+#include "llfile.h"
+
+struct sqlite3;
+
+class HBCookiesMerger
+{
+public:
+    HBCookiesMerger(const std::string& source_db, const std::string& dest_db,
+                    const std::string& debug_log = LLStringUtil::null);
+    ~HBCookiesMerger();
+
+    bool merge();
+
+    // Allows to retreive the last error message (e.g for when debug_log was
+    // not used).
+    inline const std::string& getErrorMessage() { return mErrMsg; }
+
+private:
+    void close();
+    bool hasError(sqlite3* db, int result);
+    std::set<std::string> getTables();
+    bool mergeTable(const std::string& table_name);
+
+private:
+    sqlite3*    mSrcDb;
+    sqlite3*    mDstDb;
+    std::string mErrMsg;
+    std::string mSrcFileName;
+    std::string mDstFileName;
+    std::string mLogFileName;
+    llofstream* mLogStream;
+};
+
+#endif    // HB_HBCOOKIESMERGER_H


### PR DESCRIPTION
LL's viewer is currently using CEF 118, which is riddled with security holes and shall be updated for the current CEF version. Problem: with CEF 120, a new caching scheme was introduced which forbids sharing a same cache between several CEF instances, like what we did so far, and which allowed to keep Cookies in sync between instances.

For my viewer and under Linux, I came up with an easy "solution" (more like a hack), which involved pre-populating each CEF instance cache with a symbolic link to a central Cookies store, and it does work just like it used to do with older CEF versions (i.e. with a shared Cookies file between instances).
While this solution/hack would also likely work with macOS (after we will have a Dullahan/CEF 131 available for it), it however won't work under Windows (Callum Linden and I tried, but Windows is not a POSIX system...).

During our email-exchanges/brainstorming with Callum, I came up with the idea of a Cookies store "merger". The principle is that each new CEF session sees its cache primed by the CEF plugin with a copy of a central Cookies store before launch, and that on exit of that CEF session, the plugin syncs the central Cookies store file with the session updated Cookies file (adding new cookies found in the latter and updating cookies already in the central database but that got changed during the session).

This commit implements this mechanism. It has been in use in the Cool VL Viewer releases for over a couple of weeks already, without any bug report or user complaint about it.

Implementation notes:
====================
1. The "merger" code requires sqlite3, and not knowing how to create a 3p-libsqlite3 repository, this commit links (via autobuild.xml) to personal builds of libsqlite3. You will want to replace those links with LL-built packages. For your 3p-libsqlite3, you can reuse the build scripts I wrote, available here:
http://sldev.free.fr/libraries/sources/cvlv-libsqlite3-20241112.tar.bz2

2. The cache structure changed (see my comment in media_plugin_cef.cpp for "set_user_data_path", around line 1008), but this should not be an issue.

3. The session caches are now temporary and get erased at each session exit (after the added/changed Cookies have been saved into the central Cookies store); sadly, under Windows (this is not happening under Linux), CEF keeps writing a few files back into the destroyed temporary cache after the plugin destructor returns (see my comment at the end of ~MediaPluginCEF() around line 263), meaning the temp cache directory is recreated and will contain a few remnants.
This is harmless but in my viewer I added code to clear everything _but_ the "Cookies*" files into cef_cache/ (i.e. clearing all temp caches remnants in there) on viewer launch (for the "anonymous" cache used at login screen) and after login (for the per-account cache); since there is no equivalent in LL's code to my method in my improved/expanded/ rewritten LLDiriterator for doing this, I did not "bother" adding such code to this commit. Let me know if you are interested in my LLDiriterator implementation. Alternatively, an ad hoc cleaning up code could be implemented.

4. So far, only Windows is concerned by this commit since I only have the link for a Dullahan/CEF131 pre-built library Callum Linden kindly passed to me. macOS and Linux will keep using CEF 118 for now (the plugin will automatically compile for it) and this commit should not break anything for them.
But when LL will come up with a Linux pre-built library, the code is ready for it (just change the link to dullahan in autobuild.xml and the CEF plugin will automatically compile for CEF 131); the same *might* be true for macOS, however a few of things will need to be checked:
 a. Where the "Cookies" file lives in the macOS CEF cache tree.
 b. Whether there is a crypto key stored in "Local State" (like for
    Windows) or not (like for Linux) that prompts saving that file as
    well or not.
 c. What marker file to watch for at CEF exit, before attempting to
    merge the Cookies
I do not have a MAC, so I cannot check for the above. However, all it will take will be to adjust the corresponding #defines in the media_plugin_cef.cpp file for LL_DARWIN case; see my comments in that line 84 and line 101. To be safe, I added a #warning for macOS and CEF 120 or newer.