### PR TITLE
Two crashfixes

### DIFF
--- a/indra/newview/lltoast.cpp
+++ b/indra/newview/lltoast.cpp
@@ -436,6 +436,14 @@ void LLToast::setVisible(bool show)
 
 void LLToast::updateHoveredState()
 {
+    if (!mWrapperPanel)
+    {
+        // Shouldn't be happening.
+        // mWrapperPanel should have been inited in the constructor
+        // This needs to be figured out and fixed
+        llassert(false);
+        return;
+    }
     S32 x, y;
     LLUI::getInstance()->getMousePositionScreen(&x, &y);
 

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -547,7 +547,7 @@ public:
     U32         renderTransparent(bool first_pass);
     void        renderCollisionVolumes();
     void        renderBones(const std::string &selected_joint = std::string());
-    void        renderJoints();
+    virtual void renderJoints();
     static void deleteCachedImages(bool clearAll=true);
     static void destroyGL();
     static void restoreGL();

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -697,6 +697,7 @@ void LLVOAvatarSelf::idleUpdate(LLAgent &agent, const F64 &time)
 // virtual
 LLJoint *LLVOAvatarSelf::getJoint(const std::string &name)
 {
+    std::lock_guard lock(mJointMapMutex);
     LLJoint *jointp = NULL;
     jointp = LLVOAvatar::getJoint(name);
     if (!jointp && mScreenp)
@@ -712,6 +713,14 @@ LLJoint *LLVOAvatarSelf::getJoint(const std::string &name)
         llassert(LLVOAvatar::getJoint((S32)jointp->getJointNum())==jointp);
     }
     return jointp;
+}
+
+
+//virtual
+void LLVOAvatarSelf::renderJoints()
+{
+    std::lock_guard lock(mJointMapMutex);
+    LLVOAvatar::renderJoints();
 }
 
 // virtual

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -92,6 +92,8 @@ public:
     /*virtual*/ void        requestStopMotion(LLMotion* motion);
     /*virtual*/ LLJoint*    getJoint(const std::string &name);
 
+    /*virtual*/ void renderJoints();
+
     /*virtual*/ bool setVisualParamWeight(const LLVisualParam *which_param, F32 weight);
     /*virtual*/ bool setVisualParamWeight(const char* param_name, F32 weight);
     /*virtual*/ bool setVisualParamWeight(S32 index, F32 weight);
@@ -102,6 +104,8 @@ public:
 private:
     // helper function. Passed in param is assumed to be in avatar's parameter list.
     bool setParamWeight(const LLViewerVisualParam *param, F32 weight);
+
+    std::mutex          mJointMapMutex; // getJoint gets used from mesh thread
 
 /********************************************************************************
  **                                                                            **


### PR DESCRIPTION
1. Bugspalt claims that mWrapperPanel is null, I don't know how that is possible, but that's the best we have at the moment
2. Long standing issue with getJoint being used from mesh thread 