### PR TITLE
#3319 Crash at LLInitParam::Param::setProvided

### DIFF
--- a/indra/llui/llstyle.cpp
+++ b/indra/llui/llstyle.cpp
@@ -39,7 +39,7 @@ LLStyle::Params::Params()
     readonly_color("readonly_color", LLColor4::black),
     selected_color("selected_color", LLColor4::black),
     alpha("alpha", 1.f),
-    font("font", LLFontGL::getFontMonospace()),
+    font("font", LLStyle::getDefaultFont()),
     image("image"),
     link_href("href"),
     is_link("is_link")
@@ -68,6 +68,11 @@ void LLStyle::setFont(const LLFontGL* font)
 const LLFontGL* LLStyle::getFont() const
 {
     return mFont;
+}
+
+const LLFontGL* LLStyle::getDefaultFont()
+{
+    return LLFontGL::getFontMonospace();
 }
 
 void LLStyle::setLinkHREF(const std::string& href)

--- a/indra/llui/llstyle.h
+++ b/indra/llui/llstyle.h
@@ -72,6 +72,7 @@ public:
 
     void setFont(const LLFontGL* font);
     const LLFontGL* getFont() const;
+    static const LLFontGL* getDefaultFont();
 
     const std::string& getLinkHREF() const { return mLink; }
     void setLinkHREF(const std::string& href);

--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1438,7 +1438,8 @@ void LLTextBase::onVisibilityChange( bool new_visibility )
 //virtual
 void LLTextBase::setValue(const LLSD& value )
 {
-    setText(value.asString());
+    static const LLStyle::Params input_params = LLStyle::Params();
+    setText(value.asString(), input_params);
 }
 
 //virtual
@@ -3880,8 +3881,7 @@ bool LLInlineViewSegment::getDimensionsF32(S32 first_char, S32 num_chars, F32& w
         if (mForceNewLine)
         {
             // Chat, string can't be smaller then font height even if it is empty
-            LLStyleSP s(new LLStyle(LLStyle::Params().visible(true)));
-            height = s->getFont()->getLineHeight();
+            height = LLStyle::getDefaultFont()->getLineHeight();
 
             return true; // new line
         }
@@ -3945,9 +3945,7 @@ void LLInlineViewSegment::linkToDocument(LLTextBase* editor)
 
 LLLineBreakTextSegment::LLLineBreakTextSegment(S32 pos):LLTextSegment(pos,pos+1)
 {
-    LLStyleSP s( new LLStyle(LLStyle::Params().visible(true)));
-
-    mFontHeight = s->getFont()->getLineHeight();
+    mFontHeight = LLStyle::getDefaultFont()->getLineHeight();
 }
 LLLineBreakTextSegment::LLLineBreakTextSegment(LLStyleConstSP style,S32 pos):LLTextSegment(pos,pos+1)
 {

--- a/indra/llui/lltextbox.cpp
+++ b/indra/llui/lltextbox.cpp
@@ -159,7 +159,8 @@ LLSD LLTextBox::getValue() const
 bool LLTextBox::setTextArg( const std::string& key, const LLStringExplicit& text )
 {
     mText.setArg(key, text);
-    LLTextBase::setText(mText.getString());
+    static const LLStyle::Params input_params = LLStyle::Params();
+    LLTextBase::setText(mText.getString(), input_params);
 
     return true;
 }

--- a/indra/newview/llfloaterimsessiontab.cpp
+++ b/indra/newview/llfloaterimsessiontab.cpp
@@ -633,7 +633,8 @@ void LLFloaterIMSessionTab::appendMessage(const LLChat& chat, const LLSD& args)
     chat_args["show_names_for_p2p_conv"] = !mIsP2PChat ||
             gSavedSettings.getBOOL("IMShowNamesForP2PConv");
 
-    mChatHistory->appendMessage(chat, chat_args);
+    static const LLStyle::Params input_append_params = LLStyle::Params();
+    mChatHistory->appendMessage(chat, chat_args, input_append_params);
 }
 
 void LLFloaterIMSessionTab::updateUsedEmojis(LLWStringView text)


### PR DESCRIPTION
Most crashes are related to LLStyle, log analysis suggests that it might be a number of different issues, including memory and disk issues. Just avoid recreating expensive LLStyle without reason.