### PR TITLE
Add RenderTextureVRAMDivisor

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7794,6 +7794,17 @@
     <key>Value</key>
     <integer>0</integer>
   </map>
+  <key>RenderTextureVRAMDivisor</key>
+  <map>
+      <key>Comment</key>
+      <string>Divisor for maximum amount of VRAM the viewer will use for textures. 1 = all the VRAM.  Used in conjunction with RenderMaxVRAMBudget.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>U32</string>
+      <key>Value</key>
+      <integer>2</integer>
+  </map>
   <key>RenderMinFreeMainMemoryThreshold</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -489,7 +489,12 @@ void LLViewerTexture::updateClass()
     }
 
     LLViewerMediaTexture::updateClass();
-
+    // This is a divisor used to determine how much VRAM from our overall VRAM budget to use.
+    // This is **cumulative** on whatever the detected or manually set VRAM budget is.
+    // If we detect 2048MB of VRAM, this will, by default, only use 1024.
+    // If you set 1024MB of VRAM, this will, by default, use 512.
+    // -Geenz 2025-03-03
+    static LLCachedControl<U32> tex_vram_divisor(gSavedSettings, "RenderTextureVRAMDivisor", 2);
     static LLCachedControl<U32> max_vram_budget(gSavedSettings, "RenderMaxVRAMBudget", 0);
 
     F64 texture_bytes_alloc = LLImageGL::getTextureBytesAllocated() / 1024.0 / 512.0;
@@ -500,6 +505,7 @@ void LLViewerTexture::updateClass()
     F32 used = (F32)ll_round(texture_bytes_alloc + vertex_bytes_alloc);
 
     F32 budget = max_vram_budget == 0 ? (F32)gGLManager.mVRAM : (F32)max_vram_budget;
+    budget /= tex_vram_divisor;
 
     // Try to leave at least half a GB for everyone else and for bias,
     // but keep at least 768MB for ourselves


### PR DESCRIPTION
# Rationale
Many users utilize SL along side other applications, including video games, content creation apps, and so on.  Presently, the viewer will attempt to cannibalize any available VRAM on the system unless it is manually set by `RenderMaxVRAMBudget`.  This change adds a new `RenderTextureVRAMDivisor` debug setting which defaults to 2 (half of detected VRAM or manually set VRAM).

# Related issues
#3647
#3575
#3348

# Testing
1. Go to a texture heavy region.  Preferably something that takes north of 4GB of VRAM
2. Open the texture console.
3. Set RenderTextureVRAMDivisor to something high.  For example, 8.
4. Watch as the estimated free VRAM decreases.
  * If it doesn't, fail
5. Watch as texture VRAM usage decreases to try and match the VRAM divisor's new budget.
  * If it doesn't, fail 

# Future work
UX mainly.  Maybe a "Low (4) / Medium (3) / High (2) / Ultra (1)" drop down in graphics settings?