### PR TITLE
Backport tag-release token fix to release/2024.12-ForeverFPS branch

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -37,7 +37,12 @@ jobs:
       - name: Update Tag
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # use a real access token instead of GITHUB_TOKEN default.
+          # required so that the results of this tag creation can trigger the build workflow
+          # https://stackoverflow.com/a/71372524
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+          # this token will need to be renewed anually in January
+          github-token: ${{ secrets.LL_TAG_RELEASE_TOKEN }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
I believe this is why the manual dispatch for tagging builds didn't work.  the latest version of tag-release.yaml needs to be present in the branch being built