### PR TITLE
#3745 fix for showing system notification on login #2

### DIFF
--- a/indra/newview/llcallingcard.cpp
+++ b/indra/newview/llcallingcard.cpp
@@ -504,7 +504,7 @@ void LLAvatarTracker::idleNotifyObservers()
 
 void LLAvatarTracker::notifyObservers()
 {
-    if (mIsNotifyObservers)
+    if (mIsNotifyObservers || (LLStartUp::getStartupState() <= STATE_INVENTORY_CALLBACKS))
     {
         // Don't allow multiple calls.
         // new masks and ids will be processed later from idle.


### PR DESCRIPTION
Skip notifying observers before inventory fetcher is started (if friends related updates were received too early).
