### PR TITLE
Fix: Remove potentially redundant RenderAutoHideSurfaceAreaLimit sett…

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -599,7 +599,6 @@ void LLPipeline::init()
     connectRefreshCachedSettingsSafe("RenderMirrors");
     connectRefreshCachedSettingsSafe("RenderHeroProbeUpdateRate");
     connectRefreshCachedSettingsSafe("RenderHeroProbeConservativeUpdateMultiplier");
-    connectRefreshCachedSettingsSafe("RenderAutoHideSurfaceAreaLimit");
 
     LLPointer<LLControlVariable> cntrl_ptr = gSavedSettings.getControl("CollectFontVertexBuffers");
     if (cntrl_ptr.notNull())


### PR DESCRIPTION
This pull request removes a seemingly duplicated `connectRefreshCachedSettingsSafe` call in `LLPipeline::init()` for the `RenderAutoHideSurfaceAreaLimit` setting.

**Context:**

During a routine code review of `LLPipeline::init()`, a duplicated registration for the `RenderAutoHideSurfaceAreaLimit` setting was identified. While the impact is likely minimal, double registration can lead to:

* Potential for the associated callback function to be executed twice, increasing CPU overhead.
* The second registration overriding the first, rendering the first call ineffective.

It's *possible* this duplication was introduced with commit 440c7b2 (Added CollectFontVertexBuffers feature); however, further investigation by other developers is encouraged.

**Testing:**

To ensure the intended functionality remains intact, I performed the following tests after removing the duplicate registration:

* Verified that setting the value to 0 (zero) causes all objects to appear, regardless of size.
* Confirmed that values slightly above zero result in only small objects appearing, with all others hidden.
* Demonstrated that increasing the value causes objects of increasing size to appear, while smaller objects remain visible (additive behavior).

A video screencapture demonstrating this testing process has been embedded within this pull request for easy review.

![SecondLifeViewer_GzaEnDWrrS2](https://github.com/user-attachments/assets/11e077c2-5091-4a50-b6c0-70ef41fb1644)

This change is submitted for careful review by other developers to ensure it has no unintended side effects. Please verify these observations and provide any feedback. The goal is to improve code quality without impacting user experience.