### PR TITLE
Add a bunch of old and new math improvements

### DIFF
--- a/indra/llappearance/llpolymorph.cpp
+++ b/indra/llappearance/llpolymorph.cpp
@@ -550,12 +550,12 @@ void LLPolyMorphTarget::apply( ESex avatar_sex )
 
     mLastSex = avatar_sex;
 
-    // Check for NaN condition (NaN is detected if a variable doesn't equal itself.
-    if (mCurWeight != mCurWeight)
+    // Check for NaN condition
+    if (llisnan(mCurWeight))
     {
-        mCurWeight = 0.0;
+        mCurWeight = 0.f;
     }
-    if (mLastWeight != mLastWeight)
+    if (llisnan(mLastWeight))
     {
         mLastWeight = mCurWeight+.001f;
     }

--- a/indra/llcommon/indra_constants.h
+++ b/indra/llcommon/indra_constants.h
@@ -31,15 +31,15 @@
 
 class LLUUID;
 
-static const F32 REGION_WIDTH_METERS = 256.f;
-static const S32 REGION_WIDTH_UNITS = 256;
-static const U32 REGION_WIDTH_U32 = 256;
+static constexpr F32 REGION_WIDTH_METERS = 256.f;
+static constexpr S32 REGION_WIDTH_UNITS = 256;
+static constexpr U32 REGION_WIDTH_U32 = 256;
 
-const F32 REGION_HEIGHT_METERS = 4096.f;
+constexpr F32 REGION_HEIGHT_METERS = 4096.f;
 
