### PR TITLE
Fix memory leak in LLImageDimensionsInfo

### DIFF
--- a/indra/llimage/llimagedimensionsinfo.h
+++ b/indra/llimage/llimagedimensionsinfo.h
@@ -38,7 +38,7 @@ class LLImageDimensionsInfo
 {
 public:
     LLImageDimensionsInfo():
-        mData(NULL)
+        mData(nullptr)
         ,mHeight(0)
         ,mWidth(0)
     {}
@@ -67,7 +67,7 @@ protected:
     {
         mInfile.close();
         delete[] mData;
-        mData = NULL;
+        mData = nullptr;
         mWidth = 0;
         mHeight = 0;
     }


### PR DESCRIPTION
Fixes memory leaks and adds constexpr to LLImageDimensionsInfo - another lost fix from former `develop` branch.