### PR TITLE
theoretical earlier start to asset downloads during startup

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -348,8 +348,6 @@ std::string gLastVersionChannel;
 LLVector3 gWindVec(3.0, 3.0, 0.0);
 LLVector3 gRelativeWindVec(0.0, 0.0, 0.0);
 
-U32 gPacketsIn = 0;
-
 bool gRandomizeFramerate = false;
 bool gPeriodicSlowFrame = false;
 
@@ -358,6 +356,7 @@ bool gLLErrorActivated = false;
 bool gLogoutInProgress = false;
 
 bool gSimulateMemLeak = false;
+bool gDoDisconnect = false;
 
 // We don't want anyone, especially threads working on the graphics pipeline,
 // to have to block due to this WorkQueue being full.
@@ -372,7 +371,6 @@ const std::string START_MARKER_FILE_NAME("SecondLife.start_marker");
 const std::string ERROR_MARKER_FILE_NAME("SecondLife.error_marker");
 const std::string LLERROR_MARKER_FILE_NAME("SecondLife.llerror_marker");
 const std::string LOGOUT_MARKER_FILE_NAME("SecondLife.logout_marker");
-static bool gDoDisconnect = false;
 static std::string gLaunchFileOnQuit;
 
 // Used on Win32 for other apps to identify our window (eg, win_setup)
@@ -5257,7 +5255,6 @@ void LLAppViewer::idleNetwork()
                 }
 
                 total_decoded++;
-                gPacketsIn++;
 
                 if (total_decoded > MESSAGE_MAX_PER_FRAME)
                 {

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -399,10 +399,10 @@ extern std::string gLastVersionChannel;
 
 extern LLVector3 gWindVec;
 extern LLVector3 gRelativeWindVec;
-extern U32  gPacketsIn;
 
 extern bool gRandomizeFramerate;
 extern bool gPeriodicSlowFrame;
+extern bool gDoDisconnect;
 
 extern bool gSimulateMemLeak;
 

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -299,6 +299,9 @@ void callback_cache_name(const LLUUID& id, const std::string& full_name, bool is
 
 void do_startup_frame()
 {
+    // Until after STATE_AGENT_SEND we don't get very many UDP packets to poll the socket,
+    // and after STATE_PRECACHE the LLAppViewer::idleNetwork() will do UDP processing,
+    // so we only bother to process between those two states.
     EStartupState state = LLStartUp::getStartupState();
     if (state > STATE_AGENT_SEND && state < STATE_PRECACHE)
     {

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -297,16 +297,59 @@ void callback_cache_name(const LLUUID& id, const std::string& full_name, bool is
 // exported functionality
 //
 
+void do_startup_frame()
+{
+    EStartupState state = LLStartUp::getStartupState();
+    if (state > STATE_AGENT_SEND && state < STATE_PRECACHE)
+    {
+        // drain the UDP socket...
+        U64 t0 = totalTime();
+        constexpr U64 MAX_STARTUP_FRAME_TIME = 2000; // usec
+        constexpr U64 MAX_STARTUP_FRAME_MESSAGES = 100;
+        S32 num_messages = 0;
+        bool needs_drain = false;
+        LockMessageChecker lmc(gMessageSystem);
+        while (lmc.checkAllMessages(gFrameCount, gServicePump))
+        {
+            if (gDoDisconnect)
+            {
+                // We're disconnecting, don't process any more messages from the server
+                // We're usually disconnecting due to either network corruption or a
+                // server going down, so this is OK.
+                break;
+            }
+            if (++num_messages >= MAX_STARTUP_FRAME_MESSAGES
+                || (totalTime() - t0) > MAX_STARTUP_FRAME_TIME)
+            {
+                needs_drain = true;
+                break;
+            }
+        }
+        if (needs_drain || gMessageSystem->mPacketRing.getNumBufferedPackets() > 0)
+        {
+             gMessageSystem->drainUdpSocket();
+        }
+        lmc.processAcks();
+    }
+    // ...then call display_startup()
+    display_startup();
+}
+
 void pump_idle_startup_network(void)
 {
+    // while there are message to process:
+    //     process one then call display_startup()
+    S32 num_messages = 0;
     {
         LockMessageChecker lmc(gMessageSystem);
         while (lmc.checkAllMessages(gFrameCount, gServicePump))
         {
             display_startup();
+            ++num_messages;
         }
         lmc.processAcks();
     }
+    // finally call one last display_startup()
     display_startup();
 }
 
@@ -728,7 +771,7 @@ bool idle_startup()
         LL_DEBUGS("AppInit") << "STATE_BROWSER_INIT" << LL_ENDL;
         std::string msg = LLTrans::getString("LoginInitializingBrowser");
         set_startup_status(0.03f, msg.c_str(), gAgent.mMOTD.c_str());
-        display_startup();
+        do_startup_frame();
         // LLViewerMedia::initBrowser();
         LLStartUp::setStartupState( STATE_LOGIN_SHOW );
         return false;
@@ -793,7 +836,7 @@ bool idle_startup()
                     LL_DEBUGS("AppInit") << "FirstLoginThisInstall off" << LL_ENDL;
                 }
             }
-            display_startup();
+            do_startup_frame();
             LLStartUp::setStartupState( STATE_LOGIN_WAIT );     // Wait for user input
         }
         else
@@ -824,7 +867,7 @@ bool idle_startup()
         }
         LL_DEBUGS("AppInit") << "PeekMessage processed" << LL_ENDL;
 #endif
-        display_startup();
+        do_startup_frame();
         timeout.reset();
         return false;
     }
