### PR TITLE
#3346 crash at LLConversationItemSession::clearAndDeparentModels

### DIFF
--- a/indra/newview/llconversationmodel.cpp
+++ b/indra/newview/llconversationmodel.cpp
@@ -357,8 +357,9 @@ void LLConversationItemSession::clearParticipants()
 
 void LLConversationItemSession::clearAndDeparentModels()
 {
-    for (LLFolderViewModelItem* child : mChildren)
+    for (child_list_t::iterator it = mChildren.begin(); it != mChildren.end();)
     {
+        LLFolderViewModelItem* child = *it;
         if (child->getNumRefs() == 0)
         {
             // LLConversationItemParticipant can be created but not assigned to any view,
@@ -370,8 +371,8 @@ void LLConversationItemSession::clearAndDeparentModels()
             // Model is still assigned to some view/widget
             child->setParent(NULL);
         }
+        it = mChildren.erase(it);
     }
-    mChildren.clear();
 }
 
 LLConversationItemParticipant* LLConversationItemSession::findParticipant(const LLUUID& participant_id)


### PR DESCRIPTION
One more attempt to fix this crash without overhauling conversations (at some point we may need to separate it from the inventory): let's try to clear models right away.