### PR TITLE
#3795 Fix macos shutdown crash

### DIFF
--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -279,6 +279,10 @@ void callResetKeys()
 
 bool callUnicodeCallback(wchar_t character, unsigned int mask)
 {
+    if (!gWindowImplementation)
+    {
+        return false;
+    }
     NativeKeyEventData eventData;
 
     memset(&eventData, 0, sizeof(NativeKeyEventData));
@@ -300,7 +304,7 @@ bool callUnicodeCallback(wchar_t character, unsigned int mask)
 
 void callFocus()
 {
-    if (gWindowImplementation)
+    if (gWindowImplementation && gWindowImplementation->getCallbacks())
     {
         gWindowImplementation->getCallbacks()->handleFocus(gWindowImplementation);
     }
@@ -308,7 +312,7 @@ void callFocus()
 
 void callFocusLost()
 {
-    if (gWindowImplementation)
+    if (gWindowImplementation && gWindowImplementation->getCallbacks())
     {
         gWindowImplementation->getCallbacks()->handleFocusLost(gWindowImplementation);
     }
@@ -316,6 +320,10 @@ void callFocusLost()
 
 void callRightMouseDown(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     if (gWindowImplementation->allowsLanguageInput())
     {
         gWindowImplementation->interruptLanguageTextInput();
@@ -329,6 +337,10 @@ void callRightMouseDown(float *pos, MASK mask)
 
 void callRightMouseUp(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     if (gWindowImplementation->allowsLanguageInput())
     {
         gWindowImplementation->interruptLanguageTextInput();
@@ -342,6 +354,10 @@ void callRightMouseUp(float *pos, MASK mask)
 
 void callLeftMouseDown(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     if (gWindowImplementation->allowsLanguageInput())
     {
         gWindowImplementation->interruptLanguageTextInput();
@@ -355,6 +371,10 @@ void callLeftMouseDown(float *pos, MASK mask)
 
 void callLeftMouseUp(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     if (gWindowImplementation->allowsLanguageInput())
     {
         gWindowImplementation->interruptLanguageTextInput();
@@ -369,6 +389,10 @@ void callLeftMouseUp(float *pos, MASK mask)
 
 void callDoubleClick(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     if (gWindowImplementation->allowsLanguageInput())
     {
         gWindowImplementation->interruptLanguageTextInput();
@@ -382,7 +406,7 @@ void callDoubleClick(float *pos, MASK mask)
 
 void callResize(unsigned int width, unsigned int height)
 {
-    if (gWindowImplementation != NULL)
+    if (gWindowImplementation && gWindowImplementation->getCallbacks())
     {
         gWindowImplementation->getCallbacks()->handleResize(gWindowImplementation, width, height);
     }
@@ -390,6 +414,10 @@ void callResize(unsigned int width, unsigned int height)
 
 void callMouseMoved(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     LLCoordGL       outCoords;
     outCoords.mX = ll_round(pos[0]);
     outCoords.mY = ll_round(pos[1]);
@@ -403,6 +431,10 @@ void callMouseMoved(float *pos, MASK mask)
 
 void callMouseDragged(float *pos, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     LLCoordGL       outCoords;
     outCoords.mX = ll_round(pos[0]);
     outCoords.mY = ll_round(pos[1]);
@@ -424,6 +456,10 @@ void callScrollMoved(float deltaX, float deltaY)
 
 void callMouseExit()
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->getCallbacks()->handleMouseLeave(gWindowImplementation);
 }
 
@@ -475,11 +511,19 @@ void callWindowDidChangeScreen()
 
 void callDeltaUpdate(float *delta, MASK mask)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->updateMouseDeltas(delta);
 }
 
 void callOtherMouseDown(float *pos, MASK mask, int button)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     LLCoordGL       outCoords;
     outCoords.mX = ll_round(pos[0]);
     outCoords.mY = ll_round(pos[1]);
@@ -500,6 +544,10 @@ void callOtherMouseDown(float *pos, MASK mask, int button)
 
 void callOtherMouseUp(float *pos, MASK mask, int button)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     LLCoordGL outCoords;
     outCoords.mX = ll_round(pos[0]);
     outCoords.mY = ll_round(pos[1]);
@@ -524,27 +572,43 @@ void callModifier(MASK mask)
 
 void callHandleDragEntered(std::string url)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->handleDragNDrop(url, LLWindowCallbacks::DNDA_START_TRACKING);
 }
 
 void callHandleDragExited(std::string url)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->handleDragNDrop(url, LLWindowCallbacks::DNDA_STOP_TRACKING);
 }
 
 void callHandleDragUpdated(std::string url)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->handleDragNDrop(url, LLWindowCallbacks::DNDA_TRACK);
 }
 
 void callHandleDragDropped(std::string url)
 {
+    if (!gWindowImplementation)
+    {
+        return;
+    }
     gWindowImplementation->handleDragNDrop(url, LLWindowCallbacks::DNDA_DROPPED);
 }
 
 void callQuitHandler()
 {
-    if (gWindowImplementation)
+    if (gWindowImplementation && gWindowImplementation->getCallbacks())
     {
         if(gWindowImplementation->getCallbacks()->handleCloseRequest(gWindowImplementation))
         {
@@ -555,7 +619,7 @@ void callQuitHandler()
 
 void getPreeditSelectionRange(int *position, int *length)
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         gWindowImplementation->getPreeditor()->getSelectionRange(position, length);
     }
@@ -563,7 +627,7 @@ void getPreeditSelectionRange(int *position, int *length)
 
 void getPreeditMarkedRange(int *position, int *length)
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         gWindowImplementation->getPreeditor()->getPreeditRange(position, length);
     }
@@ -571,7 +635,7 @@ void getPreeditMarkedRange(int *position, int *length)
 
 void setPreeditMarkedRange(int position, int length)
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         gWindowImplementation->getPreeditor()->markAsPreedit(position, length);
     }
@@ -580,7 +644,7 @@ void setPreeditMarkedRange(int position, int length)
 bool handleUnicodeCharacter(wchar_t c)
 {
     bool success = false;
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         success = gWindowImplementation->getPreeditor()->handleUnicodeCharHere(c);
     }
@@ -590,7 +654,7 @@ bool handleUnicodeCharacter(wchar_t c)
 
 void resetPreedit()
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         gWindowImplementation->getPreeditor()->resetPreedit();
     }
@@ -600,7 +664,7 @@ void resetPreedit()
 // This largely mirrors the old implementation, only sans the carbon parameters.
 void setMarkedText(unsigned short *unitext, unsigned int *selectedRange, unsigned int *replacementRange, long text_len, attributedStringInfo segments)
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         LLPreeditor *preeditor = gWindowImplementation->getPreeditor();
         preeditor->resetPreedit();
@@ -623,7 +687,7 @@ void setMarkedText(unsigned short *unitext, unsigned int *selectedRange, unsigne
 
 void getPreeditLocation(float *location, unsigned int length)
 {
-    if (gWindowImplementation->getPreeditor())
+    if (gWindowImplementation && gWindowImplementation->getPreeditor())
     {
         LLPreeditor *preeditor = gWindowImplementation->getPreeditor();
         LLCoordGL coord;

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -1450,10 +1450,13 @@ void LLViewerWindow::handleMouseLeave(LLWindow *window)
 
 bool LLViewerWindow::handleCloseRequest(LLWindow *window)
 {
-    // User has indicated they want to close, but we may need to ask
-    // about modified documents.
-    LLAppViewer::instance()->userQuit();
-    // Don't quit immediately
+    if (!LLApp::isExiting())
+    {
+        // User has indicated they want to close, but we may need to ask
+        // about modified documents.
+        LLAppViewer::instance()->userQuit();
+        // Don't quit immediately
+    }
     return false;
 }
 


### PR DESCRIPTION
1. Covers case of handleCloseRequest arriving during shutdown (no idea how that is possible, but logs indicate that quit was requester right after an error was triggered)
2. Covers case of user trying to close window before callabcks are ready (and covered everything else too, I think there were some crashees around those calls)