@@ -839,7 +882,7 @@ bool idle_startup()
         // Don't do anything.  Wait for the login view to call the login_callback,
         // which will push us to the next state.
 
-        // display() function will be the one to run display_startup()
+        // display() function will be the one to run do_startup_frame()
         // Sleep so we don't spin the CPU
         ms_sleep(1);
         return false;
@@ -1021,7 +1064,7 @@ bool idle_startup()
         auth_desc = LLTrans::getString("LoginInProgress");
         set_startup_status(progress, auth_desc, auth_message);
         progress += 0.02f;
-        display_startup();
+        do_startup_frame();
 
         // Setting initial values...
         LLLoginInstance* login = LLLoginInstance::getInstance();
@@ -1057,7 +1100,7 @@ bool idle_startup()
         emsg << LLTrans::getString("LoginFailedHeader") << "\n";
         if(LLLoginInstance::getInstance()->authFailure())
         {
-            LL_INFOS("LLStartup") << "Login failed, LLLoginInstance::getResponse(): "
+            LL_INFOS("LLStartUp") << "Login failed, LLLoginInstance::getResponse(): "
                                   << LLLoginInstance::getInstance()->getResponse() << LL_ENDL;
             LLSD response = LLLoginInstance::getInstance()->getResponse();
             // Still have error conditions that may need some
@@ -1129,7 +1172,7 @@ bool idle_startup()
                 // If optional was skipped this case shouldn't
                 // be reached.
 
-                LL_INFOS("LLStartup") << "Forcing a quit due to update." << LL_ENDL;
+                LL_INFOS("LLStartUp") << "Forcing a quit due to update." << LL_ENDL;
                 LLLoginInstance::getInstance()->disconnect();
                 LLAppViewer::instance()->forceQuit();
             }
@@ -1157,7 +1200,7 @@ bool idle_startup()
                         }
                         catch (LLCertException &cert_exception)
                         {
-                            LL_WARNS("LLStartup", "SECAPI") << "Caught " << cert_exception.what() << " certificate expception on getCertificate("<< response["certificate"] << ")" << LL_ENDL;
+                            LL_WARNS("LLStartUp", "SECAPI") << "Caught " << cert_exception.what() << " certificate expception on getCertificate("<< response["certificate"] << ")" << LL_ENDL;
                             LLSD args;
                             args["REASON"] = LLTrans::getString(cert_exception.what());
 
@@ -1209,7 +1252,7 @@ bool idle_startup()
                         // notificatioin message.
                         LLSD args;
                         args["ERROR_MESSAGE"] = emsg.str();
-                        LL_INFOS("LLStartup") << "Notification: " << args << LL_ENDL;
+                        LL_INFOS("LLStartUp") << "Notification: " << args << LL_ENDL;
                         LLNotificationsUtil::add("ErrorMessage", args, LLSD(), login_alert_done);
                     }
                 }
