### PR TITLE
#3644 Adjust throttle based of how busy buffer is

### DIFF
--- a/indra/llmessage/llpacketring.cpp
+++ b/indra/llmessage/llpacketring.cpp
@@ -344,6 +344,12 @@ bool LLPacketRing::expandRing()
     return true;
 }
 
+F32 LLPacketRing::getBufferLoadRate() const
+{
+    // goes up to MAX_BUFFER_RING_SIZE
+    return (F32)mNumBufferedPackets / (F32)DEFAULT_BUFFER_RING_SIZE;
+}
+
 void LLPacketRing::dumpPacketRingStats()
 {
     mNumDroppedPacketsTotal += mNumDroppedPackets;

--- a/indra/llmessage/llpacketring.h
+++ b/indra/llmessage/llpacketring.h
@@ -64,6 +64,7 @@ public:
     S32 getNumBufferedBytes() const { return mNumBufferedBytes; }
     S32 getNumDroppedPackets() const { return mNumDroppedPacketsTotal + mNumDroppedPackets; }
 
+    F32 getBufferLoadRate() const; // from 0 to 4 (0 - empty, 1 - default size is full)
     void dumpPacketRingStats();
 protected:
     // returns 'true' if we should intentionally drop a packet

--- a/indra/llmessage/message.h
+++ b/indra/llmessage/message.h
@@ -538,7 +538,6 @@ public:
 
     //void  buildMessage();
 
-    S32     zeroCode(U8 **data, S32 *data_size);
     S32     zeroCodeExpand(U8 **data, S32 *data_size);
     S32     zeroCodeAdjustCurrentSendTotal();
 
@@ -755,6 +754,7 @@ public:
     S32     getReceiveBytes() const;
 
     S32     getUnackedListSize() const          { return mUnackedListSize; }
+    F32     getBufferLoadRate() const           { return mPacketRing.getBufferLoadRate(); }
 
     //const char* getCurrentSMessageName() const { return mCurrentSMessageName; }
     //const char* getCurrentSBlockName() const { return mCurrentSBlockName; }
@@ -842,12 +842,10 @@ private:
     LLUUID mSessionID;
 
     void    addTemplate(LLMessageTemplate *templatep);
-    bool        decodeTemplate( const U8* buffer, S32 buffer_size, LLMessageTemplate** msg_template );
 
     void        logMsgFromInvalidCircuit( const LLHost& sender, bool recv_reliable );
     void        logTrustedMsgFromUntrustedCircuit( const LLHost& sender );
     void        logValidMsg(LLCircuitData *cdp, const LLHost& sender, bool recv_reliable, bool recv_resent, bool recv_acks );
-    void        logRanOffEndOfPacket( const LLHost& sender );
 
     class LLMessageCountInfo
     {

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5443,6 +5443,7 @@ void LLAppViewer::idleNetwork()
     // Retransmit unacknowledged packets.
     gXferManager->retransmitUnackedPackets();
     gAssetStorage->checkForTimeouts();
+    gViewerThrottle.setBufferLoadRate(gMessageSystem->getBufferLoadRate());
     gViewerThrottle.updateDynamicThrottle();
 
     // Check that the circuit between the viewer and the agent's current

--- a/indra/newview/llviewerthrottle.h
+++ b/indra/newview/llviewerthrottle.h
@@ -70,12 +70,15 @@ public:
     void updateDynamicThrottle();
     void resetDynamicThrottle();
 
+    void setBufferLoadRate(F32 rate) { mBufferLoadRate = llmax(mBufferLoadRate, rate); }
+
     LLViewerThrottleGroup getThrottleGroup(const F32 bandwidth_kbps);
 
     static const std::string sNames[TC_EOF];
 protected:
     F32 mMaxBandwidth;
     F32 mCurrentBandwidth;
+    F32 mBufferLoadRate = 0;
 
     LLViewerThrottleGroup mCurrent;
 


### PR DESCRIPTION
Addition to network changes that are already in this branch. It's a placeholder untill we add proper threading.

Doesn't work as well as I hoped, partially because of how slow throttle is to catch up (we can get or drop a lot of packets in 5 seconds), but fixing throttle to be more responsive makes things too risky so kipping things simple.