### PR TITLE
Cherry-picking develop fixes into 2025.03

### DIFF
--- a/indra/newview/lldrawable.cpp
+++ b/indra/newview/lldrawable.cpp
@@ -33,6 +33,7 @@
 
 // viewer includes
 #include "llagent.h"
+#include "llagentcamera.h"
 #include "llcriticaldamp.h"
 #include "llface.h"
 #include "lllightconstants.h"
@@ -777,6 +778,14 @@ bool LLDrawable::updateMove()
     }
 
     makeActive();
+
+    // #3256 force undampened movement for attached objects in mouselook
+    // to prevent animation bork for linkset with animated parts
+    if (!isRoot() && gAgentCamera.cameraMouselook() &&
+        !mVObjp->isRiggedMesh() && mVObjp->getAvatar() && mVObjp->getAvatar()->isSelf())
+    {
+        return updateMoveUndamped();
+    }
 
     return isState(MOVE_UNDAMPED) ? updateMoveUndamped() : updateMoveDamped();
 }

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -851,6 +851,13 @@ void LLPanelRegionInfo::initCtrl(const std::string& name)
     getChild<LLUICtrl>(name)->setCommitCallback(boost::bind(&LLPanelRegionInfo::onChangeAnything, this));
 }
 
+void LLPanelRegionInfo::initAndSetTexCtrl(LLTextureCtrl*& ctrl, const std::string& name)
+{
+    ctrl = findChild<LLTextureCtrl>(name);
+    if (ctrl)
+        ctrl->setOnSelectCallback([this](LLUICtrl* ctrl, const LLSD& param){ onChangeAnything(); });
+}
+
 template<typename CTRL>
 void LLPanelRegionInfo::initAndSetCtrl(CTRL*& ctrl, const std::string& name)
 {
@@ -1580,7 +1587,7 @@ bool LLPanelRegionTerrainInfo::postBuild()
 
     for(S32 i = 0; i < LLTerrainMaterials::ASSET_COUNT; ++i)
     {
-        initAndSetCtrl(mTextureDetailCtrl[i], llformat("texture_detail_%d", i));
+        initAndSetTexCtrl(mTextureDetailCtrl[i], llformat("texture_detail_%d", i));
         if (mTextureDetailCtrl[i])
         {
             mTextureDetailCtrl[i]->setBakeTextureEnabled(false);

--- a/indra/newview/llfloaterregioninfo.h
+++ b/indra/newview/llfloaterregioninfo.h
@@ -159,6 +159,7 @@ public:
 protected:
     void initCtrl(const std::string& name);
     template<typename CTRL> void initAndSetCtrl(CTRL*& ctrl, const std::string& name);
+    void initAndSetTexCtrl(LLTextureCtrl*& ctrl, const std::string& name);
 
     // Returns true if update sent and apply button should be
     // disabled.

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -650,14 +650,6 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                     asset_type = (LLAssetType::EType)(atoi((*(iter++)).c_str()));
                     iter++; // wearable type if applicable, otherwise asset type
                     item_name = std::string((*(iter++)).c_str());
-                    // Note There is more elements in 'tokens' ...
-
-
-                    for (int i = 0; i < 6; i++)
-                    {
-                        LL_WARNS() << *(iter++) << LL_ENDL;
-                        iter++;
-                    }
                 }
             }
             else

--- a/indra/newview/llimview.cpp
+++ b/indra/newview/llimview.cpp
@@ -3550,6 +3550,7 @@ void LLIMMgr::inviteToSession(
             && voice_invite && "VoiceInviteQuestionDefault" == question_type)
         {
             LL_INFOS("IMVIEW") << "Rejecting voice call from initiating muted resident " << caller_name << LL_ENDL;
+            payload["voice_channel_info"] = voice_channel_info;
             LLIncomingCallDialog::processCallResponse(1, payload);
             return;
         }
@@ -3598,6 +3599,7 @@ void LLIMMgr::inviteToSession(
                 send_do_not_disturb_message(gMessageSystem, caller_id, session_id);
             }
             // silently decline the call
+            payload["voice_channel_info"] = voice_channel_info;
             LLIncomingCallDialog::processCallResponse(1, payload);
             return;
         }

--- a/indra/newview/lllogchat.cpp
+++ b/indra/newview/lllogchat.cpp
@@ -892,6 +892,11 @@ bool LLLogChat::isTranscriptFileFound(std::string fullname)
     return result;
 }
 
+std::string LLLogChat::getGroupChatSuffix()
+{
+    return GROUP_CHAT_SUFFIX;
+}
+
 //*TODO mark object's names in a special way so that they will be distinguishable form avatar name
 //which are more strict by its nature (only firstname and secondname)
 //Example, an object's name can be written like "Object <actual_object's_name>"

--- a/indra/newview/lllogchat.h
+++ b/indra/newview/lllogchat.h
@@ -127,6 +127,8 @@ public:
     static bool isAdHocTranscriptExist(std::string file_name);
     static bool isTranscriptFileFound(std::string fullname);
 
