### PR TITLE
Fix: ignore *pass-on* counters when detecting left-button grabs from `llTakeControl`

### DIFF
--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -3469,11 +3469,14 @@ void LLAgent::initOriginGlobal(const LLVector3d &origin_global)
 
 bool LLAgent::leftButtonGrabbed() const
 {
-    const bool camera_mouse_look = gAgentCamera.cameraMouselook();
-    return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-        || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0)
-        || (!camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
-        || (camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
+    if (gAgentCamera.cameraMouselook())
+    {
+        return mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0;
+    }
+    else
+    {
+        return mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0;
+    }
 }
 
 bool LLAgent::rotateGrabbed() const


### PR DESCRIPTION
A script that takes CONTROL_ML_LBUTTON with pass_on = TRUE should not prevent the viewer from normal clicking in mouse look, yet in practice it does:
```lsl
llTakeControls(CONTROL_ML_LBUTTON, TRUE, TRUE);
```
This happens because `LLAgent::leftButtonGrabbed()` treats “pass-on” requests as a full grab, unlike the other `…Grabbed()` helpers.

ref: [Wiki: llTakeControls](https://wiki.secondlife.com/wiki/LlTakeControls)

### Solution

Remove the two `mControlsTakenPassedOnCount` checks; the function now tests only the real grab counters, exactly like `rotateGrabbed()`, `upGrabbed()`, etc.

### Testing

1. Drop the script below into any prim, accept the permission request
```lsl
default {
    state_entry() {
        llRequestPermissions(llGetOwner(), PERMISSION_TAKE_CONTROLS);
    }
    run_time_permissions(integer perm) {
        if(PERMISSION_TAKE_CONTROLS & perm) {
            llTakeControls(CONTROL_ML_LBUTTON, TRUE, TRUE);              
        }
    }
    control(key id, integer level, integer edge)
    {}
}
```
2. Enter mouse look (first person mode)
_Before_ this patch you cannot click doors, HUDs, etc.
_After_ this patch clicks work normally.

#### Note
I only tested this change on Firestorm as building LL viewer on Linux is not straight forward, but this issue is also present in LL viewer and the code is exactly the same, here is the corresponding PR on FS side: [FS PR #113](https://github.com/FirestormViewer/phoenix-firestorm/pull/113)