### PR TITLE
#3739 Friends list login race condition fix

### DIFF
--- a/indra/newview/llcallingcard.h
+++ b/indra/newview/llcallingcard.h
@@ -109,6 +109,7 @@ public:
     // add or remove agents from buddy list. Each method takes a set
     // of buddies and returns how many were actually added or removed.
     typedef std::map<LLUUID, LLRelationship*> buddy_map_t;
+    typedef std::queue<std::pair<LLUUID, bool>> buddy_status_queue_t;
 
     S32 addBuddyList(const buddy_map_t& buddies);
     //S32 removeBuddyList(const buddy_list_t& exes);
@@ -194,6 +195,7 @@ protected:
     //LLInventoryObserver* mInventoryObserver;
 
     buddy_map_t mBuddyInfo;
+    buddy_status_queue_t mBuddyStatusQueue;
 
     typedef std::set<LLUUID> changed_buddy_t;
     changed_buddy_t mChangedBuddyIDs;

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1306,6 +1306,15 @@ bool idle_startup()
         do_startup_frame();
         do_startup_frame();
 
+
+        // It is entirely possible that we may get the friends list _before_ we have the callbacks registered to process that.
+        // This will lead to the friends list not being processed properly and online statuses not being updated appropriately at login.
+        // So, we need to make sure that we have the callbacks registered before we get the friends list.
+        // -Geenz 2025-03-12
+        LL_INFOS() << " AvatarTracker" << LL_ENDL;
+        LLAvatarTracker::instance().registerCallbacks(gMessageSystem);
+        do_startup_frame();
+
         // Since we connected, save off the settings so the user doesn't have to
         // type the name/password again if we crash.
         gSavedSettings.saveToFile(gSavedSettings.getString("ClientSettingsFile"), true);
@@ -2013,8 +2022,6 @@ bool idle_startup()
         LLMessageSystem* msg = gMessageSystem;
         LL_INFOS() << " Inventory" << LL_ENDL;
         LLInventoryModel::registerCallbacks(msg);
-        LL_INFOS() << " AvatarTracker" << LL_ENDL;
-        LLAvatarTracker::instance().registerCallbacks(msg);
         LL_INFOS() << " Landmark" << LL_ENDL;
         LLLandmark::registerCallbacks(msg);
         do_startup_frame();

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -1306,15 +1306,6 @@ bool idle_startup()
         do_startup_frame();
         do_startup_frame();
 
-
-        // It is entirely possible that we may get the friends list _before_ we have the callbacks registered to process that.
-        // This will lead to the friends list not being processed properly and online statuses not being updated appropriately at login.
-        // So, we need to make sure that we have the callbacks registered before we get the friends list.
-        // -Geenz 2025-03-12
-        LL_INFOS() << " AvatarTracker" << LL_ENDL;
-        LLAvatarTracker::instance().registerCallbacks(gMessageSystem);
-        do_startup_frame();
-
         // Since we connected, save off the settings so the user doesn't have to
         // type the name/password again if we crash.
         gSavedSettings.saveToFile(gSavedSettings.getString("ClientSettingsFile"), true);
@@ -1723,6 +1714,15 @@ bool idle_startup()
             gAssetStorage->setUpstream(regionp->getHost());
             gCacheName->setUpstream(regionp->getHost());
         }
+
+        // It is entirely possible that we may get the friends list _before_ we have the callbacks registered to process that.
+        // This will lead to the friends list not being processed properly and online statuses not being updated appropriately at login.
+        // So, we need to make sure that we have the callbacks registered before we get the friends list.
+        // This appears to crop up on some systems somewhere between STATE_AGENT_SEND and STATE_INVENTORY_SEND.  It's happened to me a few times now.
+        // -Geenz 2025-03-12
+        LL_INFOS() << " AvatarTracker" << LL_ENDL;
+        LLAvatarTracker::instance().registerCallbacks(gMessageSystem);
+
         do_startup_frame();
 
         // Create login effect


### PR DESCRIPTION
This addresses a potential race condition where the server may send friend online status before the viewer is ready to receive them.