@@ -1232,7 +1275,7 @@ bool idle_startup()
             {
                 LLSD args;
                 args["ERROR_MESSAGE"] = emsg.str();
-                LL_INFOS("LLStartup") << "Notification: " << args << LL_ENDL;
+                LL_INFOS("LLStartUp") << "Notification: " << args << LL_ENDL;
                 LLNotificationsUtil::add("ErrorMessage", args, LLSD(), login_alert_done);
                 transition_back_to_login_panel(emsg.str());
                 show_connect_box = true;
@@ -1248,71 +1291,71 @@ bool idle_startup()
     if (STATE_WORLD_INIT == LLStartUp::getStartupState())
     {
         set_startup_status(0.30f, LLTrans::getString("LoginInitializingWorld"), gAgent.mMOTD);
-        display_startup();
+        do_startup_frame();
         // We should have an agent id by this point.
         llassert(!(gAgentID == LLUUID::null));
 
         // Finish agent initialization.  (Requires gSavedSettings, builds camera)
         gAgent.init();
-        display_startup();
+        do_startup_frame();
         gAgentCamera.init();
-        display_startup();
-        display_startup();
+        do_startup_frame();
+        do_startup_frame();
 
         // Since we connected, save off the settings so the user doesn't have to
         // type the name/password again if we crash.
         gSavedSettings.saveToFile(gSavedSettings.getString("ClientSettingsFile"), true);
         LLUIColorTable::instance().saveUserSettings();
 
-        display_startup();
+        do_startup_frame();
 
         //
         // Initialize classes w/graphics stuff.
         //
         LLSurface::initClasses();
-        display_startup();
+        do_startup_frame();
 
-        display_startup();
+        do_startup_frame();
 
         LLDrawable::initClass();
-        display_startup();
+        do_startup_frame();
 
         // init the shader managers
         LLPostProcess::initClass();
-        display_startup();
+        do_startup_frame();
 
         LLAvatarAppearance::initClass("avatar_lad.xml","avatar_skeleton.xml");
-        display_startup();
+        do_startup_frame();
 
         LLViewerObject::initVOClasses();
-        display_startup();
+        do_startup_frame();
 
         // Initialize all our tools.  Must be done after saved settings loaded.
         // NOTE: This also is where gToolMgr used to be instantiated before being turned into a singleton.
         LLToolMgr::getInstance()->initTools();
-        display_startup();
+        do_startup_frame();
 
         // Pre-load floaters, like the world map, that are slow to spawn
         // due to XML complexity.
         gViewerWindow->initWorldUI();
 
-        display_startup();
+        do_startup_frame();
 
         // This is where we used to initialize gWorldp. Original comment said:
         // World initialization must be done after above window init
 
         // User might have overridden far clip
         LLWorld::getInstance()->setLandFarClip(gAgentCamera.mDrawDistance);
-        display_startup();
+        do_startup_frame();
         // Before we create the first region, we need to set the agent's mOriginGlobal
         // This is necessary because creating objects before this is set will result in a
         // bad mPositionAgent cache.
 
         gAgent.initOriginGlobal(from_region_handle(gFirstSimHandle));
-        display_startup();
+        do_startup_frame();
 
         LLWorld::getInstance()->addRegion(gFirstSimHandle, gFirstSim);
-        display_startup();
+        do_startup_frame();
 
         LLViewerRegion *regionp = LLWorld::getInstance()->getRegionFromHandle(gFirstSimHandle);
         LL_INFOS("AppInit") << "Adding initial simulator " << regionp->getOriginGlobal() << LL_ENDL;
@@ -1321,18 +1364,18 @@ bool idle_startup()
         << gFirstSimSeedCap << LL_ENDL;
         regionp->setSeedCapability(gFirstSimSeedCap);
         LL_DEBUGS("AppInit") << "Waiting for seed grant ...." << LL_ENDL;
-        display_startup();
+        do_startup_frame();
         // Set agent's initial region to be the one we just created.
         gAgent.setRegion(regionp);
-        display_startup();
+        do_startup_frame();
         // Set agent's initial position, which will be read by LLVOAvatar when the avatar
         // object is created.  I think this must be done after setting the region.  JC
         gAgent.setPositionAgent(agent_start_position_region);
 
-        display_startup();
+        do_startup_frame();
         LLStartUp::initExperiences();
 
-        display_startup();
+        do_startup_frame();
 
         // If logging should be enebled, turns it on and loads history from disk
         // Note: does not happen on init of singleton because preferences can use
@@ -1353,7 +1396,7 @@ bool idle_startup()
     {
         LLStartUp::multimediaInit();
         LLStartUp::setStartupState( STATE_FONT_INIT );
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1362,7 +1405,7 @@ bool idle_startup()
     {
         LLStartUp::fontInit();
         LLStartUp::setStartupState( STATE_SEED_GRANTED_WAIT );
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1416,7 +1459,7 @@ bool idle_startup()
                 set_startup_status(0.4f, LLTrans::getString("LoginRequestSeedCapGrant"), gAgent.mMOTD.c_str());
             }
         }
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1427,7 +1470,7 @@ bool idle_startup()
     //---------------------------------------------------------------------
     if (STATE_SEED_CAP_GRANTED == LLStartUp::getStartupState())
     {
-        display_startup();
+        do_startup_frame();
 
         // These textures are not warrantied to be cached, so needs
         // to hapen with caps granted
@@ -1436,9 +1479,9 @@ bool idle_startup()
         // will init images, should be done with caps, but before gSky.init()
         LLEnvironment::getInstance()->initSingleton();
 
-        display_startup();
+        do_startup_frame();
         update_texture_fetch();
-        display_startup();
+        do_startup_frame();
 
         if ( gViewerWindow != NULL)
         {   // This isn't the first logon attempt, so show the UI
@@ -1446,15 +1489,15 @@ bool idle_startup()
         }
         gLoginMenuBarView->setVisible( false );
         gLoginMenuBarView->setEnabled( false );
-        display_startup();
+        do_startup_frame();
 
         // direct logging to the debug console's line buffer
         LLError::logToFixedBuffer(gDebugView->mDebugConsolep);
-        display_startup();
+        do_startup_frame();
 
         // set initial visibility of debug console
         gDebugView->mDebugConsolep->setVisible(gSavedSettings.getBOOL("ShowDebugConsole"));
-        display_startup();
+        do_startup_frame();
 
         //
         // Set message handlers
@@ -1463,23 +1506,23 @@ bool idle_startup()
 
         // register callbacks for messages. . . do this after initial handshake to make sure that we don't catch any unwanted
         register_viewer_callbacks(gMessageSystem);
-        display_startup();
+        do_startup_frame();
 
         // Debugging info parameters
         gMessageSystem->setMaxMessageTime( 0.5f );          // Spam if decoding all msgs takes more than 500 ms
-        display_startup();
+        do_startup_frame();
 
         #ifndef LL_RELEASE_FOR_DOWNLOAD
             gMessageSystem->setTimeDecodes( true );             // Time the decode of each msg
             gMessageSystem->setTimeDecodesSpamThreshold( 0.05f );  // Spam if a single msg takes over 50ms to decode
         #endif
-        display_startup();
+        do_startup_frame();
 
         gXferManager->registerCallbacks(gMessageSystem);
-        display_startup();
+        do_startup_frame();
 
         LLStartUp::initNameCache();
-        display_startup();
+        do_startup_frame();
 
         // update the voice settings *after* gCacheName initialization
         // so that we can construct voice UI that relies on the name cache
@@ -1487,7 +1530,7 @@ bool idle_startup()
         {
             LLVoiceClient::getInstance()->updateSettings();
         }
-        display_startup();
+        do_startup_frame();
 
         // create a container's instance for start a controlling conversation windows
         // by the voice's events
@@ -1508,12 +1551,12 @@ bool idle_startup()
         // register null callbacks for audio until the audio system is initialized
         gMessageSystem->setHandlerFuncFast(_PREHASH_SoundTrigger, null_message_callback, NULL);
         gMessageSystem->setHandlerFuncFast(_PREHASH_AttachedSound, null_message_callback, NULL);
-        display_startup();
+        do_startup_frame();
 
         //reset statistics
         LLViewerStats::instance().resetStats();
 
-        display_startup();
+        do_startup_frame();
         //
         // Set up region and surface defaults
         //
@@ -1538,7 +1581,7 @@ bool idle_startup()
         LLViewerCamera::getInstance()->setAspect(gViewerWindow->getWorldViewAspectRatio());
         // Initialize FOV
         LLViewerCamera::getInstance()->setDefaultFOV(gSavedSettings.getF32("CameraAngle"));
-        display_startup();
+        do_startup_frame();
 
         // Move agent to starting location. The position handed to us by
         // the space server is in global coordinates, but the agent frame
@@ -1549,7 +1592,7 @@ bool idle_startup()
         gAgent.resetAxes(gAgentStartLookAt);
         gAgentCamera.stopCameraAnimation();
         gAgentCamera.resetCamera();
-        display_startup();
+        do_startup_frame();
 
         // Initialize global class data needed for surfaces (i.e. textures)
         LL_DEBUGS("AppInit") << "Initializing sky..." << LL_ENDL;
@@ -1560,7 +1603,7 @@ bool idle_startup()
 
         LLGLState::checkStates();
 
-        display_startup();
+        do_startup_frame();
 
         LL_DEBUGS("AppInit") << "Decoding images..." << LL_ENDL;
         // For all images pre-loaded into viewer cache, init
@@ -1574,12 +1617,12 @@ bool idle_startup()
         {
             F32 frac = (F32)i / (F32)DECODE_TIME_SEC;
             set_startup_status(0.45f + frac*0.1f, LLTrans::getString("LoginDecodingImages"), gAgent.mMOTD);
-            display_startup();
+            do_startup_frame();
             gTextureList.decodeAllImages(1.f);
         }
         LLStartUp::setStartupState( STATE_WORLD_WAIT );
 
-        display_startup();
+        do_startup_frame();
 
         // JC - Do this as late as possible to increase likelihood Purify
         // will run.
@@ -1608,7 +1651,7 @@ bool idle_startup()
             NULL);
 
         timeout.reset();
-        display_startup();
+        do_startup_frame();
 
         return false;
     }
@@ -1635,7 +1678,7 @@ bool idle_startup()
     {
         LL_DEBUGS("AppInit") << "Connecting to region..." << LL_ENDL;
         set_startup_status(0.60f, LLTrans::getString("LoginConnectingToRegion"), gAgent.mMOTD);
-        display_startup();
+        do_startup_frame();
         // register with the message system so it knows we're
         // expecting this message
         LLMessageSystem* msg = gMessageSystem;
@@ -1649,7 +1692,7 @@ bool idle_startup()
             gAssetStorage->setUpstream(regionp->getHost());
             gCacheName->setUpstream(regionp->getHost());
         }
-        display_startup();
+        do_startup_frame();
 
         // Create login effect
         // But not on first login, because you can't see your avatar then
@@ -1664,7 +1707,7 @@ bool idle_startup()
         LLStartUp::setStartupState( STATE_AGENT_WAIT );     // Go to STATE_AGENT_WAIT
 
         timeout.reset();
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1673,35 +1716,13 @@ bool idle_startup()
     //---------------------------------------------------------------------
     if (STATE_AGENT_WAIT == LLStartUp::getStartupState())
     {
-        {
-            LockMessageChecker lmc(gMessageSystem);
-            while (lmc.checkAllMessages(gFrameCount, gServicePump))
-            {
-                if (gAgentMovementCompleted)
-                {
-                    // Sometimes we have more than one message in the
-                    // queue. break out of this loop and continue
-                    // processing. If we don't, then this could skip one
-                    // or more login steps.
-                    break;
-                }
-                else
-                {
-                    LL_DEBUGS("AppInit") << "Awaiting AvatarInitComplete, got "
-                                         << gMessageSystem->getMessageName() << LL_ENDL;
-                }
-                display_startup();
-            }
-            lmc.processAcks();
-        }
-
-        display_startup();
+        do_startup_frame();
 
         if (gAgentMovementCompleted)
         {
             LLStartUp::setStartupState( STATE_INVENTORY_SEND );
         }
-        display_startup();
+        do_startup_frame();
 
         if (!gAgentMovementCompleted && timeout.getElapsedTimeF32() > STATE_AGENT_WAIT_TIMEOUT)
         {
@@ -1725,7 +1746,7 @@ bool idle_startup()
     if (STATE_INVENTORY_SEND == LLStartUp::getStartupState())
     {
         LL_PROFILE_ZONE_NAMED("State inventory send")
-        display_startup();
+        do_startup_frame();
 
         // request mute list
         LL_INFOS() << "Requesting Mute List" << LL_ENDL;
@@ -1735,12 +1756,12 @@ bool idle_startup()
         LL_INFOS() << "Requesting Money Balance" << LL_ENDL;
         LLStatusBar::sendMoneyBalanceRequest();
 
-        display_startup();
+        do_startup_frame();
 
         // Inform simulator of our language preference
         LLAgentLanguage::update();
 
-        display_startup();
+        do_startup_frame();
         // unpack thin inventory
         LLSD response = LLLoginInstance::getInstance()->getResponse();
         //bool dump_buffer = false;
@@ -1755,7 +1776,7 @@ bool idle_startup()
                 gInventory.setLibraryRootFolderID(id.asUUID());
             }
         }
-        display_startup();
+        do_startup_frame();
 
         LLSD inv_lib_owner = response["inventory-lib-owner"];
         if(inv_lib_owner.isDefined())
@@ -1767,9 +1788,9 @@ bool idle_startup()
                 gInventory.setLibraryOwnerID(LLUUID(id.asUUID()));
             }
         }
