### PR TITLE
#3597 Fix crash when RenderDebugGLSession is True

### DIFF
--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -2458,12 +2458,15 @@ void LLGLState::checkStates(GLboolean writeAlpha)
         return;
     }
 
-    GLint src;
-    GLint dst;
-    glGetIntegerv(GL_BLEND_SRC, &src);
-    glGetIntegerv(GL_BLEND_DST, &dst);
-    llassert_always(src == GL_SRC_ALPHA);
-    llassert_always(dst == GL_ONE_MINUS_SRC_ALPHA);
+    GLint srcRGB, dstRGB, srcAlpha, dstAlpha;
+    glGetIntegerv(GL_BLEND_SRC_RGB, &srcRGB);
+    glGetIntegerv(GL_BLEND_DST_RGB, &dstRGB);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &srcAlpha);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &dstAlpha);
+    llassert_always(srcRGB == GL_SRC_ALPHA);
+    llassert_always(srcAlpha == GL_SRC_ALPHA);
+    llassert_always(dstRGB == GL_ONE_MINUS_SRC_ALPHA);
+    llassert_always(dstAlpha == GL_ONE_MINUS_SRC_ALPHA);
 
     // disable for now until usage is consistent
     //GLboolean colorMask[4];


### PR DESCRIPTION
The crash wasn't 100% reproducible, but I managed to catch it.

The problem is that `GL_BLEND_SRC` and `GL_BLEND_DST` are not valid parameters for `glGetIntegerv()` in modern OpenGL. So far, the only version where I see them referenced is [1.1](https://registry.khronos.org/OpenGL-Refpages/es1.1/xhtml/glGet.xml).

So, in order to check the values, we need to query the RGB and alpha factors separately. Using the old enums can cause the driver to return junk data, leading to the observed crash.