### PR TITLE
#3466 Crash at LLScrollingPanelParam::draw

### DIFF
--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -537,9 +537,14 @@ LLUpdateAppearanceOnDestroy::~LLUpdateAppearanceOnDestroy()
 
         selfStopPhase("update_appearance_on_destroy");
 
-        LLAppearanceMgr::instance().updateAppearanceFromCOF(mEnforceItemRestrictions,
-                                                            mEnforceOrdering,
-                                                            mPostUpdateFunc);
+        //avoid calling an update inside coroutine
+        bool force_restrictions(mEnforceItemRestrictions);
+        bool enforce_ordering(mEnforceOrdering);
+        nullary_func_t post_update_func(mPostUpdateFunc);
+        doOnIdleOneTime([force_restrictions,enforce_ordering,post_update_func]()
+        {
+            LLAppearanceMgr::instance().updateAppearanceFromCOF(force_restrictions, enforce_ordering, post_update_func);
+        });
     }
 }
 


### PR DESCRIPTION
Although I wasn't able to repro the crash itself, `llassert(LLCoros::on_main_coro());` consistently triggered when trying to follow the steps according to the logs:
1. Ctrl-O to open Avatar floater
2. Click 'Edit this outfit' (Wrench icon)button
3. Body parts tab>Right click 'Shape'>'Create new shape'

Sol let's avoid calling the update inside coro.