### PR TITLE
#3344 Crash at LLFloater::openFloater

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1507,7 +1507,7 @@ bool idle_startup()
         // create a container's instance for start a controlling conversation windows
         // by the voice's events
         LLFloaterIMContainer *im_inst = LLFloaterIMContainer::getInstance();
-        if(gAgent.isFirstLogin())
+        if(gAgent.isFirstLogin() && im_inst)
         {
             im_inst->openFloater(im_inst->getKey());
         }


### PR DESCRIPTION
I'm not sure why 'im_container' is missing, but a bunch of different floaters is also missing and we are just skipping those and most crashes happen for tester accounts, so might be some kind of 'UI-less' test that does not need to crash.