### PR TITLE
PR #3366 didn't work, revert it and fix the right way

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,6 @@ on:
   push:
     branches: ["main", "release/*", "project/*"]
     tags: ["Second_Life*"]
-  workflow_run:
-    workflows: ["Tag a Build"]
-    types:
-      - completed
 
 jobs:
   # The whole point of the setup job is that we want to set variables once
@@ -29,7 +25,7 @@ jobs:
       # When you want to use a string variable as a workflow YAML boolean, it's
       # important to ensure it's the empty string when false. If you omit || '',
       # its value when false is "false", which is interpreted as true.
-      RELEASE_RUN: ${{ (github.event.inputs.release_run || github.event_name == 'workflow_run' || github.ref_type == 'tag' && startsWith(github.ref_name, 'Second_Life')) && 'Y' || '' }}
+      RELEASE_RUN: ${{ (github.event.inputs.release_run || github.ref_type == 'tag' && startsWith(github.ref_name, 'Second_Life')) && 'Y' || '' }}
       FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
     steps:
       - name: Set Variables

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -37,7 +37,12 @@ jobs:
       - name: Update Tag
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # use a real access token instead of GITHUB_TOKEN default.
+          # required so that the results of this tag creation can trigger the build workflow
+          # https://stackoverflow.com/a/71372524
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          # this token will need to be renewed anually in January
+          github-token: ${{ secrets.LL_TAG_RELEASE_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
Revert "attempt to get the tag-release.yaml workflow to actually succeed at triggering a release build (#3366)"

This reverts commit 3b79d2ca2405cac4bc7ea7892a45767e3f2b5538.

will be proceeding with provisioning a new token to try to fix this the right way:
https://stackoverflow.com/a/71372524