### PR TITLE
viewer#3147 Thumbnail picker's image is grey

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1965,7 +1965,9 @@ bool LLViewerFetchedTexture::updateFetch()
 
         if (!mIsFetching)
         {
-            if ((decode_priority > 0) && (mRawDiscardLevel < 0 || mRawDiscardLevel == INVALID_DISCARD_LEVEL))
+            if ((decode_priority > 0)
+                && (mRawDiscardLevel < 0 || mRawDiscardLevel == INVALID_DISCARD_LEVEL)
+                && mFetchState > 1) // 1 - initial, make sure fetcher did at least something
             {
                 // We finished but received no data
                 if (getDiscardLevel() < 0)
@@ -2003,6 +2005,9 @@ bool LLViewerFetchedTexture::updateFetch()
             {
                 // We have data, but our fetch failed to return raw data
                 // *TODO: FIgure out why this is happening and fix it
+                // Potentially can happen when TEX_LIST_SCALE and TEX_LIST_STANDARD
+                // get requested for the same texture id at the same time
+                // (two textures, one fetcher)
                 destroyRawImage();
             }
         }


### PR DESCRIPTION
When both thumnail and normal image attempt to fetch, one creates a fetcher, another fails, since fetcher is already there, potentially in a transitional state, second image thinks fetch failed.