### PR TITLE
#3317 Fix full screen issue with Windows 11 24H2

### DIFF
--- a/indra/llwindow/llwindow.cpp
+++ b/indra/llwindow/llwindow.cpp
@@ -104,7 +104,6 @@ LLWindow::LLWindow(LLWindowCallbacks* callbacks, bool fullscreen, U32 flags)
       mFullscreen(fullscreen),
       mFullscreenWidth(0),
       mFullscreenHeight(0),
-      mFullscreenBits(0),
       mFullscreenRefresh(0),
       mSupportedResolutions(NULL),
       mNumSupportedResolutions(0),

--- a/indra/llwindow/llwindow.h
+++ b/indra/llwindow/llwindow.h
@@ -226,7 +226,6 @@ protected:
     bool        mFullscreen;
     S32         mFullscreenWidth;
     S32         mFullscreenHeight;
-    S32         mFullscreenBits;
     S32         mFullscreenRefresh;
     LLWindowResolution* mSupportedResolutions;
     S32         mNumSupportedResolutions;

--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -690,8 +690,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
             }
 
             if (dev_mode.dmPelsWidth == width &&
-                dev_mode.dmPelsHeight == height &&
-                dev_mode.dmBitsPerPel == BITS_PER_PIXEL)
+                dev_mode.dmPelsHeight == height)
             {
                 success = true;
                 if ((dev_mode.dmDisplayFrequency - current_refresh)
@@ -731,7 +730,7 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
         // If we found a good resolution, use it.
         if (success)
         {
-            success = setDisplayResolution(width, height, BITS_PER_PIXEL, closest_refresh);
+            success = setDisplayResolution(width, height, closest_refresh);
         }
 
         // Keep a copy of the actual current device mode in case we minimize
@@ -744,7 +743,6 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
             mFullscreen = true;
             mFullscreenWidth   = dev_mode.dmPelsWidth;
             mFullscreenHeight  = dev_mode.dmPelsHeight;
-            mFullscreenBits    = dev_mode.dmBitsPerPel;
             mFullscreenRefresh = dev_mode.dmDisplayFrequency;
 
             LL_INFOS("Window") << "Running at " << dev_mode.dmPelsWidth
@@ -758,7 +756,6 @@ LLWindowWin32::LLWindowWin32(LLWindowCallbacks* callbacks,
             mFullscreen = false;
             mFullscreenWidth   = -1;
             mFullscreenHeight  = -1;
-            mFullscreenBits    = -1;
             mFullscreenRefresh = -1;
 
             std::map<std::string,std::string> args;
@@ -1175,7 +1172,7 @@ bool LLWindowWin32::switchContext(bool fullscreen, const LLCoordScreen& size, bo
         // If we found a good resolution, use it.
         if (success)
         {
-            success = setDisplayResolution(width, height, BITS_PER_PIXEL, closest_refresh);
+            success = setDisplayResolution(width, height, closest_refresh);
         }
 
         // Keep a copy of the actual current device mode in case we minimize
@@ -1187,7 +1184,6 @@ bool LLWindowWin32::switchContext(bool fullscreen, const LLCoordScreen& size, bo
             mFullscreen = true;
             mFullscreenWidth = dev_mode.dmPelsWidth;
             mFullscreenHeight = dev_mode.dmPelsHeight;
-            mFullscreenBits = dev_mode.dmBitsPerPel;
             mFullscreenRefresh = dev_mode.dmDisplayFrequency;
 
             LL_INFOS("Window") << "Running at " << dev_mode.dmPelsWidth
@@ -1213,7 +1209,6 @@ bool LLWindowWin32::switchContext(bool fullscreen, const LLCoordScreen& size, bo
             mFullscreen = false;
             mFullscreenWidth = -1;
             mFullscreenHeight = -1;
-            mFullscreenBits = -1;
             mFullscreenRefresh = -1;
 
             LL_INFOS("Window") << "Unable to run fullscreen at " << width << "x" << height << LL_ENDL;
@@ -3509,7 +3504,7 @@ F32 LLWindowWin32::getPixelAspectRatio()
 
 // Change display resolution.  Returns true if successful.
 // protected
-bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh)
+bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 refresh)
 {
     DEVMODE dev_mode;
     ::ZeroMemory(&dev_mode, sizeof(DEVMODE));
@@ -3521,7 +3516,6 @@ bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 re
     {
         if (dev_mode.dmPelsWidth        == width &&
             dev_mode.dmPelsHeight       == height &&
-            dev_mode.dmBitsPerPel       == bits &&
             dev_mode.dmDisplayFrequency == refresh )
         {
             // ...display mode identical, do nothing
@@ -3533,9 +3527,8 @@ bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 re
     dev_mode.dmSize = sizeof(dev_mode);
     dev_mode.dmPelsWidth        = width;
     dev_mode.dmPelsHeight       = height;
-    dev_mode.dmBitsPerPel       = bits;
     dev_mode.dmDisplayFrequency = refresh;
-    dev_mode.dmFields = DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY;
+    dev_mode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY;
 
     // CDS_FULLSCREEN indicates that this is a temporary change to the device mode.
     LONG cds_result = ChangeDisplaySettings(&dev_mode, CDS_FULLSCREEN);
@@ -3545,7 +3538,7 @@ bool LLWindowWin32::setDisplayResolution(S32 width, S32 height, S32 bits, S32 re
     if (!success)
     {
         LL_WARNS("Window") << "setDisplayResolution failed, "
-            << width << "x" << height << "x" << bits << " @ " << refresh << LL_ENDL;
+            << width << "x" << height << " @ " << refresh << LL_ENDL;
     }
 
     return success;
@@ -3556,7 +3549,7 @@ bool LLWindowWin32::setFullscreenResolution()
 {
     if (mFullscreen)
     {
-        return setDisplayResolution( mFullscreenWidth, mFullscreenHeight, mFullscreenBits, mFullscreenRefresh);
+        return setDisplayResolution( mFullscreenWidth, mFullscreenHeight, mFullscreenRefresh);
     }
     else
     {

--- a/indra/llwindow/llwindowwin32.h
+++ b/indra/llwindow/llwindowwin32.h
@@ -151,7 +151,7 @@ protected:
     LLSD    getNativeKeyData() const override;
 
     // Changes display resolution. Returns true if successful
-    bool    setDisplayResolution(S32 width, S32 height, S32 bits, S32 refresh);
+    bool    setDisplayResolution(S32 width, S32 height, S32 refresh);
 
     // Go back to last fullscreen display resolution.
     bool    setFullscreenResolution();


### PR DESCRIPTION
Documentation is fairly lacking, so I'm not sure why things went wrong, but I assume that by now anything less than 32bit is not possible and variable is redundant, safe to remove and for some reason without the variable call for full screen doesn't fail.