### PR TITLE
Build `develop` branch on every commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build
 on:
   pull_request:
   push:
-    branches: ["main", "release/*", "project/*"]
+    branches: ["develop", "main", "release/*", "project/*"]
     tags: ["Second_Life*"]
 
 jobs:


### PR DESCRIPTION
Add `develop` to the list of branches that always builds. **This is critical as develop is the primary integration and development branch.**