### PR TITLE
Allow QA workflow to run on Second_Life_X branches

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -31,7 +31,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       (
-        startsWith(github.ref, 'refs/tags/Second_Life')
+        startsWith(github.event.workflow_run.head_branch, 'Second_Life')
       )
 
     steps:


### PR DESCRIPTION
Using the echos from the last run, it appears that the tagged builds have `Workflow Head Branch = Second_Life_X`.  Edit made so the file looks for this rather than what was there previously.

Last run workflow variables:
Tagged Develop build: https://github.com/secondlife/viewer/actions/runs/14116509542/job/39547898755
Tagged Release build: https://github.com/secondlife/viewer/actions/runs/14116509542/job/39547898755
 