-const   F32     DEFAULT_AGENT_DEPTH     = 0.45f;
-const   F32     DEFAULT_AGENT_WIDTH     = 0.60f;
-const   F32     DEFAULT_AGENT_HEIGHT    = 1.9f;
+constexpr   F32     DEFAULT_AGENT_DEPTH     = 0.45f;
+constexpr   F32     DEFAULT_AGENT_WIDTH     = 0.60f;
+constexpr   F32     DEFAULT_AGENT_HEIGHT    = 1.9f;
 
 enum ETerrainBrushType
 {
@@ -67,112 +67,112 @@ enum EMouseClickType{
 
 // keys
 // Bit masks for various keyboard modifier keys.
-const MASK MASK_NONE =          0x0000;
-const MASK MASK_CONTROL =       0x0001;     // Mapped to cmd on Macs
-const MASK MASK_ALT =           0x0002;
-const MASK MASK_SHIFT =         0x0004;
-const MASK MASK_NORMALKEYS =    0x0007;     // A real mask - only get the bits for normal modifier keys
-const MASK MASK_MAC_CONTROL =   0x0008;     // Un-mapped Ctrl key on Macs, not used on Windows
-const MASK MASK_MODIFIERS =     MASK_CONTROL|MASK_ALT|MASK_SHIFT|MASK_MAC_CONTROL;
+constexpr MASK MASK_NONE =          0x0000;
+constexpr MASK MASK_CONTROL =       0x0001;     // Mapped to cmd on Macs
+constexpr MASK MASK_ALT =           0x0002;
+constexpr MASK MASK_SHIFT =         0x0004;
+constexpr MASK MASK_NORMALKEYS =    0x0007;     // A real mask - only get the bits for normal modifier keys
+constexpr MASK MASK_MAC_CONTROL =   0x0008;     // Un-mapped Ctrl key on Macs, not used on Windows
+constexpr MASK MASK_MODIFIERS =     MASK_CONTROL|MASK_ALT|MASK_SHIFT|MASK_MAC_CONTROL;
 
 // Special keys go into >128
-const KEY KEY_SPECIAL = 0x80;   // special keys start here
-const KEY KEY_RETURN =  0x81;
-const KEY KEY_LEFT =    0x82;
-const KEY KEY_RIGHT =   0x83;
-const KEY KEY_UP =      0x84;
-const KEY KEY_DOWN =    0x85;
-const KEY KEY_ESCAPE =  0x86;
-const KEY KEY_BACKSPACE =0x87;
-const KEY KEY_DELETE =  0x88;
-const KEY KEY_SHIFT =   0x89;
-const KEY KEY_CONTROL = 0x8A;
-const KEY KEY_ALT =     0x8B;
-const KEY KEY_HOME =    0x8C;
-const KEY KEY_END =     0x8D;
-const KEY KEY_PAGE_UP = 0x8E;
-const KEY KEY_PAGE_DOWN = 0x8F;
-const KEY KEY_HYPHEN = 0x90;
-const KEY KEY_EQUALS = 0x91;
-const KEY KEY_INSERT = 0x92;
-const KEY KEY_CAPSLOCK = 0x93;
-const KEY KEY_TAB =     0x94;
-const KEY KEY_ADD =     0x95;
-const KEY KEY_SUBTRACT =0x96;
-const KEY KEY_MULTIPLY =0x97;
-const KEY KEY_DIVIDE =  0x98;
-const KEY KEY_F1        = 0xA1;
-const KEY KEY_F2        = 0xA2;
-const KEY KEY_F3        = 0xA3;
-const KEY KEY_F4        = 0xA4;
-const KEY KEY_F5        = 0xA5;
-const KEY KEY_F6        = 0xA6;
-const KEY KEY_F7        = 0xA7;
-const KEY KEY_F8        = 0xA8;
-const KEY KEY_F9        = 0xA9;
-const KEY KEY_F10       = 0xAA;
-const KEY KEY_F11       = 0xAB;
-const KEY KEY_F12       = 0xAC;
+constexpr KEY KEY_SPECIAL = 0x80;   // special keys start here
+constexpr KEY KEY_RETURN =  0x81;
+constexpr KEY KEY_LEFT =    0x82;
+constexpr KEY KEY_RIGHT =   0x83;
+constexpr KEY KEY_UP =      0x84;
+constexpr KEY KEY_DOWN =    0x85;
+constexpr KEY KEY_ESCAPE =  0x86;
+constexpr KEY KEY_BACKSPACE =0x87;
+constexpr KEY KEY_DELETE =  0x88;
+constexpr KEY KEY_SHIFT =   0x89;
+constexpr KEY KEY_CONTROL = 0x8A;
+constexpr KEY KEY_ALT =     0x8B;
+constexpr KEY KEY_HOME =    0x8C;
+constexpr KEY KEY_END =     0x8D;
+constexpr KEY KEY_PAGE_UP = 0x8E;
+constexpr KEY KEY_PAGE_DOWN = 0x8F;
+constexpr KEY KEY_HYPHEN = 0x90;
+constexpr KEY KEY_EQUALS = 0x91;
+constexpr KEY KEY_INSERT = 0x92;
+constexpr KEY KEY_CAPSLOCK = 0x93;
+constexpr KEY KEY_TAB =     0x94;
+constexpr KEY KEY_ADD =     0x95;
+constexpr KEY KEY_SUBTRACT =0x96;
+constexpr KEY KEY_MULTIPLY =0x97;
+constexpr KEY KEY_DIVIDE =  0x98;
+constexpr KEY KEY_F1        = 0xA1;
+constexpr KEY KEY_F2        = 0xA2;
+constexpr KEY KEY_F3        = 0xA3;
+constexpr KEY KEY_F4        = 0xA4;
+constexpr KEY KEY_F5        = 0xA5;
+constexpr KEY KEY_F6        = 0xA6;
+constexpr KEY KEY_F7        = 0xA7;
+constexpr KEY KEY_F8        = 0xA8;
+constexpr KEY KEY_F9        = 0xA9;
+constexpr KEY KEY_F10       = 0xAA;
+constexpr KEY KEY_F11       = 0xAB;
+constexpr KEY KEY_F12       = 0xAC;
 
-const KEY KEY_PAD_UP        = 0xC0;
-const KEY KEY_PAD_DOWN      = 0xC1;
-const KEY KEY_PAD_LEFT      = 0xC2;
-const KEY KEY_PAD_RIGHT     = 0xC3;
-const KEY KEY_PAD_HOME      = 0xC4;
-const KEY KEY_PAD_END       = 0xC5;
-const KEY KEY_PAD_PGUP      = 0xC6;
-const KEY KEY_PAD_PGDN      = 0xC7;
-const KEY KEY_PAD_CENTER    = 0xC8; // the 5 in the middle
-const KEY KEY_PAD_INS       = 0xC9;
-const KEY KEY_PAD_DEL       = 0xCA;
-const KEY KEY_PAD_RETURN    = 0xCB;
-const KEY KEY_PAD_ADD       = 0xCC; // not used
-const KEY KEY_PAD_SUBTRACT  = 0xCD; // not used
-const KEY KEY_PAD_MULTIPLY  = 0xCE; // not used
-const KEY KEY_PAD_DIVIDE    = 0xCF; // not used
+constexpr KEY KEY_PAD_UP        = 0xC0;
+constexpr KEY KEY_PAD_DOWN      = 0xC1;
+constexpr KEY KEY_PAD_LEFT      = 0xC2;
+constexpr KEY KEY_PAD_RIGHT     = 0xC3;
+constexpr KEY KEY_PAD_HOME      = 0xC4;
+constexpr KEY KEY_PAD_END       = 0xC5;
+constexpr KEY KEY_PAD_PGUP      = 0xC6;
+constexpr KEY KEY_PAD_PGDN      = 0xC7;
+constexpr KEY KEY_PAD_CENTER    = 0xC8; // the 5 in the middle
+constexpr KEY KEY_PAD_INS       = 0xC9;
+constexpr KEY KEY_PAD_DEL       = 0xCA;
+constexpr KEY KEY_PAD_RETURN    = 0xCB;
+constexpr KEY KEY_PAD_ADD       = 0xCC; // not used
+constexpr KEY KEY_PAD_SUBTRACT  = 0xCD; // not used
+constexpr KEY KEY_PAD_MULTIPLY  = 0xCE; // not used
+constexpr KEY KEY_PAD_DIVIDE    = 0xCF; // not used
 
-const KEY KEY_BUTTON0   = 0xD0;
-const KEY KEY_BUTTON1   = 0xD1;
-const KEY KEY_BUTTON2   = 0xD2;
-const KEY KEY_BUTTON3   = 0xD3;
-const KEY KEY_BUTTON4   = 0xD4;
-const KEY KEY_BUTTON5   = 0xD5;
-const KEY KEY_BUTTON6   = 0xD6;
-const KEY KEY_BUTTON7   = 0xD7;
-const KEY KEY_BUTTON8   = 0xD8;
-const KEY KEY_BUTTON9   = 0xD9;
-const KEY KEY_BUTTON10  = 0xDA;
-const KEY KEY_BUTTON11  = 0xDB;
-const KEY KEY_BUTTON12  = 0xDC;
-const KEY KEY_BUTTON13  = 0xDD;
-const KEY KEY_BUTTON14  = 0xDE;
-const KEY KEY_BUTTON15  = 0xDF;
+constexpr KEY KEY_BUTTON0   = 0xD0;
+constexpr KEY KEY_BUTTON1   = 0xD1;
+constexpr KEY KEY_BUTTON2   = 0xD2;
+constexpr KEY KEY_BUTTON3   = 0xD3;
+constexpr KEY KEY_BUTTON4   = 0xD4;
+constexpr KEY KEY_BUTTON5   = 0xD5;
+constexpr KEY KEY_BUTTON6   = 0xD6;
+constexpr KEY KEY_BUTTON7   = 0xD7;
+constexpr KEY KEY_BUTTON8   = 0xD8;
+constexpr KEY KEY_BUTTON9   = 0xD9;
+constexpr KEY KEY_BUTTON10  = 0xDA;
+constexpr KEY KEY_BUTTON11  = 0xDB;
+constexpr KEY KEY_BUTTON12  = 0xDC;
+constexpr KEY KEY_BUTTON13  = 0xDD;
+constexpr KEY KEY_BUTTON14  = 0xDE;
+constexpr KEY KEY_BUTTON15  = 0xDF;
 
-const KEY KEY_NONE =    0xFF; // not sent from keyboard.  For internal use only.
+constexpr KEY KEY_NONE =    0xFF; // not sent from keyboard.  For internal use only.
 
-const S32 KEY_COUNT = 256;
+constexpr S32 KEY_COUNT = 256;
 
 
-const F32 DEFAULT_WATER_HEIGHT  = 20.0f;
+constexpr F32 DEFAULT_WATER_HEIGHT  = 20.0f;
 
 // Maturity ratings for simulators
-const U8 SIM_ACCESS_MIN     = 0;        // Treated as 'unknown', usually ends up being SIM_ACCESS_PG
-const U8 SIM_ACCESS_PG      = 13;
-const U8 SIM_ACCESS_MATURE  = 21;
-const U8 SIM_ACCESS_ADULT   = 42;       // Seriously Adult Only
-const U8 SIM_ACCESS_DOWN    = 254;
-const U8 SIM_ACCESS_MAX     = SIM_ACCESS_ADULT;
+constexpr U8 SIM_ACCESS_MIN     = 0;        // Treated as 'unknown', usually ends up being SIM_ACCESS_PG
+constexpr U8 SIM_ACCESS_PG      = 13;
+constexpr U8 SIM_ACCESS_MATURE  = 21;
+constexpr U8 SIM_ACCESS_ADULT   = 42;       // Seriously Adult Only
+constexpr U8 SIM_ACCESS_DOWN    = 254;
+constexpr U8 SIM_ACCESS_MAX     = SIM_ACCESS_ADULT;
 
 // attachment constants
-const U8  ATTACHMENT_ADD = 0x80;
+constexpr U8  ATTACHMENT_ADD = 0x80;
 
 // god levels
-const U8 GOD_MAINTENANCE = 250;
-const U8 GOD_FULL = 200;
-const U8 GOD_LIAISON = 150;
-const U8 GOD_CUSTOMER_SERVICE = 100;
-const U8 GOD_LIKE = 1;
-const U8 GOD_NOT = 0;
+constexpr U8 GOD_MAINTENANCE = 250;
+constexpr U8 GOD_FULL = 200;
+constexpr U8 GOD_LIAISON = 150;
+constexpr U8 GOD_CUSTOMER_SERVICE = 100;
+constexpr U8 GOD_LIKE = 1;
+constexpr U8 GOD_NOT = 0;
 
 // "agent id" for things that should be done to ALL agents
 LL_COMMON_API extern const LLUUID LL_UUID_ALL_AGENTS;
@@ -239,120 +239,120 @@ LL_COMMON_API extern const LLUUID BLANK_OBJECT_NORMAL;
 LL_COMMON_API extern const LLUUID BLANK_MATERIAL_ASSET_ID;
 
 // radius within which a chat message is fully audible
-const F32 CHAT_NORMAL_RADIUS = 20.f;
+constexpr F32 CHAT_NORMAL_RADIUS = 20.f;
 
 // media commands
-const U32 PARCEL_MEDIA_COMMAND_STOP  = 0;
-const U32 PARCEL_MEDIA_COMMAND_PAUSE = 1;
-const U32 PARCEL_MEDIA_COMMAND_PLAY  = 2;
-const U32 PARCEL_MEDIA_COMMAND_LOOP  = 3;
-const U32 PARCEL_MEDIA_COMMAND_TEXTURE = 4;
-const U32 PARCEL_MEDIA_COMMAND_URL = 5;
-const U32 PARCEL_MEDIA_COMMAND_TIME = 6;
-const U32 PARCEL_MEDIA_COMMAND_AGENT = 7;
-const U32 PARCEL_MEDIA_COMMAND_UNLOAD = 8;
-const U32 PARCEL_MEDIA_COMMAND_AUTO_ALIGN = 9;
-const U32 PARCEL_MEDIA_COMMAND_TYPE = 10;
-const U32 PARCEL_MEDIA_COMMAND_SIZE = 11;
-const U32 PARCEL_MEDIA_COMMAND_DESC = 12;
-const U32 PARCEL_MEDIA_COMMAND_LOOP_SET = 13;
+constexpr U32 PARCEL_MEDIA_COMMAND_STOP  = 0;
+constexpr U32 PARCEL_MEDIA_COMMAND_PAUSE = 1;
+constexpr U32 PARCEL_MEDIA_COMMAND_PLAY  = 2;
+constexpr U32 PARCEL_MEDIA_COMMAND_LOOP  = 3;
+constexpr U32 PARCEL_MEDIA_COMMAND_TEXTURE = 4;
+constexpr U32 PARCEL_MEDIA_COMMAND_URL = 5;
+constexpr U32 PARCEL_MEDIA_COMMAND_TIME = 6;
+constexpr U32 PARCEL_MEDIA_COMMAND_AGENT = 7;
+constexpr U32 PARCEL_MEDIA_COMMAND_UNLOAD = 8;
+constexpr U32 PARCEL_MEDIA_COMMAND_AUTO_ALIGN = 9;
+constexpr U32 PARCEL_MEDIA_COMMAND_TYPE = 10;
+constexpr U32 PARCEL_MEDIA_COMMAND_SIZE = 11;
+constexpr U32 PARCEL_MEDIA_COMMAND_DESC = 12;
+constexpr U32 PARCEL_MEDIA_COMMAND_LOOP_SET = 13;
 
 const S32 CHAT_CHANNEL_DEBUG = S32_MAX;
 
 // agent constants
-const U32 CONTROL_AT_POS_INDEX              = 0;
-const U32 CONTROL_AT_NEG_INDEX              = 1;
-const U32 CONTROL_LEFT_POS_INDEX            = 2;
-const U32 CONTROL_LEFT_NEG_INDEX            = 3;
-const U32 CONTROL_UP_POS_INDEX              = 4;
-const U32 CONTROL_UP_NEG_INDEX              = 5;
-const U32 CONTROL_PITCH_POS_INDEX           = 6;
-const U32 CONTROL_PITCH_NEG_INDEX           = 7;
-const U32 CONTROL_YAW_POS_INDEX             = 8;
-const U32 CONTROL_YAW_NEG_INDEX             = 9;
-const U32 CONTROL_FAST_AT_INDEX             = 10;
-const U32 CONTROL_FAST_LEFT_INDEX           = 11;
-const U32 CONTROL_FAST_UP_INDEX             = 12;
-const U32 CONTROL_FLY_INDEX                 = 13;
-const U32 CONTROL_STOP_INDEX                = 14;
-const U32 CONTROL_FINISH_ANIM_INDEX         = 15;
-const U32 CONTROL_STAND_UP_INDEX            = 16;
-const U32 CONTROL_SIT_ON_GROUND_INDEX       = 17;
-const U32 CONTROL_MOUSELOOK_INDEX           = 18;
-const U32 CONTROL_NUDGE_AT_POS_INDEX        = 19;
-const U32 CONTROL_NUDGE_AT_NEG_INDEX        = 20;
-const U32 CONTROL_NUDGE_LEFT_POS_INDEX      = 21;
-const U32 CONTROL_NUDGE_LEFT_NEG_INDEX      = 22;
-const U32 CONTROL_NUDGE_UP_POS_INDEX        = 23;
-const U32 CONTROL_NUDGE_UP_NEG_INDEX        = 24;
-const U32 CONTROL_TURN_LEFT_INDEX           = 25;
-const U32 CONTROL_TURN_RIGHT_INDEX          = 26;
-const U32 CONTROL_AWAY_INDEX                = 27;
-const U32 CONTROL_LBUTTON_DOWN_INDEX        = 28;
-const U32 CONTROL_LBUTTON_UP_INDEX          = 29;
-const U32 CONTROL_ML_LBUTTON_DOWN_INDEX     = 30;
-const U32 CONTROL_ML_LBUTTON_UP_INDEX       = 31;
-const U32 TOTAL_CONTROLS                    = 32;
+constexpr U32 CONTROL_AT_POS_INDEX              = 0;
+constexpr U32 CONTROL_AT_NEG_INDEX              = 1;
+constexpr U32 CONTROL_LEFT_POS_INDEX            = 2;
+constexpr U32 CONTROL_LEFT_NEG_INDEX            = 3;
+constexpr U32 CONTROL_UP_POS_INDEX              = 4;
+constexpr U32 CONTROL_UP_NEG_INDEX              = 5;
+constexpr U32 CONTROL_PITCH_POS_INDEX           = 6;
+constexpr U32 CONTROL_PITCH_NEG_INDEX           = 7;
+constexpr U32 CONTROL_YAW_POS_INDEX             = 8;
+constexpr U32 CONTROL_YAW_NEG_INDEX             = 9;
+constexpr U32 CONTROL_FAST_AT_INDEX             = 10;
+constexpr U32 CONTROL_FAST_LEFT_INDEX           = 11;
+constexpr U32 CONTROL_FAST_UP_INDEX             = 12;
+constexpr U32 CONTROL_FLY_INDEX                 = 13;
+constexpr U32 CONTROL_STOP_INDEX                = 14;
+constexpr U32 CONTROL_FINISH_ANIM_INDEX         = 15;
+constexpr U32 CONTROL_STAND_UP_INDEX            = 16;
+constexpr U32 CONTROL_SIT_ON_GROUND_INDEX       = 17;
+constexpr U32 CONTROL_MOUSELOOK_INDEX           = 18;
+constexpr U32 CONTROL_NUDGE_AT_POS_INDEX        = 19;
+constexpr U32 CONTROL_NUDGE_AT_NEG_INDEX        = 20;
+constexpr U32 CONTROL_NUDGE_LEFT_POS_INDEX      = 21;
+constexpr U32 CONTROL_NUDGE_LEFT_NEG_INDEX      = 22;
+constexpr U32 CONTROL_NUDGE_UP_POS_INDEX        = 23;
+constexpr U32 CONTROL_NUDGE_UP_NEG_INDEX        = 24;
+constexpr U32 CONTROL_TURN_LEFT_INDEX           = 25;
+constexpr U32 CONTROL_TURN_RIGHT_INDEX          = 26;
+constexpr U32 CONTROL_AWAY_INDEX                = 27;
+constexpr U32 CONTROL_LBUTTON_DOWN_INDEX        = 28;
+constexpr U32 CONTROL_LBUTTON_UP_INDEX          = 29;
+constexpr U32 CONTROL_ML_LBUTTON_DOWN_INDEX     = 30;
+constexpr U32 CONTROL_ML_LBUTTON_UP_INDEX       = 31;
+constexpr U32 TOTAL_CONTROLS                    = 32;
 
-const U32 AGENT_CONTROL_AT_POS              = 0x1 << CONTROL_AT_POS_INDEX;          // 0x00000001
-const U32 AGENT_CONTROL_AT_NEG              = 0x1 << CONTROL_AT_NEG_INDEX;          // 0x00000002
-const U32 AGENT_CONTROL_LEFT_POS            = 0x1 << CONTROL_LEFT_POS_INDEX;        // 0x00000004
-const U32 AGENT_CONTROL_LEFT_NEG            = 0x1 << CONTROL_LEFT_NEG_INDEX;        // 0x00000008
-const U32 AGENT_CONTROL_UP_POS              = 0x1 << CONTROL_UP_POS_INDEX;          // 0x00000010
-const U32 AGENT_CONTROL_UP_NEG              = 0x1 << CONTROL_UP_NEG_INDEX;          // 0x00000020
-const U32 AGENT_CONTROL_PITCH_POS           = 0x1 << CONTROL_PITCH_POS_INDEX;       // 0x00000040
-const U32 AGENT_CONTROL_PITCH_NEG           = 0x1 << CONTROL_PITCH_NEG_INDEX;       // 0x00000080
-const U32 AGENT_CONTROL_YAW_POS             = 0x1 << CONTROL_YAW_POS_INDEX;         // 0x00000100
-const U32 AGENT_CONTROL_YAW_NEG             = 0x1 << CONTROL_YAW_NEG_INDEX;         // 0x00000200
+constexpr U32 AGENT_CONTROL_AT_POS              = 0x1 << CONTROL_AT_POS_INDEX;          // 0x00000001
+constexpr U32 AGENT_CONTROL_AT_NEG              = 0x1 << CONTROL_AT_NEG_INDEX;          // 0x00000002
+constexpr U32 AGENT_CONTROL_LEFT_POS            = 0x1 << CONTROL_LEFT_POS_INDEX;        // 0x00000004
+constexpr U32 AGENT_CONTROL_LEFT_NEG            = 0x1 << CONTROL_LEFT_NEG_INDEX;        // 0x00000008
+constexpr U32 AGENT_CONTROL_UP_POS              = 0x1 << CONTROL_UP_POS_INDEX;          // 0x00000010
+constexpr U32 AGENT_CONTROL_UP_NEG              = 0x1 << CONTROL_UP_NEG_INDEX;          // 0x00000020
+constexpr U32 AGENT_CONTROL_PITCH_POS           = 0x1 << CONTROL_PITCH_POS_INDEX;       // 0x00000040
+constexpr U32 AGENT_CONTROL_PITCH_NEG           = 0x1 << CONTROL_PITCH_NEG_INDEX;       // 0x00000080
+constexpr U32 AGENT_CONTROL_YAW_POS             = 0x1 << CONTROL_YAW_POS_INDEX;         // 0x00000100
+constexpr U32 AGENT_CONTROL_YAW_NEG             = 0x1 << CONTROL_YAW_NEG_INDEX;         // 0x00000200
 
-const U32 AGENT_CONTROL_FAST_AT             = 0x1 << CONTROL_FAST_AT_INDEX;         // 0x00000400
-const U32 AGENT_CONTROL_FAST_LEFT           = 0x1 << CONTROL_FAST_LEFT_INDEX;       // 0x00000800
-const U32 AGENT_CONTROL_FAST_UP             = 0x1 << CONTROL_FAST_UP_INDEX;         // 0x00001000
+constexpr U32 AGENT_CONTROL_FAST_AT             = 0x1 << CONTROL_FAST_AT_INDEX;         // 0x00000400
+constexpr U32 AGENT_CONTROL_FAST_LEFT           = 0x1 << CONTROL_FAST_LEFT_INDEX;       // 0x00000800
+constexpr U32 AGENT_CONTROL_FAST_UP             = 0x1 << CONTROL_FAST_UP_INDEX;         // 0x00001000
 
-const U32 AGENT_CONTROL_FLY                 = 0x1 << CONTROL_FLY_INDEX;             // 0x00002000
-const U32 AGENT_CONTROL_STOP                = 0x1 << CONTROL_STOP_INDEX;            // 0x00004000
-const U32 AGENT_CONTROL_FINISH_ANIM         = 0x1 << CONTROL_FINISH_ANIM_INDEX;     // 0x00008000
-const U32 AGENT_CONTROL_STAND_UP            = 0x1 << CONTROL_STAND_UP_INDEX;        // 0x00010000
-const U32 AGENT_CONTROL_SIT_ON_GROUND       = 0x1 << CONTROL_SIT_ON_GROUND_INDEX;   // 0x00020000
-const U32 AGENT_CONTROL_MOUSELOOK           = 0x1 << CONTROL_MOUSELOOK_INDEX;       // 0x00040000
+constexpr U32 AGENT_CONTROL_FLY                 = 0x1 << CONTROL_FLY_INDEX;             // 0x00002000
+constexpr U32 AGENT_CONTROL_STOP                = 0x1 << CONTROL_STOP_INDEX;            // 0x00004000
+constexpr U32 AGENT_CONTROL_FINISH_ANIM         = 0x1 << CONTROL_FINISH_ANIM_INDEX;     // 0x00008000
+constexpr U32 AGENT_CONTROL_STAND_UP            = 0x1 << CONTROL_STAND_UP_INDEX;        // 0x00010000
+constexpr U32 AGENT_CONTROL_SIT_ON_GROUND       = 0x1 << CONTROL_SIT_ON_GROUND_INDEX;   // 0x00020000
+constexpr U32 AGENT_CONTROL_MOUSELOOK           = 0x1 << CONTROL_MOUSELOOK_INDEX;       // 0x00040000
 
-const U32 AGENT_CONTROL_NUDGE_AT_POS        = 0x1 << CONTROL_NUDGE_AT_POS_INDEX;    // 0x00080000
-const U32 AGENT_CONTROL_NUDGE_AT_NEG        = 0x1 << CONTROL_NUDGE_AT_NEG_INDEX;    // 0x00100000
-const U32 AGENT_CONTROL_NUDGE_LEFT_POS      = 0x1 << CONTROL_NUDGE_LEFT_POS_INDEX;  // 0x00200000
-const U32 AGENT_CONTROL_NUDGE_LEFT_NEG      = 0x1 << CONTROL_NUDGE_LEFT_NEG_INDEX;  // 0x00400000
-const U32 AGENT_CONTROL_NUDGE_UP_POS        = 0x1 << CONTROL_NUDGE_UP_POS_INDEX;    // 0x00800000
-const U32 AGENT_CONTROL_NUDGE_UP_NEG        = 0x1 << CONTROL_NUDGE_UP_NEG_INDEX;    // 0x01000000
-const U32 AGENT_CONTROL_TURN_LEFT           = 0x1 << CONTROL_TURN_LEFT_INDEX;       // 0x02000000
-const U32 AGENT_CONTROL_TURN_RIGHT          = 0x1 << CONTROL_TURN_RIGHT_INDEX;      // 0x04000000
+constexpr U32 AGENT_CONTROL_NUDGE_AT_POS        = 0x1 << CONTROL_NUDGE_AT_POS_INDEX;    // 0x00080000
+constexpr U32 AGENT_CONTROL_NUDGE_AT_NEG        = 0x1 << CONTROL_NUDGE_AT_NEG_INDEX;    // 0x00100000
+constexpr U32 AGENT_CONTROL_NUDGE_LEFT_POS      = 0x1 << CONTROL_NUDGE_LEFT_POS_INDEX;  // 0x00200000
+constexpr U32 AGENT_CONTROL_NUDGE_LEFT_NEG      = 0x1 << CONTROL_NUDGE_LEFT_NEG_INDEX;  // 0x00400000
+constexpr U32 AGENT_CONTROL_NUDGE_UP_POS        = 0x1 << CONTROL_NUDGE_UP_POS_INDEX;    // 0x00800000
+constexpr U32 AGENT_CONTROL_NUDGE_UP_NEG        = 0x1 << CONTROL_NUDGE_UP_NEG_INDEX;    // 0x01000000
+constexpr U32 AGENT_CONTROL_TURN_LEFT           = 0x1 << CONTROL_TURN_LEFT_INDEX;       // 0x02000000
+constexpr U32 AGENT_CONTROL_TURN_RIGHT          = 0x1 << CONTROL_TURN_RIGHT_INDEX;      // 0x04000000
 
-const U32 AGENT_CONTROL_AWAY                = 0x1 << CONTROL_AWAY_INDEX;            // 0x08000000
+constexpr U32 AGENT_CONTROL_AWAY                = 0x1 << CONTROL_AWAY_INDEX;            // 0x08000000
 
-const U32 AGENT_CONTROL_LBUTTON_DOWN        = 0x1 << CONTROL_LBUTTON_DOWN_INDEX;    // 0x10000000
-const U32 AGENT_CONTROL_LBUTTON_UP          = 0x1 << CONTROL_LBUTTON_UP_INDEX;      // 0x20000000
-const U32 AGENT_CONTROL_ML_LBUTTON_DOWN     = 0x1 << CONTROL_ML_LBUTTON_DOWN_INDEX; // 0x40000000
-const U32 AGENT_CONTROL_ML_LBUTTON_UP       = ((U32)0x1) << CONTROL_ML_LBUTTON_UP_INDEX;    // 0x80000000
+constexpr U32 AGENT_CONTROL_LBUTTON_DOWN        = 0x1 << CONTROL_LBUTTON_DOWN_INDEX;    // 0x10000000
+constexpr U32 AGENT_CONTROL_LBUTTON_UP          = 0x1 << CONTROL_LBUTTON_UP_INDEX;      // 0x20000000
+constexpr U32 AGENT_CONTROL_ML_LBUTTON_DOWN     = 0x1 << CONTROL_ML_LBUTTON_DOWN_INDEX; // 0x40000000
+constexpr U32 AGENT_CONTROL_ML_LBUTTON_UP       = ((U32)0x1) << CONTROL_ML_LBUTTON_UP_INDEX;    // 0x80000000
 
 // move these up so that we can hide them in "State" for object updates
 // (for now)
-const U32 AGENT_ATTACH_OFFSET               = 4;
-const U32 AGENT_ATTACH_MASK                 = 0xf << AGENT_ATTACH_OFFSET;
+constexpr U32 AGENT_ATTACH_OFFSET               = 4;
+constexpr U32 AGENT_ATTACH_MASK                 = 0xf << AGENT_ATTACH_OFFSET;
 
 // RN: this method swaps the upper and lower nibbles to maintain backward
 // compatibility with old objects that only used the upper nibble
 #define ATTACHMENT_ID_FROM_STATE(state) ((S32)((((U8)state & AGENT_ATTACH_MASK) >> 4) | (((U8)state & ~AGENT_ATTACH_MASK) << 4)))
 
 // DO NOT CHANGE THE SEQUENCE OF THIS LIST!!
-const U8 CLICK_ACTION_NONE = 0;
-const U8 CLICK_ACTION_TOUCH = 0;
-const U8 CLICK_ACTION_SIT = 1;
-const U8 CLICK_ACTION_BUY = 2;
-const U8 CLICK_ACTION_PAY = 3;
-const U8 CLICK_ACTION_OPEN = 4;
-const U8 CLICK_ACTION_PLAY = 5;
-const U8 CLICK_ACTION_OPEN_MEDIA = 6;
-const U8 CLICK_ACTION_ZOOM = 7;
-const U8 CLICK_ACTION_DISABLED = 8;
-const U8 CLICK_ACTION_IGNORE = 9;
+constexpr U8 CLICK_ACTION_NONE = 0;
+constexpr U8 CLICK_ACTION_TOUCH = 0;
+constexpr U8 CLICK_ACTION_SIT = 1;
+constexpr U8 CLICK_ACTION_BUY = 2;
+constexpr U8 CLICK_ACTION_PAY = 3;
+constexpr U8 CLICK_ACTION_OPEN = 4;
+constexpr U8 CLICK_ACTION_PLAY = 5;
+constexpr U8 CLICK_ACTION_OPEN_MEDIA = 6;
+constexpr U8 CLICK_ACTION_ZOOM = 7;
+constexpr U8 CLICK_ACTION_DISABLED = 8;
+constexpr U8 CLICK_ACTION_IGNORE = 9;
 // DO NOT CHANGE THE SEQUENCE OF THIS LIST!!
 
 constexpr U32 BEACON_SHOW_MAP  = 0x0001;

--- a/indra/llcommon/lldefs.h
+++ b/indra/llcommon/lldefs.h
@@ -171,13 +171,13 @@ constexpr U32   MAXADDRSTR      = 17;       // 123.567.901.345 = 15 chars + \0 +
 
 // recursion tail
 template <typename T>
-inline auto llmax(T data)
+constexpr auto llmax(T data)
 {
     return data;
 }
 
 template <typename T0, typename T1, typename... Ts>
-inline auto llmax(T0 d0, T1 d1, Ts... rest)
+constexpr auto llmax(T0 d0, T1 d1, Ts... rest)
 {
     auto maxrest = llmax(d1, rest...);
     return (d0 > maxrest)? d0 : maxrest;
@@ -185,20 +185,20 @@ inline auto llmax(T0 d0, T1 d1, Ts... rest)
 
 // recursion tail
 template <typename T>
-inline auto llmin(T data)
+constexpr auto llmin(T data)
 {
     return data;
 }
 
 template <typename T0, typename T1, typename... Ts>
-inline auto llmin(T0 d0, T1 d1, Ts... rest)
+constexpr auto llmin(T0 d0, T1 d1, Ts... rest)
 {
     auto minrest = llmin(d1, rest...);
     return (d0 < minrest) ? d0 : minrest;
 }
 
 template <typename A, typename MIN, typename MAX>
-inline A llclamp(A a, MIN minval, MAX maxval)
+constexpr A llclamp(A a, MIN minval, MAX maxval)
 {
     A aminval{ static_cast<A>(minval) }, amaxval{ static_cast<A>(maxval) };
     if ( a < aminval )
@@ -213,13 +213,13 @@ inline A llclamp(A a, MIN minval, MAX maxval)
 }
 
 template <class LLDATATYPE>
-inline LLDATATYPE llclampf(LLDATATYPE a)
+constexpr LLDATATYPE llclampf(LLDATATYPE a)
 {
     return llmin(llmax(a, LLDATATYPE(0)), LLDATATYPE(1));
 }
 
 template <class LLDATATYPE>
-inline LLDATATYPE llclampb(LLDATATYPE a)
+constexpr LLDATATYPE llclampb(LLDATATYPE a)
 {
     return llmin(llmax(a, LLDATATYPE(0)), LLDATATYPE(255));
 }

--- a/indra/llcommon/stdtypes.h
+++ b/indra/llcommon/stdtypes.h
@@ -164,14 +164,14 @@ private:
     FROM mValue;
 
 public:
-    narrow(FROM value): mValue(value) {}
+    constexpr narrow(FROM value): mValue(value) {}
 
     /*---------------------- Narrowing unsigned to signed ----------------------*/
     template <typename TO,
               typename std::enable_if<std::is_unsigned<FROM>::value &&
                                       std::is_signed<TO>::value,
                                       bool>::type = true>
-    inline
+    constexpr
     operator TO() const
     {
         // The reason we skip the
@@ -189,7 +189,7 @@ public:
               typename std::enable_if<! (std::is_unsigned<FROM>::value &&
                                          std::is_signed<TO>::value),
                                       bool>::type = true>
-    inline
+    constexpr
     operator TO() const
     {
         // two different assert()s so we can tell which condition failed

--- a/indra/llmath/llcamera.h
+++ b/indra/llmath/llcamera.h
@@ -33,23 +33,23 @@
 #include "llplane.h"
 #include "llvector4a.h"
 
-const F32 DEFAULT_FIELD_OF_VIEW     = 60.f * DEG_TO_RAD;
-const F32 DEFAULT_ASPECT_RATIO      = 640.f / 480.f;
-const F32 DEFAULT_NEAR_PLANE        = 0.25f;
-const F32 DEFAULT_FAR_PLANE         = 64.f; // far reaches across two horizontal, not diagonal, regions
+constexpr F32 DEFAULT_FIELD_OF_VIEW = 60.f * DEG_TO_RAD;
+constexpr F32 DEFAULT_ASPECT_RATIO  = 640.f / 480.f;
+constexpr F32 DEFAULT_NEAR_PLANE    = 0.25f;
+constexpr F32 DEFAULT_FAR_PLANE     = 64.f; // far reaches across two horizontal, not diagonal, regions
 
-const F32 MAX_ASPECT_RATIO  = 50.0f;
-const F32 MAX_NEAR_PLANE    = 1023.9f; // Clamp the near plane just before the skybox ends
-const F32 MAX_FAR_PLANE     = 100000.0f; //1000000.0f; // Max allowed. Not good Z precision though.
-const F32 MAX_FAR_CLIP      = 512.0f;
+constexpr F32 MAX_ASPECT_RATIO  = 50.0f;
+constexpr F32 MAX_NEAR_PLANE    = 1023.9f;   // Clamp the near plane just before the skybox ends
+constexpr F32 MAX_FAR_PLANE     = 100000.0f; //1000000.0f; // Max allowed. Not good Z precision though.
+constexpr F32 MAX_FAR_CLIP      = 512.0f;
 
-const F32 MIN_ASPECT_RATIO  = 0.02f;
-const F32 MIN_NEAR_PLANE    = 0.1f;
-const F32 MIN_FAR_PLANE     = 0.2f;
+constexpr F32 MIN_ASPECT_RATIO  = 0.02f;
+constexpr F32 MIN_NEAR_PLANE    = 0.1f;
+constexpr F32 MIN_FAR_PLANE     = 0.2f;
 
 // Min/Max FOV values for square views. Call getMin/MaxView to get extremes based on current aspect ratio.
-static const F32 MIN_FIELD_OF_VIEW = 5.0f * DEG_TO_RAD;
-static const F32 MAX_FIELD_OF_VIEW = 175.f * DEG_TO_RAD;
+constexpr F32 MIN_FIELD_OF_VIEW = 5.0f * DEG_TO_RAD;
+constexpr F32 MAX_FIELD_OF_VIEW = 175.f * DEG_TO_RAD;
 
 // An LLCamera is an LLCoorFrame with a view frustum.
 // This means that it has several methods for moving it around

--- a/indra/llmath/llcoordframe.cpp
+++ b/indra/llmath/llcoordframe.cpp
@@ -26,7 +26,6 @@
 
 #include "linden_common.h"
 
-//#include "vmath.h"
 #include "v3math.h"
 #include "m3math.h"
 #include "v4math.h"

--- a/indra/llmath/llcoordframe.h
+++ b/indra/llmath/llcoordframe.h
@@ -61,7 +61,7 @@ public:
     //LLCoordFrame(const F32 *origin, const F32 *rotation); // Assumes "origin" is 1x3 and "rotation" is 1x9 array
     //LLCoordFrame(const F32 *origin_and_rotation);         // Assumes "origin_and_rotation" is 1x12 array
 
-    bool isFinite() { return mOrigin.isFinite() && mXAxis.isFinite() && mYAxis.isFinite() && mZAxis.isFinite(); }
+    bool isFinite() const { return mOrigin.isFinite() && mXAxis.isFinite() && mYAxis.isFinite() && mZAxis.isFinite(); }
 
     void reset();
     void resetAxes();

--- a/indra/llmath/llline.h
+++ b/indra/llmath/llline.h
@@ -33,7 +33,7 @@
 #include "stdtypes.h"
 #include "v3math.h"
 
-const F32 DEFAULT_INTERSECTION_ERROR = 0.000001f;
+constexpr F32 DEFAULT_INTERSECTION_ERROR = 0.000001f;
 
 class LLLine
 {

--- a/indra/llmath/llmath.h
+++ b/indra/llmath/llmath.h
@@ -39,18 +39,8 @@
 // llcommon depend on llmath.
 #include "is_approx_equal_fraction.h"
 
-// work around for Windows & older gcc non-standard function names.
-#if LL_WINDOWS
-#include <float.h>
-#define llisnan(val)    _isnan(val)
-#define llfinite(val)   _finite(val)
-#elif (LL_LINUX && __GNUC__ <= 2)
-#define llisnan(val)    isnan(val)
-#define llfinite(val)   isfinite(val)
-#else
-#define llisnan(val)    std::isnan(val)
-#define llfinite(val)   std::isfinite(val)
-#endif
+#define llisnan(val)  std::isnan(val)
+#define llfinite(val) std::isfinite(val)
 
 // Single Precision Floating Point Routines
 // (There used to be more defined here, but they appeared to be redundant and

--- a/indra/llmath/llmath.h
+++ b/indra/llmath/llmath.h
@@ -79,7 +79,7 @@ constexpr F32   GIMBAL_THRESHOLD = 0.000436f; // sets the gimballock threshold 0
 constexpr F32 FP_MAG_THRESHOLD = 0.0000001f;
 
 // TODO: Replace with logic like is_approx_equal
-inline bool is_approx_zero( F32 f ) { return (-F_APPROXIMATELY_ZERO < f) && (f < F_APPROXIMATELY_ZERO); }
+constexpr bool is_approx_zero(F32 f) { return (-F_APPROXIMATELY_ZERO < f) && (f < F_APPROXIMATELY_ZERO); }
 
 // These functions work by interpreting sign+exp+mantissa as an unsigned
 // integer.
@@ -138,33 +138,17 @@ inline F64 llabs(const F64 a)
     return F64(std::fabs(a));
 }
 
-inline S32 lltrunc( F32 f )
+constexpr S32 lltrunc(F32 f)
 {
-#if LL_WINDOWS && !defined( __INTEL_COMPILER ) && (ADDRESS_SIZE == 32)
-        // Avoids changing the floating point control word.
-        // Add or subtract 0.5 - epsilon and then round
-        const static U32 zpfp[] = { 0xBEFFFFFF, 0x3EFFFFFF };
-        S32 result;
-        __asm {
-            fld     f
-            mov     eax,    f
-            shr     eax,    29
-            and     eax,    4
-            fadd    dword ptr [zpfp + eax]
-            fistp   result
-        }
-        return result;
-#else
-        return (S32)f;
-#endif
+    return narrow(f);
 }
 
-inline S32 lltrunc( F64 f )
+constexpr S32 lltrunc(F64 f)
 {
-    return (S32)f;
+    return narrow(f);
 }
 
-inline S32 llfloor( F32 f )
+inline S32 llfloor(F32 f)
 {
 #if LL_WINDOWS && !defined( __INTEL_COMPILER ) && (ADDRESS_SIZE == 32)
         // Avoids changing the floating point control word.
@@ -274,7 +258,7 @@ constexpr F32 FAST_MAG_BETA = 0.397824734759f;
 //constexpr F32 FAST_MAG_ALPHA = 0.948059448969f;
 //constexpr F32 FAST_MAG_BETA = 0.392699081699f;
 
-inline F32 fastMagnitude(F32 a, F32 b)
+constexpr F32 fastMagnitude(F32 a, F32 b)
 {
     a = (a > 0) ? a : -a;
     b = (b > 0) ? b : -b;
@@ -332,7 +316,7 @@ inline F32 llfastpow(const F32 x, const F32 y)
 }
 
 
-inline F32 snap_to_sig_figs(F32 foo, S32 sig_figs)
+constexpr F32 snap_to_sig_figs(F32 foo, S32 sig_figs)
 {
     // compute the power of ten
     F32 bar = 1.f;
@@ -350,7 +334,7 @@ inline F32 snap_to_sig_figs(F32 foo, S32 sig_figs)
 
 using std::lerp;
 
-inline F32 lerp2d(F32 x00, F32 x01, F32 x10, F32 x11, F32 u, F32 v)
+constexpr F32 lerp2d(F32 x00, F32 x01, F32 x10, F32 x11, F32 u, F32 v)
 {
     F32 a = x00 + (x01-x00)*u;
     F32 b = x10 + (x11-x10)*u;
@@ -358,17 +342,17 @@ inline F32 lerp2d(F32 x00, F32 x01, F32 x10, F32 x11, F32 u, F32 v)
     return r;
 }
 
-inline F32 ramp(F32 x, F32 a, F32 b)
+constexpr F32 ramp(F32 x, F32 a, F32 b)
 {
     return (a == b) ? 0.0f : ((a - x) / (a - b));
 }
 
-inline F32 rescale(F32 x, F32 x1, F32 x2, F32 y1, F32 y2)
+constexpr F32 rescale(F32 x, F32 x1, F32 x2, F32 y1, F32 y2)
 {
     return lerp(y1, y2, ramp(x, x1, x2));
 }
 
-inline F32 clamp_rescale(F32 x, F32 x1, F32 x2, F32 y1, F32 y2)
+constexpr F32 clamp_rescale(F32 x, F32 x1, F32 x2, F32 y1, F32 y2)
 {
     if (y1 < y2)
     {
@@ -381,7 +365,7 @@ inline F32 clamp_rescale(F32 x, F32 x1, F32 x2, F32 y1, F32 y2)
 }
 
 
-inline F32 cubic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
+constexpr F32 cubic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
 {
     if (x <= x0)
         return s0;
@@ -394,14 +378,14 @@ inline F32 cubic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
     return  s0 + (s1 - s0) * (f * f) * (3.0f - 2.0f * f);
 }
 
-inline F32 cubic_step( F32 x )
+constexpr F32 cubic_step( F32 x )
 {
     x = llclampf(x);
 
     return  (x * x) * (3.0f - 2.0f * x);
 }
 
-inline F32 quadratic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
+constexpr F32 quadratic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
 {
     if (x <= x0)
         return s0;
@@ -415,7 +399,7 @@ inline F32 quadratic_step( F32 x, F32 x0, F32 x1, F32 s0, F32 s1 )
     return  (s0 * (1.f - f_squared)) + ((s1 - s0) * f_squared);
 }
 
-inline F32 llsimple_angle(F32 angle)
+constexpr F32 llsimple_angle(F32 angle)
 {
     while(angle <= -F_PI)
         angle += F_TWO_PI;
@@ -425,7 +409,7 @@ inline F32 llsimple_angle(F32 angle)
 }
 
 //SDK - Renamed this to get_lower_power_two, since this is what this actually does.
-inline U32 get_lower_power_two(U32 val, U32 max_power_two)
+constexpr U32 get_lower_power_two(U32 val, U32 max_power_two)
 {
     if(!max_power_two)
     {
@@ -447,7 +431,7 @@ inline U32 get_lower_power_two(U32 val, U32 max_power_two)
 // number of digits, then add one.  We subtract 1 initially to handle
 // the case where the number passed in is actually a power of two.
 // WARNING: this only works with 32 bit ints.
-inline U32 get_next_power_two(U32 val, U32 max_power_two)
+constexpr U32 get_next_power_two(U32 val, U32 max_power_two)
 {
     if(!max_power_two)
     {
@@ -473,7 +457,7 @@ inline U32 get_next_power_two(U32 val, U32 max_power_two)
 //get the gaussian value given the linear distance from axis x and guassian value o
 inline F32 llgaussian(F32 x, F32 o)
 {
-    return 1.f/(F_SQRT_TWO_PI*o)*powf(F_E, -(x*x)/(2*o*o));
+    return 1.f/(F_SQRT_TWO_PI*o)*powf(F_E, -(x*x)/(2.f*o*o));
 }
 
 //helper function for removing outliers
@@ -526,7 +510,8 @@ inline void ll_remove_outliers(std::vector<VEC_TYPE>& data, F32 k)
 // Note: in our code, values labeled as sRGB are ALWAYS gamma corrected linear values, NOT linear values with monitor gamma applied
 // Note: stored color values should always be gamma corrected linear (i.e. the values returned from an on-screen color swatch)
 // Note: DO NOT cache the conversion.  This leads to error prone synchronization and is actually slower in the typical case due to cache misses
-inline float linearTosRGB(const float val) {
+inline float linearTosRGB(const float val)
+{
     if (val < 0.0031308f) {
         return val * 12.92f;
     }
@@ -541,7 +526,8 @@ inline float linearTosRGB(const float val) {
 // Note: Stored color values should generally be gamma corrected sRGB.
 //       If you're serializing the return value of this function, you're probably doing it wrong.
 // Note: DO NOT cache the conversion.  This leads to error prone synchronization and is actually slower in the typical case due to cache misses.
-inline float sRGBtoLinear(const float val) {
+inline float sRGBtoLinear(const float val)
+{
     if (val < 0.04045f) {
         return val / 12.92f;
     }

--- a/indra/llmath/llmath.h
+++ b/indra/llmath/llmath.h
@@ -348,10 +348,7 @@ inline F32 snap_to_sig_figs(F32 foo, S32 sig_figs)
     return new_foo;
 }
 
-inline F32 lerp(F32 a, F32 b, F32 u)
-{
-    return a + ((b - a) * u);
-}
+using std::lerp;
 
 inline F32 lerp2d(F32 x00, F32 x01, F32 x10, F32 x11, F32 u, F32 v)
 {

--- a/indra/llmath/llquaternion.cpp
+++ b/indra/llmath/llquaternion.cpp
@@ -30,7 +30,6 @@
 
 #include "llquaternion.h"
 
-//#include "vmath.h"
 #include "v3math.h"
 #include "v3dmath.h"
 #include "v4math.h"

--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -1294,10 +1294,11 @@ void LLPath::genNGon(const LLPathParams& params, S32 sides, F32 startOff, F32 en
     c       = cos(ang)*lerp(radius_start, radius_end, t);
 
 
-    pt->mPos.set(0 + lerp(0,params.getShear().mV[0],s)
+    pt->mPos.set(0 + lerp(0.f, params.getShear().mV[VX], s)
                       + lerp(-skew ,skew, t) * 0.5f,
-                    c + lerp(0,params.getShear().mV[1],s),
+                    c + lerp(0.f, params.getShear().mV[VY], s),
                     s);
+
     pt->mScale.set(hole_x * lerp(taper_x_begin, taper_x_end, t),
         hole_y * lerp(taper_y_begin, taper_y_end, t),
         0,1);
@@ -1327,9 +1328,9 @@ void LLPath::genNGon(const LLPathParams& params, S32 sides, F32 startOff, F32 en
         c   = cos(ang)*lerp(radius_start, radius_end, t);
         s   = sin(ang)*lerp(radius_start, radius_end, t);
 
-        pt->mPos.set(0 + lerp(0,params.getShear().mV[0],s)
+        pt->mPos.set(0 + lerp(0.f, params.getShear().mV[VX], s)
                           + lerp(-skew ,skew, t) * 0.5f,
-                        c + lerp(0,params.getShear().mV[1],s),
+                        c + lerp(0.f, params.getShear().mV[VY], s),
                         s);
 
         pt->mScale.set(hole_x * lerp(taper_x_begin, taper_x_end, t),
@@ -1354,9 +1355,9 @@ void LLPath::genNGon(const LLPathParams& params, S32 sides, F32 startOff, F32 en
     c   = cos(ang)*lerp(radius_start, radius_end, t);
     s   = sin(ang)*lerp(radius_start, radius_end, t);
 
-    pt->mPos.set(0 + lerp(0,params.getShear().mV[0],s)
+    pt->mPos.set(0 + lerp(0.f, params.getShear().mV[VX], s)
                       + lerp(-skew ,skew, t) * 0.5f,
-                    c + lerp(0,params.getShear().mV[1],s),
+                    c + lerp(0.f, params.getShear().mV[VY], s),
                     s);
     pt->mScale.set(hole_x * lerp(taper_x_begin, taper_x_end, t),
                    hole_y * lerp(taper_y_begin, taper_y_end, t),
@@ -1494,8 +1495,8 @@ bool LLPath::generate(const LLPathParams& params, F32 detail, S32 split,
             for (S32 i=0;i<np;i++)
             {
                 F32 t = lerp(params.getBegin(),params.getEnd(),(F32)i * mStep);
-                mPath[i].mPos.set(lerp(0,params.getShear().mV[0],t),
-                                     lerp(0,params.getShear().mV[1],t),
+                mPath[i].mPos.set(lerp(0.f, params.getShear().mV[VX], t),
+                                     lerp(0.f ,params.getShear().mV[VY], t),
                                      t - 0.5f);
                 LLQuaternion quat;
                 quat.setQuat(lerp(F_PI * params.getTwistBegin(),F_PI * params.getTwist(),t),0,0,1);
@@ -1559,10 +1560,10 @@ bool LLPath::generate(const LLPathParams& params, F32 detail, S32 split,
         {
             F32 t = (F32)i * mStep;
             mPath[i].mPos.set(0,
-                                lerp(0,   -sin(F_PI*params.getTwist()*t)*0.5f,t),
-                                lerp(-0.5f, cos(F_PI*params.getTwist()*t)*0.5f,t));
-            mPath[i].mScale.set(lerp(1,params.getScale().mV[0],t),
-                                lerp(1,params.getScale().mV[1],t), 0,1);
+                                lerp(0.f,  -sin(F_PI*params.getTwist() * t) * 0.5f, t),
+                                lerp(-0.5f, cos(F_PI*params.getTwist() * t) * 0.5f, t));
+            mPath[i].mScale.set(lerp(1.f, params.getScale().mV[VX], t),
+                                lerp(1.f, params.getScale().mV[VY], t), 0.f, 1.f);
             mPath[i].mTexT  = t;
             LLQuaternion quat;
             quat.setQuat(F_PI * params.getTwist() * t,1,0,0);

--- a/indra/llmath/llvolume.h
+++ b/indra/llmath/llvolume.h
@@ -45,7 +45,6 @@ class LLVolumeOctree;
 
 #include "lluuid.h"
 #include "v4color.h"
-//#include "vmath.h"
 #include "v2math.h"
 #include "v3math.h"
 #include "v3dmath.h"

--- a/indra/llmath/m3math.cpp
+++ b/indra/llmath/m3math.cpp
@@ -26,7 +26,6 @@
 
 #include "linden_common.h"
 
-//#include "vmath.h"
 #include "v3math.h"
 #include "v3dmath.h"
 #include "v4math.h"

--- a/indra/llmath/m4math.cpp
+++ b/indra/llmath/m4math.cpp
@@ -26,7 +26,6 @@
 
 #include "linden_common.h"
 
-//#include "vmath.h"
 #include "v3math.h"
 #include "v4math.h"
 #include "m4math.h"

--- a/indra/llmath/v2math.cpp
+++ b/indra/llmath/v2math.cpp
@@ -26,7 +26,6 @@
 
 #include "linden_common.h"
 
-//#include "vmath.h"
 #include "v2math.h"
 #include "v3math.h"
 #include "v4math.h"
@@ -47,8 +46,8 @@ bool LLVector2::abs()
 {
     bool ret{ false };
 
-    if (mV[0] < 0.f) { mV[0] = -mV[0]; ret = true; }
-    if (mV[1] < 0.f) { mV[1] = -mV[1]; ret = true; }
+    if (mV[VX] < 0.f) { mV[VX] = -mV[VX]; ret = true; }
+    if (mV[VY] < 0.f) { mV[VY] = -mV[VY]; ret = true; }
 
     return ret;
 }
@@ -67,14 +66,14 @@ F32 angle_between(const LLVector2& a, const LLVector2& b)
     return angle;
 }
 
-bool are_parallel(const LLVector2 &a, const LLVector2 &b, float epsilon)
+bool are_parallel(const LLVector2& a, const LLVector2& b, F32 epsilon)
 {
     LLVector2 an = a;
     LLVector2 bn = b;
     an.normVec();
     bn.normVec();
     F32 dot = an * bn;
-    if ( (1.0f - fabs(dot)) < epsilon)
+    if ((1.0f - fabs(dot)) < epsilon)
     {
         return true;
     }
@@ -82,28 +81,28 @@ bool are_parallel(const LLVector2 &a, const LLVector2 &b, float epsilon)
 }
 
 
-F32 dist_vec(const LLVector2 &a, const LLVector2 &b)
+F32 dist_vec(const LLVector2& a, const LLVector2& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
     return (F32) sqrt( x*x + y*y );
 }
 
-F32 dist_vec_squared(const LLVector2 &a, const LLVector2 &b)
+F32 dist_vec_squared(const LLVector2& a, const LLVector2& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
     return x*x + y*y;
 }
 
-F32 dist_vec_squared2D(const LLVector2 &a, const LLVector2 &b)
+F32 dist_vec_squared2D(const LLVector2& a, const LLVector2& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
     return x*x + y*y;
 }
 
-LLVector2 lerp(const LLVector2 &a, const LLVector2 &b, F32 u)
+LLVector2 lerp(const LLVector2& a, const LLVector2& b, F32 u)
 {
     return LLVector2(
         a.mV[VX] + (b.mV[VX] - a.mV[VX]) * u,
@@ -113,14 +112,14 @@ LLVector2 lerp(const LLVector2 &a, const LLVector2 &b, F32 u)
 LLSD LLVector2::getValue() const
 {
     LLSD ret;
-    ret[0] = mV[0];
-    ret[1] = mV[1];
+    ret[VX] = mV[VX];
+    ret[VY] = mV[VY];
     return ret;
 }
 
 void LLVector2::setValue(const LLSD& sd)
 {
-    mV[0] = (F32) sd[0].asReal();
-    mV[1] = (F32) sd[1].asReal();
+    mV[VX] = (F32) sd[0].asReal();
+    mV[VY] = (F32) sd[1].asReal();
 }
 

--- a/indra/llmath/v2math.h
+++ b/indra/llmath/v2math.h
@@ -36,7 +36,7 @@ class LLQuaternion;
 
 //  Llvector2 = |x y z w|
 
-static const U32 LENGTHOFVECTOR2 = 2;
+static constexpr U32 LENGTHOFVECTOR2 = 2;
 
 class LLVector2
 {
@@ -82,7 +82,7 @@ class LLVector2
 
         const LLVector2&    scaleVec(const LLVector2& vec);             // scales per component by vec
 
-        bool isNull();          // Returns true if vector has a _very_small_ length
+        bool isNull() const;          // Returns true if vector has a _very_small_ length
         bool isExactlyZero() const      { return !mV[VX] && !mV[VY]; }
 
         F32 operator[](int idx) const { return mV[idx]; }
@@ -113,16 +113,16 @@ class LLVector2
 
 // Non-member functions
 
-F32 angle_between(const LLVector2 &a, const LLVector2 &b);  // Returns angle (radians) between a and b
-bool are_parallel(const LLVector2 &a, const LLVector2 &b, F32 epsilon=F_APPROXIMATELY_ZERO);    // Returns true if a and b are very close to parallel
-F32 dist_vec(const LLVector2 &a, const LLVector2 &b);       // Returns distance between a and b
-F32 dist_vec_squared(const LLVector2 &a, const LLVector2 &b);// Returns distance squared between a and b
-F32 dist_vec_squared2D(const LLVector2 &a, const LLVector2 &b);// Returns distance squared between a and b ignoring Z component
-LLVector2 lerp(const LLVector2 &a, const LLVector2 &b, F32 u); // Returns a vector that is a linear interpolation between a and b
+F32 angle_between(const LLVector2& a, const LLVector2& b);  // Returns angle (radians) between a and b
+bool are_parallel(const LLVector2& a, const LLVector2& b, F32 epsilon = F_APPROXIMATELY_ZERO);    // Returns true if a and b are very close to parallel
+F32 dist_vec(const LLVector2& a, const LLVector2& b);       // Returns distance between a and b
+F32 dist_vec_squared(const LLVector2& a, const LLVector2& b);// Returns distance squared between a and b
+F32 dist_vec_squared2D(const LLVector2& a, const LLVector2& b);// Returns distance squared between a and b ignoring Z component
+LLVector2 lerp(const LLVector2& a, const LLVector2& b, F32 u); // Returns a vector that is a linear interpolation between a and b
 
 // Constructors
 
-inline LLVector2::LLVector2(void)
+inline LLVector2::LLVector2()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
@@ -153,27 +153,27 @@ inline LLVector2::LLVector2(const LLSD &sd)
 
 // Clear and Assignment Functions
 
-inline void LLVector2::clear(void)
+inline void LLVector2::clear()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
 }
 
-inline void LLVector2::setZero(void)
-{
-    mV[VX] = 0.f;
-    mV[VY] = 0.f;
-}
-
-// deprecated
-inline void LLVector2::clearVec(void)
+inline void LLVector2::setZero()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
 }
 
 // deprecated
-inline void LLVector2::zeroVec(void)
+inline void LLVector2::clearVec()
+{
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+}
+
+// deprecated
+inline void LLVector2::zeroVec()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
@@ -222,31 +222,31 @@ inline void LLVector2::setVec(const F32 *vec)
 
 // LLVector2 Magnitude and Normalization Functions
 
-inline F32 LLVector2::length(void) const
+inline F32 LLVector2::length() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY]);
 }
 
-inline F32 LLVector2::lengthSquared(void) const
+inline F32 LLVector2::lengthSquared() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1];
+    return mV[VX]*mV[VX] + mV[VY]*mV[VY];
 }
 
-inline F32 LLVector2::normalize(void)
+inline F32 LLVector2::normalize()
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1]);
+    F32 mag = sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
+        mV[VX] *= oomag;
+        mV[VY] *= oomag;
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
         mag = 0;
     }
     return (mag);
@@ -259,33 +259,33 @@ inline bool LLVector2::isFinite() const
 }
 
 // deprecated
-inline F32      LLVector2::magVec(void) const
+inline F32 LLVector2::magVec() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY]);
 }
 
 // deprecated
-inline F32      LLVector2::magVecSquared(void) const
+inline F32 LLVector2::magVecSquared() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1];
+    return mV[VX]*mV[VX] + mV[VY]*mV[VY];
 }
 
 // deprecated
-inline F32      LLVector2::normVec(void)
+inline F32 LLVector2::normVec()
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1]);
+    F32 mag = sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
+        mV[VX] *= oomag;
+        mV[VY] *= oomag;
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
         mag = 0;
     }
     return (mag);
@@ -299,9 +299,9 @@ inline const LLVector2& LLVector2::scaleVec(const LLVector2& vec)
     return *this;
 }
 
-inline bool LLVector2::isNull()
+inline bool LLVector2::isNull() const
 {
-    if ( F_APPROXIMATELY_ZERO > mV[VX]*mV[VX] + mV[VY]*mV[VY] )
+    if (F_APPROXIMATELY_ZERO > mV[VX]*mV[VX] + mV[VY]*mV[VY])
     {
         return true;
     }
@@ -312,9 +312,9 @@ inline bool LLVector2::isNull()
 // LLVector2 Operators
 
 // For sorting. By convention, x is "more significant" than y.
-inline bool operator<(const LLVector2 &a, const LLVector2 &b)
+inline bool operator<(const LLVector2& a, const LLVector2& b)
 {
-    if( a.mV[VX] == b.mV[VX] )
+    if (a.mV[VX] == b.mV[VX])
     {
         return a.mV[VY] < b.mV[VY];
     }
@@ -325,95 +325,95 @@ inline bool operator<(const LLVector2 &a, const LLVector2 &b)
 }
 
 
-inline LLVector2 operator+(const LLVector2 &a, const LLVector2 &b)
+inline LLVector2 operator+(const LLVector2& a, const LLVector2& b)
 {
     LLVector2 c(a);
     return c += b;
 }
 
-inline LLVector2 operator-(const LLVector2 &a, const LLVector2 &b)
+inline LLVector2 operator-(const LLVector2& a, const LLVector2& b)
 {
     LLVector2 c(a);
     return c -= b;
 }
 
-inline F32  operator*(const LLVector2 &a, const LLVector2 &b)
+inline F32 operator*(const LLVector2& a, const LLVector2& b)
 {
-    return (a.mV[0]*b.mV[0] + a.mV[1]*b.mV[1]);
+    return (a.mV[VX]*b.mV[VX] + a.mV[VY]*b.mV[VY]);
 }
 
-inline LLVector2 operator%(const LLVector2 &a, const LLVector2 &b)
+inline LLVector2 operator%(const LLVector2& a, const LLVector2& b)
 {
-    return LLVector2(a.mV[0]*b.mV[1] - b.mV[0]*a.mV[1], a.mV[1]*b.mV[0] - b.mV[1]*a.mV[0]);
+    return LLVector2(a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY], a.mV[VY]*b.mV[VX] - b.mV[VY]*a.mV[VX]);
 }
 
-inline LLVector2 operator/(const LLVector2 &a, F32 k)
+inline LLVector2 operator/(const LLVector2& a, F32 k)
 {
     F32 t = 1.f / k;
-    return LLVector2( a.mV[0] * t, a.mV[1] * t );
+    return LLVector2( a.mV[VX] * t, a.mV[VY] * t );
 }
 
-inline LLVector2 operator*(const LLVector2 &a, F32 k)
+inline LLVector2 operator*(const LLVector2& a, F32 k)
 {
-    return LLVector2( a.mV[0] * k, a.mV[1] * k );
+    return LLVector2( a.mV[VX] * k, a.mV[VY] * k );
 }
 
-inline LLVector2 operator*(F32 k, const LLVector2 &a)
+inline LLVector2 operator*(F32 k, const LLVector2& a)
 {
-    return LLVector2( a.mV[0] * k, a.mV[1] * k );
+    return LLVector2( a.mV[VX] * k, a.mV[VY] * k );
 }
 
-inline bool operator==(const LLVector2 &a, const LLVector2 &b)
+inline bool operator==(const LLVector2& a, const LLVector2& b)
 {
-    return (  (a.mV[0] == b.mV[0])
-            &&(a.mV[1] == b.mV[1]));
+    return (  (a.mV[VX] == b.mV[VX])
+            &&(a.mV[VY] == b.mV[VY]));
 }
 
-inline bool operator!=(const LLVector2 &a, const LLVector2 &b)
+inline bool operator!=(const LLVector2& a, const LLVector2& b)
 {
-    return (  (a.mV[0] != b.mV[0])
-            ||(a.mV[1] != b.mV[1]));
+    return (  (a.mV[VX] != b.mV[VX])
+            ||(a.mV[VY] != b.mV[VY]));
 }
 
-inline const LLVector2& operator+=(LLVector2 &a, const LLVector2 &b)
+inline const LLVector2& operator+=(LLVector2& a, const LLVector2& b)
 {
-    a.mV[0] += b.mV[0];
-    a.mV[1] += b.mV[1];
+    a.mV[VX] += b.mV[VX];
+    a.mV[VY] += b.mV[VY];
     return a;
 }
 
-inline const LLVector2& operator-=(LLVector2 &a, const LLVector2 &b)
+inline const LLVector2& operator-=(LLVector2& a, const LLVector2& b)
 {
-    a.mV[0] -= b.mV[0];
-    a.mV[1] -= b.mV[1];
+    a.mV[VX] -= b.mV[VX];
+    a.mV[VY] -= b.mV[VY];
     return a;
 }
 
-inline const LLVector2& operator%=(LLVector2 &a, const LLVector2 &b)
+inline const LLVector2& operator%=(LLVector2& a, const LLVector2& b)
 {
-    LLVector2 ret(a.mV[0]*b.mV[1] - b.mV[0]*a.mV[1], a.mV[1]*b.mV[0] - b.mV[1]*a.mV[0]);
+    LLVector2 ret(a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY], a.mV[VY]*b.mV[VX] - b.mV[VY]*a.mV[VX]);
     a = ret;
     return a;
 }
 
-inline const LLVector2& operator*=(LLVector2 &a, F32 k)
+inline const LLVector2& operator*=(LLVector2& a, F32 k)
 {
-    a.mV[0] *= k;
-    a.mV[1] *= k;
+    a.mV[VX] *= k;
+    a.mV[VY] *= k;
     return a;
 }
 
-inline const LLVector2& operator/=(LLVector2 &a, F32 k)
+inline const LLVector2& operator/=(LLVector2& a, F32 k)
 {
     F32 t = 1.f / k;
-    a.mV[0] *= t;
-    a.mV[1] *= t;
+    a.mV[VX] *= t;
+    a.mV[VY] *= t;
     return a;
 }
 
-inline LLVector2 operator-(const LLVector2 &a)
+inline LLVector2 operator-(const LLVector2& a)
 {
-    return LLVector2( -a.mV[0], -a.mV[1] );
+    return LLVector2( -a.mV[VX], -a.mV[VY] );
 }
 
 inline void update_min_max(LLVector2& min, LLVector2& max, const LLVector2& pos)
@@ -431,7 +431,7 @@ inline void update_min_max(LLVector2& min, LLVector2& max, const LLVector2& pos)
     }
 }
 
-inline std::ostream& operator<<(std::ostream& s, const LLVector2 &a)
+inline std::ostream& operator<<(std::ostream& s, const LLVector2& a)
 {
     s << "{ " << a.mV[VX] << ", " << a.mV[VY] << " }";
     return s;

--- a/indra/llmath/v3color.cpp
+++ b/indra/llmath/v3color.cpp
@@ -32,74 +32,79 @@
 
 LLColor3 LLColor3::white(1.0f, 1.0f, 1.0f);
 LLColor3 LLColor3::black(0.0f, 0.0f, 0.0f);
-LLColor3 LLColor3::grey (0.5f, 0.5f, 0.5f);
+LLColor3 LLColor3::grey(0.5f, 0.5f, 0.5f);
 
-LLColor3::LLColor3(const LLColor4 &a)
+LLColor3::LLColor3(const LLColor4& a)
 {
-    mV[0] = a.mV[0];
-    mV[1] = a.mV[1];
-    mV[2] = a.mV[2];
+    mV[VRED]   = a.mV[VRED];
+    mV[VGREEN] = a.mV[VGREEN];
+    mV[VBLUE]  = a.mV[VBLUE];
 }
 
-LLColor3::LLColor3(const LLVector4 &a)
+LLColor3::LLColor3(const LLVector4& a)
 {
-    mV[0] = a.mV[0];
-    mV[1] = a.mV[1];
-    mV[2] = a.mV[2];
+    mV[VRED]   = a.mV[VRED];
+    mV[VGREEN] = a.mV[VGREEN];
+    mV[VBLUE]  = a.mV[VBLUE];
 }
 
-LLColor3::LLColor3(const LLSD &sd)
+LLColor3::LLColor3(const LLSD& sd)
 {
     setValue(sd);
 }
 
-const LLColor3& LLColor3::operator=(const LLColor4 &a)
+const LLColor3& LLColor3::operator=(const LLColor4& a)
 {
-    mV[0] = a.mV[0];
-    mV[1] = a.mV[1];
-    mV[2] = a.mV[2];
+    mV[VRED]   = a.mV[VRED];
+    mV[VGREEN] = a.mV[VGREEN];
+    mV[VBLUE]  = a.mV[VBLUE];
     return (*this);
 }
 
-std::ostream& operator<<(std::ostream& s, const LLColor3 &a)
+std::ostream& operator<<(std::ostream& s, const LLColor3& a)
 {
     s << "{ " << a.mV[VRED] << ", " << a.mV[VGREEN] << ", " << a.mV[VBLUE] << " }";
     return s;
 }
 
-static F32 hueToRgb ( F32 val1In, F32 val2In, F32 valHUeIn )
+static F32 hueToRgb(F32 val1In, F32 val2In, F32 valHUeIn)
 {
-    if ( valHUeIn < 0.0f ) valHUeIn += 1.0f;
-    if ( valHUeIn > 1.0f ) valHUeIn -= 1.0f;
-    if ( ( 6.0f * valHUeIn ) < 1.0f ) return ( val1In + ( val2In - val1In ) * 6.0f * valHUeIn );
-    if ( ( 2.0f * valHUeIn ) < 1.0f ) return ( val2In );
-    if ( ( 3.0f * valHUeIn ) < 2.0f ) return ( val1In + ( val2In - val1In ) * ( ( 2.0f / 3.0f ) - valHUeIn ) * 6.0f );
-    return ( val1In );
+    if (valHUeIn < 0.0f)
+        valHUeIn += 1.0f;
+    if (valHUeIn > 1.0f)
+        valHUeIn -= 1.0f;
+    if ((6.0f * valHUeIn) < 1.0f)
+        return (val1In + (val2In - val1In) * 6.0f * valHUeIn);
+    if ((2.0f * valHUeIn) < 1.0f)
+        return (val2In);
+    if ((3.0f * valHUeIn) < 2.0f)
+        return (val1In + (val2In - val1In) * ((2.0f / 3.0f) - valHUeIn) * 6.0f);
+    return (val1In);
 }
 
-void LLColor3::setHSL ( F32 hValIn, F32 sValIn, F32 lValIn)
+void LLColor3::setHSL(F32 hValIn, F32 sValIn, F32 lValIn)
 {
-    if ( sValIn < 0.00001f )
+    if (sValIn < 0.00001f)
     {
-        mV[VRED] = lValIn;
+        mV[VRED]   = lValIn;
         mV[VGREEN] = lValIn;
-        mV[VBLUE] = lValIn;
+        mV[VBLUE]  = lValIn;
     }
     else
     {
         F32 interVal1;
         F32 interVal2;
 
-        if ( lValIn < 0.5f )
-            interVal2 = lValIn * ( 1.0f + sValIn );
+        if (lValIn < 0.5f)
+            interVal2 = lValIn * (1.0f + sValIn);
         else
-            interVal2 = ( lValIn + sValIn ) - ( sValIn * lValIn );
+            interVal2 = (lValIn + sValIn) - (sValIn * lValIn);
 
         interVal1 = 2.0f * lValIn - interVal2;
 
-        mV[VRED] = hueToRgb ( interVal1, interVal2, hValIn + ( 1.f / 3.f ) );
-        mV[VGREEN] = hueToRgb ( interVal1, interVal2, hValIn );
-        mV[VBLUE] = hueToRgb ( interVal1, interVal2, hValIn - ( 1.f / 3.f ) );
+        mV[VRED]   = hueToRgb(interVal1, interVal2, hValIn + (1.f / 3.f));
+        mV[VGREEN] = hueToRgb(interVal1, interVal2, hValIn);
+        mV[VBLUE]  = hueToRgb(interVal1, interVal2, hValIn - (1.f / 3.f));
     }
 }
 
@@ -109,45 +114,48 @@ void LLColor3::calcHSL(F32* hue, F32* saturation, F32* luminance) const
     F32 var_G = mV[VGREEN];
     F32 var_B = mV[VBLUE];
 
-    F32 var_Min = ( var_R < ( var_G < var_B ? var_G : var_B ) ? var_R : ( var_G < var_B ? var_G : var_B ) );
-    F32 var_Max = ( var_R > ( var_G > var_B ? var_G : var_B ) ? var_R : ( var_G > var_B ? var_G : var_B ) );
+    F32 var_Min = (var_R < (var_G < var_B ? var_G : var_B) ? var_R : (var_G < var_B ? var_G : var_B));
+    F32 var_Max = (var_R > (var_G > var_B ? var_G : var_B) ? var_R : (var_G > var_B ? var_G : var_B));
 
     F32 del_Max = var_Max - var_Min;
 
-    F32 L = ( var_Max + var_Min ) / 2.0f;
+    F32 L = (var_Max + var_Min) / 2.0f;
     F32 H = 0.0f;
     F32 S = 0.0f;
 
-    if ( del_Max == 0.0f )
+    if (del_Max == 0.0f)
     {
-       H = 0.0f;
-       S = 0.0f;
+        H = 0.0f;
+        S = 0.0f;
     }
     else
     {
-        if ( L < 0.5 )
-            S = del_Max / ( var_Max + var_Min );
+        if (L < 0.5)
+            S = del_Max / (var_Max + var_Min);
         else
-            S = del_Max / ( 2.0f - var_Max - var_Min );
+            S = del_Max / (2.0f - var_Max - var_Min);
 
-        F32 del_R = ( ( ( var_Max - var_R ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
-        F32 del_G = ( ( ( var_Max - var_G ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
-        F32 del_B = ( ( ( var_Max - var_B ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
+        F32 del_R = (((var_Max - var_R) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+        F32 del_G = (((var_Max - var_G) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+        F32 del_B = (((var_Max - var_B) / 6.0f) + (del_Max / 2.0f)) / del_Max;
 
-        if ( var_R >= var_Max )
+        if (var_R >= var_Max)
             H = del_B - del_G;
-        else
-        if ( var_G >= var_Max )
-            H = ( 1.0f / 3.0f ) + del_R - del_B;
-        else
-        if ( var_B >= var_Max )
-            H = ( 2.0f / 3.0f ) + del_G - del_R;
+        else if (var_G >= var_Max)
+            H = (1.0f / 3.0f) + del_R - del_B;
+        else if (var_B >= var_Max)
+            H = (2.0f / 3.0f) + del_G - del_R;
 
-        if ( H < 0.0f ) H += 1.0f;
-        if ( H > 1.0f ) H -= 1.0f;
+        if (H < 0.0f)
+            H += 1.0f;
+        if (H > 1.0f)
+            H -= 1.0f;
     }
 
-    if (hue) *hue = H;
-    if (saturation) *saturation = S;
-    if (luminance) *luminance = L;
+    if (hue)
+        *hue = H;
+    if (saturation)
+        *saturation = S;
+    if (luminance)
+        *luminance = L;
 }

--- a/indra/llmath/v3color.h
+++ b/indra/llmath/v3color.h
@@ -33,12 +33,12 @@ class LLVector4;
 #include "llerror.h"
 #include "llmath.h"
 #include "llsd.h"
-#include "v3math.h"  // needed for linearColor3v implemtation below
+#include "v3math.h" // needed for linearColor3v implemtation below
 #include <string.h>
 
 //  LLColor3 = |r g b|
 
-static const U32 LENGTHOFCOLOR3 = 3;
+static constexpr U32 LENGTHOFCOLOR3 = 3;
 
 class LLColor3
 {
@@ -50,44 +50,43 @@ public:
     static LLColor3 grey;
 
 public:
-    LLColor3();                         // Initializes LLColor3 to (0, 0, 0)
-    LLColor3(F32 r, F32 g, F32 b);      // Initializes LLColor3 to (r, g, b)
-    LLColor3(const F32 *vec);           // Initializes LLColor3 to (vec[0]. vec[1], vec[2])
-    LLColor3(const char *color_string);       // html format color ie "#FFDDEE"
-    explicit LLColor3(const LLColor4& color4);  // "explicit" to avoid automatic conversion
-    explicit LLColor3(const LLVector4& vector4);  // "explicit" to avoid automatic conversion
+    LLColor3();                                  // Initializes LLColor3 to (0, 0, 0)
+    LLColor3(F32 r, F32 g, F32 b);               // Initializes LLColor3 to (r, g, b)
+    LLColor3(const F32* vec);                    // Initializes LLColor3 to (vec[0]. vec[1], vec[2])
+    LLColor3(const char* color_string);          // html format color ie "#FFDDEE"
+    explicit LLColor3(const LLColor4& color4);   // "explicit" to avoid automatic conversion
+    explicit LLColor3(const LLVector4& vector4); // "explicit" to avoid automatic conversion
     LLColor3(const LLSD& sd);
-
 
     LLSD getValue() const
     {
         LLSD ret;
-        ret[0] = mV[0];
-        ret[1] = mV[1];
-        ret[2] = mV[2];
+        ret[VRED]   = mV[VRED];
+        ret[VGREEN] = mV[VGREEN];
+        ret[VBLUE]  = mV[VBLUE];
         return ret;
     }
 
     void setValue(const LLSD& sd)
     {
-        mV[0] = (F32) sd[0].asReal();;
-        mV[1] = (F32) sd[1].asReal();;
-        mV[2] = (F32) sd[2].asReal();;
+        mV[VRED]   = (F32)sd[VRED].asReal();
+        mV[VGREEN] = (F32)sd[VGREEN].asReal();
+        mV[VBLUE]  = (F32)sd[VBLUE].asReal();
     }
 
     void setHSL(F32 hue, F32 saturation, F32 luminance);
     void calcHSL(F32* hue, F32* saturation, F32* luminance) const;
 
-    const LLColor3& setToBlack();                   // Clears LLColor3 to (0, 0, 0)
-    const LLColor3& setToWhite();                   // Zero LLColor3 to (0, 0, 0)
+    const LLColor3& setToBlack(); // Clears LLColor3 to (0, 0, 0)
+    const LLColor3& setToWhite(); // Zero LLColor3 to (0, 0, 0)
 
-    const LLColor3& setVec(F32 x, F32 y, F32 z);    // deprecated
-    const LLColor3& setVec(const LLColor3 &vec);    // deprecated
-    const LLColor3& setVec(const F32 *vec);         // deprecated
+    const LLColor3& setVec(F32 x, F32 y, F32 z); // deprecated
+    const LLColor3& setVec(const LLColor3& vec); // deprecated
+    const LLColor3& setVec(const F32* vec);      // deprecated
 
-    const LLColor3& set(F32 x, F32 y, F32 z);   // Sets LLColor3 to (x, y, z)
-    const LLColor3& set(const LLColor3 &vec);   // Sets LLColor3 to vec
-    const LLColor3& set(const F32 *vec);        // Sets LLColor3 to vec
+    const LLColor3& set(F32 x, F32 y, F32 z); // Sets LLColor3 to (x, y, z)
+    const LLColor3& set(const LLColor3& vec); // Sets LLColor3 to vec
+    const LLColor3& set(const F32* vec);      // Sets LLColor3 to vec
 
     // set from a vector of unknown type and size
     // may leave some data unmodified
@@ -99,414 +98,390 @@ public:
     template<typename T>
     void write(std::vector<T>& v) const;
 
-    F32     magVec() const;             // deprecated
-    F32     magVecSquared() const;      // deprecated
-    F32     normVec();                  // deprecated
+    F32 magVec() const;        // deprecated
+    F32 magVecSquared() const; // deprecated
+    F32 normVec();             // deprecated
 
-    F32     length() const;             // Returns magnitude of LLColor3
-    F32     lengthSquared() const;      // Returns magnitude squared of LLColor3
-    F32     normalize();                // Normalizes and returns the magnitude of LLColor3
+    F32 length() const;        // Returns magnitude of LLColor3
+    F32 lengthSquared() const; // Returns magnitude squared of LLColor3
+    F32 normalize();           // Normalizes and returns the magnitude of LLColor3
 
-    F32     brightness() const;         // Returns brightness of LLColor3
+    F32 brightness() const; // Returns brightness of LLColor3
 
-    const LLColor3& operator=(const LLColor4 &a);
+    const LLColor3& operator=(const LLColor4& a);
 
-    LL_FORCE_INLINE LLColor3 divide(const LLColor3 &col2)
+    LL_FORCE_INLINE LLColor3 divide(const LLColor3& col2) const
     {
-        return LLColor3(
-                mV[0] / col2.mV[0],
-                mV[1] / col2.mV[1],
-                mV[2] / col2.mV[2] );
+        return LLColor3(mV[VRED] / col2.mV[VRED], mV[VGREEN] / col2.mV[VGREEN], mV[VBLUE] / col2.mV[VBLUE]);
     }
 
-    LL_FORCE_INLINE LLColor3 color_norm()
+    LL_FORCE_INLINE LLColor3 color_norm() const
     {
         F32 l = length();
-        return LLColor3(
-                mV[0] / l,
-                mV[1] / l,
-                mV[2] / l );
+        return LLColor3(mV[VRED] / l, mV[VGREEN] / l, mV[VBLUE] / l);
     }
 
-    friend std::ostream&     operator<<(std::ostream& s, const LLColor3 &a);        // Print a
-    friend LLColor3 operator+(const LLColor3 &a, const LLColor3 &b);    // Return vector a + b
-    friend LLColor3 operator-(const LLColor3 &a, const LLColor3 &b);    // Return vector a minus b
+    friend std::ostream& operator<<(std::ostream& s, const LLColor3& a);  // Print a
+    friend LLColor3      operator+(const LLColor3& a, const LLColor3& b); // Return vector a + b
+    friend LLColor3      operator-(const LLColor3& a, const LLColor3& b); // Return vector a minus b
 
-    friend const LLColor3& operator+=(LLColor3 &a, const LLColor3 &b);  // Return vector a + b
-    friend const LLColor3& operator-=(LLColor3 &a, const LLColor3 &b);  // Return vector a minus b
-    friend const LLColor3& operator*=(LLColor3 &a, const LLColor3 &b);
+    friend const LLColor3& operator+=(LLColor3& a, const LLColor3& b); // Return vector a + b
+    friend const LLColor3& operator-=(LLColor3& a, const LLColor3& b); // Return vector a minus b
+    friend const LLColor3& operator*=(LLColor3& a, const LLColor3& b);
 
-    friend LLColor3 operator*(const LLColor3 &a, const LLColor3 &b);    // Return component wise a * b
-    friend LLColor3 operator*(const LLColor3 &a, F32 k);                // Return a times scaler k
-    friend LLColor3 operator*(F32 k, const LLColor3 &a);                // Return a times scaler k
+    friend LLColor3 operator*(const LLColor3& a, const LLColor3& b); // Return component wise a * b
+    friend LLColor3 operator*(const LLColor3& a, F32 k);             // Return a times scaler k
+    friend LLColor3 operator*(F32 k, const LLColor3& a);             // Return a times scaler k
 
-    friend bool operator==(const LLColor3 &a, const LLColor3 &b);       // Return a == b
-    friend bool operator!=(const LLColor3 &a, const LLColor3 &b);       // Return a != b
+    friend bool operator==(const LLColor3& a, const LLColor3& b); // Return a == b
+    friend bool operator!=(const LLColor3& a, const LLColor3& b); // Return a != b
 
-    friend const LLColor3& operator*=(LLColor3 &a, F32 k);              // Return a times scaler k
+    friend const LLColor3& operator*=(LLColor3& a, F32 k); // Return a times scaler k
 
-    friend LLColor3 operator-(const LLColor3 &a);                   // Return vector 1-rgb (inverse)
+    friend LLColor3 operator-(const LLColor3& a); // Return vector 1-rgb (inverse)
 
     inline void clamp();
-    inline void exp();  // Do an exponential on the color
+    inline void exp(); // Do an exponential on the color
 };
 
-LLColor3 lerp(const LLColor3 &a, const LLColor3 &b, F32 u);
-
+LLColor3 lerp(const LLColor3& a, const LLColor3& b, F32 u);
 
 void LLColor3::clamp()
 {
     // Clamp the color...
-    if (mV[0] < 0.f)
+    if (mV[VRED] < 0.f)
     {
-        mV[0] = 0.f;
+        mV[VRED] = 0.f;
     }
-    else if (mV[0] > 1.f)
+    else if (mV[VRED] > 1.f)
     {
-        mV[0] = 1.f;
+        mV[VRED] = 1.f;
     }
-    if (mV[1] < 0.f)
+    if (mV[VGREEN] < 0.f)
     {
-        mV[1] = 0.f;
+        mV[VGREEN] = 0.f;
     }
-    else if (mV[1] > 1.f)
+    else if (mV[VGREEN] > 1.f)
     {
-        mV[1] = 1.f;
+        mV[VGREEN] = 1.f;
     }
-    if (mV[2] < 0.f)
+    if (mV[VBLUE] < 0.f)
     {
-        mV[2] = 0.f;
+        mV[VBLUE] = 0.f;
     }
-    else if (mV[2] > 1.f)
+    else if (mV[VBLUE] > 1.f)
     {
-        mV[2] = 1.f;
+        mV[VBLUE] = 1.f;
     }
 }
 
 // Non-member functions
-F32     distVec(const LLColor3 &a, const LLColor3 &b);      // Returns distance between a and b
-F32     distVec_squared(const LLColor3 &a, const LLColor3 &b);// Returns distance squared between a and b
+F32 distVec(const LLColor3& a, const LLColor3& b);         // Returns distance between a and b
+F32 distVec_squared(const LLColor3& a, const LLColor3& b); // Returns distance squared between a and b
 
-inline LLColor3::LLColor3(void)
+inline LLColor3::LLColor3()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VRED]   = 0.f;
+    mV[VGREEN] = 0.f;
+    mV[VBLUE]  = 0.f;
 }
 
 inline LLColor3::LLColor3(F32 r, F32 g, F32 b)
 {
-    mV[VRED] = r;
+    mV[VRED]   = r;
     mV[VGREEN] = g;
-    mV[VBLUE] = b;
+    mV[VBLUE]  = b;
 }
 
-
-inline LLColor3::LLColor3(const F32 *vec)
+inline LLColor3::LLColor3(const F32* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
 }
 
 inline LLColor3::LLColor3(const char* color_string) // takes a string of format "RRGGBB" where RR is hex 00..FF
 {
-    if (strlen(color_string) <  6)      /* Flawfinder: ignore */
+    if (strlen(color_string) < 6) /* Flawfinder: ignore */
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
-        mV[2] = 0.f;
+        mV[VRED]   = 0.f;
+        mV[VGREEN] = 0.f;
+        mV[VBLUE]  = 0.f;
         return;
     }
 
     char tempstr[7];
-    strncpy(tempstr,color_string,6);        /* Flawfinder: ignore */
+    strncpy(tempstr, color_string, 6); /* Flawfinder: ignore */
     tempstr[6] = '\0';
-    mV[VBLUE] = (F32)strtol(&tempstr[4],NULL,16)/255.f;
+    mV[VBLUE]  = (F32)strtol(&tempstr[4], nullptr, 16) / 255.f;
     tempstr[4] = '\0';
-    mV[VGREEN] = (F32)strtol(&tempstr[2],NULL,16)/255.f;
+    mV[VGREEN] = (F32)strtol(&tempstr[2], nullptr, 16) / 255.f;
     tempstr[2] = '\0';
-    mV[VRED] = (F32)strtol(&tempstr[0],NULL,16)/255.f;
+    mV[VRED]   = (F32)strtol(&tempstr[0], nullptr, 16) / 255.f;
 }
 
-inline const LLColor3&  LLColor3::setToBlack(void)
+inline const LLColor3& LLColor3::setToBlack()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VRED]   = 0.f;
+    mV[VGREEN] = 0.f;
+    mV[VBLUE]  = 0.f;
     return (*this);
 }
 
-inline const LLColor3&  LLColor3::setToWhite(void)
+inline const LLColor3& LLColor3::setToWhite()
 {
-    mV[0] = 1.f;
-    mV[1] = 1.f;
-    mV[2] = 1.f;
+    mV[VRED]   = 1.f;
+    mV[VGREEN] = 1.f;
+    mV[VBLUE]  = 1.f;
     return (*this);
 }
 
-inline const LLColor3&  LLColor3::set(F32 r, F32 g, F32 b)
+inline const LLColor3& LLColor3::set(F32 r, F32 g, F32 b)
 {
-    mV[0] = r;
-    mV[1] = g;
-    mV[2] = b;
+    mV[VRED]   = r;
+    mV[VGREEN] = g;
+    mV[VBLUE]  = b;
     return (*this);
 }
 
-inline const LLColor3&  LLColor3::set(const LLColor3 &vec)
+inline const LLColor3& LLColor3::set(const LLColor3& vec)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VRED]   = vec.mV[VRED];
+    mV[VGREEN] = vec.mV[VGREEN];
+    mV[VBLUE]  = vec.mV[VBLUE];
     return (*this);
 }
 
-inline const LLColor3&  LLColor3::set(const F32 *vec)
+inline const LLColor3& LLColor3::set(const F32* vec)
 {
-    mV[0] = vec[0];
-    mV[1] = vec[1];
-    mV[2] = vec[2];
-    return (*this);
-}
-
-// deprecated
-inline const LLColor3&  LLColor3::setVec(F32 r, F32 g, F32 b)
-{
-    mV[0] = r;
-    mV[1] = g;
-    mV[2] = b;
+    mV[VRED]   = vec[VRED];
+    mV[VGREEN] = vec[VGREEN];
+    mV[VBLUE]  = vec[VBLUE];
     return (*this);
 }
 
 // deprecated
-inline const LLColor3&  LLColor3::setVec(const LLColor3 &vec)
+inline const LLColor3& LLColor3::setVec(F32 r, F32 g, F32 b)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VRED]   = r;
+    mV[VGREEN] = g;
+    mV[VBLUE]  = b;
     return (*this);
 }
 
 // deprecated
-inline const LLColor3&  LLColor3::setVec(const F32 *vec)
+inline const LLColor3& LLColor3::setVec(const LLColor3& vec)
 {
-    mV[0] = vec[0];
-    mV[1] = vec[1];
-    mV[2] = vec[2];
+    mV[VRED]   = vec.mV[VRED];
+    mV[VGREEN] = vec.mV[VGREEN];
+    mV[VBLUE]  = vec.mV[VBLUE];
     return (*this);
 }
 
-inline F32      LLColor3::brightness(void) const
+// deprecated
+inline const LLColor3& LLColor3::setVec(const F32* vec)
 {
-    return (mV[0] + mV[1] + mV[2]) / 3.0f;
+    mV[VRED]   = vec[VRED];
+    mV[VGREEN] = vec[VGREEN];
+    mV[VBLUE]  = vec[VBLUE];
+    return (*this);
 }
 
-inline F32      LLColor3::length(void) const
+inline F32 LLColor3::brightness() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    return (mV[VRED] + mV[VGREEN] + mV[VBLUE]) / 3.0f;
 }
 
-inline F32      LLColor3::lengthSquared(void) const
+inline F32 LLColor3::length() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2];
+    return sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
 }
 
-inline F32      LLColor3::normalize(void)
+inline F32 LLColor3::lengthSquared() const
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    return mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE];
+}
+
+inline F32 LLColor3::normalize()
+{
+    F32 mag = sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
     F32 oomag;
 
     if (mag)
     {
-        oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
-        mV[2] *= oomag;
+        oomag = 1.f / mag;
+        mV[VRED] *= oomag;
+        mV[VGREEN] *= oomag;
+        mV[VBLUE] *= oomag;
     }
-    return (mag);
+    return mag;
 }
 
 // deprecated
-inline F32      LLColor3::magVec(void) const
+inline F32 LLColor3::magVec() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    return sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
 }
 
 // deprecated
-inline F32      LLColor3::magVecSquared(void) const
+inline F32 LLColor3::magVecSquared() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2];
+    return mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE];
 }
 
 // deprecated
-inline F32      LLColor3::normVec(void)
+inline F32 LLColor3::normVec()
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    F32 mag = sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
     F32 oomag;
 
     if (mag)
     {
-        oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
-        mV[2] *= oomag;
+        oomag = 1.f / mag;
+        mV[VRED] *= oomag;
+        mV[VGREEN] *= oomag;
+        mV[VBLUE] *= oomag;
     }
-    return (mag);
+    return mag;
 }
 
 inline void LLColor3::exp()
 {
 #if 0
-    mV[0] = ::exp(mV[0]);
-    mV[1] = ::exp(mV[1]);
-    mV[2] = ::exp(mV[2]);
+    mV[VRED] = ::exp(mV[VRED]);
+    mV[VGREEN] = ::exp(mV[VGREEN]);
+    mV[VBLUE] = ::exp(mV[VBLUE]);
 #else
-    mV[0] = (F32)LL_FAST_EXP(mV[0]);
-    mV[1] = (F32)LL_FAST_EXP(mV[1]);
-    mV[2] = (F32)LL_FAST_EXP(mV[2]);
+    mV[VRED]   = (F32)LL_FAST_EXP(mV[VRED]);
+    mV[VGREEN] = (F32)LL_FAST_EXP(mV[VGREEN]);
+    mV[VBLUE]  = (F32)LL_FAST_EXP(mV[VBLUE]);
 #endif
 }
 
-
-inline LLColor3 operator+(const LLColor3 &a, const LLColor3 &b)
+inline LLColor3 operator+(const LLColor3& a, const LLColor3& b)
 {
-    return LLColor3(
-        a.mV[0] + b.mV[0],
-        a.mV[1] + b.mV[1],
-        a.mV[2] + b.mV[2]);
+    return LLColor3(a.mV[VRED] + b.mV[VRED], a.mV[VGREEN] + b.mV[VGREEN], a.mV[VBLUE] + b.mV[VBLUE]);
 }
 
-inline LLColor3 operator-(const LLColor3 &a, const LLColor3 &b)
+inline LLColor3 operator-(const LLColor3& a, const LLColor3& b)
 {
-    return LLColor3(
-        a.mV[0] - b.mV[0],
-        a.mV[1] - b.mV[1],
-        a.mV[2] - b.mV[2]);
+    return LLColor3(a.mV[VRED] - b.mV[VRED], a.mV[VGREEN] - b.mV[VGREEN], a.mV[VBLUE] - b.mV[VBLUE]);
 }
 
-inline LLColor3  operator*(const LLColor3 &a, const LLColor3 &b)
+inline LLColor3 operator*(const LLColor3& a, const LLColor3& b)
 {
-    return LLColor3(
-        a.mV[0] * b.mV[0],
-        a.mV[1] * b.mV[1],
-        a.mV[2] * b.mV[2]);
+    return LLColor3(a.mV[VRED] * b.mV[VRED], a.mV[VGREEN] * b.mV[VGREEN], a.mV[VBLUE] * b.mV[VBLUE]);
 }
 
-inline LLColor3 operator*(const LLColor3 &a, F32 k)
+inline LLColor3 operator*(const LLColor3& a, F32 k)
 {
-    return LLColor3( a.mV[0] * k, a.mV[1] * k, a.mV[2] * k );
+    return LLColor3(a.mV[VRED] * k, a.mV[VGREEN] * k, a.mV[VBLUE] * k);
 }
 
-inline LLColor3 operator*(F32 k, const LLColor3 &a)
+inline LLColor3 operator*(F32 k, const LLColor3& a)
 {
-    return LLColor3( a.mV[0] * k, a.mV[1] * k, a.mV[2] * k );
+    return LLColor3(a.mV[VRED] * k, a.mV[VGREEN] * k, a.mV[VBLUE] * k);
 }
 
-inline bool operator==(const LLColor3 &a, const LLColor3 &b)
+inline bool operator==(const LLColor3& a, const LLColor3& b)
 {
-    return (  (a.mV[0] == b.mV[0])
-            &&(a.mV[1] == b.mV[1])
-            &&(a.mV[2] == b.mV[2]));
+    return ((a.mV[VRED] == b.mV[VRED]) && (a.mV[VGREEN] == b.mV[VGREEN]) && (a.mV[VBLUE] == b.mV[VBLUE]));
 }
 
-inline bool operator!=(const LLColor3 &a, const LLColor3 &b)
+inline bool operator!=(const LLColor3& a, const LLColor3& b)
 {
-    return (  (a.mV[0] != b.mV[0])
-            ||(a.mV[1] != b.mV[1])
-            ||(a.mV[2] != b.mV[2]));
+    return ((a.mV[VRED] != b.mV[VRED]) || (a.mV[VGREEN] != b.mV[VGREEN]) || (a.mV[VBLUE] != b.mV[VBLUE]));
 }
 
-inline const LLColor3 &operator*=(LLColor3 &a, const LLColor3 &b)
+inline const LLColor3& operator*=(LLColor3& a, const LLColor3& b)
 {
-    a.mV[0] *= b.mV[0];
-    a.mV[1] *= b.mV[1];
-    a.mV[2] *= b.mV[2];
+    a.mV[VRED] *= b.mV[VRED];
+    a.mV[VGREEN] *= b.mV[VGREEN];
+    a.mV[VBLUE] *= b.mV[VBLUE];
     return a;
 }
 
-inline const LLColor3& operator+=(LLColor3 &a, const LLColor3 &b)
+inline const LLColor3& operator+=(LLColor3& a, const LLColor3& b)
 {
-    a.mV[0] += b.mV[0];
-    a.mV[1] += b.mV[1];
-    a.mV[2] += b.mV[2];
+    a.mV[VRED] += b.mV[VRED];
+    a.mV[VGREEN] += b.mV[VGREEN];
+    a.mV[VBLUE] += b.mV[VBLUE];
     return a;
 }
 
-inline const LLColor3& operator-=(LLColor3 &a, const LLColor3 &b)
+inline const LLColor3& operator-=(LLColor3& a, const LLColor3& b)
 {
-    a.mV[0] -= b.mV[0];
-    a.mV[1] -= b.mV[1];
-    a.mV[2] -= b.mV[2];
+    a.mV[VRED] -= b.mV[VRED];
+    a.mV[VGREEN] -= b.mV[VGREEN];
+    a.mV[VBLUE] -= b.mV[VBLUE];
     return a;
 }
 
-inline const LLColor3& operator*=(LLColor3 &a, F32 k)
+inline const LLColor3& operator*=(LLColor3& a, F32 k)
 {
-    a.mV[0] *= k;
-    a.mV[1] *= k;
-    a.mV[2] *= k;
+    a.mV[VRED] *= k;
+    a.mV[VGREEN] *= k;
+    a.mV[VBLUE] *= k;
     return a;
 }
 
-inline LLColor3 operator-(const LLColor3 &a)
+inline LLColor3 operator-(const LLColor3& a)
 {
-    return LLColor3(
-        1.f - a.mV[0],
-        1.f - a.mV[1],
-        1.f - a.mV[2] );
+    return LLColor3(1.f - a.mV[VRED], 1.f - a.mV[VGREEN], 1.f - a.mV[VBLUE]);
 }
 
 // Non-member functions
 
-inline F32      distVec(const LLColor3 &a, const LLColor3 &b)
+inline F32 distVec(const LLColor3& a, const LLColor3& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
-    F32 z = a.mV[2] - b.mV[2];
-    return (F32) sqrt( x*x + y*y + z*z );
+    F32 x = a.mV[VRED] - b.mV[VRED];
+    F32 y = a.mV[VGREEN] - b.mV[VGREEN];
+    F32 z = a.mV[VBLUE] - b.mV[VBLUE];
+    return sqrt(x * x + y * y + z * z);
 }
 
-inline F32      distVec_squared(const LLColor3 &a, const LLColor3 &b)
+inline F32 distVec_squared(const LLColor3& a, const LLColor3& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
-    F32 z = a.mV[2] - b.mV[2];
-    return x*x + y*y + z*z;
+    F32 x = a.mV[VRED] - b.mV[VRED];
+    F32 y = a.mV[VGREEN] - b.mV[VGREEN];
+    F32 z = a.mV[VBLUE] - b.mV[VBLUE];
+    return x * x + y * y + z * z;
 }
 
-inline LLColor3 lerp(const LLColor3 &a, const LLColor3 &b, F32 u)
+inline LLColor3 lerp(const LLColor3& a, const LLColor3& b, F32 u)
 {
-    return LLColor3(
-        a.mV[VX] + (b.mV[VX] - a.mV[VX]) * u,
-        a.mV[VY] + (b.mV[VY] - a.mV[VY]) * u,
-        a.mV[VZ] + (b.mV[VZ] - a.mV[VZ]) * u);
+    return LLColor3(a.mV[VX] + (b.mV[VX] - a.mV[VX]) * u, a.mV[VY] + (b.mV[VY] - a.mV[VY]) * u, a.mV[VZ] + (b.mV[VZ] - a.mV[VZ]) * u);
 }
 
-inline const LLColor3 srgbColor3(const LLColor3 &a) {
+inline const LLColor3 srgbColor3(const LLColor3& a)
+{
     LLColor3 srgbColor;
-    srgbColor.mV[0] = linearTosRGB(a.mV[0]);
-    srgbColor.mV[1] = linearTosRGB(a.mV[1]);
-    srgbColor.mV[2] = linearTosRGB(a.mV[2]);
+    srgbColor.mV[VRED]   = linearTosRGB(a.mV[VRED]);
+    srgbColor.mV[VGREEN] = linearTosRGB(a.mV[VGREEN]);
+    srgbColor.mV[VBLUE]  = linearTosRGB(a.mV[VBLUE]);
 
     return srgbColor;
 }
 
-inline const LLColor3 linearColor3p(const F32* v) {
+inline const LLColor3 linearColor3p(const F32* v)
+{
     LLColor3 linearColor;
-    linearColor.mV[0] = sRGBtoLinear(v[0]);
-    linearColor.mV[1] = sRGBtoLinear(v[1]);
-    linearColor.mV[2] = sRGBtoLinear(v[2]);
+    linearColor.mV[VRED]   = sRGBtoLinear(v[VRED]);
+    linearColor.mV[VGREEN] = sRGBtoLinear(v[VGREEN]);
+    linearColor.mV[VBLUE]  = sRGBtoLinear(v[VBLUE]);
 
     return linearColor;
 }
 
 template<class T>
-inline const LLColor3 linearColor3(const T& a) {
+inline const LLColor3 linearColor3(const T& a)
+{
     return linearColor3p(a.mV);
 }
 
 template<class T>
-inline const LLVector3 linearColor3v(const T& a) {
+inline const LLVector3 linearColor3v(const T& a)
+{
     return LLVector3(linearColor3p(a.mV).mV);
 }
 

--- a/indra/llmath/v3colorutil.h
+++ b/indra/llmath/v3colorutil.h
@@ -30,59 +30,46 @@
 #include "v3color.h"
 #include "v4color.h"
 
-inline LLColor3 componentDiv(LLColor3 const &left, LLColor3 const & right)
+inline LLColor3 componentDiv(const LLColor3& left, const LLColor3& right)
 {
-    return LLColor3(left.mV[0] / right.mV[0],
-        left.mV[1] / right.mV[1],
-        left.mV[2] / right.mV[2]);
+    return LLColor3(left.mV[VRED] / right.mV[VRED], left.mV[VGREEN] / right.mV[VGREEN], left.mV[VBLUE] / right.mV[VBLUE]);
 }
 
-
-inline LLColor3 componentMult(LLColor3 const &left, LLColor3 const & right)
+inline LLColor3 componentMult(const LLColor3& left, const LLColor3& right)
 {
-    return LLColor3(left.mV[0] * right.mV[0],
-        left.mV[1] * right.mV[1],
-        left.mV[2] * right.mV[2]);
+    return LLColor3(left.mV[VRED] * right.mV[VRED], left.mV[VGREEN] * right.mV[VGREEN], left.mV[VBLUE] * right.mV[VBLUE]);
 }
 
-
-inline LLColor3 componentExp(LLColor3 const &v)
+inline LLColor3 componentExp(const LLColor3& v)
 {
-    return LLColor3(exp(v.mV[0]),
-        exp(v.mV[1]),
-        exp(v.mV[2]));
+    return LLColor3(exp(v.mV[VRED]), exp(v.mV[VGREEN]), exp(v.mV[VBLUE]));
 }
 
-inline LLColor3 componentPow(LLColor3 const &v, F32 exponent)
+inline LLColor3 componentPow(const LLColor3& v, F32 exponent)
 {
-    return LLColor3(pow(v.mV[0], exponent),
-        pow(v.mV[1], exponent),
-        pow(v.mV[2], exponent));
+    return LLColor3(pow(v.mV[VRED], exponent), pow(v.mV[VGREEN], exponent), pow(v.mV[VBLUE], exponent));
 }
 
-inline LLColor3 componentSaturate(LLColor3 const &v)
+inline LLColor3 componentSaturate(const LLColor3& v)
 {
-    return LLColor3(std::max(std::min(v.mV[0], 1.f), 0.f),
-        std::max(std::min(v.mV[1], 1.f), 0.f),
-        std::max(std::min(v.mV[2], 1.f), 0.f));
+    return LLColor3(std::max(std::min(v.mV[VRED], 1.f), 0.f),
+                    std::max(std::min(v.mV[VGREEN], 1.f), 0.f),
+                    std::max(std::min(v.mV[VBLUE], 1.f), 0.f));
 }
 
-
-inline LLColor3 componentSqrt(LLColor3 const &v)
+inline LLColor3 componentSqrt(const LLColor3& v)
 {
-    return LLColor3(sqrt(v.mV[0]),
-        sqrt(v.mV[1]),
-        sqrt(v.mV[2]));
+    return LLColor3(sqrt(v.mV[VRED]), sqrt(v.mV[VGREEN]), sqrt(v.mV[VBLUE]));
 }
 
-inline void componentMultBy(LLColor3 & left, LLColor3 const & right)
+inline void componentMultBy(LLColor3& left, const LLColor3& right)
 {
-    left.mV[0] *= right.mV[0];
-    left.mV[1] *= right.mV[1];
-    left.mV[2] *= right.mV[2];
+    left.mV[VRED] *= right.mV[VRED];
+    left.mV[VGREEN] *= right.mV[VGREEN];
+    left.mV[VBLUE] *= right.mV[VBLUE];
 }
 
-inline LLColor3 colorMix(LLColor3 const & left, LLColor3 const & right, F32 amount)
+inline LLColor3 colorMix(const LLColor3& left, const LLColor3& right, F32 amount)
 {
     return (left + ((right - left) * amount));
 }
@@ -92,25 +79,24 @@ inline LLColor3 smear(F32 val)
     return LLColor3(val, val, val);
 }
 
-inline F32 color_intens(const LLColor3 &col)
+inline F32 color_intens(const LLColor3& col)
 {
-    return col.mV[0] + col.mV[1] + col.mV[2];
+    return col.mV[VRED] + col.mV[VGREEN] + col.mV[VBLUE];
 }
 
-inline F32 color_max(const LLColor3 &col)
+inline F32 color_max(const LLColor3& col)
 {
-    return llmax(col.mV[0], col.mV[1], col.mV[2]);
+    return llmax(col.mV[VRED], col.mV[VGREEN], col.mV[VBLUE]);
 }
 
-inline F32 color_max(const LLColor4 &col)
+inline F32 color_max(const LLColor4& col)
 {
-    return llmax(col.mV[0], col.mV[1], col.mV[2]);
+    return llmax(col.mV[VRED], col.mV[VGREEN], col.mV[VBLUE]);
 }
 
-
-inline F32 color_min(const LLColor3 &col)
+inline F32 color_min(const LLColor3& col)
 {
-    return llmin(col.mV[0], col.mV[1], col.mV[2]);
+    return llmin(col.mV[VRED], col.mV[VGREEN], col.mV[VBLUE]);
 }
 
 #endif

--- a/indra/llmath/v3dmath.cpp
+++ b/indra/llmath/v3dmath.cpp
@@ -30,7 +30,6 @@
 
 #include "v3dmath.h"
 
-//#include "vmath.h"
 #include "v4math.h"
 #include "m4math.h"
 #include "m3math.h"
@@ -57,13 +56,13 @@ bool LLVector3d::clamp(F64 min, F64 max)
 {
     bool ret{ false };
 
-    if (mdV[0] < min) { mdV[0] = min; ret = true; }
-    if (mdV[1] < min) { mdV[1] = min; ret = true; }
-    if (mdV[2] < min) { mdV[2] = min; ret = true; }
+    if (mdV[VX] < min) { mdV[VX] = min; ret = true; }
+    if (mdV[VY] < min) { mdV[VY] = min; ret = true; }
+    if (mdV[VZ] < min) { mdV[VZ] = min; ret = true; }
 
-    if (mdV[0] > max) { mdV[0] = max; ret = true; }
-    if (mdV[1] > max) { mdV[1] = max; ret = true; }
-    if (mdV[2] > max) { mdV[2] = max; ret = true; }
+    if (mdV[VX] > max) { mdV[VX] = max; ret = true; }
+    if (mdV[VY] > max) { mdV[VY] = max; ret = true; }
+    if (mdV[VZ] > max) { mdV[VZ] = max; ret = true; }
 
     return ret;
 }
@@ -74,9 +73,9 @@ bool LLVector3d::abs()
 {
     bool ret{ false };
 
-    if (mdV[0] < 0.0) { mdV[0] = -mdV[0]; ret = true; }
-    if (mdV[1] < 0.0) { mdV[1] = -mdV[1]; ret = true; }
-    if (mdV[2] < 0.0) { mdV[2] = -mdV[2]; ret = true; }
+    if (mdV[VX] < 0.0) { mdV[VX] = -mdV[VX]; ret = true; }
+    if (mdV[VY] < 0.0) { mdV[VY] = -mdV[VY]; ret = true; }
+    if (mdV[VZ] < 0.0) { mdV[VZ] = -mdV[VZ]; ret = true; }
 
     return ret;
 }
@@ -89,37 +88,37 @@ std::ostream& operator<<(std::ostream& s, const LLVector3d &a)
 
 const LLVector3d& LLVector3d::operator=(const LLVector4 &a)
 {
-    mdV[0] = a.mV[0];
-    mdV[1] = a.mV[1];
-    mdV[2] = a.mV[2];
+    mdV[VX] = a.mV[VX];
+    mdV[VY] = a.mV[VY];
+    mdV[VZ] = a.mV[VZ];
     return *this;
 }
 
-const LLVector3d&   LLVector3d::rotVec(const LLMatrix3 &mat)
+const LLVector3d& LLVector3d::rotVec(const LLMatrix3& mat)
 {
     *this = *this * mat;
     return *this;
 }
 
-const LLVector3d&   LLVector3d::rotVec(const LLQuaternion &q)
+const LLVector3d& LLVector3d::rotVec(const LLQuaternion& q)
 {
     *this = *this * q;
     return *this;
 }
 
-const LLVector3d&   LLVector3d::rotVec(F64 angle, const LLVector3d &vec)
+const LLVector3d& LLVector3d::rotVec(F64 angle, const LLVector3d& vec)
 {
-    if ( !vec.isExactlyZero() && angle )
+    if (!vec.isExactlyZero() && angle)
     {
         *this = *this * LLMatrix3((F32)angle, vec);
     }
     return *this;
 }
 
-const LLVector3d&   LLVector3d::rotVec(F64 angle, F64 x, F64 y, F64 z)
+const LLVector3d& LLVector3d::rotVec(F64 angle, F64 x, F64 y, F64 z)
 {
     LLVector3d vec(x, y, z);
-    if ( !vec.isExactlyZero() && angle )
+    if (!vec.isExactlyZero() && angle)
     {
         *this = *this * LLMatrix3((F32)angle, vec);
     }
@@ -129,16 +128,16 @@ const LLVector3d&   LLVector3d::rotVec(F64 angle, F64 x, F64 y, F64 z)
 
 bool LLVector3d::parseVector3d(const std::string& buf, LLVector3d* value)
 {
-    if( buf.empty() || value == nullptr)
+    if (buf.empty() || value == nullptr)
     {
         return false;
     }
 
     LLVector3d v;
-    S32 count = sscanf( buf.c_str(), "%lf %lf %lf", v.mdV + 0, v.mdV + 1, v.mdV + 2 );
-    if( 3 == count )
+    S32 count = sscanf(buf.c_str(), "%lf %lf %lf", v.mdV + VX, v.mdV + VY, v.mdV + VZ);
+    if (3 == count)
     {
-        value->setVec( v );
+        value->setVec(v);
         return true;
     }
 

--- a/indra/llmath/v3dmath.h
+++ b/indra/llmath/v3dmath.h
@@ -32,128 +32,127 @@
 
 class LLVector3d
 {
-    public:
-        F64 mdV[3];
+public:
+    F64 mdV[3];
 
-        const static LLVector3d zero;
-        const static LLVector3d x_axis;
-        const static LLVector3d y_axis;
-        const static LLVector3d z_axis;
-        const static LLVector3d x_axis_neg;
-        const static LLVector3d y_axis_neg;
-        const static LLVector3d z_axis_neg;
+    const static LLVector3d zero;
+    const static LLVector3d x_axis;
+    const static LLVector3d y_axis;
+    const static LLVector3d z_axis;
+    const static LLVector3d x_axis_neg;
+    const static LLVector3d y_axis_neg;
+    const static LLVector3d z_axis_neg;
 
-        inline LLVector3d();                            // Initializes LLVector3d to (0, 0, 0)
-        inline LLVector3d(const F64 x, const F64 y, const F64 z);           // Initializes LLVector3d to (x. y, z)
-        inline explicit LLVector3d(const F64 *vec);             // Initializes LLVector3d to (vec[0]. vec[1], vec[2])
-        inline explicit LLVector3d(const LLVector3 &vec);
-        explicit LLVector3d(const LLSD& sd)
-        {
-            setValue(sd);
-        }
+    inline LLVector3d();                            // Initializes LLVector3d to (0, 0, 0)
+    inline LLVector3d(const F64 x, const F64 y, const F64 z);           // Initializes LLVector3d to (x. y, z)
+    inline explicit LLVector3d(const F64 *vec);             // Initializes LLVector3d to (vec[0]. vec[1], vec[2])
+    inline explicit LLVector3d(const LLVector3 &vec);
+    explicit LLVector3d(const LLSD& sd)
+    {
+        setValue(sd);
+    }
 
-        void setValue(const LLSD& sd)
-        {
-            mdV[0] = sd[0].asReal();
-            mdV[1] = sd[1].asReal();
-            mdV[2] = sd[2].asReal();
-        }
+    void setValue(const LLSD& sd)
+    {
+        mdV[VX] = sd[0].asReal();
+        mdV[VY] = sd[1].asReal();
+        mdV[VZ] = sd[2].asReal();
+    }
 
-        LLSD getValue() const
-        {
-            LLSD ret;
-            ret[0] = mdV[0];
-            ret[1] = mdV[1];
-            ret[2] = mdV[2];
-            return ret;
-        }
+    LLSD getValue() const
+    {
+        LLSD ret;
+        ret[0] = mdV[VX];
+        ret[1] = mdV[VY];
+        ret[2] = mdV[VZ];
+        return ret;
+    }
 
-        inline bool isFinite() const;                                   // checks to see if all values of LLVector3d are finite
-        bool        clamp(const F64 min, const F64 max);        // Clamps all values to (min,max), returns true if data changed
-        bool        abs();                      // sets all values to absolute value of original value (first octant), returns true if changed
+    inline bool isFinite() const;                                   // checks to see if all values of LLVector3d are finite
+    bool        clamp(const F64 min, const F64 max);        // Clamps all values to (min,max), returns true if data changed
+    bool        abs();                      // sets all values to absolute value of original value (first octant), returns true if changed
 
-        inline const LLVector3d&    clear();        // Clears LLVector3d to (0, 0, 0, 1)
-        inline const LLVector3d&    clearVec();     // deprecated
-        inline const LLVector3d&    setZero();      // Zero LLVector3d to (0, 0, 0, 0)
-        inline const LLVector3d&    zeroVec();      // deprecated
-        inline const LLVector3d&    set(const F64 x, const F64 y, const F64 z); // Sets LLVector3d to (x, y, z, 1)
-        inline const LLVector3d&    set(const LLVector3d &vec); // Sets LLVector3d to vec
-        inline const LLVector3d&    set(const F64 *vec);        // Sets LLVector3d to vec
-        inline const LLVector3d&    set(const LLVector3 &vec);
-        inline const LLVector3d&    setVec(const F64 x, const F64 y, const F64 z);  // deprecated
-        inline const LLVector3d&    setVec(const LLVector3d &vec);  // deprecated
-        inline const LLVector3d&    setVec(const F64 *vec);         // deprecated
-        inline const LLVector3d&    setVec(const LLVector3 &vec);   // deprecated
+    inline const LLVector3d&    clear();        // Clears LLVector3d to (0, 0, 0, 1)
+    inline const LLVector3d&    clearVec();     // deprecated
+    inline const LLVector3d&    setZero();      // Zero LLVector3d to (0, 0, 0, 0)
+    inline const LLVector3d&    zeroVec();      // deprecated
+    inline const LLVector3d&    set(const F64 x, const F64 y, const F64 z); // Sets LLVector3d to (x, y, z, 1)
+    inline const LLVector3d&    set(const LLVector3d &vec); // Sets LLVector3d to vec
+    inline const LLVector3d&    set(const F64 *vec);        // Sets LLVector3d to vec
+    inline const LLVector3d&    set(const LLVector3 &vec);
+    inline const LLVector3d&    setVec(const F64 x, const F64 y, const F64 z);  // deprecated
+    inline const LLVector3d&    setVec(const LLVector3d &vec);  // deprecated
+    inline const LLVector3d&    setVec(const F64 *vec);         // deprecated
+    inline const LLVector3d&    setVec(const LLVector3 &vec);   // deprecated
 
-        F64     magVec() const;             // deprecated
-        F64     magVecSquared() const;      // deprecated
-        inline F64      normVec();                  // deprecated
+    F64     magVec() const;             // deprecated
+    F64     magVecSquared() const;      // deprecated
+    inline F64      normVec();                  // deprecated
 
-        F64 length() const;         // Returns magnitude of LLVector3d
-        F64 lengthSquared() const;  // Returns magnitude squared of LLVector3d
-        inline F64 normalize();     // Normalizes and returns the magnitude of LLVector3d
+    F64 length() const;         // Returns magnitude of LLVector3d
+    F64 lengthSquared() const;  // Returns magnitude squared of LLVector3d
+    inline F64 normalize();     // Normalizes and returns the magnitude of LLVector3d
 
-        const LLVector3d&   rotVec(const F64 angle, const LLVector3d &vec); // Rotates about vec by angle radians
-        const LLVector3d&   rotVec(const F64 angle, const F64 x, const F64 y, const F64 z);     // Rotates about x,y,z by angle radians
-        const LLVector3d&   rotVec(const LLMatrix3 &mat);               // Rotates by LLMatrix4 mat
-        const LLVector3d&   rotVec(const LLQuaternion &q);              // Rotates by LLQuaternion q
+    const LLVector3d&   rotVec(const F64 angle, const LLVector3d &vec); // Rotates about vec by angle radians
+    const LLVector3d&   rotVec(const F64 angle, const F64 x, const F64 y, const F64 z);     // Rotates about x,y,z by angle radians
+    const LLVector3d&   rotVec(const LLMatrix3 &mat);               // Rotates by LLMatrix4 mat
+    const LLVector3d&   rotVec(const LLQuaternion &q);              // Rotates by LLQuaternion q
 
-        bool isNull() const;            // Returns true if vector has a _very_small_ length
-        bool isExactlyZero() const      { return !mdV[VX] && !mdV[VY] && !mdV[VZ]; }
+    bool isNull() const;            // Returns true if vector has a _very_small_ length
+    bool isExactlyZero() const      { return !mdV[VX] && !mdV[VY] && !mdV[VZ]; }
 
-        const LLVector3d&   operator=(const LLVector4 &a);
+    const LLVector3d&   operator=(const LLVector4 &a);
 
-        F64 operator[](int idx) const { return mdV[idx]; }
-        F64 &operator[](int idx) { return mdV[idx]; }
+    F64 operator[](int idx) const { return mdV[idx]; }
+    F64 &operator[](int idx) { return mdV[idx]; }
 
-        friend LLVector3d operator+(const LLVector3d& a, const LLVector3d& b);  // Return vector a + b
-        friend LLVector3d operator-(const LLVector3d& a, const LLVector3d& b);  // Return vector a minus b
-        friend F64 operator*(const LLVector3d& a, const LLVector3d& b);     // Return a dot b
-        friend LLVector3d operator%(const LLVector3d& a, const LLVector3d& b);  // Return a cross b
-        friend LLVector3d operator*(const LLVector3d& a, const F64 k);              // Return a times scaler k
-        friend LLVector3d operator/(const LLVector3d& a, const F64 k);              // Return a divided by scaler k
-        friend LLVector3d operator*(const F64 k, const LLVector3d& a);              // Return a times scaler k
-        friend bool operator==(const LLVector3d& a, const LLVector3d& b);       // Return a == b
-        friend bool operator!=(const LLVector3d& a, const LLVector3d& b);       // Return a != b
+    friend LLVector3d operator+(const LLVector3d& a, const LLVector3d& b);  // Return vector a + b
+    friend LLVector3d operator-(const LLVector3d& a, const LLVector3d& b);  // Return vector a minus b
+    friend F64 operator*(const LLVector3d& a, const LLVector3d& b);     // Return a dot b
+    friend LLVector3d operator%(const LLVector3d& a, const LLVector3d& b);  // Return a cross b
+    friend LLVector3d operator*(const LLVector3d& a, const F64 k);              // Return a times scaler k
+    friend LLVector3d operator/(const LLVector3d& a, const F64 k);              // Return a divided by scaler k
+    friend LLVector3d operator*(const F64 k, const LLVector3d& a);              // Return a times scaler k
+    friend bool operator==(const LLVector3d& a, const LLVector3d& b);       // Return a == b
+    friend bool operator!=(const LLVector3d& a, const LLVector3d& b);       // Return a != b
 
-        friend const LLVector3d& operator+=(LLVector3d& a, const LLVector3d& b);    // Return vector a + b
-        friend const LLVector3d& operator-=(LLVector3d& a, const LLVector3d& b);    // Return vector a minus b
-        friend const LLVector3d& operator%=(LLVector3d& a, const LLVector3d& b);    // Return a cross b
-        friend const LLVector3d& operator*=(LLVector3d& a, const F64 k);                // Return a times scaler k
-        friend const LLVector3d& operator/=(LLVector3d& a, const F64 k);                // Return a divided by scaler k
+    friend const LLVector3d& operator+=(LLVector3d& a, const LLVector3d& b);    // Return vector a + b
+    friend const LLVector3d& operator-=(LLVector3d& a, const LLVector3d& b);    // Return vector a minus b
+    friend const LLVector3d& operator%=(LLVector3d& a, const LLVector3d& b);    // Return a cross b
+    friend const LLVector3d& operator*=(LLVector3d& a, const F64 k);                // Return a times scaler k
+    friend const LLVector3d& operator/=(LLVector3d& a, const F64 k);                // Return a divided by scaler k
 
-        friend LLVector3d operator-(const LLVector3d& a);                   // Return vector -a
+    friend LLVector3d operator-(const LLVector3d& a);                   // Return vector -a
 
-        friend std::ostream&     operator<<(std::ostream& s, const LLVector3d& a);      // Stream a
+    friend std::ostream&     operator<<(std::ostream& s, const LLVector3d& a);      // Stream a
 
-        static bool parseVector3d(const std::string& buf, LLVector3d* value);
-
+    static bool parseVector3d(const std::string& buf, LLVector3d* value);
 };
 
 typedef LLVector3d LLGlobalVec;
 
 inline const LLVector3d &LLVector3d::set(const LLVector3 &vec)
 {
-    mdV[0] = vec.mV[0];
-    mdV[1] = vec.mV[1];
-    mdV[2] = vec.mV[2];
+    mdV[VX] = vec.mV[VX];
+    mdV[VY] = vec.mV[VY];
+    mdV[VZ] = vec.mV[VZ];
     return *this;
 }
 
 inline const LLVector3d &LLVector3d::setVec(const LLVector3 &vec)
 {
-    mdV[0] = vec.mV[0];
-    mdV[1] = vec.mV[1];
-    mdV[2] = vec.mV[2];
+    mdV[VX] = vec.mV[VX];
+    mdV[VY] = vec.mV[VY];
+    mdV[VZ] = vec.mV[VZ];
     return *this;
 }
 
 
 inline LLVector3d::LLVector3d(void)
 {
-    mdV[0] = 0.f;
-    mdV[1] = 0.f;
-    mdV[2] = 0.f;
+    mdV[VX] = 0.f;
+    mdV[VY] = 0.f;
+    mdV[VZ] = 0.f;
 }
 
 inline LLVector3d::LLVector3d(const F64 x, const F64 y, const F64 z)
@@ -199,33 +198,33 @@ inline bool LLVector3d::isFinite() const
 
 inline const LLVector3d&    LLVector3d::clear(void)
 {
-    mdV[0] = 0.f;
-    mdV[1] = 0.f;
-    mdV[2]= 0.f;
+    mdV[VX] = 0.f;
+    mdV[VY] = 0.f;
+    mdV[VZ] = 0.f;
     return (*this);
 }
 
 inline const LLVector3d&    LLVector3d::clearVec(void)
 {
-    mdV[0] = 0.f;
-    mdV[1] = 0.f;
-    mdV[2]= 0.f;
+    mdV[VX] = 0.f;
+    mdV[VY] = 0.f;
+    mdV[VZ] = 0.f;
     return (*this);
 }
 
 inline const LLVector3d&    LLVector3d::setZero(void)
 {
-    mdV[0] = 0.f;
-    mdV[1] = 0.f;
-    mdV[2] = 0.f;
+    mdV[VX] = 0.f;
+    mdV[VY] = 0.f;
+    mdV[VZ] = 0.f;
     return (*this);
 }
 
 inline const LLVector3d&    LLVector3d::zeroVec(void)
 {
-    mdV[0] = 0.f;
-    mdV[1] = 0.f;
-    mdV[2] = 0.f;
+    mdV[VX] = 0.f;
+    mdV[VY] = 0.f;
+    mdV[VZ] = 0.f;
     return (*this);
 }
 
@@ -239,17 +238,17 @@ inline const LLVector3d&    LLVector3d::set(const F64 x, const F64 y, const F64 
 
 inline const LLVector3d&    LLVector3d::set(const LLVector3d &vec)
 {
-    mdV[0] = vec.mdV[0];
-    mdV[1] = vec.mdV[1];
-    mdV[2] = vec.mdV[2];
+    mdV[VX] = vec.mdV[VX];
+    mdV[VY] = vec.mdV[VY];
+    mdV[VZ] = vec.mdV[VZ];
     return (*this);
 }
 
 inline const LLVector3d&    LLVector3d::set(const F64 *vec)
 {
-    mdV[0] = vec[0];
-    mdV[1] = vec[1];
-    mdV[2] = vec[2];
+    mdV[VX] = vec[0];
+    mdV[VY] = vec[1];
+    mdV[VZ] = vec[2];
     return (*this);
 }
 
@@ -261,61 +260,61 @@ inline const LLVector3d&    LLVector3d::setVec(const F64 x, const F64 y, const F
     return (*this);
 }
 
-inline const LLVector3d&    LLVector3d::setVec(const LLVector3d &vec)
+inline const LLVector3d&    LLVector3d::setVec(const LLVector3d& vec)
 {
-    mdV[0] = vec.mdV[0];
-    mdV[1] = vec.mdV[1];
-    mdV[2] = vec.mdV[2];
+    mdV[VX] = vec.mdV[VX];
+    mdV[VY] = vec.mdV[VY];
+    mdV[VZ] = vec.mdV[VZ];
     return (*this);
 }
 
-inline const LLVector3d&    LLVector3d::setVec(const F64 *vec)
+inline const LLVector3d&    LLVector3d::setVec(const F64* vec)
 {
-    mdV[0] = vec[0];
-    mdV[1] = vec[1];
-    mdV[2] = vec[2];
+    mdV[VX] = vec[VX];
+    mdV[VY] = vec[VY];
+    mdV[VZ] = vec[VZ];
     return (*this);
 }
 
-inline F64 LLVector3d::normVec(void)
+inline F64 LLVector3d::normVec()
 {
-    F64 mag = (F32) sqrt(mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2]);
+    F64 mag = sqrt(mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ]);
     F64 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mdV[0] *= oomag;
-        mdV[1] *= oomag;
-        mdV[2] *= oomag;
+        mdV[VX] *= oomag;
+        mdV[VY] *= oomag;
+        mdV[VZ] *= oomag;
     }
     else
     {
-        mdV[0] = 0.f;
-        mdV[1] = 0.f;
-        mdV[2] = 0.f;
+        mdV[VX] = 0.f;
+        mdV[VY] = 0.f;
+        mdV[VZ] = 0.f;
         mag = 0;
     }
     return (mag);
 }
 
-inline F64 LLVector3d::normalize(void)
+inline F64 LLVector3d::normalize()
 {
-    F64 mag = (F32) sqrt(mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2]);
+    F64 mag = sqrt(mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ]);
     F64 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mdV[0] *= oomag;
-        mdV[1] *= oomag;
-        mdV[2] *= oomag;
+        mdV[VX] *= oomag;
+        mdV[VY] *= oomag;
+        mdV[VZ] *= oomag;
     }
     else
     {
-        mdV[0] = 0.f;
-        mdV[1] = 0.f;
-        mdV[2] = 0.f;
+        mdV[VX] = 0.f;
+        mdV[VY] = 0.f;
+        mdV[VZ] = 0.f;
         mag = 0;
     }
     return (mag);
@@ -323,24 +322,24 @@ inline F64 LLVector3d::normalize(void)
 
 // LLVector3d Magnitude and Normalization Functions
 
-inline F64  LLVector3d::magVec(void) const
+inline F64  LLVector3d::magVec() const
 {
-    return (F32) sqrt(mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2]);
+    return sqrt(mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ]);
 }
 
-inline F64  LLVector3d::magVecSquared(void) const
+inline F64  LLVector3d::magVecSquared() const
 {
-    return mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2];
+    return mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ];
 }
 
