### PR TITLE
prevent erroneous edit of wrong parcel - redux

### DIFF
--- a/indra/llinventory/llparcel.h
+++ b/indra/llinventory/llparcel.h
@@ -262,6 +262,8 @@ public:
 
     void setMediaURLResetTimer(F32 time);
     virtual void    setLocalID(S32 local_id);
+    void setRegionID(const LLUUID& id) { mRegionID = id; }
+    const LLUUID& getRegionID() const { return mRegionID; }
 
     // blow away all the extra stuff lurking in parcels, including urls, access lists, etc
     void clearParcel();
@@ -651,6 +653,7 @@ public:
     S32                 mLocalID;
     LLUUID              mBanListTransactionID;
     LLUUID              mAccessListTransactionID;
+    LLUUID              mRegionID;
     std::map<LLUUID,LLAccessEntry>  mAccessList;
     std::map<LLUUID,LLAccessEntry>  mBanList;
     std::map<LLUUID,LLAccessEntry>  mTempBanList;

--- a/indra/newview/llviewerparcelmgr.cpp
+++ b/indra/newview/llviewerparcelmgr.cpp
@@ -1327,7 +1327,7 @@ const S32 LLViewerParcelMgr::getAgentParcelId() const
     return INVALID_PARCEL_ID;
 }
 
-void LLViewerParcelMgr::sendParcelPropertiesUpdate(LLParcel* parcel, bool use_agent_region)
+void LLViewerParcelMgr::sendParcelPropertiesUpdate(LLParcel* parcel)
 {
     if(!parcel)
         return;

--- a/indra/newview/llviewerparcelmgr.cpp
+++ b/indra/newview/llviewerparcelmgr.cpp
@@ -1332,7 +1332,7 @@ void LLViewerParcelMgr::sendParcelPropertiesUpdate(LLParcel* parcel, bool use_ag
     if(!parcel)
         return;
 
-    LLViewerRegion *region = use_agent_region ? gAgent.getRegion() : LLWorld::getInstance()->getRegionFromPosGlobal( mWestSouth );
+    LLViewerRegion *region = LLWorld::getInstance()->getRegionFromID(parcel->getRegionID());
     if (!region)
         return;
 
@@ -1676,10 +1676,16 @@ void LLViewerParcelMgr::processParcelProperties(LLMessageSystem *msg, void **use
     // Actually extract the data.
     if (parcel)
     {
+        // store region_id in the parcel so we can find it again later
+        LLViewerRegion* parcel_region = LLWorld::getInstance()->getRegion(msg->getSender());
+        if (parcel_region)
+        {
+            parcel->setRegionID(parcel_region->getRegionID());
+        }
+
         if (local_id == parcel_mgr.mAgentParcel->getLocalID())
         {
             // Parcels in different regions can have same ids.
-            LLViewerRegion* parcel_region = LLWorld::getInstance()->getRegion(msg->getSender());
             LLViewerRegion* agent_region = gAgent.getRegion();
             if (parcel_region && agent_region && parcel_region->getRegionID() == agent_region->getRegionID())
             {

--- a/indra/newview/llviewerparcelmgr.h
+++ b/indra/newview/llviewerparcelmgr.h
@@ -219,7 +219,7 @@ public:
     // containing the southwest corner of the selection.
     // If want_reply_to_update, simulator will send back a ParcelProperties
     // message.
-    void    sendParcelPropertiesUpdate(LLParcel* parcel, bool use_agent_region = false);
+    void    sendParcelPropertiesUpdate(LLParcel* parcel);
 
     // Takes an Access List flag, like AL_ACCESS or AL_BAN
     void    sendParcelAccessListUpdate(U32 which);


### PR DESCRIPTION
This PR provides a cherry-pick of the fixes in #3129 which were abandoned in **archive/develop** and which fix the archived jira issue about how sometimes parcel edits get incorrectly written to the wrong region:

https://github.com/secondlife/jira-archive-internal/issues/70771