### PR TITLE
Fix preferences search not finding text defined in text boxes (#3653)

### DIFF
--- a/indra/llui/lltextbox.h
+++ b/indra/llui/lltextbox.h
@@ -76,6 +76,12 @@ protected:
     LLUIString          mText;
     callback_t          mClickedCallback;
     bool                mShowCursorHand;
+
+protected:
+    virtual std::string _getSearchText() const
+    {
+        return LLTextBase::_getSearchText() + mText.getString();
+    }
 };
 
 // Build time optimization, generate once in .cpp file


### PR DESCRIPTION
# Rationale
Being unable to find certain preferences via search. This fixes the first case in issue #3653 The second case is due to preferences search also considering the text in tooltips as part of its results.

# Related issues
#3653 

# Testing
Verify that Avatar Display is now highlighted on the graphics preferences tab when searching for Avatar

# Future work
Examine if tooltips should or should not be included in the preferences text search