-inline F64  LLVector3d::length(void) const
+inline F64  LLVector3d::length() const
 {
-    return (F32) sqrt(mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2]);
+    return sqrt(mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ]);
 }
 
-inline F64  LLVector3d::lengthSquared(void) const
+inline F64  LLVector3d::lengthSquared() const
 {
-    return mdV[0]*mdV[0] + mdV[1]*mdV[1] + mdV[2]*mdV[2];
+    return mdV[VX]*mdV[VX] + mdV[VY]*mdV[VY] + mdV[VZ]*mdV[VZ];
 }
 
 inline LLVector3d operator+(const LLVector3d& a, const LLVector3d& b)
@@ -357,109 +356,109 @@ inline LLVector3d operator-(const LLVector3d& a, const LLVector3d& b)
 
 inline F64  operator*(const LLVector3d& a, const LLVector3d& b)
 {
-    return (a.mdV[0]*b.mdV[0] + a.mdV[1]*b.mdV[1] + a.mdV[2]*b.mdV[2]);
+    return (a.mdV[VX]*b.mdV[VX] + a.mdV[VY]*b.mdV[VY] + a.mdV[VZ]*b.mdV[VZ]);
 }
 
 inline LLVector3d operator%(const LLVector3d& a, const LLVector3d& b)
 {
-    return LLVector3d( a.mdV[1]*b.mdV[2] - b.mdV[1]*a.mdV[2], a.mdV[2]*b.mdV[0] - b.mdV[2]*a.mdV[0], a.mdV[0]*b.mdV[1] - b.mdV[0]*a.mdV[1] );
+    return LLVector3d( a.mdV[VY]*b.mdV[VZ] - b.mdV[VY]*a.mdV[VZ], a.mdV[VZ]*b.mdV[VX] - b.mdV[VZ]*a.mdV[VX], a.mdV[VX]*b.mdV[VY] - b.mdV[VX]*a.mdV[VY] );
 }
 
 inline LLVector3d operator/(const LLVector3d& a, const F64 k)
 {
     F64 t = 1.f / k;
-    return LLVector3d( a.mdV[0] * t, a.mdV[1] * t, a.mdV[2] * t );
+    return LLVector3d( a.mdV[VX] * t, a.mdV[VY] * t, a.mdV[VZ] * t );
 }
 
 inline LLVector3d operator*(const LLVector3d& a, const F64 k)
 {
-    return LLVector3d( a.mdV[0] * k, a.mdV[1] * k, a.mdV[2] * k );
+    return LLVector3d( a.mdV[VX] * k, a.mdV[VY] * k, a.mdV[VZ] * k );
 }
 
 inline LLVector3d operator*(F64 k, const LLVector3d& a)
 {
-    return LLVector3d( a.mdV[0] * k, a.mdV[1] * k, a.mdV[2] * k );
+    return LLVector3d( a.mdV[VX] * k, a.mdV[VY] * k, a.mdV[VZ] * k );
 }
 
 inline bool operator==(const LLVector3d& a, const LLVector3d& b)
 {
-    return (  (a.mdV[0] == b.mdV[0])
-            &&(a.mdV[1] == b.mdV[1])
-            &&(a.mdV[2] == b.mdV[2]));
+    return (  (a.mdV[VX] == b.mdV[VX])
+            &&(a.mdV[VY] == b.mdV[VY])
+            &&(a.mdV[VZ] == b.mdV[VZ]));
 }
 
 inline bool operator!=(const LLVector3d& a, const LLVector3d& b)
 {
-    return (  (a.mdV[0] != b.mdV[0])
-            ||(a.mdV[1] != b.mdV[1])
-            ||(a.mdV[2] != b.mdV[2]));
+    return (  (a.mdV[VX] != b.mdV[VX])
+            ||(a.mdV[VY] != b.mdV[VY])
+            ||(a.mdV[VZ] != b.mdV[VZ]));
 }
 
 inline const LLVector3d& operator+=(LLVector3d& a, const LLVector3d& b)
 {
-    a.mdV[0] += b.mdV[0];
-    a.mdV[1] += b.mdV[1];
-    a.mdV[2] += b.mdV[2];
+    a.mdV[VX] += b.mdV[VX];
+    a.mdV[VY] += b.mdV[VY];
+    a.mdV[VZ] += b.mdV[VZ];
     return a;
 }
 
 inline const LLVector3d& operator-=(LLVector3d& a, const LLVector3d& b)
 {
-    a.mdV[0] -= b.mdV[0];
-    a.mdV[1] -= b.mdV[1];
-    a.mdV[2] -= b.mdV[2];
+    a.mdV[VX] -= b.mdV[VX];
+    a.mdV[VY] -= b.mdV[VY];
+    a.mdV[VZ] -= b.mdV[VZ];
     return a;
 }
 
 inline const LLVector3d& operator%=(LLVector3d& a, const LLVector3d& b)
 {
-    LLVector3d ret( a.mdV[1]*b.mdV[2] - b.mdV[1]*a.mdV[2], a.mdV[2]*b.mdV[0] - b.mdV[2]*a.mdV[0], a.mdV[0]*b.mdV[1] - b.mdV[0]*a.mdV[1]);
+    LLVector3d ret( a.mdV[VY]*b.mdV[VZ] - b.mdV[VY]*a.mdV[VZ], a.mdV[VZ]*b.mdV[VX] - b.mdV[VZ]*a.mdV[VX], a.mdV[VX]*b.mdV[VY] - b.mdV[VX]*a.mdV[VY]);
     a = ret;
     return a;
 }
 
 inline const LLVector3d& operator*=(LLVector3d& a, const F64 k)
 {
-    a.mdV[0] *= k;
-    a.mdV[1] *= k;
-    a.mdV[2] *= k;
+    a.mdV[VX] *= k;
+    a.mdV[VY] *= k;
+    a.mdV[VZ] *= k;
     return a;
 }
 
 inline const LLVector3d& operator/=(LLVector3d& a, const F64 k)
 {
     F64 t = 1.f / k;
-    a.mdV[0] *= t;
-    a.mdV[1] *= t;
-    a.mdV[2] *= t;
+    a.mdV[VX] *= t;
+    a.mdV[VY] *= t;
+    a.mdV[VZ] *= t;
     return a;
 }
 
 inline LLVector3d operator-(const LLVector3d& a)
 {
-    return LLVector3d( -a.mdV[0], -a.mdV[1], -a.mdV[2] );
+    return LLVector3d( -a.mdV[VX], -a.mdV[VY], -a.mdV[VZ] );
 }
 
 inline F64  dist_vec(const LLVector3d& a, const LLVector3d& b)
 {
-    F64 x = a.mdV[0] - b.mdV[0];
-    F64 y = a.mdV[1] - b.mdV[1];
-    F64 z = a.mdV[2] - b.mdV[2];
+    F64 x = a.mdV[VX] - b.mdV[VX];
+    F64 y = a.mdV[VY] - b.mdV[VY];
+    F64 z = a.mdV[VZ] - b.mdV[VZ];
     return (F32) sqrt( x*x + y*y + z*z );
 }
 
 inline F64  dist_vec_squared(const LLVector3d& a, const LLVector3d& b)
 {
-    F64 x = a.mdV[0] - b.mdV[0];
-    F64 y = a.mdV[1] - b.mdV[1];
-    F64 z = a.mdV[2] - b.mdV[2];
+    F64 x = a.mdV[VX] - b.mdV[VX];
+    F64 y = a.mdV[VY] - b.mdV[VY];
+    F64 z = a.mdV[VZ] - b.mdV[VZ];
     return x*x + y*y + z*z;
 }
 
 inline F64  dist_vec_squared2D(const LLVector3d& a, const LLVector3d& b)
 {
-    F64 x = a.mdV[0] - b.mdV[0];
-    F64 y = a.mdV[1] - b.mdV[1];
+    F64 x = a.mdV[VX] - b.mdV[VX];
+    F64 y = a.mdV[VY] - b.mdV[VY];
     return x*x + y*y;
 }
 

