### PR TITLE
Disable shoreline fade

### DIFF
--- a/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
+++ b/indra/newview/app_settings/shaders/class3/environment/waterF.glsl
@@ -26,7 +26,6 @@
 // class3/environment/waterF.glsl
 
 #define WATER_MINIMAL 1
-#define SHORELINE_FADE 1
 
 out vec4 frag_color;
 
@@ -267,9 +266,9 @@ void main()
 #ifdef SHORELINE_FADE
     fade = max(0,min(1, (pos.z - refPos.z) / 10));
 #else
-    fade = 1 * water_mask;
+    fade = 1;
 #endif
-
+    fade *= water_mask;
     distort2 = mix(distort, distort2, min(1, fade * 10));
     depth = texture(depthMap, distort2).r;
 


### PR DESCRIPTION
Accidentally enabled this in a prior PR.  Also fix water exclusion when shoreline fade is enabled.