### PR TITLE
#3547 Store and restore position when rebulding picks

### DIFF
--- a/indra/newview/llavatarpropertiesprocessor.cpp
+++ b/indra/newview/llavatarpropertiesprocessor.cpp
@@ -669,6 +669,7 @@ void LLAvatarPropertiesProcessor::sendClassifiedInfoUpdate(const LLAvatarClassif
 
 void LLAvatarPropertiesProcessor::sendPickInfoRequest(const LLUUID& creator_id, const LLUUID& pick_id)
 {
+    LL_DEBUGS("PickInfo") << " Requiesting pick info for " << pick_id << LL_ENDL;
     // Must ask for a pick based on the creator id because
     // the pick database is distributed to the inventory cluster. JC
     std::vector<std::string> request_params{ creator_id.asString(), pick_id.asString() };

--- a/indra/newview/llpanelprofilepicks.cpp
+++ b/indra/newview/llpanelprofilepicks.cpp
@@ -55,6 +55,8 @@
 static LLPanelInjector<LLPanelProfilePicks> t_panel_profile_picks("panel_profile_picks");
 static LLPanelInjector<LLPanelProfilePick> t_panel_profile_pick("panel_profile_pick");
 
+static const F32 REQUEST_TIMOUT = 60;
+static const F32 LOCATION_CACHE_TIMOUT = 900;
 
 class LLPickHandler : public LLCommandHandler
 {
@@ -306,6 +308,7 @@ void LLPanelProfilePicks::processProperties(void* data, EAvatarProcessorType typ
 
 void LLPanelProfilePicks::processProperties(const LLAvatarData* avatar_picks)
 {
+    LL_DEBUGS("PickInfo") << "Processing picks for avatar " << getAvatarId() << LL_ENDL;
     LLUUID selected_id = mPickToSelectOnLoad;
     bool has_selection = false;
     if (mPickToSelectOnLoad.isNull())
@@ -316,6 +319,25 @@ void LLPanelProfilePicks::processProperties(const LLAvatarData* avatar_picks)
             if (active_pick_panel)
             {
                 selected_id = active_pick_panel->getPickId();
+            }
+        }
+    }
+
+    // Avoid pointlesly requesting parcel data,
+    // store previous values
+    std::map<LLUUID, std::string> parcelid_location_map;
+    std::map<LLUUID, LLUUID> pickid_parcelid_map;
+
+    for (S32 tab_idx = 0; tab_idx < mTabContainer->getTabCount(); ++tab_idx)
+    {
+        LLPanelProfilePick* pick_panel = dynamic_cast<LLPanelProfilePick*>(mTabContainer->getPanelByIndex(tab_idx));
+        if (pick_panel && pick_panel->getPickId().notNull())
+        {
+            std::string location = pick_panel->getPickLocation();
+            if (!location.empty())
+            {
+                parcelid_location_map[pick_panel->getParcelID()] = pick_panel->getPickLocation();
+                pickid_parcelid_map[pick_panel->getPickId()] = pick_panel->getParcelID();
             }
         }
     }
@@ -334,6 +356,15 @@ void LLPanelProfilePicks::processProperties(const LLAvatarData* avatar_picks)
         pick_panel->setPickName(pick_name);
         pick_panel->setAvatarId(getAvatarId());
 
+        std::map<LLUUID, LLUUID>::const_iterator found_pick = pickid_parcelid_map.find(pick_id);
+        if (found_pick != pickid_parcelid_map.end())
+        {
+            std::map<LLUUID, std::string>::const_iterator found = parcelid_location_map.find(found_pick->second);
+            if (found != parcelid_location_map.end() && !found->second.empty())
+            {
+                pick_panel->setPickLocation(found_pick->second, found->second);
+            }
+        }
         mTabContainer->addTabPanel(
             LLTabContainer::TabPanelParams().
             panel(pick_panel).
@@ -353,6 +384,11 @@ void LLPanelProfilePicks::processProperties(const LLAvatarData* avatar_picks)
 
         LLPanelProfilePick* pick_panel = LLPanelProfilePick::create();
         pick_panel->setAvatarId(getAvatarId());
+        std::map<LLUUID, std::string>::const_iterator found = parcelid_location_map.find(data.parcel_id);
+        if (found != parcelid_location_map.end() && !found->second.empty())
+        {
+            pick_panel->setPickLocation(data.parcel_id, found->second);
+        }
         pick_panel->processProperties(&data);
         mTabContainer->addTabPanel(
             LLTabContainer::TabPanelParams().
@@ -638,9 +674,14 @@ void LLPanelProfilePick::processProperties(void* data, EAvatarProcessorType type
 
 void LLPanelProfilePick::processProperties(const LLPickData* pick_info)
 {
+    LL_DEBUGS("PickInfo") << "Processing properties for pick " << mPickId << LL_ENDL;
     mIsEditing = false;
     mPickDescription->setParseHTML(true);
-    mParcelId = pick_info->parcel_id;
+    if (mParcelId != pick_info->parcel_id)
+    {
+        mParcelId = pick_info->parcel_id;
+        mPickLocationStr.clear();
+    }
     setSnapshotId(pick_info->snapshot_id);
     if (!getSelfProfile())
     {
@@ -650,8 +691,11 @@ void LLPanelProfilePick::processProperties(const LLPickData* pick_info)
     setPickDesc(pick_info->desc);
     setPosGlobal(pick_info->pos_global);
 
-    // Send remote parcel info request to get parcel name and sim (region) name.
-    sendParcelInfoRequest();
+    if (mPickLocationStr.empty() || mLastRequestTimer.getElapsedTimeF32() > LOCATION_CACHE_TIMOUT)
+    {
+        // Send remote parcel info request to get parcel name and sim (region) name.
+        sendParcelInfoRequest();
+    }
 
     // *NOTE dzaporozhan
     // We want to keep listening to APT_PICK_INFO because user may
@@ -691,9 +735,17 @@ void LLPanelProfilePick::setPickDesc(const std::string& desc)
     mPickDescription->setValue(desc);
 }
 
+void LLPanelProfilePick::setPickLocation(const LLUUID &parcel_id, const std::string& location)
+{
+    setParcelID(parcel_id); // resets mPickLocationStr
+    setPickLocation(location);
+}
+
 void LLPanelProfilePick::setPickLocation(const std::string& location)
 {
     getChild<LLUICtrl>("pick_location")->setValue(location);
+    mPickLocationStr = location;
+    mLastRequestTimer.reset();
 }
 
 void LLPanelProfilePick::onClickMap()
@@ -790,16 +842,19 @@ std::string LLPanelProfilePick::getLocationNotice()
 
 void LLPanelProfilePick::sendParcelInfoRequest()
 {
-    if (mParcelId != mRequestedId)
+    if (mParcelId != mRequestedId || mLastRequestTimer.getElapsedTimeF32() > REQUEST_TIMOUT)
     {
         if (mRequestedId.notNull())
         {
             LLRemoteParcelInfoProcessor::getInstance()->removeObserver(mRequestedId, this);
         }
+        LL_DEBUGS("PickInfo") << "Sending parcel request " << mParcelId << " for pick " << mPickId << LL_ENDL;
         LLRemoteParcelInfoProcessor::getInstance()->addObserver(mParcelId, this);
         LLRemoteParcelInfoProcessor::getInstance()->sendParcelInfoRequest(mParcelId);
 
         mRequestedId = mParcelId;
+        mLastRequestTimer.reset();
+        mPickLocationStr.clear();
     }
 }
 
@@ -813,6 +868,20 @@ void LLPanelProfilePick::processParcelInfo(const LLParcelData& parcel_data)
     if (mParcelId.notNull())
     {
         LLRemoteParcelInfoProcessor::getInstance()->removeObserver(mParcelId, this);
+    }
+}
+
+void LLPanelProfilePick::setParcelID(const LLUUID& parcel_id)
+{
+    if (mParcelId != parcel_id)
+    {
+        mParcelId = parcel_id;
+        mPickLocationStr.clear();
+    }
+    if (mRequestedId.notNull() && mRequestedId != parcel_id)
+    {
+        LLRemoteParcelInfoProcessor::getInstance()->removeObserver(mRequestedId, this);
+        mRequestedId.setNull();
     }
 }
 

--- a/indra/newview/llpanelprofilepicks.h
+++ b/indra/newview/llpanelprofilepicks.h
@@ -117,6 +117,8 @@ public:
 
     virtual void setPickName(const std::string& name);
     const std::string getPickName();
+    virtual void setPickLocation(const LLUUID& parcel_id, const std::string& location);
+    std::string getPickLocation() { return mPickLocationStr; };
 
     void processProperties(void* data, EAvatarProcessorType type) override;
     void processProperties(const LLPickData* pick_data);
@@ -135,7 +137,8 @@ public:
 
     //This stuff we got from LLRemoteParcelObserver, in the last one we intentionally do nothing
     void processParcelInfo(const LLParcelData& parcel_data) override;
-    void setParcelID(const LLUUID& parcel_id) override { mParcelId = parcel_id; }
+    void setParcelID(const LLUUID& parcel_id) override;
+    LLUUID getParcelID() const { return mParcelId; }
     void setErrorStatus(S32 status, const std::string& reason) override {};
 
   protected:
@@ -230,6 +233,8 @@ protected:
     LLUUID mPickId;
     LLUUID mRequestedId;
     std::string mPickNameStr;
+    std::string mPickLocationStr;
+    LLTimer mLastRequestTimer;
 
     boost::signals2::connection mRegionCallbackConnection;
     boost::signals2::connection mParcelCallbackConnection;


### PR DESCRIPTION
instead of re-requesting parcel data for a dozen parcels. Add request timeout in case parcel request hits throttle