### PR TITLE
#3316 Crash in LLReflectionMap::getIsDynamic()

### DIFF
--- a/indra/newview/llheroprobemanager.cpp
+++ b/indra/newview/llheroprobemanager.cpp
@@ -222,7 +222,7 @@ void LLHeroProbeManager::renderProbes()
     static LLCachedControl<S32> sUpdateRate(gSavedSettings, "RenderHeroProbeUpdateRate", 0);
 
     F32 near_clip = 0.01f;
-    if (mNearestHero != nullptr &&
+    if (mNearestHero != nullptr && !mNearestHero->isDead() &&
         !gTeleportDisplay && !gDisconnected && !LLAppViewer::instance()->logoutRequestSent())
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("hpmu - realtime");
@@ -251,12 +251,13 @@ void LLHeroProbeManager::renderProbes()
             LL_PROFILE_ZONE_NUM(gFrameCount % rate);
             LL_PROFILE_ZONE_NUM(rate);
 
+            bool dynamic = mNearestHero->getReflectionProbeIsDynamic() && sDetail() > 0;
             for (U32 i = 0; i < 6; ++i)
             {
                 if ((gFrameCount % rate) == (i % rate))
                 { // update 6/rate faces per frame
                     LL_PROFILE_ZONE_NUM(i);
-                    updateProbeFace(mProbes[0], i, mNearestHero->getReflectionProbeIsDynamic() && sDetail > 0, near_clip);
+                    updateProbeFace(mProbes[0], i, dynamic, near_clip);
                 }
             }
             generateRadiance(mProbes[0]);

--- a/indra/newview/llreflectionmap.cpp
+++ b/indra/newview/llreflectionmap.cpp
@@ -65,8 +65,9 @@ void LLReflectionMap::update(U32 resolution, U32 face, bool force_dynamic, F32 n
     }
 
     F32 clip = (near_clip > 0) ? near_clip : getNearClip();
+    bool dynamic = force_dynamic || getIsDynamic();
 
-    gViewerWindow->cubeSnapshot(LLVector3(mOrigin), mCubeArray, mCubeIndex, face, clip, getIsDynamic() || force_dynamic, useClipPlane, clipPlane);
+    gViewerWindow->cubeSnapshot(LLVector3(mOrigin), mCubeArray, mCubeIndex, face, clip, dynamic, useClipPlane, clipPlane);
 }
 
 void LLReflectionMap::autoAdjustOrigin()
@@ -185,7 +186,7 @@ void LLReflectionMap::autoAdjustOrigin()
     }
 }
 
-bool LLReflectionMap::intersects(LLReflectionMap* other)
+bool LLReflectionMap::intersects(LLReflectionMap* other) const
 {
     LLVector4a delta;
     delta.setSub(other->mOrigin, mOrigin);
@@ -201,24 +202,24 @@ bool LLReflectionMap::intersects(LLReflectionMap* other)
 
 extern LLControlGroup gSavedSettings;
 
-F32 LLReflectionMap::getAmbiance()
+F32 LLReflectionMap::getAmbiance() const
 {
     F32 ret = 0.f;
-    if (mViewerObject && mViewerObject->getVolume())
+    if (mViewerObject && mViewerObject->getVolumeConst())
     {
-        ret = ((LLVOVolume*)mViewerObject)->getReflectionProbeAmbiance();
+        ret = mViewerObject->getReflectionProbeAmbiance();
     }
 
     return ret;
 }
 
-F32 LLReflectionMap::getNearClip()
+F32 LLReflectionMap::getNearClip() const
 {
     const F32 MINIMUM_NEAR_CLIP = 0.1f;
 
     F32 ret = 0.f;
 
-    if (mViewerObject && mViewerObject->getVolume())
+    if (mViewerObject && mViewerObject->getVolumeConst())
     {
         ret = mViewerObject->getReflectionProbeNearClip();
     }
@@ -234,11 +235,13 @@ F32 LLReflectionMap::getNearClip()
     return llmax(ret, MINIMUM_NEAR_CLIP);
 }
 
-bool LLReflectionMap::getIsDynamic()
+bool LLReflectionMap::getIsDynamic() const
 {
-    if (gSavedSettings.getS32("RenderReflectionProbeDetail") > (S32) LLReflectionMapManager::DetailLevel::STATIC_ONLY &&
+    static LLCachedControl<S32> detail(gSavedSettings, "RenderReflectionProbeDetail", 1);
+    if (detail() > (S32)LLReflectionMapManager::DetailLevel::STATIC_ONLY &&
         mViewerObject &&
-        mViewerObject->getVolume())
+        !mViewerObject->isDead() &&
+        mViewerObject->getVolumeConst())
     {
         return mViewerObject->getReflectionProbeIsDynamic();
     }
@@ -278,12 +281,12 @@ bool LLReflectionMap::getBox(LLMatrix4& box)
     return false;
 }
 
-bool LLReflectionMap::isActive()
+bool LLReflectionMap::isActive() const
 {
     return mCubeIndex != -1;
 }
 
-bool LLReflectionMap::isRelevant()
+bool LLReflectionMap::isRelevant() const
 {
     static LLCachedControl<S32> RenderReflectionProbeLevel(gSavedSettings, "RenderReflectionProbeLevel", 3);
 

--- a/indra/newview/llreflectionmap.h
+++ b/indra/newview/llreflectionmap.h
@@ -58,16 +58,16 @@ public:
     void autoAdjustOrigin();
 
     // return true if given Reflection Map's influence volume intersect's with this one's
-    bool intersects(LLReflectionMap* other);
+    bool intersects(LLReflectionMap* other) const;
 
     // Get the ambiance value to use for this probe
-    F32 getAmbiance();
+    F32 getAmbiance() const;
 
     // Get the near clip plane distance to use for this probe
-    F32 getNearClip();
+    F32 getNearClip() const;
 
     // Return true if this probe should include avatars in its reflection map
-    bool getIsDynamic();
+    bool getIsDynamic() const;
 
     // get the encoded bounding box of this probe's influence volume
     // will only return a box if this probe is associated with a VOVolume
@@ -76,13 +76,13 @@ public:
     bool getBox(LLMatrix4& box);
 
     // return true if this probe is active for rendering
-    bool isActive();
+    bool isActive() const;
 
     // perform occlusion query/readback
     void doOcclusion(const LLVector4a& eye);
 
     // return false if this probe isn't currently relevant (for example, disabled due to graphics preferences)
-    bool isRelevant();
+    bool isRelevant() const;
 
     // point at which environment map was last generated from (in agent space)
     LLVector4a mOrigin;


### PR DESCRIPTION
I doubt isDead() check will actually fix the issues, feels like mViewerObject pointer is invalid, but there is no point jumping the gun yet, isDead() might be enough.