### PR TITLE
#3044 Add option to hide L$ balance for Snapshots with Interface showing

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9540,6 +9540,17 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>RenderBalanceInSnapshot</key>
+    <map>
+      <key>Comment</key>
+      <string>Display L$ balance in snapshot</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
     <key>RenderUIBuffer</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -4540,6 +4540,7 @@ void LLAppViewer::saveFinalSnapshot()
                                     false,
                                     gSavedSettings.getBOOL("RenderHUDInSnapshot"),
                                     true,
+                                    false,
                                     LLSnapshotModel::SNAPSHOT_TYPE_COLOR,
                                     LLSnapshotModel::SNAPSHOT_FORMAT_PNG);
         mSavedFinalSnapshot = true;

--- a/indra/newview/llfloatersnapshot.cpp
+++ b/indra/newview/llfloatersnapshot.cpp
@@ -60,12 +60,13 @@ LLPanelSnapshot* LLFloaterSnapshot::Impl::getActivePanel(LLFloaterSnapshotBase* 
 {
     LLSideTrayPanelContainer* panel_container = floater->getChild<LLSideTrayPanelContainer>("panel_container");
     LLPanelSnapshot* active_panel = dynamic_cast<LLPanelSnapshot*>(panel_container->getCurrentPanel());
-    if (!active_panel)
-    {
-        LL_WARNS() << "No snapshot active panel, current panel index: " << panel_container->getCurrentPanelIndex() << LL_ENDL;
-    }
+
     if (!ok_if_not_found)
     {
+        if (!active_panel)
+        {
+            LL_WARNS() << "No snapshot active panel, current panel index: " << panel_container->getCurrentPanelIndex() << LL_ENDL;
+        }
         llassert_always(active_panel != NULL);
     }
     return active_panel;
@@ -516,34 +517,13 @@ void LLFloaterSnapshotBase::ImplBase::onClickFilter(LLUICtrl *ctrl, void* data)
 }
 
 // static
-void LLFloaterSnapshotBase::ImplBase::onClickUICheck(LLUICtrl *ctrl, void* data)
+void LLFloaterSnapshotBase::ImplBase::onClickDisplaySetting(LLUICtrl* ctrl, void* data)
 {
-    LLCheckBoxCtrl *check = (LLCheckBoxCtrl *)ctrl;
-    gSavedSettings.setBOOL( "RenderUIInSnapshot", check->get() );
-
-    LLFloaterSnapshot *view = (LLFloaterSnapshot *)data;
+    LLFloaterSnapshot* view = (LLFloaterSnapshot*)data;
     if (view)
     {
         LLSnapshotLivePreview* previewp = view->getPreviewView();
-        if(previewp)
-        {
-            previewp->updateSnapshot(true, true);
-        }
-        view->impl->updateControls(view);
-    }
-}
-
-// static
-void LLFloaterSnapshotBase::ImplBase::onClickHUDCheck(LLUICtrl *ctrl, void* data)
-{
-    LLCheckBoxCtrl *check = (LLCheckBoxCtrl *)ctrl;
-    gSavedSettings.setBOOL( "RenderHUDInSnapshot", check->get() );
-
-    LLFloaterSnapshot *view = (LLFloaterSnapshot *)data;
-    if (view)
-    {
-        LLSnapshotLivePreview* previewp = view->getPreviewView();
-        if(previewp)
+        if (previewp)
         {
             previewp->updateSnapshot(true, true);
         }
@@ -1002,11 +982,9 @@ bool LLFloaterSnapshot::postBuild()
     mSucceessLblPanel = getChild<LLUICtrl>("succeeded_panel");
     mFailureLblPanel = getChild<LLUICtrl>("failed_panel");
 
-    childSetCommitCallback("ui_check", ImplBase::onClickUICheck, this);
-    getChild<LLUICtrl>("ui_check")->setValue(gSavedSettings.getBOOL("RenderUIInSnapshot"));
-
-    childSetCommitCallback("hud_check", ImplBase::onClickHUDCheck, this);
-    getChild<LLUICtrl>("hud_check")->setValue(gSavedSettings.getBOOL("RenderHUDInSnapshot"));
+    childSetCommitCallback("ui_check", ImplBase::onClickDisplaySetting, this);
+    childSetCommitCallback("balance_check", ImplBase::onClickDisplaySetting, this);
+    childSetCommitCallback("hud_check", ImplBase::onClickDisplaySetting, this);
 
     ((Impl*)impl)->setAspectRatioCheckboxValue(this, gSavedSettings.getBOOL("KeepAspectForSnapshot"));
 

--- a/indra/newview/llfloatersnapshot.h
+++ b/indra/newview/llfloatersnapshot.h
@@ -103,8 +103,7 @@ public:
     static void onClickAutoSnap(LLUICtrl *ctrl, void* data);
     static void onClickNoPost(LLUICtrl *ctrl, void* data);
     static void onClickFilter(LLUICtrl *ctrl, void* data);
-    static void onClickUICheck(LLUICtrl *ctrl, void* data);
-    static void onClickHUDCheck(LLUICtrl *ctrl, void* data);
+    static void onClickDisplaySetting(LLUICtrl *ctrl, void* data);
     static void onCommitFreezeFrame(LLUICtrl* ctrl, void* data);
 
     virtual LLPanelSnapshot* getActivePanel(LLFloaterSnapshotBase* floater, bool ok_if_not_found = true) = 0;

--- a/indra/newview/llsnapshotlivepreview.cpp
+++ b/indra/newview/llsnapshotlivepreview.cpp
@@ -694,6 +694,7 @@ bool LLSnapshotLivePreview::onIdle( void* snapshot_preview )
     static LLCachedControl<bool> freeze_time(gSavedSettings, "FreezeTime", false);
     static LLCachedControl<bool> use_freeze_frame(gSavedSettings, "UseFreezeFrame", false);
     static LLCachedControl<bool> render_ui(gSavedSettings, "RenderUIInSnapshot", false);
+    static LLCachedControl<bool> render_balance(gSavedSettings, "RenderBalanceInSnapshot", false);
     static LLCachedControl<bool> render_hud(gSavedSettings, "RenderHUDInSnapshot", false);
     static LLCachedControl<bool> render_no_post(gSavedSettings, "RenderSnapshotNoPost", false);
 
@@ -750,6 +751,7 @@ bool LLSnapshotLivePreview::onIdle( void* snapshot_preview )
                 render_hud,
                 false,
                 render_no_post,
+                render_balance,
                 previewp->mSnapshotBufferType,
                 previewp->getMaxImageSize()))
         {

--- a/indra/newview/llstatusbar.cpp
+++ b/indra/newview/llstatusbar.cpp
@@ -738,6 +738,10 @@ void LLStatusBar::updateBalancePanelPosition()
     balance_bg_view->setShape(balance_bg_rect);
 }
 
+void LLStatusBar::setBalanceVisible(bool visible)
+{
+    mBoxBalance->setVisible(visible);
+}
 
 // Implements secondlife:///app/balance/request to request a L$ balance
 // update via UDP message system. JC

--- a/indra/newview/llstatusbar.h
+++ b/indra/newview/llstatusbar.h
@@ -93,6 +93,8 @@ public:
     S32 getSquareMetersCommitted() const;
     S32 getSquareMetersLeft() const;
 
+    void setBalanceVisible(bool visible);
+
     LLPanelNearByMedia* getNearbyMediaPanel() { return mPanelNearByMedia; }
 
 private:

--- a/indra/newview/llviewermenufile.cpp
+++ b/indra/newview/llviewermenufile.cpp
@@ -932,6 +932,7 @@ class LLFileTakeSnapshotToDisk : public view_listener_t
         bool render_ui = gSavedSettings.getBOOL("RenderUIInSnapshot");
         bool render_hud = gSavedSettings.getBOOL("RenderHUDInSnapshot");
         bool render_no_post = gSavedSettings.getBOOL("RenderSnapshotNoPost");
+        bool render_balance = gSavedSettings.getBOOL("RenderBalanceInSnapshot");
 
         bool high_res = gSavedSettings.getBOOL("HighResSnapshot");
         if (high_res)
@@ -952,6 +953,7 @@ class LLFileTakeSnapshotToDisk : public view_listener_t
                                        render_hud,
                                        false,
                                        render_no_post,
+                                       render_balance,
                                        LLSnapshotModel::SNAPSHOT_TYPE_COLOR,
                                        high_res ? S32_MAX : MAX_SNAPSHOT_IMAGE_SIZE)) //per side
         {

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -5039,6 +5039,7 @@ bool attempt_standard_notification(LLMessageSystem* msgsystem)
                                         false, //UI
                                         gSavedSettings.getBOOL("RenderHUDInSnapshot"),
                                         false,
+                                        false,
                                         LLSnapshotModel::SNAPSHOT_TYPE_COLOR,
                                         LLSnapshotModel::SNAPSHOT_FORMAT_PNG);
         }
