### PR TITLE
#3347 Crashes in LLFontFreetype::renderGlyph

### DIFF
--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -552,7 +552,7 @@ LLFontGlyphInfo* LLFontFreetype::addGlyphFromFont(const LLFontFreetype *fontp, l
         return NULL;
 
     llassert(!mIsFallback);
-    fontp->renderGlyph(requested_glyph_type, glyph_index);
+    fontp->renderGlyph(requested_glyph_type, glyph_index, wch);
 
     EFontGlyphType bitmap_glyph_type = EFontGlyphType::Unspecified;
     switch (fontp->mFTFace->glyph->bitmap.pixel_mode)
@@ -697,7 +697,7 @@ void LLFontFreetype::insertGlyphInfo(llwchar wch, LLFontGlyphInfo* gi) const
     }
 }
 
-void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index) const
+void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index, llwchar wch) const
 {
     if (mFTFace == NULL)
         return;
@@ -712,11 +712,28 @@ void LLFontFreetype::renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index) co
     FT_Error error = FT_Load_Glyph(mFTFace, glyph_index, load_flags);
     if (FT_Err_Ok != error)
     {
+        if (error == FT_Err_Out_Of_Memory)
+        {
+            LLError::LLUserWarningMsg::showOutOfMemory();
+            LL_ERRS() << "Out of memory loading glyph for character " << wch << LL_ENDL;
+        }
+
         std::string message = llformat(
-            "Error %d (%s) loading glyph %u: bitmap_type=%u, load_flags=%d",
-            error, FT_Error_String(error), glyph_index, bitmap_type, load_flags);
+            "Error %d (%s) loading wchar %u glyph %u/%u: bitmap_type=%u, load_flags=%d",
+            error, FT_Error_String(error), wch, glyph_index, mFTFace->num_glyphs, bitmap_type, load_flags);
         LL_WARNS_ONCE() << message << LL_ENDL;
         error = FT_Load_Glyph(mFTFace, glyph_index, load_flags ^ FT_LOAD_COLOR);
+        if (FT_Err_Invalid_Outline == error
+            || FT_Err_Invalid_Composite == error
+            || (FT_Err_Ok != error && LLStringOps::isEmoji(wch)))
+        {
+            glyph_index = FT_Get_Char_Index(mFTFace, '?');
+            // if '?' is not present, potentially can use last index, that's supposed to be null glyph
+            if (glyph_index > 0)
+            {
+                error = FT_Load_Glyph(mFTFace, glyph_index, load_flags ^ FT_LOAD_COLOR);
+            }
+        }
         llassert_always_msg(FT_Err_Ok == error, message.c_str());
     }
 

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -156,7 +156,7 @@ private:
     bool hasGlyph(llwchar wch) const;       // Has a glyph for this character
     LLFontGlyphInfo* addGlyph(llwchar wch, EFontGlyphType glyph_type) const;        // Add a new character to the font if necessary
     LLFontGlyphInfo* addGlyphFromFont(const LLFontFreetype *fontp, llwchar wch, U32 glyph_index, EFontGlyphType bitmap_type) const; // Add a glyph from this font to the other (returns the glyph_index, 0 if not found)
-    void renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index) const;
+    void renderGlyph(EFontGlyphType bitmap_type, U32 glyph_index, llwchar wch) const;
     void insertGlyphInfo(llwchar wch, LLFontGlyphInfo* gi) const;
 
     std::string mName;


### PR DESCRIPTION
Try to handle this more gracefully by falling back to '?', but primary purpose of this change is to log wchars in case issue is reproducible.