--- a/indra/llmath/v3math.cpp
+++ b/indra/llmath/v3math.cpp
@@ -28,7 +28,6 @@
 
 #include "v3math.h"
 
-//#include "vmath.h"
 #include "v2math.h"
 #include "v4math.h"
 #include "m4math.h"
@@ -58,13 +57,13 @@ bool LLVector3::clamp(F32 min, F32 max)
 {
     bool ret{ false };
 
-    if (mV[0] < min) { mV[0] = min; ret = true; }
-    if (mV[1] < min) { mV[1] = min; ret = true; }
-    if (mV[2] < min) { mV[2] = min; ret = true; }
+    if (mV[VX] < min) { mV[VX] = min; ret = true; }
+    if (mV[VY] < min) { mV[VY] = min; ret = true; }
+    if (mV[VZ] < min) { mV[VZ] = min; ret = true; }
 
-    if (mV[0] > max) { mV[0] = max; ret = true; }
-    if (mV[1] > max) { mV[1] = max; ret = true; }
-    if (mV[2] > max) { mV[2] = max; ret = true; }
+    if (mV[VX] > max) { mV[VX] = max; ret = true; }
+    if (mV[VY] > max) { mV[VY] = max; ret = true; }
+    if (mV[VZ] > max) { mV[VZ] = max; ret = true; }
 
     return ret;
 }
@@ -85,9 +84,9 @@ bool LLVector3::clampLength( F32 length_limit )
             {
                 length_limit = 0.f;
             }
-            mV[0] *= length_limit;
-            mV[1] *= length_limit;
-            mV[2] *= length_limit;
+            mV[VX] *= length_limit;
+            mV[VY] *= length_limit;
+            mV[VZ] *= length_limit;
             changed = true;
         }
     }
@@ -116,35 +115,35 @@ bool LLVector3::clampLength( F32 length_limit )
         {
             // yes it can be salvaged -->
             // bring the components down before we normalize
-            mV[0] /= max_abs_component;
-            mV[1] /= max_abs_component;
-            mV[2] /= max_abs_component;
+            mV[VX] /= max_abs_component;
+            mV[VY] /= max_abs_component;
+            mV[VZ] /= max_abs_component;
             normalize();
 
             if (length_limit < 0.f)
             {
                 length_limit = 0.f;
             }
-            mV[0] *= length_limit;
-            mV[1] *= length_limit;
-            mV[2] *= length_limit;
+            mV[VX] *= length_limit;
+            mV[VY] *= length_limit;
+            mV[VZ] *= length_limit;
         }
     }
 
     return changed;
 }
 
-bool LLVector3::clamp(const LLVector3 &min_vec, const LLVector3 &max_vec)
+bool LLVector3::clamp(const LLVector3& min_vec, const LLVector3& max_vec)
 {
     bool ret{ false };
 
-    if (mV[0] < min_vec[0]) { mV[0] = min_vec[0]; ret = true; }
-    if (mV[1] < min_vec[1]) { mV[1] = min_vec[1]; ret = true; }
-    if (mV[2] < min_vec[2]) { mV[2] = min_vec[2]; ret = true; }
+    if (mV[VX] < min_vec[0]) { mV[VX] = min_vec[0]; ret = true; }
+    if (mV[VY] < min_vec[1]) { mV[VY] = min_vec[1]; ret = true; }
+    if (mV[VZ] < min_vec[2]) { mV[VZ] = min_vec[2]; ret = true; }
 
-    if (mV[0] > max_vec[0]) { mV[0] = max_vec[0]; ret = true; }
-    if (mV[1] > max_vec[1]) { mV[1] = max_vec[1]; ret = true; }
-    if (mV[2] > max_vec[2]) { mV[2] = max_vec[2]; ret = true; }
+    if (mV[VX] > max_vec[0]) { mV[VX] = max_vec[0]; ret = true; }
+    if (mV[VY] > max_vec[1]) { mV[VY] = max_vec[1]; ret = true; }
+    if (mV[VZ] > max_vec[2]) { mV[VZ] = max_vec[2]; ret = true; }
 
     return ret;
 }
@@ -156,15 +155,15 @@ bool LLVector3::abs()
 {
     bool ret{ false };
 
-    if (mV[0] < 0.f) { mV[0] = -mV[0]; ret = true; }
-    if (mV[1] < 0.f) { mV[1] = -mV[1]; ret = true; }
-    if (mV[2] < 0.f) { mV[2] = -mV[2]; ret = true; }
+    if (mV[VX] < 0.f) { mV[VX] = -mV[VX]; ret = true; }
+    if (mV[VY] < 0.f) { mV[VY] = -mV[VY]; ret = true; }
+    if (mV[VZ] < 0.f) { mV[VZ] = -mV[VZ]; ret = true; }
 
     return ret;
 }
 
 // Quatizations