@@ -5143,6 +5144,7 @@ static void process_special_alert_messages(const std::string & message)
                                     gViewerWindow->getWindowHeightRaw(),
                                     false,
                                     gSavedSettings.getBOOL("RenderHUDInSnapshot"),
+                                    false,
                                     false,
                                     LLSnapshotModel::SNAPSHOT_TYPE_COLOR,
                                     LLSnapshotModel::SNAPSHOT_FORMAT_PNG);

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -4849,12 +4849,12 @@ void LLViewerWindow::movieSize(S32 new_width, S32 new_height)
     }
 }
 
-bool LLViewerWindow::saveSnapshot(const std::string& filepath, S32 image_width, S32 image_height, bool show_ui, bool show_hud, bool do_rebuild, LLSnapshotModel::ESnapshotLayerType type, LLSnapshotModel::ESnapshotFormat format)
+bool LLViewerWindow::saveSnapshot(const std::string& filepath, S32 image_width, S32 image_height, bool show_ui, bool show_hud, bool do_rebuild, bool show_balance, LLSnapshotModel::ESnapshotLayerType type, LLSnapshotModel::ESnapshotFormat format)
 {
     LL_INFOS() << "Saving snapshot to: " << filepath << LL_ENDL;
 
     LLPointer<LLImageRaw> raw = new LLImageRaw;
-    bool success = rawSnapshot(raw, image_width, image_height, true, false, show_ui, show_hud, do_rebuild);
+    bool success = rawSnapshot(raw, image_width, image_height, true, false, show_ui, show_hud, do_rebuild, show_balance);
 
     if (success)
     {
@@ -4915,14 +4915,14 @@ void LLViewerWindow::resetSnapshotLoc() const
 
 bool LLViewerWindow::thumbnailSnapshot(LLImageRaw *raw, S32 preview_width, S32 preview_height, bool show_ui, bool show_hud, bool do_rebuild, bool no_post, LLSnapshotModel::ESnapshotLayerType type)
 {
-    return rawSnapshot(raw, preview_width, preview_height, false, false, show_ui, show_hud, do_rebuild, no_post, type);
+    return rawSnapshot(raw, preview_width, preview_height, false, false, show_ui, show_hud, do_rebuild, no_post, gSavedSettings.getBOOL("RenderBalanceInSnapshot"), type);
 }
 
 // Saves the image from the screen to a raw image
 // Since the required size might be bigger than the available screen, this method rerenders the scene in parts (called subimages) and copy
 // the results over to the final raw image.
 bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_height,
-    bool keep_window_aspect, bool is_texture, bool show_ui, bool show_hud, bool do_rebuild, bool no_post, LLSnapshotModel::ESnapshotLayerType type, S32 max_size)
+    bool keep_window_aspect, bool is_texture, bool show_ui, bool show_hud, bool do_rebuild, bool no_post, bool show_balance, LLSnapshotModel::ESnapshotLayerType type, S32 max_size)
 {
     if (!raw)
     {
@@ -4980,6 +4980,8 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
         // If the user wants the UI, limit the output size to the available screen size
         image_width  = llmin(image_width, window_width);
         image_height = llmin(image_height, window_height);
+
+        setBalanceVisible(show_balance);
     }
 
     S32 original_width = 0;
@@ -5057,11 +5059,13 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
     }
     else
     {
+        setBalanceVisible(true);
         return false;
     }
 
     if (raw->isBufferInvalid())
     {
+        setBalanceVisible(true);
         return false;
     }
 
