### PR TITLE
Remove pwsh 7.0 feature from qatest.yaml

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -67,7 +67,7 @@ jobs:
           $InstallerPath = "$DownloadPath\installer.zip"
 
           # Download the ZIP
-          Invoke-WebRequest -Uri $ARTIFACT_NAME -Headers @{Authorization="token ${{ secrets.GITHUB_TOKEN }}"} -OutFile $InstallerPath -NoProgress
+          Invoke-WebRequest -Uri $ARTIFACT_NAME -Headers @{Authorization="token ${{ secrets.GITHUB_TOKEN }}"} -OutFile $InstallerPath
 
           # Ensure download succeeded
           if (-Not (Test-Path $InstallerPath)) {


### PR DESCRIPTION
Resolving the following error: 
```
Line |
  22 |  … 0EJgh7B0O9Ah3biE67bG5q5163Q18Mt"} -OutFile $InstallerPath -NoProgress
     |                                                              ~~~~~~~~~~~
     | A parameter cannot be found that matches parameter name 'NoProgress'.
Error: Process completed with exit code 1.
```
It appears `-NoProgress` is specific to Powershell 7+. 
Removing as it's not necessary.