### PR TITLE
Mitigate some of the frame stuttering we're seeing by setting the VRAM divisor to 1

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7814,7 +7814,7 @@
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-      <integer>2</integer>
+      <integer>1</integer>
   </map>
   <key>RenderMinFreeMainMemoryThreshold</key>
   <map>


### PR DESCRIPTION
This helps avoid frequent texture reuploads to VRAM in some texture heavy areas.  This speaks to some bigger problems we're seeing in our texture streaming system however.  You will see similar problems by manually setting the texture VRAM manually.