### PR TITLE
#3975 Crash at LLSpatialGroup::dirtyGeom

### DIFF
--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -860,8 +860,11 @@ void LLVOVolume::updateTextureVirtualSize(bool forced)
                 // animated faces get moved to a smaller partition to reduce
                 // side-effects of their updates (see shrinkWrap in
                 // LLVOVolume::animateTextures).
-                mDrawable->getSpatialGroup()->dirtyGeom();
-                gPipeline.markRebuild(mDrawable->getSpatialGroup());
+                if (mDrawable->getSpatialGroup())
+                {
+                    mDrawable->getSpatialGroup()->dirtyGeom();
+                    gPipeline.markRebuild(mDrawable->getSpatialGroup());
+                }
             }
         }
 


### PR DESCRIPTION
According to bugplat, spatial group is null.
I suspect we shouldn't be updating object at all, but can't repro this situation, so just adding a safeguard.