### PR TITLE
#3119 crash when lua requests debug settings value

### DIFF
--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -122,7 +122,7 @@ public:
     void set_interrupts_counter(S32 counter);
     void check_interrupts_counter();
 
-    bool push_debug_traceback();
+    int push_debug_traceback();
 
 private:
     /*---------------------------- feature flag ----------------------------*/

--- a/indra/llcommon/lua_function.h
+++ b/indra/llcommon/lua_function.h
@@ -122,6 +122,8 @@ public:
     void set_interrupts_counter(S32 counter);
     void check_interrupts_counter();
 
+    bool push_debug_traceback();
+
 private:
     /*---------------------------- feature flag ----------------------------*/
     bool mFeature{ false };

--- a/indra/newview/scripts/lua/test_debugsettings.lua
+++ b/indra/newview/scripts/lua/test_debugsettings.lua
@@ -4,7 +4,6 @@ LL.atexit(function() LL.print_info('Finished') end)
 
 LL.print_info('Updating ' .. SETTING_NAME)
 LLDebugSettings.set(SETTING_NAME, 100)
-
+-- 'inadvertently' using Luau library as variable name to hide it
 debug = LLDebugSettings.get(SETTING_NAME)
 LL.print_info(debug)
-

--- a/indra/newview/scripts/lua/test_debugsettings.lua
+++ b/indra/newview/scripts/lua/test_debugsettings.lua
@@ -1,0 +1,10 @@
+local LLDebugSettings = require 'LLDebugSettings'
+local SETTING_NAME = '360CaptureCameraFOV'
+LL.atexit(function() LL.print_info('Finished') end)
+
+LL.print_info('Updating ' .. SETTING_NAME)
+LLDebugSettings.set(SETTING_NAME, 100)
+
+debug = LLDebugSettings.get(SETTING_NAME)
+LL.print_info(debug)
+


### PR DESCRIPTION
'Quick fix' to eliminate the crash #3119
(later we should investigate and don't allow overwriting the global table)