-        display_startup();
+        do_startup_frame();
         LLStartUp::setStartupState(STATE_INVENTORY_SKEL);
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1788,7 +1809,7 @@ bool idle_startup()
                 LL_WARNS("AppInit") << "Problem loading inventory-skel-lib" << LL_ENDL;
             }
         }
-        display_startup();
+        do_startup_frame();
 
         LLSD inv_skeleton = response["inventory-skeleton"];
         if (inv_skeleton.isDefined())
@@ -1799,9 +1820,9 @@ bool idle_startup()
                 LL_WARNS("AppInit") << "Problem loading inventory-skel-targets" << LL_ENDL;
             }
         }
-        display_startup();
+        do_startup_frame();
         LLStartUp::setStartupState(STATE_INVENTORY_SEND2);
-        display_startup();
+        do_startup_frame();
         return false;
     }
 
@@ -1847,7 +1868,7 @@ bool idle_startup()
                 list[agent_id] = new LLRelationship(given_rights, has_rights, false);
             }
             LLAvatarTracker::instance().addBuddyList(list);
-            display_startup();
+            do_startup_frame();
         }
 
         bool show_hud = false;
@@ -1875,7 +1896,7 @@ bool idle_startup()
                 //}
             }
         }
-        display_startup();
+        do_startup_frame();
 
         // Either we want to show tutorial because this is the first login
         // to a Linden Help Island or the user quit with the tutorial