@@ -5237,6 +5241,7 @@ bool LLViewerWindow::rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_hei
     {
         send_agent_resume();
     }
+    setBalanceVisible(true);
 
     return ret;
 }
@@ -5699,6 +5704,14 @@ void LLViewerWindow::setProgressCancelButtonVisible( bool b, const std::string& 
     if (mProgressView)
     {
         mProgressView->setCancelButtonVisible( b, label );
+    }
+}
+
+void LLViewerWindow::setBalanceVisible(bool visible)
+{
+    if (gStatusBar)
+    {
+        gStatusBar->setBalanceVisible(visible);
     }
 }
 

--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -364,9 +364,11 @@ public:
     // snapshot functionality.
     // perhaps some of this should move to llfloatershapshot?  -MG
 
-    bool            saveSnapshot(const std::string&  filename, S32 image_width, S32 image_height, bool show_ui = true, bool show_hud = true, bool do_rebuild = false, LLSnapshotModel::ESnapshotLayerType type = LLSnapshotModel::SNAPSHOT_TYPE_COLOR, LLSnapshotModel::ESnapshotFormat format = LLSnapshotModel::SNAPSHOT_FORMAT_BMP);
-    bool            rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_height, bool keep_window_aspect = true, bool is_texture = false,
-        bool show_ui = true, bool show_hud = true, bool do_rebuild = false, bool no_post = false, LLSnapshotModel::ESnapshotLayerType type = LLSnapshotModel::SNAPSHOT_TYPE_COLOR, S32 max_size = MAX_SNAPSHOT_IMAGE_SIZE);
+    bool saveSnapshot(const std::string&  filename, S32 image_width, S32 image_height, bool show_ui = true, bool show_hud = true, bool do_rebuild = false, bool show_balance = true,
+                     LLSnapshotModel::ESnapshotLayerType type = LLSnapshotModel::SNAPSHOT_TYPE_COLOR, LLSnapshotModel::ESnapshotFormat format = LLSnapshotModel::SNAPSHOT_FORMAT_BMP);
+    bool rawSnapshot(LLImageRaw *raw, S32 image_width, S32 image_height, bool keep_window_aspect = true, bool is_texture = false,
+                     bool show_ui = true, bool show_hud = true, bool do_rebuild = false, bool no_post = false, bool show_balance = true,
+                     LLSnapshotModel::ESnapshotLayerType type = LLSnapshotModel::SNAPSHOT_TYPE_COLOR, S32 max_size = MAX_SNAPSHOT_IMAGE_SIZE);
 
     bool            simpleSnapshot(LLImageRaw *raw, S32 image_width, S32 image_height, const int num_render_passes);
 