-void    LLVector3::quantize16(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
+void LLVector3::quantize16(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
 {
     F32 x = mV[VX];
     F32 y = mV[VY];
@@ -179,7 +178,7 @@ void    LLVector3::quantize16(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
     mV[VZ] = z;
 }
 
-void    LLVector3::quantize8(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
+void LLVector3::quantize8(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
 {
     mV[VX] = U8_to_F32(F32_to_U8(mV[VX], lowerxy, upperxy), lowerxy, upperxy);;
     mV[VY] = U8_to_F32(F32_to_U8(mV[VY], lowerxy, upperxy), lowerxy, upperxy);
@@ -187,20 +186,20 @@ void    LLVector3::quantize8(F32 lowerxy, F32 upperxy, F32 lowerz, F32 upperz)
 }
 
 
-void    LLVector3::snap(S32 sig_digits)
+void LLVector3::snap(S32 sig_digits)
 {
     mV[VX] = snap_to_sig_figs(mV[VX], sig_digits);
     mV[VY] = snap_to_sig_figs(mV[VY], sig_digits);
     mV[VZ] = snap_to_sig_figs(mV[VZ], sig_digits);
 }
 
-const LLVector3&    LLVector3::rotVec(const LLMatrix3 &mat)
+const LLVector3& LLVector3::rotVec(const LLMatrix3& mat)
 {
     *this = *this * mat;
     return *this;
 }
 
-const LLVector3&    LLVector3::rotVec(const LLQuaternion &q)
+const LLVector3& LLVector3::rotVec(const LLQuaternion& q)
 {
     *this = *this * q;
     return *this;
@@ -228,26 +227,26 @@ const LLVector3& LLVector3::transVec(const LLMatrix4& mat)
 }
 
 
-const LLVector3&    LLVector3::rotVec(F32 angle, const LLVector3 &vec)
+const LLVector3& LLVector3::rotVec(F32 angle, const LLVector3& vec)
 {
-    if ( !vec.isExactlyZero() && angle )
+    if (!vec.isExactlyZero() && angle)
     {
         *this = *this * LLQuaternion(angle, vec);
     }
     return *this;
 }
 
-const LLVector3&    LLVector3::rotVec(F32 angle, F32 x, F32 y, F32 z)
+const LLVector3& LLVector3::rotVec(F32 angle, F32 x, F32 y, F32 z)
 {
     LLVector3 vec(x, y, z);
-    if ( !vec.isExactlyZero() && angle )
+    if (!vec.isExactlyZero() && angle)
     {
         *this = *this * LLQuaternion(angle, vec);
     }
     return *this;
 }
 
-const LLVector3&    LLVector3::scaleVec(const LLVector3& vec)
+const LLVector3& LLVector3::scaleVec(const LLVector3& vec)
 {
     mV[VX] *= vec.mV[VX];
     mV[VY] *= vec.mV[VY];
@@ -256,42 +255,42 @@ const LLVector3&    LLVector3::scaleVec(const LLVector3& vec)
     return *this;
 }
 
-LLVector3           LLVector3::scaledVec(const LLVector3& vec) const
+LLVector3 LLVector3::scaledVec(const LLVector3& vec) const
 {
     LLVector3 ret = LLVector3(*this);
     ret.scaleVec(vec);
     return ret;
 }
 
-const LLVector3&    LLVector3::set(const LLVector3d &vec)
+const LLVector3& LLVector3::set(const LLVector3d& vec)
 {
-    mV[0] = (F32)vec.mdV[0];
-    mV[1] = (F32)vec.mdV[1];
-    mV[2] = (F32)vec.mdV[2];
+    mV[VX] = (F32)vec.mdV[VX];
+    mV[VY] = (F32)vec.mdV[VY];
+    mV[VZ] = (F32)vec.mdV[VZ];
     return (*this);
 }
 
-const LLVector3&    LLVector3::set(const LLVector4 &vec)
+const LLVector3& LLVector3::set(const LLVector4& vec)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VX] = vec.mV[VX];
+    mV[VY] = vec.mV[VY];
+    mV[VZ] = vec.mV[VZ];
     return (*this);
 }
 
-const LLVector3&    LLVector3::setVec(const LLVector3d &vec)
+const LLVector3& LLVector3::setVec(const LLVector3d& vec)
 {
-    mV[0] = (F32)vec.mdV[0];
-    mV[1] = (F32)vec.mdV[1];
-    mV[2] = (F32)vec.mdV[2];
+    mV[VX] = (F32)vec.mdV[0];
+    mV[VY] = (F32)vec.mdV[1];
+    mV[VZ] = (F32)vec.mdV[2];
     return (*this);
 }
 
-const LLVector3&    LLVector3::setVec(const LLVector4 &vec)
+const LLVector3& LLVector3::setVec(const LLVector4& vec)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VX] = vec.mV[VX];
+    mV[VY] = vec.mV[VY];
+    mV[VZ] = vec.mV[VZ];
     return (*this);
 }
 
@@ -299,17 +298,17 @@ LLVector3::LLVector3(const LLVector2 &vec)
 {
     mV[VX] = (F32)vec.mV[VX];
     mV[VY] = (F32)vec.mV[VY];
-    mV[VZ] = 0;
+    mV[VZ] = 0.f;
 }
 
-LLVector3::LLVector3(const LLVector3d &vec)
+LLVector3::LLVector3(const LLVector3d& vec)
 {
     mV[VX] = (F32)vec.mdV[VX];
     mV[VY] = (F32)vec.mdV[VY];
     mV[VZ] = (F32)vec.mdV[VZ];
 }
 
-LLVector3::LLVector3(const LLVector4 &vec)
+LLVector3::LLVector3(const LLVector4& vec)
 {
     mV[VX] = (F32)vec.mV[VX];
     mV[VY] = (F32)vec.mV[VY];
@@ -319,7 +318,6 @@ LLVector3::LLVector3(const LLVector4 &vec)
 LLVector3::LLVector3(const LLVector4a& vec)
     : LLVector3(vec.getF32ptr())
 {
-
 }
 
 LLVector3::LLVector3(const LLSD& sd)
@@ -330,20 +328,20 @@ LLVector3::LLVector3(const LLSD& sd)
 LLSD LLVector3::getValue() const
 {
     LLSD ret;
-    ret[0] = mV[0];
-    ret[1] = mV[1];
-    ret[2] = mV[2];
+    ret[VX] = mV[VX];
+    ret[VY] = mV[VY];
+    ret[VZ] = mV[VZ];
     return ret;
 }
 
 void LLVector3::setValue(const LLSD& sd)
 {
-    mV[0] = (F32) sd[0].asReal();
-    mV[1] = (F32) sd[1].asReal();
-    mV[2] = (F32) sd[2].asReal();
+    mV[VX] = (F32) sd[VX].asReal();
+    mV[VY] = (F32) sd[VY].asReal();
+    mV[VZ] = (F32) sd[VZ].asReal();
 }
 
-const LLVector3& operator*=(LLVector3 &a, const LLQuaternion &rot)
+const LLVector3& operator*=(LLVector3& a, const LLQuaternion& rot)
 {
     const F32 rw = - rot.mQ[VX] * a.mV[VX] - rot.mQ[VY] * a.mV[VY] - rot.mQ[VZ] * a.mV[VZ];
     const F32 rx =   rot.mQ[VW] * a.mV[VX] + rot.mQ[VY] * a.mV[VZ] - rot.mQ[VZ] * a.mV[VY];
@@ -360,16 +358,16 @@ const LLVector3& operator*=(LLVector3 &a, const LLQuaternion &rot)
 // static
 bool LLVector3::parseVector3(const std::string& buf, LLVector3* value)
 {
-    if( buf.empty() || value == nullptr)
+    if (buf.empty() || value == nullptr)
     {
         return false;
     }
 
     LLVector3 v;
-    S32 count = sscanf( buf.c_str(), "%f %f %f", v.mV + 0, v.mV + 1, v.mV + 2 );
-    if( 3 == count )
+    S32 count = sscanf(buf.c_str(), "%f %f %f", v.mV + VX, v.mV + VY, v.mV + VZ);
+    if (3 == count)
     {
-        value->setVec( v );
+        value->setVec(v);
         return true;
     }
 
@@ -381,7 +379,7 @@ bool LLVector3::parseVector3(const std::string& buf, LLVector3* value)
 LLVector3 point_to_box_offset(LLVector3& pos, const LLVector3* box)
 {
     LLVector3 offset;
-    for (S32 k=0; k<3; k++)
+    for (S32 k = 0; k < 3; k++)
     {
         offset[k] = 0;
         if (pos[k] < box[0][k])
@@ -410,4 +408,3 @@ bool box_valid_and_non_zero(const LLVector3* box)
     }
     return false;
 }
-

--- a/indra/llmath/v3math.h
+++ b/indra/llmath/v3math.h
@@ -46,7 +46,7 @@ class LLQuaternion;
 
 //  LLvector3 = |x y z w|
 
-static const U32 LENGTHOFVECTOR3 = 3;
+static constexpr U32 LENGTHOFVECTOR3 = 3;
 
 class LLVector3
 {
@@ -181,11 +181,11 @@ LLVector3 lerp(const LLVector3 &a, const LLVector3 &b, F32 u); // Returns a vect
 LLVector3 point_to_box_offset(LLVector3& pos, const LLVector3* box); // Displacement from query point to nearest point on bounding box.
 bool box_valid_and_non_zero(const LLVector3* box);
 
-inline LLVector3::LLVector3(void)
+inline LLVector3::LLVector3()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+    mV[VZ] = 0.f;
 }
 
 inline LLVector3::LLVector3(const F32 x, const F32 y, const F32 z)
@@ -236,32 +236,32 @@ inline bool LLVector3::isFinite() const
 
 // Clear and Assignment Functions
 
-inline void LLVector3::clear(void)
+inline void LLVector3::clear()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+    mV[VZ] = 0.f;
 }
 
-inline void LLVector3::setZero(void)
+inline void LLVector3::setZero()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+    mV[VZ] = 0.f;
 }
 
-inline void LLVector3::clearVec(void)
+inline void LLVector3::clearVec()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+    mV[VZ] = 0.f;
 }
 
-inline void LLVector3::zeroVec(void)
+inline void LLVector3::zeroVec()
 {
-    mV[0] = 0.f;
-    mV[1] = 0.f;
-    mV[2] = 0.f;
+    mV[VX] = 0.f;
+    mV[VY] = 0.f;
+    mV[VZ] = 0.f;
 }
 
 inline void LLVector3::set(F32 x, F32 y, F32 z)
@@ -271,18 +271,18 @@ inline void LLVector3::set(F32 x, F32 y, F32 z)
     mV[VZ] = z;
 }
 
-inline void LLVector3::set(const LLVector3 &vec)
+inline void LLVector3::set(const LLVector3& vec)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VX] = vec.mV[VX];
+    mV[VY] = vec.mV[VY];
+    mV[VZ] = vec.mV[VZ];
 }
 
-inline void LLVector3::set(const F32 *vec)
+inline void LLVector3::set(const F32* vec)
 {
-    mV[0] = vec[0];
-    mV[1] = vec[1];
-    mV[2] = vec[2];
+    mV[VX] = vec[VX];
+    mV[VY] = vec[VY];
+    mV[VZ] = vec[VZ];
 }
 
 inline void LLVector3::set(const glm::vec4& vec)
@@ -308,61 +308,61 @@ inline void LLVector3::setVec(F32 x, F32 y, F32 z)
 }
 
 // deprecated
-inline void LLVector3::setVec(const LLVector3 &vec)
+inline void LLVector3::setVec(const LLVector3& vec)
 {
-    mV[0] = vec.mV[0];
-    mV[1] = vec.mV[1];
-    mV[2] = vec.mV[2];
+    mV[VX] = vec.mV[VX];
+    mV[VY] = vec.mV[VY];
+    mV[VZ] = vec.mV[VZ];
 }
 
 // deprecated
-inline void LLVector3::setVec(const F32 *vec)
+inline void LLVector3::setVec(const F32* vec)
 {
-    mV[0] = vec[0];
-    mV[1] = vec[1];
-    mV[2] = vec[2];
+    mV[VX] = vec[0];
+    mV[VY] = vec[1];
+    mV[VZ] = vec[2];
 }
 
-inline F32 LLVector3::normalize(void)
+inline F32 LLVector3::normalize()
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    F32 mag = (F32) sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
-        mV[2] *= oomag;
+        mV[VX] *= oomag;
+        mV[VY] *= oomag;
+        mV[VZ] *= oomag;
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
-        mV[2] = 0.f;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
+        mV[VZ] = 0.f;
         mag = 0;
     }
     return (mag);
 }
 
 // deprecated
-inline F32 LLVector3::normVec(void)
+inline F32 LLVector3::normVec()
 {
-    F32 mag = (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    F32 mag = sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
     {
         oomag = 1.f/mag;
-        mV[0] *= oomag;
-        mV[1] *= oomag;
-        mV[2] *= oomag;
+        mV[VX] *= oomag;
+        mV[VY] *= oomag;
+        mV[VZ] *= oomag;
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
-        mV[2] = 0.f;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
+        mV[VZ] = 0.f;
         mag = 0;
     }
     return (mag);
@@ -370,145 +370,144 @@ inline F32 LLVector3::normVec(void)
 
 // LLVector3 Magnitude and Normalization Functions
 
-inline F32  LLVector3::length(void) const
+inline F32  LLVector3::length() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
 }
 
-inline F32  LLVector3::lengthSquared(void) const
+inline F32  LLVector3::lengthSquared() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2];
+    return mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ];
 }
 
-inline F32  LLVector3::magVec(void) const
+inline F32  LLVector3::magVec() const
 {
-    return (F32) sqrt(mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
 }
 
-inline F32  LLVector3::magVecSquared(void) const
+inline F32  LLVector3::magVecSquared() const
 {
-    return mV[0]*mV[0] + mV[1]*mV[1] + mV[2]*mV[2];
+    return mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ];
 }
 
 inline bool LLVector3::inRange( F32 min, F32 max ) const
 {
-    return mV[0] >= min && mV[0] <= max &&
-           mV[1] >= min && mV[1] <= max &&
-           mV[2] >= min && mV[2] <= max;
+    return mV[VX] >= min && mV[VX] <= max &&
+           mV[VY] >= min && mV[VY] <= max &&
+           mV[VZ] >= min && mV[VZ] <= max;
 }
 
-inline LLVector3 operator+(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 operator+(const LLVector3& a, const LLVector3& b)
 {
     LLVector3 c(a);
     return c += b;
 }
 
-inline LLVector3 operator-(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 operator-(const LLVector3& a, const LLVector3& b)
 {
     LLVector3 c(a);
     return c -= b;
 }
 
-inline F32  operator*(const LLVector3 &a, const LLVector3 &b)
+inline F32  operator*(const LLVector3& a, const LLVector3& b)
 {
-    return (a.mV[0]*b.mV[0] + a.mV[1]*b.mV[1] + a.mV[2]*b.mV[2]);
+    return (a.mV[VX]*b.mV[VX] + a.mV[VY]*b.mV[VY] + a.mV[VZ]*b.mV[VZ]);
 }
 
-inline LLVector3 operator%(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 operator%(const LLVector3& a, const LLVector3& b)
 {
-    return LLVector3( a.mV[1]*b.mV[2] - b.mV[1]*a.mV[2], a.mV[2]*b.mV[0] - b.mV[2]*a.mV[0], a.mV[0]*b.mV[1] - b.mV[0]*a.mV[1] );
+    return LLVector3( a.mV[VY]*b.mV[VZ] - b.mV[VY]*a.mV[VZ], a.mV[VZ]*b.mV[VX] - b.mV[VZ]*a.mV[VX], a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY] );
 }
 
-inline LLVector3 operator/(const LLVector3 &a, F32 k)
+inline LLVector3 operator/(const LLVector3& a, F32 k)
 {
     F32 t = 1.f / k;
-    return LLVector3( a.mV[0] * t, a.mV[1] * t, a.mV[2] * t );
+    return LLVector3( a.mV[VX] * t, a.mV[VY] * t, a.mV[VZ] * t );
 }
 
-inline LLVector3 operator*(const LLVector3 &a, F32 k)
+inline LLVector3 operator*(const LLVector3& a, F32 k)
 {
-    return LLVector3( a.mV[0] * k, a.mV[1] * k, a.mV[2] * k );
+    return LLVector3( a.mV[VX] * k, a.mV[VY] * k, a.mV[VZ] * k );
 }
 
-inline LLVector3 operator*(F32 k, const LLVector3 &a)
+inline LLVector3 operator*(F32 k, const LLVector3& a)
 {
-    return LLVector3( a.mV[0] * k, a.mV[1] * k, a.mV[2] * k );
+    return LLVector3( a.mV[VX] * k, a.mV[VY] * k, a.mV[VZ] * k );
 }
 
-inline bool operator==(const LLVector3 &a, const LLVector3 &b)
+inline bool operator==(const LLVector3& a, const LLVector3& b)
 {
-    return (  (a.mV[0] == b.mV[0])
-            &&(a.mV[1] == b.mV[1])
-            &&(a.mV[2] == b.mV[2]));
+    return (  (a.mV[VX] == b.mV[VX])
+            &&(a.mV[VY] == b.mV[VY])
+            &&(a.mV[VZ] == b.mV[VZ]));
 }
 
-inline bool operator!=(const LLVector3 &a, const LLVector3 &b)
+inline bool operator!=(const LLVector3& a, const LLVector3& b)
 {
-    return (  (a.mV[0] != b.mV[0])
-            ||(a.mV[1] != b.mV[1])
-            ||(a.mV[2] != b.mV[2]));
+    return (  (a.mV[VX] != b.mV[VX])
+            ||(a.mV[VY] != b.mV[VY])
+            ||(a.mV[VZ] != b.mV[VZ]));
 }
 
-inline bool operator<(const LLVector3 &a, const LLVector3 &b)
+inline bool operator<(const LLVector3& a, const LLVector3& b)
 {
-    return (a.mV[0] < b.mV[0]
-            || (a.mV[0] == b.mV[0]
-                && (a.mV[1] < b.mV[1]
-                    || ((a.mV[1] == b.mV[1])
-                        && a.mV[2] < b.mV[2]))));
+    return (a.mV[VX] < b.mV[VX]
+            || (a.mV[VX] == b.mV[VX]
+                && (a.mV[VY] < b.mV[VY]
+                    || ((a.mV[VY] == b.mV[VY])
+                        && a.mV[VZ] < b.mV[VZ]))));
 }
 
-inline const LLVector3& operator+=(LLVector3 &a, const LLVector3 &b)
+inline const LLVector3& operator+=(LLVector3& a, const LLVector3& b)
 {
-    a.mV[0] += b.mV[0];
-    a.mV[1] += b.mV[1];
-    a.mV[2] += b.mV[2];
+    a.mV[VX] += b.mV[VX];
+    a.mV[VY] += b.mV[VY];
+    a.mV[VZ] += b.mV[VZ];
     return a;
 }
 
-inline const LLVector3& operator-=(LLVector3 &a, const LLVector3 &b)
+inline const LLVector3& operator-=(LLVector3& a, const LLVector3& b)
 {
-    a.mV[0] -= b.mV[0];
-    a.mV[1] -= b.mV[1];
-    a.mV[2] -= b.mV[2];
+    a.mV[VX] -= b.mV[VX];
+    a.mV[VY] -= b.mV[VY];
+    a.mV[VZ] -= b.mV[VZ];
     return a;
 }
 
-inline const LLVector3& operator%=(LLVector3 &a, const LLVector3 &b)
+inline const LLVector3& operator%=(LLVector3& a, const LLVector3& b)
 {
-    LLVector3 ret( a.mV[1]*b.mV[2] - b.mV[1]*a.mV[2], a.mV[2]*b.mV[0] - b.mV[2]*a.mV[0], a.mV[0]*b.mV[1] - b.mV[0]*a.mV[1]);
+    LLVector3 ret( a.mV[VY]*b.mV[VZ] - b.mV[VY]*a.mV[VZ], a.mV[VZ]*b.mV[VX] - b.mV[VZ]*a.mV[VX], a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY]);
     a = ret;
     return a;
 }
 
-inline const LLVector3& operator*=(LLVector3 &a, F32 k)
+inline const LLVector3& operator*=(LLVector3& a, F32 k)
 {
-    a.mV[0] *= k;
-    a.mV[1] *= k;
-    a.mV[2] *= k;
+    a.mV[VX] *= k;
+    a.mV[VY] *= k;
+    a.mV[VZ] *= k;
     return a;
 }
 
-inline const LLVector3& operator*=(LLVector3 &a, const LLVector3 &b)
+inline const LLVector3& operator*=(LLVector3& a, const LLVector3& b)
 {
-    a.mV[0] *= b.mV[0];
-    a.mV[1] *= b.mV[1];
-    a.mV[2] *= b.mV[2];
+    a.mV[VX] *= b.mV[VX];
+    a.mV[VY] *= b.mV[VY];
+    a.mV[VZ] *= b.mV[VZ];
     return a;
 }
 
-inline const LLVector3& operator/=(LLVector3 &a, F32 k)
+inline const LLVector3& operator/=(LLVector3& a, F32 k)
 {
-    F32 t = 1.f / k;
-    a.mV[0] *= t;
-    a.mV[1] *= t;
-    a.mV[2] *= t;
+    a.mV[VX] /= k;
+    a.mV[VY] /= k;
+    a.mV[VZ] /= k;
     return a;
 }
 
-inline LLVector3 operator-(const LLVector3 &a)
+inline LLVector3 operator-(const LLVector3& a)
 {
-    return LLVector3( -a.mV[0], -a.mV[1], -a.mV[2] );
+    return LLVector3(-a.mV[VX], -a.mV[VY], -a.mV[VZ]);
 }
 
 inline LLVector3::operator glm::vec3() const
@@ -522,30 +521,30 @@ inline LLVector3::operator glm::vec4() const
     return glm::vec4(mV[VX], mV[VY], mV[VZ], 1.f);
 }
 
-inline F32  dist_vec(const LLVector3 &a, const LLVector3 &b)
+inline F32 dist_vec(const LLVector3& a, const LLVector3& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
-    F32 z = a.mV[2] - b.mV[2];
-    return (F32) sqrt( x*x + y*y + z*z );
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
+    F32 z = a.mV[VZ] - b.mV[VZ];
+    return sqrt( x*x + y*y + z*z );
 }
 
-inline F32  dist_vec_squared(const LLVector3 &a, const LLVector3 &b)
+inline F32 dist_vec_squared(const LLVector3& a, const LLVector3& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
-    F32 z = a.mV[2] - b.mV[2];
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
+    F32 z = a.mV[VZ] - b.mV[VZ];
     return x*x + y*y + z*z;
 }
 
-inline F32  dist_vec_squared2D(const LLVector3 &a, const LLVector3 &b)
+inline F32 dist_vec_squared2D(const LLVector3& a, const LLVector3& b)
 {
-    F32 x = a.mV[0] - b.mV[0];
-    F32 y = a.mV[1] - b.mV[1];
+    F32 x = a.mV[VX] - b.mV[VX];
+    F32 y = a.mV[VY] - b.mV[VY];
     return x*x + y*y;
 }
 
-inline LLVector3 projected_vec(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 projected_vec(const LLVector3& a, const LLVector3& b)
 {
     F32 bb = b * b;
     if (bb > FP_MAG_THRESHOLD * FP_MAG_THRESHOLD)
@@ -570,18 +569,18 @@ inline LLVector3 inverse_projected_vec(const LLVector3& a, const LLVector3& b)
     return normalized_a * (b_length / dot_product);
 }
 
-inline LLVector3 parallel_component(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 parallel_component(const LLVector3& a, const LLVector3& b)
 {
     return projected_vec(a, b);
 }
 
-inline LLVector3 orthogonal_component(const LLVector3 &a, const LLVector3 &b)
+inline LLVector3 orthogonal_component(const LLVector3& a, const LLVector3& b)
 {
     return a - projected_vec(a, b);
 }
 
 
-inline LLVector3 lerp(const LLVector3 &a, const LLVector3 &b, F32 u)
+inline LLVector3 lerp(const LLVector3& a, const LLVector3& b, F32 u)
 {
     return LLVector3(
         a.mV[VX] + (b.mV[VX] - a.mV[VX]) * u,
@@ -640,7 +639,7 @@ inline F32 angle_between(const LLVector3& a, const LLVector3& b)
     return atan2f(sqrtf(c * c), ab); // return the angle
 }
 
-inline bool are_parallel(const LLVector3 &a, const LLVector3 &b, F32 epsilon)
+inline bool are_parallel(const LLVector3& a, const LLVector3& b, F32 epsilon)
 {
     LLVector3 an = a;
     LLVector3 bn = b;

--- a/indra/llmath/v4color.cpp
+++ b/indra/llmath/v4color.cpp
@@ -124,65 +124,64 @@ LLColor4 LLColor4::cyan6(0.2f, 0.6f, 0.6f, 1.0f);
 // conversion
 LLColor4::operator LLColor4U() const
 {
-    return LLColor4U(
-        (U8)llclampb(ll_round(mV[VRED]*255.f)),
-        (U8)llclampb(ll_round(mV[VGREEN]*255.f)),
-        (U8)llclampb(ll_round(mV[VBLUE]*255.f)),
-        (U8)llclampb(ll_round(mV[VALPHA]*255.f)));
+    return LLColor4U((U8)llclampb(ll_round(mV[VRED] * 255.f)),
+                     (U8)llclampb(ll_round(mV[VGREEN] * 255.f)),
+                     (U8)llclampb(ll_round(mV[VBLUE] * 255.f)),
+                     (U8)llclampb(ll_round(mV[VALPHA] * 255.f)));
 }
 
-LLColor4::LLColor4(const LLColor3 &vec, F32 a)
+LLColor4::LLColor4(const LLColor3& vec, F32 a)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = a;
 }
 
 LLColor4::LLColor4(const LLColor4U& color4u)
 {
-    const F32 SCALE = 1.f/255.f;
-    mV[VRED] = color4u.mV[VRED] * SCALE;
-    mV[VGREEN] = color4u.mV[VGREEN] * SCALE;
-    mV[VBLUE] = color4u.mV[VBLUE] * SCALE;
-    mV[VALPHA] = color4u.mV[VALPHA] * SCALE;
+    constexpr F32 SCALE = 1.f / 255.f;
+    mV[VRED]            = color4u.mV[VRED] * SCALE;
+    mV[VGREEN]          = color4u.mV[VGREEN] * SCALE;
+    mV[VBLUE]           = color4u.mV[VBLUE] * SCALE;
+    mV[VALPHA]          = color4u.mV[VALPHA] * SCALE;
 }
 
 LLColor4::LLColor4(const LLVector4& vector4)
 {
-    mV[VRED] = vector4.mV[VRED];
+    mV[VRED]   = vector4.mV[VRED];
     mV[VGREEN] = vector4.mV[VGREEN];
-    mV[VBLUE] = vector4.mV[VBLUE];
+    mV[VBLUE]  = vector4.mV[VBLUE];
     mV[VALPHA] = vector4.mV[VALPHA];
 }
 
 const LLColor4& LLColor4::set(const LLColor4U& color4u)
 {
-    const F32 SCALE = 1.f/255.f;
-    mV[VRED] = color4u.mV[VRED] * SCALE;
-    mV[VGREEN] = color4u.mV[VGREEN] * SCALE;
-    mV[VBLUE] = color4u.mV[VBLUE] * SCALE;
-    mV[VALPHA] = color4u.mV[VALPHA] * SCALE;
+    constexpr F32 SCALE = 1.f / 255.f;
+    mV[VRED]            = color4u.mV[VRED] * SCALE;
+    mV[VGREEN]          = color4u.mV[VGREEN] * SCALE;
+    mV[VBLUE]           = color4u.mV[VBLUE] * SCALE;
+    mV[VALPHA]          = color4u.mV[VALPHA] * SCALE;
     return (*this);
 }
 
-const LLColor4& LLColor4::set(const LLColor3 &vec)
+const LLColor4& LLColor4::set(const LLColor3& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
 
-//  no change to alpha!
-//  mV[VALPHA] = 1.f;
+    //  no change to alpha!
+    //  mV[VALPHA] = 1.f;
 
     return (*this);
 }
 
-const LLColor4& LLColor4::set(const LLColor3 &vec, F32 a)
+const LLColor4& LLColor4::set(const LLColor3& vec, F32 a)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = a;
     return (*this);
 }
@@ -190,33 +189,33 @@ const LLColor4& LLColor4::set(const LLColor3 &vec, F32 a)
 // deprecated -- use set()
 const LLColor4& LLColor4::setVec(const LLColor4U& color4u)
 {
-    const F32 SCALE = 1.f/255.f;
-    mV[VRED] = color4u.mV[VRED] * SCALE;
-    mV[VGREEN] = color4u.mV[VGREEN] * SCALE;
-    mV[VBLUE] = color4u.mV[VBLUE] * SCALE;
-    mV[VALPHA] = color4u.mV[VALPHA] * SCALE;
+    constexpr F32 SCALE = 1.f / 255.f;
+    mV[VRED]            = color4u.mV[VRED] * SCALE;
+    mV[VGREEN]          = color4u.mV[VGREEN] * SCALE;
+    mV[VBLUE]           = color4u.mV[VBLUE] * SCALE;
+    mV[VALPHA]          = color4u.mV[VALPHA] * SCALE;
     return (*this);
 }
 
 // deprecated -- use set()
-const LLColor4& LLColor4::setVec(const LLColor3 &vec)
+const LLColor4& LLColor4::setVec(const LLColor3& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
 
-//  no change to alpha!
-//  mV[VALPHA] = 1.f;
+    //  no change to alpha!
+    //  mV[VALPHA] = 1.f;
 
     return (*this);
 }
 
 // deprecated -- use set()
-const LLColor4& LLColor4::setVec(const LLColor3 &vec, F32 a)
+const LLColor4& LLColor4::setVec(const LLColor3& vec, F32 a)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = a;
     return (*this);
 }
@@ -228,110 +227,110 @@ void LLColor4::setValue(const LLSD& sd)
     F32 val;
     bool out_of_range = false;
     val = sd[0].asReal();
-    mV[0] = llclamp(val, 0.f, 1.f);
-    out_of_range = mV[0] != val;
+    mV[VRED] = llclamp(val, 0.f, 1.f);
+    out_of_range = mV[VRED] != val;
 
     val = sd[1].asReal();
-    mV[1] = llclamp(val, 0.f, 1.f);
-    out_of_range |= mV[1] != val;
+    mV[VGREEN] = llclamp(val, 0.f, 1.f);
+    out_of_range |= mV[VGREEN] != val;
 
     val = sd[2].asReal();
-    mV[2] = llclamp(val, 0.f, 1.f);
-    out_of_range |= mV[2] != val;
+    mV[VBLUE] = llclamp(val, 0.f, 1.f);
+    out_of_range |= mV[VBLUE] != val;
 
     val = sd[3].asReal();
-    mV[3] = llclamp(val, 0.f, 1.f);
-    out_of_range |= mV[3] != val;
+    mV[VALPHA] = llclamp(val, 0.f, 1.f);
+    out_of_range |= mV[VALPHA] != val;
 
     if (out_of_range)
     {
         LL_WARNS() << "LLSD color value out of range!" << LL_ENDL;
     }
 #else
-    mV[0] = (F32) sd[0].asReal();
-    mV[1] = (F32) sd[1].asReal();
-    mV[2] = (F32) sd[2].asReal();
-    mV[3] = (F32) sd[3].asReal();
+    mV[VRED]   = (F32)sd[VRED].asReal();
+    mV[VGREEN] = (F32)sd[VGREEN].asReal();
+    mV[VBLUE]  = (F32)sd[VBLUE].asReal();
+    mV[VALPHA] = (F32)sd[VALPHA].asReal();
 #endif
 }
 
-const LLColor4& LLColor4::operator=(const LLColor3 &a)
+const LLColor4& LLColor4::operator=(const LLColor3& a)
 {
-    mV[VRED] = a.mV[VRED];
+    mV[VRED]   = a.mV[VRED];
     mV[VGREEN] = a.mV[VGREEN];
-    mV[VBLUE] = a.mV[VBLUE];
+    mV[VBLUE]  = a.mV[VBLUE];
 
-// converting from an rgb sets a=1 (opaque)
+    // converting from an rgb sets a=1 (opaque)
     mV[VALPHA] = 1.f;
     return (*this);
 }
 
-
-std::ostream& operator<<(std::ostream& s, const LLColor4 &a)
+std::ostream& operator<<(std::ostream& s, const LLColor4& a)
 {
     s << "{ " << a.mV[VRED] << ", " << a.mV[VGREEN] << ", " << a.mV[VBLUE] << ", " << a.mV[VALPHA] << " }";
     return s;
 }
 
-bool operator==(const LLColor4 &a, const LLColor3 &b)
+bool operator==(const LLColor4& a, const LLColor3& b)
 {
-    return (  (a.mV[VRED] == b.mV[VRED])
-            &&(a.mV[VGREEN] == b.mV[VGREEN])
-            &&(a.mV[VBLUE] == b.mV[VBLUE]));
+    return ((a.mV[VRED] == b.mV[VRED]) && (a.mV[VGREEN] == b.mV[VGREEN]) && (a.mV[VBLUE] == b.mV[VBLUE]));
 }
 
-bool operator!=(const LLColor4 &a, const LLColor3 &b)
+bool operator!=(const LLColor4& a, const LLColor3& b)
 {
-    return (  (a.mV[VRED] != b.mV[VRED])
-            ||(a.mV[VGREEN] != b.mV[VGREEN])
-            ||(a.mV[VBLUE] != b.mV[VBLUE]));
+    return ((a.mV[VRED] != b.mV[VRED]) || (a.mV[VGREEN] != b.mV[VGREEN]) || (a.mV[VBLUE] != b.mV[VBLUE]));
 }
 
-LLColor3    vec4to3(const LLColor4 &vec)
+LLColor3 vec4to3(const LLColor4& vec)
 {
-    LLColor3    temp(vec.mV[VRED], vec.mV[VGREEN], vec.mV[VBLUE]);
+    LLColor3 temp(vec.mV[VRED], vec.mV[VGREEN], vec.mV[VBLUE]);
     return temp;
 }
 
-LLColor4    vec3to4(const LLColor3 &vec)
+LLColor4 vec3to4(const LLColor3& vec)
 {
-    LLColor3    temp(vec.mV[VRED], vec.mV[VGREEN], vec.mV[VBLUE]);
+    LLColor3 temp(vec.mV[VRED], vec.mV[VGREEN], vec.mV[VBLUE]);
     return temp;
 }
 
-static F32 hueToRgb ( F32 val1In, F32 val2In, F32 valHUeIn )
+static F32 hueToRgb(F32 val1In, F32 val2In, F32 valHUeIn)
 {
-    if ( valHUeIn < 0.0f ) valHUeIn += 1.0f;
-    if ( valHUeIn > 1.0f ) valHUeIn -= 1.0f;
-    if ( ( 6.0f * valHUeIn ) < 1.0f ) return ( val1In + ( val2In - val1In ) * 6.0f * valHUeIn );
-    if ( ( 2.0f * valHUeIn ) < 1.0f ) return ( val2In );
-    if ( ( 3.0f * valHUeIn ) < 2.0f ) return ( val1In + ( val2In - val1In ) * ( ( 2.0f / 3.0f ) - valHUeIn ) * 6.0f );
-    return ( val1In );
+    if (valHUeIn < 0.0f)
+        valHUeIn += 1.0f;
+    if (valHUeIn > 1.0f)
+        valHUeIn -= 1.0f;
+    if ((6.0f * valHUeIn) < 1.0f)
+        return (val1In + (val2In - val1In) * 6.0f * valHUeIn);
+    if ((2.0f * valHUeIn) < 1.0f)
+        return (val2In);
+    if ((3.0f * valHUeIn) < 2.0f)
+        return (val1In + (val2In - val1In) * ((2.0f / 3.0f) - valHUeIn) * 6.0f);
+    return (val1In);
 }
 
-void LLColor4::setHSL ( F32 hValIn, F32 sValIn, F32 lValIn)
+void LLColor4::setHSL(F32 hValIn, F32 sValIn, F32 lValIn)
 {
-    if ( sValIn < 0.00001f )
+    if (sValIn < 0.00001f)
     {
-        mV[VRED] = lValIn;
+        mV[VRED]   = lValIn;
         mV[VGREEN] = lValIn;
-        mV[VBLUE] = lValIn;
+        mV[VBLUE]  = lValIn;
     }
     else
     {
         F32 interVal1;
         F32 interVal2;
 
-        if ( lValIn < 0.5f )
-            interVal2 = lValIn * ( 1.0f + sValIn );
+        if (lValIn < 0.5f)
+            interVal2 = lValIn * (1.0f + sValIn);
         else
-            interVal2 = ( lValIn + sValIn ) - ( sValIn * lValIn );
+            interVal2 = (lValIn + sValIn) - (sValIn * lValIn);
 
         interVal1 = 2.0f * lValIn - interVal2;
 
-        mV[VRED] = hueToRgb ( interVal1, interVal2, hValIn + ( 1.f / 3.f ) );
-        mV[VGREEN] = hueToRgb ( interVal1, interVal2, hValIn );
-        mV[VBLUE] = hueToRgb ( interVal1, interVal2, hValIn - ( 1.f / 3.f ) );
+        mV[VRED]   = hueToRgb(interVal1, interVal2, hValIn + (1.f / 3.f));
+        mV[VGREEN] = hueToRgb(interVal1, interVal2, hValIn);
+        mV[VBLUE]  = hueToRgb(interVal1, interVal2, hValIn - (1.f / 3.f));
     }
 }
 
@@ -341,58 +340,61 @@ void LLColor4::calcHSL(F32* hue, F32* saturation, F32* luminance) const
     F32 var_G = mV[VGREEN];
     F32 var_B = mV[VBLUE];
 
-    F32 var_Min = ( var_R < ( var_G < var_B ? var_G : var_B ) ? var_R : ( var_G < var_B ? var_G : var_B ) );
-    F32 var_Max = ( var_R > ( var_G > var_B ? var_G : var_B ) ? var_R : ( var_G > var_B ? var_G : var_B ) );
+    F32 var_Min = (var_R < (var_G < var_B ? var_G : var_B) ? var_R : (var_G < var_B ? var_G : var_B));
+    F32 var_Max = (var_R > (var_G > var_B ? var_G : var_B) ? var_R : (var_G > var_B ? var_G : var_B));
 
     F32 del_Max = var_Max - var_Min;
 
-    F32 L = ( var_Max + var_Min ) / 2.0f;
+    F32 L = (var_Max + var_Min) / 2.0f;
     F32 H = 0.0f;
     F32 S = 0.0f;
 