@@ -1884,21 +1905,21 @@ bool idle_startup()
         {
             LLFloaterReg::showInstance("hud", LLSD(), false);
         }
-        display_startup();
+        do_startup_frame();
 
         LLSD event_notifications = response["event_notifications"];
         if(event_notifications.isDefined())
         {
             gEventNotifier.load(event_notifications);
         }
-        display_startup();
+        do_startup_frame();
 
         LLSD classified_categories = response["classified_categories"];
         if(classified_categories.isDefined())
         {
             LLClassifiedInfo::loadCategories(classified_categories);
         }
-        display_startup();
+        do_startup_frame();
 
         // This method MUST be called before gInventory.findCategoryUUIDForType because of
         // gInventory.mIsAgentInvUsable is set to true in the gInventory.buildParentChildMap.
@@ -1917,7 +1938,7 @@ bool idle_startup()
         LLInventoryModelBackgroundFetch::instance().start();
         gInventory.createCommonSystemCategories();
         LLStartUp::setStartupState(STATE_INVENTORY_CALLBACKS );
-        display_startup();
+        do_startup_frame();
 
         return false;
     }
@@ -1929,7 +1950,7 @@ bool idle_startup()
     {
         if (!LLInventoryModel::isSysFoldersReady())
         {
-            display_startup();
+            do_startup_frame();
             return false;
         }
 
@@ -1954,7 +1975,7 @@ bool idle_startup()
         gInventory.addChangedMask(LLInventoryObserver::ALL, LLUUID::null);
         gInventory.notifyObservers();
 
-        display_startup();
+        do_startup_frame();
 
         // set up callbacks
         LL_INFOS() << "Registering Callbacks" << LL_ENDL;
@@ -1965,18 +1986,18 @@ bool idle_startup()
         LLAvatarTracker::instance().registerCallbacks(msg);
         LL_INFOS() << " Landmark" << LL_ENDL;
         LLLandmark::registerCallbacks(msg);
-        display_startup();
+        do_startup_frame();
 
         // request all group information
         LL_INFOS() << "Requesting Agent Data" << LL_ENDL;
         gAgent.sendAgentDataUpdateRequest();
-        display_startup();
+        do_startup_frame();
         // Create the inventory views
         LL_INFOS() << "Creating Inventory Views" << LL_ENDL;
         LLFloaterReg::getInstance("inventory");
-        display_startup();
+        do_startup_frame();
         LLStartUp::setStartupState( STATE_MISC );
-        display_startup();
+        do_startup_frame();
 
         return false;
     }
