### PR TITLE
#3332 Fix buffers not accounting for dynamic cache values

### DIFF
--- a/indra/llrender/llfontbitmapcache.cpp
+++ b/indra/llrender/llfontbitmapcache.cpp
@@ -107,7 +107,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32& pos_x, S32& pos_y, EFontGlyp
             mBitmapHeight = image_height;
 
             S32 num_components = getNumComponents(bitmap_type);
-            mImageRawVec[bitmap_idx].push_back(new LLImageRaw(mBitmapWidth, mBitmapHeight, num_components));
+            mImageRawVec[bitmap_idx].emplace_back(new LLImageRaw(mBitmapWidth, mBitmapHeight, num_components));
             bitmap_num = static_cast<U32>(mImageRawVec[bitmap_idx].size()) - 1;
 
             LLImageRaw* image_raw = getImageRaw(bitmap_type, bitmap_num);
@@ -117,7 +117,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32& pos_x, S32& pos_y, EFontGlyp
             }
 
             // Make corresponding GL image.
-            mImageGLVec[bitmap_idx].push_back(new LLImageGL(image_raw, false, false));
+            mImageGLVec[bitmap_idx].emplace_back(new LLImageGL(image_raw, false, false));
             LLImageGL* image_gl = getImageGL(bitmap_type, bitmap_num);
 
             // Start at beginning of the new image.

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -148,6 +148,7 @@ public:
 
     void setStyle(U8 style);
     U8 getStyle() const;
+    S32 getAddedGlyphs() const { return mAddGlyphCount; }
 
 private:
     void resetBitmapCache();

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -110,6 +110,11 @@ S32 LLFontGL::getNumFaces(const std::string& filename)
     return mFontFreetype->getNumFaces(filename);
 }
 
+S32 LLFontGL::getKnownGlyphCount() const
+{
+    return mFontFreetype ? mFontFreetype->getAddedGlyphs() : 0;
+}
+
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRect& rect, const LLColor4 &color, HAlign halign, VAlign valign, U8 style,
     ShadowType shadow, S32 max_chars, F32* right_x, bool use_ellipses, bool use_color) const
 {
@@ -250,6 +255,10 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
     const LLFontBitmapCache* font_bitmap_cache = mFontFreetype->getFontBitmapCache();
 
+    // This looks wrong, value is dynamic.
+    // LLFontBitmapCache::nextOpenPos can alter these values when
+    // new characters get added to cache, which affects whole string.
+    // Todo: Perhaps value should update after symbols were added?
     F32 inv_width = 1.f / font_bitmap_cache->getBitmapWidth();
     F32 inv_height = 1.f / font_bitmap_cache->getBitmapHeight();
 
@@ -271,12 +280,14 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
 
     const LLFontGlyphInfo* next_glyph = NULL;
 
+    // string can have more than one glyph per char (ex: bold or shadow),
+    // make sure that GLYPH_BATCH_SIZE won't end up with half a symbol.
+    // See drawGlyph.
+    // Ex: with shadows it's 6 glyps per char. 30 fits exactly 5 chars.
     static constexpr S32 GLYPH_BATCH_SIZE = 30;
-    // string can have more than one glyph per char, make sure last one can fit
-    static constexpr S32 BUFFER_SIZE = GLYPH_BATCH_SIZE * 2;
-    static thread_local LLVector4a vertices[BUFFER_SIZE * 6];
-    static thread_local LLVector2 uvs[BUFFER_SIZE * 6];
-    static thread_local LLColor4U colors[BUFFER_SIZE * 6];
+    static thread_local LLVector4a vertices[GLYPH_BATCH_SIZE * 6];
+    static thread_local LLVector2 uvs[GLYPH_BATCH_SIZE * 6];
+    static thread_local LLColor4U colors[GLYPH_BATCH_SIZE * 6];
 
     LLColor4U text_color(color);
     // Preserve the transparency to render fading emojis in fading text (e.g.
@@ -321,8 +332,9 @@ S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, F32 x, F32 y, cons
             LLImageGL* font_image = font_bitmap_cache->getImageGL(bitmap_entry.first, bitmap_entry.second);
             gGL.getTexUnit(0)->bind(font_image);
 
-            // For multi-byte characters just draw each time character changes
-            // Might be overkill and might be better to detect multybyte
+            // For some reason it's not enough to compare by bitmap_entry.
+            // Issue hits emojis, japenese and chinese glyphs, only on first run.
+            // Todo: figure it out, there might be a bug with raw image data.
             last_char = wch;
         }
 

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -90,6 +90,7 @@ public:
     bool loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, bool is_fallback, S32 face_n);
 
     S32 getNumFaces(const std::string& filename);
+    S32 getKnownGlyphCount() const;
 
     S32 render(const LLWString &text, S32 begin_offset,
                 const LLRect& rect,

--- a/indra/llrender/llfontvertexbuffer.cpp
+++ b/indra/llrender/llfontvertexbuffer.cpp
@@ -147,7 +147,8 @@ S32 LLFontVertexBuffer::render(
              || mLastVertDPI != LLFontGL::sVertDPI
              || mLastHorizDPI != LLFontGL::sHorizDPI
              || mLastOrigin != LLFontGL::sCurOrigin
-             || mLastResGeneration != LLFontGL::sResolutionGeneration)
+             || mLastResGeneration != LLFontGL::sResolutionGeneration
+             || mLastFontGlyphCount != fontp->getKnownGlyphCount())
     {
         genBuffers(fontp, text, begin_offset, x, y, color, halign, valign,
             style, shadow, max_chars, max_pixels, right_x, use_ellipses, use_color);
@@ -203,6 +204,7 @@ void LLFontVertexBuffer::genBuffers(
     mLastHorizDPI = LLFontGL::sHorizDPI;
     mLastOrigin = LLFontGL::sCurOrigin;
     mLastResGeneration = LLFontGL::sResolutionGeneration;
+    mLastFontGlyphCount = fontp->getKnownGlyphCount();
 
     if (right_x)
     {

--- a/indra/llrender/llfontvertexbuffer.h
+++ b/indra/llrender/llfontvertexbuffer.h
@@ -120,6 +120,10 @@ private:
     S32 mLastResGeneration = 0;
     LLCoordGL mLastOrigin;
 
+    // Adding new characters to bitmap cache can alter value from getBitmapWidth();
+    // which alters whole string. So rerender when new characters were added to cache.
+    S32 mLastFontGlyphCount = 0;
+
     static bool sEnableBufferCollection;
 };
 


### PR DESCRIPTION

1. Fix previous lapse of judgement with GLYPH_BATCH_SIZE
2. We record width/height once per string rendering, but values are actually dynamic and additing new symbols invalidates them. Added mLastFontGlyphCount to track addition of new symbols. Likely not the best way to handle the issue, but we can fix rendering later, mLastFontGlyphCount should be safe in scope of foreverFPS.