### PR TITLE
Fix: Apply Cloud Texture Changes from Environment Settings Floater

### DIFF
--- a/indra/newview/llfloaterenvironmentadjust.cpp
+++ b/indra/newview/llfloaterenvironmentadjust.cpp
@@ -455,26 +455,28 @@ void LLFloaterEnvironmentAdjust::onMoonAzimElevChanged()
 void LLFloaterEnvironmentAdjust::onCloudMapChanged()
 {
     if (!mLiveSky)
-        return;
-
-    // Get the texture picker control
-    LLTextureCtrl* picker_ctrl = getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP);
-    if (!picker_ctrl)
     {
-         // Optional: Log an error if the control isn't found, though unlikely
-         return;
+        return;
     }
 
-    // Get the new texture ID selected by the user
+    LLTextureCtrl* picker_ctrl = getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP);
+
     LLUUID new_texture_id = picker_ctrl->getValue().asUUID();
 
-    // Update the internal sky settings object
-    mLiveSky->setCloudNoiseTextureId(new_texture_id);
+    LLEnvironment::instance().setSelectedEnvironment(LLEnvironment::ENV_LOCAL);
 
-    // Trigger the update for the sky rendering
-    mLiveSky->update();
+    LLSettingsSky::ptr_t sky_to_set = mLiveSky->buildClone();
+    if (!sky_to_set)
+    {
+        return;
+    }
 
-    // Explicitly refresh the UI picker control to match the applied change
+    sky_to_set->setCloudNoiseTextureId(new_texture_id);
+
+    LLEnvironment::instance().setEnvironment(LLEnvironment::ENV_LOCAL, sky_to_set);
+
+    LLEnvironment::instance().updateEnvironment(LLEnvironment::TRANSITION_INSTANT, true);
+
     picker_ctrl->setValue(new_texture_id);
 }
 

--- a/indra/newview/llfloaterenvironmentadjust.cpp
+++ b/indra/newview/llfloaterenvironmentadjust.cpp
@@ -456,8 +456,26 @@ void LLFloaterEnvironmentAdjust::onCloudMapChanged()
 {
     if (!mLiveSky)
         return;
-    mLiveSky->setCloudNoiseTextureId(getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP)->getValue().asUUID());
+
+    // Get the texture picker control
+    LLTextureCtrl* picker_ctrl = getChild<LLTextureCtrl>(FIELD_SKY_CLOUD_MAP);
+    if (!picker_ctrl)
+    {
+         // Optional: Log an error if the control isn't found, though unlikely
+         return;
+    }
+
+    // Get the new texture ID selected by the user
+    LLUUID new_texture_id = picker_ctrl->getValue().asUUID();
+
+    // Update the internal sky settings object
+    mLiveSky->setCloudNoiseTextureId(new_texture_id);
+
+    // Trigger the update for the sky rendering
     mLiveSky->update();
+
+    // Explicitly refresh the UI picker control to match the applied change
+    picker_ctrl->setValue(new_texture_id);
 }
 
 void LLFloaterEnvironmentAdjust::onWaterMapChanged()


### PR DESCRIPTION
Problem:
The Personal Lighting floater (LLFloaterEnvironmentAdjust) allows users to select a custom cloud texture. However, when a new texture was selected via the texture picker, the change was not reflected in the rendered sky. The sky continued to display the previous cloud texture.

Cause:
The onCloudMapChanged function, triggered upon texture selection, only updated the internal mLiveSky settings object and called its update() method. This was insufficient to notify the core environment system and the renderer about the change. Applying live environment modifications requires interaction with the central LLEnvironment manager to update the correct environment layer (specifically ENV_LOCAL for user overrides) and trigger the necessary rendering pipeline updates.

Solution:
This PR modifies LLFloaterEnvironmentAdjust::onCloudMapChanged to correctly apply the user's selection:

- The function now uses the LLEnvironment singleton to manage the update process.
- It ensures the ENV_LOCAL layer is targeted for the modification.
- It clones the existing mLiveSky settings to avoid modifying a potentially shared object directly.
- The new cloud texture ID is set on the cloned object.
- LLEnvironment::setEnvironment(LLEnvironment::ENV_LOCAL, ...) is used to apply the modified settings object to the local override layer.
- LLEnvironment::updateEnvironment(...) is called to signal the system and renderer to process the change.
- Finally, the LLTextureCtrl UI widget is explicitly updated via setValue() to ensure its preview remains synchronized with the applied texture.

Result:
This change ensures that when a user selects a new cloud texture in the Environment Settings floater, the sky rendering updates immediately and correctly, resolving the bug. The UI preview is also synchronized.

Testing:

- Open the Personal Lighting floater
- Navigate to the Clouds tab.
- Click the cloud texture preview image.
- Select a cloud texture different from the current one and click "OK".
- Expected: The sky should immediately update to use the new texture. The texture preview image within the floater should also immediately update.
- Repeat steps 3-5 with different textures to confirm consistent behavior.