@@ -2026,7 +2047,7 @@ bool idle_startup()
             gSavedSettings.setBOOL("ShowStartLocation", true);
         }
 
-        display_startup();
+        do_startup_frame();
 
         // Load stored local environment if needed.
         LLEnvironment::instance().loadFromSettings();
@@ -2034,7 +2055,7 @@ bool idle_startup()
         // *TODO : Uncomment that line once the whole grid migrated to SLM and suppress it from LLAgent::handleTeleportFinished() (llagent.cpp)
         //check_merchant_status();
 
-        display_startup();
+        do_startup_frame();
 
         if (gSavedSettings.getBOOL("HelpFloaterOpen"))
         {
@@ -2042,7 +2063,7 @@ bool idle_startup()
             LLViewerHelp::instance().showTopic("");
         }
 
-        display_startup();
+        do_startup_frame();
 
         // We're successfully logged in.
         gSavedSettings.setBOOL("FirstLoginThisInstall", false);
@@ -2051,12 +2072,12 @@ bool idle_startup()
 
         LLFloaterGridStatus::getInstance()->startGridStatusTimer();
 
-        display_startup();
+        do_startup_frame();
 
-        display_startup();
+        do_startup_frame();
         // JC: Initializing audio requests many sounds for download.
         init_audio();
