### PR TITLE
#3897 Fix favorite's stars being hidden in some cases #2

### DIFF
--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -1693,11 +1693,6 @@ LLRect LLFolderView::getVisibleRect()
     return visible_rect;
 }
 
-S32 LLFolderView::getVisibleContentWidth()
-{
-    return (mScrollContainer ? mScrollContainer->getVisibleContentRect().getWidth() : 0);
-}
-
 bool LLFolderView::getShowSelectionContext()
 {
     if (mShowSelectionContext)

--- a/indra/llui/llfolderview.h
+++ b/indra/llui/llfolderview.h
@@ -221,8 +221,8 @@ public:
     void scrollToShowSelection();
     void scrollToShowItem(LLFolderViewItem* item, const LLRect& constraint_rect);
     void setScrollContainer( LLScrollContainer* parent ) { mScrollContainer = parent; }
+    LLScrollContainer* getScrollContainer() { return mScrollContainer; }
     LLRect getVisibleRect();
-    S32 getVisibleContentWidth();
 
     bool search(LLFolderViewItem* first_item, const std::string &search_string, bool backward);
     void setShowSelectionContext(bool show) { mShowSelectionContext = show; }

--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -73,6 +73,9 @@ const F32 LLFolderViewItem::FOLDER_OPEN_TIME_CONSTANT = 0.03f;
 
 const LLColor4U DEFAULT_WHITE(255, 255, 255);
 
+constexpr S32 FAVORITE_IMAGE_SIZE = 14;
+constexpr S32 FAVORITE_IMAGE_PAD = 3;
+
 
 //static
 LLFontGL* LLFolderViewItem::getLabelFontForStyle(U8 style)
@@ -460,6 +463,10 @@ S32 LLFolderViewItem::arrange( S32* width, S32* height )
         }
         mLabelWidth = getLabelXPos() + getLabelFontForStyle(mLabelStyle)->getWidth(mLabel.c_str()) + getLabelFontForStyle(LLFontGL::NORMAL)->getWidth(mLabelSuffix.c_str()) + mLabelPaddingRight;
         mLabelWidthDirty = false;
+        if (mIsFavorite)
+        {
+            mLabelWidth += FAVORITE_IMAGE_SIZE + FAVORITE_IMAGE_PAD;
+        }
     }
 
     *width = llmax(*width, mLabelWidth);
@@ -825,18 +832,25 @@ void LLFolderViewItem::drawFavoriteIcon()
 
     if (favorite_image)
     {
-        constexpr S32 PAD = 3;
-        constexpr S32 image_size = 14;
-
-        S32 width = mRoot->getVisibleContentWidth(); // star should stick to scroller's right side
-        if (width <= 0)
+        S32 x_offset = 0;
+        LLScrollContainer* scroll = mRoot->getScrollContainer();
+        if (scroll)
         {
-            width = getRect().getWidth();
+            S32 width = scroll->getVisibleContentRect().getWidth();
+            S32 offset = scroll->getDocPosHorizontal();
+            x_offset = width + offset;
         }
-
+        else
+        {
+            x_offset = getRect().getWidth();
+        }
         gl_draw_scaled_image(
-            width - image_size - PAD, getRect().getHeight() - mItemHeight + PAD,
-            image_size, image_size, favorite_image->getImage(), sFgColor);
+            x_offset - FAVORITE_IMAGE_SIZE - FAVORITE_IMAGE_PAD,
+            getRect().getHeight() - mItemHeight + FAVORITE_IMAGE_PAD,
+            FAVORITE_IMAGE_SIZE,
+            FAVORITE_IMAGE_SIZE,
+            favorite_image->getImage(),
+            sFgColor);
     }
 }
 


### PR DESCRIPTION
1. Star should follow scroll
2. Account for a star in label's width