### PR TITLE
Fix mesa failing to link shaders due to missing vertex shader outputs

### DIFF
--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -79,7 +79,7 @@ bool LLShaderMgr::attachShaderFeatures(LLGLSLShader * shader)
     //////////////////////////////////////
 
     // NOTE order of shader object attaching is VERY IMPORTANT!!!
-    if (features->calculatesAtmospherics)
+    if (features->calculatesAtmospherics || features->hasGamma || features->isDeferred)
     {
         if (!shader->attachVertexObject("windlight/atmosphericsVarsV.glsl"))
         {


### PR DESCRIPTION
This ensures the vertex shader outputs for `atmosphericsVarsF.glsl` from `atmosphericsVarsV.glsl` are available at shader link time to avoid error state in mesa 24.3.x

https://jira.firestormviewer.org/browse/FIRE-34877