-        display_startup();
+        do_startup_frame();
 
         // JC: Initialize "active" gestures.  This may also trigger
         // many gesture downloads, if this is the user's first
@@ -2094,7 +2115,7 @@ bool idle_startup()
             LLGestureMgr::instance().startFetch();
         }
         gDisplaySwapBuffers = true;
-        display_startup();
+        do_startup_frame();
 
         LLMessageSystem* msg = gMessageSystem;
         msg->setHandlerFuncFast(_PREHASH_SoundTrigger,              process_sound_trigger);
@@ -2172,10 +2193,10 @@ bool idle_startup()
             }
         }
 
-        display_startup();
+        do_startup_frame();
         //DEV-17797.  get null folder.  Any items found here moved to Lost and Found
         LLInventoryModelBackgroundFetch::instance().findLostItems();
-        display_startup();
+        do_startup_frame();
 
         LLStartUp::setStartupState( STATE_PRECACHE );
         timeout.reset();
@@ -2184,7 +2205,7 @@ bool idle_startup()
 
     if (STATE_PRECACHE == LLStartUp::getStartupState())
     {
-        display_startup();
+        do_startup_frame();
         F32 timeout_frac = timeout.getElapsedTimeF32()/PRECACHING_DELAY;
 
         // We now have an inventory skeleton, so if this is a user's first
@@ -2210,7 +2231,7 @@ bool idle_startup()
             callAfterCOFFetch(set_flags_and_update_appearance);
         }
 
-        display_startup();
+        do_startup_frame();
 
         // wait precache-delay and for agent's avatar or a lot longer.
         if ((timeout_frac > 1.f) && isAgentAvatarValid())
@@ -2235,7 +2256,7 @@ bool idle_startup()
             set_startup_status(0.60f + 0.30f * timeout_frac,
                 LLTrans::getString("LoginPrecaching"),
                     gAgent.mMOTD.c_str());
-            display_startup();
+            do_startup_frame();
         }
 
         return true;
@@ -2263,7 +2284,7 @@ bool idle_startup()
             LLStartUp::setStartupState( STATE_CLEANUP );
         }
 
