### PR TITLE
Update qatest.yaml upload-artifact version

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -110,7 +110,7 @@ jobs:
           python C:\viewer-sikulix-main\runTests.py
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: C:\viewer-sikulix-main\regressionTest\test_results.html


### PR DESCRIPTION
Resolving the following error: "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`." This is now updated to v4 according to https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/