### PR TITLE
#3745 fix for showing system notification on login

### DIFF
--- a/indra/newview/llcallingcard.cpp
+++ b/indra/newview/llcallingcard.cpp
@@ -42,6 +42,7 @@
 #include "llinventorymodel.h"
 #include "llnotifications.h"
 #include "llslurl.h"
+#include "llstartup.h"
 #include "llimview.h"
 #include "lltrans.h"
 #include "llviewercontrol.h"
@@ -743,7 +744,11 @@ void LLAvatarTracker::processNotify(LLMessageSystem* msg, bool online)
 
         mModifyMask |= LLFriendObserver::ONLINE;
         instance().notifyObservers();
-        gInventory.notifyObservers();
+        // Skip if we had received the friends list before the inventory callbacks were properly initialized
+        if (LLStartUp::getStartupState() > STATE_INVENTORY_CALLBACKS)
+        {
+            gInventory.notifyObservers();
+        }
     }
 }
 


### PR DESCRIPTION
It was caused by https://github.com/secondlife/viewer/commit/693e05ab85b3fcdc65bcb9f4123c2fae4ecc27fc#diff-52824df088f3c59801ccbe28b0f4651f99a77fa37304996351d295b1f717e577R1724
Basically `LLAvatarTracker::instance().registerCallbacks` was called before initializing inventory callbacks - so don't try to notify inventory observers, if the friends list arrives early.