### PR TITLE
Improvements for #3456

### DIFF
--- a/indra/newview/app_settings/shaders/class1/environment/srgbF.glsl
+++ b/indra/newview/app_settings/shaders/class1/environment/srgbF.glsl
@@ -41,6 +41,26 @@ vec3 srgb_to_linear(vec3 cs)
 
 }
 
+
+vec4 srgb_to_linear4(vec4 cs)
+{
+    vec4 low_range = cs / vec4(12.92);
+    vec4 high_range = pow((cs+vec4(0.055))/vec4(1.055), vec4(2.4));
+    bvec4 lte = lessThanEqual(cs,vec4(0.04045));
+
+#ifdef OLD_SELECT
+    vec4 result;
+    result.r = lte.r ? low_range.r : high_range.r;
+    result.g = lte.g ? low_range.g : high_range.g;
+    result.b = lte.b ? low_range.b : high_range.b;
+    result.a = lte.a ? low_range.a : high_range.a;
+    return result;
+#else
+    return mix(high_range, low_range, lte);
+#endif
+
+}
+
 vec3 linear_to_srgb(vec3 cl)
 {
     cl = clamp(cl, vec3(0), vec3(1));

--- a/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
+++ b/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
@@ -69,8 +69,8 @@ vec4 getWaterFogViewNoClip(vec3 pos)
     float L = min(t1/t2*t3, 1.0);
 
     float D = pow(0.98, l*kd);
-
-    return vec4(srgb_to_linear(kc.rgb*L), D);
+    
+    return vec4(srgb_to_linear(kc.rgb)*L, D);
 }
 
 vec4 getWaterFogView(vec3 pos)

--- a/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
+++ b/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
@@ -66,7 +66,7 @@ vec4 getWaterFogViewNoClip(vec3 pos)
     float t2 = kd + ks * es;
     float t3 = pow(F, t2*l) - 1.0;
 
-    float L = min(t1/t2*t3, 1.0);
+    float L = pow(min(t1/t2*t3, 1.0), 1.0/1.7);
 
     float D = pow(0.98, l*kd);
     

--- a/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
+++ b/indra/newview/app_settings/shaders/class1/environment/waterFogF.glsl
@@ -69,7 +69,7 @@ vec4 getWaterFogViewNoClip(vec3 pos)
     float L = pow(min(t1/t2*t3, 1.0), 1.0/1.7);
 
     float D = pow(0.98, l*kd);
-    
+
     return vec4(srgb_to_linear(kc.rgb)*L, D);
 }
 

--- a/indra/newview/app_settings/shaders/class3/deferred/waterHazeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/waterHazeF.glsl
@@ -56,7 +56,7 @@ void main()
     vec4  pos          = getPositionWithDepth(tc, depth);
 
     vec4 fogged = getWaterFogView(pos.xyz);
-
+    fogged.a = max(pow(fogged.a * 0.25, 0.4545), 0);
     frag_color = max(fogged, vec4(0)); //output linear since local lights will be added to this shader's results
 
 }

--- a/indra/newview/app_settings/shaders/class3/deferred/waterHazeF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/waterHazeF.glsl
@@ -56,7 +56,7 @@ void main()
     vec4  pos          = getPositionWithDepth(tc, depth);
 
     vec4 fogged = getWaterFogView(pos.xyz);
-    fogged.a = max(pow(fogged.a * 0.25, 0.4545), 0);
+    fogged.a = max(pow(fogged.a, 1.7), 0);
     frag_color = max(fogged, vec4(0)); //output linear since local lights will be added to this shader's results
 
 }

--- a/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
@@ -165,7 +165,7 @@ void calculateFresnelFactors(out vec3 df3, out vec2 df2, vec3 viewVec, vec3 wave
 {
     // We calculate the fresnel here.
     // We do this by getting the dot product for each sets of waves, and applying scale and offset.
-    
+
     df3 = vec3(
         dot(viewVec, wave1),
         dot(viewVec, (wave2 + wave3) * 0.5),

--- a/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
@@ -205,7 +205,7 @@ void main()
     vec2 distort = (refCoord.xy/refCoord.z) * 0.5 + 0.5;
 
     vec3 wavef = (wave1 + wave2 * 0.4 + wave3 * 0.6) * 0.5;
-    
+
     vec3 df3 = vec3(0);
     vec2 df2 = vec2(0);
 


### PR DESCRIPTION
This address #3456.  This doesn't get us 100% of the way there - with how reflection probes currently work that's a bit more complicated.  But it restores:
- Legacy fresnel
- Makes water fog look closer to where we were at with 6.6.17 - this can never look 100% due to changes in the rendering pipeline around water fog specifically to help optimize the pipeline and reduce banding
- Adjusts specular to be much closer to 6.6.17 in appearance

Will work on a test plan later - this is a bit of a weird one to really QA.