### PR TITLE
#3488 Reduce locking

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4549,6 +4549,7 @@ void LLMeshRepository::notifyLoadedMeshes()
 
             if (mPendingRequests.size() > push_count)
             {
+                LL_PROFILE_ZONE_NAMED("Mesh score_map");
                 // More requests than the high-water limit allows so
                 // sort and forward the most important.
 

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -6375,6 +6375,16 @@ LLJoint *LLVOAvatar::getJoint( S32 joint_num )
     return pJoint;
 }
 
+void LLVOAvatar::initAllJoints()
+{
+    getJointAliases();
+    for (auto& alias : mJointAliasMap)
+    {
+        mJointMap[alias.first] = mRoot->findJoint(alias.second);
+    }
+    // ignore mScreen and mRoot
+}
+
 //-----------------------------------------------------------------------------
 // getRiggedMeshID
 //

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -204,6 +204,7 @@ public:
 
     virtual LLJoint*        getJoint(const std::string &name);
     LLJoint*                getJoint(S32 num);
+    void                    initAllJoints();
 
     //if you KNOW joint_num is a valid animated joint index, use getSkeletonJoint for efficiency
     inline LLJoint* getSkeletonJoint(S32 joint_num) { return mSkeleton[joint_num]; }

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -225,6 +225,8 @@ void LLVOAvatarSelf::initInstance()
     doPeriodically(update_avatar_rez_metrics, 5.0);
     doPeriodically(boost::bind(&LLVOAvatarSelf::checkStuckAppearance, this), 30.0);
 
+    initAllJoints(); // mesh thread uses LLVOAvatarSelf as a joint source
+
     mInitFlags |= 1<<2;
 }
 


### PR DESCRIPTION
1. 'sActive' variables are atomic, no locks needed
2. Fix trylocks. There are internal locks inside loadMeshLOD so without checking locks 3 and 4 viewer would be locked on each loadMeshLOD, potentially making main thread wait for threads to unlock.
3. Sometimes viewer crashes when initing gAgentAvatarp's joints from mesh thread. Preinit joints to avoid having to add extra thread protections.