### PR TITLE
#3627 std::bad_alloc when loading a model

### DIFF
--- a/indra/newview/gltfscenemanager.cpp
+++ b/indra/newview/gltfscenemanager.cpp
@@ -69,9 +69,16 @@ void GLTFSceneManager::load()
                 {
                     return;
                 }
-                if (filenames.size() > 0)
+                try
                 {
-                    GLTFSceneManager::instance().load(filenames[0]);
+                    if (filenames.size() > 0)
+                    {
+                        GLTFSceneManager::instance().load(filenames[0]);
+                    }
+                }
+                catch (std::bad_alloc&)
+                {
+                    LLNotificationsUtil::add("CannotOpenFileTooBig");
                 }
             },
             LLFilePicker::FFLOAD_GLTF,

--- a/indra/newview/llmaterialeditor.cpp
+++ b/indra/newview/llmaterialeditor.cpp
@@ -2857,9 +2857,16 @@ void LLMaterialEditor::importMaterial()
                 {
                     return;
                 }
-                if (filenames.size() > 0)
+                try
                 {
-                    LLMaterialEditor::loadMaterialFromFile(filenames[0], -1);
+                    if (filenames.size() > 0)
+                    {
+                        LLMaterialEditor::loadMaterialFromFile(filenames[0], -1);
+                    }
+                }
+                catch (std::bad_alloc&)
+                {
+                    LLNotificationsUtil::add("CannotOpenFileTooBig");
                 }
             },
         LLFilePicker::FFLOAD_MATERIAL,

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -2408,6 +2408,16 @@ Unable to upload snapshot.
 File might be too big, try reducing resolution or try again later.
   <tag>fail</tag>
   </notification>
+    
+  <notification
+   icon="alertmodal.tga"
+   name="CannotOpenFileTooBig"
+   type="alertmodal">
+Unable to open file.
+
+Viewer run out of memory while opening file. File might be too big.
+  <tag>fail</tag>
+  </notification>
 
   <notification
    icon="notifytip.tga"


### PR DESCRIPTION
Since file might be massive it's better to show a notification instead of crashing.