### PR TITLE
#3597 Improve error handling at LLGLSLShader::disableTexture()

### DIFF
--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -1247,23 +1247,40 @@ S32 LLGLSLShader::disableTexture(S32 uniform, LLTexUnit::eTextureType mode)
         llassert(false);
         return -1;
     }
+
     S32 index = mTexture[uniform];
-    if (index != -1 && gGL.getTexUnit(index)->getCurrType() != LLTexUnit::TT_NONE)
+    if (index < 0)
     {
-        if (gDebugGL && gGL.getTexUnit(index)->getCurrType() != mode)
+        // Invalid texture index - nothing to disable
+        return index;
+    }
+
+    LLTexUnit* tex_unit = gGL.getTexUnit(index);
+    if (!tex_unit)
+    {
+        // Invalid texture unit
+        LL_WARNS_ONCE("Shader") << "Invalid texture unit at index: " << index << LL_ENDL;
+        return index;
+    }
+
+    LLTexUnit::eTextureType curr_type = tex_unit->getCurrType();
+    if (curr_type != LLTexUnit::TT_NONE)
+    {
+        if (gDebugGL && curr_type != mode)
         {
             if (gDebugSession)
             {
-                gFailLog << "Texture channel " << index << " texture type corrupted." << std::endl;
+                gFailLog << "Texture channel " << index << " texture type corrupted. Expected: " << mode << ", Found: " << curr_type << std::endl;
                 ll_fail("LLGLSLShader::disableTexture failed");
             }
             else
             {
-                LL_ERRS() << "Texture channel " << index << " texture type corrupted." << LL_ENDL;
+                LL_ERRS() << "Texture channel " << index << " texture type corrupted. Expected: " << mode << ", Found: " << curr_type << LL_ENDL;
             }
         }
-        gGL.getTexUnit(index)->disable();
+        tex_unit->disable();
     }
+
     return index;
 }
 


### PR DESCRIPTION
The crash has stopped reproducing, but careful error handling and additional logging may still be useful.