### PR TITLE
#3413 Shutdown crash at removeFromLocalIDTable

### DIFF
--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -727,6 +727,9 @@ public:
     // index into LLViewerObjectList::mActiveObjects or -1 if not in list
     S32             mListIndex;
 
+    // last index data for mIndexAndLocalIDToUUID
+    U32             mRegionIndex;
+
     LLPointer<LLViewerTexture> *mTEImages;
     LLPointer<LLViewerTexture> *mTENormalMaps;
     LLPointer<LLViewerTexture> *mTESpecularMaps;

--- a/indra/newview/llviewerobjectlist.h
+++ b/indra/newview/llviewerobjectlist.h
@@ -179,9 +179,10 @@ public:
     void setUUIDAndLocal(const LLUUID &id,
                                 const U32 local_id,
                                 const U32 ip,
-                                const U32 port); // Requires knowledge of message system info!
+                                const U32 port,
+                                LLViewerObject* objectp); // Requires knowledge of message system info!
 
-    bool removeFromLocalIDTable(const LLViewerObject* objectp);
+    bool removeFromLocalIDTable(LLViewerObject* objectp);
     // Used ONLY by the orphaned object code.
     U64 getIndex(const U32 local_id, const U32 ip, const U32 port);
 


### PR DESCRIPTION
Callstacks indicate that this happens only on shutdown. No point to erase items one at a time, just clear the list beforehand.