### PR TITLE
brad/3335 set shaders abort logging

### DIFF
--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -466,6 +466,7 @@ GLuint LLShaderMgr::loadShaderFile(const std::string& filename, S32 & shader_lev
 
     if (filename.empty())
     {
+        LL_WARNS("ShaderLoading") << "tried loading empty filename" << LL_ENDL;
         return 0;
     }
 
@@ -923,6 +924,8 @@ GLuint LLShaderMgr::loadShaderFile(const std::string& filename, S32 & shader_lev
         }
         LL_WARNS("ShaderLoading") << "Failed to load " << filename << LL_ENDL;
     }
+
+    LL_DEBUGS("ShaderLoading") << "loadShaderFile() completed, ret: " << U32(ret) << LL_ENDL;
     return ret;
 }
 

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -623,6 +623,8 @@ void LLViewerShaderMgr::setShaders()
     else
     {
         // "ShaderLoading" and "Shader" need to be logged
+        LL_WARNS("Shader") << "Failed loading basic shaders.  Retrying with increased log level..." << LL_ENDL;
+
         LLError::ELevel lvl = LLError::getDefaultLevel();
         LLError::setDefaultLevel(LLError::LEVEL_DEBUG);
         loadBasicShaders();
@@ -843,7 +845,7 @@ std::string LLViewerShaderMgr::loadBasicShaders()
         // Note usage of GL_VERTEX_SHADER
         if (loadShaderFile(shaders[i].first, shaders[i].second, GL_VERTEX_SHADER, &attribs) == 0)
         {
-            LL_WARNS("Shader") << "Failed to load vertex shader " << shaders[i].first << LL_ENDL;
+            LL_WARNS("Shader") << "Failed to load basic vertex shader " << i << ": " << shaders[i].first << LL_ENDL;
             return shaders[i].first;
         }
     }


### PR DESCRIPTION
Attempt to get more log info in secondlife/viewer#3335 crash reports when failing to load basic vertex shaders