### PR TITLE
#3809 Partial revert of "Fix J2C Upload"

### DIFF
--- a/indra/llimage/llimagedimensionsinfo.cpp
+++ b/indra/llimage/llimagedimensionsinfo.cpp
@@ -27,7 +27,6 @@
 #include "stdtypes.h"
 
 #include "llimagejpeg.h"
-#include "llimagej2c.h"
 
 #include "llimagedimensionsinfo.h"
 
@@ -64,8 +63,6 @@ bool LLImageDimensionsInfo::load(const std::string& src_filename,U32 codec)
         return getImageDimensionsTga();
     case IMG_CODEC_JPEG:
         return getImageDimensionsJpeg();
-    case IMG_CODEC_J2C:
-        return getImageDimensionsJ2c();
     case IMG_CODEC_PNG:
         return getImageDimensionsPng();
     default:
@@ -215,23 +212,6 @@ bool LLImageDimensionsInfo::getImageDimensionsJpeg()
     fclose(fp);
 
     return !sJpegErrorEncountered;
-}
-
-bool LLImageDimensionsInfo::getImageDimensionsJ2c()
-{
-    clean();
-
-    LLPointer<LLImageJ2C> jpeg_image = new LLImageJ2C;
-    if (jpeg_image->load(mSrcFilename))
-    {
-        mWidth = jpeg_image->getWidth();
-        mHeight = jpeg_image->getHeight();
-        return true;
-    }
-    mWarning = "texture_load_format_error";
-    LL_WARNS() << "J2C load error: " << LLImage::getLastThreadError() << LL_ENDL;
-
-    return false;
 }
 
 bool LLImageDimensionsInfo::checkFileLength(S32 min_len)

--- a/indra/llimage/llimagedimensionsinfo.h
+++ b/indra/llimage/llimagedimensionsinfo.h
@@ -91,7 +91,6 @@ protected:
     bool getImageDimensionsTga();
     bool getImageDimensionsPng();
     bool getImageDimensionsJpeg();
-    bool getImageDimensionsJ2c();
 
     S32 read_s32()
     {

--- a/indra/newview/llfilepicker.cpp
+++ b/indra/newview/llfilepicker.cpp
@@ -52,7 +52,7 @@ LLFilePicker LLFilePicker::sInstance;
 
 #if LL_WINDOWS
 #define SOUND_FILTER L"Sounds (*.wav)\0*.wav\0"
-#define IMAGE_FILTER L"Images (*.tga; *.bmp; *.jpg; *.jpeg; *.j2c; *.jp2; *.png)\0*.tga;*.bmp;*.jpg;*.jpeg;*.j2c;*.jp2;*.png\0"
+#define IMAGE_FILTER L"Images (*.tga; *.bmp; *.jpg; *.jpeg; *.png)\0*.tga;*.bmp;*.jpg;*.jpeg;*.png\0"
 #define ANIM_FILTER L"Animations (*.bvh; *.anim)\0*.bvh;*.anim\0"
 #define COLLADA_FILTER L"Scene (*.dae)\0*.dae\0"
 #define GLTF_FILTER L"glTF (*.gltf; *.glb)\0*.gltf;*.glb\0"
@@ -559,7 +559,7 @@ bool LLFilePicker::getSaveFile(ESaveFilter filter, const std::string& filename, 
         }
         mOFN.lpstrDefExt = L"j2c";
         mOFN.lpstrFilter =
-            L"Compressed Images (*.j2c *.jp2)\0*.j2c;*.jp2\0" \
+            L"Compressed Images (*.j2c)\0*.j2c\0" \
             L"\0";
         break;
     case FFSAVE_SCRIPT:
@@ -649,8 +649,6 @@ std::unique_ptr<std::vector<std::string>> LLFilePicker::navOpenFilterProc(ELoadF
         case FFLOAD_IMAGE:
             allowedv->push_back("jpg");
             allowedv->push_back("jpeg");
-            allowedv->push_back("j2c");
-            allowedv->push_back("jp2");
             allowedv->push_back("bmp");
             allowedv->push_back("tga");
             allowedv->push_back("bmpf");

--- a/indra/newview/llviewermenufile.cpp
+++ b/indra/newview/llviewermenufile.cpp
@@ -378,7 +378,7 @@ void LLMediaFilePicker::notify(const std::vector<std::string>& filenames)
 
 #if LL_WINDOWS
 static std::string SOUND_EXTENSIONS = "wav";
-static std::string IMAGE_EXTENSIONS = "tga bmp jpg jpeg j2c jp2 png";
+static std::string IMAGE_EXTENSIONS = "tga bmp jpg jpeg png";
 static std::string ANIM_EXTENSIONS =  "bvh anim";
 static std::string XML_EXTENSIONS = "xml";
 static std::string SLOBJECT_EXTENSIONS = "slobject";


### PR DESCRIPTION
This partially reverts commit 8d5dab9f67d54ce20768c0ccda58f27693cb20c9.

Apparently viewer doesn't support some jp2 variants, so I'm leaving only the fix for bulk upload and reverting everything else.