-    if ( del_Max == 0.0f )
+    if (del_Max == 0.0f)
     {
-       H = 0.0f;
-       S = 0.0f;
+        H = 0.0f;
+        S = 0.0f;
     }
     else
     {
-        if ( L < 0.5 )
-            S = del_Max / ( var_Max + var_Min );
+        if (L < 0.5f)
+            S = del_Max / (var_Max + var_Min);
         else
-            S = del_Max / ( 2.0f - var_Max - var_Min );
+            S = del_Max / (2.0f - var_Max - var_Min);
 
-        F32 del_R = ( ( ( var_Max - var_R ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
-        F32 del_G = ( ( ( var_Max - var_G ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
-        F32 del_B = ( ( ( var_Max - var_B ) / 6.0f ) + ( del_Max / 2.0f ) ) / del_Max;
+        F32 del_R = (((var_Max - var_R) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+        F32 del_G = (((var_Max - var_G) / 6.0f) + (del_Max / 2.0f)) / del_Max;
+        F32 del_B = (((var_Max - var_B) / 6.0f) + (del_Max / 2.0f)) / del_Max;
 
-        if ( var_R >= var_Max )
+        if (var_R >= var_Max)
             H = del_B - del_G;
-        else
-        if ( var_G >= var_Max )
-            H = ( 1.0f / 3.0f ) + del_R - del_B;
-        else
-        if ( var_B >= var_Max )
-            H = ( 2.0f / 3.0f ) + del_G - del_R;
+        else if (var_G >= var_Max)
+            H = (1.0f / 3.0f) + del_R - del_B;
+        else if (var_B >= var_Max)
+            H = (2.0f / 3.0f) + del_G - del_R;
 
-        if ( H < 0.0f ) H += 1.0f;
-        if ( H > 1.0f ) H -= 1.0f;
+        if (H < 0.0f)
+            H += 1.0f;
+        if (H > 1.0f)
+            H -= 1.0f;
     }
 
-    if (hue) *hue = H;
-    if (saturation) *saturation = S;
-    if (luminance) *luminance = L;
+    if (hue)
+        *hue = H;
+    if (saturation)
+        *saturation = S;
+    if (luminance)
+        *luminance = L;
 }
 
 // static
 bool LLColor4::parseColor(const std::string& buf, LLColor4* color)
 {
-    if( buf.empty() || color == nullptr)
+    if (buf.empty() || color == nullptr)
     {
         return false;
     }
 
-    boost_tokenizer tokens(buf, boost::char_separator<char>(", "));
+    boost_tokenizer           tokens(buf, boost::char_separator<char>(", "));
     boost_tokenizer::iterator token_iter = tokens.begin();
     if (token_iter == tokens.end())
     {
@@ -401,16 +403,16 @@ bool LLColor4::parseColor(const std::string& buf, LLColor4* color)
 
     // Grab the first token into a string, since we don't know
     // if this is a float or a color name.
-    std::string color_name( (*token_iter) );
+    std::string color_name((*token_iter));
     ++token_iter;
 
     if (token_iter != tokens.end())
     {
         // There are more tokens to read.  This must be a vector.
         LLColor4 v;
-        LLStringUtil::convertToF32( color_name,  v.mV[VRED] );
-        LLStringUtil::convertToF32( *token_iter, v.mV[VGREEN] );
-        v.mV[VBLUE] = 0.0f;
+        LLStringUtil::convertToF32(color_name, v.mV[VRED]);
+        LLStringUtil::convertToF32(*token_iter, v.mV[VGREEN]);
+        v.mV[VBLUE]  = 0.0f;
         v.mV[VALPHA] = 1.0f;
 
         ++token_iter;
@@ -422,283 +424,284 @@ bool LLColor4::parseColor(const std::string& buf, LLColor4* color)
         else
         {
             // There is a z-component.
-            LLStringUtil::convertToF32( *token_iter, v.mV[VBLUE] );
+            LLStringUtil::convertToF32(*token_iter, v.mV[VBLUE]);
 
             ++token_iter;
             if (token_iter != tokens.end())
             {
                 // There is an alpha component.
-                LLStringUtil::convertToF32( *token_iter, v.mV[VALPHA] );
+                LLStringUtil::convertToF32(*token_iter, v.mV[VALPHA]);
             }
         }
 
         //  Make sure all values are between 0 and 1.
         if (v.mV[VRED] > 1.f || v.mV[VGREEN] > 1.f || v.mV[VBLUE] > 1.f || v.mV[VALPHA] > 1.f)
         {
-            v = v * (1.f / 255.f);
+            constexpr F32 SCALE{ 1.f / 255.f };
+            v *= SCALE;
         }
-        color->set( v );
+        color->set(v);
     }
     else // Single value.  Read as a named color.
     {
         // We have a color name
-        if ( "red" == color_name )
+        if ("red" == color_name)
         {
             color->set(LLColor4::red);
         }
-        else if ( "red1" == color_name )
+        else if ("red1" == color_name)
         {
             color->set(LLColor4::red1);
         }
-        else if ( "red2" == color_name )
+        else if ("red2" == color_name)
         {
             color->set(LLColor4::red2);
         }
-        else if ( "red3" == color_name )
+        else if ("red3" == color_name)
         {
             color->set(LLColor4::red3);
         }
-        else if ( "red4" == color_name )
+        else if ("red4" == color_name)
         {
             color->set(LLColor4::red4);
         }
-        else if ( "red5" == color_name )
+        else if ("red5" == color_name)
         {
             color->set(LLColor4::red5);
         }
-        else if( "green" == color_name )
+        else if ("green" == color_name)
         {
             color->set(LLColor4::green);
         }
-        else if( "green1" == color_name )
+        else if ("green1" == color_name)
         {
             color->set(LLColor4::green1);
         }
-        else if( "green2" == color_name )
+        else if ("green2" == color_name)
         {
             color->set(LLColor4::green2);
         }
-        else if( "green3" == color_name )
+        else if ("green3" == color_name)
         {
             color->set(LLColor4::green3);
         }
-        else if( "green4" == color_name )
+        else if ("green4" == color_name)
         {
             color->set(LLColor4::green4);
         }
-        else if( "green5" == color_name )
+        else if ("green5" == color_name)
         {
             color->set(LLColor4::green5);
         }
-        else if( "green6" == color_name )
+        else if ("green6" == color_name)
         {
             color->set(LLColor4::green6);
         }
-        else if( "blue" == color_name )
+        else if ("blue" == color_name)
         {
             color->set(LLColor4::blue);
         }
-        else if( "blue1" == color_name )
+        else if ("blue1" == color_name)
         {
             color->set(LLColor4::blue1);
         }
-        else if( "blue2" == color_name )
+        else if ("blue2" == color_name)
         {
             color->set(LLColor4::blue2);
         }
-        else if( "blue3" == color_name )
+        else if ("blue3" == color_name)
         {
             color->set(LLColor4::blue3);
         }
-        else if( "blue4" == color_name )
+        else if ("blue4" == color_name)
         {
             color->set(LLColor4::blue4);
         }
-        else if( "blue5" == color_name )
+        else if ("blue5" == color_name)
         {
             color->set(LLColor4::blue5);
         }
-        else if( "blue6" == color_name )
+        else if ("blue6" == color_name)
         {
             color->set(LLColor4::blue6);
         }
-        else if( "black" == color_name )
+        else if ("black" == color_name)
         {
             color->set(LLColor4::black);
         }
-        else if( "white" == color_name )
+        else if ("white" == color_name)
         {
             color->set(LLColor4::white);
         }
-        else if( "yellow" == color_name )
+        else if ("yellow" == color_name)
         {
             color->set(LLColor4::yellow);
         }
-        else if( "yellow1" == color_name )
+        else if ("yellow1" == color_name)
         {
             color->set(LLColor4::yellow1);
         }
-        else if( "yellow2" == color_name )
+        else if ("yellow2" == color_name)
         {
             color->set(LLColor4::yellow2);
         }
-        else if( "yellow3" == color_name )
+        else if ("yellow3" == color_name)
         {
             color->set(LLColor4::yellow3);
         }
-        else if( "yellow4" == color_name )
+        else if ("yellow4" == color_name)
         {
             color->set(LLColor4::yellow4);
         }
-        else if( "yellow5" == color_name )
+        else if ("yellow5" == color_name)
         {
             color->set(LLColor4::yellow5);
         }
-        else if( "yellow6" == color_name )
+        else if ("yellow6" == color_name)
         {
             color->set(LLColor4::yellow6);
         }
-        else if( "magenta" == color_name )
+        else if ("magenta" == color_name)
         {
             color->set(LLColor4::magenta);
         }
-        else if( "magenta1" == color_name )
+        else if ("magenta1" == color_name)
         {
             color->set(LLColor4::magenta1);
         }
-        else if( "magenta2" == color_name )
+        else if ("magenta2" == color_name)
         {
             color->set(LLColor4::magenta2);
         }
-        else if( "magenta3" == color_name )
+        else if ("magenta3" == color_name)
         {
             color->set(LLColor4::magenta3);
         }
-        else if( "magenta4" == color_name )
+        else if ("magenta4" == color_name)
         {
             color->set(LLColor4::magenta4);
         }
-        else if( "purple" == color_name )
+        else if ("purple" == color_name)
         {
             color->set(LLColor4::purple);
         }
-        else if( "purple1" == color_name )
+        else if ("purple1" == color_name)
         {
             color->set(LLColor4::purple1);
         }
-        else if( "purple2" == color_name )
+        else if ("purple2" == color_name)
         {
             color->set(LLColor4::purple2);
         }
-        else if( "purple3" == color_name )
+        else if ("purple3" == color_name)
         {
             color->set(LLColor4::purple3);
         }
-        else if( "purple4" == color_name )
+        else if ("purple4" == color_name)
         {
             color->set(LLColor4::purple4);
         }
-        else if( "purple5" == color_name )
+        else if ("purple5" == color_name)
         {
             color->set(LLColor4::purple5);
         }
-        else if( "purple6" == color_name )
+        else if ("purple6" == color_name)
         {
             color->set(LLColor4::purple6);
         }
-        else if( "pink" == color_name )
+        else if ("pink" == color_name)
         {
             color->set(LLColor4::pink);
         }
-        else if( "pink1" == color_name )
+        else if ("pink1" == color_name)
         {
             color->set(LLColor4::pink1);
         }
-        else if( "pink2" == color_name )
+        else if ("pink2" == color_name)
         {
             color->set(LLColor4::pink2);
         }
-        else if( "cyan" == color_name )
+        else if ("cyan" == color_name)
         {
             color->set(LLColor4::cyan);
         }
-        else if( "cyan1" == color_name )
+        else if ("cyan1" == color_name)
         {
             color->set(LLColor4::cyan1);
         }
-        else if( "cyan2" == color_name )
+        else if ("cyan2" == color_name)
         {
             color->set(LLColor4::cyan2);
         }
-        else if( "cyan3" == color_name )
+        else if ("cyan3" == color_name)
         {
             color->set(LLColor4::cyan3);
         }
-        else if( "cyan4" == color_name )
+        else if ("cyan4" == color_name)
         {
             color->set(LLColor4::cyan4);
         }
-        else if( "cyan5" == color_name )
+        else if ("cyan5" == color_name)
         {
             color->set(LLColor4::cyan5);
         }
-        else if( "cyan6" == color_name )
+        else if ("cyan6" == color_name)
         {
             color->set(LLColor4::cyan6);
         }
-        else if( "smoke" == color_name )
+        else if ("smoke" == color_name)
         {
             color->set(LLColor4::smoke);
         }
-        else if( "grey" == color_name )
+        else if ("grey" == color_name)
         {
             color->set(LLColor4::grey);
         }
-        else if( "grey1" == color_name )
+        else if ("grey1" == color_name)
         {
             color->set(LLColor4::grey1);
         }
-        else if( "grey2" == color_name )
+        else if ("grey2" == color_name)
         {
             color->set(LLColor4::grey2);
         }
-        else if( "grey3" == color_name )
+        else if ("grey3" == color_name)
         {
             color->set(LLColor4::grey3);
         }
-        else if( "grey4" == color_name )
+        else if ("grey4" == color_name)
         {
             color->set(LLColor4::grey4);
         }
-        else if( "orange" == color_name )
+        else if ("orange" == color_name)
         {
             color->set(LLColor4::orange);
         }
-        else if( "orange1" == color_name )
+        else if ("orange1" == color_name)
         {
             color->set(LLColor4::orange1);
         }
-        else if( "orange2" == color_name )
+        else if ("orange2" == color_name)
         {
             color->set(LLColor4::orange2);
         }
-        else if( "orange3" == color_name )
+        else if ("orange3" == color_name)
         {
             color->set(LLColor4::orange3);
         }
-        else if( "orange4" == color_name )
+        else if ("orange4" == color_name)
         {
             color->set(LLColor4::orange4);
         }
-        else if( "orange5" == color_name )
+        else if ("orange5" == color_name)
         {
             color->set(LLColor4::orange5);
         }
-        else if( "orange6" == color_name )
+        else if ("orange6" == color_name)
         {
             color->set(LLColor4::orange6);
         }
-        else if ( "clear" == color_name )
+        else if ("clear" == color_name)
         {
             color->set(0.f, 0.f, 0.f, 0.f);
         }
@@ -714,21 +717,21 @@ bool LLColor4::parseColor(const std::string& buf, LLColor4* color)
 // static
 bool LLColor4::parseColor4(const std::string& buf, LLColor4* value)
 {
-    if( buf.empty() || value == nullptr)
+    if (buf.empty() || value == nullptr)
     {
         return false;
     }
 
     LLColor4 v;
-    S32 count = sscanf( buf.c_str(), "%f, %f, %f, %f", v.mV + 0, v.mV + 1, v.mV + 2, v.mV + 3 );
-    if (1 == count )
+    S32      count = sscanf(buf.c_str(), "%f, %f, %f, %f", v.mV + 0, v.mV + 1, v.mV + 2, v.mV + 3);
+    if (1 == count)
     {
         // try this format
-        count = sscanf( buf.c_str(), "%f %f %f %f", v.mV + 0, v.mV + 1, v.mV + 2, v.mV + 3 );
+        count = sscanf(buf.c_str(), "%f %f %f %f", v.mV + 0, v.mV + 1, v.mV + 2, v.mV + 3);
     }
-    if( 4 == count )
+    if (4 == count)
     {
-        value->setVec( v );
+        value->setVec(v);
         return true;
     }
 

--- a/indra/llmath/v4color.h
+++ b/indra/llmath/v4color.h
@@ -28,7 +28,6 @@
 #define LL_V4COLOR_H
 
 #include "llerror.h"
-//#include "vmath.h"
 #include "llmath.h"
 #include "llsd.h"
 
@@ -38,213 +37,212 @@ class LLVector4;
 
 //  LLColor4 = |x y z w|
 
-static const U32 LENGTHOFCOLOR4 = 4;
+static constexpr U32 LENGTHOFCOLOR4 = 4;
 
-static const U32 MAX_LENGTH_OF_COLOR_NAME = 15; //Give plenty of room for additional colors...
+static constexpr U32 MAX_LENGTH_OF_COLOR_NAME = 15; // Give plenty of room for additional colors...
 
 class LLColor4
 {
-    public:
-        F32 mV[LENGTHOFCOLOR4];
-        LLColor4();                     // Initializes LLColor4 to (0, 0, 0, 1)
-        LLColor4(F32 r, F32 g, F32 b);      // Initializes LLColor4 to (r, g, b, 1)
-        LLColor4(F32 r, F32 g, F32 b, F32 a);       // Initializes LLColor4 to (r. g, b, a)
-        LLColor4(const LLColor3 &vec, F32 a = 1.f); // Initializes LLColor4 to (vec, a)
-        explicit LLColor4(const LLSD& sd);
-        explicit LLColor4(const F32 *vec);          // Initializes LLColor4 to (vec[0]. vec[1], vec[2], 1)
-        explicit LLColor4(U32 clr);                         // Initializes LLColor4 to (r=clr>>24, etc))
-        explicit LLColor4(const LLColor4U& color4u);  // "explicit" to avoid automatic conversion
-        explicit LLColor4(const LLVector4& vector4);  // "explicit" to avoid automatic conversion
+public:
+    F32 mV[LENGTHOFCOLOR4];
+    LLColor4();                                 // Initializes LLColor4 to (0, 0, 0, 1)
+    LLColor4(F32 r, F32 g, F32 b);              // Initializes LLColor4 to (r, g, b, 1)
+    LLColor4(F32 r, F32 g, F32 b, F32 a);       // Initializes LLColor4 to (r. g, b, a)
+    LLColor4(const LLColor3& vec, F32 a = 1.f); // Initializes LLColor4 to (vec, a)
+    explicit LLColor4(const LLSD& sd);
+    explicit LLColor4(const F32* vec);           // Initializes LLColor4 to (vec[0]. vec[1], vec[2], 1)
+    explicit LLColor4(U32 clr);                  // Initializes LLColor4 to (r=clr>>24, etc))
+    explicit LLColor4(const LLColor4U& color4u); // "explicit" to avoid automatic conversion
+    explicit LLColor4(const LLVector4& vector4); // "explicit" to avoid automatic conversion
 
-        LLSD getValue() const
-        {
-            LLSD ret;
-            ret[0] = mV[0];
-            ret[1] = mV[1];
-            ret[2] = mV[2];
-            ret[3] = mV[3];
-            return ret;
-        }
+    LLSD getValue() const
+    {
+        LLSD ret;
+        ret[VRED]   = mV[VRED];
+        ret[VGREEN] = mV[VGREEN];
+        ret[VBLUE]  = mV[VBLUE];
+        ret[VALPHA] = mV[VALPHA];
+        return ret;
+    }
 
-        void setValue(const LLSD& sd);
+    void setValue(const LLSD& sd);
 
-        void setHSL(F32 hue, F32 saturation, F32 luminance);
-        void calcHSL(F32* hue, F32* saturation, F32* luminance) const;
+    void setHSL(F32 hue, F32 saturation, F32 luminance);
+    void calcHSL(F32* hue, F32* saturation, F32* luminance) const;
 
-        const LLColor4& setToBlack();                       // zero LLColor4 to (0, 0, 0, 1)
-        const LLColor4& setToWhite();                       // zero LLColor4 to (0, 0, 0, 1)
+    const LLColor4& setToBlack(); // zero LLColor4 to (0, 0, 0, 1)
+    const LLColor4& setToWhite(); // zero LLColor4 to (0, 0, 0, 1)
 
-        const LLColor4& setVec(F32 r, F32 g, F32 b, F32 a); // deprecated -- use set()
-        const LLColor4& setVec(F32 r, F32 g, F32 b);        // deprecated -- use set()
-        const LLColor4& setVec(const LLColor4 &vec);        // deprecated -- use set()
-        const LLColor4& setVec(const LLColor3 &vec);        // deprecated -- use set()
-        const LLColor4& setVec(const LLColor3 &vec, F32 a); // deprecated -- use set()
-        const LLColor4& setVec(const F32 *vec);             // deprecated -- use set()
-        const LLColor4& setVec(const LLColor4U& color4u);   // deprecated -- use set()
+    const LLColor4& setVec(F32 r, F32 g, F32 b, F32 a); // deprecated -- use set()
+    const LLColor4& setVec(F32 r, F32 g, F32 b);        // deprecated -- use set()
+    const LLColor4& setVec(const LLColor4& vec);        // deprecated -- use set()
+    const LLColor4& setVec(const LLColor3& vec);        // deprecated -- use set()
+    const LLColor4& setVec(const LLColor3& vec, F32 a); // deprecated -- use set()
+    const LLColor4& setVec(const F32* vec);             // deprecated -- use set()
+    const LLColor4& setVec(const LLColor4U& color4u);   // deprecated -- use set()
 
-        const LLColor4& set(F32 r, F32 g, F32 b, F32 a);    // Sets LLColor4 to (r, g, b, a)
-        const LLColor4& set(F32 r, F32 g, F32 b);   // Sets LLColor4 to (r, g, b) (no change in a)
-        const LLColor4& set(const LLColor4 &vec);   // Sets LLColor4 to vec
-        const LLColor4& set(const LLColor3 &vec);   // Sets LLColor4 to LLColor3 vec (no change in alpha)
-        const LLColor4& set(const LLColor3 &vec, F32 a);    // Sets LLColor4 to LLColor3 vec, with alpha specified
-        const LLColor4& set(const F32 *vec);            // Sets LLColor4 to vec
-        const LLColor4& set(const F64 *vec);            // Sets LLColor4 to (double)vec
-        const LLColor4& set(const LLColor4U& color4u); // Sets LLColor4 to color4u, rescaled.
+    const LLColor4& set(F32 r, F32 g, F32 b, F32 a); // Sets LLColor4 to (r, g, b, a)
+    const LLColor4& set(F32 r, F32 g, F32 b);        // Sets LLColor4 to (r, g, b) (no change in a)
+    const LLColor4& set(const LLColor4& vec);        // Sets LLColor4 to vec
+    const LLColor4& set(const LLColor3& vec);        // Sets LLColor4 to LLColor3 vec (no change in alpha)
+    const LLColor4& set(const LLColor3& vec, F32 a); // Sets LLColor4 to LLColor3 vec, with alpha specified
+    const LLColor4& set(const F32* vec);             // Sets LLColor4 to vec
+    const LLColor4& set(const F64* vec);             // Sets LLColor4 to (double)vec
+    const LLColor4& set(const LLColor4U& color4u);   // Sets LLColor4 to color4u, rescaled.
 
-        // set from a vector of unknown type and size
-        // may leave some data unmodified
-        template<typename T>
-        const LLColor4& set(const std::vector<T>& v);
+    // set from a vector of unknown type and size
+    // may leave some data unmodified
+    template<typename T>
+    const LLColor4& set(const std::vector<T>& v);
 
-        // write to a vector of unknown type and size
-        // maye leave some data unmodified
-        template<typename T>
-        void write(std::vector<T>& v) const;
+    // write to a vector of unknown type and size
+    // maye leave some data unmodified
+    template<typename T>
+    void write(std::vector<T>& v) const;
 
-        const LLColor4&    setAlpha(F32 a);
+    const LLColor4& setAlpha(F32 a);
 
-        F32         magVec() const;             // deprecated -- use length()
-        F32         magVecSquared() const;      // deprecated -- use lengthSquared()
-        F32         normVec();                  // deprecated -- use normalize()
+    F32 magVec() const;        // deprecated -- use length()
+    F32 magVecSquared() const; // deprecated -- use lengthSquared()
+    F32 normVec();             // deprecated -- use normalize()
 
-        F32         length() const;             // Returns magnitude of LLColor4
-        F32         lengthSquared() const;      // Returns magnitude squared of LLColor4
-        F32         normalize();                // deprecated -- use normalize()
+    F32 length() const;        // Returns magnitude of LLColor4
+    F32 lengthSquared() const; // Returns magnitude squared of LLColor4
+    F32 normalize();           // deprecated -- use normalize()
 
-        bool        isOpaque() { return mV[VALPHA] == 1.f; }
+    bool isOpaque() const { return mV[VALPHA] == 1.f; }
 
-        F32 operator[](int idx) const { return mV[idx]; }
-        F32 &operator[](int idx) { return mV[idx]; }
+    F32  operator[](int idx) const { return mV[idx]; }
+    F32& operator[](int idx) { return mV[idx]; }
 
-        const LLColor4& operator=(const LLColor3 &a);   // Assigns vec3 to vec4 and returns vec4
+    const LLColor4& operator=(const LLColor3& a); // Assigns vec3 to vec4 and returns vec4
 
-        bool operator<(const LLColor4& rhs) const;
-        friend std::ostream&     operator<<(std::ostream& s, const LLColor4 &a);        // Print a
-        friend LLColor4 operator+(const LLColor4 &a, const LLColor4 &b);    // Return vector a + b
-        friend LLColor4 operator-(const LLColor4 &a, const LLColor4 &b);    // Return vector a minus b
-        friend LLColor4 operator*(const LLColor4 &a, const LLColor4 &b);    // Return component wise a * b
-        friend LLColor4 operator*(const LLColor4 &a, F32 k);                // Return rgb times scaler k (no alpha change)
-        friend LLColor4 operator/(const LLColor4 &a, F32 k);                // Return rgb divided by scalar k (no alpha change)
-        friend LLColor4 operator*(F32 k, const LLColor4 &a);                // Return rgb times scaler k (no alpha change)
-        friend LLColor4 operator%(const LLColor4 &a, F32 k);                // Return alpha times scaler k (no rgb change)
-        friend LLColor4 operator%(F32 k, const LLColor4 &a);                // Return alpha times scaler k (no rgb change)
+    bool                 operator<(const LLColor4& rhs) const;
+    friend std::ostream& operator<<(std::ostream& s, const LLColor4& a);  // Print a
+    friend LLColor4      operator+(const LLColor4& a, const LLColor4& b); // Return vector a + b
+    friend LLColor4      operator-(const LLColor4& a, const LLColor4& b); // Return vector a minus b
+    friend LLColor4      operator*(const LLColor4& a, const LLColor4& b); // Return component wise a * b
+    friend LLColor4      operator*(const LLColor4& a, F32 k);             // Return rgb times scaler k (no alpha change)
+    friend LLColor4      operator/(const LLColor4& a, F32 k);             // Return rgb divided by scalar k (no alpha change)
+    friend LLColor4      operator*(F32 k, const LLColor4& a);             // Return rgb times scaler k (no alpha change)
+    friend LLColor4      operator%(const LLColor4& a, F32 k);             // Return alpha times scaler k (no rgb change)
+    friend LLColor4      operator%(F32 k, const LLColor4& a);             // Return alpha times scaler k (no rgb change)
 
-        friend bool operator==(const LLColor4 &a, const LLColor4 &b);       // Return a == b
-        friend bool operator!=(const LLColor4 &a, const LLColor4 &b);       // Return a != b
+    friend bool operator==(const LLColor4& a, const LLColor4& b); // Return a == b
+    friend bool operator!=(const LLColor4& a, const LLColor4& b); // Return a != b
 
-        friend bool operator==(const LLColor4 &a, const LLColor3 &b);       // Return a == b
-        friend bool operator!=(const LLColor4 &a, const LLColor3 &b);       // Return a != b
+    friend bool operator==(const LLColor4& a, const LLColor3& b); // Return a == b
+    friend bool operator!=(const LLColor4& a, const LLColor3& b); // Return a != b
 
-        friend const LLColor4& operator+=(LLColor4 &a, const LLColor4 &b);  // Return vector a + b
-        friend const LLColor4& operator-=(LLColor4 &a, const LLColor4 &b);  // Return vector a minus b
-        friend const LLColor4& operator*=(LLColor4 &a, F32 k);              // Return rgb times scaler k (no alpha change)
-        friend const LLColor4& operator%=(LLColor4 &a, F32 k);              // Return alpha times scaler k (no rgb change)
+    friend const LLColor4& operator+=(LLColor4& a, const LLColor4& b); // Return vector a + b
+    friend const LLColor4& operator-=(LLColor4& a, const LLColor4& b); // Return vector a minus b
+    friend const LLColor4& operator*=(LLColor4& a, F32 k);             // Return rgb times scaler k (no alpha change)
+    friend const LLColor4& operator%=(LLColor4& a, F32 k);             // Return alpha times scaler k (no rgb change)
 
-        friend const LLColor4& operator*=(LLColor4 &a, const LLColor4 &b); // Doesn't multiply alpha! (for lighting)
+    friend const LLColor4& operator*=(LLColor4& a, const LLColor4& b); // Doesn't multiply alpha! (for lighting)
 
-        // conversion
-        operator LLColor4U() const;
+    // conversion
+    operator LLColor4U() const;
 
-        // Basic color values.
-        static LLColor4 red;
-        static LLColor4 green;
-        static LLColor4 blue;
-        static LLColor4 black;
-        static LLColor4 white;
-        static LLColor4 yellow;
-        static LLColor4 magenta;
-        static LLColor4 cyan;
-        static LLColor4 smoke;
-        static LLColor4 grey;
-        static LLColor4 orange;
-        static LLColor4 purple;
-        static LLColor4 pink;
-        static LLColor4 transparent;
+    // Basic color values.
+    static LLColor4 red;
+    static LLColor4 green;
+    static LLColor4 blue;
+    static LLColor4 black;
+    static LLColor4 white;
+    static LLColor4 yellow;
+    static LLColor4 magenta;
+    static LLColor4 cyan;
+    static LLColor4 smoke;
+    static LLColor4 grey;
+    static LLColor4 orange;
+    static LLColor4 purple;
+    static LLColor4 pink;
+    static LLColor4 transparent;
 
-        // Extra color values.
-        static LLColor4 grey1;
-        static LLColor4 grey2;
-        static LLColor4 grey3;
-        static LLColor4 grey4;
+    // Extra color values.
+    static LLColor4 grey1;
+    static LLColor4 grey2;
+    static LLColor4 grey3;
+    static LLColor4 grey4;
 
-        static LLColor4 red1;
-        static LLColor4 red2;
-        static LLColor4 red3;
-        static LLColor4 red4;
-        static LLColor4 red5;
+    static LLColor4 red1;
+    static LLColor4 red2;
+    static LLColor4 red3;
+    static LLColor4 red4;
+    static LLColor4 red5;
 
-        static LLColor4 green1;
-        static LLColor4 green2;
-        static LLColor4 green3;
-        static LLColor4 green4;
-        static LLColor4 green5;
-        static LLColor4 green6;
+    static LLColor4 green1;
+    static LLColor4 green2;
+    static LLColor4 green3;
+    static LLColor4 green4;
+    static LLColor4 green5;
+    static LLColor4 green6;
 
-        static LLColor4 blue1;
-        static LLColor4 blue2;
-        static LLColor4 blue3;
-        static LLColor4 blue4;
-        static LLColor4 blue5;
-        static LLColor4 blue6;
+    static LLColor4 blue1;
+    static LLColor4 blue2;
+    static LLColor4 blue3;
+    static LLColor4 blue4;
+    static LLColor4 blue5;
+    static LLColor4 blue6;
 
-        static LLColor4 yellow1;
-        static LLColor4 yellow2;
-        static LLColor4 yellow3;
-        static LLColor4 yellow4;
-        static LLColor4 yellow5;
-        static LLColor4 yellow6;
-        static LLColor4 yellow7;
-        static LLColor4 yellow8;
-        static LLColor4 yellow9;
+    static LLColor4 yellow1;
+    static LLColor4 yellow2;
+    static LLColor4 yellow3;
+    static LLColor4 yellow4;
+    static LLColor4 yellow5;
+    static LLColor4 yellow6;
+    static LLColor4 yellow7;
+    static LLColor4 yellow8;
+    static LLColor4 yellow9;
 
-        static LLColor4 orange1;
-        static LLColor4 orange2;
-        static LLColor4 orange3;
-        static LLColor4 orange4;
-        static LLColor4 orange5;
-        static LLColor4 orange6;
+    static LLColor4 orange1;
+    static LLColor4 orange2;
+    static LLColor4 orange3;
+    static LLColor4 orange4;
+    static LLColor4 orange5;
+    static LLColor4 orange6;
 
-        static LLColor4 magenta1;
-        static LLColor4 magenta2;
-        static LLColor4 magenta3;
-        static LLColor4 magenta4;
+    static LLColor4 magenta1;
+    static LLColor4 magenta2;
+    static LLColor4 magenta3;
+    static LLColor4 magenta4;
 
-        static LLColor4 purple1;
-        static LLColor4 purple2;
-        static LLColor4 purple3;
-        static LLColor4 purple4;
-        static LLColor4 purple5;
-        static LLColor4 purple6;
+    static LLColor4 purple1;
+    static LLColor4 purple2;
+    static LLColor4 purple3;
+    static LLColor4 purple4;
+    static LLColor4 purple5;
+    static LLColor4 purple6;
 
-        static LLColor4 pink1;
-        static LLColor4 pink2;
+    static LLColor4 pink1;
+    static LLColor4 pink2;
 
-        static LLColor4 cyan1;
-        static LLColor4 cyan2;
-        static LLColor4 cyan3;
-        static LLColor4 cyan4;
-        static LLColor4 cyan5;
-        static LLColor4 cyan6;
+    static LLColor4 cyan1;
+    static LLColor4 cyan2;
+    static LLColor4 cyan3;
+    static LLColor4 cyan4;
+    static LLColor4 cyan5;
+    static LLColor4 cyan6;
 
-        static bool parseColor(const std::string& buf, LLColor4* color);
-        static bool parseColor4(const std::string& buf, LLColor4* color);
+    static bool parseColor(const std::string& buf, LLColor4* color);
+    static bool parseColor4(const std::string& buf, LLColor4* color);
 
-        inline void clamp();
+    inline void clamp();
 };
 
-
 // Non-member functions
-F32     distVec(const LLColor4 &a, const LLColor4 &b);          // Returns distance between a and b
-F32     distVec_squared(const LLColor4 &a, const LLColor4 &b);  // Returns distance squared between a and b
-LLColor3    vec4to3(const LLColor4 &vec);
-LLColor4    vec3to4(const LLColor3 &vec);
-LLColor4 lerp(const LLColor4 &a, const LLColor4 &b, F32 u);
+F32      distVec(const LLColor4& a, const LLColor4& b);         // Returns distance between a and b
+F32      distVec_squared(const LLColor4& a, const LLColor4& b); // Returns distance squared between a and b
+LLColor3 vec4to3(const LLColor4& vec);
+LLColor4 vec3to4(const LLColor3& vec);
+LLColor4 lerp(const LLColor4& a, const LLColor4& b, F32 u);
 
-inline LLColor4::LLColor4(void)
+inline LLColor4::LLColor4()
 {
-    mV[VRED] = 0.f;
+    mV[VRED]   = 0.f;
     mV[VGREEN] = 0.f;
-    mV[VBLUE] = 0.f;
+    mV[VBLUE]  = 0.f;
     mV[VALPHA] = 1.f;
 }
 
@@ -255,149 +253,146 @@ inline LLColor4::LLColor4(const LLSD& sd)
 
 inline LLColor4::LLColor4(F32 r, F32 g, F32 b)
 {
-    mV[VRED] = r;
+    mV[VRED]   = r;
     mV[VGREEN] = g;
-    mV[VBLUE] = b;
+    mV[VBLUE]  = b;
     mV[VALPHA] = 1.f;
 }
 
 inline LLColor4::LLColor4(F32 r, F32 g, F32 b, F32 a)
 {
-    mV[VRED] = r;
+    mV[VRED]   = r;
     mV[VGREEN] = g;
-    mV[VBLUE] = b;
+    mV[VBLUE]  = b;
     mV[VALPHA] = a;
 }
 
 inline LLColor4::LLColor4(U32 clr)
 {
-    mV[VRED] = (clr&0xff) * (1.0f/255.0f);
-    mV[VGREEN] = ((clr>>8)&0xff) * (1.0f/255.0f);
-    mV[VBLUE] = ((clr>>16)&0xff) * (1.0f/255.0f);
-    mV[VALPHA] = (clr>>24) * (1.0f/255.0f);
+    mV[VRED]   = (clr & 0xff) * (1.0f / 255.0f);
+    mV[VGREEN] = ((clr >> 8) & 0xff) * (1.0f / 255.0f);
+    mV[VBLUE]  = ((clr >> 16) & 0xff) * (1.0f / 255.0f);
+    mV[VALPHA] = (clr >> 24) * (1.0f / 255.0f);
 }
 
-
-inline LLColor4::LLColor4(const F32 *vec)
+inline LLColor4::LLColor4(const F32* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
 }
 
-inline const LLColor4&  LLColor4::setToBlack(void)
+inline const LLColor4& LLColor4::setToBlack(void)
 {
-    mV[VRED] = 0.f;
+    mV[VRED]   = 0.f;
     mV[VGREEN] = 0.f;
-    mV[VBLUE] = 0.f;
+    mV[VBLUE]  = 0.f;
     mV[VALPHA] = 1.f;
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::setToWhite(void)
+inline const LLColor4& LLColor4::setToWhite(void)
 {
-    mV[VRED] = 1.f;
+    mV[VRED]   = 1.f;
     mV[VGREEN] = 1.f;
-    mV[VBLUE] = 1.f;
+    mV[VBLUE]  = 1.f;
     mV[VALPHA] = 1.f;
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::set(F32 x, F32 y, F32 z)
+inline const LLColor4& LLColor4::set(F32 x, F32 y, F32 z)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
 
-//  no change to alpha!
-//  mV[VALPHA] = 1.f;
+    //  no change to alpha!
+    //  mV[VALPHA] = 1.f;
 
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::set(F32 x, F32 y, F32 z, F32 a)
+inline const LLColor4& LLColor4::set(F32 x, F32 y, F32 z, F32 a)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
     mV[VALPHA] = a;
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::set(const LLColor4 &vec)
+inline const LLColor4& LLColor4::set(const LLColor4& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = vec.mV[VALPHA];
     return (*this);
 }
 
-
-inline const LLColor4&  LLColor4::set(const F32 *vec)
+inline const LLColor4& LLColor4::set(const F32* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::set(const F64 *vec)
+inline const LLColor4& LLColor4::set(const F64* vec)
 {
-    mV[VRED] = static_cast<F32>(vec[VRED]);
+    mV[VRED]   = static_cast<F32>(vec[VRED]);
     mV[VGREEN] = static_cast<F32>(vec[VGREEN]);
-    mV[VBLUE] = static_cast<F32>(vec[VBLUE]);
+    mV[VBLUE]  = static_cast<F32>(vec[VBLUE]);
     mV[VALPHA] = static_cast<F32>(vec[VALPHA]);
     return (*this);
 }
 
 // deprecated
-inline const LLColor4&  LLColor4::setVec(F32 x, F32 y, F32 z)
+inline const LLColor4& LLColor4::setVec(F32 x, F32 y, F32 z)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
 
-//  no change to alpha!
-//  mV[VALPHA] = 1.f;
+    //  no change to alpha!
+    //  mV[VALPHA] = 1.f;
 
     return (*this);
 }
 
 // deprecated
-inline const LLColor4&  LLColor4::setVec(F32 x, F32 y, F32 z, F32 a)
+inline const LLColor4& LLColor4::setVec(F32 x, F32 y, F32 z, F32 a)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
     mV[VALPHA] = a;
     return (*this);
 }
 
 // deprecated
-inline const LLColor4&  LLColor4::setVec(const LLColor4 &vec)
+inline const LLColor4& LLColor4::setVec(const LLColor4& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = vec.mV[VALPHA];
     return (*this);
 }
 
-
 // deprecated
-inline const LLColor4&  LLColor4::setVec(const F32 *vec)
+inline const LLColor4& LLColor4::setVec(const F32* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
     return (*this);
 }
 
-inline const LLColor4&  LLColor4::setAlpha(F32 a)
+inline const LLColor4& LLColor4::setAlpha(F32 a)
 {
     mV[VALPHA] = a;
     return (*this);
@@ -405,155 +400,116 @@ inline const LLColor4&  LLColor4::setAlpha(F32 a)
 
 // LLColor4 Magnitude and Normalization Functions
 
-inline F32      LLColor4::length(void) const
+inline F32 LLColor4::length() const
 {
-    return (F32) sqrt(mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE]);
+    return sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
 }
 
-inline F32      LLColor4::lengthSquared(void) const
+inline F32 LLColor4::lengthSquared() const
 {
-    return mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE];
+    return mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE];
 }
 
-inline F32      LLColor4::normalize(void)
+inline F32 LLColor4::normalize()
 {
-    F32 mag = (F32) sqrt(mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE]);
+    F32 mag = sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
     F32 oomag;
 
     if (mag)
     {
-        oomag = 1.f/mag;
+        oomag = 1.f / mag;
         mV[VRED] *= oomag;
         mV[VGREEN] *= oomag;
         mV[VBLUE] *= oomag;
     }
-    return (mag);
+    return mag;
 }
 
 // deprecated
-inline F32      LLColor4::magVec(void) const
+inline F32 LLColor4::magVec() const
 {
-    return (F32) sqrt(mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE]);
+    return sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
 }
 
 // deprecated
-inline F32      LLColor4::magVecSquared(void) const
+inline F32 LLColor4::magVecSquared() const
 {
-    return mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE];
+    return mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE];
 }
 
 // deprecated
-inline F32      LLColor4::normVec(void)
+inline F32 LLColor4::normVec()
 {
-    F32 mag = (F32) sqrt(mV[VRED]*mV[VRED] + mV[VGREEN]*mV[VGREEN] + mV[VBLUE]*mV[VBLUE]);
+    F32 mag = sqrt(mV[VRED] * mV[VRED] + mV[VGREEN] * mV[VGREEN] + mV[VBLUE] * mV[VBLUE]);
     F32 oomag;
 
     if (mag)
     {
-        oomag = 1.f/mag;
+        oomag = 1.f / mag;
         mV[VRED] *= oomag;
         mV[VGREEN] *= oomag;
         mV[VBLUE] *= oomag;
     }
-    return (mag);
+    return mag;
 }
 
 // LLColor4 Operators
 
-
-inline LLColor4 operator+(const LLColor4 &a, const LLColor4 &b)
+inline LLColor4 operator+(const LLColor4& a, const LLColor4& b)
 {
-    return LLColor4(
-        a.mV[VRED] + b.mV[VRED],
-        a.mV[VGREEN] + b.mV[VGREEN],
-        a.mV[VBLUE] + b.mV[VBLUE],
-        a.mV[VALPHA] + b.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] + b.mV[VRED], a.mV[VGREEN] + b.mV[VGREEN], a.mV[VBLUE] + b.mV[VBLUE], a.mV[VALPHA] + b.mV[VALPHA]);
 }
 
-inline LLColor4 operator-(const LLColor4 &a, const LLColor4 &b)
+inline LLColor4 operator-(const LLColor4& a, const LLColor4& b)
 {
-    return LLColor4(
-        a.mV[VRED] - b.mV[VRED],
-        a.mV[VGREEN] - b.mV[VGREEN],
-        a.mV[VBLUE] - b.mV[VBLUE],
-        a.mV[VALPHA] - b.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] - b.mV[VRED], a.mV[VGREEN] - b.mV[VGREEN], a.mV[VBLUE] - b.mV[VBLUE], a.mV[VALPHA] - b.mV[VALPHA]);
 }
 
-inline LLColor4  operator*(const LLColor4 &a, const LLColor4 &b)
+inline LLColor4 operator*(const LLColor4& a, const LLColor4& b)
 {
-    return LLColor4(
-        a.mV[VRED] * b.mV[VRED],
-        a.mV[VGREEN] * b.mV[VGREEN],
-        a.mV[VBLUE] * b.mV[VBLUE],
-        a.mV[VALPHA] * b.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] * b.mV[VRED], a.mV[VGREEN] * b.mV[VGREEN], a.mV[VBLUE] * b.mV[VBLUE], a.mV[VALPHA] * b.mV[VALPHA]);
 }
 
-inline LLColor4 operator*(const LLColor4 &a, F32 k)
+inline LLColor4 operator*(const LLColor4& a, F32 k)
 {
     // only affects rgb (not a!)
-    return LLColor4(
-        a.mV[VRED] * k,
-        a.mV[VGREEN] * k,
-        a.mV[VBLUE] * k,
-        a.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] * k, a.mV[VGREEN] * k, a.mV[VBLUE] * k, a.mV[VALPHA]);
 }
 
-inline LLColor4 operator/(const LLColor4 &a, F32 k)
+inline LLColor4 operator/(const LLColor4& a, F32 k)
 {
-    return LLColor4(
-        a.mV[VRED] / k,
-        a.mV[VGREEN] / k,
-        a.mV[VBLUE] / k,
-        a.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] / k, a.mV[VGREEN] / k, a.mV[VBLUE] / k, a.mV[VALPHA]);
 }
 
-inline LLColor4 operator*(F32 k, const LLColor4 &a)
+inline LLColor4 operator*(F32 k, const LLColor4& a)
 {
     // only affects rgb (not a!)
-    return LLColor4(
-        a.mV[VRED] * k,
-        a.mV[VGREEN] * k,
-        a.mV[VBLUE] * k,
-        a.mV[VALPHA]);
+    return LLColor4(a.mV[VRED] * k, a.mV[VGREEN] * k, a.mV[VBLUE] * k, a.mV[VALPHA]);
 }
 
-inline LLColor4 operator%(F32 k, const LLColor4 &a)
+inline LLColor4 operator%(F32 k, const LLColor4& a)
 {
     // only affects alpha (not rgb!)
-    return LLColor4(
-        a.mV[VRED],
-        a.mV[VGREEN],
-        a.mV[VBLUE],
-        a.mV[VALPHA] * k);
+    return LLColor4(a.mV[VRED], a.mV[VGREEN], a.mV[VBLUE], a.mV[VALPHA] * k);
 }
 
-inline LLColor4 operator%(const LLColor4 &a, F32 k)
+inline LLColor4 operator%(const LLColor4& a, F32 k)
 {
     // only affects alpha (not rgb!)
-    return LLColor4(
-        a.mV[VRED],
-        a.mV[VGREEN],
-        a.mV[VBLUE],
-        a.mV[VALPHA] * k);
+    return LLColor4(a.mV[VRED], a.mV[VGREEN], a.mV[VBLUE], a.mV[VALPHA] * k);
 }
 
-inline bool operator==(const LLColor4 &a, const LLColor4 &b)
+inline bool operator==(const LLColor4& a, const LLColor4& b)
 {
-    return (  (a.mV[VRED] == b.mV[VRED])
-            &&(a.mV[VGREEN] == b.mV[VGREEN])
-            &&(a.mV[VBLUE] == b.mV[VBLUE])
-            &&(a.mV[VALPHA] == b.mV[VALPHA]));
+    return ((a.mV[VRED] == b.mV[VRED]) && (a.mV[VGREEN] == b.mV[VGREEN]) && (a.mV[VBLUE] == b.mV[VBLUE]) && (a.mV[VALPHA] == b.mV[VALPHA]));
 }
 
-inline bool operator!=(const LLColor4 &a, const LLColor4 &b)
+inline bool operator!=(const LLColor4& a, const LLColor4& b)
 {
-    return (  (a.mV[VRED] != b.mV[VRED])
-            ||(a.mV[VGREEN] != b.mV[VGREEN])
-            ||(a.mV[VBLUE] != b.mV[VBLUE])
-            ||(a.mV[VALPHA] != b.mV[VALPHA]));
+    return ((a.mV[VRED] != b.mV[VRED]) || (a.mV[VGREEN] != b.mV[VGREEN]) || (a.mV[VBLUE] != b.mV[VBLUE]) || (a.mV[VALPHA] != b.mV[VALPHA]));
 }
 
-inline const LLColor4& operator+=(LLColor4 &a, const LLColor4 &b)
+inline const LLColor4& operator+=(LLColor4& a, const LLColor4& b)
 {
     a.mV[VRED] += b.mV[VRED];
     a.mV[VGREEN] += b.mV[VGREEN];
@@ -562,7 +518,7 @@ inline const LLColor4& operator+=(LLColor4 &a, const LLColor4 &b)
     return a;
 }
 
-inline const LLColor4& operator-=(LLColor4 &a, const LLColor4 &b)
+inline const LLColor4& operator-=(LLColor4& a, const LLColor4& b)
 {
     a.mV[VRED] -= b.mV[VRED];
     a.mV[VGREEN] -= b.mV[VGREEN];
@@ -571,7 +527,7 @@ inline const LLColor4& operator-=(LLColor4 &a, const LLColor4 &b)
     return a;
 }
 
-inline const LLColor4& operator*=(LLColor4 &a, F32 k)
+inline const LLColor4& operator*=(LLColor4& a, F32 k)
 {
     // only affects rgb (not a!)
     a.mV[VRED] *= k;
@@ -580,121 +536,120 @@ inline const LLColor4& operator*=(LLColor4 &a, F32 k)
     return a;
 }
 
-inline const LLColor4& operator *=(LLColor4 &a, const LLColor4 &b)
+inline const LLColor4& operator*=(LLColor4& a, const LLColor4& b)
 {
     a.mV[VRED] *= b.mV[VRED];
     a.mV[VGREEN] *= b.mV[VGREEN];
     a.mV[VBLUE] *= b.mV[VBLUE];
-//  a.mV[VALPHA] *= b.mV[VALPHA];
+    //  a.mV[VALPHA] *= b.mV[VALPHA];
     return a;
 }
 
-inline const LLColor4& operator%=(LLColor4 &a, F32 k)
+inline const LLColor4& operator%=(LLColor4& a, F32 k)
 {
     // only affects alpha (not rgb!)
     a.mV[VALPHA] *= k;
     return a;
 }
 
-
 // Non-member functions
 
-inline F32      distVec(const LLColor4 &a, const LLColor4 &b)
+inline F32 distVec(const LLColor4& a, const LLColor4& b)
 {
     LLColor4 vec = a - b;
-    return (vec.length());
+    return vec.length();
 }
 
-inline F32      distVec_squared(const LLColor4 &a, const LLColor4 &b)
+inline F32 distVec_squared(const LLColor4& a, const LLColor4& b)
 {
     LLColor4 vec = a - b;
-    return (vec.lengthSquared());
+    return vec.lengthSquared();
 }
 
-inline LLColor4 lerp(const LLColor4 &a, const LLColor4 &b, F32 u)
+inline LLColor4 lerp(const LLColor4& a, const LLColor4& b, F32 u)
 {
-    return LLColor4(
-        a.mV[VRED] + (b.mV[VRED] - a.mV[VRED]) * u,
-        a.mV[VGREEN] + (b.mV[VGREEN] - a.mV[VGREEN]) * u,
-        a.mV[VBLUE] + (b.mV[VBLUE] - a.mV[VBLUE]) * u,
-        a.mV[VALPHA] + (b.mV[VALPHA] - a.mV[VALPHA]) * u);
+    return LLColor4(a.mV[VRED] + (b.mV[VRED] - a.mV[VRED]) * u,
+                    a.mV[VGREEN] + (b.mV[VGREEN] - a.mV[VGREEN]) * u,
+                    a.mV[VBLUE] + (b.mV[VBLUE] - a.mV[VBLUE]) * u,
+                    a.mV[VALPHA] + (b.mV[VALPHA] - a.mV[VALPHA]) * u);
 }
 
 inline bool LLColor4::operator<(const LLColor4& rhs) const
 {
-    if (mV[0] != rhs.mV[0])
+    if (mV[VRED] != rhs.mV[VRED])
     {
-        return mV[0] < rhs.mV[0];
+        return mV[VRED] < rhs.mV[VRED];
     }
-    if (mV[1] != rhs.mV[1])
+    if (mV[VGREEN] != rhs.mV[VGREEN])
     {
-        return mV[1] < rhs.mV[1];
+        return mV[VGREEN] < rhs.mV[VGREEN];
     }
-    if (mV[2] != rhs.mV[2])
+    if (mV[VBLUE] != rhs.mV[VBLUE])
     {
-        return mV[2] < rhs.mV[2];
+        return mV[VBLUE] < rhs.mV[VBLUE];
     }
 
-    return mV[3] < rhs.mV[3];
+    return mV[VALPHA] < rhs.mV[VALPHA];
 }
 
 void LLColor4::clamp()
 {
     // Clamp the color...
-    if (mV[0] < 0.f)
+    if (mV[VRED] < 0.f)
     {
-        mV[0] = 0.f;
+        mV[VRED] = 0.f;
     }
-    else if (mV[0] > 1.f)
+    else if (mV[VRED] > 1.f)
     {
-        mV[0] = 1.f;
+        mV[VRED] = 1.f;
     }
-    if (mV[1] < 0.f)
+    if (mV[VGREEN] < 0.f)
     {
-        mV[1] = 0.f;
+        mV[VGREEN] = 0.f;
     }
-    else if (mV[1] > 1.f)
+    else if (mV[VGREEN] > 1.f)
     {
-        mV[1] = 1.f;
+        mV[VGREEN] = 1.f;
     }
-    if (mV[2] < 0.f)
+    if (mV[VBLUE] < 0.f)
     {
-        mV[2] = 0.f;
+        mV[VBLUE] = 0.f;
     }
-    else if (mV[2] > 1.f)
+    else if (mV[VBLUE] > 1.f)
     {
-        mV[2] = 1.f;
+        mV[VBLUE] = 1.f;
     }
-    if (mV[3] < 0.f)
+    if (mV[VALPHA] < 0.f)
     {
-        mV[3] = 0.f;
+        mV[VALPHA] = 0.f;
     }
-    else if (mV[3] > 1.f)
+    else if (mV[VALPHA] > 1.f)
     {
-        mV[3] = 1.f;
+        mV[VALPHA] = 1.f;
     }
 }
 
 // Return the given linear space color value in gamma corrected (sRGB) space
-inline const LLColor4 srgbColor4(const LLColor4 &a) {
+inline const LLColor4 srgbColor4(const LLColor4& a)
+{
     LLColor4 srgbColor;
 
-    srgbColor.mV[0] = linearTosRGB(a.mV[0]);
-    srgbColor.mV[1] = linearTosRGB(a.mV[1]);
-    srgbColor.mV[2] = linearTosRGB(a.mV[2]);
-    srgbColor.mV[3] = a.mV[3];
+    srgbColor.mV[VRED]   = linearTosRGB(a.mV[VRED]);
+    srgbColor.mV[VGREEN] = linearTosRGB(a.mV[VGREEN]);
+    srgbColor.mV[VBLUE]  = linearTosRGB(a.mV[VBLUE]);
+    srgbColor.mV[VALPHA] = a.mV[VALPHA];
 
     return srgbColor;
 }
 
 // Return the given gamma corrected (sRGB) color in linear space
-inline const LLColor4 linearColor4(const LLColor4 &a)
+inline const LLColor4 linearColor4(const LLColor4& a)
 {
     LLColor4 linearColor;
-    linearColor.mV[0] = sRGBtoLinear(a.mV[0]);
-    linearColor.mV[1] = sRGBtoLinear(a.mV[1]);
-    linearColor.mV[2] = sRGBtoLinear(a.mV[2]);
-    linearColor.mV[3] = a.mV[3];
+    linearColor.mV[VRED]   = sRGBtoLinear(a.mV[VRED]);
+    linearColor.mV[VGREEN] = sRGBtoLinear(a.mV[VGREEN]);
+    linearColor.mV[VBLUE]  = sRGBtoLinear(a.mV[VBLUE]);
+    linearColor.mV[VALPHA] = a.mV[VALPHA];
 
     return linearColor;
 }
@@ -720,4 +675,3 @@ void LLColor4::write(std::vector<T>& v) const
 }
 
 #endif
-

--- a/indra/llmath/v4coloru.cpp
+++ b/indra/llmath/v4coloru.cpp
@@ -26,10 +26,7 @@
 
 #include "linden_common.h"
 
-//#include "v3coloru.h"
 #include "v4coloru.h"
-#include "v4color.h"
-//#include "vmath.h"
 #include "llmath.h"
 
 // LLColor4U
@@ -39,49 +36,7 @@ LLColor4U LLColor4U::red  (255,   0,   0, 255);
 LLColor4U LLColor4U::green(  0, 255,   0, 255);
 LLColor4U LLColor4U::blue (  0,   0, 255, 255);
 
-// conversion
-/* inlined to fix gcc compile link error
-LLColor4U::operator LLColor4()
-{
-    return(LLColor4((F32)mV[VRED]/255.f,(F32)mV[VGREEN]/255.f,(F32)mV[VBLUE]/255.f,(F32)mV[VALPHA]/255.f));
-}
-*/
-
-// Constructors
-
-
-/*
-LLColor4U::LLColor4U(const LLColor3 &vec)
-{
-    mV[VRED] = vec.mV[VRED];
-    mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
-    mV[VALPHA] = 255;
-}
-*/
-
-
-// Clear and Assignment Functions
-
-
-
-// LLColor4U Operators
-
-/*
-LLColor4U LLColor4U::operator=(const LLColor3 &a)
-{
-    mV[VRED] = a.mV[VRED];
-    mV[VGREEN] = a.mV[VGREEN];
-    mV[VBLUE] = a.mV[VBLUE];
-
-// converting from an rgb sets a=1 (opaque)
-    mV[VALPHA] = 255;
-    return (*this);
-}
-*/
-
-
-std::ostream& operator<<(std::ostream& s, const LLColor4U &a)
+std::ostream& operator<<(std::ostream& s, const LLColor4U& a)
 {
     s << "{ " << (S32)a.mV[VRED] << ", " << (S32)a.mV[VGREEN] << ", " << (S32)a.mV[VBLUE] << ", " << (S32)a.mV[VALPHA] << " }";
     return s;
@@ -90,31 +45,31 @@ std::ostream& operator<<(std::ostream& s, const LLColor4U &a)
 // static
 bool LLColor4U::parseColor4U(const std::string& buf, LLColor4U* value)
 {
-    if( buf.empty() || value == nullptr)
+    if (buf.empty() || value == nullptr)
     {
         return false;
     }
 
-    U32 v[4];
-    S32 count = sscanf( buf.c_str(), "%u, %u, %u, %u", v + 0, v + 1, v + 2, v + 3 );
-    if (1 == count )
+    U32 v[4]{};
+    S32 count = sscanf(buf.c_str(), "%u, %u, %u, %u", v + 0, v + 1, v + 2, v + 3);
+    if (1 == count)
     {
         // try this format
-        count = sscanf( buf.c_str(), "%u %u %u %u", v + 0, v + 1, v + 2, v + 3 );
+        count = sscanf(buf.c_str(), "%u %u %u %u", v + 0, v + 1, v + 2, v + 3);
     }
-    if( 4 != count )
+    if (4 != count)
     {
         return false;
     }
 
-    for( S32 i = 0; i < 4; i++ )
+    for (S32 i = 0; i < 4; i++)
     {
-        if( v[i] > U8_MAX )
+        if (v[i] > U8_MAX)
         {
             return false;
         }
     }
 
-    value->set( U8(v[0]), U8(v[1]), U8(v[2]), U8(v[3]) );
+    value->set(U8(v[VRED]), U8(v[VGREEN]), U8(v[VBLUE]), U8(v[VALPHA]));
     return true;
 }

--- a/indra/llmath/v4coloru.h
+++ b/indra/llmath/v4coloru.h
@@ -28,104 +28,93 @@
 #define LL_V4COLORU_H
 
 #include "llerror.h"
-//#include "vmath.h"
 #include "llmath.h"
-//#include "v4color.h"
 
 #include "v3color.h"
 #include "v4color.h"
 
-//class LLColor3U;
 class LLColor4;
 
 //  LLColor4U = | red green blue alpha |
 
-static const U32 LENGTHOFCOLOR4U = 4;
-
+static constexpr U32 LENGTHOFCOLOR4U = 4;
 
 class LLColor4U
 {
 public:
-
     U8 mV[LENGTHOFCOLOR4U];
 
-    LLColor4U();                        // Initializes LLColor4U to (0, 0, 0, 1)
-    LLColor4U(U8 r, U8 g, U8 b);        // Initializes LLColor4U to (r, g, b, 1)
-    LLColor4U(U8 r, U8 g, U8 b, U8 a);      // Initializes LLColor4U to (r. g, b, a)
-    LLColor4U(const U8 *vec);           // Initializes LLColor4U to (vec[0]. vec[1], vec[2], 1)
-    explicit LLColor4U(const LLSD& sd)
-    {
-        setValue(sd);
-    }
+    LLColor4U();                       // Initializes LLColor4U to (0, 0, 0, 1)
+    LLColor4U(U8 r, U8 g, U8 b);       // Initializes LLColor4U to (r, g, b, 1)
+    LLColor4U(U8 r, U8 g, U8 b, U8 a); // Initializes LLColor4U to (r. g, b, a)
+    LLColor4U(const U8* vec);          // Initializes LLColor4U to (vec[0]. vec[1], vec[2], 1)
+    explicit LLColor4U(const LLSD& sd) { setValue(sd); }
 
     void setValue(const LLSD& sd)
     {
-        mV[0] = sd[0].asInteger();
-        mV[1] = sd[1].asInteger();
-        mV[2] = sd[2].asInteger();
-        mV[3] = sd[3].asInteger();
+        mV[VRED]   = sd[VRED].asInteger();
+        mV[VGREEN] = sd[VGREEN].asInteger();
+        mV[VBLUE]  = sd[VBLUE].asInteger();
+        mV[VALPHA] = sd[VALPHA].asInteger();
     }
 
     LLSD getValue() const
     {
         LLSD ret;
-        ret[0] = mV[0];
-        ret[1] = mV[1];
-        ret[2] = mV[2];
-        ret[3] = mV[3];
+        ret[VRED]   = mV[VRED];
+        ret[VGREEN] = mV[VGREEN];
+        ret[VBLUE]  = mV[VBLUE];
+        ret[VALPHA] = mV[VALPHA];
         return ret;
     }
 
-    const LLColor4U&    setToBlack();                       // zero LLColor4U to (0, 0, 0, 1)
-    const LLColor4U&    setToWhite();                       // zero LLColor4U to (0, 0, 0, 1)
+    const LLColor4U& setToBlack(); // zero LLColor4U to (0, 0, 0, 1)
+    const LLColor4U& setToWhite(); // zero LLColor4U to (0, 0, 0, 1)
 
-    const LLColor4U&    set(U8 r, U8 g, U8 b, U8 a);// Sets LLColor4U to (r, g, b, a)
-    const LLColor4U&    set(U8 r, U8 g, U8 b);      // Sets LLColor4U to (r, g, b) (no change in a)
-    const LLColor4U&    set(const LLColor4U &vec);  // Sets LLColor4U to vec
-    const LLColor4U&    set(const U8 *vec);         // Sets LLColor4U to vec
+    const LLColor4U& set(U8 r, U8 g, U8 b, U8 a); // Sets LLColor4U to (r, g, b, a)
+    const LLColor4U& set(U8 r, U8 g, U8 b);       // Sets LLColor4U to (r, g, b) (no change in a)
+    const LLColor4U& set(const LLColor4U& vec);   // Sets LLColor4U to vec
+    const LLColor4U& set(const U8* vec);          // Sets LLColor4U to vec
 
-    const LLColor4U&    setVec(U8 r, U8 g, U8 b, U8 a); // deprecated -- use set()
-    const LLColor4U&    setVec(U8 r, U8 g, U8 b);       // deprecated -- use set()
-    const LLColor4U&    setVec(const LLColor4U &vec);   // deprecated -- use set()
-    const LLColor4U&    setVec(const U8 *vec);          // deprecated -- use set()
+    const LLColor4U& setVec(U8 r, U8 g, U8 b, U8 a); // deprecated -- use set()
+    const LLColor4U& setVec(U8 r, U8 g, U8 b);       // deprecated -- use set()
+    const LLColor4U& setVec(const LLColor4U& vec);   // deprecated -- use set()
+    const LLColor4U& setVec(const U8* vec);          // deprecated -- use set()
 
-    const LLColor4U&    setAlpha(U8 a);
+    const LLColor4U& setAlpha(U8 a);
 
-    F32         magVec() const;             // deprecated -- use length()
-    F32         magVecSquared() const;      // deprecated -- use lengthSquared()
+    F32 magVec() const;        // deprecated -- use length()
+    F32 magVecSquared() const; // deprecated -- use lengthSquared()
 
-    F32         length() const;             // Returns magnitude squared of LLColor4U
-    F32         lengthSquared() const;      // Returns magnitude squared of LLColor4U
+    F32 length() const;        // Returns magnitude squared of LLColor4U
+    F32 lengthSquared() const; // Returns magnitude squared of LLColor4U
 
-    friend std::ostream&     operator<<(std::ostream& s, const LLColor4U &a);       // Print a
-    friend LLColor4U operator+(const LLColor4U &a, const LLColor4U &b); // Return vector a + b
-    friend LLColor4U operator-(const LLColor4U &a, const LLColor4U &b); // Return vector a minus b
-    friend LLColor4U operator*(const LLColor4U &a, const LLColor4U &b); // Return a * b
-    friend bool operator==(const LLColor4U &a, const LLColor4U &b);     // Return a == b
-    friend bool operator!=(const LLColor4U &a, const LLColor4U &b);     // Return a != b
+    friend std::ostream& operator<<(std::ostream& s, const LLColor4U& a);    // Print a
+    friend LLColor4U     operator+(const LLColor4U& a, const LLColor4U& b);  // Return vector a + b
+    friend LLColor4U     operator-(const LLColor4U& a, const LLColor4U& b);  // Return vector a minus b
+    friend LLColor4U     operator*(const LLColor4U& a, const LLColor4U& b);  // Return a * b
+    friend bool          operator==(const LLColor4U& a, const LLColor4U& b); // Return a == b
+    friend bool          operator!=(const LLColor4U& a, const LLColor4U& b); // Return a != b
 
-    friend const LLColor4U& operator+=(LLColor4U &a, const LLColor4U &b);   // Return vector a + b
-    friend const LLColor4U& operator-=(LLColor4U &a, const LLColor4U &b);   // Return vector a minus b
-    friend const LLColor4U& operator*=(LLColor4U &a, U8 k);             // Return rgb times scaler k (no alpha change)
-    friend const LLColor4U& operator%=(LLColor4U &a, U8 k);             // Return alpha times scaler k (no rgb change)
+    friend const LLColor4U& operator+=(LLColor4U& a, const LLColor4U& b); // Return vector a + b
+    friend const LLColor4U& operator-=(LLColor4U& a, const LLColor4U& b); // Return vector a minus b
+    friend const LLColor4U& operator*=(LLColor4U& a, U8 k);               // Return rgb times scaler k (no alpha change)
+    friend const LLColor4U& operator%=(LLColor4U& a, U8 k);               // Return alpha times scaler k (no rgb change)
 
-    LLColor4U addClampMax(const LLColor4U &color);                      // Add and clamp the max
+    LLColor4U addClampMax(const LLColor4U& color); // Add and clamp the max
 
-    LLColor4U multAll(const F32 k);                                     // Multiply ALL channels by scalar k
+    LLColor4U multAll(const F32 k); // Multiply ALL channels by scalar k
 
-    inline void setVecScaleClamp(const LLColor3 &color);
-    inline void setVecScaleClamp(const LLColor4 &color);
+    inline void setVecScaleClamp(const LLColor3& color);
+    inline void setVecScaleClamp(const LLColor4& color);
 
     static bool parseColor4U(const std::string& buf, LLColor4U* value);
 
     // conversion
-    operator LLColor4() const
-    {
-        return LLColor4(*this);
-    }
+    operator LLColor4() const { return LLColor4(*this); }
 
-    U32 asRGBA() const;
-    void fromRGBA( U32 aVal );
+    U32  asRGBA() const;
+    void fromRGBA(U32 aVal);
 
     static LLColor4U white;
     static LLColor4U black;
@@ -134,104 +123,95 @@ public:
     static LLColor4U blue;
 };
 
-
 // Non-member functions
-F32     distVec(const LLColor4U &a, const LLColor4U &b);            // Returns distance between a and b
-F32     distVec_squared(const LLColor4U &a, const LLColor4U &b);    // Returns distance squared between a and b
-
+F32 distVec(const LLColor4U& a, const LLColor4U& b);         // Returns distance between a and b
+F32 distVec_squared(const LLColor4U& a, const LLColor4U& b); // Returns distance squared between a and b
 
 inline LLColor4U::LLColor4U()
 {
-    mV[VRED] = 0;
+    mV[VRED]   = 0;
     mV[VGREEN] = 0;
-    mV[VBLUE] = 0;
+    mV[VBLUE]  = 0;
     mV[VALPHA] = 255;
 }
 
 inline LLColor4U::LLColor4U(U8 r, U8 g, U8 b)
 {
-    mV[VRED] = r;
+    mV[VRED]   = r;
     mV[VGREEN] = g;
-    mV[VBLUE] = b;
+    mV[VBLUE]  = b;
     mV[VALPHA] = 255;
 }
 
 inline LLColor4U::LLColor4U(U8 r, U8 g, U8 b, U8 a)
 {
-    mV[VRED] = r;
+    mV[VRED]   = r;
     mV[VGREEN] = g;
-    mV[VBLUE] = b;
+    mV[VBLUE]  = b;
     mV[VALPHA] = a;
 }
 
-inline LLColor4U::LLColor4U(const U8 *vec)
+inline LLColor4U::LLColor4U(const U8* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
 }
 
-/*
-inline LLColor4U::operator LLColor4()
-{
-    return(LLColor4((F32)mV[VRED]/255.f,(F32)mV[VGREEN]/255.f,(F32)mV[VBLUE]/255.f,(F32)mV[VALPHA]/255.f));
-}
-*/
-
 inline const LLColor4U& LLColor4U::setToBlack(void)
 {
-    mV[VRED] = 0;
+    mV[VRED]   = 0;
     mV[VGREEN] = 0;
-    mV[VBLUE] = 0;
+    mV[VBLUE]  = 0;
     mV[VALPHA] = 255;
     return (*this);
 }
 
 inline const LLColor4U& LLColor4U::setToWhite(void)
 {
-    mV[VRED] = 255;
+    mV[VRED]   = 255;
     mV[VGREEN] = 255;
-    mV[VBLUE] = 255;
+    mV[VBLUE]  = 255;
     mV[VALPHA] = 255;
     return (*this);
 }
 
 inline const LLColor4U& LLColor4U::set(const U8 x, const U8 y, const U8 z)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
 
-//  no change to alpha!
-//  mV[VALPHA] = 255;
+    //  no change to alpha!
+    //  mV[VALPHA] = 255;
 
     return (*this);
 }
 
 inline const LLColor4U& LLColor4U::set(const U8 r, const U8 g, const U8 b, U8 a)
 {
-    mV[0] = r;
-    mV[1] = g;
-    mV[2] = b;
-    mV[3] = a;
+    mV[VRED]   = r;
+    mV[VGREEN] = g;
+    mV[VBLUE]  = b;
+    mV[VALPHA] = a;
     return (*this);
 }
 
-inline const LLColor4U& LLColor4U::set(const LLColor4U &vec)
+inline const LLColor4U& LLColor4U::set(const LLColor4U& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = vec.mV[VALPHA];
     return (*this);
 }
 
-inline const LLColor4U& LLColor4U::set(const U8 *vec)
+inline const LLColor4U& LLColor4U::set(const U8* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
     return (*this);
 }
@@ -239,12 +219,12 @@ inline const LLColor4U& LLColor4U::set(const U8 *vec)
 // deprecated
 inline const LLColor4U& LLColor4U::setVec(const U8 x, const U8 y, const U8 z)
 {
-    mV[VRED] = x;
+    mV[VRED]   = x;
     mV[VGREEN] = y;
-    mV[VBLUE] = z;
+    mV[VBLUE]  = z;
 
-//  no change to alpha!
-//  mV[VALPHA] = 255;
+    //  no change to alpha!
+    //  mV[VALPHA] = 255;
 
     return (*this);
 }
@@ -252,29 +232,29 @@ inline const LLColor4U& LLColor4U::setVec(const U8 x, const U8 y, const U8 z)
 // deprecated
 inline const LLColor4U& LLColor4U::setVec(const U8 r, const U8 g, const U8 b, U8 a)
 {
-    mV[0] = r;
-    mV[1] = g;
-    mV[2] = b;
-    mV[3] = a;
+    mV[VRED]   = r;
+    mV[VGREEN] = g;
+    mV[VBLUE]  = b;
+    mV[VALPHA] = a;
     return (*this);
 }
 
 // deprecated
-inline const LLColor4U& LLColor4U::setVec(const LLColor4U &vec)
+inline const LLColor4U& LLColor4U::setVec(const LLColor4U& vec)
 {
-    mV[VRED] = vec.mV[VRED];
+    mV[VRED]   = vec.mV[VRED];
     mV[VGREEN] = vec.mV[VGREEN];
-    mV[VBLUE] = vec.mV[VBLUE];
+    mV[VBLUE]  = vec.mV[VBLUE];
     mV[VALPHA] = vec.mV[VALPHA];
     return (*this);
 }
 
 // deprecated
-inline const LLColor4U& LLColor4U::setVec(const U8 *vec)
+inline const LLColor4U& LLColor4U::setVec(const U8* vec)
 {
-    mV[VRED] = vec[VRED];
+    mV[VRED]   = vec[VRED];
     mV[VGREEN] = vec[VGREEN];
-    mV[VBLUE] = vec[VBLUE];
+    mV[VBLUE]  = vec[VBLUE];
     mV[VALPHA] = vec[VALPHA];
     return (*this);
 }
@@ -287,131 +267,68 @@ inline const LLColor4U& LLColor4U::setAlpha(U8 a)
 
 // LLColor4U Magnitude and Normalization Functions
 
-inline F32      LLColor4U::length(void) const
+inline F32 LLColor4U::length() const
 {
-    return (F32) sqrt( ((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE] );
+    return sqrt(((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE]);
 }
 
-inline F32      LLColor4U::lengthSquared(void) const
+inline F32 LLColor4U::lengthSquared() const
 {
     return ((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE];
 }
 
 // deprecated
-inline F32      LLColor4U::magVec(void) const
+inline F32 LLColor4U::magVec() const
 {
-    return (F32) sqrt( ((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE] );
+    return sqrt(((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE]);
 }
 
 // deprecated
-inline F32      LLColor4U::magVecSquared(void) const
+inline F32 LLColor4U::magVecSquared() const
 {
     return ((F32)mV[VRED]) * mV[VRED] + ((F32)mV[VGREEN]) * mV[VGREEN] + ((F32)mV[VBLUE]) * mV[VBLUE];
 }
 
-inline LLColor4U operator+(const LLColor4U &a, const LLColor4U &b)
+inline LLColor4U operator+(const LLColor4U& a, const LLColor4U& b)
 {
-    return LLColor4U(
-        a.mV[VRED] + b.mV[VRED],
-        a.mV[VGREEN] + b.mV[VGREEN],
-        a.mV[VBLUE] + b.mV[VBLUE],
-        a.mV[VALPHA] + b.mV[VALPHA]);
+    return LLColor4U(a.mV[VRED] + b.mV[VRED], a.mV[VGREEN] + b.mV[VGREEN], a.mV[VBLUE] + b.mV[VBLUE], a.mV[VALPHA] + b.mV[VALPHA]);
 }
 
-inline LLColor4U operator-(const LLColor4U &a, const LLColor4U &b)
+inline LLColor4U operator-(const LLColor4U& a, const LLColor4U& b)
 {
-    return LLColor4U(
-        a.mV[VRED] - b.mV[VRED],
-        a.mV[VGREEN] - b.mV[VGREEN],
-        a.mV[VBLUE] - b.mV[VBLUE],
-        a.mV[VALPHA] - b.mV[VALPHA]);
+    return LLColor4U(a.mV[VRED] - b.mV[VRED], a.mV[VGREEN] - b.mV[VGREEN], a.mV[VBLUE] - b.mV[VBLUE], a.mV[VALPHA] - b.mV[VALPHA]);
 }
 
-inline LLColor4U  operator*(const LLColor4U &a, const LLColor4U &b)
+inline LLColor4U operator*(const LLColor4U& a, const LLColor4U& b)
 {
-    return LLColor4U(
-        a.mV[VRED] * b.mV[VRED],
-        a.mV[VGREEN] * b.mV[VGREEN],
-        a.mV[VBLUE] * b.mV[VBLUE],
-        a.mV[VALPHA] * b.mV[VALPHA]);
+    return LLColor4U(a.mV[VRED] * b.mV[VRED], a.mV[VGREEN] * b.mV[VGREEN], a.mV[VBLUE] * b.mV[VBLUE], a.mV[VALPHA] * b.mV[VALPHA]);
 }
 
-inline LLColor4U LLColor4U::addClampMax(const LLColor4U &color)
+inline LLColor4U LLColor4U::addClampMax(const LLColor4U& color)
 {
     return LLColor4U(llmin((S32)mV[VRED] + color.mV[VRED], 255),
-                    llmin((S32)mV[VGREEN] + color.mV[VGREEN], 255),
-                    llmin((S32)mV[VBLUE] + color.mV[VBLUE], 255),
-                    llmin((S32)mV[VALPHA] + color.mV[VALPHA], 255));
+                     llmin((S32)mV[VGREEN] + color.mV[VGREEN], 255),
+                     llmin((S32)mV[VBLUE] + color.mV[VBLUE], 255),
+                     llmin((S32)mV[VALPHA] + color.mV[VALPHA], 255));
 }
 
 inline LLColor4U LLColor4U::multAll(const F32 k)
 {
     // Round to nearest
-    return LLColor4U(
-        (U8)ll_round(mV[VRED] * k),
-        (U8)ll_round(mV[VGREEN] * k),
-        (U8)ll_round(mV[VBLUE] * k),
-        (U8)ll_round(mV[VALPHA] * k));
-}
-/*
-inline LLColor4U operator*(const LLColor4U &a, U8 k)
-{
-    // only affects rgb (not a!)
-    return LLColor4U(
-        a.mV[VRED] * k,
-        a.mV[VGREEN] * k,
-        a.mV[VBLUE] * k,
-        a.mV[VALPHA]);
+    return LLColor4U((U8)ll_round(mV[VRED] * k), (U8)ll_round(mV[VGREEN] * k), (U8)ll_round(mV[VBLUE] * k), (U8)ll_round(mV[VALPHA] * k));
 }
 
-inline LLColor4U operator*(U8 k, const LLColor4U &a)
+inline bool operator==(const LLColor4U& a, const LLColor4U& b)
 {
-    // only affects rgb (not a!)
-    return LLColor4U(
-        a.mV[VRED] * k,
-        a.mV[VGREEN] * k,
-        a.mV[VBLUE] * k,
-        a.mV[VALPHA]);
+    return ((a.mV[VRED] == b.mV[VRED]) && (a.mV[VGREEN] == b.mV[VGREEN]) && (a.mV[VBLUE] == b.mV[VBLUE]) && (a.mV[VALPHA] == b.mV[VALPHA]));
 }
 
-inline LLColor4U operator%(U8 k, const LLColor4U &a)
+inline bool operator!=(const LLColor4U& a, const LLColor4U& b)
 {
-    // only affects alpha (not rgb!)
-    return LLColor4U(
-        a.mV[VRED],
-        a.mV[VGREEN],
-        a.mV[VBLUE],
-        a.mV[VALPHA] * k );
+    return ((a.mV[VRED] != b.mV[VRED]) || (a.mV[VGREEN] != b.mV[VGREEN]) || (a.mV[VBLUE] != b.mV[VBLUE]) || (a.mV[VALPHA] != b.mV[VALPHA]));
 }
 
-inline LLColor4U operator%(const LLColor4U &a, U8 k)
-{
-    // only affects alpha (not rgb!)
-    return LLColor4U(
-        a.mV[VRED],
-        a.mV[VGREEN],
-        a.mV[VBLUE],
-        a.mV[VALPHA] * k );
-}
-*/
-
-inline bool operator==(const LLColor4U &a, const LLColor4U &b)
-{
-    return (  (a.mV[VRED] == b.mV[VRED])
-            &&(a.mV[VGREEN] == b.mV[VGREEN])
-            &&(a.mV[VBLUE] == b.mV[VBLUE])
-            &&(a.mV[VALPHA] == b.mV[VALPHA]));
-}
-
-inline bool operator!=(const LLColor4U &a, const LLColor4U &b)
-{
-    return (  (a.mV[VRED] != b.mV[VRED])
-            ||(a.mV[VGREEN] != b.mV[VGREEN])
-            ||(a.mV[VBLUE] != b.mV[VBLUE])
-            ||(a.mV[VALPHA] != b.mV[VALPHA]));
-}
-
-inline const LLColor4U& operator+=(LLColor4U &a, const LLColor4U &b)
+inline const LLColor4U& operator+=(LLColor4U& a, const LLColor4U& b)
 {
     a.mV[VRED] += b.mV[VRED];
     a.mV[VGREEN] += b.mV[VGREEN];
@@ -420,7 +337,7 @@ inline const LLColor4U& operator+=(LLColor4U &a, const LLColor4U &b)
     return a;
 }
 
-inline const LLColor4U& operator-=(LLColor4U &a, const LLColor4U &b)
+inline const LLColor4U& operator-=(LLColor4U& a, const LLColor4U& b)
 {
     a.mV[VRED] -= b.mV[VRED];
     a.mV[VGREEN] -= b.mV[VGREEN];
@@ -429,7 +346,7 @@ inline const LLColor4U& operator-=(LLColor4U &a, const LLColor4U &b)
     return a;
 }
 
-inline const LLColor4U& operator*=(LLColor4U &a, U8 k)
+inline const LLColor4U& operator*=(LLColor4U& a, U8 k)
 {
     // only affects rgb (not a!)
     a.mV[VRED] *= k;
@@ -438,20 +355,20 @@ inline const LLColor4U& operator*=(LLColor4U &a, U8 k)
     return a;
 }
 
-inline const LLColor4U& operator%=(LLColor4U &a, U8 k)
+inline const LLColor4U& operator%=(LLColor4U& a, U8 k)
 {
     // only affects alpha (not rgb!)
     a.mV[VALPHA] *= k;
     return a;
 }
 
-inline F32      distVec(const LLColor4U &a, const LLColor4U &b)
+inline F32 distVec(const LLColor4U& a, const LLColor4U& b)
 {
     LLColor4U vec = a - b;
     return (vec.length());
 }
 
-inline F32      distVec_squared(const LLColor4U &a, const LLColor4U &b)
+inline F32 distVec_squared(const LLColor4U& a, const LLColor4U& b)
 {
     LLColor4U vec = a - b;
     return (vec.lengthSquared());
@@ -460,13 +377,13 @@ inline F32      distVec_squared(const LLColor4U &a, const LLColor4U &b)
 void LLColor4U::setVecScaleClamp(const LLColor4& color)
 {
     F32 color_scale_factor = 255.f;
-    F32 max_color = llmax(color.mV[0], color.mV[1], color.mV[2]);
+    F32 max_color          = llmax(color.mV[VRED], color.mV[VGREEN], color.mV[VBLUE]);
     if (max_color > 1.f)
     {
         color_scale_factor /= max_color;
     }
-    const S32 MAX_COLOR = 255;
-    S32 r = ll_round(color.mV[0] * color_scale_factor);
+    constexpr S32 MAX_COLOR = 255;
+    S32           r         = ll_round(color.mV[VRED] * color_scale_factor);
     if (r > MAX_COLOR)
     {
         r = MAX_COLOR;
@@ -475,9 +392,9 @@ void LLColor4U::setVecScaleClamp(const LLColor4& color)
     {
         r = 0;
     }
-    mV[0] = r;
+    mV[VRED] = r;
 
-    S32 g = ll_round(color.mV[1] * color_scale_factor);
+    S32 g = ll_round(color.mV[VGREEN] * color_scale_factor);
     if (g > MAX_COLOR)
     {
         g = MAX_COLOR;
@@ -486,9 +403,9 @@ void LLColor4U::setVecScaleClamp(const LLColor4& color)
     {
         g = 0;
     }
-    mV[1] = g;
+    mV[VGREEN] = g;
 
-    S32 b = ll_round(color.mV[2] * color_scale_factor);
+    S32 b = ll_round(color.mV[VBLUE] * color_scale_factor);
     if (b > MAX_COLOR)
     {
         b = MAX_COLOR;
@@ -497,10 +414,10 @@ void LLColor4U::setVecScaleClamp(const LLColor4& color)
     {
         b = 0;
     }
-    mV[2] = b;
+    mV[VBLUE] = b;
 
     // Alpha shouldn't be scaled, just clamped...
-    S32 a = ll_round(color.mV[3] * MAX_COLOR);
+    S32 a = ll_round(color.mV[VALPHA] * MAX_COLOR);
     if (a > MAX_COLOR)
     {
         a = MAX_COLOR;
@@ -509,44 +426,42 @@ void LLColor4U::setVecScaleClamp(const LLColor4& color)
     {
         a = 0;
     }
-    mV[3] = a;
+    mV[VALPHA] = a;
 }
 
 void LLColor4U::setVecScaleClamp(const LLColor3& color)
 {
     F32 color_scale_factor = 255.f;
-    F32 max_color = llmax(color.mV[0], color.mV[1], color.mV[2]);
+    F32 max_color          = llmax(color.mV[VRED], color.mV[VGREEN], color.mV[VBLUE]);
     if (max_color > 1.f)
     {
         color_scale_factor /= max_color;
     }
 
     const S32 MAX_COLOR = 255;
-    S32 r = ll_round(color.mV[0] * color_scale_factor);
+    S32       r         = ll_round(color.mV[VRED] * color_scale_factor);
     if (r > MAX_COLOR)
     {
         r = MAX_COLOR;
     }
-    else
-    if (r < 0)
+    else if (r < 0)
     {
         r = 0;
     }
-    mV[0] = r;
+    mV[VRED] = r;
 
-    S32 g = ll_round(color.mV[1] * color_scale_factor);
+    S32 g = ll_round(color.mV[VGREEN] * color_scale_factor);
     if (g > MAX_COLOR)
     {
         g = MAX_COLOR;
     }
-    else
-    if (g < 0)
+    else if (g < 0)
     {
         g = 0;
     }
-    mV[1] = g;
+    mV[VGREEN] = g;
 
-    S32 b = ll_round(color.mV[2] * color_scale_factor);
+    S32 b = ll_round(color.mV[VBLUE] * color_scale_factor);
     if (b > MAX_COLOR)
     {
         b = MAX_COLOR;
@@ -555,31 +470,29 @@ void LLColor4U::setVecScaleClamp(const LLColor3& color)
     {
         b = 0;
     }
-    mV[2] = b;
+    mV[VBLUE] = b;
 
-    mV[3] = 255;
+    mV[VALPHA] = 255;
 }
 
 inline U32 LLColor4U::asRGBA() const
 {
     // Little endian: values are swapped in memory. The original code access the array like a U32, so we need to swap here
 
-    return (mV[3] << 24) | (mV[2] << 16) | (mV[1] << 8) | mV[0];
+    return (mV[VALPHA] << 24) | (mV[VBLUE] << 16) | (mV[VGREEN] << 8) | mV[VRED];
 }
 
-inline void LLColor4U::fromRGBA( U32 aVal )
+inline void LLColor4U::fromRGBA(U32 aVal)
 {
     // Little endian: values are swapped in memory. The original code access the array like a U32, so we need to swap here
 
-    mV[ 0 ] = aVal & 0xFF;
+    mV[VRED] = aVal & 0xFF;
     aVal >>= 8;
-    mV[ 1 ] = aVal & 0xFF;
+    mV[VGREEN] = aVal & 0xFF;
     aVal >>= 8;
-    mV[ 2 ] = aVal & 0xFF;
+    mV[VBLUE] = aVal & 0xFF;
     aVal >>= 8;
-    mV[ 3 ] = aVal & 0xFF;
+    mV[VALPHA] = aVal & 0xFF;
 }
 
-
 #endif
-

--- a/indra/llmath/v4math.cpp
+++ b/indra/llmath/v4math.cpp
@@ -26,7 +26,6 @@
 
 #include "linden_common.h"
 
-//#include "vmath.h"
 #include "v3math.h"
 #include "v4math.h"
 #include "m4math.h"
@@ -36,13 +35,13 @@
 // LLVector4
 
 // Axis-Angle rotations
-const LLVector4&    LLVector4::rotVec(const LLMatrix4 &mat)
+const LLVector4&    LLVector4::rotVec(const LLMatrix4& mat)
 {
     *this = *this * mat;
     return *this;
 }
 
-const LLVector4&    LLVector4::rotVec(const LLQuaternion &q)
+const LLVector4&    LLVector4::rotVec(const LLQuaternion& q)
 {
     *this = *this * q;
     return *this;
@@ -64,16 +63,16 @@ bool LLVector4::abs()
 {
     bool ret{ false };
 
-    if (mV[0] < 0.f) { mV[0] = -mV[0]; ret = true; }
-    if (mV[1] < 0.f) { mV[1] = -mV[1]; ret = true; }
-    if (mV[2] < 0.f) { mV[2] = -mV[2]; ret = true; }
-    if (mV[3] < 0.f) { mV[3] = -mV[3]; ret = true; }
+    if (mV[VX] < 0.f) { mV[VX] = -mV[VX]; ret = true; }
+    if (mV[VY] < 0.f) { mV[VY] = -mV[VY]; ret = true; }
+    if (mV[VZ] < 0.f) { mV[VZ] = -mV[VZ]; ret = true; }
+    if (mV[VW] < 0.f) { mV[VW] = -mV[VW]; ret = true; }
 
     return ret;
 }
 
 
-std::ostream& operator<<(std::ostream& s, const LLVector4 &a)
+std::ostream& operator<<(std::ostream& s, const LLVector4& a)
 {
     s << "{ " << a.mV[VX] << ", " << a.mV[VY] << ", " << a.mV[VZ] << ", " << a.mV[VW] << " }";
     return s;
@@ -108,12 +107,12 @@ bool are_parallel(const LLVector4 &a, const LLVector4 &b, F32 epsilon)
 }
 
 
-LLVector3 vec4to3(const LLVector4 &vec)
+LLVector3 vec4to3(const LLVector4& vec)
 {
     return LLVector3( vec.mV[VX], vec.mV[VY], vec.mV[VZ] );
 }
 
-LLVector4 vec3to4(const LLVector3 &vec)
+LLVector4 vec3to4(const LLVector3& vec)
 {
     return LLVector4(vec.mV[VX], vec.mV[VY], vec.mV[VZ]);
 }

--- a/indra/llmath/v4math.h
+++ b/indra/llmath/v4math.h
@@ -42,108 +42,108 @@ class LLQuaternion;
 
 //  LLVector4 = |x y z w|
 
-static const U32 LENGTHOFVECTOR4 = 4;
+static constexpr U32 LENGTHOFVECTOR4 = 4;
 
 class LLVector4
 {
-    public:
-        F32 mV[LENGTHOFVECTOR4];
-        LLVector4();                        // Initializes LLVector4 to (0, 0, 0, 1)
-        explicit LLVector4(const F32 *vec);         // Initializes LLVector4 to (vec[0]. vec[1], vec[2], vec[3])
-        explicit LLVector4(const F64 *vec);         // Initialized LLVector4 to ((F32) vec[0], (F32) vec[1], (F32) vec[3], (F32) vec[4]);
-        explicit LLVector4(const LLVector2 &vec);
-        explicit LLVector4(const LLVector2 &vec, F32 z, F32 w);
-        explicit LLVector4(const LLVector3 &vec);           // Initializes LLVector4 to (vec, 1)
-        explicit LLVector4(const LLVector3 &vec, F32 w);    // Initializes LLVector4 to (vec, w)
-        explicit LLVector4(const LLSD &sd);
-        LLVector4(F32 x, F32 y, F32 z);     // Initializes LLVector4 to (x. y, z, 1)
-        LLVector4(F32 x, F32 y, F32 z, F32 w);
+public:
+    F32 mV[LENGTHOFVECTOR4];
+    LLVector4();                        // Initializes LLVector4 to (0, 0, 0, 1)
+    explicit LLVector4(const F32 *vec);         // Initializes LLVector4 to (vec[0]. vec[1], vec[2], vec[3])
+    explicit LLVector4(const F64 *vec);         // Initialized LLVector4 to ((F32) vec[0], (F32) vec[1], (F32) vec[3], (F32) vec[4]);
+    explicit LLVector4(const LLVector2 &vec);
+    explicit LLVector4(const LLVector2 &vec, F32 z, F32 w);
+    explicit LLVector4(const LLVector3 &vec);           // Initializes LLVector4 to (vec, 1)
+    explicit LLVector4(const LLVector3 &vec, F32 w);    // Initializes LLVector4 to (vec, w)
+    explicit LLVector4(const LLSD &sd);
+    LLVector4(F32 x, F32 y, F32 z);     // Initializes LLVector4 to (x. y, z, 1)
+    LLVector4(F32 x, F32 y, F32 z, F32 w);
 
-        LLSD getValue() const
-        {
-            LLSD ret;
-            ret[0] = mV[0];
-            ret[1] = mV[1];
-            ret[2] = mV[2];
-            ret[3] = mV[3];
-            return ret;
-        }
+    LLSD getValue() const
+    {
+        LLSD ret;
+        ret[VX] = mV[VX];
+        ret[VY] = mV[VY];
+        ret[VZ] = mV[VZ];
+        ret[VW] = mV[VW];
+        return ret;
+    }
 
-        void setValue(const LLSD& sd)
-        {
-            mV[0] = (F32)sd[0].asReal();
-            mV[1] = (F32)sd[1].asReal();
-            mV[2] = (F32)sd[2].asReal();
-            mV[3] = (F32)sd[3].asReal();
-        }
+    void setValue(const LLSD& sd)
+    {
+        mV[VX] = (F32)sd[VX].asReal();
+        mV[VY] = (F32)sd[VY].asReal();
+        mV[VZ] = (F32)sd[VZ].asReal();
+        mV[VW] = (F32)sd[VW].asReal();
+    }
 
-        // GLM interop
-        explicit LLVector4(const glm::vec3& vec); // Initializes LLVector4 to (vec, 1)
-        explicit LLVector4(const glm::vec4& vec); // Initializes LLVector4 to vec
-        explicit operator glm::vec3() const;      // Initializes glm::vec3 to (vec[0]. vec[1], vec[2])
-        explicit operator glm::vec4() const;      // Initializes glm::vec4 to (vec[0]. vec[1], vec[2], vec[3])
+    // GLM interop
+    explicit LLVector4(const glm::vec3& vec); // Initializes LLVector4 to (vec, 1)
+    explicit LLVector4(const glm::vec4& vec); // Initializes LLVector4 to vec
+    explicit operator glm::vec3() const;      // Initializes glm::vec3 to (vec[0]. vec[1], vec[2])
+    explicit operator glm::vec4() const;      // Initializes glm::vec4 to (vec[0]. vec[1], vec[2], vec[3])
 
-        inline bool isFinite() const;                                   // checks to see if all values of LLVector3 are finite
+    inline bool isFinite() const;                                   // checks to see if all values of LLVector3 are finite
 
-        inline void clear();        // Clears LLVector4 to (0, 0, 0, 1)
-        inline void clearVec();     // deprecated
-        inline void zeroVec();      // deprecated
+    inline void clear();        // Clears LLVector4 to (0, 0, 0, 1)
+    inline void clearVec();     // deprecated
+    inline void zeroVec();      // deprecated
 
-        inline void set(F32 x, F32 y, F32 z);           // Sets LLVector4 to (x, y, z, 1)
-        inline void set(F32 x, F32 y, F32 z, F32 w);    // Sets LLVector4 to (x, y, z, w)
-        inline void set(const LLVector4 &vec);          // Sets LLVector4 to vec
-        inline void set(const LLVector3 &vec, F32 w = 1.f); // Sets LLVector4 to LLVector3 vec
-        inline void set(const F32 *vec);                // Sets LLVector4 to vec
-        inline void set(const glm::vec4& vec); // Sets LLVector4 to vec
-        inline void set(const glm::vec3& vec, F32 w = 1.f); // Sets LLVector4 to LLVector3 vec with w defaulted to 1
+    inline void set(F32 x, F32 y, F32 z);           // Sets LLVector4 to (x, y, z, 1)
+    inline void set(F32 x, F32 y, F32 z, F32 w);    // Sets LLVector4 to (x, y, z, w)
+    inline void set(const LLVector4 &vec);          // Sets LLVector4 to vec
+    inline void set(const LLVector3 &vec, F32 w = 1.f); // Sets LLVector4 to LLVector3 vec
+    inline void set(const F32 *vec);                // Sets LLVector4 to vec
+    inline void set(const glm::vec4& vec); // Sets LLVector4 to vec
+    inline void set(const glm::vec3& vec, F32 w = 1.f); // Sets LLVector4 to LLVector3 vec with w defaulted to 1
 
-        inline void setVec(F32 x, F32 y, F32 z);        // deprecated
-        inline void setVec(F32 x, F32 y, F32 z, F32 w); // deprecated
-        inline void setVec(const LLVector4 &vec);       // deprecated
-        inline void setVec(const LLVector3 &vec, F32 w = 1.f); // deprecated
-        inline void setVec(const F32 *vec);             // deprecated
+    inline void setVec(F32 x, F32 y, F32 z);        // deprecated
+    inline void setVec(F32 x, F32 y, F32 z, F32 w); // deprecated
+    inline void setVec(const LLVector4 &vec);       // deprecated
+    inline void setVec(const LLVector3 &vec, F32 w = 1.f); // deprecated
+    inline void setVec(const F32 *vec);             // deprecated
 
-        F32 length() const;             // Returns magnitude of LLVector4
-        F32 lengthSquared() const;      // Returns magnitude squared of LLVector4
-        F32 normalize();                // Normalizes and returns the magnitude of LLVector4
+    F32 length() const;             // Returns magnitude of LLVector4
+    F32 lengthSquared() const;      // Returns magnitude squared of LLVector4
+    F32 normalize();                // Normalizes and returns the magnitude of LLVector4
 
-        F32         magVec() const;             // deprecated
-        F32         magVecSquared() const;      // deprecated
-        F32         normVec();                  // deprecated
+    F32         magVec() const;             // deprecated
+    F32         magVecSquared() const;      // deprecated
+    F32         normVec();                  // deprecated
 
-        // Sets all values to absolute value of their original values
-        // Returns true if data changed
-        bool abs();
+    // Sets all values to absolute value of their original values
+    // Returns true if data changed
+    bool abs();
 
-        bool isExactlyClear() const     { return (mV[VW] == 1.0f) && !mV[VX] && !mV[VY] && !mV[VZ]; }
-        bool isExactlyZero() const      { return !mV[VW] && !mV[VX] && !mV[VY] && !mV[VZ]; }
+    bool isExactlyClear() const     { return (mV[VW] == 1.0f) && !mV[VX] && !mV[VY] && !mV[VZ]; }
+    bool isExactlyZero() const      { return !mV[VW] && !mV[VX] && !mV[VY] && !mV[VZ]; }
 
-        const LLVector4&    rotVec(const LLMatrix4 &mat);               // Rotates by MAT4 mat
-        const LLVector4&    rotVec(const LLQuaternion &q);              // Rotates by QUAT q
+    const LLVector4&    rotVec(const LLMatrix4 &mat);               // Rotates by MAT4 mat
+    const LLVector4&    rotVec(const LLQuaternion &q);              // Rotates by QUAT q
 
-        const LLVector4&    scaleVec(const LLVector4& vec); // Scales component-wise by vec
+    const LLVector4&    scaleVec(const LLVector4& vec); // Scales component-wise by vec
 
-        F32 operator[](int idx) const { return mV[idx]; }
-        F32 &operator[](int idx) { return mV[idx]; }
+    F32 operator[](int idx) const { return mV[idx]; }
+    F32 &operator[](int idx) { return mV[idx]; }
 
-        friend std::ostream&     operator<<(std::ostream& s, const LLVector4 &a);       // Print a
-        friend LLVector4 operator+(const LLVector4 &a, const LLVector4 &b); // Return vector a + b
-        friend LLVector4 operator-(const LLVector4 &a, const LLVector4 &b); // Return vector a minus b
-        friend F32  operator*(const LLVector4 &a, const LLVector4 &b);      // Return a dot b
-        friend LLVector4 operator%(const LLVector4 &a, const LLVector4 &b); // Return a cross b
-        friend LLVector4 operator/(const LLVector4 &a, F32 k);              // Return a divided by scaler k
-        friend LLVector4 operator*(const LLVector4 &a, F32 k);              // Return a times scaler k
-        friend LLVector4 operator*(F32 k, const LLVector4 &a);              // Return a times scaler k
-        friend bool operator==(const LLVector4 &a, const LLVector4 &b);     // Return a == b
-        friend bool operator!=(const LLVector4 &a, const LLVector4 &b);     // Return a != b
+    friend std::ostream&     operator<<(std::ostream& s, const LLVector4 &a);       // Print a
+    friend LLVector4 operator+(const LLVector4 &a, const LLVector4 &b); // Return vector a + b
+    friend LLVector4 operator-(const LLVector4 &a, const LLVector4 &b); // Return vector a minus b
+    friend F32  operator*(const LLVector4 &a, const LLVector4 &b);      // Return a dot b
+    friend LLVector4 operator%(const LLVector4 &a, const LLVector4 &b); // Return a cross b
+    friend LLVector4 operator/(const LLVector4 &a, F32 k);              // Return a divided by scaler k
+    friend LLVector4 operator*(const LLVector4 &a, F32 k);              // Return a times scaler k
+    friend LLVector4 operator*(F32 k, const LLVector4 &a);              // Return a times scaler k
+    friend bool operator==(const LLVector4 &a, const LLVector4 &b);     // Return a == b
+    friend bool operator!=(const LLVector4 &a, const LLVector4 &b);     // Return a != b
 
-        friend const LLVector4& operator+=(LLVector4 &a, const LLVector4 &b);   // Return vector a + b
-        friend const LLVector4& operator-=(LLVector4 &a, const LLVector4 &b);   // Return vector a minus b
-        friend const LLVector4& operator%=(LLVector4 &a, const LLVector4 &b);   // Return a cross b
-        friend const LLVector4& operator*=(LLVector4 &a, F32 k);                // Return a times scaler k
-        friend const LLVector4& operator/=(LLVector4 &a, F32 k);                // Return a divided by scaler k
+    friend const LLVector4& operator+=(LLVector4 &a, const LLVector4 &b);   // Return vector a + b
+    friend const LLVector4& operator-=(LLVector4 &a, const LLVector4 &b);   // Return vector a minus b
+    friend const LLVector4& operator%=(LLVector4 &a, const LLVector4 &b);   // Return a cross b
+    friend const LLVector4& operator*=(LLVector4 &a, F32 k);                // Return a times scaler k
+    friend const LLVector4& operator/=(LLVector4 &a, F32 k);                // Return a divided by scaler k
 
-        friend LLVector4 operator-(const LLVector4 &a);                 // Return vector -a
+    friend LLVector4 operator-(const LLVector4 &a);                 // Return vector -a
 };
 
 // Non-member functions
@@ -257,7 +257,7 @@ inline bool LLVector4::isFinite() const
 
 // Clear and Assignment Functions
 
-inline void LLVector4::clear(void)
+inline void LLVector4::clear()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
@@ -266,7 +266,7 @@ inline void LLVector4::clear(void)
 }
 
 // deprecated
-inline void LLVector4::clearVec(void)
+inline void LLVector4::clearVec()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
@@ -275,7 +275,7 @@ inline void LLVector4::clearVec(void)
 }
 
 // deprecated
-inline void LLVector4::zeroVec(void)
+inline void LLVector4::zeroVec()
 {
     mV[VX] = 0.f;
     mV[VY] = 0.f;
@@ -299,7 +299,7 @@ inline void LLVector4::set(F32 x, F32 y, F32 z, F32 w)
     mV[VW] = w;
 }
 
-inline void LLVector4::set(const LLVector4 &vec)
+inline void LLVector4::set(const LLVector4& vec)
 {
     mV[VX] = vec.mV[VX];
     mV[VY] = vec.mV[VY];
@@ -307,7 +307,7 @@ inline void LLVector4::set(const LLVector4 &vec)
     mV[VW] = vec.mV[VW];
 }
 
-inline void LLVector4::set(const LLVector3 &vec, F32 w)
+inline void LLVector4::set(const LLVector3& vec, F32 w)
 {
     mV[VX] = vec.mV[VX];
     mV[VY] = vec.mV[VY];
@@ -315,7 +315,7 @@ inline void LLVector4::set(const LLVector3 &vec, F32 w)
     mV[VW] = w;
 }
 
-inline void LLVector4::set(const F32 *vec)
+inline void LLVector4::set(const F32* vec)
 {
     mV[VX] = vec[VX];
     mV[VY] = vec[VY];
@@ -358,7 +358,7 @@ inline void LLVector4::setVec(F32 x, F32 y, F32 z, F32 w)
 }
 
 // deprecated
-inline void LLVector4::setVec(const LLVector4 &vec)
+inline void LLVector4::setVec(const LLVector4& vec)
 {
     mV[VX] = vec.mV[VX];
     mV[VY] = vec.mV[VY];
@@ -367,7 +367,7 @@ inline void LLVector4::setVec(const LLVector4 &vec)
 }
 
 // deprecated
-inline void LLVector4::setVec(const LLVector3 &vec, F32 w)
+inline void LLVector4::setVec(const LLVector3& vec, F32 w)
 {
     mV[VX] = vec.mV[VX];
     mV[VY] = vec.mV[VY];
@@ -376,7 +376,7 @@ inline void LLVector4::setVec(const LLVector3 &vec, F32 w)
 }
 
 // deprecated
-inline void LLVector4::setVec(const F32 *vec)
+inline void LLVector4::setVec(const F32* vec)
 {
     mV[VX] = vec[VX];
     mV[VY] = vec[VY];
@@ -386,75 +386,75 @@ inline void LLVector4::setVec(const F32 *vec)
 
 // LLVector4 Magnitude and Normalization Functions
 
-inline F32      LLVector4::length(void) const
+inline F32      LLVector4::length() const
 {
-    return (F32) sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
 }
 
-inline F32      LLVector4::lengthSquared(void) const
+inline F32      LLVector4::lengthSquared() const
 {
     return mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ];
 }
 
-inline F32      LLVector4::magVec(void) const
+inline F32      LLVector4::magVec() const
 {
-    return (F32) sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
+    return sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
 }
 
-inline F32      LLVector4::magVecSquared(void) const
+inline F32      LLVector4::magVecSquared() const
 {
     return mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ];
 }
 
 // LLVector4 Operators
 
-inline LLVector4 operator+(const LLVector4 &a, const LLVector4 &b)
+inline LLVector4 operator+(const LLVector4& a, const LLVector4& b)
 {
     LLVector4 c(a);
     return c += b;
 }
 
-inline LLVector4 operator-(const LLVector4 &a, const LLVector4 &b)
+inline LLVector4 operator-(const LLVector4& a, const LLVector4& b)
 {
     LLVector4 c(a);
     return c -= b;
 }
 
-inline F32  operator*(const LLVector4 &a, const LLVector4 &b)
+inline F32  operator*(const LLVector4& a, const LLVector4& b)
 {
     return (a.mV[VX]*b.mV[VX] + a.mV[VY]*b.mV[VY] + a.mV[VZ]*b.mV[VZ]);
 }
 
-inline LLVector4 operator%(const LLVector4 &a, const LLVector4 &b)
+inline LLVector4 operator%(const LLVector4& a, const LLVector4& b)
 {
     return LLVector4(a.mV[VY]*b.mV[VZ] - b.mV[VY]*a.mV[VZ], a.mV[VZ]*b.mV[VX] - b.mV[VZ]*a.mV[VX], a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY]);
 }
 
-inline LLVector4 operator/(const LLVector4 &a, F32 k)
+inline LLVector4 operator/(const LLVector4& a, F32 k)
 {
     F32 t = 1.f / k;
     return LLVector4( a.mV[VX] * t, a.mV[VY] * t, a.mV[VZ] * t );
 }
 
 
-inline LLVector4 operator*(const LLVector4 &a, F32 k)
+inline LLVector4 operator*(const LLVector4& a, F32 k)
 {
     return LLVector4( a.mV[VX] * k, a.mV[VY] * k, a.mV[VZ] * k );
 }
 
-inline LLVector4 operator*(F32 k, const LLVector4 &a)
+inline LLVector4 operator*(F32 k, const LLVector4& a)
 {
     return LLVector4( a.mV[VX] * k, a.mV[VY] * k, a.mV[VZ] * k );
 }
 
-inline bool operator==(const LLVector4 &a, const LLVector4 &b)
+inline bool operator==(const LLVector4& a, const LLVector4& b)
 {
     return (  (a.mV[VX] == b.mV[VX])
             &&(a.mV[VY] == b.mV[VY])
             &&(a.mV[VZ] == b.mV[VZ]));
 }
 
-inline bool operator!=(const LLVector4 &a, const LLVector4 &b)
+inline bool operator!=(const LLVector4& a, const LLVector4& b)
 {
     return (  (a.mV[VX] != b.mV[VX])
             ||(a.mV[VY] != b.mV[VY])
@@ -462,7 +462,7 @@ inline bool operator!=(const LLVector4 &a, const LLVector4 &b)
             ||(a.mV[VW] != b.mV[VW]) );
 }
 
-inline const LLVector4& operator+=(LLVector4 &a, const LLVector4 &b)
+inline const LLVector4& operator+=(LLVector4& a, const LLVector4& b)
 {
     a.mV[VX] += b.mV[VX];
     a.mV[VY] += b.mV[VY];
@@ -470,7 +470,7 @@ inline const LLVector4& operator+=(LLVector4 &a, const LLVector4 &b)
     return a;
 }
 
-inline const LLVector4& operator-=(LLVector4 &a, const LLVector4 &b)
+inline const LLVector4& operator-=(LLVector4& a, const LLVector4& b)
 {
     a.mV[VX] -= b.mV[VX];
     a.mV[VY] -= b.mV[VY];
@@ -478,14 +478,14 @@ inline const LLVector4& operator-=(LLVector4 &a, const LLVector4 &b)
     return a;
 }
 
-inline const LLVector4& operator%=(LLVector4 &a, const LLVector4 &b)
+inline const LLVector4& operator%=(LLVector4& a, const LLVector4& b)
 {
     LLVector4 ret(a.mV[VY]*b.mV[VZ] - b.mV[VY]*a.mV[VZ], a.mV[VZ]*b.mV[VX] - b.mV[VZ]*a.mV[VX], a.mV[VX]*b.mV[VY] - b.mV[VX]*a.mV[VY]);
     a = ret;
     return a;
 }
 
-inline const LLVector4& operator*=(LLVector4 &a, F32 k)
+inline const LLVector4& operator*=(LLVector4& a, F32 k)
 {
     a.mV[VX] *= k;
     a.mV[VY] *= k;
@@ -493,7 +493,7 @@ inline const LLVector4& operator*=(LLVector4 &a, F32 k)
     return a;
 }
 
-inline const LLVector4& operator/=(LLVector4 &a, F32 k)
+inline const LLVector4& operator/=(LLVector4& a, F32 k)
 {
     F32 t = 1.f / k;
     a.mV[VX] *= t;
@@ -502,7 +502,7 @@ inline const LLVector4& operator/=(LLVector4 &a, F32 k)
     return a;
 }
 
-inline LLVector4 operator-(const LLVector4 &a)
+inline LLVector4 operator-(const LLVector4& a)
 {
     return LLVector4( -a.mV[VX], -a.mV[VY], -a.mV[VZ] );
 }
@@ -517,19 +517,19 @@ inline LLVector4::operator glm::vec4() const
     return glm::make_vec4(mV);
 }
 
-inline F32  dist_vec(const LLVector4 &a, const LLVector4 &b)
+inline F32  dist_vec(const LLVector4& a, const LLVector4& b)
 {
     LLVector4 vec = a - b;
     return (vec.length());
 }
 
-inline F32  dist_vec_squared(const LLVector4 &a, const LLVector4 &b)
+inline F32  dist_vec_squared(const LLVector4& a, const LLVector4& b)
 {
     LLVector4 vec = a - b;
     return (vec.lengthSquared());
 }
 
-inline LLVector4 lerp(const LLVector4 &a, const LLVector4 &b, F32 u)
+inline LLVector4 lerp(const LLVector4& a, const LLVector4& b, F32 u)
 {
     return LLVector4(
         a.mV[VX] + (b.mV[VX] - a.mV[VX]) * u,
@@ -538,9 +538,9 @@ inline LLVector4 lerp(const LLVector4 &a, const LLVector4 &b, F32 u)
         a.mV[VW] + (b.mV[VW] - a.mV[VW]) * u);
 }
 
-inline F32      LLVector4::normalize(void)
+inline F32      LLVector4::normalize()
 {
-    F32 mag = (F32) sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
+    F32 mag = sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
@@ -552,18 +552,18 @@ inline F32      LLVector4::normalize(void)
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
-        mV[2] = 0.f;
-        mag = 0;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
+        mV[VZ] = 0.f;
+        mag = 0.f;
     }
     return (mag);
 }
 
 // deprecated
-inline F32      LLVector4::normVec(void)
+inline F32      LLVector4::normVec()
 {
-    F32 mag = (F32) sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
+    F32 mag = sqrt(mV[VX]*mV[VX] + mV[VY]*mV[VY] + mV[VZ]*mV[VZ]);
     F32 oomag;
 
     if (mag > FP_MAG_THRESHOLD)
@@ -575,22 +575,23 @@ inline F32      LLVector4::normVec(void)
     }
     else
     {
-        mV[0] = 0.f;
-        mV[1] = 0.f;
-        mV[2] = 0.f;
-        mag = 0;
+        mV[VX] = 0.f;
+        mV[VY] = 0.f;
+        mV[VZ] = 0.f;
+        mag = 0.f;
     }
     return (mag);
 }
 
 // Because apparently some parts of the viewer use this for color info.
-inline const LLVector4 srgbVector4(const LLVector4 &a) {
+inline const LLVector4 srgbVector4(const LLVector4& a)
+{
     LLVector4 srgbColor;
 
-    srgbColor.mV[0] = linearTosRGB(a.mV[0]);
-    srgbColor.mV[1] = linearTosRGB(a.mV[1]);
-    srgbColor.mV[2] = linearTosRGB(a.mV[2]);
-    srgbColor.mV[3] = a.mV[3];
+    srgbColor.mV[VX] = linearTosRGB(a.mV[VX]);
+    srgbColor.mV[VY] = linearTosRGB(a.mV[VY]);
+    srgbColor.mV[VZ] = linearTosRGB(a.mV[VZ]);
+    srgbColor.mV[VW] = a.mV[VW];
 
     return srgbColor;
 }

--- a/indra/llmath/xform.h
+++ b/indra/llmath/xform.h
@@ -115,7 +115,7 @@ public:
     void        clearChanged(U32 bits)                      { mChanged &= ~bits; }
 
     void        setScaleChildOffset(bool scale)             { mScaleChildOffset = scale; }
-    bool        getScaleChildOffset()                       { return mScaleChildOffset; }
+    bool        getScaleChildOffset() const                 { return mScaleChildOffset; }
 
     LLXform* getParent() const { return mParent; }
     LLXform* getRoot() const;

--- a/indra/newview/llpanelprimmediacontrols.cpp
+++ b/indra/newview/llpanelprimmediacontrols.cpp
@@ -777,7 +777,7 @@ void LLPanelPrimMediaControls::draw()
     else if(mFadeTimer.getStarted())
     {
         F32 time = mFadeTimer.getElapsedTimeF32();
-        alpha *= llmax(lerp(1.0, 0.0, time / mControlFadeTime), 0.0f);
+        alpha *= llmax(lerp(1.f, 0.f, time / mControlFadeTime), 0.0f);
 
         if(time >= mControlFadeTime)
         {

--- a/indra/newview/llphysicsmotion.cpp
+++ b/indra/newview/llphysicsmotion.cpp
@@ -646,18 +646,17 @@ bool LLPhysicsMotion::onUpdate(F32 time)
             velocity_new_local = 0;
         }
 
-        // Check for NaN values.  A NaN value is detected if the variables doesn't equal itself.
-        // If NaN, then reset everything.
-        if ((mPosition_local != mPosition_local) ||
-            (mVelocity_local != mVelocity_local) ||
-            (position_new_local != position_new_local))
+        // Check for NaN values. If NaN, then reset everything.
+        if (llisnan(mPosition_local) ||
+            llisnan(mVelocity_local) ||
+            llisnan(position_new_local))
         {
-            position_new_local = 0;
-            mVelocity_local = 0;
-            mVelocityJoint_local = 0;
-            mAccelerationJoint_local = 0;
-            mPosition_local = 0;
-            mPosition_world = LLVector3(0,0,0);
+            position_new_local = 0.f;
+            mVelocity_local = 0.f;
+            mVelocityJoint_local = 0.f;
+            mAccelerationJoint_local = 0.f;
+            mPosition_local = 0.f;
+            mPosition_world = LLVector3(0.f,0.f,0.f);
         }
 
         const F32 position_new_local_clamped = llclamp(position_new_local,


### PR DESCRIPTION
These include:

- Use standard library functions for llisnan and replace obvious NaN checks that don't work using /fp:fast floating point behavior under MSVC
- Fix lerp issues on newer GCC versions (from old `develop` branch)
- Make eligible functions constexpr (from old `develop` branch)
- Use constants for vector indices where applicable (from old `develop` branch)
- Reformat to match actual coding conventions (from old `develop` branch)