### PR TITLE
#3288 null overrides crashes

### DIFF
--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -2251,21 +2251,25 @@ void LLSelectMgr::selectionRevertGLTFMaterials()
 
                 // Update material locally
                 objectp->setRenderMaterialID(te, asset_id, false /*wait for LLGLTFMaterialList update*/);
-                LLGLTFMaterial* material = new LLGLTFMaterial(*nodep->mSavedGLTFOverrideMaterials[te]);
-                objectp->setTEGLTFMaterialOverride(te, material);
 
-                // Enqueue update to server
-                if (asset_id.notNull())
+                LLGLTFMaterial* override_mat = nodep->mSavedGLTFOverrideMaterials[te];
+                if (override_mat)
                 {
-                    // Restore overrides and base material
-                    LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
-                }
-                else
-                {
-                    //blank override out
-                    LLGLTFMaterialList::queueApply(objectp, te, asset_id);
-                }
+                    LLGLTFMaterial* material = new LLGLTFMaterial(*override_mat);
+                    objectp->setTEGLTFMaterialOverride(te, material);
 
+                    // Enqueue update to server
+                    if (asset_id.notNull())
+                    {
+                        // Restore overrides and base material
+                        LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
+                    }
+                    else
+                    {
+                        //blank override out
+                        LLGLTFMaterialList::queueApply(objectp, te, asset_id);
+                    }
+                }
             }
             return true;
         }

--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -2251,25 +2251,25 @@ void LLSelectMgr::selectionRevertGLTFMaterials()
 
                 // Update material locally
                 objectp->setRenderMaterialID(te, asset_id, false /*wait for LLGLTFMaterialList update*/);
-
-                LLGLTFMaterial* override_mat = nodep->mSavedGLTFOverrideMaterials[te];
-                if (override_mat)
+                LLGLTFMaterial* material = nodep->mSavedGLTFOverrideMaterials[te];
+                if (material)
                 {
-                    LLGLTFMaterial* material = new LLGLTFMaterial(*override_mat);
+                    material = new LLGLTFMaterial(*material);
                     objectp->setTEGLTFMaterialOverride(te, material);
-
-                    // Enqueue update to server
-                    if (asset_id.notNull())
-                    {
-                        // Restore overrides and base material
-                        LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
-                    }
-                    else
-                    {
-                        //blank override out
-                        LLGLTFMaterialList::queueApply(objectp, te, asset_id);
-                    }
                 }
+
+                // Enqueue update to server
+                if (asset_id.notNull() && material)
+                {
+                    // Restore overrides and base material
+                    LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
+                }
+                else
+                {
+                    //blank override out
+                    LLGLTFMaterialList::queueApply(objectp, te, asset_id);
+                }
+
             }
             return true;
         }

--- a/indra/newview/lltooldraganddrop.cpp
+++ b/indra/newview/lltooldraganddrop.cpp
@@ -1447,9 +1447,10 @@ void LLToolDragAndDrop::dropTexture(LLViewerObject* hit_obj,
             }
 
             LLTextureEntry* te = hit_obj->getTE(hit_face);
-            if (te && !remove_pbr)
+            LLGLTFMaterial * override_mat = nullptr;
+            if (te && !remove_pbr && (override_mat = te->getGLTFMaterialOverride()))
             {
-                LLGLTFMaterial* copy = new LLGLTFMaterial(*te->getGLTFMaterialOverride());
+                LLGLTFMaterial* copy = new LLGLTFMaterial(*override_mat);
                 nodep->mSavedGLTFOverrideMaterials[hit_face] = copy;
             }
             else


### PR DESCRIPTION
Fixes for secondlife/viewer#3288 override copy related crashes when overrides can be nullptr