### PR TITLE
#3512 Add UX for marking water exclusion surfaces

### DIFF
--- a/indra/newview/llpanelface.h
+++ b/indra/newview/llpanelface.h
@@ -139,6 +139,8 @@ protected:
     void updateMediaSettings();
     void updateMediaTitle();
 
+    bool isMediaTexSelected();
+
     void getState();
 
     void sendTexture();            // applies and sends texture
@@ -238,6 +240,7 @@ protected:
     void onCommitShiny();
     void onCommitAlphaMode();
     void onCommitFullbright();
+    void onCommitHideWater();
     void onCommitGlow();
     void onCommitPlanarAlign();
     void onCommitRepeatsPerMeter();
@@ -308,6 +311,7 @@ private:
     LLRadioGroup* mRadioPbrType { nullptr };
 
     LLCheckBoxCtrl* mCheckFullbright { nullptr };
+    LLCheckBoxCtrl* mCheckHideWater{ nullptr };
 
     LLTextBox* mLabelColorTransp { nullptr };
     LLSpinCtrl* mCtrlColorTransp { nullptr }; // transparency = 1 - alpha
@@ -555,6 +559,7 @@ private:
     LLMenuButton*   mMenuClipboardTexture;
 
     bool mIsAlpha;
+    bool mExcludeWater { false };
 
     LLSD            mClipboardParams;
 

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -12580,4 +12580,16 @@ are wearing now.
        name="okbutton"
        yestext="OK"/>
   </notification>
+
+  <notification
+   icon="alertmodal.tga"
+   name="WaterExclusionSurfacesWarning"
+   type="alertmodal">
+    Checking the hide water box will overwrite the texture, bumpiness, and shininess choices.
+    <tag>confirm</tag>
+    <usetemplate
+      name="okcancelbuttons"
+      notext="Cancel"
+      yestext="Continue"/>
+  </notification>
 </notifications>

--- a/indra/newview/skins/default/xui/en/panel_tools_texture.xml
+++ b/indra/newview/skins/default/xui/en/panel_tools_texture.xml
@@ -123,6 +123,14 @@
              name="checkbox fullbright"
              top_pad="4"
              width="81" />
+            <check_box
+             height="19"
+             label="Hide water"
+             layout="topleft"
+             left="172"
+             top_delta="0"
+             name="checkbox_hide_water"
+             width="81" />
             <view_border
              bevel_style="none"
              follows="top|left"


### PR DESCRIPTION
"Hide water" checkbox is added to allow mark selected face(s) as water exclusion surface(invisiprim).

- Checkbox is disabled if selected face has pbr material or media;
- Confirmation dialog appears when user checks the box;
- When the box is checked, all other controls are disabled.

