### PR TITLE
Small FPS related adjustments

### DIFF
--- a/indra/llappearance/llwearable.cpp
+++ b/indra/llappearance/llwearable.cpp
@@ -645,9 +645,10 @@ void LLWearable::addVisualParam(LLVisualParam *param)
 
 void LLWearable::setVisualParamWeight(S32 param_index, F32 value)
 {
-    if( is_in_map(mVisualParamIndexMap, param_index ) )
+    visual_param_index_map_t::iterator found = mVisualParamIndexMap.find(param_index);
+    if(found != mVisualParamIndexMap.end())
     {
-        LLVisualParam *wearable_param = mVisualParamIndexMap[param_index];
+        LLVisualParam *wearable_param = found->second;
         wearable_param->setWeight(value);
     }
     else
@@ -658,10 +659,10 @@ void LLWearable::setVisualParamWeight(S32 param_index, F32 value)
 
 F32 LLWearable::getVisualParamWeight(S32 param_index) const
 {
-    if( is_in_map(mVisualParamIndexMap, param_index ) )
+    visual_param_index_map_t::const_iterator found = mVisualParamIndexMap.find(param_index);
+    if(found != mVisualParamIndexMap.end())
     {
-        const LLVisualParam *wearable_param = mVisualParamIndexMap.find(param_index)->second;
-        return wearable_param->getWeight();
+        return found->second->getWeight();
     }
     else
     {
@@ -726,7 +727,7 @@ void LLWearable::writeToAvatar(LLAvatarAppearance* avatarp)
     if (!avatarp) return;
 
     // Pull params
-    for( LLVisualParam* param = avatarp->getFirstVisualParam(); param; param = avatarp->getNextVisualParam() )
+    for( const LLVisualParam* param = avatarp->getFirstVisualParam(); param; param = avatarp->getNextVisualParam() )
     {
         // cross-wearable parameters are not authoritative, as they are driven by a different wearable. So don't copy the values to the
         // avatar object if cross wearable. Cross wearable params get their values from the avatar, they shouldn't write the other way.

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -445,8 +445,8 @@ void idle_afk_check()
 {
     // check idle timers
     F32 current_idle = gAwayTriggerTimer.getElapsedTimeF32();
-    F32 afk_timeout  = (F32)gSavedSettings.getS32("AFKTimeout");
-    if (afk_timeout && (current_idle > afk_timeout) && ! gAgent.getAFK())
+    static LLCachedControl<S32> afk_timeout(gSavedSettings, "AFKTimeout", 300);
+    if (afk_timeout() && (current_idle > (F32)afk_timeout()) && !gAgent.getAFK())
     {
         LL_INFOS("IdleAway") << "Idle more than " << afk_timeout << " seconds: automatically changing to Away status" << LL_ENDL;
         gAgent.setAFK();
@@ -5376,7 +5376,8 @@ void LLAppViewer::idleNetwork()
     gObjectList.mNumNewObjects = 0;
     S32 total_decoded = 0;
 
-    if (!gSavedSettings.getBOOL("SpeedTest"))
+    static LLCachedControl<bool> speed_test(gSavedSettings, "SpeedTest", false);
+    if (!speed_test())
     {
         LL_PROFILE_ZONE_NAMED_CATEGORY_NETWORK("idle network"); //LL_RECORD_BLOCK_TIME(FTM_IDLE_NETWORK); // decode
 
@@ -5435,7 +5436,9 @@ void LLAppViewer::idleNetwork()
             }
 
             // Handle per-frame message system processing.
-            lmc.processAcks(gSavedSettings.getF32("AckCollectTime"));
+
+            static LLCachedControl<F32> ack_collection_time(gSavedSettings, "AckCollectTime", 0.1f);
+            lmc.processAcks(ack_collection_time());
         }
     }
     add(LLStatViewer::NUM_NEW_OBJECTS, gObjectList.mNumNewObjects);

--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -899,6 +899,9 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 {
     llassert(!gCubeSnapshot);
 
+    constexpr F32 BIAS_TRS_OUT_OF_SCREEN = 1.5f;
+    constexpr F32 BIAS_TRS_ON_SCREEN = 1.f;
+
     if (imagep->getBoostLevel() < LLViewerFetchedTexture::BOOST_HIGH)  // don't bother checking face list for boosted textures
     {
         static LLCachedControl<F32> texture_scale_min(gSavedSettings, "TextureScaleMinAreaFactor", 0.0095f);
@@ -940,7 +943,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
 
                     F32 vsize = face->getPixelArea();
 
-                    on_screen = face->mInFrustum;
+                    on_screen |= face->mInFrustum;
 
                     // Scale desired texture resolution higher or lower depending on texture scale
                     //
@@ -972,7 +975,20 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
                     }
 
                     max_vsize = llmax(max_vsize, vsize);
+
+                    // addTextureStats limits size to sMaxVirtualSize
+                    if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize
+                        && (on_screen || LLViewerTexture::sDesiredDiscardBias <= BIAS_TRS_ON_SCREEN))
+                    {
+                        break;
+                    }
                 }
+            }
+
+            if (max_vsize >= LLViewerFetchedTexture::sMaxVirtualSize
+                && (on_screen || LLViewerTexture::sDesiredDiscardBias <= BIAS_TRS_ON_SCREEN))
+            {
+                break;
             }
         }
 
@@ -980,6 +996,7 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
         { // this texture is used in so many places we should just boost it and not bother checking its vsize
             // this is especially important because the above is not time sliced and can hit multiple ms for a single texture
             imagep->setBoostLevel(LLViewerFetchedTexture::BOOST_HIGH);
+            // Do we ever remove it? This also sets texture nodelete!
         }
 
         if (imagep->getType() == LLViewerTexture::LOD_TEXTURE && imagep->getBoostLevel() == LLViewerTexture::BOOST_NONE)
@@ -987,8 +1004,8 @@ void LLViewerTextureList::updateImageDecodePriority(LLViewerFetchedTexture* imag
           // this is an alternative to decaying mMaxVirtualSize over time
           // that keeps textures from continously downrezzing and uprezzing in the background
 
-        if (LLViewerTexture::sDesiredDiscardBias > 1.5f ||
-                (!on_screen && LLViewerTexture::sDesiredDiscardBias > 1.f))
+            if (LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_OUT_OF_SCREEN ||
+                (!on_screen && LLViewerTexture::sDesiredDiscardBias > BIAS_TRS_ON_SCREEN))
             {
                 imagep->mMaxVirtualSize = 0.f;
             }

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -489,7 +489,8 @@ public:
 
         clearText();
 
-        if (gSavedSettings.getBOOL("DebugShowTime"))
+        static LLCachedControl<bool> debug_show_time(gSavedSettings, "DebugShowTime", false);
+        if (debug_show_time())
         {
             F32 time = gFrameTimeSeconds;
             S32 hours = (S32)(time / (60*60));
@@ -498,7 +499,8 @@ public:
             addText(xpos, ypos, llformat("Time: %d:%02d:%02d", hours,mins,secs)); ypos += y_inc;
         }
 
-        if (gSavedSettings.getBOOL("DebugShowMemory"))
+        static LLCachedControl<bool> debug_show_memory(gSavedSettings, "DebugShowMemory", false);
+        if (debug_show_memory())
         {
             addText(xpos, ypos,
                     STRINGIZE("Memory: " << (LLMemory::getCurrentRSS() / 1024) << " (KB)"));
@@ -591,7 +593,8 @@ public:
             ypos += y_inc;
         }*/
 
-        if (gSavedSettings.getBOOL("DebugShowRenderInfo"))
+        static LLCachedControl<bool> debug_show_render_info(gSavedSettings, "DebugShowRenderInfo", false);
+        if (debug_show_render_info())
         {
             LLTrace::Recording& last_frame_recording = LLTrace::get_frame_recording().getLastRecording();
 
@@ -730,7 +733,8 @@ public:
 
             gPipeline.mNumVisibleNodes = LLPipeline::sVisibleLightCount = 0;
         }
-        if (gSavedSettings.getBOOL("DebugShowAvatarRenderInfo"))
+        static LLCachedControl<bool> debug_show_avatar_render_info(gSavedSettings, "DebugShowAvatarRenderInfo", false);
+        if (debug_show_avatar_render_info())
         {
             std::map<std::string, LLVOAvatar*> sorted_avs;
             {
@@ -763,7 +767,8 @@ public:
                 av_iter++;
             }
         }
-        if (gSavedSettings.getBOOL("DebugShowRenderMatrices"))
+        static LLCachedControl<bool> debug_show_render_matrices(gSavedSettings, "DebugShowRenderMatrices", false);
+        if (debug_show_render_matrices())
         {
             char camera_lines[8][32];
             memset(camera_lines, ' ', sizeof(camera_lines));
@@ -789,7 +794,8 @@ public:
             ypos += y_inc;
         }
         // disable use of glReadPixels which messes up nVidia nSight graphics debugging
-        if (gSavedSettings.getBOOL("DebugShowColor") && !LLRender::sNsightDebugSupport)
+        static LLCachedControl<bool> debug_show_color(gSavedSettings, "DebugShowColor", false);
+        if (debug_show_color() && !LLRender::sNsightDebugSupport)
         {
             U8 color[4];
             LLCoordGL coord = gViewerWindow->getCurrentMouse();
@@ -881,7 +887,8 @@ public:
             }
         }
 
-        if (gSavedSettings.getBOOL("DebugShowTextureInfo"))
+        static LLCachedControl<bool> debug_show_texture_info(gSavedSettings, "DebugShowTextureInfo", false);
+        if (debug_show_texture_info())
         {
             LLViewerObject* objectp = NULL ;
 
@@ -1600,7 +1607,8 @@ bool LLViewerWindow::handleActivate(LLWindow *window, bool activated)
         mActive = false;
 
         // if the user has chosen to go Away automatically after some time, then go Away when minimizing
-        if (gSavedSettings.getS32("AFKTimeout"))
+        static LLCachedControl<S32> afk_time(gSavedSettings, "AFKTimeout", 300);
+        if (afk_time())
         {
             gAgent.setAFK();
         }


### PR DESCRIPTION
Tectures (Leaves?) in our meeting spot were pointlesly calculating vsize fpr dozens of faces per texture, couldn't resist cutting it a bit (probably can be optimized a lot more, ex: record last heaviest face). LLViewerTextureList::updateImagesFetchTextures dropped from 200mks to 130mks.

Also on_screen was working wrongly using last face only.

@Geenz if you are fine with this I will find a ticket to attach this to.


