### PR TITLE
Removed unnecessary comments in QA workflow file

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -27,15 +27,11 @@ jobs:
 
   install-viewer-and-run-tests:
     runs-on: [self-hosted, qa-machine]
-    # Run test only on successful builds of develop or Second_Life_X branches
+    # Run test only on successful builds of Second_Life_X branches
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       (
         startsWith(github.ref, 'refs/tags/Second_Life')
-
-        # For now this will only run on Second_Life_X tagged builds
-        # || startsWith(github.event.workflow_run.head_branch, 'release')
-        # || github.event.workflow_run.head_branch == 'develop'
       )
 
     steps:


### PR DESCRIPTION
GHA does not like comments inside an if statement. These have been removed.
Error: 
```
[Invalid workflow file: .github/workflows/qatest.yaml#L31](https://github.com/secondlife/viewer/actions/runs/14098268136/workflow)
The workflow is not valid. .github/workflows/qatest.yaml (Line: 31, Col: 9): Unexpected symbol: '#'. Located at position 109 within expression: github.event.workflow_run.conclusion == 'success' && (
  startsWith(github.ref, 'refs/tags/Second_Life')

  # For now this will only run on Second_Life_X tagged builds
  # || startsWith(github.event.workflow_run.head_branch, 'release')
  # || github.event.workflow_run.head_branch == 'develop'
)
```