### PR TITLE
#2900 Fix incorrect 'Content type' maturity text in the classified floater

### DIFF
--- a/indra/llui/llcombobox.cpp
+++ b/indra/llui/llcombobox.cpp
@@ -519,7 +519,7 @@ bool LLComboBox::setCurrentByIndex(S32 index)
         if (item->getEnabled())
         {
             mList->selectItem(item, -1, true);
-            LLSD::String label = item->getColumn(0)->getValue().asString();
+            LLSD::String label = getSelectedItemLabel();
             if (mTextEntry)
             {
                 mTextEntry->setText(label);


### PR DESCRIPTION
Column[0] is reserved for an icon in combo box items that have one, so the label should be used instead.