@@ -461,6 +463,8 @@ public:
     const LLVector2& getDisplayScale() const { return mDisplayScale; }
     void            calcDisplayScale();
     static LLRect   calcScaledRect(const LLRect & rect, const LLVector2& display_scale);
+
+    void setBalanceVisible(bool visible);
 
     static std::string getLastSnapshotDir();
 

--- a/indra/newview/llviewerwindowlistener.cpp
+++ b/indra/newview/llviewerwindowlistener.cpp
@@ -100,7 +100,7 @@ void LLViewerWindowListener::saveSnapshot(const LLSD& event) const
         }
         type = found->second;
     }
-    bool ok = mViewerWindow->saveSnapshot(event["filename"], width, height, showui, showhud, rebuild, type);
+    bool ok = mViewerWindow->saveSnapshot(event["filename"], width, height, showui, showhud, rebuild, true /*L$ Balance*/, type);
     sendReply(LLSDMap("ok", ok), event);
 }
 

--- a/indra/newview/skins/default/xui/en/floater_snapshot.xml
+++ b/indra/newview/skins/default/xui/en/floater_snapshot.xml
@@ -167,8 +167,19 @@
          left="30"
 		 height="16"
          top_pad="8"
-         width="180"
+         width="80"
+         control_name="RenderUIInSnapshot"
          name="ui_check" />
+       <check_box
+         label="L$ Balance"
+         layout="topleft"
+         left_pad="16"
+         height="16"
+         top_delta="0"
+         width="80"
+         control_name="RenderBalanceInSnapshot"
+         enabled_control="RenderUIInSnapshot"
+         name="balance_check" />
         <check_box
          label="HUDs"
          layout="topleft"
@@ -176,6 +187,7 @@
          left="30"
          top_pad="1"
          width="180"
+         control_name="RenderHUDInSnapshot"
          name="hud_check" />
         <check_box
          label="Freeze frame (fullscreen)"


### PR DESCRIPTION
Added a new setting for Snapshot floater
![image](https://github.com/user-attachments/assets/1603e110-ea61-48c0-b434-08b1b5a83495)


Also removed spam, when refreshing a snapshot.