### PR TITLE
[#3972] Implemented Texture Panel Repeats per meter improvements and PBR feature

### DIFF
--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -1456,9 +1456,18 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
             spec_scale_s = editable ? spec_scale_s : 1.0f;
             spec_scale_s *= identical_planar_texgen ? 2.0f : 1.0f;
 
-            mTexScaleU->setValue(diff_scale_s);
-            mShinyScaleU->setValue(spec_scale_s);
-            mBumpyScaleU->setValue(norm_scale_s);
+            if (force_set_values)
+            {
+                mTexScaleU->forceSetValue(diff_scale_s);
+                mShinyScaleU->forceSetValue(spec_scale_s);
+                mBumpyScaleU->forceSetValue(norm_scale_s);
+            }
+            else
+            {
+                mTexScaleU->setValue(diff_scale_s);
+                mShinyScaleU->setValue(spec_scale_s);
+                mBumpyScaleU->setValue(norm_scale_s);
+            }
 
             mTexScaleU->setEnabled(editable && has_material);
             mShinyScaleU->setEnabled(editable && has_material && specmap_id.notNull());
@@ -1506,13 +1515,16 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
             if (force_set_values)
             {
                 mTexScaleV->forceSetValue(diff_scale_t);
+                mShinyScaleV->forceSetValue(spec_scale_t);
+                mBumpyScaleV->forceSetValue(norm_scale_t);
             }
             else
             {
                 mTexScaleV->setValue(diff_scale_t);
+                mShinyScaleV->setValue(spec_scale_t);
+                mBumpyScaleV->setValue(norm_scale_t);
             }
-            mShinyScaleV->setValue(spec_scale_t);
-            mBumpyScaleV->setValue(norm_scale_t);
+
 
             mTexScaleV->setTentative(LLSD(diff_scale_tentative));
             mShinyScaleV->setTentative(LLSD(spec_scale_tentative));
@@ -4838,8 +4850,9 @@ void LLPanelFace::setMaterialOverridesFromSelection()
         }
     }
 
-    mPBRScaleU->setValue(transform.mScale[VX]);
-    mPBRScaleV->setValue(transform.mScale[VY]);
+    // Force set scales just in case they were set by repeats per meter and their spinner is focused
+    mPBRScaleU->forceSetValue(transform.mScale[VX]);
+    mPBRScaleV->forceSetValue(transform.mScale[VY]);
     mPBRRotate->setValue(transform.mRotation * RAD_TO_DEG);
     mPBROffsetU->setValue(transform.mOffset[VX]);
     mPBROffsetV->setValue(transform.mOffset[VY]);

--- a/indra/newview/llpanelface.h
+++ b/indra/newview/llpanelface.h
@@ -650,6 +650,8 @@ public:
         static void getMaxSpecularRepeats(F32& repeats, bool& identical);
         static void getMaxNormalRepeats(F32& repeats, bool& identical);
         static void getCurrentDiffuseAlphaMode(U8& diffuse_alpha_mode, bool& identical, bool diffuse_texture_has_alpha);
+        static void selectionNormalScaleAutofit(LLPanelFace* panel_face, F32 repeats_per_meter);
+        static void selectionSpecularScaleAutofit(LLPanelFace* panel_face, F32 repeats_per_meter);
 
         DEF_GET_MAT_STATE(LLUUID, const LLUUID&, getNormalID, LLUUID::null, false, LLUUID::null);
         DEF_GET_MAT_STATE(LLUUID, const LLUUID&, getSpecularID, LLUUID::null, false, LLUUID::null);

--- a/indra/newview/llpanelface.h
+++ b/indra/newview/llpanelface.h
@@ -250,6 +250,7 @@ protected:
     void onCommitGLTFRotation();
     void onCommitGLTFTextureOffsetU();
     void onCommitGLTFTextureOffsetV();
+    void onCommitGLTFRepeatsPerMeter();
 
     void onClickAutoFix();
     void onAlignTexture();
@@ -358,6 +359,7 @@ private:
     LLButton* mDelMedia { nullptr };
     LLSpinCtrl* mPBRScaleU { nullptr };
     LLSpinCtrl* mPBRScaleV { nullptr };
+    LLSpinCtrl* mPBRRepeat { nullptr };
     LLSpinCtrl* mPBRRotate { nullptr };
     LLSpinCtrl* mPBROffsetU { nullptr };
     LLSpinCtrl* mPBROffsetV { nullptr };
@@ -551,7 +553,9 @@ private:
     void updateVisibilityGLTF(LLViewerObject* objectp = nullptr);
 
     void updateSelectedGLTFMaterials(std::function<void(LLGLTFMaterial*)> func);
+    void updateSelectedGLTFMaterialsWithScale(std::function<void(LLGLTFMaterial*, const F32, const F32)> func);
     void updateGLTFTextureTransform(std::function<void(LLGLTFMaterial::TextureTransform*)> edit);
+    void updateGLTFTextureTransformWithScale(const LLGLTFMaterial::TextureInfo texture_info, std::function<void(LLGLTFMaterial::TextureTransform*, const F32, const F32)> edit);
 
     void setMaterialOverridesFromSelection();
 

--- a/indra/newview/skins/default/xui/en/panel_tools_texture.xml
+++ b/indra/newview/skins/default/xui/en/panel_tools_texture.xml
@@ -986,6 +986,19 @@
              name="gltfTextureScaleV"
              width="265" />
             <spinner
+             decimal_digits="1"
+             follows="left|top"
+             height="19"
+             initial_value=""
+			 label="Repeats per meter"
+             layout="topleft"
+			 label_width="205"
+             left="10"
+             max_val="100"
+             min_val="-100"
+             name="gltfRptctrl"
+             width="265" />
+            <spinner
              follows="left|top"
              height="19"
              initial_value="0"


### PR DESCRIPTION
https://github.com/secondlife/viewer/issues/3972

Implements the mentioned improvements and feature in the above issue.

1. Implemented repeats per meter for PBR
	- Video showcasing the working feature- [PBR Repeats per meter working](https://drive.usercontent.google.com/download?id=1XCk6wTVGGa1vBbEZGM-F7jnqe08Klnzn&export=download&authuser=0&confirm=t)

2. Improved adjusting normal and specular BP scales while using repeats per meter so they respect the size of the face the texture is on (like it does for diffuse already)
	- Video showcasing the improvement- [Normal and Specular correctly scaling with repeats per meter](https://drive.usercontent.google.com/download?id=1UFV9jqzFyURKtRf_lgYS0HPHoDxICosf&export=download&authuser=0&confirm=t)

3. Improved adjusting repeats per meter while a scale control was focused, so the UI will correctly update the value as you change repeats per meter
	- Video showcasing the improvement- [Scale controls updating while focused](https://drive.usercontent.google.com/download?id=1oNHrTMjot3eqs-hi46z1UGsmLrmMrHJt&export=download&authuser=0&confirm=t)


All videos showing the original behaviour before the improvements can be found in the linked issue above.