+    static std::string getGroupChatSuffix();
+
     bool historyThreadsFinished(LLUUID session_id);
     LLLoadHistoryThread* getLoadHistoryThread(LLUUID session_id);
     LLDeleteHistoryThread* getDeleteHistoryThread(LLUUID session_id);

--- a/indra/newview/llnotificationhandlerutil.cpp
+++ b/indra/newview/llnotificationhandlerutil.cpp
@@ -92,10 +92,18 @@ void LLHandlerUtil::logToIM(const EInstantMessage& session_type,
             from = SYSTEM_FROM;
         }
 
-        // Build a new format username or firstname_lastname for legacy names
-        // to use it for a history log filename.
-        std::string user_name = LLCacheName::buildUsername(session_name);
-        LLIMModel::instance().logToFile(user_name, from, from_id, message);
+        std::string file_name;
+        if (session_type == IM_SESSION_GROUP_START)
+        {
+            file_name = session_name + LLLogChat::getGroupChatSuffix();
+        }
+        else
+        {
+            // Build a new format username or firstname_lastname for legacy names
+            // to use it for a history log filename.
+            file_name = LLCacheName::buildUsername(session_name);
+        }
+        LLIMModel::instance().logToFile(file_name, from, from_id, message);
     }
     else
     {

--- a/indra/newview/lltooldraganddrop.cpp
+++ b/indra/newview/lltooldraganddrop.cpp
@@ -574,12 +574,13 @@ bool LLToolDragAndDrop::handleKey(KEY key, MASK mask)
 
 bool LLToolDragAndDrop::handleToolTip(S32 x, S32 y, MASK mask)
 {
+    const F32 DRAG_N_DROP_TOOLTIP_DELAY = 0.1f;
     if (!mToolTipMsg.empty())
     {
         LLToolTipMgr::instance().unblockToolTips();
         LLToolTipMgr::instance().show(LLToolTip::Params()
             .message(mToolTipMsg)
-            .delay_time(gSavedSettings.getF32( "DragAndDropToolTipDelay" )));
+            .delay_time(DRAG_N_DROP_TOOLTIP_DELAY));
         return true;
     }
     return false;

--- a/indra/newview/skins/default/xui/de/strings.xml
+++ b/indra/newview/skins/default/xui/de/strings.xml
@@ -31,7 +31,6 @@ Sichtweite: [DRAW_DISTANCE] m
 Bandbreite: [NET_BANDWITH] kbit/s
 LOD-Faktor: [LOD_FACTOR]
 Darstellungsqualität: [RENDER_QUALITY]
-Erweitertes Beleuchtungsmodell: [GPU_SHADERS]
 Texturspeicher: [TEXTURE_MEMORY] MB</string>
 	<string name="AboutOSXHiDPI">HiDPI-Anzeigemodus: [HIDPI]</string>
 	<string name="AboutLibs">J2C-Decoderversion: [J2C_VERSION]

--- a/indra/newview/skins/default/xui/en/panel_performance_preferences.xml
+++ b/indra/newview/skins/default/xui/en/panel_performance_preferences.xml
@@ -427,6 +427,16 @@
    layout="topleft"
    top="80"
    left="213"
+   name="0_lbl"
+   width="7">
+    0
+  </text>
+  <text
+   follows="left|top"
+   font="SansSerifSmall"
+   height="18"
+   layout="topleft"
+   left_pad="31"
    name="1_lbl"
    width="7">
     1
@@ -436,7 +446,7 @@
    font="SansSerifSmall"
    height="18"
    layout="topleft"
-   left_pad="31"
+   left_pad="30"
    name="2_lbl"
    width="7">
     2
@@ -479,16 +489,6 @@
    left_pad="30"
    name="6_lbl"
    width="7">
-      6
-  </text>
-  <text
-   follows="left|top"
-   font="SansSerifSmall"
-   height="18"
-   layout="topleft"
-   left_pad="30"
-   name="7_lbl"
-   width="7">
-    7
+    6
   </text>
 </panel>

--- a/indra/newview/skins/default/xui/es/strings.xml
+++ b/indra/newview/skins/default/xui/es/strings.xml
@@ -29,7 +29,6 @@ Distancia de dibujo: [DRAW_DISTANCE]m
 Ancho de banda: [NET_BANDWITH]kbit/s
 Factor LOD: [LOD_FACTOR]
 Calidad de renderización: [RENDER_QUALITY]
-Modelo de iluminación avanzado: [GPU_SHADERS]
 Memoria de textura: [TEXTURE_MEMORY]MB</string>
 	<string name="AboutOSXHiDPI">Modo de visualización HiDPi: [HIDPI]</string>
 	<string name="AboutLibs">Versión de descodificador J2C: [J2C_VERSION] 

--- a/indra/newview/skins/default/xui/fr/strings.xml
+++ b/indra/newview/skins/default/xui/fr/strings.xml
@@ -32,7 +32,6 @@ Distance de dessin : [DRAW_DISTANCE]m
 Bande passante : [NET_BANDWITH] kbit/s
 Facteur LOD (niveau de détail) : [LOD_FACTOR]
 Qualité de rendu : [RENDER_QUALITY]
-Modèle d’éclairage avancé : [GPU_SHADERS]
 Mémoire textures : [TEXTURE_MEMORY] Mo</string>
 	<string name="AboutOSXHiDPI">Mode d'affichage HiDPI : [HIDPI]</string>
 	<string name="AboutLibs">J2C Decoder Version: [J2C_VERSION] 

--- a/indra/newview/skins/default/xui/it/strings.xml
+++ b/indra/newview/skins/default/xui/it/strings.xml
@@ -31,7 +31,6 @@ Distanza visualizzazione: [DRAW_DISTANCE]m
 Larghezza banda: [NET_BANDWITH]kbit/s
 Fattore livello di dettaglio: [LOD_FACTOR]
 Qualità di rendering: [RENDER_QUALITY]
-Modello illuminazione avanzato: [GPU_SHADERS]
 Memoria texture: [TEXTURE_MEMORY]MB</string>
 	<string name="AboutOSXHiDPI">Modalità display HiDPI: [HIDPI]</string>
 	<string name="AboutLibs">J2C Versione decoder: [J2C_VERSION] 

--- a/indra/newview/skins/default/xui/ja/panel_performance_preferences.xml
+++ b/indra/newview/skins/default/xui/ja/panel_performance_preferences.xml
@@ -96,25 +96,4 @@
 	<text name="photo_desc">
 		（0.0～4.0の値を入れてください）
 	</text>
-	<text name="1_lbl">
-		1
-	</text>
-	<text name="2_lbl">
-		2
-	</text>
-	<text name="3_lbl">
-		3
-	</text>
-	<text name="4_lbl">
-		4
-	</text>
-	<text name="5_lbl">
-		5
-	</text>
-	<text name="6_lbl">
-		6
-	</text>
-	<text name="7_lbl">
-		7
-	</text>
 </panel>

--- a/indra/newview/skins/default/xui/pl/strings.xml
+++ b/indra/newview/skins/default/xui/pl/strings.xml
@@ -49,7 +49,6 @@ Pole widzenia (Draw Distance): [DRAW_DISTANCE]m
 Przepustowość (Bandwidth): [NET_BANDWITH]kbit/s
 Mnożnik poziomu detali (LOD Factor): [LOD_FACTOR]
 Jakość wyświetlania (Render quality): [RENDER_QUALITY]
-Zaawansowane oświetlenie (Advanced Lighting Model): [GPU_SHADERS]
 Pamięć tekstur (Texture memory): [TEXTURE_MEMORY]MB
 Pamięć podręczna dysku (Disk cache): [DISK_CACHE_INFO]
 	</string>

--- a/indra/newview/skins/default/xui/pt/strings.xml
+++ b/indra/newview/skins/default/xui/pt/strings.xml
@@ -29,7 +29,6 @@ Estabelecer a distância: [DRAW_DISTANCE]m
 Largura da banda: [NET_BANDWITH]kbit/s
 LOD fator: [LOD_FACTOR]
 Qualidade de renderização: [RENDER_QUALITY]
-Modelo avançado de luzes: [GPU_SHADERS]
 Memória de textura: [TEXTURE_MEMORY]MB</string>
 	<string name="AboutOSXHiDPI">HiDPI modo de exibição: [HIDPI]</string>
 	<string name="AboutLibs">Versão do J2C Decoder: [J2C_VERSION] 

--- a/indra/newview/skins/default/xui/ru/strings.xml
+++ b/indra/newview/skins/default/xui/ru/strings.xml
@@ -69,7 +69,6 @@ SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 Ширина канала: [NET_BANDWITH] кбит/с
 Коэффициент детализации: [LOD_FACTOR]
 Качество визуализации: [RENDER_QUALITY]
-Расширенная модель освещения: [GPU_SHADERS]
 Память текстур: [TEXTURE_MEMORY] МБ
 	</string>
 	<string name="AboutOSXHiDPI">

--- a/indra/newview/skins/default/xui/tr/strings.xml
+++ b/indra/newview/skins/default/xui/tr/strings.xml
@@ -69,7 +69,6 @@ UI Ölçeklendirme: [UI_SCALE]
 Bant genişliği: [NET_BANDWITH]kbit/s
 LOD faktörü: [LOD_FACTOR]
 İşleme kalitesi: [RENDER_QUALITY]
-Gelişmiş Aydınlatma Modeli: [GPU_SHADERS]
 Doku belleği: [TEXTURE_MEMORY]MB
 	</string>
 	<string name="AboutOSXHiDPI">


### PR DESCRIPTION
Cherry-picking a batch of my low-risk fixes from archive/develop branch for the following bugs:
#3256 Moving in mouselook mode may cause attached linksets to visually break apart. (Example shows firing a gun while moving/jumping in that mode).
#2626 When you're calling to a resident with active DND, call is not automatically rejected, and it will end only after a timeout.
#3051 Wrong chat history file is used if you receive a notice before opening group chat window for that group
#3029 Log spamming when dragging a folder in inventory, instead of showing the tooltip
#3072 UI is not updated correctly after interaction with texture picker
#3314 Make Quality & Speed labels consistent with "Render quality" value in Debug settings/About SL
#3052 Pointless log spam when group notice is received
#2711 Clear ALM from About land info 