### PR TITLE
#3302 Crash at LLSaveFolderState::doFolder

### DIFF
--- a/indra/newview/llpanelcontents.cpp
+++ b/indra/newview/llpanelcontents.cpp
@@ -145,6 +145,7 @@ void LLPanelContents::onFilterEdit()
     }
     else
     {
+        LLFolderView* root_folder = mPanelInventoryObject->getRootFolder();
         if (filter_substring.empty())
         {
             if (mPanelInventoryObject->getFilter().getFilterSubString().empty())
@@ -155,19 +156,28 @@ void LLPanelContents::onFilterEdit()
 
             if (mDirtyFilter && !mSavedFolderState.hasOpenFolders())
             {
-                mPanelInventoryObject->getRootFolder()->setOpenArrangeRecursively(true, LLFolderViewFolder::ERecurseType::RECURSE_DOWN);
+                if (root_folder)
+                {
+                    root_folder->setOpenArrangeRecursively(true, LLFolderViewFolder::ERecurseType::RECURSE_DOWN);
+                }
             }
             else
             {
                 mSavedFolderState.setApply(true);
-                mPanelInventoryObject->getRootFolder()->applyFunctorRecursively(mSavedFolderState);
+                if (root_folder)
+                {
+                    root_folder->applyFunctorRecursively(mSavedFolderState);
+                }
             }
             mDirtyFilter = false;
 
             // Add a folder with the current item to the list of previously opened folders
-            LLOpenFoldersWithSelection opener;
-            mPanelInventoryObject->getRootFolder()->applyFunctorRecursively(opener);
-            mPanelInventoryObject->getRootFolder()->scrollToShowSelection();
+            if (root_folder)
+            {
+                LLOpenFoldersWithSelection opener;
+                root_folder->applyFunctorRecursively(opener);
+                root_folder->scrollToShowSelection();
+            }
         }
         else if (mPanelInventoryObject->getFilter().getFilterSubString().empty())
         {
@@ -175,7 +185,10 @@ void LLPanelContents::onFilterEdit()
             if (!mPanelInventoryObject->getFilter().isNotDefault())
             {
                 mSavedFolderState.setApply(false);
-                mPanelInventoryObject->getRootFolder()->applyFunctorRecursively(mSavedFolderState);
+                if (root_folder)
+                {
+                    root_folder->applyFunctorRecursively(mSavedFolderState);
+                }
                 mDirtyFilter = false;
             }
         }


### PR DESCRIPTION
Maxim likely fixed the crash with the 'has inventory' check, but I feel existence of root should be checked regardless (looks like there is a subcase where root might not exists while 'having' inventory).