### PR TITLE
#3332 Remake glyph count into cache generation

### DIFF
--- a/indra/llrender/llfontbitmapcache.cpp
+++ b/indra/llrender/llfontbitmapcache.cpp
@@ -141,6 +141,7 @@ bool LLFontBitmapCache::nextOpenPos(S32 width, S32& pos_x, S32& pos_y, EFontGlyp
     bitmap_num = getNumBitmaps(bitmap_type) - 1;
 
     mCurrentOffsetX[bitmap_idx] += width + 1;
+    mGeneration++;
 
     return true;
 }
@@ -168,6 +169,7 @@ void LLFontBitmapCache::reset()
 
     mBitmapWidth = 0;
     mBitmapHeight = 0;
+    mGeneration++;
 }
 
 //static

--- a/indra/llrender/llfontbitmapcache.h
+++ b/indra/llrender/llfontbitmapcache.h
@@ -63,6 +63,7 @@ public:
     U32 getNumBitmaps(EFontGlyphType bitmapType) const { return (bitmapType < EFontGlyphType::Count) ? static_cast<U32>(mImageRawVec[static_cast<U32>(bitmapType)].size()) : 0U; }
     S32 getBitmapWidth() const { return mBitmapWidth; }
     S32 getBitmapHeight() const { return mBitmapHeight; }
+    S32 getCacheGeneration() const { return mGeneration; }
 
 protected:
     static U32 getNumComponents(EFontGlyphType bitmap_type);
@@ -74,6 +75,7 @@ private:
     S32 mCurrentOffsetY[static_cast<U32>(EFontGlyphType::Count)] = { 1 };
     S32 mMaxCharWidth = 0;
     S32 mMaxCharHeight = 0;
+    S32 mGeneration = 0;
     std::vector<LLPointer<LLImageRaw>> mImageRawVec[static_cast<U32>(EFontGlyphType::Count)];
     std::vector<LLPointer<LLImageGL>> mImageGLVec[static_cast<U32>(EFontGlyphType::Count)];
 };

--- a/indra/llrender/llfontfreetype.cpp
+++ b/indra/llrender/llfontfreetype.cpp
@@ -146,7 +146,6 @@ LLFontFreetype::LLFontFreetype()
     mIsFallback(false),
     mFTFace(NULL),
     mRenderGlyphCount(0),
-    mAddGlyphCount(0),
     mStyle(0),
     mPointSize(0)
 {
@@ -574,7 +573,6 @@ LLFontGlyphInfo* LLFontFreetype::addGlyphFromFont(const LLFontFreetype *fontp, l
     S32 pos_x, pos_y;
     U32 bitmap_num;
     mFontBitmapCachep->nextOpenPos(width, pos_x, pos_y, bitmap_glyph_type, bitmap_num);
-    mAddGlyphCount++;
 
     LLFontGlyphInfo* gi = new LLFontGlyphInfo(glyph_index, requested_glyph_type);
     gi->mXBitmapOffset = pos_x;

--- a/indra/llrender/llfontfreetype.h
+++ b/indra/llrender/llfontfreetype.h
@@ -148,7 +148,6 @@ public:
 
     void setStyle(U8 style);
     U8 getStyle() const;
-    S32 getAddedGlyphs() const { return mAddGlyphCount; }
 
 private:
     void resetBitmapCache();
@@ -188,7 +187,6 @@ private:
     mutable LLFontBitmapCache* mFontBitmapCachep;
 
     mutable S32 mRenderGlyphCount;
-    mutable S32 mAddGlyphCount;
 };
 
 #endif // LL_FONTFREETYPE_H

--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -110,9 +110,10 @@ S32 LLFontGL::getNumFaces(const std::string& filename)
     return mFontFreetype->getNumFaces(filename);
 }
 
-S32 LLFontGL::getKnownGlyphCount() const
+S32 LLFontGL::getCacheGeneration() const
 {
-    return mFontFreetype ? mFontFreetype->getAddedGlyphs() : 0;
+    const LLFontBitmapCache* font_bitmap_cache = mFontFreetype->getFontBitmapCache();
+    return font_bitmap_cache->getCacheGeneration();
 }
 
 S32 LLFontGL::render(const LLWString &wstr, S32 begin_offset, const LLRect& rect, const LLColor4 &color, HAlign halign, VAlign valign, U8 style,

--- a/indra/llrender/llfontgl.h
+++ b/indra/llrender/llfontgl.h
@@ -90,7 +90,7 @@ public:
     bool loadFace(const std::string& filename, F32 point_size, const F32 vert_dpi, const F32 horz_dpi, bool is_fallback, S32 face_n);
 
     S32 getNumFaces(const std::string& filename);
-    S32 getKnownGlyphCount() const;
+    S32 getCacheGeneration() const;
 
     S32 render(const LLWString &text, S32 begin_offset,
                 const LLRect& rect,

--- a/indra/llrender/llfontvertexbuffer.cpp
+++ b/indra/llrender/llfontvertexbuffer.cpp
@@ -148,7 +148,7 @@ S32 LLFontVertexBuffer::render(
              || mLastHorizDPI != LLFontGL::sHorizDPI
              || mLastOrigin != LLFontGL::sCurOrigin
              || mLastResGeneration != LLFontGL::sResolutionGeneration
-             || mLastFontGlyphCount != fontp->getKnownGlyphCount())
+             || mLastFontCacheGen != fontp->getCacheGeneration())
     {
         genBuffers(fontp, text, begin_offset, x, y, color, halign, valign,
             style, shadow, max_chars, max_pixels, right_x, use_ellipses, use_color);
@@ -180,6 +180,9 @@ void LLFontVertexBuffer::genBuffers(
 {
     // todo: add a debug build assert if this triggers too often for to long?
     mBufferList.clear();
+    // Save before rendreing, it can change mid-render,
+    // so will need to rerender previous characters
+    mLastFontCacheGen = fontp->getCacheGeneration();
 
     gGL.beginList(&mBufferList);
     mChars = fontp->render(text, begin_offset, x, y, color, halign, valign,
@@ -204,7 +207,6 @@ void LLFontVertexBuffer::genBuffers(
     mLastHorizDPI = LLFontGL::sHorizDPI;
     mLastOrigin = LLFontGL::sCurOrigin;
     mLastResGeneration = LLFontGL::sResolutionGeneration;
-    mLastFontGlyphCount = fontp->getKnownGlyphCount();
 
     if (right_x)
     {

--- a/indra/llrender/llfontvertexbuffer.h
+++ b/indra/llrender/llfontvertexbuffer.h
@@ -122,7 +122,7 @@ private:
 
     // Adding new characters to bitmap cache can alter value from getBitmapWidth();
     // which alters whole string. So rerender when new characters were added to cache.
-    S32 mLastFontGlyphCount = 0;
+    S32 mLastFontCacheGen = 0;
 
     static bool sEnableBufferCollection;
 };


### PR DESCRIPTION
1. Cover reset with 'generation'
2. Fix lapse of judgement with mLastFontGlyphCount, it should have been saved before render(), not after