-        display_startup();
+        do_startup_frame();
 
         if (gAgent.isOutfitChosen() && (wearables_time > MAX_WEARABLES_TIME))
         {
@@ -2304,7 +2325,7 @@ bool idle_startup()
     if (STATE_CLEANUP == LLStartUp::getStartupState())
     {
         set_startup_status(1.0, "", "");
-        display_startup();
+        do_startup_frame();
 
         if (!mBenefitsSuccessfullyInit)
         {
@@ -2325,7 +2346,7 @@ bool idle_startup()
         //gViewerWindow->revealIntroPanel();
         gViewerWindow->setStartupComplete();
         gViewerWindow->setProgressCancelButtonVisible(false);
-        display_startup();
+        do_startup_frame();
 
         // We're not away from keyboard, even though login might have taken
         // a while. JC
@@ -2357,7 +2378,7 @@ bool idle_startup()
         // LLUserAuth::getInstance()->reset();
 
         LLStartUp::setStartupState( STATE_STARTED );
-        display_startup();
+        do_startup_frame();
 
         // Unmute audio if desired and setup volumes.
         // This is a not-uncommon crash site, so surround it with
@@ -2373,7 +2394,7 @@ bool idle_startup()
 
         LLAgentPicksInfo::getInstance()->requestNumberOfPicks();
 
-        display_startup();
+        do_startup_frame();
 
         llassert(LLPathfindingManager::getInstance() != NULL);
         LLPathfindingManager::getInstance()->initSystem();
@@ -2978,9 +2999,7 @@ std::string LLStartUp::startupStateToString(EStartupState state)
 // static
 void LLStartUp::setStartupState( EStartupState state )
 {
-    LL_INFOS("AppInit") << "Startup state changing from " <<
-        getStartupStateString() << " to " <<
-        startupStateToString(state) << LL_ENDL;
+    LL_INFOS("AppInit") << getStartupStateString() << " --> " << startupStateToString(state) << LL_ENDL;
 
     getPhases().stopPhase(getStartupStateString());
     gStartupState = state;
@@ -3044,7 +3063,7 @@ void LLStartUp::multimediaInit()
     LL_DEBUGS("AppInit") << "Initializing Multimedia...." << LL_ENDL;
     std::string msg = LLTrans::getString("LoginInitializingMultimedia");
     set_startup_status(0.42f, msg.c_str(), gAgent.mMOTD.c_str());
-    display_startup();
+    do_startup_frame();
 }
 
 void LLStartUp::fontInit()
@@ -3052,7 +3071,7 @@ void LLStartUp::fontInit()
     LL_DEBUGS("AppInit") << "Initializing fonts...." << LL_ENDL;
     std::string msg = LLTrans::getString("LoginInitializingFonts");
     set_startup_status(0.45f, msg.c_str(), gAgent.mMOTD.c_str());
-    display_startup();
+    do_startup_frame();
 
     LLFontGL::loadDefaultFonts();
 }
@@ -3748,14 +3767,14 @@ bool process_login_success_response()
     {
         // We got an answer from the grid -> use that for map for the current session
         gSavedSettings.setString("CurrentMapServerURL", map_server_url);
-        LL_INFOS("LLStartup") << "map-server-url : we got an answer from the grid : " << map_server_url << LL_ENDL;
+        LL_INFOS("LLStartUp") << "map-server-url : we got an answer from the grid : " << map_server_url << LL_ENDL;
     }
     else
     {
         // No answer from the grid -> use the default setting for current session
         map_server_url = gSavedSettings.getString("MapServerURL");
         gSavedSettings.setString("CurrentMapServerURL", map_server_url);
-        LL_INFOS("LLStartup") << "map-server-url : no map-server-url answer, we use the default setting for the map : " << map_server_url << LL_ENDL;
+        LL_INFOS("LLStartUp") << "map-server-url : no map-server-url answer, we use the default setting for the map : " << map_server_url << LL_ENDL;
     }
 
     // Default male and female avatars allowing the user to choose their avatar on first login.

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -2794,7 +2794,10 @@ void LLVOAvatar::idleUpdate(LLAgent &agent, const F64 &time)
     }
 
     // attach objects that were waiting for a drawable
-    lazyAttach();
+    if (!mPendingAttachment.empty())
+    {
+        lazyAttach();
+    }
 
     // animate the character
     // store off last frame's root position to be consistent with camera position


### PR DESCRIPTION
I seemed like maybe we could start processing UDP messages a little earlier during the startup sequence, however I wasn't able to measure much improvement: there was just too much noise during login.  Some logins go faster than others both with or without these changes.