### PR TITLE
Only run QA Test workflow for certain branches

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -31,7 +31,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       (
-        startsWith(github.event.workflow_run.head_branch, 'Second_Life') ||
+        startsWith(github.ref, 'refs/tags/Second_Life') ||
         startsWith(github.event.workflow_run.head_branch, 'release') ||
         github.event.workflow_run.head_branch == 'develop'
       )

--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -27,9 +27,14 @@ jobs:
 
   install-viewer-and-run-tests:
     runs-on: [self-hosted, qa-machine]
+    # Run test only on successful builds of develop or Second_Life_X branches
     if: >
-      github.event.workflow_run.conclusion == 'success'
-    # startsWith(github.event.workflow_run.head_branch, 'Second_Life_Release')
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        startsWith(github.event.workflow_run.head_branch, 'Second_Life') ||
+        startsWith(github.event.workflow_run.head_branch, 'release') ||
+        github.event.workflow_run.head_branch == 'develop'
+      )
 
     steps:
       - name: Temporarily Allow PowerShell Scripts (Process Scope)


### PR DESCRIPTION
Only trigger on the following branches: 
- `release/X`
- `develop `

And tagged builds (these presently begin with `Second_Life_X`)