### PR TITLE
#4015 Restore formatting for strings.xml and teleport_strings.xml

### DIFF
--- a/indra/newview/skins/default/xui/da/strings.xml
+++ b/indra/newview/skins/default/xui/da/strings.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<!-- This file contains strings that used to be hardcoded in the source.
-     It is only for those strings which do not belong in a floater.
-     For example, the strings used in avatar chat bubbles, and strings
-     that are returned from one component and may appear in many places-->
 <strings>
 	<string name="CAPITALIZED_APP_NAME">
 		SECOND LIFE
@@ -554,9 +550,9 @@ Prøv venligst om lidt igen.
 	<string name="mesh">
 		mesh
 	</string>
-    <string name="settings">
-        indstillinger
-    </string>
+	<string name="settings">
+		indstillinger
+	</string>
 	<string name="AvatarEditingAppearance">
 		(Redigering Udseende)
 	</string>
@@ -819,10 +815,10 @@ Prøv venligst om lidt igen.
 		Du vil nu blive dirigeret til lokal stemme chat
 	</string>
 	<string name="ScriptQuestionCautionChatGranted">
-		&apos;[OBJECTNAME]&apos;, en genstand, ejet af &apos;[OWNERNAME]&apos;, lokaliseret i [REGIONNAME] på [REGIONPOS], har fået tilladelse til: [PERMISSIONS].
+		'[OBJECTNAME]', en genstand, ejet af '[OWNERNAME]', lokaliseret i [REGIONNAME] på [REGIONPOS], har fået tilladelse til: [PERMISSIONS].
 	</string>
 	<string name="ScriptQuestionCautionChatDenied">
-		&apos;[OBJECTNAME]&apos;, en genstand, ejet af &apos;[OWNERNAME]&apos;, lokaliseret i [REGIONNAME] på [REGIONPOS], er afvist tilladelse til: [PERMISSIONS].
+		'[OBJECTNAME]', en genstand, ejet af '[OWNERNAME]', lokaliseret i [REGIONNAME] på [REGIONPOS], er afvist tilladelse til: [PERMISSIONS].
 	</string>
 	<string name="ScriptTakeMoney">
 		Tag Linden dollars (L$) fra dig
@@ -933,16 +929,16 @@ Prøv venligst om lidt igen.
 		Vælg bibliotek
 	</string>
 	<string name="AvatarSetNotAway">
-		Sæt &quot;til stede&quot;
+		Sæt "til stede"
 	</string>
 	<string name="AvatarSetAway">
-		Sæt &quot;væk&quot;
+		Sæt "væk"
 	</string>
 	<string name="AvatarSetNotBusy">
-		Sæt &quot;ledig&quot;
+		Sæt "ledig"
 	</string>
 	<string name="AvatarSetBusy">
-		Sæt &quot;optaget&quot;
+		Sæt "optaget"
 	</string>
 	<string name="shape">
 		Form
@@ -1169,8 +1165,10 @@ Prøv venligst om lidt igen.
 	<string name="InventoryNoTexture">
 		Du har ikke en kopi af denne tekstur i din beholdning
 	</string>
-  <string name="Unconstrained">Ikke låst</string>
-  <string name="no_transfer" value=" (ikke overdragbar)"/>
+	<string name="Unconstrained">
+		Ikke låst
+	</string>
+	<string name="no_transfer" value=" (ikke overdragbar)"/>
 	<string name="no_modify" value=" (ikke redigere)"/>
 	<string name="no_copy" value=" (ikke kopiere)"/>
 	<string name="worn" value=" (båret)"/>
@@ -1568,16 +1566,16 @@ Prøv venligst om lidt igen.
 		nulstil
 	</string>
 	<string name="RunQueueTitle">
-		Sæt &quot;running&quot; fremskridt
+		Sæt "running" fremskridt
 	</string>
 	<string name="RunQueueStart">
-		sæt til &quot;running&quot;
+		sæt til "running"
 	</string>
 	<string name="NotRunQueueTitle">
-		Sæt &quot;Not Running&quot; fremskridt
+		Sæt "Not Running" fremskridt
 	</string>
 	<string name="NotRunQueueStart">
-		sæt til &quot;not running&quot;
+		sæt til "not running"
 	</string>
 	<string name="CompileSuccessful">
 		Kompleret uden fejl!
@@ -1589,7 +1587,7 @@ Prøv venligst om lidt igen.
 		Gemt.
 	</string>
 	<string name="ObjectOutOfRange">
-		Script (&quot;object out of range&quot;)
+		Script ("object out of range")
 	</string>
 	<string name="GodToolsObjectOwnedBy">
 		Objekt [OBJECT] ejet af [OWNER]
@@ -1660,13 +1658,13 @@ Prøv venligst om lidt igen.
 		Memory brugt: [COUNT] kb
 	</string>
 	<string name="ScriptLimitsParcelScriptURLs">
-		Parcel Script URL&apos;er
+		Parcel Script URL'er
 	</string>
 	<string name="ScriptLimitsURLsUsed">
-		URL&apos;er brugt: [COUNT] ud af [MAX]; [AVAILABLE] tilgængelige
+		URL'er brugt: [COUNT] ud af [MAX]; [AVAILABLE] tilgængelige
 	</string>
 	<string name="ScriptLimitsURLsUsedSimple">
-		URL&apos;er brugt: [COUNT]
+		URL'er brugt: [COUNT]
 	</string>
 	<string name="ScriptLimitsRequestError">
 		Fejl ved anmodning om information
@@ -1813,7 +1811,7 @@ Prøv venligst om lidt igen.
 		Nyt script
 	</string>
 	<string name="BusyModeResponseDefault">
-		Beboeren du sendte en besked er &apos;optaget&apos;, hvilket betyder at han/hun ikke vil forstyrres. Din besked vil blive vis i hans/hendes IM panel til senere visning.
+		Beboeren du sendte en besked er 'optaget', hvilket betyder at han/hun ikke vil forstyrres. Din besked vil blive vis i hans/hendes IM panel til senere visning.
 	</string>
 	<string name="MuteByName">
 		(Efter navn)
@@ -2121,11 +2119,11 @@ Hvis fejlen stadig bliver ved, kan det være nødvendigt at afinstallere [APP_NA
 	</string>
 	<string name="MBAlreadyRunning">
 		[APP_NAME] kører allerede.
-Undersøg din &quot;task bar&quot; for at se efter minimeret version af programmet.
+Undersøg din "task bar" for at se efter minimeret version af programmet.
 Hvis fejlen fortsætter, prøv at genstarte din computer.
 	</string>
 	<string name="MBFrozenCrashed">
-		[APP_NAME] ser ud til at være &quot;frosset&quot; eller gået ned tidligere.
+		[APP_NAME] ser ud til at være "frosset" eller gået ned tidligere.
 Ønsker du at sende en fejlrapport?
 	</string>
 	<string name="MBAlert">
@@ -2161,39 +2159,39 @@ Afvikler i vindue.
 		Fejl ved nedlukning
 	</string>
 	<string name="MBDevContextErr">
-		Kan ikke oprette &quot;GL device context&quot;
+		Kan ikke oprette "GL device context"
 	</string>
 	<string name="MBPixelFmtErr">
-		Kan ikke finde passende &quot;pixel format&quot;
+		Kan ikke finde passende "pixel format"
 	</string>
 	<string name="MBPixelFmtDescErr">
-		Kan ikke finde &quot;pixel format&quot; beskrivelse
+		Kan ikke finde "pixel format" beskrivelse
 	</string>
 	<string name="MBTrueColorWindow">
-		[APP_NAME] kræver &quot;True Color (32-bit)&quot; for at kunne køre.
-Gå venligst til din computers skærmopsætning og sæt &quot;color mode&quot; til 32-bit.
+		[APP_NAME] kræver "True Color (32-bit)" for at kunne køre.
+Gå venligst til din computers skærmopsætning og sæt "color mode" til 32-bit.
 	</string>
 	<string name="MBAlpha">
-		[APP_NAME] kan ikke køre, da den ikke kan finde en &quot;8 bit alpha channel&quot;.  Normalt skyldes dette et problem med en video driver.
+		[APP_NAME] kan ikke køre, da den ikke kan finde en "8 bit alpha channel".  Normalt skyldes dette et problem med en video driver.
 Venligst undersøg om du har de nyeste drivere til dit videokort installeret.
-Din skærm skal også være sat op til at køre &quot;True Color (32-bit)&quot;  i din displayopsætning.
+Din skærm skal også være sat op til at køre "True Color (32-bit)"  i din displayopsætning.
 Hvis du bliver ved med at modtage denne besked, kontakt [SUPPORT_SITE].
 	</string>
 	<string name="MBPixelFmtSetErr">
-		Kan ikke sætte &quot;pixel format&quot;
+		Kan ikke sætte "pixel format"
 	</string>
 	<string name="MBGLContextErr">
-		Kan ikke oprette &quot;GL rendering context&quot;
+		Kan ikke oprette "GL rendering context"
 	</string>
 	<string name="MBGLContextActErr">
-		Kan ikke aktivere &quot;GL rendering context&quot;
+		Kan ikke aktivere "GL rendering context"
 	</string>
 	<string name="MBVideoDrvErr">
 		[APP_NAME] kan ikke afvikles da driverne til dit videokort ikke blev installeret korrekt, er forældede, eller du benytter hardware der ikke er supporteret. Undersøg venligst om du har installeret de nyeste drivere til dit grafikkort, og selv om du har de nyeste, prøv at geninstallere dem.
 
 Hvis du bliver ved med at modtage denne besked, kontakt venligst [SUPPORT_SITE].
 	</string>
-	<string name="5 O&apos;Clock Shadow">
+	<string name="5 O'Clock Shadow">
 		Skægstubbe
 	</string>
 	<string name="All White">
@@ -3328,7 +3326,7 @@ Hvis du bliver ved med at modtage denne besked, kontakt venligst [SUPPORT_SITE].
 		Skævt ansigt
 	</string>
 	<string name="Shear Front">
-		&quot;Måne&quot;
+		"Måne"
 	</string>
 	<string name="Shear Left Up">
 		Venstre op
@@ -3463,7 +3461,7 @@ Hvis du bliver ved med at modtage denne besked, kontakt venligst [SUPPORT_SITE].
 		Sparsomt
 	</string>
 	<string name="Spiked Hair">
-		Hår med &quot;spikes&quot;
+		Hår med "spikes"
 	</string>
 	<string name="Square">
 		Firkantet
@@ -3724,7 +3722,7 @@ Hvis du bliver ved med at modtage denne besked, kontakt venligst [SUPPORT_SITE].
 		Konference med [AGENT_NAME]
 	</string>
 	<string name="bot_warning">
-Du chatter med en bot, [NAME]. Del ikke personlige oplysninger.
+		Du chatter med en bot, [NAME]. Del ikke personlige oplysninger.
 Læs mere på https://second.life/scripted-agents.
 	</string>
 	<string name="no_session_message">
@@ -3767,7 +3765,7 @@ Læs mere på https://second.life/scripted-agents.
 		En gruppe moderator har deaktiveret din tekst chat.
 	</string>
 	<string name="muted_error">
-		Du er blevet &quot;blokeret&quot;.
+		Du er blevet "blokeret".
 	</string>
 	<string name="add_session_event">
 		Ikke muligt at tilføge brugere til samtale med [RECIPIENT].
@@ -3797,7 +3795,7 @@ Læs mere på https://second.life/scripted-agents.
 		[SOURCES] har sagt noget nyt
 	</string>
 	<string name="session_initialization_timed_out_error">
-		Initialisering af session er &quot;timed out&quot;
+		Initialisering af session er "timed out"
 	</string>
 	<string name="Home position set.">
 		Hjemmeposition sat.
@@ -4030,7 +4028,7 @@ Krænkelsesanmeldelse
 		Kvinde - Latter
 	</string>
 	<string name="Female - Looking good">
-		Kvinde - &quot;Ser godt ud&quot;
+		Kvinde - "Ser godt ud"
 	</string>
 	<string name="Female - Over here">
 		Kvinde - Herovre
@@ -4144,7 +4142,7 @@ Krænkelsesanmeldelse
 	<string name="ExternalEditorNotFound">
 		Kan ikke benytte deb eksterne editor der er angivet.
 Prøv at omkrandse stien til editor med anførselstegn.				
-(f.eks. &quot;/stil til min editor&quot; &quot;%s&quot;)
+(f.eks. "/stil til min editor" "%s")
 	</string>
 	<string name="ExternalEditorCommandParseError">
 		Fejl ved håndtering af kommando til ekstern editor.
@@ -4468,10 +4466,10 @@ Prøv at omkrandse stien til editor med anførselstegn.
 		Viser pejlelys for fysiske objekter (grøn)
 	</string>
 	<string name="BeaconScripted">
-		Viser pejlelys for &quot;scriptede&quot; objekter (rød)
+		Viser pejlelys for "scriptede" objekter (rød)
 	</string>
 	<string name="BeaconScriptedTouch">
-		Viser pejlelys for &quot;scriptede&quot; objekter med berøringsfunktion (rød)
+		Viser pejlelys for "scriptede" objekter med berøringsfunktion (rød)
 	</string>
 	<string name="BeaconSound">
 		Viser pejlelys for lyd  (gul)

--- a/indra/newview/skins/default/xui/da/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/da/teleport_strings.xml
@@ -21,8 +21,8 @@ Hvis du stadig ikke kan teleporte, prøv venligst at logge ud og ligge ind for a
 Prøv igen om lidt.
 		</message>
 		<message name="NoHelpIslandTP">
-		Du kan ikke teleportere tilbage til Welcome Island.
-Gå til &apos;Welcome Island Puclic&apos; for at prøve tutorial igen.
+			Du kan ikke teleportere tilbage til Welcome Island.
+Gå til 'Welcome Island Puclic' for at prøve tutorial igen.
 		</message>
 		<message name="noaccess_tport">
 			Beklager, du har ikke adgang til denne teleport destination.

--- a/indra/newview/skins/default/xui/de/strings.xml
+++ b/indra/newview/skins/default/xui/de/strings.xml
@@ -1,618 +1,1686 @@
 <?xml version="1.0" ?>
 <strings>
-	<string name="SECOND_LIFE">Second Life</string>
-	<string name="APP_NAME">Second Life</string>
-	<string name="CAPITALIZED_APP_NAME">SECOND LIFE</string>
-	<string name="SECOND_LIFE_GRID">Second Life-Grid:</string>
-	<string name="SUPPORT_SITE">Second Life Support-Portal</string>
-	<string name="StartupDetectingHardware">Hardware wird erfasst...</string>
-	<string name="StartupLoading">[APP_NAME] wird geladen...</string>
-	<string name="StartupClearingCache">Cache wird gelöscht...</string>
-	<string name="StartupInitializingTextureCache">Textur-Cache wird initialisiert...</string>
-	<string name="StartupRequireDriverUpdate">Grafikinitialisierung fehlgeschlagen. Bitte aktualisieren Sie Ihren Grafiktreiber.</string>
-	<string name="AboutHeader">[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]Bit) [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]</string>
-	<string name="BuildConfig">Build-Konfiguration [BUILD_CONFIG]</string>
-	<string name="AboutPosition">Sie befinden sich an [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] in [REGION] auf &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+	<string name="SECOND_LIFE">
+		Second Life
+	</string>
+	<string name="APP_NAME">
+		Second Life
+	</string>
+	<string name="CAPITALIZED_APP_NAME">
+		SECOND LIFE
+	</string>
+	<string name="SECOND_LIFE_GRID">
+		Second Life-Grid:
+	</string>
+	<string name="SUPPORT_SITE">
+		Second Life Support-Portal
+	</string>
+	<string name="StartupDetectingHardware">
+		Hardware wird erfasst...
+	</string>
+	<string name="StartupLoading">
+		[APP_NAME] wird geladen...
+	</string>
+	<string name="StartupClearingCache">
+		Cache wird gelöscht...
+	</string>
+	<string name="StartupInitializingTextureCache">
+		Textur-Cache wird initialisiert...
+	</string>
+	<string name="StartupRequireDriverUpdate">
+		Grafikinitialisierung fehlgeschlagen. Bitte aktualisieren Sie Ihren Grafiktreiber.
+	</string>
+	<string name="AboutHeader">
+		[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]Bit) [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
+	</string>
+	<string name="BuildConfig">
+		Build-Konfiguration [BUILD_CONFIG]
+	</string>
+	<string name="AboutPosition">
+		Sie befinden sich an [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] in [REGION] auf &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (globale Koordinaten [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
-[SERVER_RELEASE_NOTES_URL]</string>
-	<string name="AboutSystem">CPU: [CPU]
+[SERVER_RELEASE_NOTES_URL]
+	</string>
+	<string name="AboutSystem">
+		CPU: [CPU]
 Speicher: [MEMORY_MB] MB
 Betriebssystemversion: [OS_VERSION]
 Grafikkartenhersteller: [GRAPHICS_CARD_VENDOR]
-Grafikkarte: [GRAPHICS_CARD]</string>
-	<string name="AboutDriver">Windows-Grafiktreiberversion: [GRAPHICS_DRIVER_VERSION]</string>
-	<string name="AboutOGL">OpenGL-Version: [OPENGL_VERSION]</string>
-	<string name="AboutSettings">Fenstergröße: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+Grafikkarte: [GRAPHICS_CARD]
+	</string>
+	<string name="AboutDriver">
+		Windows-Grafiktreiberversion: [GRAPHICS_DRIVER_VERSION]
+	</string>
+	<string name="AboutOGL">
+		OpenGL-Version: [OPENGL_VERSION]
+	</string>
+	<string name="AboutSettings">
+		Fenstergröße: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Schriftgrößenanpassung: [FONT_SIZE_ADJUSTMENT] pt
 UI-Skalierung: [UI_SCALE]
 Sichtweite: [DRAW_DISTANCE] m
 Bandbreite: [NET_BANDWITH] kbit/s
 LOD-Faktor: [LOD_FACTOR]
 Darstellungsqualität: [RENDER_QUALITY]
-Texturspeicher: [TEXTURE_MEMORY] MB</string>
-	<string name="AboutOSXHiDPI">HiDPI-Anzeigemodus: [HIDPI]</string>
-	<string name="AboutLibs">J2C-Decoderversion: [J2C_VERSION]
+Texturspeicher: [TEXTURE_MEMORY] MB
+	</string>
+	<string name="AboutOSXHiDPI">
+		HiDPI-Anzeigemodus: [HIDPI]
+	</string>
+	<string name="AboutLibs">
+		J2C-Decoderversion: [J2C_VERSION]
 Audiotreiberversion: [AUDIO_DRIVER_VERSION]
 [LIBCEF_VERSION]
 LibVLC-Version: [LIBVLC_VERSION]
-Voice-Server-Version: [VOICE_VERSION]</string>
-	<string name="AboutTraffic">Paketverlust: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1] %)</string>
-	<string name="AboutTime">[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]</string>
-	<string name="ErrorFetchingServerReleaseNotesURL">Fehler beim Abrufen der URL für die Server-Versionshinweise.</string>
-	<string name="BuildConfiguration">Build-Konfiguration</string>
-	<string name="ProgressRestoring">Wird wiederhergestellt...</string>
-	<string name="ProgressChangingResolution">Auflösung wird geändert...</string>
-	<string name="Fullbright">Fullbright (Legacy)</string>
-	<string name="LoginInProgress">Anmeldevorgang gestartet. [APP_NAME] reagiert möglicherweise nicht.  Bitte warten.</string>
-	<string name="LoginInProgressNoFrozen">Anmeldung erfolgt...</string>
-	<string name="LoginAuthenticating">Authentifizierung</string>
-	<string name="LoginMaintenance">Account wird aktualisiert...</string>
-	<string name="LoginAttempt">Ein früherer Anmeldeversuch ist fehlgeschlagen. Anmeldung, Versuch [NUMBER]</string>
-	<string name="LoginPrecaching">Welt wird geladen...</string>
-	<string name="LoginInitializingBrowser">Integrierter Webbrowser wird initialisiert...</string>
-	<string name="LoginInitializingMultimedia">Multimedia wird initialisiert...</string>
-	<string name="LoginInitializingFonts">Schriftarten werden geladen...</string>
-	<string name="LoginVerifyingCache">Cache-Dateien werden überprüft (dauert 60-90 Sekunden)...</string>
-	<string name="LoginProcessingResponse">Antwort wird verarbeitet...</string>
-	<string name="LoginInitializingWorld">Welt wird initialisiert...</string>
-	<string name="LoginDecodingImages">Bilder werden entpackt...</string>
-	<string name="LoginInitializingQuicktime">QuickTime wird initialisiert...</string>
-	<string name="LoginQuicktimeNotFound">QuickTime nicht gefunden - Initialisierung nicht möglich.</string>
-	<string name="LoginQuicktimeOK">QuickTime wurde initialisiert.</string>
-	<string name="LoginRequestSeedCapGrant">Regionsfähigkeiten anfordern...</string>
-	<string name="LoginRetrySeedCapGrant">Regionsfähigkeiten anfordern. Versuch [NUMBER]...</string>
-	<string name="LoginWaitingForRegionHandshake">Region-Handshake...</string>
-	<string name="LoginConnectingToRegion">Region-Verbindung...</string>
-	<string name="LoginDownloadingClothing">Kleidung wird geladen...</string>
-	<string name="InvalidCertificate">Der Server hat ein ungültiges oder korruptes Zertifikate zurückgegeben. Bitte kontaktieren Sie den Grid-Administrator.</string>
-	<string name="CertInvalidHostname">Ein ungültiger Hostname wurde verwendet, um auf den Server zuzugreifen. Bitte überprüfen Sie Ihre SLURL oder den Grid-Hostnamen.</string>
-	<string name="CertExpired">Das vom Grid ausgegebene Zertifikate ist abgelaufen.  Bitte überprüfen Sie Ihre Systemuhr oder kontaktieren Sie Ihren Grid-Administrator.</string>
-	<string name="CertKeyUsage">Das vom Server ausgegebene Zertifikat konnte nicht für SSL verwendet werden.  Bitte kontaktieren Sie Ihren Grid-Administrator.</string>
-	<string name="CertBasicConstraints">In der Zertifikatskette des Servers befanden sich zu viele Zertifikate.  Bitte kontaktieren Sie Ihren Grid-Administrator.</string>
-	<string name="CertInvalidSignature">Die Zertifikatsunterschrift des Gridservers konnte nicht bestätigt werden.  Bitte kontaktieren Sie Ihren Grid-Administrator.</string>
-	<string name="LoginFailedNoNetwork">Netzwerkfehler: Verbindung konnte nicht hergestellt werden. Bitte überprüfen Sie Ihre Netzwerkverbindung.</string>
-	<string name="LoginFailedHeader">Anmeldung fehlgeschlagen</string>
-	<string name="Quit">Beenden</string>
-	<string name="create_account_url">http://join.secondlife.com/?sourceid=[sourceid]</string>
-	<string name="AgniGridLabel">Second Life Main Grid (Agni)</string>
-	<string name="AditiGridLabel">Second Life Beta Test Grid (Aditi)</string>
-	<string name="ViewerDownloadURL">http://secondlife.com/download</string>
-	<string name="LoginFailedViewerNotPermitted">Mit dem von Ihnen verwendeten Viewer ist der Zugriff auf Second Life nicht mehr möglich. Laden Sie von den folgenden Seite einen neuen Viewer herunter:
+Voice-Server-Version: [VOICE_VERSION]
+	</string>
+	<string name="AboutTraffic">
+		Paketverlust: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1] %)
+	</string>
+	<string name="AboutTime">
+		[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
+	</string>
+	<string name="ErrorFetchingServerReleaseNotesURL">
+		Fehler beim Abrufen der URL für die Server-Versionshinweise.
+	</string>
+	<string name="BuildConfiguration">
+		Build-Konfiguration
+	</string>
+	<string name="ProgressRestoring">
+		Wird wiederhergestellt...
+	</string>
+	<string name="ProgressChangingResolution">
+		Auflösung wird geändert...
+	</string>
+	<string name="Fullbright">
+		Fullbright (Legacy)
+	</string>
+	<string name="LoginInProgress">
+		Anmeldevorgang gestartet. [APP_NAME] reagiert möglicherweise nicht.  Bitte warten.
+	</string>
+	<string name="LoginInProgressNoFrozen">
+		Anmeldung erfolgt...
+	</string>
+	<string name="LoginAuthenticating">
+		Authentifizierung
+	</string>
+	<string name="LoginMaintenance">
+		Account wird aktualisiert...
+	</string>
+	<string name="LoginAttempt">
+		Ein früherer Anmeldeversuch ist fehlgeschlagen. Anmeldung, Versuch [NUMBER]
+	</string>
+	<string name="LoginPrecaching">
+		Welt wird geladen...
+	</string>
+	<string name="LoginInitializingBrowser">
+		Integrierter Webbrowser wird initialisiert...
+	</string>
+	<string name="LoginInitializingMultimedia">
+		Multimedia wird initialisiert...
+	</string>
+	<string name="LoginInitializingFonts">
+		Schriftarten werden geladen...
+	</string>
+	<string name="LoginVerifyingCache">
+		Cache-Dateien werden überprüft (dauert 60-90 Sekunden)...
+	</string>
+	<string name="LoginProcessingResponse">
+		Antwort wird verarbeitet...
+	</string>
+	<string name="LoginInitializingWorld">
+		Welt wird initialisiert...
+	</string>
+	<string name="LoginDecodingImages">
+		Bilder werden entpackt...
+	</string>
+	<string name="LoginInitializingQuicktime">
+		QuickTime wird initialisiert...
+	</string>
+	<string name="LoginQuicktimeNotFound">
+		QuickTime nicht gefunden - Initialisierung nicht möglich.
+	</string>
+	<string name="LoginQuicktimeOK">
+		QuickTime wurde initialisiert.
+	</string>
+	<string name="LoginRequestSeedCapGrant">
+		Regionsfähigkeiten anfordern...
+	</string>
+	<string name="LoginRetrySeedCapGrant">
+		Regionsfähigkeiten anfordern. Versuch [NUMBER]...
+	</string>
+	<string name="LoginWaitingForRegionHandshake">
+		Region-Handshake...
+	</string>
+	<string name="LoginConnectingToRegion">
+		Region-Verbindung...
+	</string>
+	<string name="LoginDownloadingClothing">
+		Kleidung wird geladen...
+	</string>
+	<string name="InvalidCertificate">
+		Der Server hat ein ungültiges oder korruptes Zertifikate zurückgegeben. Bitte kontaktieren Sie den Grid-Administrator.
+	</string>
+	<string name="CertInvalidHostname">
+		Ein ungültiger Hostname wurde verwendet, um auf den Server zuzugreifen. Bitte überprüfen Sie Ihre SLURL oder den Grid-Hostnamen.
+	</string>
+	<string name="CertExpired">
+		Das vom Grid ausgegebene Zertifikate ist abgelaufen.  Bitte überprüfen Sie Ihre Systemuhr oder kontaktieren Sie Ihren Grid-Administrator.
+	</string>
+	<string name="CertKeyUsage">
+		Das vom Server ausgegebene Zertifikat konnte nicht für SSL verwendet werden.  Bitte kontaktieren Sie Ihren Grid-Administrator.
+	</string>
+	<string name="CertBasicConstraints">
+		In der Zertifikatskette des Servers befanden sich zu viele Zertifikate.  Bitte kontaktieren Sie Ihren Grid-Administrator.
+	</string>
+	<string name="CertInvalidSignature">
+		Die Zertifikatsunterschrift des Gridservers konnte nicht bestätigt werden.  Bitte kontaktieren Sie Ihren Grid-Administrator.
+	</string>
+	<string name="LoginFailedNoNetwork">
+		Netzwerkfehler: Verbindung konnte nicht hergestellt werden. Bitte überprüfen Sie Ihre Netzwerkverbindung.
+	</string>
+	<string name="LoginFailedHeader">
+		Anmeldung fehlgeschlagen
+	</string>
+	<string name="Quit">
+		Beenden
+	</string>
+	<string name="create_account_url">
+		http://join.secondlife.com/?sourceid=[sourceid]
+	</string>
+	<string name="AgniGridLabel">
+		Second Life Main Grid (Agni)
+	</string>
+	<string name="AditiGridLabel">
+		Second Life Beta Test Grid (Aditi)
+	</string>
+	<string name="ViewerDownloadURL">
+		http://secondlife.com/download
+	</string>
+	<string name="LoginFailedViewerNotPermitted">
+		Mit dem von Ihnen verwendeten Viewer ist der Zugriff auf Second Life nicht mehr möglich. Laden Sie von den folgenden Seite einen neuen Viewer herunter:
 http://secondlife.com/download
 
 Weitere Informationen finden Sie auf der folgenden FAQ-Seite: 
-http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginIntermediateOptionalUpdateAvailable">Optionales Viewer-Update verfügbar: [VERSION]</string>
-	<string name="LoginFailedRequiredUpdate">Erforderliches Viewer-Update: [VERSION]</string>
-	<string name="LoginFailedAlreadyLoggedIn">Dieser Agent ist bereits angemeldet.</string>
-	<string name="LoginFailedAuthenticationFailed">Wir bitten um Entschuldigung! Wir konnten Sie nicht anmelden.
+http://secondlife.com/viewer-access-faq
+	</string>
+	<string name="LoginIntermediateOptionalUpdateAvailable">
+		Optionales Viewer-Update verfügbar: [VERSION]
+	</string>
+	<string name="LoginFailedRequiredUpdate">
+		Erforderliches Viewer-Update: [VERSION]
+	</string>
+	<string name="LoginFailedAlreadyLoggedIn">
+		Dieser Agent ist bereits angemeldet.
+	</string>
+	<string name="LoginFailedAuthenticationFailed">
+		Wir bitten um Entschuldigung! Wir konnten Sie nicht anmelden.
 Stellen Sie sicher, dass Sie die richtigen Informationen eingegeben haben:
     * Benutzername (wie robertschmidt12 oder warme.sonne)
     * Kennwort
-Stellen Sie außerdem sicher, dass die Umschaltsperre deaktiviert ist.</string>
-	<string name="LoginFailedPasswordChanged">Ihr Kennwort wurde aus Sicherheitsgründen geändert.
+Stellen Sie außerdem sicher, dass die Umschaltsperre deaktiviert ist.
+	</string>
+	<string name="LoginFailedPasswordChanged">
+		Ihr Kennwort wurde aus Sicherheitsgründen geändert.
 Gehen Sie zur Seite „Mein Account“ unter http://secondlife.com/password
 und beantworten Sie die Sicherheitsfrage, um Ihr Kennwort zurückzusetzen.
-Wir entschuldigen uns für eventuell enstandene Unannehmlichkeiten.</string>
-	<string name="LoginFailedPasswordReset">Aufgrund von Systemänderungen müssen Sie Ihr Kennwort zurücksetzen.
+Wir entschuldigen uns für eventuell enstandene Unannehmlichkeiten.
+	</string>
+	<string name="LoginFailedPasswordReset">
+		Aufgrund von Systemänderungen müssen Sie Ihr Kennwort zurücksetzen.
 Gehen Sie zur Seite „Mein Account“ unter http://secondlife.com/password
 und beantworten Sie die Sicherheitsfrage, um Ihr Kennwort zurückzusetzen.
-Wir entschuldigen uns für eventuell enstandene Unannehmlichkeiten.</string>
-	<string name="LoginFailedEmployeesOnly">Second Life ist vorübergehend wegen Wartung geschlossen.
+Wir entschuldigen uns für eventuell enstandene Unannehmlichkeiten.
+	</string>
+	<string name="LoginFailedEmployeesOnly">
+		Second Life ist vorübergehend wegen Wartung geschlossen.
 Nur Mitarbeiter können sich anmelden.
-Aktuelle Informationen finden Sie unter www.secondlife.com/status.</string>
-	<string name="LoginFailedPremiumOnly">Die Anmeldung bei Second Life ist vorübergehend eingeschränkt, um sicherzustellen, dass Einwohner, die sich bereits inworld aufhalten, das bestmögliche Erlebnis haben.
+Aktuelle Informationen finden Sie unter www.secondlife.com/status.
+	</string>
+	<string name="LoginFailedPremiumOnly">
+		Die Anmeldung bei Second Life ist vorübergehend eingeschränkt, um sicherzustellen, dass Einwohner, die sich bereits inworld aufhalten, das bestmögliche Erlebnis haben.
 
-Benutzer mit kostenlosen Konten können sich während dieses Zeitraums nicht bei Second Life anmelden, damit die Kapazität Benutzern zur Verfügung steht, die ein gebührenpflichtiges Premium-Konto besitzen.</string>
-	<string name="LoginFailedComputerProhibited">Der Zugriff auf Second Life ist von diesem Computer aus nicht möglich.
+Benutzer mit kostenlosen Konten können sich während dieses Zeitraums nicht bei Second Life anmelden, damit die Kapazität Benutzern zur Verfügung steht, die ein gebührenpflichtiges Premium-Konto besitzen.
+	</string>
+	<string name="LoginFailedComputerProhibited">
+		Der Zugriff auf Second Life ist von diesem Computer aus nicht möglich.
 Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an
-support@secondlife.com.</string>
-	<string name="LoginFailedAcountSuspended">Ihr Konto ist erst ab
-[TIME] Pacific Time wieder verfügbar.</string>
-	<string name="LoginFailedAccountDisabled">Ihre Anfrage kann derzeit nicht bearbeitet werden. 
-Bitte wenden Sie sich unter http://secondlife.com/support an den Second Life-Support.</string>
-	<string name="LoginFailedTransformError">Nicht übereinstimmende Daten bei der Anmeldung festgestellt.
-Wenden Sie sich an support@secondlife.com.</string>
-	<string name="LoginFailedAccountMaintenance">An Ihrem Konto werden gerade kleinere Wartungsarbeiten durchgeführt.
+support@secondlife.com.
+	</string>
+	<string name="LoginFailedAcountSuspended">
+		Ihr Konto ist erst ab
+[TIME] Pacific Time wieder verfügbar.
+	</string>
+	<string name="LoginFailedAccountDisabled">
+		Ihre Anfrage kann derzeit nicht bearbeitet werden. 
+Bitte wenden Sie sich unter http://secondlife.com/support an den Second Life-Support.
+	</string>
+	<string name="LoginFailedTransformError">
+		Nicht übereinstimmende Daten bei der Anmeldung festgestellt.
+Wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LoginFailedAccountMaintenance">
+		An Ihrem Konto werden gerade kleinere Wartungsarbeiten durchgeführt.
 Ihr Konto ist erst ab
 [TIME] Pacific Time wieder verfügbar.
-Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.</string>
-	<string name="LoginFailedPendingLogoutFault">Abmeldeanforderung führte zu einem Simulatorfehler.</string>
-	<string name="LoginFailedPendingLogout">Das System meldet Sie gerade ab. 
-Bitte warten Sie eine Minute, bevor Sie sich erneut einloggen.</string>
-	<string name="LoginFailedUnableToCreateSession">Es kann keine gültige Sitzung erstellt werden.</string>
-	<string name="LoginFailedUnableToConnectToSimulator">Es kann keine Simulatorverbindung hergestellt werden.</string>
-	<string name="LoginFailedRestrictedHours">Mit Ihrem Konto ist der Zugriff auf Second Life
+Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LoginFailedPendingLogoutFault">
+		Abmeldeanforderung führte zu einem Simulatorfehler.
+	</string>
+	<string name="LoginFailedPendingLogout">
+		Das System meldet Sie gerade ab. 
+Bitte warten Sie eine Minute, bevor Sie sich erneut einloggen.
+	</string>
+	<string name="LoginFailedUnableToCreateSession">
+		Es kann keine gültige Sitzung erstellt werden.
+	</string>
+	<string name="LoginFailedUnableToConnectToSimulator">
+		Es kann keine Simulatorverbindung hergestellt werden.
+	</string>
+	<string name="LoginFailedRestrictedHours">
+		Mit Ihrem Konto ist der Zugriff auf Second Life
 nur zwischen [START] und [END] Pacific Time möglich.
 Schauen Sie während dieses Zeitraums vorbei.
-Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.</string>
-	<string name="LoginFailedIncorrectParameters">Falsche Parameter.
-Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.</string>
-	<string name="LoginFailedFirstNameNotAlphanumeric">Vorname muss alphanumerisch sein.
-Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.</string>
-	<string name="LoginFailedLastNameNotAlphanumeric">Nachname muss alphanumerisch sein.
-Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.</string>
-	<string name="LogoutFailedRegionGoingOffline">Die Region wird gerade offline geschaltet.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutFailedAgentNotInRegion">Agent nicht in Region.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutFailedPendingLogin">Die Region war gerade dabei, eine andere Sitzung anzumelden.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutFailedLoggingOut">Die Region war gerade dabei, die vorherige Sitzung abzumelden.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutFailedStillLoggingOut">Die Region ist noch immer dabei, die vorherige Sitzung abzumelden.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutSucceeded">Die Region hat soeben die letzte Sitzung abgemeldet.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LogoutFailedLogoutBegun">Die Region hat den Abmeldevorgang gestartet.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="LoginFailedLoggingOutSession">Das System hat begonnen, Ihre letzte Sitzung abzumelden.
-Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.</string>
-	<string name="AgentLostConnection">In dieser Region kann es zu Problemen kommen.  Bitte überprüfen Sie Ihre Internetverbindung.</string>
-	<string name="SavingSettings">Ihr Einstellungen werden gespeichert...</string>
-	<string name="LoggingOut">Abmeldung erfolgt...</string>
-	<string name="ShuttingDown">Programm wird beendet...</string>
-	<string name="YouHaveBeenDisconnected">Die Verbindung zu der Region ist abgebrochen.</string>
-	<string name="SentToInvalidRegion">Sie wurden in eine ungültige Region geschickt.</string>
-	<string name="TestingDisconnect">Verbindungsabbruch wird getestet</string>
-	<string name="SocialFacebookConnecting">Mit Facebook verbinden...</string>
-	<string name="SocialFacebookPosting">Posten...</string>
-	<string name="SocialFacebookDisconnecting">Facebook-Verbindung trennen...</string>
-	<string name="SocialFacebookErrorConnecting">Problem beim Verbinden mit Facebook</string>
-	<string name="SocialFacebookErrorPosting">Problem beim Posten auf Facebook</string>
-	<string name="SocialFacebookErrorDisconnecting">Problem beim Trennen der Facebook-Verbindung</string>
-	<string name="SocialFlickrConnecting">Verbinden mit Flickr...</string>
-	<string name="SocialFlickrPosting">Posten...</string>
-	<string name="SocialFlickrDisconnecting">Flickr-Verbindung wird getrennt...</string>
-	<string name="SocialFlickrErrorConnecting">Problem beim Verbinden mit Flickr</string>
-	<string name="SocialFlickrErrorPosting">Problem beim Posten auf Flickr</string>
-	<string name="SocialFlickrErrorDisconnecting">Problem beim Trennen der Flickr-Verbindung</string>
-	<string name="SocialTwitterConnecting">Verbinden mit Twitter...</string>
-	<string name="SocialTwitterPosting">Posten...</string>
-	<string name="SocialTwitterDisconnecting">Twitter-Verbindung wird getrennt...</string>
-	<string name="SocialTwitterErrorConnecting">Problem beim Verbinden mit Twitter</string>
-	<string name="SocialTwitterErrorPosting">Problem beim Posten auf Twitter</string>
-	<string name="SocialTwitterErrorDisconnecting">Problem beim Trennen der Twitter-Verbindung</string>
-	<string name="BlackAndWhite">Schwarzweiß</string>
-	<string name="Colors1970">Farben der Siebziger Jahre</string>
-	<string name="Intense">Intensiv</string>
-	<string name="Newspaper">Zeitungspapier</string>
-	<string name="Sepia">Sepia</string>
-	<string name="Spotlight">Spotlight</string>
-	<string name="Video">Video</string>
-	<string name="Autocontrast">Autokontrast</string>
-	<string name="LensFlare">Blendenfleck</string>
-	<string name="Miniature">Miniatur</string>
-	<string name="Toycamera">Spielzeugkamera</string>
-	<string name="TooltipPerson">Person</string>
-	<string name="TooltipNoName">(namenlos)</string>
-	<string name="TooltipOwner">Eigentümer:</string>
-	<string name="TooltipPublic">Öffentlich</string>
-	<string name="TooltipIsGroup">(Gruppe)</string>
-	<string name="TooltipForSaleL$">Zum Verkauf: [AMOUNT] L$</string>
-	<string name="TooltipFlagGroupBuild">Gruppenbau</string>
-	<string name="TooltipFlagNoBuild">Bauen aus</string>
-	<string name="TooltipFlagNoEdit">Gruppenbau</string>
-	<string name="TooltipFlagNotSafe">Unsicher</string>
-	<string name="TooltipFlagNoFly">Fliegen aus</string>
-	<string name="TooltipFlagGroupScripts">Gruppenskripte</string>
-	<string name="TooltipFlagNoScripts">Skripte aus</string>
-	<string name="TooltipLand">Land:</string>
-	<string name="TooltipMustSingleDrop">Sie können nur ein einzelnes Objekt hierher ziehen</string>
-	<string name="TooltipTooManyWearables">Sie können keinen Ordner tragen, der mehr als [AMOUNT] Elemente enthält.  Sie können diesen Höchstwert unter „Erweitert“ &gt; „Debug-Einstellungen anzeigen“ &gt; „WearFolderLimit“ ändern.</string>
+Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LoginFailedIncorrectParameters">
+		Falsche Parameter.
+Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LoginFailedFirstNameNotAlphanumeric">
+		Vorname muss alphanumerisch sein.
+Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LoginFailedLastNameNotAlphanumeric">
+		Nachname muss alphanumerisch sein.
+Wenn Sie der Ansicht sind, dass Sie diese Meldung fälschlicherweise erhalten haben, wenden Sie sich an support@secondlife.com.
+	</string>
+	<string name="LogoutFailedRegionGoingOffline">
+		Die Region wird gerade offline geschaltet.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutFailedAgentNotInRegion">
+		Agent nicht in Region.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutFailedPendingLogin">
+		Die Region war gerade dabei, eine andere Sitzung anzumelden.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutFailedLoggingOut">
+		Die Region war gerade dabei, die vorherige Sitzung abzumelden.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutFailedStillLoggingOut">
+		Die Region ist noch immer dabei, die vorherige Sitzung abzumelden.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutSucceeded">
+		Die Region hat soeben die letzte Sitzung abgemeldet.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LogoutFailedLogoutBegun">
+		Die Region hat den Abmeldevorgang gestartet.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="LoginFailedLoggingOutSession">
+		Das System hat begonnen, Ihre letzte Sitzung abzumelden.
+Warten Sie kurz und versuchen Sie dann noch einmal, sich anzumelden.
+	</string>
+	<string name="AgentLostConnection">
+		In dieser Region kann es zu Problemen kommen.  Bitte überprüfen Sie Ihre Internetverbindung.
+	</string>
+	<string name="SavingSettings">
+		Ihr Einstellungen werden gespeichert...
+	</string>
+	<string name="LoggingOut">
+		Abmeldung erfolgt...
+	</string>
+	<string name="ShuttingDown">
+		Programm wird beendet...
+	</string>
+	<string name="YouHaveBeenDisconnected">
+		Die Verbindung zu der Region ist abgebrochen.
+	</string>
+	<string name="SentToInvalidRegion">
+		Sie wurden in eine ungültige Region geschickt.
+	</string>
+	<string name="TestingDisconnect">
+		Verbindungsabbruch wird getestet
+	</string>
+	<string name="SocialFacebookConnecting">
+		Mit Facebook verbinden...
+	</string>
+	<string name="SocialFacebookPosting">
+		Posten...
+	</string>
+	<string name="SocialFacebookDisconnecting">
+		Facebook-Verbindung trennen...
+	</string>
+	<string name="SocialFacebookErrorConnecting">
+		Problem beim Verbinden mit Facebook
+	</string>
+	<string name="SocialFacebookErrorPosting">
+		Problem beim Posten auf Facebook
+	</string>
+	<string name="SocialFacebookErrorDisconnecting">
+		Problem beim Trennen der Facebook-Verbindung
+	</string>
+	<string name="SocialFlickrConnecting">
+		Verbinden mit Flickr...
+	</string>
+	<string name="SocialFlickrPosting">
+		Posten...
+	</string>
+	<string name="SocialFlickrDisconnecting">
+		Flickr-Verbindung wird getrennt...
+	</string>
+	<string name="SocialFlickrErrorConnecting">
+		Problem beim Verbinden mit Flickr
+	</string>
+	<string name="SocialFlickrErrorPosting">
+		Problem beim Posten auf Flickr
+	</string>
+	<string name="SocialFlickrErrorDisconnecting">
+		Problem beim Trennen der Flickr-Verbindung
+	</string>
+	<string name="SocialTwitterConnecting">
+		Verbinden mit Twitter...
+	</string>
+	<string name="SocialTwitterPosting">
+		Posten...
+	</string>
+	<string name="SocialTwitterDisconnecting">
+		Twitter-Verbindung wird getrennt...
+	</string>
+	<string name="SocialTwitterErrorConnecting">
+		Problem beim Verbinden mit Twitter
+	</string>
+	<string name="SocialTwitterErrorPosting">
+		Problem beim Posten auf Twitter
+	</string>
+	<string name="SocialTwitterErrorDisconnecting">
+		Problem beim Trennen der Twitter-Verbindung
+	</string>
+	<string name="BlackAndWhite">
+		Schwarzweiß
+	</string>
+	<string name="Colors1970">
+		Farben der Siebziger Jahre
+	</string>
+	<string name="Intense">
+		Intensiv
+	</string>
+	<string name="Newspaper">
+		Zeitungspapier
+	</string>
+	<string name="Sepia">
+		Sepia
+	</string>
+	<string name="Spotlight">
+		Spotlight
+	</string>
+	<string name="Video">
+		Video
+	</string>
+	<string name="Autocontrast">
+		Autokontrast
+	</string>
+	<string name="LensFlare">
+		Blendenfleck
+	</string>
+	<string name="Miniature">
+		Miniatur
+	</string>
+	<string name="Toycamera">
+		Spielzeugkamera
+	</string>
+	<string name="TooltipPerson">
+		Person
+	</string>
+	<string name="TooltipNoName">
+		(namenlos)
+	</string>
+	<string name="TooltipOwner">
+		Eigentümer:
+	</string>
+	<string name="TooltipPublic">
+		Öffentlich
+	</string>
+	<string name="TooltipIsGroup">
+		(Gruppe)
+	</string>
+	<string name="TooltipForSaleL$">
+		Zum Verkauf: [AMOUNT] L$
+	</string>
+	<string name="TooltipFlagGroupBuild">
+		Gruppenbau
+	</string>
+	<string name="TooltipFlagNoBuild">
+		Bauen aus
+	</string>
+	<string name="TooltipFlagNoEdit">
+		Gruppenbau
+	</string>
+	<string name="TooltipFlagNotSafe">
+		Unsicher
+	</string>
+	<string name="TooltipFlagNoFly">
+		Fliegen aus
+	</string>
+	<string name="TooltipFlagGroupScripts">
+		Gruppenskripte
+	</string>
+	<string name="TooltipFlagNoScripts">
+		Skripte aus
+	</string>
+	<string name="TooltipLand">
+		Land:
+	</string>
+	<string name="TooltipMustSingleDrop">
+		Sie können nur ein einzelnes Objekt hierher ziehen
+	</string>
+	<string name="TooltipTooManyWearables">
+		Sie können keinen Ordner tragen, der mehr als [AMOUNT] Elemente enthält.  Sie können diesen Höchstwert unter „Erweitert“ &gt; „Debug-Einstellungen anzeigen“ &gt; „WearFolderLimit“ ändern.
+	</string>
 	<string name="TooltipPrice" value="[AMOUNT] L$"/>
-	<string name="TooltipSLIcon">Führt zu einer Seite in der offiziellen Domäne SecondLife.com oder LindenLab.com.</string>
-	<string name="TooltipOutboxDragToWorld">Sie können keine Objekte aus dem Marktplatz-Auflistungsordner rezzen</string>
-	<string name="TooltipOutboxWorn">Sie können Objekte, die Sie tragen, nicht in den Marktplatz-Auflistungsordner stellen</string>
-	<string name="TooltipOutboxFolderLevels">Tiefe der verschachtelten Ordner überschreitet [AMOUNT]. Reduzieren Sie die Ordnertiefe. Verpacken Sie ggf. einige Artikel.</string>
-	<string name="TooltipOutboxTooManyFolders">Anzahl von Unterordnern überschreitet [AMOUNT]. Reduzieren Sie die Anzahl von Ordnern in Ihrer Auflistung. Verpacken Sie ggf. einige Artikel.</string>
-	<string name="TooltipOutboxTooManyObjects">Anzahl von Objekten überschreitet [AMOUNT]. Um mehr als [AMOUNT] Objekte in einer Auflistung verkaufen zu können, müssen Sie einige davon verpacken.</string>
-	<string name="TooltipOutboxTooManyStockItems">Anzahl von Bestandsobjekten überschreitet [AMOUNT].</string>
-	<string name="TooltipOutboxCannotDropOnRoot">Sie können Objekte oder Ordner nur in der Registerkarte „ALLE“ oder „NICHT VERKNüPFT“ ablegen. Klicken Sie auf eine dieser Registerkarten und versuchen Sie dann erneut, Ihre Objekte bzw. Ordner zu verschieben.</string>
-	<string name="TooltipOutboxNoTransfer">Mindestens eines dieser Objekte kann nicht verkauft oder übertragen werden</string>
-	<string name="TooltipOutboxNotInInventory">Sie können nur Objekte aus Ihrem Inventar in den Marktplatz einstellen</string>
-	<string name="TooltipOutboxLinked">Sie können keine verknüpften Objekte oder Ordner in den Marktplatz einstellen</string>
-	<string name="TooltipOutboxCallingCard">Sie können Visitenkarten nicht in den Marktplatz einstellen</string>
-	<string name="TooltipOutboxDragActive">Sie können keine gelistete Auflistung entfernen</string>
-	<string name="TooltipOutboxCannotMoveRoot">Der Stammordner mit Marktplatz-Auflistungen kann nicht verschoben werden.</string>
-	<string name="TooltipOutboxMixedStock">Alle Objekte in einem Bestandsordner müssen vom gleichen Typ sein und die gleiche Berechtigung haben</string>
-	<string name="TooltipDragOntoOwnChild">Sie können einen Ordner nicht in einen seiner untergeordneten Ordner verschieben</string>
-	<string name="TooltipDragOntoSelf">Sie können einen Ordner nicht in sich selbst verschieben</string>
-	<string name="TooltipHttpUrl">Anklicken, um Webseite anzuzeigen</string>
-	<string name="TooltipSLURL">Anklicken, um Informationen zu diesem Standort anzuzeigen</string>
-	<string name="TooltipAgentUrl">Anklicken, um das Profil dieses Einwohners anzuzeigen</string>
-	<string name="TooltipAgentInspect">Mehr über diesen Einwohner</string>
-	<string name="TooltipAgentMute">Klicken, um diesen Einwohner stummzuschalten</string>
-	<string name="TooltipAgentUnmute">Klicken, um diesen Einwohner freizuschalten</string>
-	<string name="TooltipAgentIM">Klicken, um diesem Einwohner eine IM zu schicken.</string>
-	<string name="TooltipAgentPay">Klicken, um diesen Einwohner zu bezahlen</string>
-	<string name="TooltipAgentOfferTeleport">Klicken, um diesem Einwohner einen Teleport anzubieten.</string>
-	<string name="TooltipAgentRequestFriend">Klicken, um diesem Einwohner ein Freundschaftsangebot zu schicken.</string>
-	<string name="TooltipGroupUrl">Anklicken, um Beschreibung der Gruppe anzuzeigen</string>
-	<string name="TooltipEventUrl">Anklicken, um Beschreibung der Veranstaltung anzuzeigen</string>
-	<string name="TooltipClassifiedUrl">Anklicken, um diese Anzeige anzuzeigen</string>
-	<string name="TooltipParcelUrl">Anklicken, um Beschreibung der Parzelle anzuzeigen</string>
-	<string name="TooltipTeleportUrl">Anklicken, um zu diesem Standort zu teleportieren</string>
-	<string name="TooltipObjectIMUrl">Anklicken, um Beschreibung des Objekts anzuzeigen</string>
-	<string name="TooltipMapUrl">Klicken, um diese Position auf der Karte anzuzeigen</string>
-	<string name="TooltipSLAPP">Anklicken, um Befehl secondlife:// auszuführen</string>
+	<string name="TooltipSLIcon">
+		Führt zu einer Seite in der offiziellen Domäne SecondLife.com oder LindenLab.com.
+	</string>
+	<string name="TooltipOutboxDragToWorld">
+		Sie können keine Objekte aus dem Marktplatz-Auflistungsordner rezzen
+	</string>
+	<string name="TooltipOutboxWorn">
+		Sie können Objekte, die Sie tragen, nicht in den Marktplatz-Auflistungsordner stellen
+	</string>
+	<string name="TooltipOutboxFolderLevels">
+		Tiefe der verschachtelten Ordner überschreitet [AMOUNT]. Reduzieren Sie die Ordnertiefe. Verpacken Sie ggf. einige Artikel.
+	</string>
+	<string name="TooltipOutboxTooManyFolders">
+		Anzahl von Unterordnern überschreitet [AMOUNT]. Reduzieren Sie die Anzahl von Ordnern in Ihrer Auflistung. Verpacken Sie ggf. einige Artikel.
+	</string>
+	<string name="TooltipOutboxTooManyObjects">
+		Anzahl von Objekten überschreitet [AMOUNT]. Um mehr als [AMOUNT] Objekte in einer Auflistung verkaufen zu können, müssen Sie einige davon verpacken.
+	</string>
+	<string name="TooltipOutboxTooManyStockItems">
+		Anzahl von Bestandsobjekten überschreitet [AMOUNT].
+	</string>
+	<string name="TooltipOutboxCannotDropOnRoot">
+		Sie können Objekte oder Ordner nur in der Registerkarte „ALLE“ oder „NICHT VERKNüPFT“ ablegen. Klicken Sie auf eine dieser Registerkarten und versuchen Sie dann erneut, Ihre Objekte bzw. Ordner zu verschieben.
+	</string>
+	<string name="TooltipOutboxNoTransfer">
+		Mindestens eines dieser Objekte kann nicht verkauft oder übertragen werden
+	</string>
+	<string name="TooltipOutboxNotInInventory">
+		Sie können nur Objekte aus Ihrem Inventar in den Marktplatz einstellen
+	</string>
+	<string name="TooltipOutboxLinked">
+		Sie können keine verknüpften Objekte oder Ordner in den Marktplatz einstellen
+	</string>
+	<string name="TooltipOutboxCallingCard">
+		Sie können Visitenkarten nicht in den Marktplatz einstellen
+	</string>
+	<string name="TooltipOutboxDragActive">
+		Sie können keine gelistete Auflistung entfernen
+	</string>
+	<string name="TooltipOutboxCannotMoveRoot">
+		Der Stammordner mit Marktplatz-Auflistungen kann nicht verschoben werden.
+	</string>
+	<string name="TooltipOutboxMixedStock">
+		Alle Objekte in einem Bestandsordner müssen vom gleichen Typ sein und die gleiche Berechtigung haben
+	</string>
+	<string name="TooltipDragOntoOwnChild">
+		Sie können einen Ordner nicht in einen seiner untergeordneten Ordner verschieben
+	</string>
+	<string name="TooltipDragOntoSelf">
+		Sie können einen Ordner nicht in sich selbst verschieben
+	</string>
+	<string name="TooltipHttpUrl">
+		Anklicken, um Webseite anzuzeigen
+	</string>
+	<string name="TooltipSLURL">
+		Anklicken, um Informationen zu diesem Standort anzuzeigen
+	</string>
+	<string name="TooltipAgentUrl">
+		Anklicken, um das Profil dieses Einwohners anzuzeigen
+	</string>
+	<string name="TooltipAgentInspect">
+		Mehr über diesen Einwohner
+	</string>
+	<string name="TooltipAgentMute">
+		Klicken, um diesen Einwohner stummzuschalten
+	</string>
+	<string name="TooltipAgentUnmute">
+		Klicken, um diesen Einwohner freizuschalten
+	</string>
+	<string name="TooltipAgentIM">
+		Klicken, um diesem Einwohner eine IM zu schicken.
+	</string>
+	<string name="TooltipAgentPay">
+		Klicken, um diesen Einwohner zu bezahlen
+	</string>
+	<string name="TooltipAgentOfferTeleport">
+		Klicken, um diesem Einwohner einen Teleport anzubieten.
+	</string>
+	<string name="TooltipAgentRequestFriend">
+		Klicken, um diesem Einwohner ein Freundschaftsangebot zu schicken.
+	</string>
+	<string name="TooltipGroupUrl">
+		Anklicken, um Beschreibung der Gruppe anzuzeigen
+	</string>
+	<string name="TooltipEventUrl">
+		Anklicken, um Beschreibung der Veranstaltung anzuzeigen
+	</string>
+	<string name="TooltipClassifiedUrl">
+		Anklicken, um diese Anzeige anzuzeigen
+	</string>
+	<string name="TooltipParcelUrl">
+		Anklicken, um Beschreibung der Parzelle anzuzeigen
+	</string>
+	<string name="TooltipTeleportUrl">
+		Anklicken, um zu diesem Standort zu teleportieren
+	</string>
+	<string name="TooltipObjectIMUrl">
+		Anklicken, um Beschreibung des Objekts anzuzeigen
+	</string>
+	<string name="TooltipMapUrl">
+		Klicken, um diese Position auf der Karte anzuzeigen
+	</string>
+	<string name="TooltipSLAPP">
+		Anklicken, um Befehl secondlife:// auszuführen
+	</string>
 	<string name="CurrentURL" value=" CurrentURL: [CurrentURL]"/>
-	<string name="TooltipEmail">Klicken, um eine E-Mail zu verfassen</string>
-	<string name="SLurlLabelTeleport">Teleportieren nach</string>
-	<string name="SLurlLabelShowOnMap">Karte anzeigen für</string>
-	<string name="SLappAgentMute">Stummschalten</string>
-	<string name="SLappAgentUnmute">Stummschaltung aufheben</string>
-	<string name="SLappAgentIM">IM</string>
-	<string name="SLappAgentPay">Bezahlen</string>
-	<string name="SLappAgentOfferTeleport">Teleportangebot an</string>
-	<string name="SLappAgentRequestFriend">Freundschaftsangebot</string>
-	<string name="SLappAgentRemoveFriend">Entfernen von Freunden</string>
-	<string name="BUTTON_CLOSE_DARWIN">Schließen (⌘W)</string>
-	<string name="BUTTON_CLOSE_WIN">Schließen (Strg+W)</string>
-	<string name="BUTTON_CLOSE_CHROME">Schließen</string>
-	<string name="BUTTON_RESTORE">Wiederherstellen</string>
-	<string name="BUTTON_MINIMIZE">Minimieren</string>
-	<string name="BUTTON_TEAR_OFF">Abnehmen</string>
-	<string name="BUTTON_DOCK">Andocken</string>
-	<string name="BUTTON_HELP">Hilfe anzeigen</string>
-	<string name="TooltipNotecardNotAllowedTypeDrop">Objekte dieses Typs können nicht an Notizkarten 
-für diese Region angehängt werden.</string>
-	<string name="TooltipNotecardOwnerRestrictedDrop">An Notizkarten können nur Objekte ohne 
+	<string name="TooltipEmail">
+		Klicken, um eine E-Mail zu verfassen
+	</string>
+	<string name="SLurlLabelTeleport">
+		Teleportieren nach
+	</string>
+	<string name="SLurlLabelShowOnMap">
+		Karte anzeigen für
+	</string>
+	<string name="SLappAgentMute">
+		Stummschalten
+	</string>
+	<string name="SLappAgentUnmute">
+		Stummschaltung aufheben
+	</string>
+	<string name="SLappAgentIM">
+		IM
+	</string>
+	<string name="SLappAgentPay">
+		Bezahlen
+	</string>
+	<string name="SLappAgentOfferTeleport">
+		Teleportangebot an
+	</string>
+	<string name="SLappAgentRequestFriend">
+		Freundschaftsangebot
+	</string>
+	<string name="SLappAgentRemoveFriend">
+		Entfernen von Freunden
+	</string>
+	<string name="BUTTON_CLOSE_DARWIN">
+		Schließen (⌘W)
+	</string>
+	<string name="BUTTON_CLOSE_WIN">
+		Schließen (Strg+W)
+	</string>
+	<string name="BUTTON_CLOSE_CHROME">
+		Schließen
+	</string>
+	<string name="BUTTON_RESTORE">
+		Wiederherstellen
+	</string>
+	<string name="BUTTON_MINIMIZE">
+		Minimieren
+	</string>
+	<string name="BUTTON_TEAR_OFF">
+		Abnehmen
+	</string>
+	<string name="BUTTON_DOCK">
+		Andocken
+	</string>
+	<string name="BUTTON_HELP">
+		Hilfe anzeigen
+	</string>
+	<string name="TooltipNotecardNotAllowedTypeDrop">
+		Objekte dieses Typs können nicht an Notizkarten 
+für diese Region angehängt werden.
+	</string>
+	<string name="TooltipNotecardOwnerRestrictedDrop">
+		An Notizkarten können nur Objekte ohne 
 Berechtigungseinschränkungen für den 
-nächsten Eigentümer angehängt werden.</string>
-	<string name="Searching">Suchen...</string>
-	<string name="NoneFound">Nicht gefunden.</string>
-	<string name="RetrievingData">Laden...</string>
-	<string name="ReleaseNotes">Versionshinweise</string>
-	<string name="RELEASE_NOTES_BASE_URL">https://releasenotes.secondlife.com/viewer/</string>
-	<string name="LoadingData">Wird geladen...</string>
-	<string name="AvatarNameNobody">(niemand)</string>
-	<string name="AvatarNameWaiting">(wartet)</string>
-	<string name="AvatarNameMultiple">(mehrere)</string>
-	<string name="GroupNameNone">(keiner)</string>
-	<string name="AssetErrorNone">Kein Fehler</string>
-	<string name="AssetErrorRequestFailed">Asset-Anforderung: fehlgeschlagen</string>
-	<string name="AssetErrorNonexistentFile">Asset-Anforderung: Datei existiert nicht</string>
-	<string name="AssetErrorNotInDatabase">Asset-Anforderung: Asset in Datenbank nicht gefunden</string>
-	<string name="AssetErrorEOF">Ende der Datei</string>
-	<string name="AssetErrorCannotOpenFile">Datei kann nicht geöffnet werden</string>
-	<string name="AssetErrorFileNotFound">Datei nicht gefunden</string>
-	<string name="AssetErrorTCPTimeout">Zeitüberschreitung bei Dateiübertragung</string>
-	<string name="AssetErrorCircuitGone">Verbindung verloren</string>
-	<string name="AssetErrorPriceMismatch">Viewer und Server sind sich nicht über Preis einig</string>
-	<string name="AssetErrorUnknownStatus">Status unbekannt</string>
-	<string name="AssetUploadServerUnreacheble">Dienst nicht verfügbar.</string>
-	<string name="AssetUploadServerDifficulties">Auf dem Server sind unerwartete Probleme aufgetreten.</string>
-	<string name="AssetUploadServerUnavaliable">Dienst nicht verfügbar oder Zeitüberschreitung beim Upload.</string>
-	<string name="AssetUploadRequestInvalid">Fehler bei der Upload-Anforderung. Um das Problem zu lösen, 
-besuchen Sie bitte http://secondlife.com/support</string>
-	<string name="SettingValidationError">Validierung für das Importieren der Einstellungen [NAME] fehlgeschlagen</string>
-	<string name="SettingImportFileError">[FILE] konnte nicht geöffnet werden</string>
-	<string name="SettingParseFileError">[FILE] konnte nicht geöffnet werden</string>
-	<string name="SettingTranslateError">Altes Windlight [NAME] konnte nicht übernommen werden</string>
-	<string name="texture">Textur</string>
-	<string name="sound">Sound</string>
-	<string name="calling card">Visitenkarte</string>
-	<string name="landmark">Landmarke</string>
-	<string name="legacy script">Skript (veraltet)</string>
-	<string name="clothing">Kleidung</string>
-	<string name="object">Objekt</string>
-	<string name="note card">Notizkarte</string>
-	<string name="folder">Ordner</string>
-	<string name="root">Hauptverzeichnis</string>
-	<string name="lsl2 script">LSL2 Skript</string>
-	<string name="lsl bytecode">LSL Bytecode</string>
-	<string name="tga texture">tga-Textur</string>
-	<string name="body part">Körperteil</string>
-	<string name="snapshot">Foto</string>
-	<string name="lost and found">Fundbüro</string>
-	<string name="targa image">targa-Bild</string>
-	<string name="trash">Papierkorb</string>
-	<string name="jpeg image">jpeg-Bild</string>
-	<string name="animation">Animation</string>
-	<string name="gesture">Geste</string>
-	<string name="simstate">simstate</string>
-	<string name="favorite">Favoriten</string>
-	<string name="symbolic link">Link</string>
-	<string name="symbolic folder link">Link zu Ordner</string>
-	<string name="settings blob">Einstellungen</string>
-	<string name="mesh">mesh</string>
-	<string name="AvatarEditingAppearance">(Aussehen wird bearbeitet)</string>
-	<string name="AvatarAway">Abwesend</string>
-	<string name="AvatarDoNotDisturb">Nicht stören</string>
-	<string name="AvatarMuted">Ignoriert</string>
-	<string name="anim_express_afraid">Ängstlich</string>
-	<string name="anim_express_anger">Verärgert</string>
-	<string name="anim_away">Abwesend</string>
-	<string name="anim_backflip">Rückwärtssalto</string>
-	<string name="anim_express_laugh">Lachkrampf</string>
-	<string name="anim_express_toothsmile">Grinsen</string>
-	<string name="anim_blowkiss">Kusshand</string>
-	<string name="anim_express_bored">Gelangweilt</string>
-	<string name="anim_bow">Verbeugen</string>
-	<string name="anim_clap">Klatschen</string>
-	<string name="anim_courtbow">Diener</string>
-	<string name="anim_express_cry">Weinen</string>
-	<string name="anim_dance1">Tanz 1</string>
-	<string name="anim_dance2">Tanz 2</string>
-	<string name="anim_dance3">Tanz 3</string>
-	<string name="anim_dance4">Tanz 4</string>
-	<string name="anim_dance5">Tanz 5</string>
-	<string name="anim_dance6">Tanz 6</string>
-	<string name="anim_dance7">Tanz 7</string>
-	<string name="anim_dance8">Tanz 8</string>
-	<string name="anim_express_disdain">Verachten</string>
-	<string name="anim_drink">Trinken</string>
-	<string name="anim_express_embarrased">Verlegen</string>
-	<string name="anim_angry_fingerwag">Drohen</string>
-	<string name="anim_fist_pump">Faust pumpen</string>
-	<string name="anim_yoga_float">Yogaflieger</string>
-	<string name="anim_express_frown">Stirnrunzeln</string>
-	<string name="anim_impatient">Ungeduldig</string>
-	<string name="anim_jumpforjoy">Freudensprung</string>
-	<string name="anim_kissmybutt">LMA</string>
-	<string name="anim_express_kiss">Küssen</string>
-	<string name="anim_laugh_short">Lachen</string>
-	<string name="anim_musclebeach">Posen</string>
-	<string name="anim_no_unhappy">Nein (Bedauernd)</string>
-	<string name="anim_no_head">Nein</string>
-	<string name="anim_nyanya">Ällabätsch</string>
-	<string name="anim_punch_onetwo">Eins-Zwei-Punch</string>
-	<string name="anim_express_open_mouth">Mund offen</string>
-	<string name="anim_peace">Friede</string>
-	<string name="anim_point_you">Auf anderen zeigen</string>
-	<string name="anim_point_me">Auf mich zeigen</string>
-	<string name="anim_punch_l">Linker Haken</string>
-	<string name="anim_punch_r">Rechter Haken</string>
-	<string name="anim_rps_countdown">SSP zählen</string>
-	<string name="anim_rps_paper">SSP Papier</string>
-	<string name="anim_rps_rock">SSP Stein</string>
-	<string name="anim_rps_scissors">SSP Schere</string>
-	<string name="anim_express_repulsed">Angewidert</string>
-	<string name="anim_kick_roundhouse_r">Rundkick</string>
-	<string name="anim_express_sad">Traurig</string>
-	<string name="anim_salute">Salutieren</string>
-	<string name="anim_shout">Rufen</string>
-	<string name="anim_express_shrug">Schulterzucken</string>
-	<string name="anim_express_smile">Lächeln</string>
-	<string name="anim_smoke_idle">Zigarette halten</string>
-	<string name="anim_smoke_inhale">Rauchen</string>
-	<string name="anim_smoke_throw_down">Zigarette wegwerfen</string>
-	<string name="anim_express_surprise">Überraschung</string>
-	<string name="anim_sword_strike_r">Schwerthieb</string>
-	<string name="anim_angry_tantrum">Wutanfall</string>
-	<string name="anim_express_tongue_out">Zunge rausstrecken</string>
-	<string name="anim_hello">Winken</string>
-	<string name="anim_whisper">Flüstern</string>
-	<string name="anim_whistle">Pfeifen</string>
-	<string name="anim_express_wink">Zwinkern</string>
-	<string name="anim_wink_hollywood">Zwinkern (Hollywood)</string>
-	<string name="anim_express_worry">Sorgenvoll</string>
-	<string name="anim_yes_happy">Ja (Erfreut)</string>
-	<string name="anim_yes_head">Ja</string>
-	<string name="multiple_textures">Mehrfach</string>
-	<string name="use_texture">Textur verwenden</string>
-	<string name="manip_hint1">Zum Einrasten Mauscursor</string>
-	<string name="manip_hint2">über Lineal bewegen</string>
-	<string name="texture_loading">Wird geladen...</string>
-	<string name="worldmap_offline">Offline</string>
-	<string name="worldmap_item_tooltip_format">[PRICE] L$ für [AREA] m²</string>
-	<string name="worldmap_results_none_found">Nicht gefunden.</string>
-	<string name="Ok">OK</string>
-	<string name="Premature end of file">Unvollständige Datei</string>
-	<string name="ST_NO_JOINT">HAUPTVERZEICHNIS oder VERBINDUNG nicht gefunden.</string>
-	<string name="NearbyChatTitle">Chat in der Nähe</string>
-	<string name="NearbyChatLabel">(Chat in der Nähe)</string>
-	<string name="whisper">flüstert:</string>
-	<string name="shout">ruft:</string>
-	<string name="ringing">Verbindung mit In-Welt-Voice-Chat...</string>
-	<string name="connected">Verbunden</string>
-	<string name="unavailable">Der aktuelle Standort unterstützt keine Voice-Kommunikation</string>
-	<string name="hang_up">Verbindung mit In-Welt-Voice-Chat getrennt</string>
-	<string name="reconnect_nearby">Sie werden nun wieder mit dem Chat in Ihrer Nähe verbunden</string>
-	<string name="ScriptQuestionCautionChatGranted">Dem Objekt „[OBJECTNAME]“, ein Objekt von „[OWNERNAME]“, in [REGIONNAME] [REGIONPOS], wurde folgende Berechtigung erteilt: [PERMISSIONS].</string>
-	<string name="ScriptQuestionCautionChatDenied">Dem Objekt „[OBJECTNAME]“, ein Objekt von „[OWNERNAME]“, in [REGIONNAME] [REGIONPOS], wurde folgende Berechtigung verweigert: [PERMISSIONS].</string>
-	<string name="AdditionalPermissionsRequestHeader">Wenn Sie dem Objekt Zugriff auf Ihr Konto gewähren, kann dieses außerdem:</string>
-	<string name="ScriptTakeMoney">Linden-Dollar (L$) von Ihnen nehmen</string>
-	<string name="ActOnControlInputs">Steuerung festlegen</string>
-	<string name="RemapControlInputs">Steuerung neu zuweisen</string>
-	<string name="AnimateYourAvatar">Avatar animieren</string>
-	<string name="AttachToYourAvatar">An Avatar anhängen</string>
-	<string name="ReleaseOwnership">Eigentum aufgeben und öffentlich machen</string>
-	<string name="LinkAndDelink">Mit Objekten verknüpfen und davon trennen</string>
-	<string name="AddAndRemoveJoints">Verbindungen zu anderen Objekten hinzufügen und entfernen</string>
-	<string name="ChangePermissions">Berechtigungen ändern</string>
-	<string name="TrackYourCamera">Kameraverfolgung</string>
-	<string name="ControlYourCamera">Kamerasteuerung</string>
-	<string name="TeleportYourAgent">Sie teleportieren</string>
-	<string name="ForceSitAvatar">Ihren Avatar zwingen, sich zu setzen</string>
-	<string name="ChangeEnvSettings">Umgebungseinstellungen ändern</string>
-	<string name="NotConnected">Nicht verbunden</string>
-	<string name="AgentNameSubst">(Sie)</string>
+nächsten Eigentümer angehängt werden.
+	</string>
+	<string name="Searching">
+		Suchen...
+	</string>
+	<string name="NoneFound">
+		Nicht gefunden.
+	</string>
+	<string name="RetrievingData">
+		Laden...
+	</string>
+	<string name="ReleaseNotes">
+		Versionshinweise
+	</string>
+	<string name="RELEASE_NOTES_BASE_URL">
+		https://releasenotes.secondlife.com/viewer/
+	</string>
+	<string name="LoadingData">
+		Wird geladen...
+	</string>
+	<string name="AvatarNameNobody">
+		(niemand)
+	</string>
+	<string name="AvatarNameWaiting">
+		(wartet)
+	</string>
+	<string name="AvatarNameMultiple">
+		(mehrere)
+	</string>
+	<string name="GroupNameNone">
+		(keiner)
+	</string>
+	<string name="AssetErrorNone">
+		Kein Fehler
+	</string>
+	<string name="AssetErrorRequestFailed">
+		Asset-Anforderung: fehlgeschlagen
+	</string>
+	<string name="AssetErrorNonexistentFile">
+		Asset-Anforderung: Datei existiert nicht
+	</string>
+	<string name="AssetErrorNotInDatabase">
+		Asset-Anforderung: Asset in Datenbank nicht gefunden
+	</string>
+	<string name="AssetErrorEOF">
+		Ende der Datei
+	</string>
+	<string name="AssetErrorCannotOpenFile">
+		Datei kann nicht geöffnet werden
+	</string>
+	<string name="AssetErrorFileNotFound">
+		Datei nicht gefunden
+	</string>
+	<string name="AssetErrorTCPTimeout">
+		Zeitüberschreitung bei Dateiübertragung
+	</string>
+	<string name="AssetErrorCircuitGone">
+		Verbindung verloren
+	</string>
+	<string name="AssetErrorPriceMismatch">
+		Viewer und Server sind sich nicht über Preis einig
+	</string>
+	<string name="AssetErrorUnknownStatus">
+		Status unbekannt
+	</string>
+	<string name="AssetUploadServerUnreacheble">
+		Dienst nicht verfügbar.
+	</string>
+	<string name="AssetUploadServerDifficulties">
+		Auf dem Server sind unerwartete Probleme aufgetreten.
+	</string>
+	<string name="AssetUploadServerUnavaliable">
+		Dienst nicht verfügbar oder Zeitüberschreitung beim Upload.
+	</string>
+	<string name="AssetUploadRequestInvalid">
+		Fehler bei der Upload-Anforderung. Um das Problem zu lösen, 
+besuchen Sie bitte http://secondlife.com/support
+	</string>
+	<string name="SettingValidationError">
+		Validierung für das Importieren der Einstellungen [NAME] fehlgeschlagen
+	</string>
+	<string name="SettingImportFileError">
+		[FILE] konnte nicht geöffnet werden
+	</string>
+	<string name="SettingParseFileError">
+		[FILE] konnte nicht geöffnet werden
+	</string>
+	<string name="SettingTranslateError">
+		Altes Windlight [NAME] konnte nicht übernommen werden
+	</string>
+	<string name="texture">
+		Textur
+	</string>
+	<string name="sound">
+		Sound
+	</string>
+	<string name="calling card">
+		Visitenkarte
+	</string>
+	<string name="landmark">
+		Landmarke
+	</string>
+	<string name="legacy script">
+		Skript (veraltet)
+	</string>
+	<string name="clothing">
+		Kleidung
+	</string>
+	<string name="object">
+		Objekt
+	</string>
+	<string name="note card">
+		Notizkarte
+	</string>
+	<string name="folder">
+		Ordner
+	</string>
+	<string name="root">
+		Hauptverzeichnis
+	</string>
+	<string name="lsl2 script">
+		LSL2 Skript
+	</string>
+	<string name="lsl bytecode">
+		LSL Bytecode
+	</string>
+	<string name="tga texture">
+		tga-Textur
+	</string>
+	<string name="body part">
+		Körperteil
+	</string>
+	<string name="snapshot">
+		Foto
+	</string>
+	<string name="lost and found">
+		Fundbüro
+	</string>
+	<string name="targa image">
+		targa-Bild
+	</string>
+	<string name="trash">
+		Papierkorb
+	</string>
+	<string name="jpeg image">
+		jpeg-Bild
+	</string>
+	<string name="animation">
+		Animation
+	</string>
+	<string name="gesture">
+		Geste
+	</string>
+	<string name="simstate">
+		simstate
+	</string>
+	<string name="favorite">
+		Favoriten
+	</string>
+	<string name="symbolic link">
+		Link
+	</string>
+	<string name="symbolic folder link">
+		Link zu Ordner
+	</string>
+	<string name="settings blob">
+		Einstellungen
+	</string>
+	<string name="mesh">
+		mesh
+	</string>
+	<string name="AvatarEditingAppearance">
+		(Aussehen wird bearbeitet)
+	</string>
+	<string name="AvatarAway">
+		Abwesend
+	</string>
+	<string name="AvatarDoNotDisturb">
+		Nicht stören
+	</string>
+	<string name="AvatarMuted">
+		Ignoriert
+	</string>
+	<string name="anim_express_afraid">
+		Ängstlich
+	</string>
+	<string name="anim_express_anger">
+		Verärgert
+	</string>
+	<string name="anim_away">
+		Abwesend
+	</string>
+	<string name="anim_backflip">
+		Rückwärtssalto
+	</string>
+	<string name="anim_express_laugh">
+		Lachkrampf
+	</string>
+	<string name="anim_express_toothsmile">
+		Grinsen
+	</string>
+	<string name="anim_blowkiss">
+		Kusshand
+	</string>
+	<string name="anim_express_bored">
+		Gelangweilt
+	</string>
+	<string name="anim_bow">
+		Verbeugen
+	</string>
+	<string name="anim_clap">
+		Klatschen
+	</string>
+	<string name="anim_courtbow">
+		Diener
+	</string>
+	<string name="anim_express_cry">
+		Weinen
+	</string>
+	<string name="anim_dance1">
+		Tanz 1
+	</string>
+	<string name="anim_dance2">
+		Tanz 2
+	</string>
+	<string name="anim_dance3">
+		Tanz 3
+	</string>
+	<string name="anim_dance4">
+		Tanz 4
+	</string>
+	<string name="anim_dance5">
+		Tanz 5
+	</string>
+	<string name="anim_dance6">
+		Tanz 6
+	</string>
+	<string name="anim_dance7">
+		Tanz 7
+	</string>
+	<string name="anim_dance8">
+		Tanz 8
+	</string>
+	<string name="anim_express_disdain">
+		Verachten
+	</string>
+	<string name="anim_drink">
+		Trinken
+	</string>
+	<string name="anim_express_embarrased">
+		Verlegen
+	</string>
+	<string name="anim_angry_fingerwag">
+		Drohen
+	</string>
+	<string name="anim_fist_pump">
+		Faust pumpen
+	</string>
+	<string name="anim_yoga_float">
+		Yogaflieger
+	</string>
+	<string name="anim_express_frown">
+		Stirnrunzeln
+	</string>
+	<string name="anim_impatient">
+		Ungeduldig
+	</string>
+	<string name="anim_jumpforjoy">
+		Freudensprung
+	</string>
+	<string name="anim_kissmybutt">
+		LMA
+	</string>
+	<string name="anim_express_kiss">
+		Küssen
+	</string>
+	<string name="anim_laugh_short">
+		Lachen
+	</string>
+	<string name="anim_musclebeach">
+		Posen
+	</string>
+	<string name="anim_no_unhappy">
+		Nein (Bedauernd)
+	</string>
+	<string name="anim_no_head">
+		Nein
+	</string>
+	<string name="anim_nyanya">
+		Ällabätsch
+	</string>
+	<string name="anim_punch_onetwo">
+		Eins-Zwei-Punch
+	</string>
+	<string name="anim_express_open_mouth">
+		Mund offen
+	</string>
+	<string name="anim_peace">
+		Friede
+	</string>
+	<string name="anim_point_you">
+		Auf anderen zeigen
+	</string>
+	<string name="anim_point_me">
+		Auf mich zeigen
+	</string>
+	<string name="anim_punch_l">
+		Linker Haken
+	</string>
+	<string name="anim_punch_r">
+		Rechter Haken
+	</string>
+	<string name="anim_rps_countdown">
+		SSP zählen
+	</string>
+	<string name="anim_rps_paper">
+		SSP Papier
+	</string>
+	<string name="anim_rps_rock">
+		SSP Stein
+	</string>
+	<string name="anim_rps_scissors">
+		SSP Schere
+	</string>
+	<string name="anim_express_repulsed">
+		Angewidert
+	</string>
+	<string name="anim_kick_roundhouse_r">
+		Rundkick
+	</string>
+	<string name="anim_express_sad">
+		Traurig
+	</string>
+	<string name="anim_salute">
+		Salutieren
+	</string>
+	<string name="anim_shout">
+		Rufen
+	</string>
+	<string name="anim_express_shrug">
+		Schulterzucken
+	</string>
+	<string name="anim_express_smile">
+		Lächeln
+	</string>
+	<string name="anim_smoke_idle">
+		Zigarette halten
+	</string>
+	<string name="anim_smoke_inhale">
+		Rauchen
+	</string>
+	<string name="anim_smoke_throw_down">
+		Zigarette wegwerfen
+	</string>
+	<string name="anim_express_surprise">
+		Überraschung
+	</string>
+	<string name="anim_sword_strike_r">
+		Schwerthieb
+	</string>
+	<string name="anim_angry_tantrum">
+		Wutanfall
+	</string>
+	<string name="anim_express_tongue_out">
+		Zunge rausstrecken
+	</string>
+	<string name="anim_hello">
+		Winken
+	</string>
+	<string name="anim_whisper">
+		Flüstern
+	</string>
+	<string name="anim_whistle">
+		Pfeifen
+	</string>
+	<string name="anim_express_wink">
+		Zwinkern
+	</string>
+	<string name="anim_wink_hollywood">
+		Zwinkern (Hollywood)
+	</string>
+	<string name="anim_express_worry">
+		Sorgenvoll
+	</string>
+	<string name="anim_yes_happy">
+		Ja (Erfreut)
+	</string>
+	<string name="anim_yes_head">
+		Ja
+	</string>
+	<string name="multiple_textures">
+		Mehrfach
+	</string>
+	<string name="use_texture">
+		Textur verwenden
+	</string>
+	<string name="manip_hint1">
+		Zum Einrasten Mauscursor
+	</string>
+	<string name="manip_hint2">
+		über Lineal bewegen
+	</string>
+	<string name="texture_loading">
+		Wird geladen...
+	</string>
+	<string name="worldmap_offline">
+		Offline
+	</string>
+	<string name="worldmap_item_tooltip_format">
+		[PRICE] L$ für [AREA] m²
+	</string>
+	<string name="worldmap_results_none_found">
+		Nicht gefunden.
+	</string>
+	<string name="Ok">
+		OK
+	</string>
+	<string name="Premature end of file">
+		Unvollständige Datei
+	</string>
+	<string name="ST_NO_JOINT">
+		HAUPTVERZEICHNIS oder VERBINDUNG nicht gefunden.
+	</string>
+	<string name="NearbyChatTitle">
+		Chat in der Nähe
+	</string>
+	<string name="NearbyChatLabel">
+		(Chat in der Nähe)
+	</string>
+	<string name="whisper">
+		flüstert:
+	</string>
+	<string name="shout">
+		ruft:
+	</string>
+	<string name="ringing">
+		Verbindung mit In-Welt-Voice-Chat...
+	</string>
+	<string name="connected">
+		Verbunden
+	</string>
+	<string name="unavailable">
+		Der aktuelle Standort unterstützt keine Voice-Kommunikation
+	</string>
+	<string name="hang_up">
+		Verbindung mit In-Welt-Voice-Chat getrennt
+	</string>
+	<string name="reconnect_nearby">
+		Sie werden nun wieder mit dem Chat in Ihrer Nähe verbunden
+	</string>
+	<string name="ScriptQuestionCautionChatGranted">
+		Dem Objekt „[OBJECTNAME]“, ein Objekt von „[OWNERNAME]“, in [REGIONNAME] [REGIONPOS], wurde folgende Berechtigung erteilt: [PERMISSIONS].
+	</string>
+	<string name="ScriptQuestionCautionChatDenied">
+		Dem Objekt „[OBJECTNAME]“, ein Objekt von „[OWNERNAME]“, in [REGIONNAME] [REGIONPOS], wurde folgende Berechtigung verweigert: [PERMISSIONS].
+	</string>
+	<string name="AdditionalPermissionsRequestHeader">
+		Wenn Sie dem Objekt Zugriff auf Ihr Konto gewähren, kann dieses außerdem:
+	</string>
+	<string name="ScriptTakeMoney">
+		Linden-Dollar (L$) von Ihnen nehmen
+	</string>
+	<string name="ActOnControlInputs">
+		Steuerung festlegen
+	</string>
+	<string name="RemapControlInputs">
+		Steuerung neu zuweisen
+	</string>
+	<string name="AnimateYourAvatar">
+		Avatar animieren
+	</string>
+	<string name="AttachToYourAvatar">
+		An Avatar anhängen
+	</string>
+	<string name="ReleaseOwnership">
+		Eigentum aufgeben und öffentlich machen
+	</string>
+	<string name="LinkAndDelink">
+		Mit Objekten verknüpfen und davon trennen
+	</string>
+	<string name="AddAndRemoveJoints">
+		Verbindungen zu anderen Objekten hinzufügen und entfernen
+	</string>
+	<string name="ChangePermissions">
+		Berechtigungen ändern
+	</string>
+	<string name="TrackYourCamera">
+		Kameraverfolgung
+	</string>
+	<string name="ControlYourCamera">
+		Kamerasteuerung
+	</string>
+	<string name="TeleportYourAgent">
+		Sie teleportieren
+	</string>
+	<string name="ForceSitAvatar">
+		Ihren Avatar zwingen, sich zu setzen
+	</string>
+	<string name="ChangeEnvSettings">
+		Umgebungseinstellungen ändern
+	</string>
+	<string name="NotConnected">
+		Nicht verbunden
+	</string>
+	<string name="AgentNameSubst">
+		(Sie)
+	</string>
 	<string name="JoinAnExperience"/>
-	<string name="SilentlyManageEstateAccess">Beim Verwalten von Grundbesitzzugangslisten Warnhinweise unterdrücken</string>
-	<string name="OverrideYourAnimations">Ihre Standardanimationen ersetzen</string>
-	<string name="ScriptReturnObjects">Objekte in Ihrem Namen zurückgeben</string>
-	<string name="UnknownScriptPermission">(unbekannt)</string>
-	<string name="SIM_ACCESS_PG">Generell</string>
-	<string name="SIM_ACCESS_MATURE">Moderat</string>
-	<string name="SIM_ACCESS_ADULT">Adult</string>
-	<string name="SIM_ACCESS_DOWN">Offline</string>
-	<string name="SIM_ACCESS_MIN">Unbekannt</string>
-	<string name="land_type_unknown">(unbekannt)</string>
-	<string name="Estate / Full Region">Grundstück / Vollständige Region</string>
-	<string name="Estate / Homestead">Grundbesitz/Homestead</string>
-	<string name="Mainland / Homestead">Mainland/Homestead</string>
-	<string name="Mainland / Full Region">Mainland / Vollständige Region</string>
-	<string name="all_files">Alle Dateien</string>
-	<string name="sound_files">Sounds</string>
-	<string name="animation_files">Animationen</string>
-	<string name="image_files">Bilder</string>
-	<string name="save_file_verb">Speichern</string>
-	<string name="load_file_verb">Laden</string>
-	<string name="targa_image_files">Targa-Bilder</string>
-	<string name="bitmap_image_files">Bitmap-Bilder</string>
-	<string name="png_image_files">PNG-Bilder</string>
-	<string name="save_texture_image_files">Targa- oder PNG-Bilder</string>
-	<string name="avi_movie_file">AVI-Filmdatei</string>
-	<string name="xaf_animation_file">XAF Anim-Datei</string>
-	<string name="xml_file">XML-Datei</string>
-	<string name="raw_file">RAW-Datei</string>
-	<string name="compressed_image_files">Komprimierte Bilder</string>
-	<string name="load_files">Dateien laden</string>
-	<string name="choose_the_directory">Verzeichnis auswählen</string>
-	<string name="script_files">Skripts</string>
-	<string name="dictionary_files">Wörterbücher</string>
-	<string name="shape">Form</string>
-	<string name="skin">Haut</string>
-	<string name="hair">Haare</string>
-	<string name="eyes">Augen</string>
-	<string name="shirt">Hemd</string>
-	<string name="pants">Hose</string>
-	<string name="shoes">Schuhe</string>
-	<string name="socks">Socken</string>
-	<string name="jacket">Jacke</string>
-	<string name="gloves">Handschuhe</string>
-	<string name="undershirt">Unterhemd</string>
-	<string name="underpants">Unterhose</string>
-	<string name="skirt">Rock</string>
-	<string name="alpha">Alpha</string>
-	<string name="tattoo">Tätowierung</string>
-	<string name="universal">Universal</string>
-	<string name="physics">Physik</string>
-	<string name="invalid">ungültig</string>
-	<string name="none">keine</string>
-	<string name="shirt_not_worn">Hemd nicht getragen</string>
-	<string name="pants_not_worn">Hosen nicht getragen</string>
-	<string name="shoes_not_worn">Schuhe nicht getragen</string>
-	<string name="socks_not_worn">Socken nicht getragen</string>
-	<string name="jacket_not_worn">Jacke nicht getragen</string>
-	<string name="gloves_not_worn">Handschuhe nicht getragen</string>
-	<string name="undershirt_not_worn">Unterhemd nicht getragen</string>
-	<string name="underpants_not_worn">Unterhose nicht getragen</string>
-	<string name="skirt_not_worn">Rock nicht getragen</string>
-	<string name="alpha_not_worn">Alpha nicht getragen</string>
-	<string name="tattoo_not_worn">Tätowierung nicht getragen</string>
-	<string name="universal_not_worn">Universal nicht getragen</string>
-	<string name="physics_not_worn">Physik nicht getragen</string>
-	<string name="invalid_not_worn">ungültig</string>
-	<string name="create_new_shape">Neue Form/Gestalt erstellen</string>
-	<string name="create_new_skin">Neue Haut erstellen</string>
-	<string name="create_new_hair">Neue Haare erstellen</string>
-	<string name="create_new_eyes">Neue Augen erstellen</string>
-	<string name="create_new_shirt">Neues Hemd erstellen</string>
-	<string name="create_new_pants">Neue Hose erstellen</string>
-	<string name="create_new_shoes">Neue Schuhe erstellen</string>
-	<string name="create_new_socks">Neue Socken erstellen</string>
-	<string name="create_new_jacket">Neue Jacke erstellen</string>
-	<string name="create_new_gloves">Neue Handschuhe erstellen</string>
-	<string name="create_new_undershirt">Neues Unterhemd erstellen</string>
-	<string name="create_new_underpants">Neue Unterhose erstellen</string>
-	<string name="create_new_skirt">Neuer Rock erstellen</string>
-	<string name="create_new_alpha">Neue Alpha erstellen</string>
-	<string name="create_new_tattoo">Neue Tätowierung erstellen</string>
-	<string name="create_new_universal">Neues Universal erstellen</string>
-	<string name="create_new_physics">Neue Physik erstellen</string>
-	<string name="create_new_invalid">ungültig</string>
-	<string name="NewWearable">Neue/r/s [WEARABLE_ITEM]</string>
-	<string name="next">Weiter</string>
-	<string name="ok">OK</string>
-	<string name="GroupNotifyGroupNotice">Gruppenmitteilung</string>
-	<string name="GroupNotifyGroupNotices">Gruppenmitteilungen</string>
-	<string name="GroupNotifySentBy">Gesendet von</string>
-	<string name="GroupNotifyAttached">Im Anhang:</string>
-	<string name="GroupNotifyViewPastNotices">Alte Mitteilungen anzeigen oder hier Auswahl treffen, um keine Mitteilungen mehr zu erhalten.</string>
-	<string name="GroupNotifyOpenAttachment">Anlage öffnen</string>
-	<string name="GroupNotifySaveAttachment">Siehe Anhang</string>
-	<string name="TeleportOffer">Teleport-Angebot</string>
-	<string name="StartUpNotifications">Sie haben neue Benachrichtigungen erhalten, während Sie abwesend waren.</string>
-	<string name="OverflowInfoChannelString">Sie haben noch %d weitere Benachrichtigungen</string>
-	<string name="BodyPartsRightArm">Rechter Arm</string>
-	<string name="BodyPartsHead">Kopf</string>
-	<string name="BodyPartsLeftArm">Linker Arm</string>
-	<string name="BodyPartsLeftLeg">Linkes Bein</string>
-	<string name="BodyPartsTorso">Oberkörper</string>
-	<string name="BodyPartsRightLeg">Rechtes Bein</string>
-	<string name="BodyPartsEnhancedSkeleton">Erweitertes Skelett</string>
-	<string name="GraphicsQualityLow">Niedrig</string>
-	<string name="GraphicsQualityMid">Mittel</string>
-	<string name="GraphicsQualityHigh">Hoch</string>
-	<string name="LeaveMouselook">ESC drücken, um zur Normalansicht zurückzukehren</string>
-	<string name="InventoryNoMatchingItems">Sie haben nicht das Richtige gefunden? Versuchen Sie es mit der [secondlife:///app/search/all/[SEARCH_TERM] Suche].</string>
-	<string name="InventoryNoMatchingRecentItems">Sie haben nicht das Richtige gefunden? Versuchen Sie [secondlife:///app/inventory/filters Show filters].</string>
-	<string name="PlacesNoMatchingItems">Sie haben nicht das Richtige gefunden? Versuchen Sie es mit der [secondlife:///app/search/places/[SEARCH_TERM] Suche].</string>
-	<string name="FavoritesNoMatchingItems">Landmarke hier hin ziehen, um diese hinzuzufügen.</string>
-	<string name="MarketplaceNoMatchingItems">Keine übereinstimmenden Objekte gefunden. Überprüfen Sie die Schreibweise des Suchbegriffs und versuchen Sie es noch einmal.</string>
-	<string name="InventoryNoTexture">Sie haben keine Kopie dieser Textur in Ihrem Inventar.</string>
-	<string name="InventoryInboxNoItems">Einkäufe aus dem Marktplatz erscheinen hier. Sie können diese dann zur Verwendung in Ihr Inventar ziehen.</string>
-	<string name="MarketplaceURL">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/</string>
-	<string name="MarketplaceURL_CreateStore">http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3</string>
-	<string name="MarketplaceURL_Dashboard">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard</string>
-	<string name="MarketplaceURL_Imports">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports</string>
-	<string name="MarketplaceURL_LearnMore">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more</string>
-	<string name="InventoryPlayAnimationTooltip">Fenster mit Spieloptionen öffnen.</string>
-	<string name="InventoryPlayGestureTooltip">Ausgewählte Geste inworld ausführen.</string>
-	<string name="InventoryPlaySoundTooltip">Fenster mit Spieloptionen öffnen.</string>
-	<string name="InventoryOutboxNotMerchantTitle">Jeder kann Artikel im Marktplatz verkaufen.</string>
+	<string name="SilentlyManageEstateAccess">
+		Beim Verwalten von Grundbesitzzugangslisten Warnhinweise unterdrücken
+	</string>
+	<string name="OverrideYourAnimations">
+		Ihre Standardanimationen ersetzen
+	</string>
+	<string name="ScriptReturnObjects">
+		Objekte in Ihrem Namen zurückgeben
+	</string>
+	<string name="UnknownScriptPermission">
+		(unbekannt)
+	</string>
+	<string name="SIM_ACCESS_PG">
+		Generell
+	</string>
+	<string name="SIM_ACCESS_MATURE">
+		Moderat
+	</string>
+	<string name="SIM_ACCESS_ADULT">
+		Adult
+	</string>
+	<string name="SIM_ACCESS_DOWN">
+		Offline
+	</string>
+	<string name="SIM_ACCESS_MIN">
+		Unbekannt
+	</string>
+	<string name="land_type_unknown">
+		(unbekannt)
+	</string>
+	<string name="Estate / Full Region">
+		Grundstück / Vollständige Region
+	</string>
+	<string name="Estate / Homestead">
+		Grundbesitz/Homestead
+	</string>
+	<string name="Mainland / Homestead">
+		Mainland/Homestead
+	</string>
+	<string name="Mainland / Full Region">
+		Mainland / Vollständige Region
+	</string>
+	<string name="all_files">
+		Alle Dateien
+	</string>
+	<string name="sound_files">
+		Sounds
+	</string>
+	<string name="animation_files">
+		Animationen
+	</string>
+	<string name="image_files">
+		Bilder
+	</string>
+	<string name="save_file_verb">
+		Speichern
+	</string>
+	<string name="load_file_verb">
+		Laden
+	</string>
+	<string name="targa_image_files">
+		Targa-Bilder
+	</string>
+	<string name="bitmap_image_files">
+		Bitmap-Bilder
+	</string>
+	<string name="png_image_files">
+		PNG-Bilder
+	</string>
+	<string name="save_texture_image_files">
+		Targa- oder PNG-Bilder
+	</string>
+	<string name="avi_movie_file">
+		AVI-Filmdatei
+	</string>
+	<string name="xaf_animation_file">
+		XAF Anim-Datei
+	</string>
+	<string name="xml_file">
+		XML-Datei
+	</string>
+	<string name="raw_file">
+		RAW-Datei
+	</string>
+	<string name="compressed_image_files">
+		Komprimierte Bilder
+	</string>
+	<string name="load_files">
+		Dateien laden
+	</string>
+	<string name="choose_the_directory">
+		Verzeichnis auswählen
+	</string>
+	<string name="script_files">
+		Skripts
+	</string>
+	<string name="dictionary_files">
+		Wörterbücher
+	</string>
+	<string name="shape">
+		Form
+	</string>
+	<string name="skin">
+		Haut
+	</string>
+	<string name="hair">
+		Haare
+	</string>
+	<string name="eyes">
+		Augen
+	</string>
+	<string name="shirt">
+		Hemd
+	</string>
+	<string name="pants">
+		Hose
+	</string>
+	<string name="shoes">
+		Schuhe
+	</string>
+	<string name="socks">
+		Socken
+	</string>
+	<string name="jacket">
+		Jacke
+	</string>
+	<string name="gloves">
+		Handschuhe
+	</string>
+	<string name="undershirt">
+		Unterhemd
+	</string>
+	<string name="underpants">
+		Unterhose
+	</string>
+	<string name="skirt">
+		Rock
+	</string>
+	<string name="alpha">
+		Alpha
+	</string>
+	<string name="tattoo">
+		Tätowierung
+	</string>
+	<string name="universal">
+		Universal
+	</string>
+	<string name="physics">
+		Physik
+	</string>
+	<string name="invalid">
+		ungültig
+	</string>
+	<string name="none">
+		keine
+	</string>
+	<string name="shirt_not_worn">
+		Hemd nicht getragen
+	</string>
+	<string name="pants_not_worn">
+		Hosen nicht getragen
+	</string>
+	<string name="shoes_not_worn">
+		Schuhe nicht getragen
+	</string>
+	<string name="socks_not_worn">
+		Socken nicht getragen
+	</string>
+	<string name="jacket_not_worn">
+		Jacke nicht getragen
+	</string>
+	<string name="gloves_not_worn">
+		Handschuhe nicht getragen
+	</string>
+	<string name="undershirt_not_worn">
+		Unterhemd nicht getragen
+	</string>
+	<string name="underpants_not_worn">
+		Unterhose nicht getragen
+	</string>
+	<string name="skirt_not_worn">
+		Rock nicht getragen
+	</string>
+	<string name="alpha_not_worn">
+		Alpha nicht getragen
+	</string>
+	<string name="tattoo_not_worn">
+		Tätowierung nicht getragen
+	</string>
+	<string name="universal_not_worn">
+		Universal nicht getragen
+	</string>
+	<string name="physics_not_worn">
+		Physik nicht getragen
+	</string>
+	<string name="invalid_not_worn">
+		ungültig
+	</string>
+	<string name="create_new_shape">
+		Neue Form/Gestalt erstellen
+	</string>
+	<string name="create_new_skin">
+		Neue Haut erstellen
+	</string>
+	<string name="create_new_hair">
+		Neue Haare erstellen
+	</string>
+	<string name="create_new_eyes">
+		Neue Augen erstellen
+	</string>
+	<string name="create_new_shirt">
+		Neues Hemd erstellen
+	</string>
+	<string name="create_new_pants">
+		Neue Hose erstellen
+	</string>
+	<string name="create_new_shoes">
+		Neue Schuhe erstellen
+	</string>
+	<string name="create_new_socks">
+		Neue Socken erstellen
+	</string>
+	<string name="create_new_jacket">
+		Neue Jacke erstellen
+	</string>
+	<string name="create_new_gloves">
+		Neue Handschuhe erstellen
+	</string>
+	<string name="create_new_undershirt">
+		Neues Unterhemd erstellen
+	</string>
+	<string name="create_new_underpants">
+		Neue Unterhose erstellen
+	</string>
+	<string name="create_new_skirt">
+		Neuer Rock erstellen
+	</string>
+	<string name="create_new_alpha">
+		Neue Alpha erstellen
+	</string>
+	<string name="create_new_tattoo">
+		Neue Tätowierung erstellen
+	</string>
+	<string name="create_new_universal">
+		Neues Universal erstellen
+	</string>
+	<string name="create_new_physics">
+		Neue Physik erstellen
+	</string>
+	<string name="create_new_invalid">
+		ungültig
+	</string>
+	<string name="NewWearable">
+		Neue/r/s [WEARABLE_ITEM]
+	</string>
+	<string name="next">
+		Weiter
+	</string>
+	<string name="ok">
+		OK
+	</string>
+	<string name="GroupNotifyGroupNotice">
+		Gruppenmitteilung
+	</string>
+	<string name="GroupNotifyGroupNotices">
+		Gruppenmitteilungen
+	</string>
+	<string name="GroupNotifySentBy">
+		Gesendet von
+	</string>
+	<string name="GroupNotifyAttached">
+		Im Anhang:
+	</string>
+	<string name="GroupNotifyViewPastNotices">
+		Alte Mitteilungen anzeigen oder hier Auswahl treffen, um keine Mitteilungen mehr zu erhalten.
+	</string>
+	<string name="GroupNotifyOpenAttachment">
+		Anlage öffnen
+	</string>
+	<string name="GroupNotifySaveAttachment">
+		Siehe Anhang
+	</string>
+	<string name="TeleportOffer">
+		Teleport-Angebot
+	</string>
+	<string name="StartUpNotifications">
+		Sie haben neue Benachrichtigungen erhalten, während Sie abwesend waren.
+	</string>
+	<string name="OverflowInfoChannelString">
+		Sie haben noch %d weitere Benachrichtigungen
+	</string>
+	<string name="BodyPartsRightArm">
+		Rechter Arm
+	</string>
+	<string name="BodyPartsHead">
+		Kopf
+	</string>
+	<string name="BodyPartsLeftArm">
+		Linker Arm
+	</string>
+	<string name="BodyPartsLeftLeg">
+		Linkes Bein
+	</string>
+	<string name="BodyPartsTorso">
+		Oberkörper
+	</string>
+	<string name="BodyPartsRightLeg">
+		Rechtes Bein
+	</string>
+	<string name="BodyPartsEnhancedSkeleton">
+		Erweitertes Skelett
+	</string>
+	<string name="GraphicsQualityLow">
+		Niedrig
+	</string>
+	<string name="GraphicsQualityMid">
+		Mittel
+	</string>
+	<string name="GraphicsQualityHigh">
+		Hoch
+	</string>
+	<string name="LeaveMouselook">
+		ESC drücken, um zur Normalansicht zurückzukehren
+	</string>
+	<string name="InventoryNoMatchingItems">
+		Sie haben nicht das Richtige gefunden? Versuchen Sie es mit der [secondlife:///app/search/all/[SEARCH_TERM] Suche].
+	</string>
+	<string name="InventoryNoMatchingRecentItems">
+		Sie haben nicht das Richtige gefunden? Versuchen Sie [secondlife:///app/inventory/filters Show filters].
+	</string>
+	<string name="PlacesNoMatchingItems">
+		Sie haben nicht das Richtige gefunden? Versuchen Sie es mit der [secondlife:///app/search/places/[SEARCH_TERM] Suche].
+	</string>
+	<string name="FavoritesNoMatchingItems">
+		Landmarke hier hin ziehen, um diese hinzuzufügen.
+	</string>
+	<string name="MarketplaceNoMatchingItems">
+		Keine übereinstimmenden Objekte gefunden. Überprüfen Sie die Schreibweise des Suchbegriffs und versuchen Sie es noch einmal.
+	</string>
+	<string name="InventoryNoTexture">
+		Sie haben keine Kopie dieser Textur in Ihrem Inventar.
+	</string>
+	<string name="InventoryInboxNoItems">
+		Einkäufe aus dem Marktplatz erscheinen hier. Sie können diese dann zur Verwendung in Ihr Inventar ziehen.
+	</string>
+	<string name="MarketplaceURL">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/
+	</string>
+	<string name="MarketplaceURL_CreateStore">
+		http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3
+	</string>
+	<string name="MarketplaceURL_Dashboard">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard
+	</string>
+	<string name="MarketplaceURL_Imports">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports
+	</string>
+	<string name="MarketplaceURL_LearnMore">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more
+	</string>
+	<string name="InventoryPlayAnimationTooltip">
+		Fenster mit Spieloptionen öffnen.
+	</string>
+	<string name="InventoryPlayGestureTooltip">
+		Ausgewählte Geste inworld ausführen.
+	</string>
+	<string name="InventoryPlaySoundTooltip">
+		Fenster mit Spieloptionen öffnen.
+	</string>
+	<string name="InventoryOutboxNotMerchantTitle">
+		Jeder kann Artikel im Marktplatz verkaufen.
+	</string>
 	<string name="InventoryOutboxNotMerchantTooltip"/>
-	<string name="InventoryOutboxNotMerchant">Wenn Sie als Händler aktiv werden möchten, müssen Sie einen [[MARKETPLACE_CREATE_STORE_URL] Laden im Marktplatz erstellen].</string>
-	<string name="InventoryOutboxNoItemsTitle">Ihre Outbox ist leer.</string>
+	<string name="InventoryOutboxNotMerchant">
+		Wenn Sie als Händler aktiv werden möchten, müssen Sie einen [[MARKETPLACE_CREATE_STORE_URL] Laden im Marktplatz erstellen].
+	</string>
+	<string name="InventoryOutboxNoItemsTitle">
+		Ihre Outbox ist leer.
+	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
-	<string name="InventoryOutboxNoItems">Ziehen Sie Ordner in dien Bereich und klicken Sie auf „In Marktplatz übertragen“, um sie im [[MARKETPLACE_DASHBOARD_URL] Marktplatz] zum Verkauf anzubieten.</string>
-	<string name="InventoryOutboxInitializingTitle">Marktplatz wird initialisiert.</string>
-	<string name="InventoryOutboxInitializing">Wir greifen auf Ihr Konto im [[MARKETPLACE_CREATE_STORE_URL] Marktplatz-Laden] zu.</string>
-	<string name="InventoryOutboxErrorTitle">Marktplatzfehler.</string>
-	<string name="InventoryOutboxError">Der [[MARKETPLACE_CREATE_STORE_URL] Marktplatz-Laden] gibt Fehler zurück.</string>
-	<string name="InventoryMarketplaceError">Beim Öffnen der Marktplatz-Auflistungen ist ein Fehler aufgetreten.
-Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich unter http://support.secondlife.com an den Support von Second Life.</string>
-	<string name="InventoryMarketplaceListingsNoItemsTitle">Ihr Ordner mit Marktplatz-Auflistungen ist leer.</string>
-	<string name="InventoryMarketplaceListingsNoItems">Ziehen Sie Ordner in diesen Bereich, um sie im [[MARKETPLACE_DASHBOARD_URL] Marktplatz] zum Verkauf anzubieten.</string>
-	<string name="InventoryItemsCount">( [ITEMS_COUNT] Artikel )</string>
-	<string name="Marketplace Validation Warning Stock">Bestandsordner müssen in einem Versionsordner gespeichert sein</string>
-	<string name="Marketplace Validation Error Mixed Stock">: Fehler: Alle Objekte in einem Bestandsordner müssen kopiergeschützt und vom gleichen Typ sein.</string>
-	<string name="Marketplace Validation Error Subfolder In Stock">: Fehler: Bestandsordner kann keine Unterordner enthalten</string>
-	<string name="Marketplace Validation Warning Empty">: Warnung: Ordner enthält keine Objekte</string>
-	<string name="Marketplace Validation Warning Create Stock">: Warnung: Bestandsordner wird erstellt</string>
-	<string name="Marketplace Validation Warning Create Version">: Warnung: Versionsordner wird erstellt</string>
-	<string name="Marketplace Validation Warning Move">: Warnung: Objekte werden verschoben</string>
-	<string name="Marketplace Validation Warning Delete">: Warnung: Ordnerinhalte wurden in Bestandsordner übertragen; leerer Ordner wird entfernt</string>
-	<string name="Marketplace Validation Error Stock Item">: Fehler: Kopiergeschützte Objekte müssen in einem Bestandsordner gespeichert sein</string>
-	<string name="Marketplace Validation Warning Unwrapped Item">: Warnung: Objekte müssen in einem Versionsordner gespeichert sein</string>
-	<string name="Marketplace Validation Error">: Fehler:</string>
-	<string name="Marketplace Validation Warning">: Warnung:</string>
-	<string name="Marketplace Validation Error Empty Version">: Warnung: Versionsordner muss mindestens 1 Objekt enthalten</string>
-	<string name="Marketplace Validation Error Empty Stock">: Warnung: Bestandsordner muss mindestens 1 Objekt enthalten</string>
-	<string name="Marketplace Validation No Error">Keine Fehler oder Warnungen</string>
-	<string name="Marketplace Error None">Keine Fehler</string>
-	<string name="Marketplace Error Prefix">Fehler:</string>
-	<string name="Marketplace Error Not Merchant">Bevor Sie Artikel in den Marktplatz übertragen können, müssen Sie sich als Händler registrieren (kostenlos).</string>
-	<string name="Marketplace Error Not Accepted">Objekt kann nicht in diesen Ordner verschoben werden.</string>
-	<string name="Marketplace Error Unsellable Item">Dieses Objekt kann nicht im Marktplatz verkauft werden.</string>
-	<string name="MarketplaceNoID">keine Mkt-ID</string>
-	<string name="MarketplaceLive">aufgelistet</string>
-	<string name="MarketplaceActive">aktiv</string>
-	<string name="MarketplaceMax">max.</string>
-	<string name="MarketplaceStock">Bestand</string>
-	<string name="MarketplaceNoStock">ausverkauft</string>
-	<string name="MarketplaceUpdating">Aktualisierung läuft...</string>
-	<string name="UploadFeeInfo">Die Gebühr richtet sich nach deiner Abonnementstufe. Für höhere Stufen werden niedrigere Gebühren erhoben. [https://secondlife.com/my/account/membership.php? Mehr erfahren]</string>
-	<string name="Open landmarks">Wegweiser öffnen</string>
-	<string name="Unconstrained">Unbegrenzt</string>
+	<string name="InventoryOutboxNoItems">
+		Ziehen Sie Ordner in dien Bereich und klicken Sie auf „In Marktplatz übertragen“, um sie im [[MARKETPLACE_DASHBOARD_URL] Marktplatz] zum Verkauf anzubieten.
+	</string>
+	<string name="InventoryOutboxInitializingTitle">
+		Marktplatz wird initialisiert.
+	</string>
+	<string name="InventoryOutboxInitializing">
+		Wir greifen auf Ihr Konto im [[MARKETPLACE_CREATE_STORE_URL] Marktplatz-Laden] zu.
+	</string>
+	<string name="InventoryOutboxErrorTitle">
+		Marktplatzfehler.
+	</string>
+	<string name="InventoryOutboxError">
+		Der [[MARKETPLACE_CREATE_STORE_URL] Marktplatz-Laden] gibt Fehler zurück.
+	</string>
+	<string name="InventoryMarketplaceError">
+		Beim Öffnen der Marktplatz-Auflistungen ist ein Fehler aufgetreten.
+Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich unter http://support.secondlife.com an den Support von Second Life.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItemsTitle">
+		Ihr Ordner mit Marktplatz-Auflistungen ist leer.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItems">
+		Ziehen Sie Ordner in diesen Bereich, um sie im [[MARKETPLACE_DASHBOARD_URL] Marktplatz] zum Verkauf anzubieten.
+	</string>
+	<string name="InventoryItemsCount">
+		( [ITEMS_COUNT] Artikel )
+	</string>
+	<string name="Marketplace Validation Warning Stock">
+		Bestandsordner müssen in einem Versionsordner gespeichert sein
+	</string>
+	<string name="Marketplace Validation Error Mixed Stock">
+		: Fehler: Alle Objekte in einem Bestandsordner müssen kopiergeschützt und vom gleichen Typ sein.
+	</string>
+	<string name="Marketplace Validation Error Subfolder In Stock">
+		: Fehler: Bestandsordner kann keine Unterordner enthalten
+	</string>
+	<string name="Marketplace Validation Warning Empty">
+		: Warnung: Ordner enthält keine Objekte
+	</string>
+	<string name="Marketplace Validation Warning Create Stock">
+		: Warnung: Bestandsordner wird erstellt
+	</string>
+	<string name="Marketplace Validation Warning Create Version">
+		: Warnung: Versionsordner wird erstellt
+	</string>
+	<string name="Marketplace Validation Warning Move">
+		: Warnung: Objekte werden verschoben
+	</string>
+	<string name="Marketplace Validation Warning Delete">
+		: Warnung: Ordnerinhalte wurden in Bestandsordner übertragen; leerer Ordner wird entfernt
+	</string>
+	<string name="Marketplace Validation Error Stock Item">
+		: Fehler: Kopiergeschützte Objekte müssen in einem Bestandsordner gespeichert sein
+	</string>
+	<string name="Marketplace Validation Warning Unwrapped Item">
+		: Warnung: Objekte müssen in einem Versionsordner gespeichert sein
+	</string>
+	<string name="Marketplace Validation Error">
+		: Fehler:
+	</string>
+	<string name="Marketplace Validation Warning">
+		: Warnung:
+	</string>
+	<string name="Marketplace Validation Error Empty Version">
+		: Warnung: Versionsordner muss mindestens 1 Objekt enthalten
+	</string>
+	<string name="Marketplace Validation Error Empty Stock">
+		: Warnung: Bestandsordner muss mindestens 1 Objekt enthalten
+	</string>
+	<string name="Marketplace Validation No Error">
+		Keine Fehler oder Warnungen
+	</string>
+	<string name="Marketplace Error None">
+		Keine Fehler
+	</string>
+	<string name="Marketplace Error Prefix">
+		Fehler:
+	</string>
+	<string name="Marketplace Error Not Merchant">
+		Bevor Sie Artikel in den Marktplatz übertragen können, müssen Sie sich als Händler registrieren (kostenlos).
+	</string>
+	<string name="Marketplace Error Not Accepted">
+		Objekt kann nicht in diesen Ordner verschoben werden.
+	</string>
+	<string name="Marketplace Error Unsellable Item">
+		Dieses Objekt kann nicht im Marktplatz verkauft werden.
+	</string>
+	<string name="MarketplaceNoID">
+		keine Mkt-ID
+	</string>
+	<string name="MarketplaceLive">
+		aufgelistet
+	</string>
+	<string name="MarketplaceActive">
+		aktiv
+	</string>
+	<string name="MarketplaceMax">
+		max.
+	</string>
+	<string name="MarketplaceStock">
+		Bestand
+	</string>
+	<string name="MarketplaceNoStock">
+		ausverkauft
+	</string>
+	<string name="MarketplaceUpdating">
+		Aktualisierung läuft...
+	</string>
+	<string name="UploadFeeInfo">
+		Die Gebühr richtet sich nach deiner Abonnementstufe. Für höhere Stufen werden niedrigere Gebühren erhoben. [https://secondlife.com/my/account/membership.php? Mehr erfahren]
+	</string>
+	<string name="Open landmarks">
+		Wegweiser öffnen
+	</string>
+	<string name="Unconstrained">
+		Unbegrenzt
+	</string>
 	<string name="no_transfer" value=" (kein Transferieren)"/>
 	<string name="no_modify" value=" (kein Bearbeiten)"/>
 	<string name="no_copy" value=" (kein Kopieren)"/>
 	<string name="worn" value=" (getragen)"/>
 	<string name="link" value=" (Link)"/>
 	<string name="broken_link" value=" (unvollständiger_Link)"/>
-	<string name="LoadingContents">Inhalte werden geladen...</string>
-	<string name="NoContents">Keine Inhalte</string>
+	<string name="LoadingContents">
+		Inhalte werden geladen...
+	</string>
+	<string name="NoContents">
+		Keine Inhalte
+	</string>
 	<string name="WornOnAttachmentPoint" value=" (getragen am [ATTACHMENT_POINT])"/>
 	<string name="AttachmentErrorMessage" value="([ATTACHMENT_ERROR])"/>
 	<string name="ActiveGesture" value="[GESLABEL] (aktiviert)"/>
-	<string name="PermYes">Ja</string>
-	<string name="PermNo">Nein</string>
+	<string name="PermYes">
+		Ja
+	</string>
+	<string name="PermNo">
+		Nein
+	</string>
 	<string name="Chat Message" value="Chat:"/>
 	<string name="Sound" value=" Sound:"/>
 	<string name="Wait" value=" --- Warten:"/>
@@ -636,1443 +1704,4215 @@ Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich unter http://suppo
 	<string name="Snapshots" value=" Fotos,"/>
 	<string name="No Filters" value="Nein "/>
 	<string name="Since Logoff" value=" - Seit Abmeldung"/>
-	<string name="InvFolder My Inventory">Mein Inventar</string>
-	<string name="InvFolder Library">Bibliothek</string>
-	<string name="InvFolder Textures">Texturen</string>
-	<string name="InvFolder Sounds">Sounds</string>
-	<string name="InvFolder Calling Cards">Visitenkarten</string>
-	<string name="InvFolder Landmarks">Landmarken</string>
-	<string name="InvFolder Scripts">Skripts</string>
-	<string name="InvFolder Clothing">Kleidung</string>
-	<string name="InvFolder Objects">Objekte</string>
-	<string name="InvFolder Notecards">Notizkarten</string>
-	<string name="InvFolder New Folder">Neuer Ordner</string>
-	<string name="InvFolder Inventory">Inventar</string>
-	<string name="InvFolder Uncompressed Images">Nicht-Komprimierte Bilder</string>
-	<string name="InvFolder Body Parts">Körperteile</string>
-	<string name="InvFolder Trash">Papierkorb</string>
-	<string name="InvFolder Photo Album">Fotoalbum</string>
-	<string name="InvFolder Lost And Found">Fundbüro</string>
-	<string name="InvFolder Uncompressed Sounds">Nicht-Komprimierte Sounds</string>
-	<string name="InvFolder Animations">Animationen</string>
-	<string name="InvFolder Gestures">Gesten</string>
-	<string name="InvFolder Favorite">Meine Favoriten</string>
-	<string name="InvFolder favorite">Meine Favoriten</string>
-	<string name="InvFolder Favorites">Meine Favoriten</string>
-	<string name="InvFolder favorites">Meine Favoriten</string>
-	<string name="InvFolder Current Outfit">Aktuelles Outfit</string>
-	<string name="InvFolder Initial Outfits">Ursprüngliche Outfits</string>
-	<string name="InvFolder My Outfits">Meine Outfits</string>
-	<string name="InvFolder Accessories">Zubehör</string>
-	<string name="InvFolder Meshes">Netze</string>
-	<string name="InvFolder Received Items">Erhaltene Artikel</string>
-	<string name="InvFolder Merchant Outbox">Händler-Outbox</string>
-	<string name="InvFolder Friends">Freunde</string>
-	<string name="InvFolder All">Alle</string>
-	<string name="no_attachments">Keine Anhänge getragen</string>
-	<string name="Attachments remain">Anhänge (noch [COUNT] Positionen frei)</string>
-	<string name="Buy">Kaufen</string>
-	<string name="BuyforL$">Kaufen für L$</string>
-	<string name="Stone">Stein</string>
-	<string name="Metal">Metall</string>
-	<string name="Glass">Glas</string>
-	<string name="Wood">Holz</string>
-	<string name="Flesh">Fleisch</string>
-	<string name="Plastic">Plastik</string>
-	<string name="Rubber">Gummi</string>
-	<string name="Light">Hell</string>
-	<string name="KBShift">Umschalt-Taste</string>
-	<string name="KBCtrl">Strg</string>
-	<string name="Chest">Brust</string>
-	<string name="Skull">Schädel</string>
-	<string name="Left Shoulder">Linke Schulter</string>
-	<string name="Right Shoulder">Rechte Schulter</string>
-	<string name="Left Hand">Linke Hand</string>
-	<string name="Right Hand">Rechte Hand</string>
-	<string name="Left Foot">Linker Fuß</string>
-	<string name="Right Foot">Rechter Fuß</string>
-	<string name="Spine">Wirbelsäule</string>
-	<string name="Pelvis">Becken</string>
-	<string name="Mouth">Mund</string>
-	<string name="Chin">Kinn</string>
-	<string name="Left Ear">Linkes Ohr</string>
-	<string name="Right Ear">Rechtes Ohr</string>
-	<string name="Left Eyeball">Linker Augapfel</string>
-	<string name="Right Eyeball">Rechter Augapfel</string>
-	<string name="Nose">Nase</string>
-	<string name="R Upper Arm">R Oberarm</string>
-	<string name="R Forearm">R Unterarm</string>
-	<string name="L Upper Arm">L Oberarm</string>
-	<string name="L Forearm">L Unterarm</string>
-	<string name="Right Hip">Rechte Hüfte</string>
-	<string name="R Upper Leg">R Oberschenkel</string>
-	<string name="R Lower Leg">R Unterschenkel</string>
-	<string name="Left Hip">Linke Hüfte</string>
-	<string name="L Upper Leg">L Oberschenkel</string>
-	<string name="L Lower Leg">L Unterschenkel</string>
-	<string name="Stomach">Bauch</string>
-	<string name="Left Pec">Linke Brust</string>
-	<string name="Right Pec">Rechts</string>
-	<string name="Neck">Hals</string>
-	<string name="Avatar Center">Avatar-Mitte</string>
-	<string name="Left Ring Finger">Linker Ringfinger</string>
-	<string name="Right Ring Finger">Rechter Ringfinger</string>
-	<string name="Tail Base">Schwanzansatz</string>
-	<string name="Tail Tip">Schwanzspitze</string>
-	<string name="Left Wing">Linker Flügel</string>
-	<string name="Right Wing">Rechter Flügel</string>
-	<string name="Jaw">Kiefer</string>
-	<string name="Alt Left Ear">Alt. linkes Ohr</string>
-	<string name="Alt Right Ear">Alt. rechtes Ohr</string>
-	<string name="Alt Left Eye">Alt. linkes Auge</string>
-	<string name="Alt Right Eye">Alt. rechtes Auge</string>
-	<string name="Tongue">Zunge</string>
-	<string name="Groin">Leiste</string>
-	<string name="Left Hind Foot">Linker hinterer Fuß</string>
-	<string name="Right Hind Foot">Rechter hinterer Fuß</string>
-	<string name="Invalid Attachment">Ungültige Stelle für Anhang</string>
-	<string name="ATTACHMENT_MISSING_ITEM">Fehler: fehlendes Objekt</string>
-	<string name="ATTACHMENT_MISSING_BASE_ITEM">Fehler: Basisobjekt fehlt</string>
-	<string name="ATTACHMENT_NOT_ATTACHED">Fehler: Objekt ist im aktuellen Outfit, aber nicht angehängt</string>
-	<string name="YearsMonthsOld">[AGEYEARS] [AGEMONTHS] alt</string>
-	<string name="YearsOld">[AGEYEARS] alt</string>
-	<string name="MonthsOld">[AGEMONTHS] alt</string>
-	<string name="WeeksOld">[AGEWEEKS] alt</string>
-	<string name="DaysOld">[AGEDAYS] alt</string>
-	<string name="TodayOld">Seit heute Mitglied</string>
-	<string name="av_render_everyone_now">Jetzt kann jeder Sie sehen.</string>
-	<string name="av_render_not_everyone">Sie sind u. U. nicht für alle Leute in Ihrer Nähe sichtbar.</string>
-	<string name="av_render_over_half">Sie sind u. U. für mehr als die Hälfte der Leute in Ihrer Nähe nicht sichtbar.</string>
-	<string name="av_render_most_of">Sie sind u. U. für die meisten Leuten in Ihrer Nähe nicht sichtbar.</string>
-	<string name="av_render_anyone">Sie sind u. U. für niemanden in Ihrer Nähe sichtbar.</string>
-	<string name="hud_description_total">Ihr HUD</string>
-	<string name="hud_name_with_joint">[OBJ_NAME] (getragen von [JNT_NAME])</string>
-	<string name="hud_render_memory_warning">[HUD_DETAILS] beansprucht viel Texturspeicher</string>
-	<string name="hud_render_cost_warning">[HUD_DETAILS] enthält zu viele ressourcenintensive Objekte und Texturen</string>
-	<string name="hud_render_heavy_textures_warning">[HUD_DETAILS] enthält viele große Texturen</string>
-	<string name="hud_render_cramped_warning">[HUD_DETAILS] enthält zu viele Objekte</string>
-	<string name="hud_render_textures_warning">[HUD_DETAILS] enthält zu viele Texturen</string>
-	<string name="AgeYearsA">[COUNT] Jahr</string>
-	<string name="AgeYearsB">[COUNT] Jahre</string>
-	<string name="AgeYearsC">[COUNT] Jahre</string>
-	<string name="AgeMonthsA">[COUNT] Monat</string>
-	<string name="AgeMonthsB">[COUNT] Monate</string>
-	<string name="AgeMonthsC">[COUNT] Monate</string>
-	<string name="AgeWeeksA">[COUNT] Woche</string>
-	<string name="AgeWeeksB">[COUNT] Wochen</string>
-	<string name="AgeWeeksC">[COUNT] Wochen</string>
-	<string name="AgeDaysA">[COUNT] Tag</string>
-	<string name="AgeDaysB">[COUNT] Tage</string>
-	<string name="AgeDaysC">[COUNT] Tage</string>
-	<string name="GroupMembersA">[COUNT] Mitglied</string>
-	<string name="GroupMembersB">[COUNT] Mitglieder</string>
-	<string name="GroupMembersC">[COUNT] Mitglieder</string>
-	<string name="AcctTypeResident">Einwohner</string>
-	<string name="AcctTypeTrial">Test</string>
-	<string name="AcctTypeCharterMember">Charta-Mitglied</string>
-	<string name="AcctTypeEmployee">Linden Lab-Mitarbeiter</string>
-	<string name="PaymentInfoUsed">Zahlungsinfo verwendet</string>
-	<string name="PaymentInfoOnFile">Zahlungsinfo archiviert</string>
-	<string name="NoPaymentInfoOnFile">Keine Zahlungsinfo archiviert</string>
-	<string name="AgeVerified">Altersgeprüft</string>
-	<string name="NotAgeVerified">Nicht altersgeprüft</string>
-	<string name="Center 2">Mitte 2</string>
-	<string name="Top Right">Oben rechts</string>
-	<string name="Top">Oben</string>
-	<string name="Top Left">Oben links</string>
-	<string name="Center">Mitte</string>
-	<string name="Bottom Left">Unten links</string>
-	<string name="Bottom">Unten</string>
-	<string name="Bottom Right">Unten rechts</string>
-	<string name="CompileQueueDownloadedCompiling">Heruntergeladen, wird kompiliert</string>
-	<string name="CompileQueueServiceUnavailable">Kein Skriptkompilierungsdienst verfügbar</string>
-	<string name="CompileQueueScriptNotFound">Skript wurde auf Server nicht gefunden.</string>
-	<string name="CompileQueueProblemDownloading">Beim Herunterladen ist ein Problem aufgetreten</string>
-	<string name="CompileQueueInsufficientPermDownload">Unzureichende Rechte zum Herunterladen eines Skripts.</string>
-	<string name="CompileQueueInsufficientPermFor">Unzureichende Berechtigungen für</string>
-	<string name="CompileQueueUnknownFailure">Unbekannter Fehler beim Herunterladen</string>
-	<string name="CompileNoExperiencePerm">Skript „[SCRIPT]“ mit Erlebnis „[EXPERIENCE]“ wird übersprungen.</string>
-	<string name="CompileQueueTitle">Rekompilierung</string>
-	<string name="CompileQueueStart">rekompilieren</string>
-	<string name="ResetQueueTitle">Zurücksetzen</string>
-	<string name="ResetQueueStart">Zurücksetzen</string>
-	<string name="RunQueueTitle">Skript ausführen</string>
-	<string name="RunQueueStart">Skript ausführen</string>
-	<string name="NotRunQueueTitle">Skript anhalten</string>
-	<string name="NotRunQueueStart">Skript anhalten</string>
-	<string name="CompileSuccessful">Kompilieren erfolgreich abgeschlossen!</string>
-	<string name="CompileSuccessfulSaving">Kompilieren erfolgreich abgeschlossen, speichern...</string>
-	<string name="SaveComplete">Speichervorgang abgeschlossen.</string>
-	<string name="UploadFailed">Datei-Upload fehlgeschlagen:</string>
-	<string name="ObjectOutOfRange">Skript (Objekt außerhalb des Bereichs)</string>
-	<string name="ScriptWasDeleted">Skript (aus Inventar gelöscht)</string>
-	<string name="GodToolsObjectOwnedBy">Objekt [OBJECT], Besitzer [OWNER]</string>
-	<string name="GroupsNone">keine</string>
+	<string name="InvFolder My Inventory">
+		Mein Inventar
+	</string>
+	<string name="InvFolder Library">
+		Bibliothek
+	</string>
+	<string name="InvFolder Textures">
+		Texturen
+	</string>
+	<string name="InvFolder Sounds">
+		Sounds
+	</string>
+	<string name="InvFolder Calling Cards">
+		Visitenkarten
+	</string>
+	<string name="InvFolder Landmarks">
+		Landmarken
+	</string>
+	<string name="InvFolder Scripts">
+		Skripts
+	</string>
+	<string name="InvFolder Clothing">
+		Kleidung
+	</string>
+	<string name="InvFolder Objects">
+		Objekte
+	</string>
+	<string name="InvFolder Notecards">
+		Notizkarten
+	</string>
+	<string name="InvFolder New Folder">
+		Neuer Ordner
+	</string>
+	<string name="InvFolder Inventory">
+		Inventar
+	</string>
+	<string name="InvFolder Uncompressed Images">
+		Nicht-Komprimierte Bilder
+	</string>
+	<string name="InvFolder Body Parts">
+		Körperteile
+	</string>
+	<string name="InvFolder Trash">
+		Papierkorb
+	</string>
+	<string name="InvFolder Photo Album">
+		Fotoalbum
+	</string>
+	<string name="InvFolder Lost And Found">
+		Fundbüro
+	</string>
+	<string name="InvFolder Uncompressed Sounds">
+		Nicht-Komprimierte Sounds
+	</string>
+	<string name="InvFolder Animations">
+		Animationen
+	</string>
+	<string name="InvFolder Gestures">
+		Gesten
+	</string>
+	<string name="InvFolder Favorite">
+		Meine Favoriten
+	</string>
+	<string name="InvFolder favorite">
+		Meine Favoriten
+	</string>
+	<string name="InvFolder Favorites">
+		Meine Favoriten
+	</string>
+	<string name="InvFolder favorites">
+		Meine Favoriten
+	</string>
+	<string name="InvFolder Current Outfit">
+		Aktuelles Outfit
+	</string>
+	<string name="InvFolder Initial Outfits">
+		Ursprüngliche Outfits
+	</string>
+	<string name="InvFolder My Outfits">
+		Meine Outfits
+	</string>
+	<string name="InvFolder Accessories">
+		Zubehör
+	</string>
+	<string name="InvFolder Meshes">
+		Netze
+	</string>
+	<string name="InvFolder Received Items">
+		Erhaltene Artikel
+	</string>
+	<string name="InvFolder Merchant Outbox">
+		Händler-Outbox
+	</string>
+	<string name="InvFolder Friends">
+		Freunde
+	</string>
+	<string name="InvFolder All">
+		Alle
+	</string>
+	<string name="no_attachments">
+		Keine Anhänge getragen
+	</string>
+	<string name="Attachments remain">
+		Anhänge (noch [COUNT] Positionen frei)
+	</string>
+	<string name="Buy">
+		Kaufen
+	</string>
+	<string name="BuyforL$">
+		Kaufen für L$
+	</string>
+	<string name="Stone">
+		Stein
+	</string>
+	<string name="Metal">
+		Metall
+	</string>
+	<string name="Glass">
+		Glas
+	</string>
+	<string name="Wood">
+		Holz
+	</string>
+	<string name="Flesh">
+		Fleisch
+	</string>
+	<string name="Plastic">
+		Plastik
+	</string>
+	<string name="Rubber">
+		Gummi
+	</string>
+	<string name="Light">
+		Hell
+	</string>
+	<string name="KBShift">
+		Umschalt-Taste
+	</string>
+	<string name="KBCtrl">
+		Strg
+	</string>
+	<string name="Chest">
+		Brust
+	</string>
+	<string name="Skull">
+		Schädel
+	</string>
+	<string name="Left Shoulder">
+		Linke Schulter
+	</string>
+	<string name="Right Shoulder">
+		Rechte Schulter
+	</string>
+	<string name="Left Hand">
+		Linke Hand
+	</string>
+	<string name="Right Hand">
+		Rechte Hand
+	</string>
+	<string name="Left Foot">
+		Linker Fuß
+	</string>
+	<string name="Right Foot">
+		Rechter Fuß
+	</string>
+	<string name="Spine">
+		Wirbelsäule
+	</string>
+	<string name="Pelvis">
+		Becken
+	</string>
+	<string name="Mouth">
+		Mund
+	</string>
+	<string name="Chin">
+		Kinn
+	</string>
+	<string name="Left Ear">
+		Linkes Ohr
+	</string>
+	<string name="Right Ear">
+		Rechtes Ohr
+	</string>
+	<string name="Left Eyeball">
+		Linker Augapfel
+	</string>
+	<string name="Right Eyeball">
+		Rechter Augapfel
+	</string>
+	<string name="Nose">
+		Nase
+	</string>
+	<string name="R Upper Arm">
+		R Oberarm
+	</string>
+	<string name="R Forearm">
+		R Unterarm
+	</string>
+	<string name="L Upper Arm">
+		L Oberarm
+	</string>
+	<string name="L Forearm">
+		L Unterarm
+	</string>
+	<string name="Right Hip">
+		Rechte Hüfte
+	</string>
+	<string name="R Upper Leg">
+		R Oberschenkel
+	</string>
+	<string name="R Lower Leg">
+		R Unterschenkel
+	</string>
+	<string name="Left Hip">
+		Linke Hüfte
+	</string>
+	<string name="L Upper Leg">
+		L Oberschenkel
+	</string>
+	<string name="L Lower Leg">
+		L Unterschenkel
+	</string>
+	<string name="Stomach">
+		Bauch
+	</string>
+	<string name="Left Pec">
+		Linke Brust
+	</string>
+	<string name="Right Pec">
+		Rechts
+	</string>
+	<string name="Neck">
+		Hals
+	</string>
+	<string name="Avatar Center">
+		Avatar-Mitte
+	</string>
+	<string name="Left Ring Finger">
+		Linker Ringfinger
+	</string>
+	<string name="Right Ring Finger">
+		Rechter Ringfinger
+	</string>
+	<string name="Tail Base">
+		Schwanzansatz
+	</string>
+	<string name="Tail Tip">
+		Schwanzspitze
+	</string>
+	<string name="Left Wing">
+		Linker Flügel
+	</string>
+	<string name="Right Wing">
+		Rechter Flügel
+	</string>
+	<string name="Jaw">
+		Kiefer
+	</string>
+	<string name="Alt Left Ear">
+		Alt. linkes Ohr
+	</string>
+	<string name="Alt Right Ear">
+		Alt. rechtes Ohr
+	</string>
+	<string name="Alt Left Eye">
+		Alt. linkes Auge
+	</string>
+	<string name="Alt Right Eye">
+		Alt. rechtes Auge
+	</string>
+	<string name="Tongue">
+		Zunge
+	</string>
+	<string name="Groin">
+		Leiste
+	</string>
+	<string name="Left Hind Foot">
+		Linker hinterer Fuß
+	</string>
+	<string name="Right Hind Foot">
+		Rechter hinterer Fuß
+	</string>
+	<string name="Invalid Attachment">
+		Ungültige Stelle für Anhang
+	</string>
+	<string name="ATTACHMENT_MISSING_ITEM">
+		Fehler: fehlendes Objekt
+	</string>
+	<string name="ATTACHMENT_MISSING_BASE_ITEM">
+		Fehler: Basisobjekt fehlt
+	</string>
+	<string name="ATTACHMENT_NOT_ATTACHED">
+		Fehler: Objekt ist im aktuellen Outfit, aber nicht angehängt
+	</string>
+	<string name="YearsMonthsOld">
+		[AGEYEARS] [AGEMONTHS] alt
+	</string>
+	<string name="YearsOld">
+		[AGEYEARS] alt
+	</string>
+	<string name="MonthsOld">
+		[AGEMONTHS] alt
+	</string>
+	<string name="WeeksOld">
+		[AGEWEEKS] alt
+	</string>
+	<string name="DaysOld">
+		[AGEDAYS] alt
+	</string>
+	<string name="TodayOld">
+		Seit heute Mitglied
+	</string>
+	<string name="av_render_everyone_now">
+		Jetzt kann jeder Sie sehen.
+	</string>
+	<string name="av_render_not_everyone">
+		Sie sind u. U. nicht für alle Leute in Ihrer Nähe sichtbar.
+	</string>
+	<string name="av_render_over_half">
+		Sie sind u. U. für mehr als die Hälfte der Leute in Ihrer Nähe nicht sichtbar.
+	</string>
+	<string name="av_render_most_of">
+		Sie sind u. U. für die meisten Leuten in Ihrer Nähe nicht sichtbar.
+	</string>
+	<string name="av_render_anyone">
+		Sie sind u. U. für niemanden in Ihrer Nähe sichtbar.
+	</string>
+	<string name="hud_description_total">
+		Ihr HUD
+	</string>
+	<string name="hud_name_with_joint">
+		[OBJ_NAME] (getragen von [JNT_NAME])
+	</string>
+	<string name="hud_render_memory_warning">
+		[HUD_DETAILS] beansprucht viel Texturspeicher
+	</string>
+	<string name="hud_render_cost_warning">
+		[HUD_DETAILS] enthält zu viele ressourcenintensive Objekte und Texturen
+	</string>
+	<string name="hud_render_heavy_textures_warning">
+		[HUD_DETAILS] enthält viele große Texturen
+	</string>
+	<string name="hud_render_cramped_warning">
+		[HUD_DETAILS] enthält zu viele Objekte
+	</string>
+	<string name="hud_render_textures_warning">
+		[HUD_DETAILS] enthält zu viele Texturen
+	</string>
+	<string name="AgeYearsA">
+		[COUNT] Jahr
+	</string>
+	<string name="AgeYearsB">
+		[COUNT] Jahre
+	</string>
+	<string name="AgeYearsC">
+		[COUNT] Jahre
+	</string>
+	<string name="AgeMonthsA">
+		[COUNT] Monat
+	</string>
+	<string name="AgeMonthsB">
+		[COUNT] Monate
+	</string>
+	<string name="AgeMonthsC">
+		[COUNT] Monate
+	</string>
+	<string name="AgeWeeksA">
+		[COUNT] Woche
+	</string>
+	<string name="AgeWeeksB">
+		[COUNT] Wochen
+	</string>
+	<string name="AgeWeeksC">
+		[COUNT] Wochen
+	</string>
+	<string name="AgeDaysA">
+		[COUNT] Tag
+	</string>
+	<string name="AgeDaysB">
+		[COUNT] Tage
+	</string>
+	<string name="AgeDaysC">
+		[COUNT] Tage
+	</string>
+	<string name="GroupMembersA">
+		[COUNT] Mitglied
+	</string>
+	<string name="GroupMembersB">
+		[COUNT] Mitglieder
+	</string>
+	<string name="GroupMembersC">
+		[COUNT] Mitglieder
+	</string>
+	<string name="AcctTypeResident">
+		Einwohner
+	</string>
+	<string name="AcctTypeTrial">
+		Test
+	</string>
+	<string name="AcctTypeCharterMember">
+		Charta-Mitglied
+	</string>
+	<string name="AcctTypeEmployee">
+		Linden Lab-Mitarbeiter
+	</string>
+	<string name="PaymentInfoUsed">
+		Zahlungsinfo verwendet
+	</string>
+	<string name="PaymentInfoOnFile">
+		Zahlungsinfo archiviert
+	</string>
+	<string name="NoPaymentInfoOnFile">
+		Keine Zahlungsinfo archiviert
+	</string>
+	<string name="AgeVerified">
+		Altersgeprüft
+	</string>
+	<string name="NotAgeVerified">
+		Nicht altersgeprüft
+	</string>
+	<string name="Center 2">
+		Mitte 2
+	</string>
+	<string name="Top Right">
+		Oben rechts
+	</string>
+	<string name="Top">
+		Oben
+	</string>
+	<string name="Top Left">
+		Oben links
+	</string>
+	<string name="Center">
+		Mitte
+	</string>
+	<string name="Bottom Left">
+		Unten links
+	</string>
+	<string name="Bottom">
+		Unten
+	</string>
+	<string name="Bottom Right">
+		Unten rechts
+	</string>
+	<string name="CompileQueueDownloadedCompiling">
+		Heruntergeladen, wird kompiliert
+	</string>
+	<string name="CompileQueueServiceUnavailable">
+		Kein Skriptkompilierungsdienst verfügbar
+	</string>
+	<string name="CompileQueueScriptNotFound">
+		Skript wurde auf Server nicht gefunden.
+	</string>
+	<string name="CompileQueueProblemDownloading">
+		Beim Herunterladen ist ein Problem aufgetreten
+	</string>
+	<string name="CompileQueueInsufficientPermDownload">
+		Unzureichende Rechte zum Herunterladen eines Skripts.
+	</string>
+	<string name="CompileQueueInsufficientPermFor">
+		Unzureichende Berechtigungen für
+	</string>
+	<string name="CompileQueueUnknownFailure">
+		Unbekannter Fehler beim Herunterladen
+	</string>
+	<string name="CompileNoExperiencePerm">
+		Skript „[SCRIPT]“ mit Erlebnis „[EXPERIENCE]“ wird übersprungen.
+	</string>
+	<string name="CompileQueueTitle">
+		Rekompilierung
+	</string>
+	<string name="CompileQueueStart">
+		rekompilieren
+	</string>
+	<string name="ResetQueueTitle">
+		Zurücksetzen
+	</string>
+	<string name="ResetQueueStart">
+		Zurücksetzen
+	</string>
+	<string name="RunQueueTitle">
+		Skript ausführen
+	</string>
+	<string name="RunQueueStart">
+		Skript ausführen
+	</string>
+	<string name="NotRunQueueTitle">
+		Skript anhalten
+	</string>
+	<string name="NotRunQueueStart">
+		Skript anhalten
+	</string>
+	<string name="CompileSuccessful">
+		Kompilieren erfolgreich abgeschlossen!
+	</string>
+	<string name="CompileSuccessfulSaving">
+		Kompilieren erfolgreich abgeschlossen, speichern...
+	</string>
+	<string name="SaveComplete">
+		Speichervorgang abgeschlossen.
+	</string>
+	<string name="UploadFailed">
+		Datei-Upload fehlgeschlagen:
+	</string>
+	<string name="ObjectOutOfRange">
+		Skript (Objekt außerhalb des Bereichs)
+	</string>
+	<string name="ScriptWasDeleted">
+		Skript (aus Inventar gelöscht)
+	</string>
+	<string name="GodToolsObjectOwnedBy">
+		Objekt [OBJECT], Besitzer [OWNER]
+	</string>
+	<string name="GroupsNone">
+		keine
+	</string>
 	<string name="Group" value=" (Gruppe)"/>
-	<string name="Unknown">(unbekannt)</string>
+	<string name="Unknown">
+		(unbekannt)
+	</string>
 	<string name="SummaryForTheWeek" value="Zusammenfassung für diese Woche, beginnend am "/>
 	<string name="NextStipendDay" value=". Der nächste Stipendium-Tag ist "/>
-	<string name="GroupPlanningDate">[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]</string>
+	<string name="GroupPlanningDate">
+		[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]
+	</string>
 	<string name="GroupIndividualShare" value="                      Gruppenanteil       Einzelanteil"/>
 	<string name="GroupColumn" value="Gruppe"/>
-	<string name="Balance">Kontostand</string>
-	<string name="Credits">Danksagung</string>
-	<string name="Debits">Soll</string>
-	<string name="Total">Gesamtbetrag</string>
-	<string name="NoGroupDataFound">Für Gruppe wurden keine Gruppendaten gefunden</string>
-	<string name="IMParentEstate">parent estate</string>
-	<string name="IMMainland">Mainland</string>
-	<string name="IMTeen">Teen</string>
-	<string name="Anyone">jeder</string>
-	<string name="RegionInfoError">Fehler</string>
-	<string name="RegionInfoAllEstatesOwnedBy">alle Grundbesitze gehören [OWNER]</string>
-	<string name="RegionInfoAllEstatesYouOwn">alle Grundbesitze, die Sie besitzen</string>
-	<string name="RegionInfoAllEstatesYouManage">alle Grundbesitze, die Sie für [OWNER] verwalten</string>
-	<string name="RegionInfoAllowedResidents">Immer zulässig: ([ALLOWEDAGENTS], max. [MAXACCESS])</string>
-	<string name="RegionInfoAllowedGroups">Immer zugelassene Gruppen: ([ALLOWEDGROUPS], max. [MAXACCESS])</string>
-	<string name="RegionInfoBannedResidents">Immer verbannt: ([BANNEDAGENTS], max. [MAXBANNED])</string>
-	<string name="RegionInfoListTypeAllowedAgents">Immer zugelassen</string>
-	<string name="RegionInfoListTypeBannedAgents">Immer verbannt</string>
-	<string name="RegionInfoAllEstates">alle Grundbesitze</string>
-	<string name="RegionInfoManagedEstates">verwaltete Grundbesitze</string>
-	<string name="RegionInfoThisEstate">dieser Grundbesitz</string>
-	<string name="AndNMore">und [EXTRA_COUNT] weitere</string>
-	<string name="ScriptLimitsParcelScriptMemory">Parzellenskript-Speicher</string>
-	<string name="ScriptLimitsParcelsOwned">Aufgeführte Parzellen: [PARCELS]</string>
-	<string name="ScriptLimitsMemoryUsed">Verwendeter Speicher: [COUNT] KB von [MAX] KB; [AVAILABLE] KB verfügbar</string>
-	<string name="ScriptLimitsMemoryUsedSimple">Verwendeter Speicher: [COUNT] KB</string>
-	<string name="ScriptLimitsParcelScriptURLs">Parzelleskript-URLs</string>
-	<string name="ScriptLimitsURLsUsed">Verwendete URLs: [COUNT] von [MAX]; [AVAILABLE] verfügbar</string>
-	<string name="ScriptLimitsURLsUsedSimple">Verwendete URLs: [COUNT]</string>
-	<string name="ScriptLimitsRequestError">Fehler bei Informationsabruf</string>
-	<string name="ScriptLimitsRequestNoParcelSelected">Keine Parzellen wurden ausgewählt</string>
-	<string name="ScriptLimitsRequestWrongRegion">Fehler: Skriptinformationen sind nur für Ihre aktuelle Region verfügbar</string>
-	<string name="ScriptLimitsRequestWaiting">Informationen werden abgerufen...</string>
-	<string name="ScriptLimitsRequestDontOwnParcel">Sie sind nicht berechtigt, diese Parzelle zu untersuchen.</string>
-	<string name="SITTING_ON">sitzt auf</string>
-	<string name="ATTACH_CHEST">Brust</string>
-	<string name="ATTACH_HEAD">Schädel</string>
-	<string name="ATTACH_LSHOULDER">Linke Schulter</string>
-	<string name="ATTACH_RSHOULDER">Rechte Schulter</string>
-	<string name="ATTACH_LHAND">Linke Hand</string>
-	<string name="ATTACH_RHAND">Rechte Hand</string>
-	<string name="ATTACH_LFOOT">Linker Fuß</string>
-	<string name="ATTACH_RFOOT">Rechter Fuß</string>
-	<string name="ATTACH_BACK">Wirbelsäule</string>
-	<string name="ATTACH_PELVIS">Becken</string>
-	<string name="ATTACH_MOUTH">Mund</string>
-	<string name="ATTACH_CHIN">Kinn</string>
-	<string name="ATTACH_LEAR">Linkes Ohr</string>
-	<string name="ATTACH_REAR">Rechtes Ohr</string>
-	<string name="ATTACH_LEYE">Linkes Auge</string>
-	<string name="ATTACH_REYE">Rechtes Auge</string>
-	<string name="ATTACH_NOSE">Nase</string>
-	<string name="ATTACH_RUARM">Rechter Oberarm</string>
-	<string name="ATTACH_RLARM">Rechter Unterarm</string>
-	<string name="ATTACH_LUARM">Linker Oberarm</string>
-	<string name="ATTACH_LLARM">Linker Unterarm</string>
-	<string name="ATTACH_RHIP">Rechte Hüfte</string>
-	<string name="ATTACH_RULEG">Rechter Oberschenkel</string>
-	<string name="ATTACH_RLLEG">Rechter Unterschenkel</string>
-	<string name="ATTACH_LHIP">Linke Hüfte</string>
-	<string name="ATTACH_LULEG">Linker Oberschenkel</string>
-	<string name="ATTACH_LLLEG">Linker Unterschenkel</string>
-	<string name="ATTACH_BELLY">Bauch</string>
-	<string name="ATTACH_LEFT_PEC">Linke Brust</string>
-	<string name="ATTACH_RIGHT_PEC">Rechte Brust</string>
-	<string name="ATTACH_HUD_CENTER_2">HUD Mitte 2</string>
-	<string name="ATTACH_HUD_TOP_RIGHT">HUD oben rechts</string>
-	<string name="ATTACH_HUD_TOP_CENTER">HUD oben Mitte</string>
-	<string name="ATTACH_HUD_TOP_LEFT">HUD oben links</string>
-	<string name="ATTACH_HUD_CENTER_1">HUD Mitte 1</string>
-	<string name="ATTACH_HUD_BOTTOM_LEFT">HUD unten links</string>
-	<string name="ATTACH_HUD_BOTTOM">HUD unten</string>
-	<string name="ATTACH_HUD_BOTTOM_RIGHT">HUD unten rechts</string>
-	<string name="ATTACH_NECK">Hals</string>
-	<string name="ATTACH_AVATAR_CENTER">Avatar-Mitte</string>
-	<string name="ATTACH_LHAND_RING1">Linker Ringfinger</string>
-	<string name="ATTACH_RHAND_RING1">Rechter Ringfinger</string>
-	<string name="ATTACH_TAIL_BASE">Schwanzansatz</string>
-	<string name="ATTACH_TAIL_TIP">Schwanzspitze</string>
-	<string name="ATTACH_LWING">Linker Flügel</string>
-	<string name="ATTACH_RWING">Rechter Flügel</string>
-	<string name="ATTACH_FACE_JAW">Kiefer</string>
-	<string name="ATTACH_FACE_LEAR">Alt. linkes Ohr</string>
-	<string name="ATTACH_FACE_REAR">Alt. rechtes Ohr</string>
-	<string name="ATTACH_FACE_LEYE">Alt. linkes Auge</string>
-	<string name="ATTACH_FACE_REYE">Alt. rechtes Auge</string>
-	<string name="ATTACH_FACE_TONGUE">Zunge</string>
-	<string name="ATTACH_GROIN">Leiste</string>
-	<string name="ATTACH_HIND_LFOOT">Linker hinterer Fuß</string>
-	<string name="ATTACH_HIND_RFOOT">Rechter hinterer Fuß</string>
-	<string name="CursorPos">Zeile [LINE], Spalte [COLUMN]</string>
-	<string name="PanelDirCountFound">[COUNT] gefunden</string>
-	<string name="PanelDirTimeStr">[hour12,datetime,slt]:[min,datetime,slt] [ampm,datetime,slt]</string>
-	<string name="PanelDirEventsDateText">[mthnum,datetime,slt]/[day,datetime,slt]</string>
-	<string name="PanelContentsTooltip">Objektinhalt</string>
-	<string name="PanelContentsNewScript">Neues Skript</string>
-	<string name="DoNotDisturbModeResponseDefault">Dieser Einwohner hat den Nicht-stören-Modus aktiviert und wird Ihre Nachricht später sehen.</string>
-	<string name="MuteByName">(Nach Namen)</string>
-	<string name="MuteAgent">(Einwohner)</string>
-	<string name="MuteObject">(Objekt)</string>
-	<string name="MuteGroup">(Gruppe)</string>
-	<string name="MuteExternal">(Extern)</string>
-	<string name="RegionNoCovenant">Für diesen Grundbesitz liegt kein Vertrag vor.</string>
-	<string name="RegionNoCovenantOtherOwner">Für diesen Grundbesitz liegt kein Vertrag vor. Das Land auf diesem Grundbesitz wird vom Grundbesitzer und nicht von Linden Lab verkauft.  Für Informationen zum Verkauf setzen Sie sich bitte mit dem Grundbesitzer in Verbindung.</string>
+	<string name="Balance">
+		Kontostand
+	</string>
+	<string name="Credits">
+		Danksagung
+	</string>
+	<string name="Debits">
+		Soll
+	</string>
+	<string name="Total">
+		Gesamtbetrag
+	</string>
+	<string name="NoGroupDataFound">
+		Für Gruppe wurden keine Gruppendaten gefunden
+	</string>
+	<string name="IMParentEstate">
+		parent estate
+	</string>
+	<string name="IMMainland">
+		Mainland
+	</string>
+	<string name="IMTeen">
+		Teen
+	</string>
+	<string name="Anyone">
+		jeder
+	</string>
+	<string name="RegionInfoError">
+		Fehler
+	</string>
+	<string name="RegionInfoAllEstatesOwnedBy">
+		alle Grundbesitze gehören [OWNER]
+	</string>
+	<string name="RegionInfoAllEstatesYouOwn">
+		alle Grundbesitze, die Sie besitzen
+	</string>
+	<string name="RegionInfoAllEstatesYouManage">
+		alle Grundbesitze, die Sie für [OWNER] verwalten
+	</string>
+	<string name="RegionInfoAllowedResidents">
+		Immer zulässig: ([ALLOWEDAGENTS], max. [MAXACCESS])
+	</string>
+	<string name="RegionInfoAllowedGroups">
+		Immer zugelassene Gruppen: ([ALLOWEDGROUPS], max. [MAXACCESS])
+	</string>
+	<string name="RegionInfoBannedResidents">
+		Immer verbannt: ([BANNEDAGENTS], max. [MAXBANNED])
+	</string>
+	<string name="RegionInfoListTypeAllowedAgents">
+		Immer zugelassen
+	</string>
+	<string name="RegionInfoListTypeBannedAgents">
+		Immer verbannt
+	</string>
+	<string name="RegionInfoAllEstates">
+		alle Grundbesitze
+	</string>
+	<string name="RegionInfoManagedEstates">
+		verwaltete Grundbesitze
+	</string>
+	<string name="RegionInfoThisEstate">
+		dieser Grundbesitz
+	</string>
+	<string name="AndNMore">
+		und [EXTRA_COUNT] weitere
+	</string>
+	<string name="ScriptLimitsParcelScriptMemory">
+		Parzellenskript-Speicher
+	</string>
+	<string name="ScriptLimitsParcelsOwned">
+		Aufgeführte Parzellen: [PARCELS]
+	</string>
+	<string name="ScriptLimitsMemoryUsed">
+		Verwendeter Speicher: [COUNT] KB von [MAX] KB; [AVAILABLE] KB verfügbar
+	</string>
+	<string name="ScriptLimitsMemoryUsedSimple">
+		Verwendeter Speicher: [COUNT] KB
+	</string>
+	<string name="ScriptLimitsParcelScriptURLs">
+		Parzelleskript-URLs
+	</string>
+	<string name="ScriptLimitsURLsUsed">
+		Verwendete URLs: [COUNT] von [MAX]; [AVAILABLE] verfügbar
+	</string>
+	<string name="ScriptLimitsURLsUsedSimple">
+		Verwendete URLs: [COUNT]
+	</string>
+	<string name="ScriptLimitsRequestError">
+		Fehler bei Informationsabruf
+	</string>
+	<string name="ScriptLimitsRequestNoParcelSelected">
+		Keine Parzellen wurden ausgewählt
+	</string>
+	<string name="ScriptLimitsRequestWrongRegion">
+		Fehler: Skriptinformationen sind nur für Ihre aktuelle Region verfügbar
+	</string>
+	<string name="ScriptLimitsRequestWaiting">
+		Informationen werden abgerufen...
+	</string>
+	<string name="ScriptLimitsRequestDontOwnParcel">
+		Sie sind nicht berechtigt, diese Parzelle zu untersuchen.
+	</string>
+	<string name="SITTING_ON">
+		sitzt auf
+	</string>
+	<string name="ATTACH_CHEST">
+		Brust
+	</string>
+	<string name="ATTACH_HEAD">
+		Schädel
+	</string>
+	<string name="ATTACH_LSHOULDER">
+		Linke Schulter
+	</string>
+	<string name="ATTACH_RSHOULDER">
+		Rechte Schulter
+	</string>
+	<string name="ATTACH_LHAND">
+		Linke Hand
+	</string>
+	<string name="ATTACH_RHAND">
+		Rechte Hand
+	</string>
+	<string name="ATTACH_LFOOT">
+		Linker Fuß
+	</string>
+	<string name="ATTACH_RFOOT">
+		Rechter Fuß
+	</string>
+	<string name="ATTACH_BACK">
+		Wirbelsäule
+	</string>
+	<string name="ATTACH_PELVIS">
+		Becken
+	</string>
+	<string name="ATTACH_MOUTH">
+		Mund
+	</string>
+	<string name="ATTACH_CHIN">
+		Kinn
+	</string>
+	<string name="ATTACH_LEAR">
+		Linkes Ohr
+	</string>
+	<string name="ATTACH_REAR">
+		Rechtes Ohr
+	</string>
+	<string name="ATTACH_LEYE">
+		Linkes Auge
+	</string>
+	<string name="ATTACH_REYE">
+		Rechtes Auge
+	</string>
+	<string name="ATTACH_NOSE">
+		Nase
+	</string>
+	<string name="ATTACH_RUARM">
+		Rechter Oberarm
+	</string>
+	<string name="ATTACH_RLARM">
+		Rechter Unterarm
+	</string>
+	<string name="ATTACH_LUARM">
+		Linker Oberarm
+	</string>
+	<string name="ATTACH_LLARM">
+		Linker Unterarm
+	</string>
+	<string name="ATTACH_RHIP">
+		Rechte Hüfte
+	</string>
+	<string name="ATTACH_RULEG">
+		Rechter Oberschenkel
+	</string>
+	<string name="ATTACH_RLLEG">
+		Rechter Unterschenkel
+	</string>
+	<string name="ATTACH_LHIP">
+		Linke Hüfte
+	</string>
+	<string name="ATTACH_LULEG">
+		Linker Oberschenkel
+	</string>
+	<string name="ATTACH_LLLEG">
+		Linker Unterschenkel
+	</string>
+	<string name="ATTACH_BELLY">
+		Bauch
+	</string>
+	<string name="ATTACH_LEFT_PEC">
+		Linke Brust
+	</string>
+	<string name="ATTACH_RIGHT_PEC">
+		Rechte Brust
+	</string>
+	<string name="ATTACH_HUD_CENTER_2">
+		HUD Mitte 2
+	</string>
+	<string name="ATTACH_HUD_TOP_RIGHT">
+		HUD oben rechts
+	</string>
+	<string name="ATTACH_HUD_TOP_CENTER">
+		HUD oben Mitte
+	</string>
+	<string name="ATTACH_HUD_TOP_LEFT">
+		HUD oben links
+	</string>
+	<string name="ATTACH_HUD_CENTER_1">
+		HUD Mitte 1
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_LEFT">
+		HUD unten links
+	</string>
+	<string name="ATTACH_HUD_BOTTOM">
+		HUD unten
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_RIGHT">
+		HUD unten rechts
+	</string>
+	<string name="ATTACH_NECK">
+		Hals
+	</string>
+	<string name="ATTACH_AVATAR_CENTER">
+		Avatar-Mitte
+	</string>
+	<string name="ATTACH_LHAND_RING1">
+		Linker Ringfinger
+	</string>
+	<string name="ATTACH_RHAND_RING1">
+		Rechter Ringfinger
+	</string>
+	<string name="ATTACH_TAIL_BASE">
+		Schwanzansatz
+	</string>
+	<string name="ATTACH_TAIL_TIP">
+		Schwanzspitze
+	</string>
+	<string name="ATTACH_LWING">
+		Linker Flügel
+	</string>
+	<string name="ATTACH_RWING">
+		Rechter Flügel
+	</string>
+	<string name="ATTACH_FACE_JAW">
+		Kiefer
+	</string>
+	<string name="ATTACH_FACE_LEAR">
+		Alt. linkes Ohr
+	</string>
+	<string name="ATTACH_FACE_REAR">
+		Alt. rechtes Ohr
+	</string>
+	<string name="ATTACH_FACE_LEYE">
+		Alt. linkes Auge
+	</string>
+	<string name="ATTACH_FACE_REYE">
+		Alt. rechtes Auge
+	</string>
+	<string name="ATTACH_FACE_TONGUE">
+		Zunge
+	</string>
+	<string name="ATTACH_GROIN">
+		Leiste
+	</string>
+	<string name="ATTACH_HIND_LFOOT">
+		Linker hinterer Fuß
+	</string>
+	<string name="ATTACH_HIND_RFOOT">
+		Rechter hinterer Fuß
+	</string>
+	<string name="CursorPos">
+		Zeile [LINE], Spalte [COLUMN]
+	</string>
+	<string name="PanelDirCountFound">
+		[COUNT] gefunden
+	</string>
+	<string name="PanelDirTimeStr">
+		[hour12,datetime,slt]:[min,datetime,slt] [ampm,datetime,slt]
+	</string>
+	<string name="PanelDirEventsDateText">
+		[mthnum,datetime,slt]/[day,datetime,slt]
+	</string>
+	<string name="PanelContentsTooltip">
+		Objektinhalt
+	</string>
+	<string name="PanelContentsNewScript">
+		Neues Skript
+	</string>
+	<string name="DoNotDisturbModeResponseDefault">
+		Dieser Einwohner hat den Nicht-stören-Modus aktiviert und wird Ihre Nachricht später sehen.
+	</string>
+	<string name="MuteByName">
+		(Nach Namen)
+	</string>
+	<string name="MuteAgent">
+		(Einwohner)
+	</string>
+	<string name="MuteObject">
+		(Objekt)
+	</string>
+	<string name="MuteGroup">
+		(Gruppe)
+	</string>
+	<string name="MuteExternal">
+		(Extern)
+	</string>
+	<string name="RegionNoCovenant">
+		Für diesen Grundbesitz liegt kein Vertrag vor.
+	</string>
+	<string name="RegionNoCovenantOtherOwner">
+		Für diesen Grundbesitz liegt kein Vertrag vor. Das Land auf diesem Grundbesitz wird vom Grundbesitzer und nicht von Linden Lab verkauft.  Für Informationen zum Verkauf setzen Sie sich bitte mit dem Grundbesitzer in Verbindung.
+	</string>
 	<string name="covenant_last_modified" value="Zuletzt geändert: "/>
 	<string name="none_text" value=" (keiner) "/>
 	<string name="never_text" value=" (nie) "/>
-	<string name="GroupOwned">In Gruppenbesitz</string>
-	<string name="Public">Öffentlich</string>
-	<string name="LocalSettings">Lokale Einstellungen</string>
-	<string name="RegionSettings">Regionseinstellungen</string>
-	<string name="NoEnvironmentSettings">Diese Region unterstützt keine Umgebungseinstellungen.</string>
-	<string name="EnvironmentSun">Sonne</string>
-	<string name="EnvironmentMoon">Mond</string>
-	<string name="EnvironmentBloom">Bloom</string>
-	<string name="EnvironmentCloudNoise">Wolkenrauschen</string>
-	<string name="EnvironmentNormalMap">Normal-Map</string>
-	<string name="EnvironmentTransparent">Transparent</string>
-	<string name="ClassifiedClicksTxt">Klicks: [TELEPORT] teleportieren, [MAP] Karte, [PROFILE] Profil</string>
-	<string name="ClassifiedUpdateAfterPublish">(wird nach Veröffentlichung aktualisiert)</string>
-	<string name="NoPicksClassifiedsText">Sie haben keine Auswahl oder Anzeigen erstelllt. Klicken Sie auf die „Plus&quot;-Schaltfläche, um eine Auswahl oder Anzeige zu erstellen.</string>
-	<string name="NoPicksText">Sie haben keine Auswahl erstellt. Klicken Sie auf die Schaltfläche &quot;Neu&quot;, um eine Auswahl zu erstellen.</string>
-	<string name="NoClassifiedsText">Sie haben keine Anzeigen erstellt. Klicken Sie auf die Schaltfläche &quot;Neu&quot;, um eine Anzeige zu erstellen.</string>
-	<string name="NoAvatarPicksClassifiedsText">Der Einwohner hat keine Auswahl oder Anzeigen</string>
-	<string name="NoAvatarPicksText">Der Einwohner hat keine Auswahl</string>
-	<string name="NoAvatarClassifiedsText">Der Einwohner hat keine Anzeigen</string>
-	<string name="PicksClassifiedsLoadingText">Wird geladen...</string>
-	<string name="MultiPreviewTitle">Vorschau</string>
-	<string name="MultiPropertiesTitle">Eigenschaften</string>
-	<string name="InvOfferAnObjectNamed">Ein Objekt namens</string>
-	<string name="InvOfferOwnedByGroup">im Besitz der Gruppe</string>
-	<string name="InvOfferOwnedByUnknownGroup">im Besitz einer unbekannten Gruppe</string>
-	<string name="InvOfferOwnedBy">im Besitz von</string>
-	<string name="InvOfferOwnedByUnknownUser">im Besitz eines unbekannten Einwohners</string>
-	<string name="InvOfferGaveYou">hat Ihnen folgendes übergeben</string>
-	<string name="InvOfferDecline">Sie lehnen [DESC] von &lt;nolink&gt;[NAME]&lt;/nolink&gt; ab.</string>
-	<string name="GroupMoneyTotal">Gesamtbetrag</string>
-	<string name="GroupMoneyBought">gekauft</string>
-	<string name="GroupMoneyPaidYou">bezahlte Ihnen</string>
-	<string name="GroupMoneyPaidInto">bezahlte an</string>
-	<string name="GroupMoneyBoughtPassTo">kaufte Pass für</string>
-	<string name="GroupMoneyPaidFeeForEvent">bezahlte Gebühr für Event</string>
-	<string name="GroupMoneyPaidPrizeForEvent">bezahlte Preis für Event</string>
-	<string name="GroupMoneyBalance">Kontostand</string>
-	<string name="GroupMoneyCredits">Danksagung</string>
-	<string name="GroupMoneyDebits">Soll</string>
-	<string name="GroupMoneyDate">[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]</string>
-	<string name="AcquiredItems">Erworbene Artikel</string>
-	<string name="Cancel">Abbrechen</string>
-	<string name="UploadingCosts">Das Hochladen von [NAME] kostet [AMOUNT] L$</string>
-	<string name="BuyingCosts">Die Kosten betragen: [AMOUNT] L$</string>
-	<string name="UnknownFileExtension">Unbekanntes Dateiformat .%s
-Gültige Formate: .wav, .tga, .bmp, .jpg, .jpeg oder .bvh</string>
-	<string name="MuteObject2">Ignorieren</string>
-	<string name="MuteAvatar">Ignorieren</string>
-	<string name="UnmuteObject">Freischalten</string>
-	<string name="UnmuteAvatar">Freischalten</string>
-	<string name="AddLandmarkNavBarMenu">Zu meinen Landmarken hinzufügen...</string>
-	<string name="EditLandmarkNavBarMenu">Meine Landmarken bearbeiten...</string>
-	<string name="accel-mac-control">⌃</string>
-	<string name="accel-mac-command">⌘</string>
-	<string name="accel-mac-option">⌥</string>
-	<string name="accel-mac-shift">⇧</string>
-	<string name="accel-win-control">Strg+</string>
-	<string name="accel-win-alt">Alt+</string>
-	<string name="accel-win-shift">Umschalt+</string>
-	<string name="FileSaved">Datei wurde gespeichert</string>
-	<string name="Receiving">Daten werden empfangen</string>
-	<string name="AM">Uhr</string>
-	<string name="PM">Uhr</string>
-	<string name="PST">PST</string>
-	<string name="PDT">PDT</string>
-	<string name="Direction_Forward">Vorwärts</string>
-	<string name="Direction_Left">Links</string>
-	<string name="Direction_Right">Rechts</string>
-	<string name="Direction_Back">Zurück</string>
-	<string name="Direction_North">Norden</string>
-	<string name="Direction_South">Süden</string>
-	<string name="Direction_West">Westen</string>
-	<string name="Direction_East">Osten</string>
-	<string name="Direction_Up">Nach oben</string>
-	<string name="Direction_Down">Nach unten</string>
-	<string name="Any Category">Alle Kategorien</string>
-	<string name="Shopping">Shopping</string>
-	<string name="Land Rental">Land mieten</string>
-	<string name="Property Rental">Immobilie mieten</string>
-	<string name="Special Attraction">Attraktionen</string>
-	<string name="New Products">Neue Produkte</string>
-	<string name="Employment">Stellenangebote</string>
-	<string name="Wanted">Gesucht</string>
-	<string name="Service">Dienstleistungen</string>
-	<string name="Personal">Sonstiges</string>
-	<string name="None">Keiner</string>
-	<string name="Linden Location">Lindenort</string>
-	<string name="Adult">Adult</string>
-	<string name="Arts&amp;Culture">Kunst &amp; Kultur</string>
-	<string name="Business">Firmen</string>
-	<string name="Educational">Bildung</string>
-	<string name="Gaming">Spielen</string>
-	<string name="Hangout">Treffpunkt</string>
-	<string name="Newcomer Friendly">Anfängergerecht</string>
-	<string name="Parks&amp;Nature">Parks und Natur</string>
-	<string name="Residential">Wohngebiet</string>
-	<string name="Stage">Phase</string>
-	<string name="Other">Sonstige</string>
-	<string name="Rental">Vermietung</string>
-	<string name="Any">Alle</string>
-	<string name="You">Sie</string>
-	<string name=":">:</string>
-	<string name=",">,</string>
-	<string name="...">...</string>
-	<string name="***">***</string>
-	<string name="(">(</string>
-	<string name=")">)</string>
-	<string name=".">.</string>
-	<string name="'">'</string>
-	<string name="---">---</string>
-	<string name="Multiple Media">Mehrere Medien</string>
-	<string name="Play Media">Medien Abspielen/Pausieren</string>
-	<string name="IntelDriverPage">http://www.intel.com/p/en_US/support/detect/graphics</string>
-	<string name="NvidiaDriverPage">http://www.nvidia.com/Download/index.aspx?lang=de-de</string>
-	<string name="AMDDriverPage">http://support.amd.com/de/Pages/AMDSupportHub.aspx</string>
-	<string name="MBCmdLineError">Beim Parsen der Befehlszeile wurde ein Fehler festgestellt.
+	<string name="GroupOwned">
+		In Gruppenbesitz
+	</string>
+	<string name="Public">
+		Öffentlich
+	</string>
+	<string name="LocalSettings">
+		Lokale Einstellungen
+	</string>
+	<string name="RegionSettings">
+		Regionseinstellungen
+	</string>
+	<string name="NoEnvironmentSettings">
+		Diese Region unterstützt keine Umgebungseinstellungen.
+	</string>
+	<string name="EnvironmentSun">
+		Sonne
+	</string>
+	<string name="EnvironmentMoon">
+		Mond
+	</string>
+	<string name="EnvironmentBloom">
+		Bloom
+	</string>
+	<string name="EnvironmentCloudNoise">
+		Wolkenrauschen
+	</string>
+	<string name="EnvironmentNormalMap">
+		Normal-Map
+	</string>
+	<string name="EnvironmentTransparent">
+		Transparent
+	</string>
+	<string name="ClassifiedClicksTxt">
+		Klicks: [TELEPORT] teleportieren, [MAP] Karte, [PROFILE] Profil
+	</string>
+	<string name="ClassifiedUpdateAfterPublish">
+		(wird nach Veröffentlichung aktualisiert)
+	</string>
+	<string name="NoPicksClassifiedsText">
+		Sie haben keine Auswahl oder Anzeigen erstelllt. Klicken Sie auf die „Plus"-Schaltfläche, um eine Auswahl oder Anzeige zu erstellen.
+	</string>
+	<string name="NoPicksText">
+		Sie haben keine Auswahl erstellt. Klicken Sie auf die Schaltfläche "Neu", um eine Auswahl zu erstellen.
+	</string>
+	<string name="NoClassifiedsText">
+		Sie haben keine Anzeigen erstellt. Klicken Sie auf die Schaltfläche "Neu", um eine Anzeige zu erstellen.
+	</string>
+	<string name="NoAvatarPicksClassifiedsText">
+		Der Einwohner hat keine Auswahl oder Anzeigen
+	</string>
+	<string name="NoAvatarPicksText">
+		Der Einwohner hat keine Auswahl
+	</string>
+	<string name="NoAvatarClassifiedsText">
+		Der Einwohner hat keine Anzeigen
+	</string>
+	<string name="PicksClassifiedsLoadingText">
+		Wird geladen...
+	</string>
+	<string name="MultiPreviewTitle">
+		Vorschau
+	</string>
+	<string name="MultiPropertiesTitle">
+		Eigenschaften
+	</string>
+	<string name="InvOfferAnObjectNamed">
+		Ein Objekt namens
+	</string>
+	<string name="InvOfferOwnedByGroup">
+		im Besitz der Gruppe
+	</string>
+	<string name="InvOfferOwnedByUnknownGroup">
+		im Besitz einer unbekannten Gruppe
+	</string>
+	<string name="InvOfferOwnedBy">
+		im Besitz von
+	</string>
+	<string name="InvOfferOwnedByUnknownUser">
+		im Besitz eines unbekannten Einwohners
+	</string>
+	<string name="InvOfferGaveYou">
+		hat Ihnen folgendes übergeben
+	</string>
+	<string name="InvOfferDecline">
+		Sie lehnen [DESC] von &lt;nolink&gt;[NAME]&lt;/nolink&gt; ab.
+	</string>
+	<string name="GroupMoneyTotal">
+		Gesamtbetrag
+	</string>
+	<string name="GroupMoneyBought">
+		gekauft
+	</string>
+	<string name="GroupMoneyPaidYou">
+		bezahlte Ihnen
+	</string>
+	<string name="GroupMoneyPaidInto">
+		bezahlte an
+	</string>
+	<string name="GroupMoneyBoughtPassTo">
+		kaufte Pass für
+	</string>
+	<string name="GroupMoneyPaidFeeForEvent">
+		bezahlte Gebühr für Event
+	</string>
+	<string name="GroupMoneyPaidPrizeForEvent">
+		bezahlte Preis für Event
+	</string>
+	<string name="GroupMoneyBalance">
+		Kontostand
+	</string>
+	<string name="GroupMoneyCredits">
+		Danksagung
+	</string>
+	<string name="GroupMoneyDebits">
+		Soll
+	</string>
+	<string name="GroupMoneyDate">
+		[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]
+	</string>
+	<string name="AcquiredItems">
+		Erworbene Artikel
+	</string>
+	<string name="Cancel">
+		Abbrechen
+	</string>
+	<string name="UploadingCosts">
+		Das Hochladen von [NAME] kostet [AMOUNT] L$
+	</string>
+	<string name="BuyingCosts">
+		Die Kosten betragen: [AMOUNT] L$
+	</string>
+	<string name="UnknownFileExtension">
+		Unbekanntes Dateiformat .%s
+Gültige Formate: .wav, .tga, .bmp, .jpg, .jpeg oder .bvh
+	</string>
+	<string name="MuteObject2">
+		Ignorieren
+	</string>
+	<string name="MuteAvatar">
+		Ignorieren
+	</string>
+	<string name="UnmuteObject">
+		Freischalten
+	</string>
+	<string name="UnmuteAvatar">
+		Freischalten
+	</string>
+	<string name="AddLandmarkNavBarMenu">
+		Zu meinen Landmarken hinzufügen...
+	</string>
+	<string name="EditLandmarkNavBarMenu">
+		Meine Landmarken bearbeiten...
+	</string>
+	<string name="accel-mac-control">
+		⌃
+	</string>
+	<string name="accel-mac-command">
+		⌘
+	</string>
+	<string name="accel-mac-option">
+		⌥
+	</string>
+	<string name="accel-mac-shift">
+		⇧
+	</string>
+	<string name="accel-win-control">
+		Strg+
+	</string>
+	<string name="accel-win-alt">
+		Alt+
+	</string>
+	<string name="accel-win-shift">
+		Umschalt+
+	</string>
+	<string name="FileSaved">
+		Datei wurde gespeichert
+	</string>
+	<string name="Receiving">
+		Daten werden empfangen
+	</string>
+	<string name="AM">
+		Uhr
+	</string>
+	<string name="PM">
+		Uhr
+	</string>
+	<string name="PST">
+		PST
+	</string>
+	<string name="PDT">
+		PDT
+	</string>
+	<string name="Direction_Forward">
+		Vorwärts
+	</string>
+	<string name="Direction_Left">
+		Links
+	</string>
+	<string name="Direction_Right">
+		Rechts
+	</string>
+	<string name="Direction_Back">
+		Zurück
+	</string>
+	<string name="Direction_North">
+		Norden
+	</string>
+	<string name="Direction_South">
+		Süden
+	</string>
+	<string name="Direction_West">
+		Westen
+	</string>
+	<string name="Direction_East">
+		Osten
+	</string>
+	<string name="Direction_Up">
+		Nach oben
+	</string>
+	<string name="Direction_Down">
+		Nach unten
+	</string>
+	<string name="Any Category">
+		Alle Kategorien
+	</string>
+	<string name="Shopping">
+		Shopping
+	</string>
+	<string name="Land Rental">
+		Land mieten
+	</string>
+	<string name="Property Rental">
+		Immobilie mieten
+	</string>
+	<string name="Special Attraction">
+		Attraktionen
+	</string>
+	<string name="New Products">
+		Neue Produkte
+	</string>
+	<string name="Employment">
+		Stellenangebote
+	</string>
+	<string name="Wanted">
+		Gesucht
+	</string>
+	<string name="Service">
+		Dienstleistungen
+	</string>
+	<string name="Personal">
+		Sonstiges
+	</string>
+	<string name="None">
+		Keiner
+	</string>
+	<string name="Linden Location">
+		Lindenort
+	</string>
+	<string name="Adult">
+		Adult
+	</string>
+	<string name="Arts&amp;Culture">
+		Kunst &amp; Kultur
+	</string>
+	<string name="Business">
+		Firmen
+	</string>
+	<string name="Educational">
+		Bildung
+	</string>
+	<string name="Gaming">
+		Spielen
+	</string>
+	<string name="Hangout">
+		Treffpunkt
+	</string>
+	<string name="Newcomer Friendly">
+		Anfängergerecht
+	</string>
+	<string name="Parks&amp;Nature">
+		Parks und Natur
+	</string>
+	<string name="Residential">
+		Wohngebiet
+	</string>
+	<string name="Stage">
+		Phase
+	</string>
+	<string name="Other">
+		Sonstige
+	</string>
+	<string name="Rental">
+		Vermietung
+	</string>
+	<string name="Any">
+		Alle
+	</string>
+	<string name="You">
+		Sie
+	</string>
+	<string name=":">
+		:
+	</string>
+	<string name=",">
+		,
+	</string>
+	<string name="...">
+		...
+	</string>
+	<string name="***">
+		***
+	</string>
+	<string name="(">
+		(
+	</string>
+	<string name=")">
+		)
+	</string>
+	<string name=".">
+		.
+	</string>
+	<string name="'">
+		'
+	</string>
+	<string name="---">
+		---
+	</string>
+	<string name="Multiple Media">
+		Mehrere Medien
+	</string>
+	<string name="Play Media">
+		Medien Abspielen/Pausieren
+	</string>
+	<string name="IntelDriverPage">
+		http://www.intel.com/p/en_US/support/detect/graphics
+	</string>
+	<string name="NvidiaDriverPage">
+		http://www.nvidia.com/Download/index.aspx?lang=de-de
+	</string>
+	<string name="AMDDriverPage">
+		http://support.amd.com/de/Pages/AMDSupportHub.aspx
+	</string>
+	<string name="MBCmdLineError">
+		Beim Parsen der Befehlszeile wurde ein Fehler festgestellt.
 Weitere Informationen: http://wiki.secondlife.com/wiki/Client_parameters (EN)
-Fehler:</string>
-	<string name="MBCmdLineUsg">[APP_NAME] Verwendung in Befehlszeile:</string>
-	<string name="MBUnableToAccessFile">[APP_NAME] kann auf die erforderliche Datei nicht zugreifen.
+Fehler:
+	</string>
+	<string name="MBCmdLineUsg">
+		[APP_NAME] Verwendung in Befehlszeile:
+	</string>
+	<string name="MBUnableToAccessFile">
+		[APP_NAME] kann auf die erforderliche Datei nicht zugreifen.
 
 Grund hierfür ist, dass Sie entweder mehrere Instanzen gleichzeitig ausführen oder dass Ihr System denkt, eine Datei sei geöffnet.
 Falls diese Nachricht erneut angezeigt wird, starten Sie bitte Ihren Computer neu und probieren Sie es noch einmal.
-Falls der Fehler dann weiterhin auftritt, müssen Sie [APP_NAME] von Ihrem System de-installieren und erneut installieren.</string>
-	<string name="MBFatalError">Unbehebbarer Fehler</string>
-	<string name="MBRequiresAltiVec">[APP_NAME] erfordert einen Prozessor mit AltiVec (G4 oder später).</string>
-	<string name="MBAlreadyRunning">[APP_NAME] läuft bereits.
+Falls der Fehler dann weiterhin auftritt, müssen Sie [APP_NAME] von Ihrem System de-installieren und erneut installieren.
+	</string>
+	<string name="MBFatalError">
+		Unbehebbarer Fehler
+	</string>
+	<string name="MBRequiresAltiVec">
+		[APP_NAME] erfordert einen Prozessor mit AltiVec (G4 oder später).
+	</string>
+	<string name="MBAlreadyRunning">
+		[APP_NAME] läuft bereits.
 Bitte sehen Sie in Ihrer Menüleiste nach, dort sollte ein Symbol für das Programm angezeigt werden.
-Falls diese Nachricht erneut angezeigt wird, starten Sie Ihren Computer bitte neu.</string>
-	<string name="MBFrozenCrashed">[APP_NAME] scheint eingefroren zu sein oder ist abgestürzt.
-Möchten Sie einen Absturz-Bericht einschicken?</string>
-	<string name="MBAlert">Benachrichtigung</string>
-	<string name="MBNoDirectX">[APP_NAME] kann DirectX 9.0b oder höher nicht feststellen.
+Falls diese Nachricht erneut angezeigt wird, starten Sie Ihren Computer bitte neu.
+	</string>
+	<string name="MBFrozenCrashed">
+		[APP_NAME] scheint eingefroren zu sein oder ist abgestürzt.
+Möchten Sie einen Absturz-Bericht einschicken?
+	</string>
+	<string name="MBAlert">
+		Benachrichtigung
+	</string>
+	<string name="MBNoDirectX">
+		[APP_NAME] kann DirectX 9.0b oder höher nicht feststellen.
 [APP_NAME] verwendet DirectX, um nach Hardware und/oder veralteten Treibern zu suchen, die zu Problemen mit der Stabilität, Leistung und Abstürzen führen können.  Sie können [APP_NAME] auch so ausführen, wir empfehlen jedoch, dass DirectX 9.0b vorhanden ist und ausgeführt wird.
 
-Möchten Sie fortfahren?</string>
-	<string name="MBWarning">Hinweis</string>
-	<string name="MBNoAutoUpdate">Für Linux ist zur Zeit noch kein automatisches Aktualisieren möglich.
-Bitte laden Sie die aktuellste Version von www.secondlife.com herunter.</string>
-	<string name="MBRegClassFailed">RegisterClass fehlgeschlagen</string>
-	<string name="MBError">Fehler</string>
-	<string name="MBFullScreenErr">Vollbildschirm mit [WIDTH] x [HEIGHT] kann nicht ausgeführt werden.
-Ausführung erfolgt in Fenster.</string>
-	<string name="MBDestroyWinFailed">Fehler beim Herunterfahren während Fenster geschlossen wurde (DestroyWindow() fehlgeschlagen)</string>
-	<string name="MBShutdownErr">Fehler beim Herunterfahren</string>
-	<string name="MBDevContextErr">Kann keinen Kontext für GL-Gerät erstellen</string>
-	<string name="MBPixelFmtErr">Passendes Pixelformat wurde nicht gefunden</string>
-	<string name="MBPixelFmtDescErr">Beschreibung für Pixelformat nicht verfügbar</string>
-	<string name="MBTrueColorWindow">Um [APP_NAME] auszuführen, ist True Color (32-bit) erforderlich.
-Klicken Sie öffnen Sie auf Ihrem Computer die Einstellungen für die Anzeige und stellen Sie den Bildschirm auf 32-bit Farbe ein.</string>
-	<string name="MBAlpha">[APP_NAME] kann nicht ausgeführt werden, da kein 8-Bit-Alpha-Kanal verfügbar ist.  Dies geschieht normalerweise bei Problemen mit dem Treiber der Video-Karte.
+Möchten Sie fortfahren?
+	</string>
+	<string name="MBWarning">
+		Hinweis
+	</string>
+	<string name="MBNoAutoUpdate">
+		Für Linux ist zur Zeit noch kein automatisches Aktualisieren möglich.
+Bitte laden Sie die aktuellste Version von www.secondlife.com herunter.
+	</string>
+	<string name="MBRegClassFailed">
+		RegisterClass fehlgeschlagen
+	</string>
+	<string name="MBError">
+		Fehler
+	</string>
+	<string name="MBFullScreenErr">
+		Vollbildschirm mit [WIDTH] x [HEIGHT] kann nicht ausgeführt werden.
+Ausführung erfolgt in Fenster.
+	</string>
+	<string name="MBDestroyWinFailed">
+		Fehler beim Herunterfahren während Fenster geschlossen wurde (DestroyWindow() fehlgeschlagen)
+	</string>
+	<string name="MBShutdownErr">
+		Fehler beim Herunterfahren
+	</string>
+	<string name="MBDevContextErr">
+		Kann keinen Kontext für GL-Gerät erstellen
+	</string>
+	<string name="MBPixelFmtErr">
+		Passendes Pixelformat wurde nicht gefunden
+	</string>
+	<string name="MBPixelFmtDescErr">
+		Beschreibung für Pixelformat nicht verfügbar
+	</string>
+	<string name="MBTrueColorWindow">
+		Um [APP_NAME] auszuführen, ist True Color (32-bit) erforderlich.
+Klicken Sie öffnen Sie auf Ihrem Computer die Einstellungen für die Anzeige und stellen Sie den Bildschirm auf 32-bit Farbe ein.
+	</string>
+	<string name="MBAlpha">
+		[APP_NAME] kann nicht ausgeführt werden, da kein 8-Bit-Alpha-Kanal verfügbar ist.  Dies geschieht normalerweise bei Problemen mit dem Treiber der Video-Karte.
 Bitte vergewissern Sie sich, dass Sie die aktuellsten Treiber für Ihre Videokarte installiert haben.
 Vergewissern Sie sich außerdem, dass Ihr Bildschirm auf True Color (32-Bit) eingestellt ist (Systemsteuerung &gt; Anzeige &gt; Einstellungen).
-Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].</string>
-	<string name="MBPixelFmtSetErr">Pixel-Format kann nicht eingestellt werden.</string>
-	<string name="MBGLContextErr">Kann keinen Kontext für GL-Gerät erstellen</string>
-	<string name="MBGLContextActErr">Kann keinen Kontext für GL-Gerät aktivieren</string>
-	<string name="MBVideoDrvErr">[APP_NAME] kann nicht ausgeführt werden, da die Treiber Ihrer Videokarte entweder nicht richtig installiert oder veraltet sind, oder die entsprechende Hardware nicht unterstützt wird. Bitte vergewissern Sie sich, dass Sie die aktuellsten Treiber für die Videokarte installiert haben. Falls Sie die aktuellsten Treiber bereits installiert haben, installieren Sie diese bitte erneut.
+Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].
+	</string>
+	<string name="MBPixelFmtSetErr">
+		Pixel-Format kann nicht eingestellt werden.
+	</string>
+	<string name="MBGLContextErr">
+		Kann keinen Kontext für GL-Gerät erstellen
+	</string>
+	<string name="MBGLContextActErr">
+		Kann keinen Kontext für GL-Gerät aktivieren
+	</string>
+	<string name="MBVideoDrvErr">
+		[APP_NAME] kann nicht ausgeführt werden, da die Treiber Ihrer Videokarte entweder nicht richtig installiert oder veraltet sind, oder die entsprechende Hardware nicht unterstützt wird. Bitte vergewissern Sie sich, dass Sie die aktuellsten Treiber für die Videokarte installiert haben. Falls Sie die aktuellsten Treiber bereits installiert haben, installieren Sie diese bitte erneut.
 
-Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].</string>
-	<string name="5 O'Clock Shadow">Bartschatten</string>
-	<string name="All White">Ganz weiß</string>
-	<string name="Anime Eyes">Anime-Augen</string>
-	<string name="Arced">Gewölbt</string>
-	<string name="Arm Length">Armlänge</string>
-	<string name="Attached">Angewachsen</string>
-	<string name="Attached Earlobes">Angewachsene Ohrläppchen</string>
-	<string name="Back Fringe">Nackenfransen</string>
-	<string name="Baggy">Tränensäcke</string>
-	<string name="Bangs">Pony</string>
-	<string name="Beady Eyes">Knopfaugen</string>
-	<string name="Belly Size">Bauchgröße</string>
-	<string name="Big">Groß</string>
-	<string name="Big Butt">Großer Hintern</string>
-	<string name="Big Hair Back">Volumen: Hinten</string>
-	<string name="Big Hair Front">Volumen: Vorne</string>
-	<string name="Big Hair Top">Volumen: Oben</string>
-	<string name="Big Head">Groß</string>
-	<string name="Big Pectorals">Große Brustmuskeln</string>
-	<string name="Big Spikes">Große Stacheln</string>
-	<string name="Black">Schwarz</string>
-	<string name="Blonde">Blond</string>
-	<string name="Blonde Hair">Blondes Haar</string>
-	<string name="Blush">Rouge</string>
-	<string name="Blush Color">Rougefarbe</string>
-	<string name="Blush Opacity">Rouge Deckkraft</string>
-	<string name="Body Definition">Körperkonturen</string>
-	<string name="Body Fat">Körperfett</string>
-	<string name="Body Freckles">Sommersprossen</string>
-	<string name="Body Thick">breit</string>
-	<string name="Body Thickness">Körperbreite</string>
-	<string name="Body Thin">schmal</string>
-	<string name="Bow Legged">o-beinig</string>
-	<string name="Breast Buoyancy">Brust, Straffheit</string>
-	<string name="Breast Cleavage">Dekolleté</string>
-	<string name="Breast Size">Brustgröße</string>
-	<string name="Bridge Width">Rückenbreite</string>
-	<string name="Broad">Breit</string>
-	<string name="Brow Size">Brauengröße</string>
-	<string name="Bug Eyes">Glubschaugen</string>
-	<string name="Bugged Eyes">Hervortretend</string>
-	<string name="Bulbous">Knollennase</string>
-	<string name="Bulbous Nose">Knollennase</string>
-	<string name="Breast Physics Mass">Brust – Masse</string>
-	<string name="Breast Physics Smoothing">Brust – Glättung</string>
-	<string name="Breast Physics Gravity">Brust – Schwerkraft</string>
-	<string name="Breast Physics Drag">Brust – Luftwiderstand</string>
-	<string name="Breast Physics InOut Max Effect">Max. Effekt</string>
-	<string name="Breast Physics InOut Spring">Federn</string>
-	<string name="Breast Physics InOut Gain">Verstärkung</string>
-	<string name="Breast Physics InOut Damping">Dämpfung</string>
-	<string name="Breast Physics UpDown Max Effect">Max. Effekt</string>
-	<string name="Breast Physics UpDown Spring">Federn</string>
-	<string name="Breast Physics UpDown Gain">Verstärkung</string>
-	<string name="Breast Physics UpDown Damping">Dämpfung</string>
-	<string name="Breast Physics LeftRight Max Effect">Max. Effekt</string>
-	<string name="Breast Physics LeftRight Spring">Federn</string>
-	<string name="Breast Physics LeftRight Gain">Verstärkung</string>
-	<string name="Breast Physics LeftRight Damping">Dämpfung</string>
-	<string name="Belly Physics Mass">Bauch – Masse</string>
-	<string name="Belly Physics Smoothing">Bauch – Glättung</string>
-	<string name="Belly Physics Gravity">Bauch – Schwerkraft</string>
-	<string name="Belly Physics Drag">Bauch – Luftwiderstand</string>
-	<string name="Belly Physics UpDown Max Effect">Max. Effekt</string>
-	<string name="Belly Physics UpDown Spring">Federn</string>
-	<string name="Belly Physics UpDown Gain">Verstärkung</string>
-	<string name="Belly Physics UpDown Damping">Dämpfung</string>
-	<string name="Butt Physics Mass">Po – Masse</string>
-	<string name="Butt Physics Smoothing">Po – Glättung</string>
-	<string name="Butt Physics Gravity">Po – Schwerkraft</string>
-	<string name="Butt Physics Drag">Po – Luftwiderstand</string>
-	<string name="Butt Physics UpDown Max Effect">Max. Effekt</string>
-	<string name="Butt Physics UpDown Spring">Federn</string>
-	<string name="Butt Physics UpDown Gain">Verstärkung</string>
-	<string name="Butt Physics UpDown Damping">Dämpfung</string>
-	<string name="Butt Physics LeftRight Max Effect">Max. Effekt</string>
-	<string name="Butt Physics LeftRight Spring">Federn</string>
-	<string name="Butt Physics LeftRight Gain">Verstärkung</string>
-	<string name="Butt Physics LeftRight Damping">Dämpfung</string>
-	<string name="Bushy Eyebrows">Buschige Augenbrauen</string>
-	<string name="Bushy Hair">Buschiges Haar</string>
-	<string name="Butt Size">Hintern, Größe</string>
-	<string name="Butt Gravity">Po – Schwerkraft</string>
-	<string name="bustle skirt">Tournürenrock</string>
-	<string name="no bustle">Ohne</string>
-	<string name="more bustle">Mit</string>
-	<string name="Chaplin">Chaplin</string>
-	<string name="Cheek Bones">Wangenknochen</string>
-	<string name="Chest Size">Brustgröße</string>
-	<string name="Chin Angle">Kinnwinkel</string>
-	<string name="Chin Cleft">Kinnspalte</string>
-	<string name="Chin Curtains">Schifferfräse</string>
-	<string name="Chin Depth">Kinnlänge</string>
-	<string name="Chin Heavy">Kinn ausgeprägt</string>
-	<string name="Chin In">Kinn zurück</string>
-	<string name="Chin Out">Kinn nach vorne</string>
-	<string name="Chin-Neck">Kinn-Hals</string>
-	<string name="Clear">Transparent</string>
-	<string name="Cleft">Spalte</string>
-	<string name="Close Set Eyes">Eng stehende Augen</string>
-	<string name="Closed">Geschlossen</string>
-	<string name="Closed Back">Hinten geschlossen</string>
-	<string name="Closed Front">Vorne geschlossen</string>
-	<string name="Closed Left">Links geschlossen</string>
-	<string name="Closed Right">Rechts geschlossen</string>
-	<string name="Coin Purse">Klein</string>
-	<string name="Collar Back">Kragen hinten</string>
-	<string name="Collar Front">Kragen vorne</string>
-	<string name="Corner Down">Nach unten</string>
-	<string name="Corner Up">Nach oben</string>
-	<string name="Creased">Schlupflid</string>
-	<string name="Crooked Nose">Krumme Nase</string>
-	<string name="Cuff Flare">Hosenaufschlag</string>
-	<string name="Dark">Dunkel</string>
-	<string name="Dark Green">Dunkelgrün</string>
-	<string name="Darker">Dunkler</string>
-	<string name="Deep">Tief</string>
-	<string name="Default Heels">Standardabsätze</string>
-	<string name="Dense">Dicht</string>
-	<string name="Double Chin">Doppelkinn</string>
-	<string name="Downturned">Nach unten</string>
-	<string name="Duffle Bag">Groß</string>
-	<string name="Ear Angle">Ohrenwinkel</string>
-	<string name="Ear Size">Ohrengröße</string>
-	<string name="Ear Tips">Ohrenspitzen</string>
-	<string name="Egg Head">Eierkopf</string>
-	<string name="Eye Bags">Augenränder</string>
-	<string name="Eye Color">Augenfarbe</string>
-	<string name="Eye Depth">Augentiefe</string>
-	<string name="Eye Lightness">Helligkeit</string>
-	<string name="Eye Opening">Öffnung</string>
-	<string name="Eye Pop">Symmetrie</string>
-	<string name="Eye Size">Augengröße</string>
-	<string name="Eye Spacing">Augenstand</string>
-	<string name="Eyebrow Arc">Brauenbogen</string>
-	<string name="Eyebrow Density">Brauendichte</string>
-	<string name="Eyebrow Height">Brauenhöhe</string>
-	<string name="Eyebrow Points">Brauenenden</string>
-	<string name="Eyebrow Size">Brauengröße</string>
-	<string name="Eyelash Length">Wimpernlänge</string>
-	<string name="Eyeliner">Eyeliner</string>
-	<string name="Eyeliner Color">Farbe des Eyeliners</string>
-	<string name="Eyes Bugged">Glubschaugen</string>
-	<string name="Face Shear">Gesichtsverzerrung</string>
-	<string name="Facial Definition">Gesichtskonturen</string>
-	<string name="Far Set Eyes">Weit auseinander</string>
-	<string name="Fat Lips">Volle Lippen</string>
-	<string name="Female">weiblich</string>
-	<string name="Fingerless">Ohne Finger</string>
-	<string name="Fingers">Finger</string>
-	<string name="Flared Cuffs">Ausgestellt</string>
-	<string name="Flat">Flach</string>
-	<string name="Flat Butt">Flacher Hintern</string>
-	<string name="Flat Head">Flacher Kopf</string>
-	<string name="Flat Toe">Flache Spitze</string>
-	<string name="Foot Size">Fußgröße</string>
-	<string name="Forehead Angle">Stirnwinkel</string>
-	<string name="Forehead Heavy">Stirn ausgeprägt</string>
-	<string name="Freckles">Sommersprossen</string>
-	<string name="Front Fringe">Fransen, vorne</string>
-	<string name="Full Back">Hinten volles Haar</string>
-	<string name="Full Eyeliner">Starker Eyeliner</string>
-	<string name="Full Front">Vorne volles Haar</string>
-	<string name="Full Hair Sides">Seitlich volles Haar</string>
-	<string name="Full Sides">Volle Seiten</string>
-	<string name="Glossy">Glänzend</string>
-	<string name="Glove Fingers">Handschuhfinger</string>
-	<string name="Glove Length">Handschuhlänge</string>
-	<string name="Hair">Haare</string>
-	<string name="Hair Back">Haare: Hinten</string>
-	<string name="Hair Front">Haare: Vorne</string>
-	<string name="Hair Sides">Haare: Seiten</string>
-	<string name="Hair Sweep">Haartolle</string>
-	<string name="Hair Thickess">Haardicke</string>
-	<string name="Hair Thickness">Haardicke</string>
-	<string name="Hair Tilt">Haarneigung</string>
-	<string name="Hair Tilted Left">Nach links</string>
-	<string name="Hair Tilted Right">Nach rechts</string>
-	<string name="Hair Volume">Haare: Volumen</string>
-	<string name="Hand Size">Handgröße</string>
-	<string name="Handlebars">Zwirbelbart</string>
-	<string name="Head Length">Kopflänge</string>
-	<string name="Head Shape">Kopfform</string>
-	<string name="Head Size">Kopfgröße</string>
-	<string name="Head Stretch">Kopfstreckung</string>
-	<string name="Heel Height">Absatzhöhe</string>
-	<string name="Heel Shape">Absatzform</string>
-	<string name="Height">Größe</string>
-	<string name="High">Hoch</string>
-	<string name="High Heels">Hohe Absätze</string>
-	<string name="High Jaw">Hoch</string>
-	<string name="High Platforms">Hohe Plattformsohlen</string>
-	<string name="High and Tight">Hoch und eng</string>
-	<string name="Higher">Höhere</string>
-	<string name="Hip Length">Länge der Hüfte</string>
-	<string name="Hip Width">Breite der Hüfte</string>
-	<string name="Hover">Schweben</string>
-	<string name="In">In</string>
-	<string name="In Shdw Color">Farbe Innenseite</string>
-	<string name="In Shdw Opacity">Deckkraft: innen</string>
-	<string name="Inner Eye Corner">Ecke: Nasenseite</string>
-	<string name="Inner Eye Shadow">Innenlid</string>
-	<string name="Inner Shadow">Innenlid</string>
-	<string name="Jacket Length">Jackenlänge</string>
-	<string name="Jacket Wrinkles">Jackenfalten</string>
-	<string name="Jaw Angle">Kinnansatz</string>
-	<string name="Jaw Jut">Kinnposition</string>
-	<string name="Jaw Shape">Kinnform</string>
-	<string name="Join">Zusammen</string>
-	<string name="Jowls">Hängebacken</string>
-	<string name="Knee Angle">Kniewinkel</string>
-	<string name="Knock Kneed">X-beinig</string>
-	<string name="Large">Groß</string>
-	<string name="Large Hands">Große Hände</string>
-	<string name="Left Part">Linksscheitel</string>
-	<string name="Leg Length">Beinlänge</string>
-	<string name="Leg Muscles">Beinmuskeln</string>
-	<string name="Less">Weniger</string>
-	<string name="Less Body Fat">Weniger Speck</string>
-	<string name="Less Curtains">Weniger</string>
-	<string name="Less Freckles">Weniger</string>
-	<string name="Less Full">Weniger</string>
-	<string name="Less Gravity">Weniger</string>
-	<string name="Less Love">Weniger</string>
-	<string name="Less Muscles">Weniger</string>
-	<string name="Less Muscular">Weniger</string>
-	<string name="Less Rosy">Weniger</string>
-	<string name="Less Round">Weniger</string>
-	<string name="Less Saddle">Weniger</string>
-	<string name="Less Square">Weniger</string>
-	<string name="Less Volume">Weniger</string>
-	<string name="Less soul">Weniger</string>
-	<string name="Lighter">Heller</string>
-	<string name="Lip Cleft">Amorbogen</string>
-	<string name="Lip Cleft Depth">Tiefe: Amorbogen</string>
-	<string name="Lip Fullness">Fülle</string>
-	<string name="Lip Pinkness">Pinkton</string>
-	<string name="Lip Ratio">Lippenproportionen</string>
-	<string name="Lip Thickness">Lippendicke</string>
-	<string name="Lip Width">Mundbreite</string>
-	<string name="Lipgloss">Lipgloss</string>
-	<string name="Lipstick">Lippenstift</string>
-	<string name="Lipstick Color">Farbe</string>
-	<string name="Long">Lang</string>
-	<string name="Long Head">Langer Kopf</string>
-	<string name="Long Hips">Lange Hüften</string>
-	<string name="Long Legs">Lange Beine</string>
-	<string name="Long Neck">Langer Hals</string>
-	<string name="Long Pigtails">Lange Zöpfe</string>
-	<string name="Long Ponytail">Langer Pferdeschwanz</string>
-	<string name="Long Torso">Langer Oberkörper</string>
-	<string name="Long arms">Lange Arme</string>
-	<string name="Loose Pants">Weite Hosen</string>
-	<string name="Loose Shirt">Weites Hemd</string>
-	<string name="Loose Sleeves">Weite Ärmel</string>
-	<string name="Love Handles">Fettpölsterchen</string>
-	<string name="Low">Niedrig</string>
-	<string name="Low Heels">Niedrig</string>
-	<string name="Low Jaw">Niedrig</string>
-	<string name="Low Platforms">Niedrig</string>
-	<string name="Low and Loose">Weit</string>
-	<string name="Lower">Absenken</string>
-	<string name="Lower Bridge">Brücke, Unterer Teil</string>
-	<string name="Lower Cheeks">Wangen, unterer Bereich</string>
-	<string name="Male">Männlich</string>
-	<string name="Middle Part">Mittelscheitel</string>
-	<string name="More">Mehr</string>
-	<string name="More Blush">Mehr</string>
-	<string name="More Body Fat">Mehr Speck</string>
-	<string name="More Curtains">Mehr</string>
-	<string name="More Eyeshadow">Mehr</string>
-	<string name="More Freckles">Mehr</string>
-	<string name="More Full">Voller</string>
-	<string name="More Gravity">Mehr</string>
-	<string name="More Lipstick">Mehr</string>
-	<string name="More Love">Mehr</string>
-	<string name="More Lower Lip">Größer</string>
-	<string name="More Muscles">Mehr</string>
-	<string name="More Muscular">Mehr</string>
-	<string name="More Rosy">Mehr</string>
-	<string name="More Round">Runder</string>
-	<string name="More Saddle">Mehr</string>
-	<string name="More Sloped">Flach</string>
-	<string name="More Square">Eckiger</string>
-	<string name="More Upper Lip">Mehr</string>
-	<string name="More Vertical">Steil</string>
-	<string name="More Volume">Mehr</string>
-	<string name="More soul">Mehr</string>
-	<string name="Moustache">Schnauzer</string>
-	<string name="Mouth Corner">Mundwinkel</string>
-	<string name="Mouth Position">Mundposition</string>
-	<string name="Mowhawk">Irokese</string>
-	<string name="Muscular">Muskulös</string>
-	<string name="Mutton Chops">Koteletten</string>
-	<string name="Nail Polish">Nagellack</string>
-	<string name="Nail Polish Color">Farbe</string>
-	<string name="Narrow">Schmal</string>
-	<string name="Narrow Back">Wenig</string>
-	<string name="Narrow Front">Wenig</string>
-	<string name="Narrow Lips">Schmale Lippen</string>
-	<string name="Natural">Natürlich</string>
-	<string name="Neck Length">Halslänge</string>
-	<string name="Neck Thickness">Halsdicke</string>
-	<string name="No Blush">Kein Rouge</string>
-	<string name="No Eyeliner">Kein Eyeliner</string>
-	<string name="No Eyeshadow">Kein Lidschatten</string>
-	<string name="No Lipgloss">Kein Lipgloss</string>
-	<string name="No Lipstick">Kein Lippenstift</string>
-	<string name="No Part">Kein Scheitel</string>
-	<string name="No Polish">Kein Nagellack</string>
-	<string name="No Red">Nicht rot</string>
-	<string name="No Spikes">Keine Stachel</string>
-	<string name="No White">Kein Weiß</string>
-	<string name="No Wrinkles">Keine Falten</string>
-	<string name="Normal Lower">Normal unten</string>
-	<string name="Normal Upper">Normal oben</string>
-	<string name="Nose Left">Links</string>
-	<string name="Nose Right">Rechts</string>
-	<string name="Nose Size">Größe</string>
-	<string name="Nose Thickness">Dicke</string>
-	<string name="Nose Tip Angle">Nasenspitze</string>
-	<string name="Nose Tip Shape">Nasenspitze</string>
-	<string name="Nose Width">Nasenbreite</string>
-	<string name="Nostril Division">Teilung</string>
-	<string name="Nostril Width">Größe</string>
-	<string name="Opaque">Deckend</string>
-	<string name="Open">Öffnen</string>
-	<string name="Open Back">Hinten offen</string>
-	<string name="Open Front">Vorne offen</string>
-	<string name="Open Left">Links offen</string>
-	<string name="Open Right">Rechts offen</string>
-	<string name="Orange">Orange</string>
-	<string name="Out">Aus</string>
-	<string name="Out Shdw Color">Farbe: Oben</string>
-	<string name="Out Shdw Opacity">Deckkraft: Oben</string>
-	<string name="Outer Eye Corner">Äußerer Augenwinkel</string>
-	<string name="Outer Eye Shadow">Lidschatten: Oben</string>
-	<string name="Outer Shadow">Lidschatten: Oben</string>
-	<string name="Overbite">Überbiss</string>
-	<string name="Package">Ausbeulung</string>
-	<string name="Painted Nails">Lackierte Nägel</string>
-	<string name="Pale">Blass</string>
-	<string name="Pants Crotch">Schritt</string>
-	<string name="Pants Fit">Passform</string>
-	<string name="Pants Length">Hosenlänge</string>
-	<string name="Pants Waist">Hüfte</string>
-	<string name="Pants Wrinkles">Falten</string>
-	<string name="Part">Scheitel</string>
-	<string name="Part Bangs">Pony scheiteln</string>
-	<string name="Pectorals">Brustmuskel</string>
-	<string name="Pigment">Pigmentierung</string>
-	<string name="Pigtails">Zöpfe</string>
-	<string name="Pink">Pink</string>
-	<string name="Pinker">Mehr Pink</string>
-	<string name="Platform Height">Höhe</string>
-	<string name="Platform Width">Breite</string>
-	<string name="Pointy">Spitz</string>
-	<string name="Pointy Heels">Pfennigabsätze</string>
-	<string name="Ponytail">Pferdeschwanz</string>
-	<string name="Poofy Skirt">Weit ausgestellt</string>
-	<string name="Pop Left Eye">Linkes Auge größer</string>
-	<string name="Pop Right Eye">Rechtes Auge größer</string>
-	<string name="Puffy">Geschwollen</string>
-	<string name="Puffy Eyelids">Geschwollene Lider</string>
-	<string name="Rainbow Color">Regenbogenfarben</string>
-	<string name="Red Hair">Rote Haare</string>
-	<string name="Regular">Normal</string>
-	<string name="Right Part">Scheitel rechts</string>
-	<string name="Rosy Complexion">Rosiger Teint</string>
-	<string name="Round">Rund</string>
-	<string name="Ruddiness">Röte</string>
-	<string name="Ruddy">Rötlich</string>
-	<string name="Rumpled Hair">Zerzauste Haare</string>
-	<string name="Saddle Bags">Hüftspeck</string>
-	<string name="Scrawny Leg">Dürres Bein</string>
-	<string name="Separate">Auseinander</string>
-	<string name="Shallow">Flach</string>
-	<string name="Shear Back">Hinterkopf rasiert</string>
-	<string name="Shear Face">Gesicht verzerren</string>
-	<string name="Shear Front">Vorne rasiert</string>
-	<string name="Shear Left Up">Links</string>
-	<string name="Shear Right Up">Rechts</string>
-	<string name="Sheared Back">Hinterkopf rasiert</string>
-	<string name="Sheared Front">Vorne rasiert</string>
-	<string name="Shift Left">Nach links</string>
-	<string name="Shift Mouth">Mund verschieben</string>
-	<string name="Shift Right">Nach rechts</string>
-	<string name="Shirt Bottom">Hemdlänge</string>
-	<string name="Shirt Fit">Passform</string>
-	<string name="Shirt Wrinkles">Falten</string>
-	<string name="Shoe Height">Schuhart</string>
-	<string name="Short">Klein</string>
-	<string name="Short Arms">Kurze Arme</string>
-	<string name="Short Legs">Kurze Beine</string>
-	<string name="Short Neck">Kurzer Hals</string>
-	<string name="Short Pigtails">Kurze Zöpfe</string>
-	<string name="Short Ponytail">Kurzer Pferdeschwanz</string>
-	<string name="Short Sideburns">Kurze Koteletten</string>
-	<string name="Short Torso">Kurzer Oberkörper</string>
-	<string name="Short hips">Kurze Hüften</string>
-	<string name="Shoulders">Schultern</string>
-	<string name="Side Fringe">Seitliche Fransen</string>
-	<string name="Sideburns">Koteletten</string>
-	<string name="Sides Hair">Seitliches Haar</string>
-	<string name="Sides Hair Down">Lang</string>
-	<string name="Sides Hair Up">Kurz</string>
-	<string name="Skinny Neck">Dünner Hals</string>
-	<string name="Skirt Fit">Passform</string>
-	<string name="Skirt Length">Rocklänge</string>
-	<string name="Slanted Forehead">Fliehende Stirn</string>
-	<string name="Sleeve Length">Ärmellänge</string>
-	<string name="Sleeve Looseness">Passform Ärmel</string>
-	<string name="Slit Back">Schlitz: Hinten</string>
-	<string name="Slit Front">Schlitz: Vorne</string>
-	<string name="Slit Left">Schlitz: Links</string>
-	<string name="Slit Right">Schlitz: Rechts</string>
-	<string name="Small">Klein</string>
-	<string name="Small Hands">Kleine Hände</string>
-	<string name="Small Head">Klein</string>
-	<string name="Smooth">Glätten</string>
-	<string name="Smooth Hair">Glattes Haar</string>
-	<string name="Socks Length">Strumpflänge</string>
-	<string name="Soulpatch">Unterlippenbart</string>
-	<string name="Sparse">Wenig</string>
-	<string name="Spiked Hair">Stachelhaare</string>
-	<string name="Square">Rechteck</string>
-	<string name="Square Toe">Eckig</string>
-	<string name="Squash Head">Gestaucht</string>
-	<string name="Stretch Head">Gestreckt</string>
-	<string name="Sunken">Eingefallen</string>
-	<string name="Sunken Chest">Trichterbrust</string>
-	<string name="Sunken Eyes">Eingesunkene Augen</string>
-	<string name="Sweep Back">Nach hinten</string>
-	<string name="Sweep Forward">Nach vorne</string>
-	<string name="Tall">Groß</string>
-	<string name="Taper Back">Ansatzbreite hinten</string>
-	<string name="Taper Front">Ansatzbreite vorne</string>
-	<string name="Thick Heels">Dicke Absätze</string>
-	<string name="Thick Neck">Dicker Hals</string>
-	<string name="Thick Toe">Dick</string>
-	<string name="Thin">Dünn</string>
-	<string name="Thin Eyebrows">Dünne Augenbrauen</string>
-	<string name="Thin Lips">Dünne Lippen</string>
-	<string name="Thin Nose">Dünne Nase</string>
-	<string name="Tight Chin">Straffes Kinn</string>
-	<string name="Tight Cuffs">Eng</string>
-	<string name="Tight Pants">Enge Hosen</string>
-	<string name="Tight Shirt">Enges Hemd</string>
-	<string name="Tight Skirt">Enger Rock</string>
-	<string name="Tight Sleeves">Enge Ärmel</string>
-	<string name="Toe Shape">Spitze</string>
-	<string name="Toe Thickness">Dicke</string>
-	<string name="Torso Length">Länge des Oberkörpers</string>
-	<string name="Torso Muscles">Muskeln</string>
-	<string name="Torso Scrawny">Dürr</string>
-	<string name="Unattached">Frei</string>
-	<string name="Uncreased">Straffes Lid</string>
-	<string name="Underbite">Unterbiss</string>
-	<string name="Unnatural">Unnatürlich</string>
-	<string name="Upper Bridge">Brücke, oberer Teil</string>
-	<string name="Upper Cheeks">Obere Wangen</string>
-	<string name="Upper Chin Cleft">Obere Kinnspalte</string>
-	<string name="Upper Eyelid Fold">Obere Lidfalte</string>
-	<string name="Upturned">Stupsnase</string>
-	<string name="Very Red">Sehr rot</string>
-	<string name="Waist Height">Bund</string>
-	<string name="Well-Fed">Gut genährt</string>
-	<string name="White Hair">Weiße Haare</string>
-	<string name="Wide">Breit</string>
-	<string name="Wide Back">Breit</string>
-	<string name="Wide Front">Breit</string>
-	<string name="Wide Lips">Breit</string>
-	<string name="Wild">Wild</string>
-	<string name="Wrinkles">Falten</string>
-	<string name="LocationCtrlAddLandmarkTooltip">Zu meinen Landmarken hinzufügen</string>
-	<string name="LocationCtrlEditLandmarkTooltip">Meine Landmarken bearbeiten</string>
-	<string name="LocationCtrlInfoBtnTooltip">Weitere Informationen über die aktuelle Position</string>
-	<string name="LocationCtrlComboBtnTooltip">Mein Reiseverlauf</string>
-	<string name="LocationCtrlForSaleTooltip">Dieses Land kaufen</string>
-	<string name="LocationCtrlVoiceTooltip">Voice hier nicht möglich</string>
-	<string name="LocationCtrlFlyTooltip">Fliegen ist unzulässig</string>
-	<string name="LocationCtrlPushTooltip">Kein Stoßen</string>
-	<string name="LocationCtrlBuildTooltip">Bauen/Fallen lassen von Objekten ist verboten</string>
-	<string name="LocationCtrlScriptsTooltip">Skripte sind unzulässig</string>
-	<string name="LocationCtrlDamageTooltip">Gesundheit</string>
-	<string name="LocationCtrlAdultIconTooltip">Adult-Region</string>
-	<string name="LocationCtrlModerateIconTooltip">Moderate Region</string>
-	<string name="LocationCtrlGeneralIconTooltip">Generelle Region</string>
-	<string name="LocationCtrlSeeAVsTooltip">Avatare in dieser Parzelle können von Avataren außerhalb dieser Parzelle weder gesehen noch gehört werden</string>
-	<string name="LocationCtrlPathfindingDirtyTooltip">Bewegliche Objekte verhalten sich in dieser Region u. U. erst dann korrekt, wenn die Region neu geformt wird.</string>
-	<string name="LocationCtrlPathfindingDisabledTooltip">Dynamisches Pathfinding ist in dieser Region nicht aktiviert.</string>
-	<string name="UpdaterWindowTitle">[APP_NAME] Aktualisierung</string>
-	<string name="UpdaterNowUpdating">[APP_NAME] wird aktualisiert...</string>
-	<string name="UpdaterNowInstalling">[APP_NAME] wird installiert...</string>
-	<string name="UpdaterUpdatingDescriptive">Ihr [APP_NAME]-Viewer wird aktualisiert.  Dies kann einen Moment dauern. Wir bitten um Ihr Verständnis.</string>
-	<string name="UpdaterProgressBarTextWithEllipses">Aktualisierung wird heruntergeladen...</string>
-	<string name="UpdaterProgressBarText">Aktualisierung wird heruntergeladen</string>
-	<string name="UpdaterFailDownloadTitle">Herunterladen ist fehlgeschlagen</string>
-	<string name="UpdaterFailUpdateDescriptive">Beim Aktualisieren von [APP_NAME] ist ein Fehler aufgetreten. Bitte laden Sie die aktuellste Version von www.secondlife.com herunter.</string>
-	<string name="UpdaterFailInstallTitle">Aktualisierung konnte nicht installiert werden</string>
-	<string name="UpdaterFailStartTitle">Viewer konnte nicht gestartet werden</string>
-	<string name="ItemsComingInTooFastFrom">[APP_NAME]: Zuviele Objekte auf einmal von [FROM_NAME]. Automaitsche Vorschau ist für [TIME] Sekunden nicht verfügbar.</string>
-	<string name="ItemsComingInTooFast">[APP_NAME]: Zuviele Objekte auf einmal. Automaitsche Vorschau ist für [TIME] Sekunden nicht verfügbar.</string>
-	<string name="IM_logging_string">-- Instant-Message-Protokoll aktiviert --</string>
-	<string name="IM_typing_start_string">[NAME] tippt...</string>
-	<string name="Unnamed">(Nicht benannt)</string>
-	<string name="IM_moderated_chat_label">(Moderiert: Stimmen in der Standardeinstellung stummgeschaltet)</string>
-	<string name="IM_unavailable_text_label">Für diese Verbindung ist kein Text-Chat verfügbar.</string>
-	<string name="IM_muted_text_label">Ihr Text-Chat wurde von einem Gruppenmoderator deaktiviert.</string>
-	<string name="IM_default_text_label">Für Instant Message hier klicken.</string>
-	<string name="IM_to_label">An</string>
-	<string name="IM_moderator_label">(Moderator)</string>
-	<string name="Saved_message">(Gespeichert am [LONG_TIMESTAMP])</string>
-	<string name="IM_unblock_only_groups_friends">Wenn Sie diese Meldung sehen, müssen Sie unter „Einstellungen“ &gt; „Privatsphäre“ die Option „Nur IMs und Anrufe von Freunden oder Gruppen durchstellen“ deaktivieren.</string>
-	<string name="OnlineStatus">Online</string>
-	<string name="OfflineStatus">Offline</string>
-	<string name="not_online_msg">Benutzer nicht online – Nachricht wird gespeichert und später zugestellt.</string>
-	<string name="not_online_inventory">Benutzer nicht online – Inventar gespeichert.</string>
-	<string name="answered_call">Ihr Anruf wurde entgegengenommen</string>
-	<string name="you_started_call">Sie haben einen Voice-Anruf begonnen</string>
-	<string name="you_joined_call">Sie sind dem Gespräch beigetreten</string>
-	<string name="you_auto_rejected_call-im">Sie haben den Voice-Anruf automatisch abgelehnt, während der Nicht-stören-Modus aktiviert war.</string>
-	<string name="name_started_call">[NAME] hat einen Voice-Anruf begonnen</string>
-	<string name="ringing-im">Verbindung wird hergestellt...</string>
-	<string name="connected-im">Verbunden. Klicken Sie auf Anruf beenden, um die Verbindung zu trennen</string>
-	<string name="hang_up-im">Anruf wurde beendet</string>
-	<string name="answering-im">Wird verbunden...</string>
-	<string name="conference-title">Chat mit mehreren Personen</string>
-	<string name="conference-title-incoming">Konferenz mit [AGENT_NAME]</string>
-	<string name="inventory_item_offered-im">Inventarobjekt „[ITEM_NAME]“ angeboten</string>
-	<string name="inventory_folder_offered-im">Inventarordner „[ITEM_NAME]“ angeboten</string>
+Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].
+	</string>
+	<string name="5 O'Clock Shadow">
+		Bartschatten
+	</string>
+	<string name="All White">
+		Ganz weiß
+	</string>
+	<string name="Anime Eyes">
+		Anime-Augen
+	</string>
+	<string name="Arced">
+		Gewölbt
+	</string>
+	<string name="Arm Length">
+		Armlänge
+	</string>
+	<string name="Attached">
+		Angewachsen
+	</string>
+	<string name="Attached Earlobes">
+		Angewachsene Ohrläppchen
+	</string>
+	<string name="Back Fringe">
+		Nackenfransen
+	</string>
+	<string name="Baggy">
+		Tränensäcke
+	</string>
+	<string name="Bangs">
+		Pony
+	</string>
+	<string name="Beady Eyes">
+		Knopfaugen
+	</string>
+	<string name="Belly Size">
+		Bauchgröße
+	</string>
+	<string name="Big">
+		Groß
+	</string>
+	<string name="Big Butt">
+		Großer Hintern
+	</string>
+	<string name="Big Hair Back">
+		Volumen: Hinten
+	</string>
+	<string name="Big Hair Front">
+		Volumen: Vorne
+	</string>
+	<string name="Big Hair Top">
+		Volumen: Oben
+	</string>
+	<string name="Big Head">
+		Groß
+	</string>
+	<string name="Big Pectorals">
+		Große Brustmuskeln
+	</string>
+	<string name="Big Spikes">
+		Große Stacheln
+	</string>
+	<string name="Black">
+		Schwarz
+	</string>
+	<string name="Blonde">
+		Blond
+	</string>
+	<string name="Blonde Hair">
+		Blondes Haar
+	</string>
+	<string name="Blush">
+		Rouge
+	</string>
+	<string name="Blush Color">
+		Rougefarbe
+	</string>
+	<string name="Blush Opacity">
+		Rouge Deckkraft
+	</string>
+	<string name="Body Definition">
+		Körperkonturen
+	</string>
+	<string name="Body Fat">
+		Körperfett
+	</string>
+	<string name="Body Freckles">
+		Sommersprossen
+	</string>
+	<string name="Body Thick">
+		breit
+	</string>
+	<string name="Body Thickness">
+		Körperbreite
+	</string>
+	<string name="Body Thin">
+		schmal
+	</string>
+	<string name="Bow Legged">
+		o-beinig
+	</string>
+	<string name="Breast Buoyancy">
+		Brust, Straffheit
+	</string>
+	<string name="Breast Cleavage">
+		Dekolleté
+	</string>
+	<string name="Breast Size">
+		Brustgröße
+	</string>
+	<string name="Bridge Width">
+		Rückenbreite
+	</string>
+	<string name="Broad">
+		Breit
+	</string>
+	<string name="Brow Size">
+		Brauengröße
+	</string>
+	<string name="Bug Eyes">
+		Glubschaugen
+	</string>
+	<string name="Bugged Eyes">
+		Hervortretend
+	</string>
+	<string name="Bulbous">
+		Knollennase
+	</string>
+	<string name="Bulbous Nose">
+		Knollennase
+	</string>
+	<string name="Breast Physics Mass">
+		Brust – Masse
+	</string>
+	<string name="Breast Physics Smoothing">
+		Brust – Glättung
+	</string>
+	<string name="Breast Physics Gravity">
+		Brust – Schwerkraft
+	</string>
+	<string name="Breast Physics Drag">
+		Brust – Luftwiderstand
+	</string>
+	<string name="Breast Physics InOut Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Breast Physics InOut Spring">
+		Federn
+	</string>
+	<string name="Breast Physics InOut Gain">
+		Verstärkung
+	</string>
+	<string name="Breast Physics InOut Damping">
+		Dämpfung
+	</string>
+	<string name="Breast Physics UpDown Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Breast Physics UpDown Spring">
+		Federn
+	</string>
+	<string name="Breast Physics UpDown Gain">
+		Verstärkung
+	</string>
+	<string name="Breast Physics UpDown Damping">
+		Dämpfung
+	</string>
+	<string name="Breast Physics LeftRight Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Breast Physics LeftRight Spring">
+		Federn
+	</string>
+	<string name="Breast Physics LeftRight Gain">
+		Verstärkung
+	</string>
+	<string name="Breast Physics LeftRight Damping">
+		Dämpfung
+	</string>
+	<string name="Belly Physics Mass">
+		Bauch – Masse
+	</string>
+	<string name="Belly Physics Smoothing">
+		Bauch – Glättung
+	</string>
+	<string name="Belly Physics Gravity">
+		Bauch – Schwerkraft
+	</string>
+	<string name="Belly Physics Drag">
+		Bauch – Luftwiderstand
+	</string>
+	<string name="Belly Physics UpDown Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Belly Physics UpDown Spring">
+		Federn
+	</string>
+	<string name="Belly Physics UpDown Gain">
+		Verstärkung
+	</string>
+	<string name="Belly Physics UpDown Damping">
+		Dämpfung
+	</string>
+	<string name="Butt Physics Mass">
+		Po – Masse
+	</string>
+	<string name="Butt Physics Smoothing">
+		Po – Glättung
+	</string>
+	<string name="Butt Physics Gravity">
+		Po – Schwerkraft
+	</string>
+	<string name="Butt Physics Drag">
+		Po – Luftwiderstand
+	</string>
+	<string name="Butt Physics UpDown Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Butt Physics UpDown Spring">
+		Federn
+	</string>
+	<string name="Butt Physics UpDown Gain">
+		Verstärkung
+	</string>
+	<string name="Butt Physics UpDown Damping">
+		Dämpfung
+	</string>
+	<string name="Butt Physics LeftRight Max Effect">
+		Max. Effekt
+	</string>
+	<string name="Butt Physics LeftRight Spring">
+		Federn
+	</string>
+	<string name="Butt Physics LeftRight Gain">
+		Verstärkung
+	</string>
+	<string name="Butt Physics LeftRight Damping">
+		Dämpfung
+	</string>
+	<string name="Bushy Eyebrows">
+		Buschige Augenbrauen
+	</string>
+	<string name="Bushy Hair">
+		Buschiges Haar
+	</string>
+	<string name="Butt Size">
+		Hintern, Größe
+	</string>
+	<string name="Butt Gravity">
+		Po – Schwerkraft
+	</string>
+	<string name="bustle skirt">
+		Tournürenrock
+	</string>
+	<string name="no bustle">
+		Ohne
+	</string>
+	<string name="more bustle">
+		Mit
+	</string>
+	<string name="Chaplin">
+		Chaplin
+	</string>
+	<string name="Cheek Bones">
+		Wangenknochen
+	</string>
+	<string name="Chest Size">
+		Brustgröße
+	</string>
+	<string name="Chin Angle">
+		Kinnwinkel
+	</string>
+	<string name="Chin Cleft">
+		Kinnspalte
+	</string>
+	<string name="Chin Curtains">
+		Schifferfräse
+	</string>
+	<string name="Chin Depth">
+		Kinnlänge
+	</string>
+	<string name="Chin Heavy">
+		Kinn ausgeprägt
+	</string>
+	<string name="Chin In">
+		Kinn zurück
+	</string>
+	<string name="Chin Out">
+		Kinn nach vorne
+	</string>
+	<string name="Chin-Neck">
+		Kinn-Hals
+	</string>
+	<string name="Clear">
+		Transparent
+	</string>
+	<string name="Cleft">
+		Spalte
+	</string>
+	<string name="Close Set Eyes">
+		Eng stehende Augen
+	</string>
+	<string name="Closed">
+		Geschlossen
+	</string>
+	<string name="Closed Back">
+		Hinten geschlossen
+	</string>
+	<string name="Closed Front">
+		Vorne geschlossen
+	</string>
+	<string name="Closed Left">
+		Links geschlossen
+	</string>
+	<string name="Closed Right">
+		Rechts geschlossen
+	</string>
+	<string name="Coin Purse">
+		Klein
+	</string>
+	<string name="Collar Back">
+		Kragen hinten
+	</string>
+	<string name="Collar Front">
+		Kragen vorne
+	</string>
+	<string name="Corner Down">
+		Nach unten
+	</string>
+	<string name="Corner Up">
+		Nach oben
+	</string>
+	<string name="Creased">
+		Schlupflid
+	</string>
+	<string name="Crooked Nose">
+		Krumme Nase
+	</string>
+	<string name="Cuff Flare">
+		Hosenaufschlag
+	</string>
+	<string name="Dark">
+		Dunkel
+	</string>
+	<string name="Dark Green">
+		Dunkelgrün
+	</string>
+	<string name="Darker">
+		Dunkler
+	</string>
+	<string name="Deep">
+		Tief
+	</string>
+	<string name="Default Heels">
+		Standardabsätze
+	</string>
+	<string name="Dense">
+		Dicht
+	</string>
+	<string name="Double Chin">
+		Doppelkinn
+	</string>
+	<string name="Downturned">
+		Nach unten
+	</string>
+	<string name="Duffle Bag">
+		Groß
+	</string>
+	<string name="Ear Angle">
+		Ohrenwinkel
+	</string>
+	<string name="Ear Size">
+		Ohrengröße
+	</string>
+	<string name="Ear Tips">
+		Ohrenspitzen
+	</string>
+	<string name="Egg Head">
+		Eierkopf
+	</string>
+	<string name="Eye Bags">
+		Augenränder
+	</string>
+	<string name="Eye Color">
+		Augenfarbe
+	</string>
+	<string name="Eye Depth">
+		Augentiefe
+	</string>
+	<string name="Eye Lightness">
+		Helligkeit
+	</string>
+	<string name="Eye Opening">
+		Öffnung
+	</string>
+	<string name="Eye Pop">
+		Symmetrie
+	</string>
+	<string name="Eye Size">
+		Augengröße
+	</string>
+	<string name="Eye Spacing">
+		Augenstand
+	</string>
+	<string name="Eyebrow Arc">
+		Brauenbogen
+	</string>
+	<string name="Eyebrow Density">
+		Brauendichte
+	</string>
+	<string name="Eyebrow Height">
+		Brauenhöhe
+	</string>
+	<string name="Eyebrow Points">
+		Brauenenden
+	</string>
+	<string name="Eyebrow Size">
+		Brauengröße
+	</string>
+	<string name="Eyelash Length">
+		Wimpernlänge
+	</string>
+	<string name="Eyeliner">
+		Eyeliner
+	</string>
+	<string name="Eyeliner Color">
+		Farbe des Eyeliners
+	</string>
+	<string name="Eyes Bugged">
+		Glubschaugen
+	</string>
+	<string name="Face Shear">
+		Gesichtsverzerrung
+	</string>
+	<string name="Facial Definition">
+		Gesichtskonturen
+	</string>
+	<string name="Far Set Eyes">
+		Weit auseinander
+	</string>
+	<string name="Fat Lips">
+		Volle Lippen
+	</string>
+	<string name="Female">
+		weiblich
+	</string>
+	<string name="Fingerless">
+		Ohne Finger
+	</string>
+	<string name="Fingers">
+		Finger
+	</string>
+	<string name="Flared Cuffs">
+		Ausgestellt
+	</string>
+	<string name="Flat">
+		Flach
+	</string>
+	<string name="Flat Butt">
+		Flacher Hintern
+	</string>
+	<string name="Flat Head">
+		Flacher Kopf
+	</string>
+	<string name="Flat Toe">
+		Flache Spitze
+	</string>
+	<string name="Foot Size">
+		Fußgröße
+	</string>
+	<string name="Forehead Angle">
+		Stirnwinkel
+	</string>
+	<string name="Forehead Heavy">
+		Stirn ausgeprägt
+	</string>
+	<string name="Freckles">
+		Sommersprossen
+	</string>
+	<string name="Front Fringe">
+		Fransen, vorne
+	</string>
+	<string name="Full Back">
+		Hinten volles Haar
+	</string>
+	<string name="Full Eyeliner">
+		Starker Eyeliner
+	</string>
+	<string name="Full Front">
+		Vorne volles Haar
+	</string>
+	<string name="Full Hair Sides">
+		Seitlich volles Haar
+	</string>
+	<string name="Full Sides">
+		Volle Seiten
+	</string>
+	<string name="Glossy">
+		Glänzend
+	</string>
+	<string name="Glove Fingers">
+		Handschuhfinger
+	</string>
+	<string name="Glove Length">
+		Handschuhlänge
+	</string>
+	<string name="Hair">
+		Haare
+	</string>
+	<string name="Hair Back">
+		Haare: Hinten
+	</string>
+	<string name="Hair Front">
+		Haare: Vorne
+	</string>
+	<string name="Hair Sides">
+		Haare: Seiten
+	</string>
+	<string name="Hair Sweep">
+		Haartolle
+	</string>
+	<string name="Hair Thickess">
+		Haardicke
+	</string>
+	<string name="Hair Thickness">
+		Haardicke
+	</string>
+	<string name="Hair Tilt">
+		Haarneigung
+	</string>
+	<string name="Hair Tilted Left">
+		Nach links
+	</string>
+	<string name="Hair Tilted Right">
+		Nach rechts
+	</string>
+	<string name="Hair Volume">
+		Haare: Volumen
+	</string>
+	<string name="Hand Size">
+		Handgröße
+	</string>
+	<string name="Handlebars">
+		Zwirbelbart
+	</string>
+	<string name="Head Length">
+		Kopflänge
+	</string>
+	<string name="Head Shape">
+		Kopfform
+	</string>
+	<string name="Head Size">
+		Kopfgröße
+	</string>
+	<string name="Head Stretch">
+		Kopfstreckung
+	</string>
+	<string name="Heel Height">
+		Absatzhöhe
+	</string>
+	<string name="Heel Shape">
+		Absatzform
+	</string>
+	<string name="Height">
+		Größe
+	</string>
+	<string name="High">
+		Hoch
+	</string>
+	<string name="High Heels">
+		Hohe Absätze
+	</string>
+	<string name="High Jaw">
+		Hoch
+	</string>
+	<string name="High Platforms">
+		Hohe Plattformsohlen
+	</string>
+	<string name="High and Tight">
+		Hoch und eng
+	</string>
+	<string name="Higher">
+		Höhere
+	</string>
+	<string name="Hip Length">
+		Länge der Hüfte
+	</string>
+	<string name="Hip Width">
+		Breite der Hüfte
+	</string>
+	<string name="Hover">
+		Schweben
+	</string>
+	<string name="In">
+		In
+	</string>
+	<string name="In Shdw Color">
+		Farbe Innenseite
+	</string>
+	<string name="In Shdw Opacity">
+		Deckkraft: innen
+	</string>
+	<string name="Inner Eye Corner">
+		Ecke: Nasenseite
+	</string>
+	<string name="Inner Eye Shadow">
+		Innenlid
+	</string>
+	<string name="Inner Shadow">
+		Innenlid
+	</string>
+	<string name="Jacket Length">
+		Jackenlänge
+	</string>
+	<string name="Jacket Wrinkles">
+		Jackenfalten
+	</string>
+	<string name="Jaw Angle">
+		Kinnansatz
+	</string>
+	<string name="Jaw Jut">
+		Kinnposition
+	</string>
+	<string name="Jaw Shape">
+		Kinnform
+	</string>
+	<string name="Join">
+		Zusammen
+	</string>
+	<string name="Jowls">
+		Hängebacken
+	</string>
+	<string name="Knee Angle">
+		Kniewinkel
+	</string>
+	<string name="Knock Kneed">
+		X-beinig
+	</string>
+	<string name="Large">
+		Groß
+	</string>
+	<string name="Large Hands">
+		Große Hände
+	</string>
+	<string name="Left Part">
+		Linksscheitel
+	</string>
+	<string name="Leg Length">
+		Beinlänge
+	</string>
+	<string name="Leg Muscles">
+		Beinmuskeln
+	</string>
+	<string name="Less">
+		Weniger
+	</string>
+	<string name="Less Body Fat">
+		Weniger Speck
+	</string>
+	<string name="Less Curtains">
+		Weniger
+	</string>
+	<string name="Less Freckles">
+		Weniger
+	</string>
+	<string name="Less Full">
+		Weniger
+	</string>
+	<string name="Less Gravity">
+		Weniger
+	</string>
+	<string name="Less Love">
+		Weniger
+	</string>
+	<string name="Less Muscles">
+		Weniger
+	</string>
+	<string name="Less Muscular">
+		Weniger
+	</string>
+	<string name="Less Rosy">
+		Weniger
+	</string>
+	<string name="Less Round">
+		Weniger
+	</string>
+	<string name="Less Saddle">
+		Weniger
+	</string>
+	<string name="Less Square">
+		Weniger
+	</string>
+	<string name="Less Volume">
+		Weniger
+	</string>
+	<string name="Less soul">
+		Weniger
+	</string>
+	<string name="Lighter">
+		Heller
+	</string>
+	<string name="Lip Cleft">
+		Amorbogen
+	</string>
+	<string name="Lip Cleft Depth">
+		Tiefe: Amorbogen
+	</string>
+	<string name="Lip Fullness">
+		Fülle
+	</string>
+	<string name="Lip Pinkness">
+		Pinkton
+	</string>
+	<string name="Lip Ratio">
+		Lippenproportionen
+	</string>
+	<string name="Lip Thickness">
+		Lippendicke
+	</string>
+	<string name="Lip Width">
+		Mundbreite
+	</string>
+	<string name="Lipgloss">
+		Lipgloss
+	</string>
+	<string name="Lipstick">
+		Lippenstift
+	</string>
+	<string name="Lipstick Color">
+		Farbe
+	</string>
+	<string name="Long">
+		Lang
+	</string>
+	<string name="Long Head">
+		Langer Kopf
+	</string>
+	<string name="Long Hips">
+		Lange Hüften
+	</string>
+	<string name="Long Legs">
+		Lange Beine
+	</string>
+	<string name="Long Neck">
+		Langer Hals
+	</string>
+	<string name="Long Pigtails">
+		Lange Zöpfe
+	</string>
+	<string name="Long Ponytail">
+		Langer Pferdeschwanz
+	</string>
+	<string name="Long Torso">
+		Langer Oberkörper
+	</string>
+	<string name="Long arms">
+		Lange Arme
+	</string>
+	<string name="Loose Pants">
+		Weite Hosen
+	</string>
+	<string name="Loose Shirt">
+		Weites Hemd
+	</string>
+	<string name="Loose Sleeves">
+		Weite Ärmel
+	</string>
+	<string name="Love Handles">
+		Fettpölsterchen
+	</string>
+	<string name="Low">
+		Niedrig
+	</string>
+	<string name="Low Heels">
+		Niedrig
+	</string>
+	<string name="Low Jaw">
+		Niedrig
+	</string>
+	<string name="Low Platforms">
+		Niedrig
+	</string>
+	<string name="Low and Loose">
+		Weit
+	</string>
+	<string name="Lower">
+		Absenken
+	</string>
+	<string name="Lower Bridge">
+		Brücke, Unterer Teil
+	</string>
+	<string name="Lower Cheeks">
+		Wangen, unterer Bereich
+	</string>
+	<string name="Male">
+		Männlich
+	</string>
+	<string name="Middle Part">
+		Mittelscheitel
+	</string>
+	<string name="More">
+		Mehr
+	</string>
+	<string name="More Blush">
+		Mehr
+	</string>
+	<string name="More Body Fat">
+		Mehr Speck
+	</string>
+	<string name="More Curtains">
+		Mehr
+	</string>
+	<string name="More Eyeshadow">
+		Mehr
+	</string>
+	<string name="More Freckles">
+		Mehr
+	</string>
+	<string name="More Full">
+		Voller
+	</string>
+	<string name="More Gravity">
+		Mehr
+	</string>
+	<string name="More Lipstick">
+		Mehr
+	</string>
+	<string name="More Love">
+		Mehr
+	</string>
+	<string name="More Lower Lip">
+		Größer
+	</string>
+	<string name="More Muscles">
+		Mehr
+	</string>
+	<string name="More Muscular">
+		Mehr
+	</string>
+	<string name="More Rosy">
+		Mehr
+	</string>
+	<string name="More Round">
+		Runder
+	</string>
+	<string name="More Saddle">
+		Mehr
+	</string>
+	<string name="More Sloped">
+		Flach
+	</string>
+	<string name="More Square">
+		Eckiger
+	</string>
+	<string name="More Upper Lip">
+		Mehr
+	</string>
+	<string name="More Vertical">
+		Steil
+	</string>
+	<string name="More Volume">
+		Mehr
+	</string>
+	<string name="More soul">
+		Mehr
+	</string>
+	<string name="Moustache">
+		Schnauzer
+	</string>
+	<string name="Mouth Corner">
+		Mundwinkel
+	</string>
+	<string name="Mouth Position">
+		Mundposition
+	</string>
+	<string name="Mowhawk">
+		Irokese
+	</string>
+	<string name="Muscular">
+		Muskulös
+	</string>
+	<string name="Mutton Chops">
+		Koteletten
+	</string>
+	<string name="Nail Polish">
+		Nagellack
+	</string>
+	<string name="Nail Polish Color">
+		Farbe
+	</string>
+	<string name="Narrow">
+		Schmal
+	</string>
+	<string name="Narrow Back">
+		Wenig
+	</string>
+	<string name="Narrow Front">
+		Wenig
+	</string>
+	<string name="Narrow Lips">
+		Schmale Lippen
+	</string>
+	<string name="Natural">
+		Natürlich
+	</string>
+	<string name="Neck Length">
+		Halslänge
+	</string>
+	<string name="Neck Thickness">
+		Halsdicke
+	</string>
+	<string name="No Blush">
+		Kein Rouge
+	</string>
+	<string name="No Eyeliner">
+		Kein Eyeliner
+	</string>
+	<string name="No Eyeshadow">
+		Kein Lidschatten
+	</string>
+	<string name="No Lipgloss">
+		Kein Lipgloss
+	</string>
+	<string name="No Lipstick">
+		Kein Lippenstift
+	</string>
+	<string name="No Part">
+		Kein Scheitel
+	</string>
+	<string name="No Polish">
+		Kein Nagellack
+	</string>
+	<string name="No Red">
+		Nicht rot
+	</string>
+	<string name="No Spikes">
+		Keine Stachel
+	</string>
+	<string name="No White">
+		Kein Weiß
+	</string>
+	<string name="No Wrinkles">
+		Keine Falten
+	</string>
+	<string name="Normal Lower">
+		Normal unten
+	</string>
+	<string name="Normal Upper">
+		Normal oben
+	</string>
+	<string name="Nose Left">
+		Links
+	</string>
+	<string name="Nose Right">
+		Rechts
+	</string>
+	<string name="Nose Size">
+		Größe
+	</string>
+	<string name="Nose Thickness">
+		Dicke
+	</string>
+	<string name="Nose Tip Angle">
+		Nasenspitze
+	</string>
+	<string name="Nose Tip Shape">
+		Nasenspitze
+	</string>
+	<string name="Nose Width">
+		Nasenbreite
+	</string>
+	<string name="Nostril Division">
+		Teilung
+	</string>
+	<string name="Nostril Width">
+		Größe
+	</string>
+	<string name="Opaque">
+		Deckend
+	</string>
+	<string name="Open">
+		Öffnen
+	</string>
+	<string name="Open Back">
+		Hinten offen
+	</string>
+	<string name="Open Front">
+		Vorne offen
+	</string>
+	<string name="Open Left">
+		Links offen
+	</string>
+	<string name="Open Right">
+		Rechts offen
+	</string>
+	<string name="Orange">
+		Orange
+	</string>
+	<string name="Out">
+		Aus
+	</string>
+	<string name="Out Shdw Color">
+		Farbe: Oben
+	</string>
+	<string name="Out Shdw Opacity">
+		Deckkraft: Oben
+	</string>
+	<string name="Outer Eye Corner">
+		Äußerer Augenwinkel
+	</string>
+	<string name="Outer Eye Shadow">
+		Lidschatten: Oben
+	</string>
+	<string name="Outer Shadow">
+		Lidschatten: Oben
+	</string>
+	<string name="Overbite">
+		Überbiss
+	</string>
+	<string name="Package">
+		Ausbeulung
+	</string>
+	<string name="Painted Nails">
+		Lackierte Nägel
+	</string>
+	<string name="Pale">
+		Blass
+	</string>
+	<string name="Pants Crotch">
+		Schritt
+	</string>
+	<string name="Pants Fit">
+		Passform
+	</string>
+	<string name="Pants Length">
+		Hosenlänge
+	</string>
+	<string name="Pants Waist">
+		Hüfte
+	</string>
+	<string name="Pants Wrinkles">
+		Falten
+	</string>
+	<string name="Part">
+		Scheitel
+	</string>
+	<string name="Part Bangs">
+		Pony scheiteln
+	</string>
+	<string name="Pectorals">
+		Brustmuskel
+	</string>
+	<string name="Pigment">
+		Pigmentierung
+	</string>
+	<string name="Pigtails">
+		Zöpfe
+	</string>
+	<string name="Pink">
+		Pink
+	</string>
+	<string name="Pinker">
+		Mehr Pink
+	</string>
+	<string name="Platform Height">
+		Höhe
+	</string>
+	<string name="Platform Width">
+		Breite
+	</string>
+	<string name="Pointy">
+		Spitz
+	</string>
+	<string name="Pointy Heels">
+		Pfennigabsätze
+	</string>
+	<string name="Ponytail">
+		Pferdeschwanz
+	</string>
+	<string name="Poofy Skirt">
+		Weit ausgestellt
+	</string>
+	<string name="Pop Left Eye">
+		Linkes Auge größer
+	</string>
+	<string name="Pop Right Eye">
+		Rechtes Auge größer
+	</string>
+	<string name="Puffy">
+		Geschwollen
+	</string>
+	<string name="Puffy Eyelids">
+		Geschwollene Lider
+	</string>
+	<string name="Rainbow Color">
+		Regenbogenfarben
+	</string>
+	<string name="Red Hair">
+		Rote Haare
+	</string>
+	<string name="Regular">
+		Normal
+	</string>
+	<string name="Right Part">
+		Scheitel rechts
+	</string>
+	<string name="Rosy Complexion">
+		Rosiger Teint
+	</string>
+	<string name="Round">
+		Rund
+	</string>
+	<string name="Ruddiness">
+		Röte
+	</string>
+	<string name="Ruddy">
+		Rötlich
+	</string>
+	<string name="Rumpled Hair">
+		Zerzauste Haare
+	</string>
+	<string name="Saddle Bags">
+		Hüftspeck
+	</string>
+	<string name="Scrawny Leg">
+		Dürres Bein
+	</string>
+	<string name="Separate">
+		Auseinander
+	</string>
+	<string name="Shallow">
+		Flach
+	</string>
+	<string name="Shear Back">
+		Hinterkopf rasiert
+	</string>
+	<string name="Shear Face">
+		Gesicht verzerren
+	</string>
+	<string name="Shear Front">
+		Vorne rasiert
+	</string>
+	<string name="Shear Left Up">
+		Links
+	</string>
+	<string name="Shear Right Up">
+		Rechts
+	</string>
+	<string name="Sheared Back">
+		Hinterkopf rasiert
+	</string>
+	<string name="Sheared Front">
+		Vorne rasiert
+	</string>
+	<string name="Shift Left">
+		Nach links
+	</string>
+	<string name="Shift Mouth">
+		Mund verschieben
+	</string>
+	<string name="Shift Right">
+		Nach rechts
+	</string>
+	<string name="Shirt Bottom">
+		Hemdlänge
+	</string>
+	<string name="Shirt Fit">
+		Passform
+	</string>
+	<string name="Shirt Wrinkles">
+		Falten
+	</string>
+	<string name="Shoe Height">
+		Schuhart
+	</string>
+	<string name="Short">
+		Klein
+	</string>
+	<string name="Short Arms">
+		Kurze Arme
+	</string>
+	<string name="Short Legs">
+		Kurze Beine
+	</string>
+	<string name="Short Neck">
+		Kurzer Hals
+	</string>
+	<string name="Short Pigtails">
+		Kurze Zöpfe
+	</string>
+	<string name="Short Ponytail">
+		Kurzer Pferdeschwanz
+	</string>
+	<string name="Short Sideburns">
+		Kurze Koteletten
+	</string>
+	<string name="Short Torso">
+		Kurzer Oberkörper
+	</string>
+	<string name="Short hips">
+		Kurze Hüften
+	</string>
+	<string name="Shoulders">
+		Schultern
+	</string>
+	<string name="Side Fringe">
+		Seitliche Fransen
+	</string>
+	<string name="Sideburns">
+		Koteletten
+	</string>
+	<string name="Sides Hair">
+		Seitliches Haar
+	</string>
+	<string name="Sides Hair Down">
+		Lang
+	</string>
+	<string name="Sides Hair Up">
+		Kurz
+	</string>
+	<string name="Skinny Neck">
+		Dünner Hals
+	</string>
+	<string name="Skirt Fit">
+		Passform
+	</string>
+	<string name="Skirt Length">
+		Rocklänge
+	</string>
+	<string name="Slanted Forehead">
+		Fliehende Stirn
+	</string>
+	<string name="Sleeve Length">
+		Ärmellänge
+	</string>
+	<string name="Sleeve Looseness">
+		Passform Ärmel
+	</string>
+	<string name="Slit Back">
+		Schlitz: Hinten
+	</string>
+	<string name="Slit Front">
+		Schlitz: Vorne
+	</string>
+	<string name="Slit Left">
+		Schlitz: Links
+	</string>
+	<string name="Slit Right">
+		Schlitz: Rechts
+	</string>
+	<string name="Small">
+		Klein
+	</string>
+	<string name="Small Hands">
+		Kleine Hände
+	</string>
+	<string name="Small Head">
+		Klein
+	</string>
+	<string name="Smooth">
+		Glätten
+	</string>
+	<string name="Smooth Hair">
+		Glattes Haar
+	</string>
+	<string name="Socks Length">
+		Strumpflänge
+	</string>
+	<string name="Soulpatch">
+		Unterlippenbart
+	</string>
+	<string name="Sparse">
+		Wenig
+	</string>
+	<string name="Spiked Hair">
+		Stachelhaare
+	</string>
+	<string name="Square">
+		Rechteck
+	</string>
+	<string name="Square Toe">
+		Eckig
+	</string>
+	<string name="Squash Head">
+		Gestaucht
+	</string>
+	<string name="Stretch Head">
+		Gestreckt
+	</string>
+	<string name="Sunken">
+		Eingefallen
+	</string>
+	<string name="Sunken Chest">
+		Trichterbrust
+	</string>
+	<string name="Sunken Eyes">
+		Eingesunkene Augen
+	</string>
+	<string name="Sweep Back">
+		Nach hinten
+	</string>
+	<string name="Sweep Forward">
+		Nach vorne
+	</string>
+	<string name="Tall">
+		Groß
+	</string>
+	<string name="Taper Back">
+		Ansatzbreite hinten
+	</string>
+	<string name="Taper Front">
+		Ansatzbreite vorne
+	</string>
+	<string name="Thick Heels">
+		Dicke Absätze
+	</string>
+	<string name="Thick Neck">
+		Dicker Hals
+	</string>
+	<string name="Thick Toe">
+		Dick
+	</string>
+	<string name="Thin">
+		Dünn
+	</string>
+	<string name="Thin Eyebrows">
+		Dünne Augenbrauen
+	</string>
+	<string name="Thin Lips">
+		Dünne Lippen
+	</string>
+	<string name="Thin Nose">
+		Dünne Nase
+	</string>
+	<string name="Tight Chin">
+		Straffes Kinn
+	</string>
+	<string name="Tight Cuffs">
+		Eng
+	</string>
+	<string name="Tight Pants">
+		Enge Hosen
+	</string>
+	<string name="Tight Shirt">
+		Enges Hemd
+	</string>
+	<string name="Tight Skirt">
+		Enger Rock
+	</string>
+	<string name="Tight Sleeves">
+		Enge Ärmel
+	</string>
+	<string name="Toe Shape">
+		Spitze
+	</string>
+	<string name="Toe Thickness">
+		Dicke
+	</string>
+	<string name="Torso Length">
+		Länge des Oberkörpers
+	</string>
+	<string name="Torso Muscles">
+		Muskeln
+	</string>
+	<string name="Torso Scrawny">
+		Dürr
+	</string>
+	<string name="Unattached">
+		Frei
+	</string>
+	<string name="Uncreased">
+		Straffes Lid
+	</string>
+	<string name="Underbite">
+		Unterbiss
+	</string>
+	<string name="Unnatural">
+		Unnatürlich
+	</string>
+	<string name="Upper Bridge">
+		Brücke, oberer Teil
+	</string>
+	<string name="Upper Cheeks">
+		Obere Wangen
+	</string>
+	<string name="Upper Chin Cleft">
+		Obere Kinnspalte
+	</string>
+	<string name="Upper Eyelid Fold">
+		Obere Lidfalte
+	</string>
+	<string name="Upturned">
+		Stupsnase
+	</string>
+	<string name="Very Red">
+		Sehr rot
+	</string>
+	<string name="Waist Height">
+		Bund
+	</string>
+	<string name="Well-Fed">
+		Gut genährt
+	</string>
+	<string name="White Hair">
+		Weiße Haare
+	</string>
+	<string name="Wide">
+		Breit
+	</string>
+	<string name="Wide Back">
+		Breit
+	</string>
+	<string name="Wide Front">
+		Breit
+	</string>
+	<string name="Wide Lips">
+		Breit
+	</string>
+	<string name="Wild">
+		Wild
+	</string>
+	<string name="Wrinkles">
+		Falten
+	</string>
+	<string name="LocationCtrlAddLandmarkTooltip">
+		Zu meinen Landmarken hinzufügen
+	</string>
+	<string name="LocationCtrlEditLandmarkTooltip">
+		Meine Landmarken bearbeiten
+	</string>
+	<string name="LocationCtrlInfoBtnTooltip">
+		Weitere Informationen über die aktuelle Position
+	</string>
+	<string name="LocationCtrlComboBtnTooltip">
+		Mein Reiseverlauf
+	</string>
+	<string name="LocationCtrlForSaleTooltip">
+		Dieses Land kaufen
+	</string>
+	<string name="LocationCtrlVoiceTooltip">
+		Voice hier nicht möglich
+	</string>
+	<string name="LocationCtrlFlyTooltip">
+		Fliegen ist unzulässig
+	</string>
+	<string name="LocationCtrlPushTooltip">
+		Kein Stoßen
+	</string>
+	<string name="LocationCtrlBuildTooltip">
+		Bauen/Fallen lassen von Objekten ist verboten
+	</string>
+	<string name="LocationCtrlScriptsTooltip">
+		Skripte sind unzulässig
+	</string>
+	<string name="LocationCtrlDamageTooltip">
+		Gesundheit
+	</string>
+	<string name="LocationCtrlAdultIconTooltip">
+		Adult-Region
+	</string>
+	<string name="LocationCtrlModerateIconTooltip">
+		Moderate Region
+	</string>
+	<string name="LocationCtrlGeneralIconTooltip">
+		Generelle Region
+	</string>
+	<string name="LocationCtrlSeeAVsTooltip">
+		Avatare in dieser Parzelle können von Avataren außerhalb dieser Parzelle weder gesehen noch gehört werden
+	</string>
+	<string name="LocationCtrlPathfindingDirtyTooltip">
+		Bewegliche Objekte verhalten sich in dieser Region u. U. erst dann korrekt, wenn die Region neu geformt wird.
+	</string>
+	<string name="LocationCtrlPathfindingDisabledTooltip">
+		Dynamisches Pathfinding ist in dieser Region nicht aktiviert.
+	</string>
+	<string name="UpdaterWindowTitle">
+		[APP_NAME] Aktualisierung
+	</string>
+	<string name="UpdaterNowUpdating">
+		[APP_NAME] wird aktualisiert...
+	</string>
+	<string name="UpdaterNowInstalling">
+		[APP_NAME] wird installiert...
+	</string>
+	<string name="UpdaterUpdatingDescriptive">
+		Ihr [APP_NAME]-Viewer wird aktualisiert.  Dies kann einen Moment dauern. Wir bitten um Ihr Verständnis.
+	</string>
+	<string name="UpdaterProgressBarTextWithEllipses">
+		Aktualisierung wird heruntergeladen...
+	</string>
+	<string name="UpdaterProgressBarText">
+		Aktualisierung wird heruntergeladen
+	</string>
+	<string name="UpdaterFailDownloadTitle">
+		Herunterladen ist fehlgeschlagen
+	</string>
+	<string name="UpdaterFailUpdateDescriptive">
+		Beim Aktualisieren von [APP_NAME] ist ein Fehler aufgetreten. Bitte laden Sie die aktuellste Version von www.secondlife.com herunter.
+	</string>
+	<string name="UpdaterFailInstallTitle">
+		Aktualisierung konnte nicht installiert werden
+	</string>
+	<string name="UpdaterFailStartTitle">
+		Viewer konnte nicht gestartet werden
+	</string>
+	<string name="ItemsComingInTooFastFrom">
+		[APP_NAME]: Zuviele Objekte auf einmal von [FROM_NAME]. Automaitsche Vorschau ist für [TIME] Sekunden nicht verfügbar.
+	</string>
+	<string name="ItemsComingInTooFast">
+		[APP_NAME]: Zuviele Objekte auf einmal. Automaitsche Vorschau ist für [TIME] Sekunden nicht verfügbar.
+	</string>
+	<string name="IM_logging_string">
+		-- Instant-Message-Protokoll aktiviert --
+	</string>
+	<string name="IM_typing_start_string">
+		[NAME] tippt...
+	</string>
+	<string name="Unnamed">
+		(Nicht benannt)
+	</string>
+	<string name="IM_moderated_chat_label">
+		(Moderiert: Stimmen in der Standardeinstellung stummgeschaltet)
+	</string>
+	<string name="IM_unavailable_text_label">
+		Für diese Verbindung ist kein Text-Chat verfügbar.
+	</string>
+	<string name="IM_muted_text_label">
+		Ihr Text-Chat wurde von einem Gruppenmoderator deaktiviert.
+	</string>
+	<string name="IM_default_text_label">
+		Für Instant Message hier klicken.
+	</string>
+	<string name="IM_to_label">
+		An
+	</string>
+	<string name="IM_moderator_label">
+		(Moderator)
+	</string>
+	<string name="Saved_message">
+		(Gespeichert am [LONG_TIMESTAMP])
+	</string>
+	<string name="IM_unblock_only_groups_friends">
+		Wenn Sie diese Meldung sehen, müssen Sie unter „Einstellungen“ &gt; „Privatsphäre“ die Option „Nur IMs und Anrufe von Freunden oder Gruppen durchstellen“ deaktivieren.
+	</string>
+	<string name="OnlineStatus">
+		Online
+	</string>
+	<string name="OfflineStatus">
+		Offline
+	</string>
+	<string name="not_online_msg">
+		Benutzer nicht online – Nachricht wird gespeichert und später zugestellt.
+	</string>
+	<string name="not_online_inventory">
+		Benutzer nicht online – Inventar gespeichert.
+	</string>
+	<string name="answered_call">
+		Ihr Anruf wurde entgegengenommen
+	</string>
+	<string name="you_started_call">
+		Sie haben einen Voice-Anruf begonnen
+	</string>
+	<string name="you_joined_call">
+		Sie sind dem Gespräch beigetreten
+	</string>
+	<string name="you_auto_rejected_call-im">
+		Sie haben den Voice-Anruf automatisch abgelehnt, während der Nicht-stören-Modus aktiviert war.
+	</string>
+	<string name="name_started_call">
+		[NAME] hat einen Voice-Anruf begonnen
+	</string>
+	<string name="ringing-im">
+		Verbindung wird hergestellt...
+	</string>
+	<string name="connected-im">
+		Verbunden. Klicken Sie auf Anruf beenden, um die Verbindung zu trennen
+	</string>
+	<string name="hang_up-im">
+		Anruf wurde beendet
+	</string>
+	<string name="answering-im">
+		Wird verbunden...
+	</string>
+	<string name="conference-title">
+		Chat mit mehreren Personen
+	</string>
+	<string name="conference-title-incoming">
+		Konferenz mit [AGENT_NAME]
+	</string>
+	<string name="inventory_item_offered-im">
+		Inventarobjekt „[ITEM_NAME]“ angeboten
+	</string>
+	<string name="inventory_folder_offered-im">
+		Inventarordner „[ITEM_NAME]“ angeboten
+	</string>
 	<string name="bot_warning">
-	Sie chatten mit einem Bot, [NAME]. Geben Sie keine persönlichen Informationen weiter.
+		Sie chatten mit einem Bot, [NAME]. Geben Sie keine persönlichen Informationen weiter.
 Erfahren Sie mehr unter https://second.life/scripted-agents.
 	</string>
-	<string name="share_alert">Objekte aus dem Inventar hier her ziehen</string>
-	<string name="facebook_post_success">Sie haben auf Facebook gepostet.</string>
-	<string name="flickr_post_success">Sie haben auf Flickr gepostet.</string>
-	<string name="twitter_post_success">Sie haben auf Twitter gepostet.</string>
-	<string name="no_session_message">(IM-Session nicht vorhanden)</string>
-	<string name="only_user_message">Sie sind der einzige Benutzer in dieser Sitzung.</string>
-	<string name="offline_message">[NAME] ist offline.</string>
-	<string name="invite_message">Klicken Sie auf [BUTTON NAME], um eine Verbindung zu diesem Voice-Chat herzustellen.</string>
-	<string name="muted_message">Sie haben diesen Einwohner ignoriert. Wenn Sie eine Nachricht senden, wird dieser freigeschaltet.</string>
-	<string name="generic">Fehler bei Anfrage, bitte versuchen Sie es später.</string>
-	<string name="generic_request_error">Fehler bei Anfrage, bitte versuchen Sie es später.</string>
-	<string name="insufficient_perms_error">Sie sind dazu nicht berechtigt.</string>
-	<string name="session_does_not_exist_error">Die Sitzung ist abgelaufen</string>
-	<string name="no_ability_error">Sie besitzen diese Fähigkeit nicht.</string>
-	<string name="no_ability">Sie besitzen diese Fähigkeit nicht.</string>
-	<string name="not_a_mod_error">Sie sind kein Sitzungsmoderator.</string>
-	<string name="muted">Ein Gruppenmoderator hat Ihren Text-Chat deaktiviert.</string>
-	<string name="muted_error">Ein Gruppenmoderator hat Ihren Text-Chat deaktiviert.</string>
-	<string name="add_session_event">Es konnten keine Benutzer zur Chat-Sitzung mit [RECIPIENT] hinzugefügt werden.</string>
-	<string name="message">Ihre Nachricht konnte nicht an die Chat-Sitzung mit [RECIPIENT] gesendet werden.</string>
-	<string name="message_session_event">Ihre Nachricht konnte nicht an die Chat-Sitzung mit [RECIPIENT] gesendet werden.</string>
-	<string name="mute">Fehler während Moderation.</string>
-	<string name="removed">Sie wurden von der Gruppe ausgeschlossen.</string>
-	<string name="removed_from_group">Sie wurden von der Gruppe ausgeschlossen.</string>
-	<string name="close_on_no_ability">Sie haben nicht mehr die Berechtigung an der Chat-Sitzung teilzunehmen.</string>
-	<string name="unread_chat_single">[SOURCES] hat etwas Neues gesagt</string>
-	<string name="unread_chat_multiple">[SOURCES] haben etwas Neues gesagt</string>
-	<string name="session_initialization_timed_out_error">Die Initialisierung der Sitzung ist fehlgeschlagen</string>
-	<string name="Home position set.">Position für Zuhause festgelegt.</string>
-	<string name="voice_morphing_url">https://secondlife.com/destination/voice-island</string>
-	<string name="premium_voice_morphing_url">https://secondlife.com/destination/voice-morphing-premium</string>
-	<string name="paid_you_ldollars">[NAME] hat Ihnen [REASON] [AMOUNT] L$ bezahlt.</string>
-	<string name="paid_you_ldollars_gift">[NAME] hat Ihnen [AMOUNT] L$ bezahlt: [REASON]</string>
-	<string name="paid_you_ldollars_no_reason">[NAME] hat Ihnen [AMOUNT] L$ bezahlt.</string>
-	<string name="you_paid_ldollars">Sie haben [REASON] [AMOUNT] L$ an [NAME] bezahlt.</string>
-	<string name="you_paid_ldollars_gift">Sie haben [NAME] [AMOUNT] L$ bezahlt: [REASON]</string>
-	<string name="you_paid_ldollars_no_info">Sie haben [AMOUNT] L$ bezahlt.</string>
-	<string name="you_paid_ldollars_no_reason">Sie haben [AMOUNT] L$ an [NAME] bezahlt.</string>
-	<string name="you_paid_ldollars_no_name">Sie haben [REASON] [AMOUNT] L$ bezahlt.</string>
-	<string name="you_paid_failure_ldollars">Sie haben [NAME] [AMOUNT] L$ [REASON] nicht bezahlt.</string>
-	<string name="you_paid_failure_ldollars_gift">Sie haben [NAME] [AMOUNT] L$ nicht bezahlt: [REASON]</string>
-	<string name="you_paid_failure_ldollars_no_info">Sie haben [AMOUNT] L$ nicht bezahlt.</string>
-	<string name="you_paid_failure_ldollars_no_reason">Sie haben [NAME] [AMOUNT] L$ nicht bezahlt.</string>
-	<string name="you_paid_failure_ldollars_no_name">Sie haben [AMOUNT] L$ [REASON] nicht bezahlt.</string>
-	<string name="for item">für [ITEM]</string>
-	<string name="for a parcel of land">für eine Landparzelle</string>
-	<string name="for a land access pass">für einen Pass</string>
-	<string name="for deeding land">für die Landübertragung</string>
-	<string name="to create a group">für die Gründung einer Gruppe</string>
-	<string name="to join a group">für den Beitritt zur Gruppe</string>
-	<string name="to upload">fürs Hochladen</string>
-	<string name="to publish a classified ad">um eine Anzeige aufzugeben</string>
-	<string name="giving">[AMOUNT] L$ werden bezahlt</string>
-	<string name="uploading_costs">Kosten für Hochladen [AMOUNT] L$</string>
-	<string name="this_costs">Kosten: [AMOUNT] L$</string>
-	<string name="buying_selected_land">Ausgewähltes Land wird für [AMOUNT] L$ gekauft.</string>
-	<string name="this_object_costs">Dieses Objekt kostet  [AMOUNT] L$</string>
-	<string name="group_role_everyone">Jeder</string>
-	<string name="group_role_officers">Offiziere</string>
-	<string name="group_role_owners">Eigentümer</string>
-	<string name="group_member_status_online">Online</string>
-	<string name="uploading_abuse_report">Hochladen...
+	<string name="share_alert">
+		Objekte aus dem Inventar hier her ziehen
+	</string>
+	<string name="facebook_post_success">
+		Sie haben auf Facebook gepostet.
+	</string>
+	<string name="flickr_post_success">
+		Sie haben auf Flickr gepostet.
+	</string>
+	<string name="twitter_post_success">
+		Sie haben auf Twitter gepostet.
+	</string>
+	<string name="no_session_message">
+		(IM-Session nicht vorhanden)
+	</string>
+	<string name="only_user_message">
+		Sie sind der einzige Benutzer in dieser Sitzung.
+	</string>
+	<string name="offline_message">
+		[NAME] ist offline.
+	</string>
+	<string name="invite_message">
+		Klicken Sie auf [BUTTON NAME], um eine Verbindung zu diesem Voice-Chat herzustellen.
+	</string>
+	<string name="muted_message">
+		Sie haben diesen Einwohner ignoriert. Wenn Sie eine Nachricht senden, wird dieser freigeschaltet.
+	</string>
+	<string name="generic">
+		Fehler bei Anfrage, bitte versuchen Sie es später.
+	</string>
+	<string name="generic_request_error">
+		Fehler bei Anfrage, bitte versuchen Sie es später.
+	</string>
+	<string name="insufficient_perms_error">
+		Sie sind dazu nicht berechtigt.
+	</string>
+	<string name="session_does_not_exist_error">
+		Die Sitzung ist abgelaufen
+	</string>
+	<string name="no_ability_error">
+		Sie besitzen diese Fähigkeit nicht.
+	</string>
+	<string name="no_ability">
+		Sie besitzen diese Fähigkeit nicht.
+	</string>
+	<string name="not_a_mod_error">
+		Sie sind kein Sitzungsmoderator.
+	</string>
+	<string name="muted">
+		Ein Gruppenmoderator hat Ihren Text-Chat deaktiviert.
+	</string>
+	<string name="muted_error">
+		Ein Gruppenmoderator hat Ihren Text-Chat deaktiviert.
+	</string>
+	<string name="add_session_event">
+		Es konnten keine Benutzer zur Chat-Sitzung mit [RECIPIENT] hinzugefügt werden.
+	</string>
+	<string name="message">
+		Ihre Nachricht konnte nicht an die Chat-Sitzung mit [RECIPIENT] gesendet werden.
+	</string>
+	<string name="message_session_event">
+		Ihre Nachricht konnte nicht an die Chat-Sitzung mit [RECIPIENT] gesendet werden.
+	</string>
+	<string name="mute">
+		Fehler während Moderation.
+	</string>
+	<string name="removed">
+		Sie wurden von der Gruppe ausgeschlossen.
+	</string>
+	<string name="removed_from_group">
+		Sie wurden von der Gruppe ausgeschlossen.
+	</string>
+	<string name="close_on_no_ability">
+		Sie haben nicht mehr die Berechtigung an der Chat-Sitzung teilzunehmen.
+	</string>
+	<string name="unread_chat_single">
+		[SOURCES] hat etwas Neues gesagt
+	</string>
+	<string name="unread_chat_multiple">
+		[SOURCES] haben etwas Neues gesagt
+	</string>
+	<string name="session_initialization_timed_out_error">
+		Die Initialisierung der Sitzung ist fehlgeschlagen
+	</string>
+	<string name="Home position set.">
+		Position für Zuhause festgelegt.
+	</string>
+	<string name="voice_morphing_url">
+		https://secondlife.com/destination/voice-island
+	</string>
+	<string name="premium_voice_morphing_url">
+		https://secondlife.com/destination/voice-morphing-premium
+	</string>
+	<string name="paid_you_ldollars">
+		[NAME] hat Ihnen [REASON] [AMOUNT] L$ bezahlt.
+	</string>
+	<string name="paid_you_ldollars_gift">
+		[NAME] hat Ihnen [AMOUNT] L$ bezahlt: [REASON]
+	</string>
+	<string name="paid_you_ldollars_no_reason">
+		[NAME] hat Ihnen [AMOUNT] L$ bezahlt.
+	</string>
+	<string name="you_paid_ldollars">
+		Sie haben [REASON] [AMOUNT] L$ an [NAME] bezahlt.
+	</string>
+	<string name="you_paid_ldollars_gift">
+		Sie haben [NAME] [AMOUNT] L$ bezahlt: [REASON]
+	</string>
+	<string name="you_paid_ldollars_no_info">
+		Sie haben [AMOUNT] L$ bezahlt.
+	</string>
+	<string name="you_paid_ldollars_no_reason">
+		Sie haben [AMOUNT] L$ an [NAME] bezahlt.
+	</string>
+	<string name="you_paid_ldollars_no_name">
+		Sie haben [REASON] [AMOUNT] L$ bezahlt.
+	</string>
+	<string name="you_paid_failure_ldollars">
+		Sie haben [NAME] [AMOUNT] L$ [REASON] nicht bezahlt.
+	</string>
+	<string name="you_paid_failure_ldollars_gift">
+		Sie haben [NAME] [AMOUNT] L$ nicht bezahlt: [REASON]
+	</string>
+	<string name="you_paid_failure_ldollars_no_info">
+		Sie haben [AMOUNT] L$ nicht bezahlt.
+	</string>
+	<string name="you_paid_failure_ldollars_no_reason">
+		Sie haben [NAME] [AMOUNT] L$ nicht bezahlt.
+	</string>
+	<string name="you_paid_failure_ldollars_no_name">
+		Sie haben [AMOUNT] L$ [REASON] nicht bezahlt.
+	</string>
+	<string name="for item">
+		für [ITEM]
+	</string>
+	<string name="for a parcel of land">
+		für eine Landparzelle
+	</string>
+	<string name="for a land access pass">
+		für einen Pass
+	</string>
+	<string name="for deeding land">
+		für die Landübertragung
+	</string>
+	<string name="to create a group">
+		für die Gründung einer Gruppe
+	</string>
+	<string name="to join a group">
+		für den Beitritt zur Gruppe
+	</string>
+	<string name="to upload">
+		fürs Hochladen
+	</string>
+	<string name="to publish a classified ad">
+		um eine Anzeige aufzugeben
+	</string>
+	<string name="giving">
+		[AMOUNT] L$ werden bezahlt
+	</string>
+	<string name="uploading_costs">
+		Kosten für Hochladen [AMOUNT] L$
+	</string>
+	<string name="this_costs">
+		Kosten: [AMOUNT] L$
+	</string>
+	<string name="buying_selected_land">
+		Ausgewähltes Land wird für [AMOUNT] L$ gekauft.
+	</string>
+	<string name="this_object_costs">
+		Dieses Objekt kostet  [AMOUNT] L$
+	</string>
+	<string name="group_role_everyone">
+		Jeder
+	</string>
+	<string name="group_role_officers">
+		Offiziere
+	</string>
+	<string name="group_role_owners">
+		Eigentümer
+	</string>
+	<string name="group_member_status_online">
+		Online
+	</string>
+	<string name="uploading_abuse_report">
+		Hochladen...
 
-Missbrauchsbericht</string>
-	<string name="New Shape">Neue Form/Gestalt</string>
-	<string name="New Skin">Neue Haut</string>
-	<string name="New Hair">Neues Haar</string>
-	<string name="New Eyes">Neue Augen</string>
-	<string name="New Shirt">Neues Hemd</string>
-	<string name="New Pants">Neue Hose</string>
-	<string name="New Shoes">Neue Schuhe</string>
-	<string name="New Socks">Neue Socken</string>
-	<string name="New Jacket">Neue Jacke</string>
-	<string name="New Gloves">Neue Handschuhe</string>
-	<string name="New Undershirt">Neues Unterhemd</string>
-	<string name="New Underpants">Neue Unterhose</string>
-	<string name="New Skirt">Neuer Rock</string>
-	<string name="New Alpha">Neues Alpha</string>
-	<string name="New Tattoo">Neue Tätowierung</string>
-	<string name="New Universal">Neues Universal</string>
-	<string name="New Physics">Neue Physik</string>
-	<string name="Invalid Wearable">Ungültiges Objekt</string>
-	<string name="New Gesture">Neue Geste</string>
-	<string name="New Script">Neues Skript</string>
-	<string name="New Note">Neue Notiz</string>
-	<string name="New Folder">Neuer Ordner</string>
-	<string name="Contents">Inhalt</string>
-	<string name="Gesture">Gesten</string>
-	<string name="Male Gestures">Männliche Gesten</string>
-	<string name="Female Gestures">Weibliche Gesten</string>
-	<string name="Other Gestures">Andere Gesten</string>
-	<string name="Speech Gestures">Sprachgesten</string>
-	<string name="Common Gestures">Häufig verwendete Gesten</string>
-	<string name="Male - Excuse me">Männlich - Excuse me</string>
-	<string name="Male - Get lost">Männlich - Get lost</string>
-	<string name="Male - Blow kiss">Männlich - Kusshand</string>
-	<string name="Male - Boo">Männlich - Buh</string>
-	<string name="Male - Bored">Männlich - Gelangweilt</string>
-	<string name="Male - Hey">Männlich - Hey</string>
-	<string name="Male - Laugh">Männlich - Lachen</string>
-	<string name="Male - Repulsed">Männlich - Angewidert</string>
-	<string name="Male - Shrug">Männlich - Achselzucken</string>
-	<string name="Male - Stick tougue out">Männlich - Zunge herausstrecken</string>
-	<string name="Male - Wow">Männlich - Wow</string>
-	<string name="Female - Chuckle">Weiblich - Kichern</string>
-	<string name="Female - Cry">Weiblich - Weinen</string>
-	<string name="Female - Embarrassed">Weiblich - Verlegen</string>
-	<string name="Female - Excuse me">Weiblich - Räuspern</string>
-	<string name="Female - Get lost">Weiblich - Get lost</string>
-	<string name="Female - Blow kiss">Weiblich - Kusshand</string>
-	<string name="Female - Boo">Weiblich  - Buh</string>
-	<string name="Female - Bored">Weiblich - Gelangweilt</string>
-	<string name="Female - Hey">Weiblich - Hey</string>
-	<string name="Female - Hey baby">Weiblich - Hey Süße(r)</string>
-	<string name="Female - Laugh">Weiblich - Lachen</string>
-	<string name="Female - Looking good">Weiblich - Looking good</string>
-	<string name="Female - Over here">Weiblich - Over here</string>
-	<string name="Female - Please">Weiblich - Please</string>
-	<string name="Female - Repulsed">Weiblich - Angewidert</string>
-	<string name="Female - Shrug">Weiblich - Achselzucken</string>
-	<string name="Female - Stick tougue out">Weiblich - Zunge herausstrecken</string>
-	<string name="Female - Wow">Weiblich - Wow</string>
-	<string name="New Daycycle">Neuer Tageszyklus</string>
-	<string name="New Water">Neues Wasser</string>
-	<string name="New Sky">Neuer Himmel</string>
-	<string name="/bow">/verbeugen</string>
-	<string name="/clap">/klatschen</string>
-	<string name="/count">/zählen</string>
-	<string name="/extinguish">/löschen</string>
-	<string name="/kmb">/lmaa</string>
-	<string name="/muscle">/Muskel</string>
-	<string name="/no">/nein</string>
-	<string name="/no!">/nein!</string>
-	<string name="/paper">/Papier</string>
-	<string name="/pointme">/auf mich zeigen</string>
-	<string name="/pointyou">/auf dich zeigen</string>
-	<string name="/rock">/Stein</string>
-	<string name="/scissor">/Schere</string>
-	<string name="/smoke">/rauchen</string>
-	<string name="/stretch">/dehnen</string>
-	<string name="/whistle">/pfeifen</string>
-	<string name="/yes">/ja</string>
-	<string name="/yes!">/ja!</string>
-	<string name="afk">afk</string>
-	<string name="dance1">Tanzen1</string>
-	<string name="dance2">Tanzen2</string>
-	<string name="dance3">Tanzen3</string>
-	<string name="dance4">Tanzen4</string>
-	<string name="dance5">Tanzen5</string>
-	<string name="dance6">Tanzen6</string>
-	<string name="dance7">Tanzen7</string>
-	<string name="dance8">Tanzen8</string>
-	<string name="AvatarBirthDateFormat">[mthnum,datetime,slt]/[day,datetime,slt]/[year,datetime,slt]</string>
-	<string name="DefaultMimeType">Keine/Keiner</string>
-	<string name="texture_load_dimensions_error">Bilder, die größer sind als [WIDTH]*[HEIGHT] können nicht geladen werden</string>
-	<string name="outfit_photo_load_dimensions_error">Max. Fotogröße für Outfit ist [WIDTH]*[HEIGHT]. Bitte verkleinern Sie das Bild oder verwenden Sie ein anderes.</string>
-	<string name="outfit_photo_select_dimensions_error">Max. Fotogröße für Outfit ist [WIDTH]*[HEIGHT]. Bitte wählen Sie eine andere Textur aus.</string>
-	<string name="outfit_photo_verify_dimensions_error">Fotoabmessungen können nicht bestätigt werden. Bitte warten Sie, bis die Fotogröße im Auswahlfenster angezeigt wird.</string>
+Missbrauchsbericht
+	</string>
+	<string name="New Shape">
+		Neue Form/Gestalt
+	</string>
+	<string name="New Skin">
+		Neue Haut
+	</string>
+	<string name="New Hair">
+		Neues Haar
+	</string>
+	<string name="New Eyes">
+		Neue Augen
+	</string>
+	<string name="New Shirt">
+		Neues Hemd
+	</string>
+	<string name="New Pants">
+		Neue Hose
+	</string>
+	<string name="New Shoes">
+		Neue Schuhe
+	</string>
+	<string name="New Socks">
+		Neue Socken
+	</string>
+	<string name="New Jacket">
+		Neue Jacke
+	</string>
+	<string name="New Gloves">
+		Neue Handschuhe
+	</string>
+	<string name="New Undershirt">
+		Neues Unterhemd
+	</string>
+	<string name="New Underpants">
+		Neue Unterhose
+	</string>
+	<string name="New Skirt">
+		Neuer Rock
+	</string>
+	<string name="New Alpha">
+		Neues Alpha
+	</string>
+	<string name="New Tattoo">
+		Neue Tätowierung
+	</string>
+	<string name="New Universal">
+		Neues Universal
+	</string>
+	<string name="New Physics">
+		Neue Physik
+	</string>
+	<string name="Invalid Wearable">
+		Ungültiges Objekt
+	</string>
+	<string name="New Gesture">
+		Neue Geste
+	</string>
+	<string name="New Script">
+		Neues Skript
+	</string>
+	<string name="New Note">
+		Neue Notiz
+	</string>
+	<string name="New Folder">
+		Neuer Ordner
+	</string>
+	<string name="Contents">
+		Inhalt
+	</string>
+	<string name="Gesture">
+		Gesten
+	</string>
+	<string name="Male Gestures">
+		Männliche Gesten
+	</string>
+	<string name="Female Gestures">
+		Weibliche Gesten
+	</string>
+	<string name="Other Gestures">
+		Andere Gesten
+	</string>
+	<string name="Speech Gestures">
+		Sprachgesten
+	</string>
+	<string name="Common Gestures">
+		Häufig verwendete Gesten
+	</string>
+	<string name="Male - Excuse me">
+		Männlich - Excuse me
+	</string>
+	<string name="Male - Get lost">
+		Männlich - Get lost
+	</string>
+	<string name="Male - Blow kiss">
+		Männlich - Kusshand
+	</string>
+	<string name="Male - Boo">
+		Männlich - Buh
+	</string>
+	<string name="Male - Bored">
+		Männlich - Gelangweilt
+	</string>
+	<string name="Male - Hey">
+		Männlich - Hey
+	</string>
+	<string name="Male - Laugh">
+		Männlich - Lachen
+	</string>
+	<string name="Male - Repulsed">
+		Männlich - Angewidert
+	</string>
+	<string name="Male - Shrug">
+		Männlich - Achselzucken
+	</string>
+	<string name="Male - Stick tougue out">
+		Männlich - Zunge herausstrecken
+	</string>
+	<string name="Male - Wow">
+		Männlich - Wow
+	</string>
+	<string name="Female - Chuckle">
+		Weiblich - Kichern
+	</string>
+	<string name="Female - Cry">
+		Weiblich - Weinen
+	</string>
+	<string name="Female - Embarrassed">
+		Weiblich - Verlegen
+	</string>
+	<string name="Female - Excuse me">
+		Weiblich - Räuspern
+	</string>
+	<string name="Female - Get lost">
+		Weiblich - Get lost
+	</string>
+	<string name="Female - Blow kiss">
+		Weiblich - Kusshand
+	</string>
+	<string name="Female - Boo">
+		Weiblich  - Buh
+	</string>
+	<string name="Female - Bored">
+		Weiblich - Gelangweilt
+	</string>
+	<string name="Female - Hey">
+		Weiblich - Hey
+	</string>
+	<string name="Female - Hey baby">
+		Weiblich - Hey Süße(r)
+	</string>
+	<string name="Female - Laugh">
+		Weiblich - Lachen
+	</string>
+	<string name="Female - Looking good">
+		Weiblich - Looking good
+	</string>
+	<string name="Female - Over here">
+		Weiblich - Over here
+	</string>
+	<string name="Female - Please">
+		Weiblich - Please
+	</string>
+	<string name="Female - Repulsed">
+		Weiblich - Angewidert
+	</string>
+	<string name="Female - Shrug">
+		Weiblich - Achselzucken
+	</string>
+	<string name="Female - Stick tougue out">
+		Weiblich - Zunge herausstrecken
+	</string>
+	<string name="Female - Wow">
+		Weiblich - Wow
+	</string>
+	<string name="New Daycycle">
+		Neuer Tageszyklus
+	</string>
+	<string name="New Water">
+		Neues Wasser
+	</string>
+	<string name="New Sky">
+		Neuer Himmel
+	</string>
+	<string name="/bow">
+		/verbeugen
+	</string>
+	<string name="/clap">
+		/klatschen
+	</string>
+	<string name="/count">
+		/zählen
+	</string>
+	<string name="/extinguish">
+		/löschen
+	</string>
+	<string name="/kmb">
+		/lmaa
+	</string>
+	<string name="/muscle">
+		/Muskel
+	</string>
+	<string name="/no">
+		/nein
+	</string>
+	<string name="/no!">
+		/nein!
+	</string>
+	<string name="/paper">
+		/Papier
+	</string>
+	<string name="/pointme">
+		/auf mich zeigen
+	</string>
+	<string name="/pointyou">
+		/auf dich zeigen
+	</string>
+	<string name="/rock">
+		/Stein
+	</string>
+	<string name="/scissor">
+		/Schere
+	</string>
+	<string name="/smoke">
+		/rauchen
+	</string>
+	<string name="/stretch">
+		/dehnen
+	</string>
+	<string name="/whistle">
+		/pfeifen
+	</string>
+	<string name="/yes">
+		/ja
+	</string>
+	<string name="/yes!">
+		/ja!
+	</string>
+	<string name="afk">
+		afk
+	</string>
+	<string name="dance1">
+		Tanzen1
+	</string>
+	<string name="dance2">
+		Tanzen2
+	</string>
+	<string name="dance3">
+		Tanzen3
+	</string>
+	<string name="dance4">
+		Tanzen4
+	</string>
+	<string name="dance5">
+		Tanzen5
+	</string>
+	<string name="dance6">
+		Tanzen6
+	</string>
+	<string name="dance7">
+		Tanzen7
+	</string>
+	<string name="dance8">
+		Tanzen8
+	</string>
+	<string name="AvatarBirthDateFormat">
+		[mthnum,datetime,slt]/[day,datetime,slt]/[year,datetime,slt]
+	</string>
+	<string name="DefaultMimeType">
+		Keine/Keiner
+	</string>
+	<string name="texture_load_dimensions_error">
+		Bilder, die größer sind als [WIDTH]*[HEIGHT] können nicht geladen werden
+	</string>
+	<string name="outfit_photo_load_dimensions_error">
+		Max. Fotogröße für Outfit ist [WIDTH]*[HEIGHT]. Bitte verkleinern Sie das Bild oder verwenden Sie ein anderes.
+	</string>
+	<string name="outfit_photo_select_dimensions_error">
+		Max. Fotogröße für Outfit ist [WIDTH]*[HEIGHT]. Bitte wählen Sie eine andere Textur aus.
+	</string>
+	<string name="outfit_photo_verify_dimensions_error">
+		Fotoabmessungen können nicht bestätigt werden. Bitte warten Sie, bis die Fotogröße im Auswahlfenster angezeigt wird.
+	</string>
 	<string name="words_separator" value=","/>
-	<string name="server_is_down">Trotz all unserer Bemühungen ist ein unerwarteter Fehler aufgetreten.
+	<string name="server_is_down">
+		Trotz all unserer Bemühungen ist ein unerwarteter Fehler aufgetreten.
 
 Bitte überprüfen Sie http://status.secondlifegrid.net, um herauszufinden, ob ein Problem mit dem Service vorliegt.
-        Falls Sie weiterhin Problem haben, überprüfen Sie bitte Ihre Netzwerk- und Firewalleinstellungen.</string>
-	<string name="dateTimeWeekdaysNames">Sonntag:Montag:Dienstag:Mittwoch:Donnerstag:Freitag:Samstag</string>
-	<string name="dateTimeWeekdaysShortNames">So:Mo:Di:Mi:Do:Fr:Sa</string>
-	<string name="dateTimeMonthNames">Januar:Februar:März:April:Mai:Juni:Juli:August:September:Oktober:November:Dezember</string>
-	<string name="dateTimeMonthShortNames">Jan:Feb:Mär:Apr:Mai:Jun:Jul:Aug:Sep:Okt:Nov:Dez</string>
-	<string name="dateTimeDayFormat">[MDAY]</string>
-	<string name="dateTimeAM">Uhr</string>
-	<string name="dateTimePM">Uhr</string>
-	<string name="LocalEstimateUSD">[AMOUNT] US$</string>
-	<string name="Group Ban">Gruppenverbannung</string>
-	<string name="Membership">Mitgliedschaft</string>
-	<string name="Roles">Rollen</string>
-	<string name="Group Identity">Gruppenidentität</string>
-	<string name="Parcel Management">Parzellenverwaltung</string>
-	<string name="Parcel Identity">Parzellenidentität</string>
-	<string name="Parcel Settings">Parzelleneinstellungen</string>
-	<string name="Parcel Powers">Parzellenfähigkeiten</string>
-	<string name="Parcel Access">Parzellenzugang</string>
-	<string name="Parcel Content">Parzelleninhalt</string>
-	<string name="Object Management">Objektmanagement</string>
-	<string name="Accounting">Kontoführung</string>
-	<string name="Notices">Mitteilungen</string>
-	<string name="Chat" value=" Chat:">Chat</string>
-	<string name="BaseMembership">Basis</string>
-	<string name="PremiumMembership">Premium</string>
-	<string name="Premium_PlusMembership">Premium Plus</string>
-	<string name="DeleteItems">Ausgewählte Objekte löschen?</string>
-	<string name="DeleteItem">Ausgewähltes Objekt löschen?</string>
-	<string name="EmptyOutfitText">Keine Objekte in diesem Outfit</string>
-	<string name="ExternalEditorNotSet">Wählen Sie über die Einstellung „ExternalEditor“ einen Editor aus</string>
-	<string name="ExternalEditorNotFound">Angegebener externer Editor nicht gefunden.
+        Falls Sie weiterhin Problem haben, überprüfen Sie bitte Ihre Netzwerk- und Firewalleinstellungen.
+	</string>
+	<string name="dateTimeWeekdaysNames">
+		Sonntag:Montag:Dienstag:Mittwoch:Donnerstag:Freitag:Samstag
+	</string>
+	<string name="dateTimeWeekdaysShortNames">
+		So:Mo:Di:Mi:Do:Fr:Sa
+	</string>
+	<string name="dateTimeMonthNames">
+		Januar:Februar:März:April:Mai:Juni:Juli:August:September:Oktober:November:Dezember
+	</string>
+	<string name="dateTimeMonthShortNames">
+		Jan:Feb:Mär:Apr:Mai:Jun:Jul:Aug:Sep:Okt:Nov:Dez
+	</string>
+	<string name="dateTimeDayFormat">
+		[MDAY]
+	</string>
+	<string name="dateTimeAM">
+		Uhr
+	</string>
+	<string name="dateTimePM">
+		Uhr
+	</string>
+	<string name="LocalEstimateUSD">
+		[AMOUNT] US$
+	</string>
+	<string name="Group Ban">
+		Gruppenverbannung
+	</string>
+	<string name="Membership">
+		Mitgliedschaft
+	</string>
+	<string name="Roles">
+		Rollen
+	</string>
+	<string name="Group Identity">
+		Gruppenidentität
+	</string>
+	<string name="Parcel Management">
+		Parzellenverwaltung
+	</string>
+	<string name="Parcel Identity">
+		Parzellenidentität
+	</string>
+	<string name="Parcel Settings">
+		Parzelleneinstellungen
+	</string>
+	<string name="Parcel Powers">
+		Parzellenfähigkeiten
+	</string>
+	<string name="Parcel Access">
+		Parzellenzugang
+	</string>
+	<string name="Parcel Content">
+		Parzelleninhalt
+	</string>
+	<string name="Object Management">
+		Objektmanagement
+	</string>
+	<string name="Accounting">
+		Kontoführung
+	</string>
+	<string name="Notices">
+		Mitteilungen
+	</string>
+	<string name="Chat" value=" Chat:">
+		Chat
+	</string>
+	<string name="BaseMembership">
+		Basis
+	</string>
+	<string name="PremiumMembership">
+		Premium
+	</string>
+	<string name="Premium_PlusMembership">
+		Premium Plus
+	</string>
+	<string name="DeleteItems">
+		Ausgewählte Objekte löschen?
+	</string>
+	<string name="DeleteItem">
+		Ausgewähltes Objekt löschen?
+	</string>
+	<string name="EmptyOutfitText">
+		Keine Objekte in diesem Outfit
+	</string>
+	<string name="ExternalEditorNotSet">
+		Wählen Sie über die Einstellung „ExternalEditor“ einen Editor aus
+	</string>
+	<string name="ExternalEditorNotFound">
+		Angegebener externer Editor nicht gefunden.
 Setzen Sie den Editorpfad in Anführungszeichen
-(z. B. &quot;/pfad/editor&quot; &quot;%s&quot;).</string>
-	<string name="ExternalEditorCommandParseError">Fehler beim Parsen des externen Editorbefehls.</string>
-	<string name="ExternalEditorFailedToRun">Externer Editor konnte nicht ausgeführt werden.</string>
-	<string name="TranslationFailed">Übersetzung fehlgeschlagen: [REASON]</string>
-	<string name="TranslationResponseParseError">Fehler beim Parsen der Übersetzungsantwort.</string>
-	<string name="Esc">Esc</string>
-	<string name="Space">Space</string>
-	<string name="Enter">Enter</string>
-	<string name="Tab">Tab</string>
-	<string name="Ins">Ins</string>
-	<string name="Del">Del</string>
-	<string name="Backsp">Backsp</string>
-	<string name="Shift">Shift</string>
-	<string name="Ctrl">Ctrl</string>
-	<string name="Alt">Alt</string>
-	<string name="CapsLock">CapsLock</string>
-	<string name="Home">Zuhause</string>
-	<string name="End">End</string>
-	<string name="PgUp">PgUp</string>
-	<string name="PgDn">PgDn</string>
-	<string name="F1">F1</string>
-	<string name="F2">F2</string>
-	<string name="F3">F3</string>
-	<string name="F4">F4</string>
-	<string name="F5">F5</string>
-	<string name="F6">F6</string>
-	<string name="F7">F7</string>
-	<string name="F8">F8</string>
-	<string name="F9">F9</string>
-	<string name="F10">F10</string>
-	<string name="F11">F11</string>
-	<string name="F12">F12</string>
-	<string name="Add">Addieren</string>
-	<string name="Subtract">Subtrahieren</string>
-	<string name="Multiply">Multiplizieren</string>
-	<string name="Divide">Dividieren</string>
-	<string name="PAD_DIVIDE">PAD_DIVIDE</string>
-	<string name="PAD_LEFT">PAD_LEFT</string>
-	<string name="PAD_RIGHT">PAD_RIGHT</string>
-	<string name="PAD_DOWN">PAD_DOWN</string>
-	<string name="PAD_UP">PAD_UP</string>
-	<string name="PAD_HOME">PAD_HOME</string>
-	<string name="PAD_END">PAD_END</string>
-	<string name="PAD_PGUP">PAD_PGUP</string>
-	<string name="PAD_PGDN">PAD_PGDN</string>
-	<string name="PAD_CENTER">PAD_CENTER</string>
-	<string name="PAD_INS">PAD_INS</string>
-	<string name="PAD_DEL">PAD_DEL</string>
-	<string name="PAD_Enter">PAD_Enter</string>
-	<string name="PAD_BUTTON0">PAD_BUTTON0</string>
-	<string name="PAD_BUTTON1">PAD_BUTTON1</string>
-	<string name="PAD_BUTTON2">PAD_BUTTON2</string>
-	<string name="PAD_BUTTON3">PAD_BUTTON3</string>
-	<string name="PAD_BUTTON4">PAD_BUTTON4</string>
-	<string name="PAD_BUTTON5">PAD_BUTTON5</string>
-	<string name="PAD_BUTTON6">PAD_BUTTON6</string>
-	<string name="PAD_BUTTON7">PAD_BUTTON7</string>
-	<string name="PAD_BUTTON8">PAD_BUTTON8</string>
-	<string name="PAD_BUTTON9">PAD_BUTTON9</string>
-	<string name="PAD_BUTTON10">PAD_BUTTON10</string>
-	<string name="PAD_BUTTON11">PAD_BUTTON11</string>
-	<string name="PAD_BUTTON12">PAD_BUTTON12</string>
-	<string name="PAD_BUTTON13">PAD_BUTTON13</string>
-	<string name="PAD_BUTTON14">PAD_BUTTON14</string>
-	<string name="PAD_BUTTON15">PAD_BUTTON15</string>
-	<string name="-">-</string>
-	<string name="=">=</string>
-	<string name="`">`</string>
-	<string name=";">;</string>
-	<string name="[">[</string>
-	<string name="]">]</string>
-	<string name="\">\</string>
-	<string name="0">0</string>
-	<string name="1">1</string>
-	<string name="2">2</string>
-	<string name="3">3</string>
-	<string name="4">4</string>
-	<string name="5">5</string>
-	<string name="6">6</string>
-	<string name="7">7</string>
-	<string name="8">8</string>
-	<string name="9">9</string>
-	<string name="A">A</string>
-	<string name="B">B</string>
-	<string name="C">C</string>
-	<string name="D">D</string>
-	<string name="E">E</string>
-	<string name="F">F</string>
-	<string name="G">G</string>
-	<string name="H">H</string>
-	<string name="I">I</string>
-	<string name="J">J</string>
-	<string name="K">K</string>
-	<string name="L">L</string>
-	<string name="M">M</string>
-	<string name="N">N</string>
-	<string name="O">O</string>
-	<string name="P">P</string>
-	<string name="Q">Q</string>
-	<string name="R">R</string>
-	<string name="S">S</string>
-	<string name="T">T</string>
-	<string name="U">U</string>
-	<string name="V">V</string>
-	<string name="W">W</string>
-	<string name="X">X</string>
-	<string name="Y">Y</string>
-	<string name="Z">Z</string>
-	<string name="BeaconParticle">Partikel-Beacons werden angezeigt (blau)</string>
-	<string name="BeaconPhysical">Beacons für physische Objekte werden angezeigt (grün)</string>
-	<string name="BeaconScripted">Beacons für Skriptobjekte werden angezeigt (rot)</string>
-	<string name="BeaconScriptedTouch">Beacons für Skriptobjekte mit Berührungsfunktion werden angezeigt (rot)</string>
-	<string name="BeaconSound">Sound-Beacons werden angezeigt (gelb)</string>
-	<string name="BeaconMedia">Medien-Beacons werden angezeigt (weiß)</string>
-	<string name="BeaconSun">Sonnenrichtungs-Beacon ansehen (orange)</string>
-	<string name="BeaconMoon">Mondrichtungs-Beacon ansehen (lila)</string>
-	<string name="ParticleHiding">Partikel werden ausgeblendet</string>
-	<string name="Command_AboutLand_Label">Landinformationen</string>
-	<string name="Command_Appearance_Label">Aussehen</string>
-	<string name="Command_Avatar_Label">Avatar</string>
-	<string name="Command_Build_Label">Bauen</string>
-	<string name="Command_Chat_Label">Chat</string>
-	<string name="Command_Conversations_Label">Unterhaltungen</string>
-	<string name="Command_Compass_Label">Kompass</string>
-	<string name="Command_Destinations_Label">Ziele</string>
-	<string name="Command_Environments_Label">Meine Umgebungen</string>
-	<string name="Command_Facebook_Label">Facebook</string>
-	<string name="Command_Flickr_Label">Flickr</string>
-	<string name="Command_Gestures_Label">Gesten</string>
-	<string name="Command_Grid_Status_Label">Grid-Status</string>
-	<string name="Command_HowTo_Label">Infos</string>
-	<string name="Command_Inventory_Label">Inventar</string>
-	<string name="Command_Map_Label">Karte</string>
-	<string name="Command_Marketplace_Label">Marktplatz</string>
-	<string name="Command_MarketplaceListings_Label">Marktplatz</string>
-	<string name="Command_MiniMap_Label">Minikarte</string>
-	<string name="Command_Move_Label">Gehen / Rennen / Fliegen</string>
-	<string name="Command_Outbox_Label">Händler-Outbox</string>
-	<string name="Command_People_Label">Leute</string>
-	<string name="Command_Picks_Label">Auswahlen</string>
-	<string name="Command_Places_Label">Orte</string>
-	<string name="Command_Preferences_Label">Einstellungen</string>
-	<string name="Command_Profile_Label">Profil</string>
-	<string name="Command_Report_Abuse_Label">Missbrauch melden</string>
-	<string name="Command_Search_Label">Suchen</string>
-	<string name="Command_Snapshot_Label">Foto</string>
-	<string name="Command_Speak_Label">Sprechen</string>
-	<string name="Command_Twitter_Label">Twitter</string>
-	<string name="Command_View_Label">Kamerasteuerungen</string>
-	<string name="Command_Voice_Label">Voice-Einstellungen</string>
-	<string name="Command_AboutLand_Tooltip">Informationen zu dem von Ihnen besuchten Land</string>
-	<string name="Command_Appearance_Tooltip">Avatar ändern</string>
-	<string name="Command_Avatar_Tooltip">Kompletten Avatar auswählen</string>
-	<string name="Command_Build_Tooltip">Objekte bauen und Terrain umformen</string>
-	<string name="Command_Chat_Tooltip">Mit Leuten in der Nähe chatten</string>
-	<string name="Command_Conversations_Tooltip">Mit allen unterhalten</string>
-	<string name="Command_Compass_Tooltip">Kompass</string>
-	<string name="Command_Destinations_Tooltip">Ziele von Interesse</string>
-	<string name="Command_Environments_Tooltip">Meine Umgebungen</string>
-	<string name="Command_Facebook_Tooltip">Auf Facebook posten</string>
-	<string name="Command_Flickr_Tooltip">Auf Flickr hochladen</string>
-	<string name="Command_Gestures_Tooltip">Gesten für Ihren Avatar</string>
-	<string name="Command_Grid_Status_Tooltip">Aktuellen Grid-Status anzeigen</string>
-	<string name="Command_HowTo_Tooltip">Wie führe ich gängige Aufgaben aus?</string>
-	<string name="Command_Inventory_Tooltip">Ihr Eigentum anzeigen und benutzen</string>
-	<string name="Command_Map_Tooltip">Weltkarte</string>
-	<string name="Command_Marketplace_Tooltip">Einkaufen gehen</string>
-	<string name="Command_MarketplaceListings_Tooltip">Ihre Kreation verkaufen</string>
-	<string name="Command_MiniMap_Tooltip">Leute in der Nähe anzeigen</string>
-	<string name="Command_Move_Tooltip">Ihren Avatar bewegen</string>
-	<string name="Command_Outbox_Tooltip">Artikel zum Verkauf in den Marktplatz übertragen</string>
-	<string name="Command_People_Tooltip">Freunde, Gruppen und Leute in der Nähe</string>
-	<string name="Command_Picks_Tooltip">Orte, die in Ihrem Profil als Favoriten angezeigt werden sollen</string>
-	<string name="Command_Places_Tooltip">Von Ihnen gespeicherte Orte</string>
-	<string name="Command_Preferences_Tooltip">Einstellungen</string>
-	<string name="Command_Profile_Tooltip">Ihr Profil bearbeiten oder anzeigen</string>
-	<string name="Command_Report_Abuse_Tooltip">Missbrauch melden</string>
-	<string name="Command_Search_Tooltip">Orte, Veranstaltungen, Leute finden</string>
-	<string name="Command_Snapshot_Tooltip">Foto aufnehmen</string>
-	<string name="Command_Speak_Tooltip">Über Ihr Mikrofon mit Leuten in der Nähe sprechen</string>
-	<string name="Command_Twitter_Tooltip">Twitter</string>
-	<string name="Command_View_Tooltip">Kamerawinkel ändern</string>
-	<string name="Command_Voice_Tooltip">Lautstärkeregler für Anrufe und Leute in Ihrer Nähe in SL</string>
-	<string name="Toolbar_Bottom_Tooltip">gegenwärtig in der unteren Symbolleiste</string>
-	<string name="Toolbar_Left_Tooltip">gegenwärtig in der linken Symbolleiste</string>
-	<string name="Toolbar_Right_Tooltip">gegenwärtig in der rechten Symbolleiste</string>
-	<string name="Retain%">% zurückbehalten</string>
-	<string name="Detail">Details</string>
-	<string name="Better Detail">Bessere Details</string>
-	<string name="Surface">Oberfläche</string>
-	<string name="Solid">Fest</string>
-	<string name="Wrap">Wickeln</string>
-	<string name="Preview">Vorschau</string>
-	<string name="Normal">Normal</string>
-	<string name="Pathfinding_Wiki_URL">http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer</string>
-	<string name="Pathfinding_Object_Attr_None">Keine</string>
-	<string name="Pathfinding_Object_Attr_Permanent">Wirkt sich auf Navmesh aus</string>
-	<string name="Pathfinding_Object_Attr_Character">Figur</string>
-	<string name="Pathfinding_Object_Attr_MultiSelect">(mehrere)</string>
-	<string name="snapshot_quality_very_low">Sehr niedrig</string>
-	<string name="snapshot_quality_low">Niedrig</string>
-	<string name="snapshot_quality_medium">Mittel</string>
-	<string name="snapshot_quality_high">Hoch</string>
-	<string name="snapshot_quality_very_high">Sehr hoch</string>
-	<string name="TeleportMaturityExceeded">Der Einwohner kann diese Region nicht besuchen.</string>
-	<string name="UserDictionary">[Benutzer]</string>
-	<string name="experience_tools_experience">Erlebnis</string>
-	<string name="ExperienceNameNull">(kein Erlebnis)</string>
-	<string name="ExperienceNameUntitled">(unbenanntes Erlebnis)</string>
-	<string name="Land-Scope">Landumfang</string>
-	<string name="Grid-Scope">Gridumfang</string>
-	<string name="Allowed_Experiences_Tab">ZULäSSIG</string>
-	<string name="Blocked_Experiences_Tab">BLOCKIERT</string>
-	<string name="Contrib_Experiences_Tab">CONTRIBUTOR</string>
-	<string name="Admin_Experiences_Tab">ADMIN</string>
-	<string name="Recent_Experiences_Tab">AKTUELL</string>
-	<string name="Owned_Experiences_Tab">EIGENE</string>
-	<string name="ExperiencesCounter">([EXPERIENCES], max. [MAXEXPERIENCES])</string>
-	<string name="ExperiencePermission1">Ihre Steuerungen übernehmen</string>
-	<string name="ExperiencePermission3">Animationen Ihres Avatars auslösen</string>
-	<string name="ExperiencePermission4">an Ihren Avatar anhängen</string>
-	<string name="ExperiencePermission9">Ihre Kamera vorfolgen</string>
-	<string name="ExperiencePermission10">Ihre Kamera steuern</string>
-	<string name="ExperiencePermission11">Sie teleportieren</string>
-	<string name="ExperiencePermission12">automatisch Erlebnisberechtigungen akzeptieren</string>
-	<string name="ExperiencePermission16">ihren Avatar zwingen, sich zu setzen</string>
-	<string name="ExperiencePermission17">Ändern Ihrer Umgebungseinstellungen</string>
-	<string name="ExperiencePermissionShortUnknown">unbekannten Vorgang durchführen: [Permission]</string>
-	<string name="ExperiencePermissionShort1">Steuerungen übernehmen</string>
-	<string name="ExperiencePermissionShort3">Animationen auslösen</string>
-	<string name="ExperiencePermissionShort4">Anhängen</string>
-	<string name="ExperiencePermissionShort9">Kamera verfolgen</string>
-	<string name="ExperiencePermissionShort10">Kamera steuern</string>
-	<string name="ExperiencePermissionShort11">Teleportieren</string>
-	<string name="ExperiencePermissionShort12">Berechtigung</string>
-	<string name="ExperiencePermissionShort16">Sitzen</string>
-	<string name="ExperiencePermissionShort17">Umgebung</string>
-	<string name="logging_calls_disabled_log_empty">Unterhaltungen werden nicht protokolliert. Um ein Protokoll zu starten, wählen Sie „Speichern: nur Protokoll“ oder „Speichern: Protokoll und Transkripte“ unter „Einstellungen“ &gt; „Chat“.</string>
-	<string name="logging_calls_disabled_log_not_empty">Es werden keine Unterhaltungen mehr protokolliert. Um weiterhin ein Protokoll zu führen, wählen Sie „Speichern: nur Protokoll“ oder „Speichern: Protokoll und Transkripte“ unter „Einstellungen“ &gt; „Chat“.</string>
-	<string name="logging_calls_enabled_log_empty">Keine protokollierten Unterhaltungen verfügbar. Hier erscheint ein Protokolleintrag, wenn Sie eine Person kontaktieren oder von einer Person kontaktiert werden.</string>
-	<string name="loading_chat_logs">Laden...</string>
-	<string name="na">Nicht zutreffend</string>
-	<string name="preset_combo_label">-Leere Liste-</string>
-	<string name="Default">Standard</string>
-	<string name="none_paren_cap">(Keine)</string>
-	<string name="no_limit">Keine Begrenzung</string>
-	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">Die Physikform enthält Dreiecke, die zu klein sind. Versuchen Sie, das Physikmodell zu vereinfachen.</string>
-	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">Die Physikform enthält ungültige Bestätigungsdaten. Versuchen Sie, das Physikmodell zu korrigieren.</string>
-	<string name="Mav_Details_MAV_UNKNOWN_VERSION">Die Physikform hat keine korrekte Version. Legen Sie die korrekte Version für das Physikmodell fest.</string>
-	<string name="couldnt_resolve_host">Der DNS konnte den Hostnamen ([HOSTNAME]) nicht auflösen Prüfen 
+(z. B. "/pfad/editor" "%s").
+	</string>
+	<string name="ExternalEditorCommandParseError">
+		Fehler beim Parsen des externen Editorbefehls.
+	</string>
+	<string name="ExternalEditorFailedToRun">
+		Externer Editor konnte nicht ausgeführt werden.
+	</string>
+	<string name="TranslationFailed">
+		Übersetzung fehlgeschlagen: [REASON]
+	</string>
+	<string name="TranslationResponseParseError">
+		Fehler beim Parsen der Übersetzungsantwort.
+	</string>
+	<string name="Esc">
+		Esc
+	</string>
+	<string name="Space">
+		Space
+	</string>
+	<string name="Enter">
+		Enter
+	</string>
+	<string name="Tab">
+		Tab
+	</string>
+	<string name="Ins">
+		Ins
+	</string>
+	<string name="Del">
+		Del
+	</string>
+	<string name="Backsp">
+		Backsp
+	</string>
+	<string name="Shift">
+		Shift
+	</string>
+	<string name="Ctrl">
+		Ctrl
+	</string>
+	<string name="Alt">
+		Alt
+	</string>
+	<string name="CapsLock">
+		CapsLock
+	</string>
+	<string name="Home">
+		Zuhause
+	</string>
+	<string name="End">
+		End
+	</string>
+	<string name="PgUp">
+		PgUp
+	</string>
+	<string name="PgDn">
+		PgDn
+	</string>
+	<string name="F1">
+		F1
+	</string>
+	<string name="F2">
+		F2
+	</string>
+	<string name="F3">
+		F3
+	</string>
+	<string name="F4">
+		F4
+	</string>
+	<string name="F5">
+		F5
+	</string>
+	<string name="F6">
+		F6
+	</string>
+	<string name="F7">
+		F7
+	</string>
+	<string name="F8">
+		F8
+	</string>
+	<string name="F9">
+		F9
+	</string>
+	<string name="F10">
+		F10
+	</string>
+	<string name="F11">
+		F11
+	</string>
+	<string name="F12">
+		F12
+	</string>
+	<string name="Add">
+		Addieren
+	</string>
+	<string name="Subtract">
+		Subtrahieren
+	</string>
+	<string name="Multiply">
+		Multiplizieren
+	</string>
+	<string name="Divide">
+		Dividieren
+	</string>
+	<string name="PAD_DIVIDE">
+		PAD_DIVIDE
+	</string>
+	<string name="PAD_LEFT">
+		PAD_LEFT
+	</string>
+	<string name="PAD_RIGHT">
+		PAD_RIGHT
+	</string>
+	<string name="PAD_DOWN">
+		PAD_DOWN
+	</string>
+	<string name="PAD_UP">
+		PAD_UP
+	</string>
+	<string name="PAD_HOME">
+		PAD_HOME
+	</string>
+	<string name="PAD_END">
+		PAD_END
+	</string>
+	<string name="PAD_PGUP">
+		PAD_PGUP
+	</string>
+	<string name="PAD_PGDN">
+		PAD_PGDN
+	</string>
+	<string name="PAD_CENTER">
+		PAD_CENTER
+	</string>
+	<string name="PAD_INS">
+		PAD_INS
+	</string>
+	<string name="PAD_DEL">
+		PAD_DEL
+	</string>
+	<string name="PAD_Enter">
+		PAD_Enter
+	</string>
+	<string name="PAD_BUTTON0">
+		PAD_BUTTON0
+	</string>
+	<string name="PAD_BUTTON1">
+		PAD_BUTTON1
+	</string>
+	<string name="PAD_BUTTON2">
+		PAD_BUTTON2
+	</string>
+	<string name="PAD_BUTTON3">
+		PAD_BUTTON3
+	</string>
+	<string name="PAD_BUTTON4">
+		PAD_BUTTON4
+	</string>
+	<string name="PAD_BUTTON5">
+		PAD_BUTTON5
+	</string>
+	<string name="PAD_BUTTON6">
+		PAD_BUTTON6
+	</string>
+	<string name="PAD_BUTTON7">
+		PAD_BUTTON7
+	</string>
+	<string name="PAD_BUTTON8">
+		PAD_BUTTON8
+	</string>
+	<string name="PAD_BUTTON9">
+		PAD_BUTTON9
+	</string>
+	<string name="PAD_BUTTON10">
+		PAD_BUTTON10
+	</string>
+	<string name="PAD_BUTTON11">
+		PAD_BUTTON11
+	</string>
+	<string name="PAD_BUTTON12">
+		PAD_BUTTON12
+	</string>
+	<string name="PAD_BUTTON13">
+		PAD_BUTTON13
+	</string>
+	<string name="PAD_BUTTON14">
+		PAD_BUTTON14
+	</string>
+	<string name="PAD_BUTTON15">
+		PAD_BUTTON15
+	</string>
+	<string name="-">
+		-
+	</string>
+	<string name="=">
+		=
+	</string>
+	<string name="`">
+		`
+	</string>
+	<string name=";">
+		;
+	</string>
+	<string name="[">
+		[
+	</string>
+	<string name="]">
+		]
+	</string>
+	<string name="\">
+		\
+	</string>
+	<string name="0">
+		0
+	</string>
+	<string name="1">
+		1
+	</string>
+	<string name="2">
+		2
+	</string>
+	<string name="3">
+		3
+	</string>
+	<string name="4">
+		4
+	</string>
+	<string name="5">
+		5
+	</string>
+	<string name="6">
+		6
+	</string>
+	<string name="7">
+		7
+	</string>
+	<string name="8">
+		8
+	</string>
+	<string name="9">
+		9
+	</string>
+	<string name="A">
+		A
+	</string>
+	<string name="B">
+		B
+	</string>
+	<string name="C">
+		C
+	</string>
+	<string name="D">
+		D
+	</string>
+	<string name="E">
+		E
+	</string>
+	<string name="F">
+		F
+	</string>
+	<string name="G">
+		G
+	</string>
+	<string name="H">
+		H
+	</string>
+	<string name="I">
+		I
+	</string>
+	<string name="J">
+		J
+	</string>
+	<string name="K">
+		K
+	</string>
+	<string name="L">
+		L
+	</string>
+	<string name="M">
+		M
+	</string>
+	<string name="N">
+		N
+	</string>
+	<string name="O">
+		O
+	</string>
+	<string name="P">
+		P
+	</string>
+	<string name="Q">
+		Q
+	</string>
+	<string name="R">
+		R
+	</string>
+	<string name="S">
+		S
+	</string>
+	<string name="T">
+		T
+	</string>
+	<string name="U">
+		U
+	</string>
+	<string name="V">
+		V
+	</string>
+	<string name="W">
+		W
+	</string>
+	<string name="X">
+		X
+	</string>
+	<string name="Y">
+		Y
+	</string>
+	<string name="Z">
+		Z
+	</string>
+	<string name="BeaconParticle">
+		Partikel-Beacons werden angezeigt (blau)
+	</string>
+	<string name="BeaconPhysical">
+		Beacons für physische Objekte werden angezeigt (grün)
+	</string>
+	<string name="BeaconScripted">
+		Beacons für Skriptobjekte werden angezeigt (rot)
+	</string>
+	<string name="BeaconScriptedTouch">
+		Beacons für Skriptobjekte mit Berührungsfunktion werden angezeigt (rot)
+	</string>
+	<string name="BeaconSound">
+		Sound-Beacons werden angezeigt (gelb)
+	</string>
+	<string name="BeaconMedia">
+		Medien-Beacons werden angezeigt (weiß)
+	</string>
+	<string name="BeaconSun">
+		Sonnenrichtungs-Beacon ansehen (orange)
+	</string>
+	<string name="BeaconMoon">
+		Mondrichtungs-Beacon ansehen (lila)
+	</string>
+	<string name="ParticleHiding">
+		Partikel werden ausgeblendet
+	</string>
+	<string name="Command_AboutLand_Label">
+		Landinformationen
+	</string>
+	<string name="Command_Appearance_Label">
+		Aussehen
+	</string>
+	<string name="Command_Avatar_Label">
+		Avatar
+	</string>
+	<string name="Command_Build_Label">
+		Bauen
+	</string>
+	<string name="Command_Chat_Label">
+		Chat
+	</string>
+	<string name="Command_Conversations_Label">
+		Unterhaltungen
+	</string>
+	<string name="Command_Compass_Label">
+		Kompass
+	</string>
+	<string name="Command_Destinations_Label">
+		Ziele
+	</string>
+	<string name="Command_Environments_Label">
+		Meine Umgebungen
+	</string>
+	<string name="Command_Facebook_Label">
+		Facebook
+	</string>
+	<string name="Command_Flickr_Label">
+		Flickr
+	</string>
+	<string name="Command_Gestures_Label">
+		Gesten
+	</string>
+	<string name="Command_Grid_Status_Label">
+		Grid-Status
+	</string>
+	<string name="Command_HowTo_Label">
+		Infos
+	</string>
+	<string name="Command_Inventory_Label">
+		Inventar
+	</string>
+	<string name="Command_Map_Label">
+		Karte
+	</string>
+	<string name="Command_Marketplace_Label">
+		Marktplatz
+	</string>
+	<string name="Command_MarketplaceListings_Label">
+		Marktplatz
+	</string>
+	<string name="Command_MiniMap_Label">
+		Minikarte
+	</string>
+	<string name="Command_Move_Label">
+		Gehen / Rennen / Fliegen
+	</string>
+	<string name="Command_Outbox_Label">
+		Händler-Outbox
+	</string>
+	<string name="Command_People_Label">
+		Leute
+	</string>
+	<string name="Command_Picks_Label">
+		Auswahlen
+	</string>
+	<string name="Command_Places_Label">
+		Orte
+	</string>
+	<string name="Command_Preferences_Label">
+		Einstellungen
+	</string>
+	<string name="Command_Profile_Label">
+		Profil
+	</string>
+	<string name="Command_Report_Abuse_Label">
+		Missbrauch melden
+	</string>
+	<string name="Command_Search_Label">
+		Suchen
+	</string>
+	<string name="Command_Snapshot_Label">
+		Foto
+	</string>
+	<string name="Command_Speak_Label">
+		Sprechen
+	</string>
+	<string name="Command_Twitter_Label">
+		Twitter
+	</string>
+	<string name="Command_View_Label">
+		Kamerasteuerungen
+	</string>
+	<string name="Command_Voice_Label">
+		Voice-Einstellungen
+	</string>
+	<string name="Command_AboutLand_Tooltip">
+		Informationen zu dem von Ihnen besuchten Land
+	</string>
+	<string name="Command_Appearance_Tooltip">
+		Avatar ändern
+	</string>
+	<string name="Command_Avatar_Tooltip">
+		Kompletten Avatar auswählen
+	</string>
+	<string name="Command_Build_Tooltip">
+		Objekte bauen und Terrain umformen
+	</string>
+	<string name="Command_Chat_Tooltip">
+		Mit Leuten in der Nähe chatten
+	</string>
+	<string name="Command_Conversations_Tooltip">
+		Mit allen unterhalten
+	</string>
+	<string name="Command_Compass_Tooltip">
+		Kompass
+	</string>
+	<string name="Command_Destinations_Tooltip">
+		Ziele von Interesse
+	</string>
+	<string name="Command_Environments_Tooltip">
+		Meine Umgebungen
+	</string>
+	<string name="Command_Facebook_Tooltip">
+		Auf Facebook posten
+	</string>
+	<string name="Command_Flickr_Tooltip">
+		Auf Flickr hochladen
+	</string>
+	<string name="Command_Gestures_Tooltip">
+		Gesten für Ihren Avatar
+	</string>
+	<string name="Command_Grid_Status_Tooltip">
+		Aktuellen Grid-Status anzeigen
+	</string>
+	<string name="Command_HowTo_Tooltip">
+		Wie führe ich gängige Aufgaben aus?
+	</string>
+	<string name="Command_Inventory_Tooltip">
+		Ihr Eigentum anzeigen und benutzen
+	</string>
+	<string name="Command_Map_Tooltip">
+		Weltkarte
+	</string>
+	<string name="Command_Marketplace_Tooltip">
+		Einkaufen gehen
+	</string>
+	<string name="Command_MarketplaceListings_Tooltip">
+		Ihre Kreation verkaufen
+	</string>
+	<string name="Command_MiniMap_Tooltip">
+		Leute in der Nähe anzeigen
+	</string>
+	<string name="Command_Move_Tooltip">
+		Ihren Avatar bewegen
+	</string>
+	<string name="Command_Outbox_Tooltip">
+		Artikel zum Verkauf in den Marktplatz übertragen
+	</string>
+	<string name="Command_People_Tooltip">
+		Freunde, Gruppen und Leute in der Nähe
+	</string>
+	<string name="Command_Picks_Tooltip">
+		Orte, die in Ihrem Profil als Favoriten angezeigt werden sollen
+	</string>
+	<string name="Command_Places_Tooltip">
+		Von Ihnen gespeicherte Orte
+	</string>
+	<string name="Command_Preferences_Tooltip">
+		Einstellungen
+	</string>
+	<string name="Command_Profile_Tooltip">
+		Ihr Profil bearbeiten oder anzeigen
+	</string>
+	<string name="Command_Report_Abuse_Tooltip">
+		Missbrauch melden
+	</string>
+	<string name="Command_Search_Tooltip">
+		Orte, Veranstaltungen, Leute finden
+	</string>
+	<string name="Command_Snapshot_Tooltip">
+		Foto aufnehmen
+	</string>
+	<string name="Command_Speak_Tooltip">
+		Über Ihr Mikrofon mit Leuten in der Nähe sprechen
+	</string>
+	<string name="Command_Twitter_Tooltip">
+		Twitter
+	</string>
+	<string name="Command_View_Tooltip">
+		Kamerawinkel ändern
+	</string>
+	<string name="Command_Voice_Tooltip">
+		Lautstärkeregler für Anrufe und Leute in Ihrer Nähe in SL
+	</string>
+	<string name="Toolbar_Bottom_Tooltip">
+		gegenwärtig in der unteren Symbolleiste
+	</string>
+	<string name="Toolbar_Left_Tooltip">
+		gegenwärtig in der linken Symbolleiste
+	</string>
+	<string name="Toolbar_Right_Tooltip">
+		gegenwärtig in der rechten Symbolleiste
+	</string>
+	<string name="Retain%">
+		% zurückbehalten
+	</string>
+	<string name="Detail">
+		Details
+	</string>
+	<string name="Better Detail">
+		Bessere Details
+	</string>
+	<string name="Surface">
+		Oberfläche
+	</string>
+	<string name="Solid">
+		Fest
+	</string>
+	<string name="Wrap">
+		Wickeln
+	</string>
+	<string name="Preview">
+		Vorschau
+	</string>
+	<string name="Normal">
+		Normal
+	</string>
+	<string name="Pathfinding_Wiki_URL">
+		http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer
+	</string>
+	<string name="Pathfinding_Object_Attr_None">
+		Keine
+	</string>
+	<string name="Pathfinding_Object_Attr_Permanent">
+		Wirkt sich auf Navmesh aus
+	</string>
+	<string name="Pathfinding_Object_Attr_Character">
+		Figur
+	</string>
+	<string name="Pathfinding_Object_Attr_MultiSelect">
+		(mehrere)
+	</string>
+	<string name="snapshot_quality_very_low">
+		Sehr niedrig
+	</string>
+	<string name="snapshot_quality_low">
+		Niedrig
+	</string>
+	<string name="snapshot_quality_medium">
+		Mittel
+	</string>
+	<string name="snapshot_quality_high">
+		Hoch
+	</string>
+	<string name="snapshot_quality_very_high">
+		Sehr hoch
+	</string>
+	<string name="TeleportMaturityExceeded">
+		Der Einwohner kann diese Region nicht besuchen.
+	</string>
+	<string name="UserDictionary">
+		[Benutzer]
+	</string>
+	<string name="experience_tools_experience">
+		Erlebnis
+	</string>
+	<string name="ExperienceNameNull">
+		(kein Erlebnis)
+	</string>
+	<string name="ExperienceNameUntitled">
+		(unbenanntes Erlebnis)
+	</string>
+	<string name="Land-Scope">
+		Landumfang
+	</string>
+	<string name="Grid-Scope">
+		Gridumfang
+	</string>
+	<string name="Allowed_Experiences_Tab">
+		ZULäSSIG
+	</string>
+	<string name="Blocked_Experiences_Tab">
+		BLOCKIERT
+	</string>
+	<string name="Contrib_Experiences_Tab">
+		CONTRIBUTOR
+	</string>
+	<string name="Admin_Experiences_Tab">
+		ADMIN
+	</string>
+	<string name="Recent_Experiences_Tab">
+		AKTUELL
+	</string>
+	<string name="Owned_Experiences_Tab">
+		EIGENE
+	</string>
+	<string name="ExperiencesCounter">
+		([EXPERIENCES], max. [MAXEXPERIENCES])
+	</string>
+	<string name="ExperiencePermission1">
+		Ihre Steuerungen übernehmen
+	</string>
+	<string name="ExperiencePermission3">
+		Animationen Ihres Avatars auslösen
+	</string>
+	<string name="ExperiencePermission4">
+		an Ihren Avatar anhängen
+	</string>
+	<string name="ExperiencePermission9">
+		Ihre Kamera vorfolgen
+	</string>
+	<string name="ExperiencePermission10">
+		Ihre Kamera steuern
+	</string>
+	<string name="ExperiencePermission11">
+		Sie teleportieren
+	</string>
+	<string name="ExperiencePermission12">
+		automatisch Erlebnisberechtigungen akzeptieren
+	</string>
+	<string name="ExperiencePermission16">
+		ihren Avatar zwingen, sich zu setzen
+	</string>
+	<string name="ExperiencePermission17">
+		Ändern Ihrer Umgebungseinstellungen
+	</string>
+	<string name="ExperiencePermissionShortUnknown">
+		unbekannten Vorgang durchführen: [Permission]
+	</string>
+	<string name="ExperiencePermissionShort1">
+		Steuerungen übernehmen
+	</string>
+	<string name="ExperiencePermissionShort3">
+		Animationen auslösen
+	</string>
+	<string name="ExperiencePermissionShort4">
+		Anhängen
+	</string>
+	<string name="ExperiencePermissionShort9">
+		Kamera verfolgen
+	</string>
+	<string name="ExperiencePermissionShort10">
+		Kamera steuern
+	</string>
+	<string name="ExperiencePermissionShort11">
+		Teleportieren
+	</string>
+	<string name="ExperiencePermissionShort12">
+		Berechtigung
+	</string>
+	<string name="ExperiencePermissionShort16">
+		Sitzen
+	</string>
+	<string name="ExperiencePermissionShort17">
+		Umgebung
+	</string>
+	<string name="logging_calls_disabled_log_empty">
+		Unterhaltungen werden nicht protokolliert. Um ein Protokoll zu starten, wählen Sie „Speichern: nur Protokoll“ oder „Speichern: Protokoll und Transkripte“ unter „Einstellungen“ &gt; „Chat“.
+	</string>
+	<string name="logging_calls_disabled_log_not_empty">
+		Es werden keine Unterhaltungen mehr protokolliert. Um weiterhin ein Protokoll zu führen, wählen Sie „Speichern: nur Protokoll“ oder „Speichern: Protokoll und Transkripte“ unter „Einstellungen“ &gt; „Chat“.
+	</string>
+	<string name="logging_calls_enabled_log_empty">
+		Keine protokollierten Unterhaltungen verfügbar. Hier erscheint ein Protokolleintrag, wenn Sie eine Person kontaktieren oder von einer Person kontaktiert werden.
+	</string>
+	<string name="loading_chat_logs">
+		Laden...
+	</string>
+	<string name="na">
+		Nicht zutreffend
+	</string>
+	<string name="preset_combo_label">
+		-Leere Liste-
+	</string>
+	<string name="Default">
+		Standard
+	</string>
+	<string name="none_paren_cap">
+		(Keine)
+	</string>
+	<string name="no_limit">
+		Keine Begrenzung
+	</string>
+	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">
+		Die Physikform enthält Dreiecke, die zu klein sind. Versuchen Sie, das Physikmodell zu vereinfachen.
+	</string>
+	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">
+		Die Physikform enthält ungültige Bestätigungsdaten. Versuchen Sie, das Physikmodell zu korrigieren.
+	</string>
+	<string name="Mav_Details_MAV_UNKNOWN_VERSION">
+		Die Physikform hat keine korrekte Version. Legen Sie die korrekte Version für das Physikmodell fest.
+	</string>
+	<string name="couldnt_resolve_host">
+		Der DNS konnte den Hostnamen ([HOSTNAME]) nicht auflösen Prüfen 
 Sie bitte, ob Sie die Website www.secondlife.com aufrufen können. Wenn Sie die 
 Website aufrufen können, jedoch weiterhin diese Fehlermeldung erhalten, 
-besuchen Sie bitte den Support-Bereich und melden Sie das Problem.</string>
-	<string name="ssl_peer_certificate">Der Anmeldeserver konnte sich nicht per SSL verifizieren. 
+besuchen Sie bitte den Support-Bereich und melden Sie das Problem.
+	</string>
+	<string name="ssl_peer_certificate">
+		Der Anmeldeserver konnte sich nicht per SSL verifizieren. 
 Wenn Sie diese Fehlermeldung weiterhin erhalten, besuchen 
 Sie bitte den Support-Bereich der Website Secondlife.com 
-und melden Sie das Problem.</string>
-	<string name="ssl_connect_error">Die Ursache hierfür ist häufig eine falsch eingestellte Uhrzeit auf Ihrem Computer. 
+und melden Sie das Problem.
+	</string>
+	<string name="ssl_connect_error">
+		Die Ursache hierfür ist häufig eine falsch eingestellte Uhrzeit auf Ihrem Computer. 
 Bitte vergewissern Sie sich, dass Datum und Uhrzeit in der Systemsteuerung korrekt 
 eingestellt sind. Überprüfen Sie außerdem, ob Ihre Netzwerk- und Firewall-Einstellungen 
 korrekt sind. Wenn Sie diese Fehlermeldung weiterhin erhalten, besuchen Sie bitte den 
 Support-Bereich der Website Secondlife.com und melden Sie das Problem. 
 
-[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Knowledge-Base]</string>
+[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Knowledge-Base]
+	</string>
 </strings>

--- a/indra/newview/skins/default/xui/de/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/de/teleport_strings.xml
@@ -1,41 +1,97 @@
 <?xml version="1.0" ?>
 <teleport_messages>
 	<message_set name="errors">
-		<message name="invalid_tport">Bei der Bearbeitung Ihrer Teleport-Anfrage ist ein Problem aufgetreten. Sie müssen sich zum Teleportieren eventuell neu anmelden.
-Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].</message>
-		<message name="invalid_region_handoff">Bei der Bearbeitung Ihres Regionswechsels ist ein Problem aufgetreten. Sie müssen eventuell neu anmelden, um die Region wechseln zu können.
-Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].</message>
-		<message name="blocked_tport">Teleportieren ist zurzeit leider nicht möglich. Versuchen Sie es später noch einmal.
-Wenn der Teleport dann immer noch nicht funktioniert, melden Sie sich bitte ab und wieder an.</message>
-		<message name="nolandmark_tport">Das System konnte das Landmarken-Ziel nicht finden.</message>
-		<message name="timeout_tport">Das System konnte keine Teleport-Verbindung herstellen.
-Versuchen Sie es später noch einmal.</message>
-		<message name="NoHelpIslandTP">Sie können nicht zurück nach Welcome Island teleportieren.
-Gehen Sie zu „Welcome Island Public“, um das Tutorial zu wiederholen.</message>
-		<message name="noaccess_tport">Sie haben leider keinen Zugang zu diesem Teleport-Ziel.</message>
-		<message name="missing_attach_tport">Ihre Anhänge sind noch nicht eingetroffen. Warten Sie kurz oder melden Sie sich ab und wieder an, bevor Sie einen neuen Teleport-Versuch unternehmen.</message>
-		<message name="too_many_uploads_tport">Die Asset-Warteschlange in dieser Region ist zurzeit überlastet.
-Ihre Teleport-Anfrage kann nicht sofort bearbeitet werden. Versuchen Sie es in einigen Minuten erneut oder besuchen Sie eine weniger überfüllte Region.</message>
-		<message name="expired_tport">Das System konnte Ihre Teleport-Anfrage nicht rechtzeitig bearbeiten. Versuchen Sie es in einigen Minuten erneut.</message>
-		<message name="expired_region_handoff">Das System konnte Ihre Anfrage zum Regionswechsel nicht rechtzeitig bearbeiten. Versuchen Sie es in einigen Minuten erneut.</message>
-		<message name="no_host">Teleport-Ziel wurde nicht gefunden. Das Ziel ist entweder im Moment nicht verfügbar oder existiert nicht mehr. Versuchen Sie es in einigen Minuten erneut.</message>
-		<message name="no_inventory_host">Das Inventarsystem ist zurzeit nicht verfügbar.</message>
-		<message name="MustGetAgeRegion">Sie müssen mindestens 18 Jahre alt sein, um diese Region betreten zu können.</message>
-		<message name="RegionTPSpecialUsageBlocked">Betreten der Region nicht gestattet. „[REGION_NAME]“ ist eine Region für Geschicklichkeitsspiele. Der Zutritt ist Einwohnern vorbehalten, die bestimmte Kriterien erfüllen. Weitere Details finden Sie unter [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ].</message>
-		<message name="preexisting_tport">Entschuldigung, aber das System konnte deinen Teleport nicht starten. Versuche es bitte in ein paar Minuten noch einmal.</message>
+		<message name="invalid_tport">
+			Bei der Bearbeitung Ihrer Teleport-Anfrage ist ein Problem aufgetreten. Sie müssen sich zum Teleportieren eventuell neu anmelden.
+Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].
+		</message>
+		<message name="invalid_region_handoff">
+			Bei der Bearbeitung Ihres Regionswechsels ist ein Problem aufgetreten. Sie müssen eventuell neu anmelden, um die Region wechseln zu können.
+Falls diese Meldung weiterhin angezeigt wird, wenden Sie sich bitte an [SUPPORT_SITE].
+		</message>
+		<message name="blocked_tport">
+			Teleportieren ist zurzeit leider nicht möglich. Versuchen Sie es später noch einmal.
+Wenn der Teleport dann immer noch nicht funktioniert, melden Sie sich bitte ab und wieder an.
+		</message>
+		<message name="nolandmark_tport">
+			Das System konnte das Landmarken-Ziel nicht finden.
+		</message>
+		<message name="timeout_tport">
+			Das System konnte keine Teleport-Verbindung herstellen.
+Versuchen Sie es später noch einmal.
+		</message>
+		<message name="NoHelpIslandTP">
+			Sie können nicht zurück nach Welcome Island teleportieren.
+Gehen Sie zu „Welcome Island Public“, um das Tutorial zu wiederholen.
+		</message>
+		<message name="noaccess_tport">
+			Sie haben leider keinen Zugang zu diesem Teleport-Ziel.
+		</message>
+		<message name="missing_attach_tport">
+			Ihre Anhänge sind noch nicht eingetroffen. Warten Sie kurz oder melden Sie sich ab und wieder an, bevor Sie einen neuen Teleport-Versuch unternehmen.
+		</message>
+		<message name="too_many_uploads_tport">
+			Die Asset-Warteschlange in dieser Region ist zurzeit überlastet.
+Ihre Teleport-Anfrage kann nicht sofort bearbeitet werden. Versuchen Sie es in einigen Minuten erneut oder besuchen Sie eine weniger überfüllte Region.
+		</message>
+		<message name="expired_tport">
+			Das System konnte Ihre Teleport-Anfrage nicht rechtzeitig bearbeiten. Versuchen Sie es in einigen Minuten erneut.
+		</message>
+		<message name="expired_region_handoff">
+			Das System konnte Ihre Anfrage zum Regionswechsel nicht rechtzeitig bearbeiten. Versuchen Sie es in einigen Minuten erneut.
+		</message>
+		<message name="no_host">
+			Teleport-Ziel wurde nicht gefunden. Das Ziel ist entweder im Moment nicht verfügbar oder existiert nicht mehr. Versuchen Sie es in einigen Minuten erneut.
+		</message>
+		<message name="no_inventory_host">
+			Das Inventarsystem ist zurzeit nicht verfügbar.
+		</message>
+		<message name="MustGetAgeRegion">
+			Sie müssen mindestens 18 Jahre alt sein, um diese Region betreten zu können.
+		</message>
+		<message name="RegionTPSpecialUsageBlocked">
+			Betreten der Region nicht gestattet. „[REGION_NAME]“ ist eine Region für Geschicklichkeitsspiele. Der Zutritt ist Einwohnern vorbehalten, die bestimmte Kriterien erfüllen. Weitere Details finden Sie unter [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ].
+		</message>
+		<message name="preexisting_tport">
+			Entschuldigung, aber das System konnte deinen Teleport nicht starten. Versuche es bitte in ein paar Minuten noch einmal.
+		</message>
 	</message_set>
 	<message_set name="progress">
-		<message name="sending_dest">Transport zum Ziel.</message>
-		<message name="redirecting">Weiterleitung an anderes Ziel.</message>
-		<message name="relaying">Weiterleitung zum Ziel.</message>
-		<message name="sending_home">Zuhause-Position wird ermittelt.</message>
-		<message name="sending_landmark">Landmarken-Position wird ermittelt.</message>
-		<message name="completing">Teleport wird abgeschlossen.</message>
-		<message name="completed_from">Teleport aus [T_SLURL] wurde erfolgreich abgeschlossen.</message>
-		<message name="resolving">Ziel wird ermittelt.</message>
-		<message name="contacting">Verbindung zu neuer Region.</message>
-		<message name="arriving">Ziel erreicht...</message>
-		<message name="requesting">Teleport wird initialisiert...</message>
-		<message name="pending">Anstehender Teleport...</message>
+		<message name="sending_dest">
+			Transport zum Ziel.
+		</message>
+		<message name="redirecting">
+			Weiterleitung an anderes Ziel.
+		</message>
+		<message name="relaying">
+			Weiterleitung zum Ziel.
+		</message>
+		<message name="sending_home">
+			Zuhause-Position wird ermittelt.
+		</message>
+		<message name="sending_landmark">
+			Landmarken-Position wird ermittelt.
+		</message>
+		<message name="completing">
+			Teleport wird abgeschlossen.
+		</message>
+		<message name="completed_from">
+			Teleport aus [T_SLURL] wurde erfolgreich abgeschlossen.
+		</message>
+		<message name="resolving">
+			Ziel wird ermittelt.
+		</message>
+		<message name="contacting">
+			Verbindung zu neuer Region.
+		</message>
+		<message name="arriving">
+			Ziel erreicht...
+		</message>
+		<message name="requesting">
+			Teleport wird initialisiert...
+		</message>
+		<message name="pending">
+			Anstehender Teleport...
+		</message>
 	</message_set>
 </teleport_messages>

--- a/indra/newview/skins/default/xui/es/strings.xml
+++ b/indra/newview/skins/default/xui/es/strings.xml
@@ -1,608 +1,1660 @@
 <?xml version="1.0" ?>
 <strings>
-	<string name="CAPITALIZED_APP_NAME">SECOND LIFE</string>
-	<string name="SUPPORT_SITE">Portal de Soporte de Second Life</string>
-	<string name="StartupDetectingHardware">Identificando el hardware...</string>
-	<string name="StartupLoading">Instalando [APP_NAME]...</string>
-	<string name="StartupClearingCache">Limpiando la caché...</string>
-	<string name="StartupInitializingTextureCache">Iniciando la caché de las texturas...</string>
-	<string name="StartupRequireDriverUpdate">Error de inicialización de gráficos. Actualiza tu controlador de gráficos.</string>
-	<string name="AboutHeader">[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
-[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]</string>
-	<string name="BuildConfig">Configuración de constitución [BUILD_CONFIG]</string>
-	<string name="AboutPosition">Estás en la posición [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1], de [REGION], alojada en &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+	<string name="CAPITALIZED_APP_NAME">
+		SECOND LIFE
+	</string>
+	<string name="SUPPORT_SITE">
+		Portal de Soporte de Second Life
+	</string>
+	<string name="StartupDetectingHardware">
+		Identificando el hardware...
+	</string>
+	<string name="StartupLoading">
+		Instalando [APP_NAME]...
+	</string>
+	<string name="StartupClearingCache">
+		Limpiando la caché...
+	</string>
+	<string name="StartupInitializingTextureCache">
+		Iniciando la caché de las texturas...
+	</string>
+	<string name="StartupRequireDriverUpdate">
+		Error de inicialización de gráficos. Actualiza tu controlador de gráficos.
+	</string>
+	<string name="AboutHeader">
+		[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
+[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
+	</string>
+	<string name="BuildConfig">
+		Configuración de constitución [BUILD_CONFIG]
+	</string>
+	<string name="AboutPosition">
+		Estás en la posición [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1], de [REGION], alojada en &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (coordenadas globales [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
-[SERVER_RELEASE_NOTES_URL]</string>
-	<string name="AboutSystem">CPU: [CPU]
+[SERVER_RELEASE_NOTES_URL]
+	</string>
+	<string name="AboutSystem">
+		CPU: [CPU]
 Memoria: [MEMORY_MB] MB
 Versión del Sistema Operativo: [OS_VERSION]
 Fabricante de la tarjeta gráfica: [GRAPHICS_CARD_VENDOR]
-Tarjeta gráfica: [GRAPHICS_CARD]</string>
-	<string name="AboutDriver">Versión de Windows Graphics Driver: [GRAPHICS_DRIVER_VERSION]</string>
-	<string name="AboutOGL">Versión de OpenGL: [OPENGL_VERSION]</string>
-	<string name="AboutSettings">Tamaño de la ventana: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+Tarjeta gráfica: [GRAPHICS_CARD]
+	</string>
+	<string name="AboutDriver">
+		Versión de Windows Graphics Driver: [GRAPHICS_DRIVER_VERSION]
+	</string>
+	<string name="AboutOGL">
+		Versión de OpenGL: [OPENGL_VERSION]
+	</string>
+	<string name="AboutSettings">
+		Tamaño de la ventana: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Ajuste del tamaño de fuente: [FONT_SIZE_ADJUSTMENT]pt
 Escala UI: [UI_SCALE]
 Distancia de dibujo: [DRAW_DISTANCE]m
 Ancho de banda: [NET_BANDWITH]kbit/s
 Factor LOD: [LOD_FACTOR]
 Calidad de renderización: [RENDER_QUALITY]
-Memoria de textura: [TEXTURE_MEMORY]MB</string>
-	<string name="AboutOSXHiDPI">Modo de visualización HiDPi: [HIDPI]</string>
-	<string name="AboutLibs">Versión de descodificador J2C: [J2C_VERSION] 
+Memoria de textura: [TEXTURE_MEMORY]MB
+	</string>
+	<string name="AboutOSXHiDPI">
+		Modo de visualización HiDPi: [HIDPI]
+	</string>
+	<string name="AboutLibs">
+		Versión de descodificador J2C: [J2C_VERSION] 
 Versión del controlador audio: [AUDIO_DRIVER_VERSION] 
 [LIBCEF_VERSION] 
 Versión LibVLC: [LIBVLC_VERSION] 
-Versión del servidor de voz: [VOICE_VERSION]</string>
-	<string name="AboutTraffic">Paquetes perdidos: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)</string>
-	<string name="AboutTime">[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]</string>
-	<string name="ErrorFetchingServerReleaseNotesURL">Error al obtener la URL de las notas de la versión del servidor.</string>
-	<string name="BuildConfiguration">Configuración de constitución</string>
-	<string name="ProgressRestoring">Restaurando...</string>
-	<string name="ProgressChangingResolution">Cambiando la resolución...</string>
-	<string name="Fullbright">Brillo al máximo (antiguo)</string>
-	<string name="LoginInProgress">Iniciando la sesión. [APP_NAME] debe de aparecer congelado. Por favor, espere.</string>
-	<string name="LoginInProgressNoFrozen">Iniciando la sesión...</string>
-	<string name="LoginAuthenticating">Autenticando</string>
-	<string name="LoginMaintenance">Realizando el mantenimiento de la cuenta...</string>
-	<string name="LoginAttempt">Ha fallado el intento previo de iniciar sesión. Iniciando sesión, intento [NUMBER]</string>
-	<string name="LoginPrecaching">Cargando el mundo...</string>
-	<string name="LoginInitializingBrowser">Iniciando el navegador web incorporado...</string>
-	<string name="LoginInitializingMultimedia">Iniciando multimedia...</string>
-	<string name="LoginInitializingFonts">Cargando las fuentes...</string>
-	<string name="LoginVerifyingCache">Comprobando los archivos de la caché (puede tardar entre 60 y 90 segundos)...</string>
-	<string name="LoginProcessingResponse">Procesando la respuesta...</string>
-	<string name="LoginInitializingWorld">Iniciando el mundo...</string>
-	<string name="LoginDecodingImages">Decodificando las imágenes...</string>
-	<string name="LoginInitializingQuicktime">Iniciando QuickTime...</string>
-	<string name="LoginQuicktimeNotFound">No se ha encontrado QuickTime. Imposible iniciarlo.</string>
-	<string name="LoginQuicktimeOK">QuickTime se ha iniciado adecuadamente.</string>
-	<string name="LoginRequestSeedCapGrant">Solicitando capacidades de la región...</string>
-	<string name="LoginRetrySeedCapGrant">Solicitando capacidades de la región, intento [NUMBER]...</string>
-	<string name="LoginWaitingForRegionHandshake">Esperando la conexión con la región...</string>
-	<string name="LoginConnectingToRegion">Conectando con la región...</string>
-	<string name="LoginDownloadingClothing">Descargando la ropa...</string>
-	<string name="InvalidCertificate">El servidor devolvió un certificado no válido o dañado. Ponte en contacto con el administrador de la cuadrícula.</string>
-	<string name="CertInvalidHostname">El nombre de host utilizado para acceder al servidor no es válido. Comprueba tu SLURL o el nombre de host de la cuadrícula.</string>
-	<string name="CertExpired">Parece que el certificado que devolvió la cuadrícula está caducado.  Comprueba el reloj del sistema o consulta al administrador de la cuadrícula.</string>
-	<string name="CertKeyUsage">El certificado que devolvió el servidor no puede utilizarse para SSL. Ponte en contacto con el administrador de la cuadrícula.</string>
-	<string name="CertBasicConstraints">La cadena de certificado del servidor contenía demasiados certificados. Ponte en contacto con el administrador de la cuadrícula.</string>
-	<string name="CertInvalidSignature">No se pudo verificar la firma del certificado devuelta por el servidor de la cuadrícula. Ponte en contacto con el administrador de la cuadrícula.</string>
-	<string name="LoginFailedNoNetwork">Error de red: no se ha podido conectar; por favor, revisa tu conexión a internet.</string>
-	<string name="LoginFailedHeader">Error en el inicio de sesión.</string>
-	<string name="Quit">Salir</string>
-	<string name="create_account_url">http://join.secondlife.com/?sourceid=[sourceid]</string>
-	<string name="AgniGridLabel">Grid principal de Second Life (Agni)</string>
-	<string name="AditiGridLabel">Grid de prueba beta de Second Life (Aditi)</string>
-	<string name="ViewerDownloadURL">http://secondlife.com/download.</string>
-	<string name="LoginFailedViewerNotPermitted">Ya no puedes acceder a Second Life con el visor que estás utilizando. Visita la siguiente página para descargar un nuevo visor:
+Versión del servidor de voz: [VOICE_VERSION]
+	</string>
+	<string name="AboutTraffic">
+		Paquetes perdidos: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)
+	</string>
+	<string name="AboutTime">
+		[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
+	</string>
+	<string name="ErrorFetchingServerReleaseNotesURL">
+		Error al obtener la URL de las notas de la versión del servidor.
+	</string>
+	<string name="BuildConfiguration">
+		Configuración de constitución
+	</string>
+	<string name="ProgressRestoring">
+		Restaurando...
+	</string>
+	<string name="ProgressChangingResolution">
+		Cambiando la resolución...
+	</string>
+	<string name="Fullbright">
+		Brillo al máximo (antiguo)
+	</string>
+	<string name="LoginInProgress">
+		Iniciando la sesión. [APP_NAME] debe de aparecer congelado. Por favor, espere.
+	</string>
+	<string name="LoginInProgressNoFrozen">
+		Iniciando la sesión...
+	</string>
+	<string name="LoginAuthenticating">
+		Autenticando
+	</string>
+	<string name="LoginMaintenance">
+		Realizando el mantenimiento de la cuenta...
+	</string>
+	<string name="LoginAttempt">
+		Ha fallado el intento previo de iniciar sesión. Iniciando sesión, intento [NUMBER]
+	</string>
+	<string name="LoginPrecaching">
+		Cargando el mundo...
+	</string>
+	<string name="LoginInitializingBrowser">
+		Iniciando el navegador web incorporado...
+	</string>
+	<string name="LoginInitializingMultimedia">
+		Iniciando multimedia...
+	</string>
+	<string name="LoginInitializingFonts">
+		Cargando las fuentes...
+	</string>
+	<string name="LoginVerifyingCache">
+		Comprobando los archivos de la caché (puede tardar entre 60 y 90 segundos)...
+	</string>
+	<string name="LoginProcessingResponse">
+		Procesando la respuesta...
+	</string>
+	<string name="LoginInitializingWorld">
+		Iniciando el mundo...
+	</string>
+	<string name="LoginDecodingImages">
+		Decodificando las imágenes...
+	</string>
+	<string name="LoginInitializingQuicktime">
+		Iniciando QuickTime...
+	</string>
+	<string name="LoginQuicktimeNotFound">
+		No se ha encontrado QuickTime. Imposible iniciarlo.
+	</string>
+	<string name="LoginQuicktimeOK">
+		QuickTime se ha iniciado adecuadamente.
+	</string>
+	<string name="LoginRequestSeedCapGrant">
+		Solicitando capacidades de la región...
+	</string>
+	<string name="LoginRetrySeedCapGrant">
+		Solicitando capacidades de la región, intento [NUMBER]...
+	</string>
+	<string name="LoginWaitingForRegionHandshake">
+		Esperando la conexión con la región...
+	</string>
+	<string name="LoginConnectingToRegion">
+		Conectando con la región...
+	</string>
+	<string name="LoginDownloadingClothing">
+		Descargando la ropa...
+	</string>
+	<string name="InvalidCertificate">
+		El servidor devolvió un certificado no válido o dañado. Ponte en contacto con el administrador de la cuadrícula.
+	</string>
+	<string name="CertInvalidHostname">
+		El nombre de host utilizado para acceder al servidor no es válido. Comprueba tu SLURL o el nombre de host de la cuadrícula.
+	</string>
+	<string name="CertExpired">
+		Parece que el certificado que devolvió la cuadrícula está caducado.  Comprueba el reloj del sistema o consulta al administrador de la cuadrícula.
+	</string>
+	<string name="CertKeyUsage">
+		El certificado que devolvió el servidor no puede utilizarse para SSL. Ponte en contacto con el administrador de la cuadrícula.
+	</string>
+	<string name="CertBasicConstraints">
+		La cadena de certificado del servidor contenía demasiados certificados. Ponte en contacto con el administrador de la cuadrícula.
+	</string>
+	<string name="CertInvalidSignature">
+		No se pudo verificar la firma del certificado devuelta por el servidor de la cuadrícula. Ponte en contacto con el administrador de la cuadrícula.
+	</string>
+	<string name="LoginFailedNoNetwork">
+		Error de red: no se ha podido conectar; por favor, revisa tu conexión a internet.
+	</string>
+	<string name="LoginFailedHeader">
+		Error en el inicio de sesión.
+	</string>
+	<string name="Quit">
+		Salir
+	</string>
+	<string name="create_account_url">
+		http://join.secondlife.com/?sourceid=[sourceid]
+	</string>
+	<string name="AgniGridLabel">
+		Grid principal de Second Life (Agni)
+	</string>
+	<string name="AditiGridLabel">
+		Grid de prueba beta de Second Life (Aditi)
+	</string>
+	<string name="ViewerDownloadURL">
+		http://secondlife.com/download.
+	</string>
+	<string name="LoginFailedViewerNotPermitted">
+		Ya no puedes acceder a Second Life con el visor que estás utilizando. Visita la siguiente página para descargar un nuevo visor:
 http://secondlife.com/download.
 
 Si deseas obtener más información, consulta las preguntas frecuentes que aparecen a continuación:
-http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginIntermediateOptionalUpdateAvailable">Actualización opcional del visor disponible: [VERSION]</string>
-	<string name="LoginFailedRequiredUpdate">Actualización necesaria del visor: [VERSION]</string>
-	<string name="LoginFailedAlreadyLoggedIn">El agente ya ha iniciado sesión.</string>
-	<string name="LoginFailedAuthenticationFailed">Lo sentimos. No ha sido posible iniciar sesión.
+http://secondlife.com/viewer-access-faq
+	</string>
+	<string name="LoginIntermediateOptionalUpdateAvailable">
+		Actualización opcional del visor disponible: [VERSION]
+	</string>
+	<string name="LoginFailedRequiredUpdate">
+		Actualización necesaria del visor: [VERSION]
+	</string>
+	<string name="LoginFailedAlreadyLoggedIn">
+		El agente ya ha iniciado sesión.
+	</string>
+	<string name="LoginFailedAuthenticationFailed">
+		Lo sentimos. No ha sido posible iniciar sesión.
 Comprueba si has introducido correctamente
     * El nombre de usuario (como juangarcia12 o estrella.polar)
     * Contraseña
-Asimismo, asegúrate de que la tecla Mayús esté desactivada.</string>
-	<string name="LoginFailedPasswordChanged">Como precaución de seguridad, se ha modificado tu contraseña.
+Asimismo, asegúrate de que la tecla Mayús esté desactivada.
+	</string>
+	<string name="LoginFailedPasswordChanged">
+		Como precaución de seguridad, se ha modificado tu contraseña.
 Dirígete a la página de tu cuenta en http://secondlife.com/password
 y responde a la pregunta de seguridad para restablecer la contraseña.
-Lamentamos las molestias.</string>
-	<string name="LoginFailedPasswordReset">Hemos realizado unos cambios en nuestro sistema, por lo que deberás restablecer la contraseña.
+Lamentamos las molestias.
+	</string>
+	<string name="LoginFailedPasswordReset">
+		Hemos realizado unos cambios en nuestro sistema, por lo que deberás restablecer la contraseña.
 Dirígete a la página de tu cuenta en http://secondlife.com/password
 y responde a la pregunta de seguridad para restablecer la contraseña.
-Lamentamos las molestias.</string>
-	<string name="LoginFailedEmployeesOnly">Second Life no está disponible temporalmente debido a tareas de mantenimiento.
+Lamentamos las molestias.
+	</string>
+	<string name="LoginFailedEmployeesOnly">
+		Second Life no está disponible temporalmente debido a tareas de mantenimiento.
 Actualmente, solo se permite iniciar sesión a los empleados.
-Consulta www.secondlife.com/status si deseas obtener actualizaciones.</string>
-	<string name="LoginFailedPremiumOnly">Las conexiones a Second Life se han restringido provisionalmente para garantizar que los usuarios que ya están conectados tengan la mejor experiencia posible.
+Consulta www.secondlife.com/status si deseas obtener actualizaciones.
+	</string>
+	<string name="LoginFailedPremiumOnly">
+		Las conexiones a Second Life se han restringido provisionalmente para garantizar que los usuarios que ya están conectados tengan la mejor experiencia posible.
 
-Durante este tiempo, las personas con cuentas gratuitas no podrán acceder a Second Life, ya que tienen prioridad los usuarios con una cuenta de pago.</string>
-	<string name="LoginFailedComputerProhibited">No se puede acceder a Second Life desde este ordenador.
+Durante este tiempo, las personas con cuentas gratuitas no podrán acceder a Second Life, ya que tienen prioridad los usuarios con una cuenta de pago.
+	</string>
+	<string name="LoginFailedComputerProhibited">
+		No se puede acceder a Second Life desde este ordenador.
 Si crees que se trata de un error, ponte en contacto con
-support@secondlife.com.</string>
-	<string name="LoginFailedAcountSuspended">No se podrá acceder a tu cuenta hasta las
-[TIME] (horario de la costa del Pacífico).</string>
-	<string name="LoginFailedAccountDisabled">En este momento no podemos completar la solicitud. 
-Por favor solicita ayuda al personal de asistencia de Second Life en http://support.secondlife.com.</string>
-	<string name="LoginFailedTransformError">Se han detectado datos incorrectos en el inicio de sesión.
-Ponte en contacto con support@secondlife.com.</string>
-	<string name="LoginFailedAccountMaintenance">Se están realizando tareas rutinarias de mantenimiento en tu cuenta.
+support@secondlife.com.
+	</string>
+	<string name="LoginFailedAcountSuspended">
+		No se podrá acceder a tu cuenta hasta las
+[TIME] (horario de la costa del Pacífico).
+	</string>
+	<string name="LoginFailedAccountDisabled">
+		En este momento no podemos completar la solicitud. 
+Por favor solicita ayuda al personal de asistencia de Second Life en http://support.secondlife.com.
+	</string>
+	<string name="LoginFailedTransformError">
+		Se han detectado datos incorrectos en el inicio de sesión.
+Ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LoginFailedAccountMaintenance">
+		Se están realizando tareas rutinarias de mantenimiento en tu cuenta.
 No se podrá acceder a tu cuenta hasta las
 [TIME] (horario de la costa del Pacífico).
-Si crees que se trata de un error, ponte en contacto con support@secondlife.com.</string>
-	<string name="LoginFailedPendingLogoutFault">La solicitud de cierre de sesión ha obtenido como resultado un error del simulador.</string>
-	<string name="LoginFailedPendingLogout">El sistema te desconectará. 
-Por favor, aguarda un momento antes de intentar conectarte nuevamente.</string>
-	<string name="LoginFailedUnableToCreateSession">No se ha podido crear una sesión válida.</string>
-	<string name="LoginFailedUnableToConnectToSimulator">No se ha podido establecer la conexión con un simulador.</string>
-	<string name="LoginFailedRestrictedHours">Tu cuenta solo puede acceder a Second Life
+Si crees que se trata de un error, ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LoginFailedPendingLogoutFault">
+		La solicitud de cierre de sesión ha obtenido como resultado un error del simulador.
+	</string>
+	<string name="LoginFailedPendingLogout">
+		El sistema te desconectará. 
+Por favor, aguarda un momento antes de intentar conectarte nuevamente.
+	</string>
+	<string name="LoginFailedUnableToCreateSession">
+		No se ha podido crear una sesión válida.
+	</string>
+	<string name="LoginFailedUnableToConnectToSimulator">
+		No se ha podido establecer la conexión con un simulador.
+	</string>
+	<string name="LoginFailedRestrictedHours">
+		Tu cuenta solo puede acceder a Second Life
 entre las [START] y las [END] (horario de la costa del Pacífico).
 Inténtalo de nuevo durante ese horario.
-Si crees que se trata de un error, ponte en contacto con support@secondlife.com.</string>
-	<string name="LoginFailedIncorrectParameters">Parámetros incorrectos.
-Si crees que se trata de un error, ponte en contacto con support@secondlife.com.</string>
-	<string name="LoginFailedFirstNameNotAlphanumeric">El parámetro correspondiente al nombre debe contener caracteres alfanuméricos.
-Si crees que se trata de un error, ponte en contacto con support@secondlife.com.</string>
-	<string name="LoginFailedLastNameNotAlphanumeric">El parámetro correspondiente al apellido debe contener caracteres alfanuméricos.
-Si crees que se trata de un error, ponte en contacto con support@secondlife.com.</string>
-	<string name="LogoutFailedRegionGoingOffline">La región se está desconectando.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutFailedAgentNotInRegion">El agente no se encuentra en la región.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutFailedPendingLogin">A esta región ya se ha accedido en otra sesión.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutFailedLoggingOut">Se ha salido de la región en la sesión anterior.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutFailedStillLoggingOut">La región aún está cerrando la sesión anterior.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutSucceeded">Se ha salido de la región en la última sesión.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LogoutFailedLogoutBegun">La región ha comenzado el proceso de cierre de sesión.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="LoginFailedLoggingOutSession">El sistema ha comenzado a cerrar la última sesión.
-Intenta iniciar sesión de nuevo en unos instantes.</string>
-	<string name="AgentLostConnection">Esta región puede estar teniendo problemas. Por favor, comprueba tu conexión a Internet.</string>
-	<string name="SavingSettings">Guardando tus configuraciones...</string>
-	<string name="LoggingOut">Cerrando sesión...</string>
-	<string name="ShuttingDown">Cerrando...</string>
-	<string name="YouHaveBeenDisconnected">Has sido desconectado de la región en la que estabas.</string>
-	<string name="SentToInvalidRegion">Has sido enviado a una región no válida.</string>
-	<string name="TestingDisconnect">Probando la desconexión del visor</string>
-	<string name="SocialFacebookConnecting">Conectando con Facebook...</string>
-	<string name="SocialFacebookPosting">Publicando...</string>
-	<string name="SocialFacebookDisconnecting">Desconectando de Facebook...</string>
-	<string name="SocialFacebookErrorConnecting">Problema al conectar con Facebook</string>
-	<string name="SocialFacebookErrorPosting">Problema al publicar en Facebook</string>
-	<string name="SocialFacebookErrorDisconnecting">Problema al desconectar de Facebook</string>
-	<string name="SocialFlickrConnecting">Conectándose a Flickr...</string>
-	<string name="SocialFlickrPosting">Publicando...</string>
-	<string name="SocialFlickrDisconnecting">Desconectándose de Flickr...</string>
-	<string name="SocialFlickrErrorConnecting">Problema con la conexión a Flickr</string>
-	<string name="SocialFlickrErrorPosting">Problema al publicar en Flickr</string>
-	<string name="SocialFlickrErrorDisconnecting">Problema con la desconexión de Flickr</string>
-	<string name="SocialTwitterConnecting">Conectándose a Twitter...</string>
-	<string name="SocialTwitterPosting">Publicando...</string>
-	<string name="SocialTwitterDisconnecting">Desconectándose de Twitter...</string>
-	<string name="SocialTwitterErrorConnecting">Problema con la conexión a Twitter</string>
-	<string name="SocialTwitterErrorPosting">Problema al publicar en Twitter</string>
-	<string name="SocialTwitterErrorDisconnecting">Problema con la desconexión de Twitter</string>
-	<string name="BlackAndWhite">Blanco y negro</string>
-	<string name="Colors1970">Colores de los 70</string>
-	<string name="Intense">Intenso</string>
-	<string name="Newspaper">Periódico</string>
-	<string name="Sepia">Sepia</string>
-	<string name="Spotlight">Foco</string>
-	<string name="Video">Vídeo</string>
-	<string name="Autocontrast">Contraste automático</string>
-	<string name="LensFlare">Destello de lente</string>
-	<string name="Miniature">Miniatura</string>
-	<string name="Toycamera">Cámara de juguete</string>
-	<string name="TooltipPerson">Persona</string>
-	<string name="TooltipNoName">(sin nombre)</string>
-	<string name="TooltipOwner">Propietario:</string>
-	<string name="TooltipPublic">Público</string>
-	<string name="TooltipIsGroup">(Grupo)</string>
-	<string name="TooltipForSaleL$">En venta: [AMOUNT] L$</string>
-	<string name="TooltipFlagGroupBuild">Construir el grupo</string>
-	<string name="TooltipFlagNoBuild">No construir</string>
-	<string name="TooltipFlagNoEdit">Construir el grupo</string>
-	<string name="TooltipFlagNotSafe">No seguro</string>
-	<string name="TooltipFlagNoFly">No volar</string>
-	<string name="TooltipFlagGroupScripts">Scripts el grupo</string>
-	<string name="TooltipFlagNoScripts">No scripts</string>
-	<string name="TooltipLand">Terreno:</string>
-	<string name="TooltipMustSingleDrop">Aquí se puede arrastrar sólo un ítem</string>
-	<string name="TooltipTooManyWearables">No puedes tener una carpeta de prendas que contenga más de [AMOUNT] elementos.  Puedes cambiar este límite en Avanzado &gt; Mostrar las configuraciones del depurador &gt; WearFolderLimit.</string>
+Si crees que se trata de un error, ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LoginFailedIncorrectParameters">
+		Parámetros incorrectos.
+Si crees que se trata de un error, ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LoginFailedFirstNameNotAlphanumeric">
+		El parámetro correspondiente al nombre debe contener caracteres alfanuméricos.
+Si crees que se trata de un error, ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LoginFailedLastNameNotAlphanumeric">
+		El parámetro correspondiente al apellido debe contener caracteres alfanuméricos.
+Si crees que se trata de un error, ponte en contacto con support@secondlife.com.
+	</string>
+	<string name="LogoutFailedRegionGoingOffline">
+		La región se está desconectando.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutFailedAgentNotInRegion">
+		El agente no se encuentra en la región.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutFailedPendingLogin">
+		A esta región ya se ha accedido en otra sesión.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutFailedLoggingOut">
+		Se ha salido de la región en la sesión anterior.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutFailedStillLoggingOut">
+		La región aún está cerrando la sesión anterior.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutSucceeded">
+		Se ha salido de la región en la última sesión.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LogoutFailedLogoutBegun">
+		La región ha comenzado el proceso de cierre de sesión.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="LoginFailedLoggingOutSession">
+		El sistema ha comenzado a cerrar la última sesión.
+Intenta iniciar sesión de nuevo en unos instantes.
+	</string>
+	<string name="AgentLostConnection">
+		Esta región puede estar teniendo problemas. Por favor, comprueba tu conexión a Internet.
+	</string>
+	<string name="SavingSettings">
+		Guardando tus configuraciones...
+	</string>
+	<string name="LoggingOut">
+		Cerrando sesión...
+	</string>
+	<string name="ShuttingDown">
+		Cerrando...
+	</string>
+	<string name="YouHaveBeenDisconnected">
+		Has sido desconectado de la región en la que estabas.
+	</string>
+	<string name="SentToInvalidRegion">
+		Has sido enviado a una región no válida.
+	</string>
+	<string name="TestingDisconnect">
+		Probando la desconexión del visor
+	</string>
+	<string name="SocialFacebookConnecting">
+		Conectando con Facebook...
+	</string>
+	<string name="SocialFacebookPosting">
+		Publicando...
+	</string>
+	<string name="SocialFacebookDisconnecting">
+		Desconectando de Facebook...
+	</string>
+	<string name="SocialFacebookErrorConnecting">
+		Problema al conectar con Facebook
+	</string>
+	<string name="SocialFacebookErrorPosting">
+		Problema al publicar en Facebook
+	</string>
+	<string name="SocialFacebookErrorDisconnecting">
+		Problema al desconectar de Facebook
+	</string>
+	<string name="SocialFlickrConnecting">
+		Conectándose a Flickr...
+	</string>
+	<string name="SocialFlickrPosting">
+		Publicando...
+	</string>
+	<string name="SocialFlickrDisconnecting">
+		Desconectándose de Flickr...
+	</string>
+	<string name="SocialFlickrErrorConnecting">
+		Problema con la conexión a Flickr
+	</string>
+	<string name="SocialFlickrErrorPosting">
+		Problema al publicar en Flickr
+	</string>
+	<string name="SocialFlickrErrorDisconnecting">
+		Problema con la desconexión de Flickr
+	</string>
+	<string name="SocialTwitterConnecting">
+		Conectándose a Twitter...
+	</string>
+	<string name="SocialTwitterPosting">
+		Publicando...
+	</string>
+	<string name="SocialTwitterDisconnecting">
+		Desconectándose de Twitter...
+	</string>
+	<string name="SocialTwitterErrorConnecting">
+		Problema con la conexión a Twitter
+	</string>
+	<string name="SocialTwitterErrorPosting">
+		Problema al publicar en Twitter
+	</string>
+	<string name="SocialTwitterErrorDisconnecting">
+		Problema con la desconexión de Twitter
+	</string>
+	<string name="BlackAndWhite">
+		Blanco y negro
+	</string>
+	<string name="Colors1970">
+		Colores de los 70
+	</string>
+	<string name="Intense">
+		Intenso
+	</string>
+	<string name="Newspaper">
+		Periódico
+	</string>
+	<string name="Sepia">
+		Sepia
+	</string>
+	<string name="Spotlight">
+		Foco
+	</string>
+	<string name="Video">
+		Vídeo
+	</string>
+	<string name="Autocontrast">
+		Contraste automático
+	</string>
+	<string name="LensFlare">
+		Destello de lente
+	</string>
+	<string name="Miniature">
+		Miniatura
+	</string>
+	<string name="Toycamera">
+		Cámara de juguete
+	</string>
+	<string name="TooltipPerson">
+		Persona
+	</string>
+	<string name="TooltipNoName">
+		(sin nombre)
+	</string>
+	<string name="TooltipOwner">
+		Propietario:
+	</string>
+	<string name="TooltipPublic">
+		Público
+	</string>
+	<string name="TooltipIsGroup">
+		(Grupo)
+	</string>
+	<string name="TooltipForSaleL$">
+		En venta: [AMOUNT] L$
+	</string>
+	<string name="TooltipFlagGroupBuild">
+		Construir el grupo
+	</string>
+	<string name="TooltipFlagNoBuild">
+		No construir
+	</string>
+	<string name="TooltipFlagNoEdit">
+		Construir el grupo
+	</string>
+	<string name="TooltipFlagNotSafe">
+		No seguro
+	</string>
+	<string name="TooltipFlagNoFly">
+		No volar
+	</string>
+	<string name="TooltipFlagGroupScripts">
+		Scripts el grupo
+	</string>
+	<string name="TooltipFlagNoScripts">
+		No scripts
+	</string>
+	<string name="TooltipLand">
+		Terreno:
+	</string>
+	<string name="TooltipMustSingleDrop">
+		Aquí se puede arrastrar sólo un ítem
+	</string>
+	<string name="TooltipTooManyWearables">
+		No puedes tener una carpeta de prendas que contenga más de [AMOUNT] elementos.  Puedes cambiar este límite en Avanzado &gt; Mostrar las configuraciones del depurador &gt; WearFolderLimit.
+	</string>
 	<string name="TooltipPrice" value="[AMOUNT] L$:"/>
-	<string name="TooltipSLIcon">Esto crea un vínculo a una página del dominio oficial SecondLife.com o LindenLab.com.</string>
-	<string name="TooltipOutboxDragToWorld">No se pueden mostrar artículos desde la carpeta Artículos del mercado</string>
-	<string name="TooltipOutboxWorn">Los artículos que tienes puestos no se pueden colocar en la carpeta Artículos del mercado</string>
-	<string name="TooltipOutboxFolderLevels">La profundidad de carpetas anidadas excede de [AMOUNT]. Disminuye la profundidad de las carpetas anidadas; si es necesario, agrupa los artículos.</string>
-	<string name="TooltipOutboxTooManyFolders">La cantidad de subcarpetas excede de [AMOUNT]. Disminuye la cantidad de carpetas de tu lista de artículos; si es necesario, agrupa los artículos.</string>
-	<string name="TooltipOutboxTooManyObjects">La cantidad de artículos excede de [AMOUNT]. Para vender más de [AMOUNT] artículos en la misma lista, debes agrupar algunos.</string>
-	<string name="TooltipOutboxTooManyStockItems">La cantidad de artículos en stock excede de [AMOUNT].</string>
-	<string name="TooltipOutboxCannotDropOnRoot">Solo se pueden soltar artículos o carpetas en las pestañas TODOS o SIN ASOCIAR. Selecciona una de estas pestañas y mueve otra vez los artículos o carpetas.</string>
-	<string name="TooltipOutboxNoTransfer">Uno o varios de estos objetos no se pueden vender o transferir</string>
-	<string name="TooltipOutboxNotInInventory">Solo puedes colocar en el mercado artículos de tu inventario</string>
-	<string name="TooltipOutboxLinked">No puedes poner carpetas o artículos vinculados en el Mercado</string>
-	<string name="TooltipOutboxCallingCard">No puedes colocar tarjetas de visita en el Mercado</string>
-	<string name="TooltipOutboxDragActive">No se puede mover una lista de artículos publicada</string>
-	<string name="TooltipOutboxCannotMoveRoot">No se puede mover la carpeta raíz de artículos del Mercado</string>
-	<string name="TooltipOutboxMixedStock">Todos los artículos de una carpeta de stock deben tener el mismo tipo y permiso</string>
-	<string name="TooltipDragOntoOwnChild">No puedes mover una carpeta a su carpeta secundaria</string>
-	<string name="TooltipDragOntoSelf">No puedes mover una carpeta dentro de sí misma</string>
-	<string name="TooltipHttpUrl">Pulsa para ver esta página web</string>
-	<string name="TooltipSLURL">Pulsa para ver la información de este lugar</string>
-	<string name="TooltipAgentUrl">Pulsa para ver el perfil del Residente</string>
-	<string name="TooltipAgentInspect">Obtén más información acerca de este residente.</string>
-	<string name="TooltipAgentMute">Pulsa para silenciar a este Residente</string>
-	<string name="TooltipAgentUnmute">Pulsa para quitar el silencio a este Residente</string>
-	<string name="TooltipAgentIM">Pulsa para enviar un MI a este Residente</string>
-	<string name="TooltipAgentPay">Pulsa para pagar a este Residente</string>
-	<string name="TooltipAgentOfferTeleport">Pulsa para enviar una petición de teleporte a este Residente</string>
-	<string name="TooltipAgentRequestFriend">Pulsa para enviar una petición de amistad a este Residente</string>
-	<string name="TooltipGroupUrl">Pulsa para ver la descripción de este grupo</string>
-	<string name="TooltipEventUrl">Pulsa para ver la descripción de este evento</string>
-	<string name="TooltipClassifiedUrl">Pulsa para ver este clasificado</string>
-	<string name="TooltipParcelUrl">Pulsa para ver la descripción de esta parcela</string>
-	<string name="TooltipTeleportUrl">Pulsa para teleportarte a esta posición</string>
-	<string name="TooltipObjectIMUrl">Pulsa para ver la descripción de este objeto</string>
-	<string name="TooltipMapUrl">Pulsa para ver en el mapa esta localización</string>
-	<string name="TooltipSLAPP">Pulsa para ejecutar el comando secondlife://</string>
+	<string name="TooltipSLIcon">
+		Esto crea un vínculo a una página del dominio oficial SecondLife.com o LindenLab.com.
+	</string>
+	<string name="TooltipOutboxDragToWorld">
+		No se pueden mostrar artículos desde la carpeta Artículos del mercado
+	</string>
+	<string name="TooltipOutboxWorn">
+		Los artículos que tienes puestos no se pueden colocar en la carpeta Artículos del mercado
+	</string>
+	<string name="TooltipOutboxFolderLevels">
+		La profundidad de carpetas anidadas excede de [AMOUNT]. Disminuye la profundidad de las carpetas anidadas; si es necesario, agrupa los artículos.
+	</string>
+	<string name="TooltipOutboxTooManyFolders">
+		La cantidad de subcarpetas excede de [AMOUNT]. Disminuye la cantidad de carpetas de tu lista de artículos; si es necesario, agrupa los artículos.
+	</string>
+	<string name="TooltipOutboxTooManyObjects">
+		La cantidad de artículos excede de [AMOUNT]. Para vender más de [AMOUNT] artículos en la misma lista, debes agrupar algunos.
+	</string>
+	<string name="TooltipOutboxTooManyStockItems">
+		La cantidad de artículos en stock excede de [AMOUNT].
+	</string>
+	<string name="TooltipOutboxCannotDropOnRoot">
+		Solo se pueden soltar artículos o carpetas en las pestañas TODOS o SIN ASOCIAR. Selecciona una de estas pestañas y mueve otra vez los artículos o carpetas.
+	</string>
+	<string name="TooltipOutboxNoTransfer">
+		Uno o varios de estos objetos no se pueden vender o transferir
+	</string>
+	<string name="TooltipOutboxNotInInventory">
+		Solo puedes colocar en el mercado artículos de tu inventario
+	</string>
+	<string name="TooltipOutboxLinked">
+		No puedes poner carpetas o artículos vinculados en el Mercado
+	</string>
+	<string name="TooltipOutboxCallingCard">
+		No puedes colocar tarjetas de visita en el Mercado
+	</string>
+	<string name="TooltipOutboxDragActive">
+		No se puede mover una lista de artículos publicada
+	</string>
+	<string name="TooltipOutboxCannotMoveRoot">
+		No se puede mover la carpeta raíz de artículos del Mercado
+	</string>
+	<string name="TooltipOutboxMixedStock">
+		Todos los artículos de una carpeta de stock deben tener el mismo tipo y permiso
+	</string>
+	<string name="TooltipDragOntoOwnChild">
+		No puedes mover una carpeta a su carpeta secundaria
+	</string>
+	<string name="TooltipDragOntoSelf">
+		No puedes mover una carpeta dentro de sí misma
+	</string>
+	<string name="TooltipHttpUrl">
+		Pulsa para ver esta página web
+	</string>
+	<string name="TooltipSLURL">
+		Pulsa para ver la información de este lugar
+	</string>
+	<string name="TooltipAgentUrl">
+		Pulsa para ver el perfil del Residente
+	</string>
+	<string name="TooltipAgentInspect">
+		Obtén más información acerca de este residente.
+	</string>
+	<string name="TooltipAgentMute">
+		Pulsa para silenciar a este Residente
+	</string>
+	<string name="TooltipAgentUnmute">
+		Pulsa para quitar el silencio a este Residente
+	</string>
+	<string name="TooltipAgentIM">
+		Pulsa para enviar un MI a este Residente
+	</string>
+	<string name="TooltipAgentPay">
+		Pulsa para pagar a este Residente
+	</string>
+	<string name="TooltipAgentOfferTeleport">
+		Pulsa para enviar una petición de teleporte a este Residente
+	</string>
+	<string name="TooltipAgentRequestFriend">
+		Pulsa para enviar una petición de amistad a este Residente
+	</string>
+	<string name="TooltipGroupUrl">
+		Pulsa para ver la descripción de este grupo
+	</string>
+	<string name="TooltipEventUrl">
+		Pulsa para ver la descripción de este evento
+	</string>
+	<string name="TooltipClassifiedUrl">
+		Pulsa para ver este clasificado
+	</string>
+	<string name="TooltipParcelUrl">
+		Pulsa para ver la descripción de esta parcela
+	</string>
+	<string name="TooltipTeleportUrl">
+		Pulsa para teleportarte a esta posición
+	</string>
+	<string name="TooltipObjectIMUrl">
+		Pulsa para ver la descripción de este objeto
+	</string>
+	<string name="TooltipMapUrl">
+		Pulsa para ver en el mapa esta localización
+	</string>
+	<string name="TooltipSLAPP">
+		Pulsa para ejecutar el comando secondlife://
+	</string>
 	<string name="CurrentURL" value="URL actual: [CurrentURL]"/>
-	<string name="TooltipEmail">Haz clic para redactar un correo electrónico</string>
-	<string name="SLurlLabelTeleport">Teleportarse a</string>
-	<string name="SLurlLabelShowOnMap">Mostrarla en el mapa</string>
-	<string name="SLappAgentMute">Silenciar</string>
-	<string name="SLappAgentUnmute">Quitar el silencio</string>
-	<string name="SLappAgentIM">MI</string>
-	<string name="SLappAgentPay">Pagar</string>
-	<string name="SLappAgentOfferTeleport">Ofrecer teleporte a</string>
-	<string name="SLappAgentRequestFriend">Petición de amistad</string>
-	<string name="SLappAgentRemoveFriend">Eliminación de amigos</string>
-	<string name="BUTTON_CLOSE_DARWIN">Cerrar (⌘W)</string>
-	<string name="BUTTON_CLOSE_WIN">Cerrar (Ctrl+W)</string>
-	<string name="BUTTON_CLOSE_CHROME">Cerrar</string>
-	<string name="BUTTON_RESTORE">Maximizar</string>
-	<string name="BUTTON_MINIMIZE">Minimizar</string>
-	<string name="BUTTON_TEAR_OFF">Separar la ventana</string>
-	<string name="BUTTON_DOCK">Fijar</string>
-	<string name="BUTTON_HELP">Ver la Ayuda</string>
-	<string name="TooltipNotecardNotAllowedTypeDrop">Los objetos de este tipo no se pueden adjuntar 
-a las notas de esta región.</string>
-	<string name="TooltipNotecardOwnerRestrictedDrop">Sólo los objetos con permisos 
+	<string name="TooltipEmail">
+		Haz clic para redactar un correo electrónico
+	</string>
+	<string name="SLurlLabelTeleport">
+		Teleportarse a
+	</string>
+	<string name="SLurlLabelShowOnMap">
+		Mostrarla en el mapa
+	</string>
+	<string name="SLappAgentMute">
+		Silenciar
+	</string>
+	<string name="SLappAgentUnmute">
+		Quitar el silencio
+	</string>
+	<string name="SLappAgentIM">
+		MI
+	</string>
+	<string name="SLappAgentPay">
+		Pagar
+	</string>
+	<string name="SLappAgentOfferTeleport">
+		Ofrecer teleporte a
+	</string>
+	<string name="SLappAgentRequestFriend">
+		Petición de amistad
+	</string>
+	<string name="SLappAgentRemoveFriend">
+		Eliminación de amigos
+	</string>
+	<string name="BUTTON_CLOSE_DARWIN">
+		Cerrar (⌘W)
+	</string>
+	<string name="BUTTON_CLOSE_WIN">
+		Cerrar (Ctrl+W)
+	</string>
+	<string name="BUTTON_CLOSE_CHROME">
+		Cerrar
+	</string>
+	<string name="BUTTON_RESTORE">
+		Maximizar
+	</string>
+	<string name="BUTTON_MINIMIZE">
+		Minimizar
+	</string>
+	<string name="BUTTON_TEAR_OFF">
+		Separar la ventana
+	</string>
+	<string name="BUTTON_DOCK">
+		Fijar
+	</string>
+	<string name="BUTTON_HELP">
+		Ver la Ayuda
+	</string>
+	<string name="TooltipNotecardNotAllowedTypeDrop">
+		Los objetos de este tipo no se pueden adjuntar 
+a las notas de esta región.
+	</string>
+	<string name="TooltipNotecardOwnerRestrictedDrop">
+		Sólo los objetos con permisos 
 «próximo propietario» sin restricciones 
-pueden adjuntarse a las notas.</string>
-	<string name="Searching">Buscando...</string>
-	<string name="NoneFound">No se ha encontrado.</string>
-	<string name="RetrievingData">Reintentando...</string>
-	<string name="ReleaseNotes">Notas de la versión</string>
-	<string name="RELEASE_NOTES_BASE_URL">https://releasenotes.secondlife.com/viewer/</string>
-	<string name="LoadingData">Cargando...</string>
-	<string name="AvatarNameNobody">(nadie)</string>
-	<string name="AvatarNameWaiting">(esperando)</string>
-	<string name="GroupNameNone">(ninguno)</string>
-	<string name="AssetErrorNone">No hay ningún error</string>
-	<string name="AssetErrorRequestFailed">Petición de asset: fallida</string>
-	<string name="AssetErrorNonexistentFile">Petición de asset: el archivo no existe</string>
-	<string name="AssetErrorNotInDatabase">Petición de asset: no se encontró el asset en la base de datos</string>
-	<string name="AssetErrorEOF">Fin del archivo</string>
-	<string name="AssetErrorCannotOpenFile">No puede abrirse el archivo</string>
-	<string name="AssetErrorFileNotFound">No se ha encontrado el archivo</string>
-	<string name="AssetErrorTCPTimeout">Tiempo de transferencia del archivo</string>
-	<string name="AssetErrorCircuitGone">Circuito desconectado</string>
-	<string name="AssetErrorPriceMismatch">No concuerda el precio en el visor y en el servidor</string>
-	<string name="AssetErrorUnknownStatus">Estado desconocido</string>
-	<string name="AssetUploadServerUnreacheble">El servicio no está disponible.</string>
-	<string name="AssetUploadServerDifficulties">Se detectaron errores inesperados en el servidor.</string>
-	<string name="AssetUploadServerUnavaliable">El servicio no está disponible o se alcanzó el tiempo de carga máxima.</string>
-	<string name="AssetUploadRequestInvalid">Error en la solicitud de carga. Por favor, ingresa a 
-http://secondlife.com/support para obtener ayuda sobre cómo solucionar este problema.</string>
-	<string name="SettingValidationError">Error en la validación para importar los parámetros [NAME]</string>
-	<string name="SettingImportFileError">No se pudo abrir el archivo [FILE]</string>
-	<string name="SettingParseFileError">No se pudo abrir el archivo [FILE]</string>
-	<string name="SettingTranslateError">No se pudo traducir el Viento de luz legado [NAME]</string>
-	<string name="texture">la textura</string>
-	<string name="sound">el sonido</string>
-	<string name="calling card">la tarjeta de visita</string>
-	<string name="landmark">el hito</string>
-	<string name="legacy script">el script antiguo</string>
-	<string name="clothing">esa ropa</string>
-	<string name="object">el objeto</string>
-	<string name="note card">la nota</string>
-	<string name="folder">la carpeta</string>
-	<string name="root">la ruta</string>
-	<string name="lsl2 script">ese script de LSL2</string>
-	<string name="lsl bytecode">el código intermedio de LSL</string>
-	<string name="tga texture">esa textura tga</string>
-	<string name="body part">esa parte del cuerpo</string>
-	<string name="snapshot">la foto</string>
-	<string name="lost and found">Objetos Perdidos</string>
-	<string name="targa image">esa imagen targa</string>
-	<string name="trash">la Papelera</string>
-	<string name="jpeg image">esa imagen jpeg</string>
-	<string name="animation">la animación</string>
-	<string name="gesture">el gesto</string>
-	<string name="simstate">simstate</string>
-	<string name="favorite">ese favorito</string>
-	<string name="symbolic link">el enlace</string>
-	<string name="symbolic folder link">enlace de la carpeta</string>
-	<string name="settings blob">opciones</string>
-	<string name="mesh">red</string>
-	<string name="AvatarEditingAppearance">(Edición de Apariencia)</string>
-	<string name="AvatarAway">Ausente</string>
-	<string name="AvatarDoNotDisturb">No molestar</string>
-	<string name="AvatarMuted">Ignorado</string>
-	<string name="anim_express_afraid">Susto</string>
-	<string name="anim_express_anger">Enfado</string>
-	<string name="anim_away">Ausente</string>
-	<string name="anim_backflip">Salto mortal atrás</string>
-	<string name="anim_express_laugh">Carcajada</string>
-	<string name="anim_express_toothsmile">Gran sonrisa</string>
-	<string name="anim_blowkiss">Mandar un beso</string>
-	<string name="anim_express_bored">Aburrimiento</string>
-	<string name="anim_bow">Reverencia</string>
-	<string name="anim_clap">Aplauso</string>
-	<string name="anim_courtbow">Reverencia floreada</string>
-	<string name="anim_express_cry">Llanto</string>
-	<string name="anim_dance1">Baile 1</string>
-	<string name="anim_dance2">Baile 2</string>
-	<string name="anim_dance3">Baile 3</string>
-	<string name="anim_dance4">Baile 4</string>
-	<string name="anim_dance5">Baile 5</string>
-	<string name="anim_dance6">Baile 6</string>
-	<string name="anim_dance7">Baile 7</string>
-	<string name="anim_dance8">Baile 8</string>
-	<string name="anim_express_disdain">Desdén</string>
-	<string name="anim_drink">Beber</string>
-	<string name="anim_express_embarrased">Azorarse</string>
-	<string name="anim_angry_fingerwag">Negar con el dedo</string>
-	<string name="anim_fist_pump">Éxito con el puño</string>
-	<string name="anim_yoga_float">Yoga flotando</string>
-	<string name="anim_express_frown">Fruncir el ceño</string>
-	<string name="anim_impatient">Impaciente</string>
-	<string name="anim_jumpforjoy">Salto de alegría</string>
-	<string name="anim_kissmybutt">Bésame el culo</string>
-	<string name="anim_express_kiss">Besar</string>
-	<string name="anim_laugh_short">Reír</string>
-	<string name="anim_musclebeach">Sacar músculo</string>
-	<string name="anim_no_unhappy">No (con enfado)</string>
-	<string name="anim_no_head">No</string>
-	<string name="anim_nyanya">Ña-Ña-Ña</string>
-	<string name="anim_punch_onetwo">Puñetazo uno-dos</string>
-	<string name="anim_express_open_mouth">Abrir la boca</string>
-	<string name="anim_peace">'V' con los dedos</string>
-	<string name="anim_point_you">Señalar a otro/a</string>
-	<string name="anim_point_me">Señalarse</string>
-	<string name="anim_punch_l">Puñetazo izquierdo</string>
-	<string name="anim_punch_r">Puñetazo derecho</string>
-	<string name="anim_rps_countdown">PPT cuenta</string>
-	<string name="anim_rps_paper">PPT papel</string>
-	<string name="anim_rps_rock">PPT piedra</string>
-	<string name="anim_rps_scissors">PPT tijera</string>
-	<string name="anim_express_repulsed">Repulsa</string>
-	<string name="anim_kick_roundhouse_r">Patada circular</string>
-	<string name="anim_express_sad">Triste</string>
-	<string name="anim_salute">Saludo militar</string>
-	<string name="anim_shout">Gritar</string>
-	<string name="anim_express_shrug">Encogerse de hombros</string>
-	<string name="anim_express_smile">Sonreír</string>
-	<string name="anim_smoke_idle">Fumar: en la mano</string>
-	<string name="anim_smoke_inhale">Fumar</string>
-	<string name="anim_smoke_throw_down">Fumar: tirar el cigarro</string>
-	<string name="anim_express_surprise">Sorpresa</string>
-	<string name="anim_sword_strike_r">Estocadas</string>
-	<string name="anim_angry_tantrum">Berrinche</string>
-	<string name="anim_express_tongue_out">Sacar la lengua</string>
-	<string name="anim_hello">Agitar la mano</string>
-	<string name="anim_whisper">Cuchichear</string>
-	<string name="anim_whistle">Pitar</string>
-	<string name="anim_express_wink">Guiño</string>
-	<string name="anim_wink_hollywood">Guiño (Hollywood)</string>
-	<string name="anim_express_worry">Preocuparse</string>
-	<string name="anim_yes_happy">Sí (contento)</string>
-	<string name="anim_yes_head">Sí</string>
-	<string name="use_texture">Usar textura</string>
-	<string name="manip_hint1">Pasa el cursor del ratón sobre la regla</string>
-	<string name="manip_hint2">para ajustar a la cuadrícula</string>
-	<string name="texture_loading">Cargando...</string>
-	<string name="worldmap_offline">Sin conexión</string>
-	<string name="worldmap_item_tooltip_format">[PRICE] L$ por [AREA] m²</string>
-	<string name="worldmap_results_none_found">No se ha encontrado.</string>
-	<string name="Ok">OK</string>
-	<string name="Premature end of file">Fin prematuro del archivo</string>
-	<string name="ST_NO_JOINT">No se puede encontrar ROOT o JOINT.</string>
-	<string name="NearbyChatTitle">Chat</string>
-	<string name="NearbyChatLabel">(Chat)</string>
-	<string name="whisper">susurra:</string>
-	<string name="shout">grita:</string>
-	<string name="ringing">Conectando al chat de voz...</string>
-	<string name="connected">Conectado</string>
-	<string name="unavailable">La voz no está disponible en su localización actual</string>
-	<string name="hang_up">Desconectado del chat de voz</string>
-	<string name="reconnect_nearby">Vas a ser reconectado al chat de voz con los cercanos</string>
-	<string name="ScriptQuestionCautionChatGranted">'[OBJECTNAME]', un objeto propiedad de '[OWNERNAME]', localizado en [REGIONNAME] con la posición [REGIONPOS], ha recibido permiso para: [PERMISSIONS].</string>
-	<string name="ScriptQuestionCautionChatDenied">A '[OBJECTNAME]', un objeto propiedad de '[OWNERNAME]', localizado en [REGIONNAME] con la posición [REGIONPOS], se le ha denegado el permiso para: [PERMISSIONS].</string>
-	<string name="AdditionalPermissionsRequestHeader">Si autorizas el acceso a tu cuenta, también permitirás al objeto:</string>
-	<string name="ScriptTakeMoney">Cogerle a usted dólares Linden (L$)</string>
-	<string name="ActOnControlInputs">Actuar en sus controles de entrada</string>
-	<string name="RemapControlInputs">Reconfigurar sus controles de entrada</string>
-	<string name="AnimateYourAvatar">Ejecutar animaciones en su avatar</string>
-	<string name="AttachToYourAvatar">Anexarse a su avatar</string>
-	<string name="ReleaseOwnership">Anular la propiedad y que pase a ser público</string>
-	<string name="LinkAndDelink">Enlazar y desenlazar de otros objetos</string>
-	<string name="AddAndRemoveJoints">Añadir y quitar uniones con otros objetos</string>
-	<string name="ChangePermissions">Cambiar sus permisos</string>
-	<string name="TrackYourCamera">Seguir su cámara</string>
-	<string name="ControlYourCamera">Controlar su cámara</string>
-	<string name="TeleportYourAgent">Teleportarte</string>
-	<string name="ForceSitAvatar">Forzar que el avatar se siente</string>
-	<string name="ChangeEnvSettings">Cambiar tu configuración del entorno</string>
-	<string name="AgentNameSubst">(Tú)</string>
+pueden adjuntarse a las notas.
+	</string>
+	<string name="Searching">
+		Buscando...
+	</string>
+	<string name="NoneFound">
+		No se ha encontrado.
+	</string>
+	<string name="RetrievingData">
+		Reintentando...
+	</string>
+	<string name="ReleaseNotes">
+		Notas de la versión
+	</string>
+	<string name="RELEASE_NOTES_BASE_URL">
+		https://releasenotes.secondlife.com/viewer/
+	</string>
+	<string name="LoadingData">
+		Cargando...
+	</string>
+	<string name="AvatarNameNobody">
+		(nadie)
+	</string>
+	<string name="AvatarNameWaiting">
+		(esperando)
+	</string>
+	<string name="GroupNameNone">
+		(ninguno)
+	</string>
+	<string name="AssetErrorNone">
+		No hay ningún error
+	</string>
+	<string name="AssetErrorRequestFailed">
+		Petición de asset: fallida
+	</string>
+	<string name="AssetErrorNonexistentFile">
+		Petición de asset: el archivo no existe
+	</string>
+	<string name="AssetErrorNotInDatabase">
+		Petición de asset: no se encontró el asset en la base de datos
+	</string>
+	<string name="AssetErrorEOF">
+		Fin del archivo
+	</string>
+	<string name="AssetErrorCannotOpenFile">
+		No puede abrirse el archivo
+	</string>
+	<string name="AssetErrorFileNotFound">
+		No se ha encontrado el archivo
+	</string>
+	<string name="AssetErrorTCPTimeout">
+		Tiempo de transferencia del archivo
+	</string>
+	<string name="AssetErrorCircuitGone">
+		Circuito desconectado
+	</string>
+	<string name="AssetErrorPriceMismatch">
+		No concuerda el precio en el visor y en el servidor
+	</string>
+	<string name="AssetErrorUnknownStatus">
+		Estado desconocido
+	</string>
+	<string name="AssetUploadServerUnreacheble">
+		El servicio no está disponible.
+	</string>
+	<string name="AssetUploadServerDifficulties">
+		Se detectaron errores inesperados en el servidor.
+	</string>
+	<string name="AssetUploadServerUnavaliable">
+		El servicio no está disponible o se alcanzó el tiempo de carga máxima.
+	</string>
+	<string name="AssetUploadRequestInvalid">
+		Error en la solicitud de carga. Por favor, ingresa a 
+http://secondlife.com/support para obtener ayuda sobre cómo solucionar este problema.
+	</string>
+	<string name="SettingValidationError">
+		Error en la validación para importar los parámetros [NAME]
+	</string>
+	<string name="SettingImportFileError">
+		No se pudo abrir el archivo [FILE]
+	</string>
+	<string name="SettingParseFileError">
+		No se pudo abrir el archivo [FILE]
+	</string>
+	<string name="SettingTranslateError">
+		No se pudo traducir el Viento de luz legado [NAME]
+	</string>
+	<string name="texture">
+		la textura
+	</string>
+	<string name="sound">
+		el sonido
+	</string>
+	<string name="calling card">
+		la tarjeta de visita
+	</string>
+	<string name="landmark">
+		el hito
+	</string>
+	<string name="legacy script">
+		el script antiguo
+	</string>
+	<string name="clothing">
+		esa ropa
+	</string>
+	<string name="object">
+		el objeto
+	</string>
+	<string name="note card">
+		la nota
+	</string>
+	<string name="folder">
+		la carpeta
+	</string>
+	<string name="root">
+		la ruta
+	</string>
+	<string name="lsl2 script">
+		ese script de LSL2
+	</string>
+	<string name="lsl bytecode">
+		el código intermedio de LSL
+	</string>
+	<string name="tga texture">
+		esa textura tga
+	</string>
+	<string name="body part">
+		esa parte del cuerpo
+	</string>
+	<string name="snapshot">
+		la foto
+	</string>
+	<string name="lost and found">
+		Objetos Perdidos
+	</string>
+	<string name="targa image">
+		esa imagen targa
+	</string>
+	<string name="trash">
+		la Papelera
+	</string>
+	<string name="jpeg image">
+		esa imagen jpeg
+	</string>
+	<string name="animation">
+		la animación
+	</string>
+	<string name="gesture">
+		el gesto
+	</string>
+	<string name="simstate">
+		simstate
+	</string>
+	<string name="favorite">
+		ese favorito
+	</string>
+	<string name="symbolic link">
+		el enlace
+	</string>
+	<string name="symbolic folder link">
+		enlace de la carpeta
+	</string>
+	<string name="settings blob">
+		opciones
+	</string>
+	<string name="mesh">
+		red
+	</string>
+	<string name="AvatarEditingAppearance">
+		(Edición de Apariencia)
+	</string>
+	<string name="AvatarAway">
+		Ausente
+	</string>
+	<string name="AvatarDoNotDisturb">
+		No molestar
+	</string>
+	<string name="AvatarMuted">
+		Ignorado
+	</string>
+	<string name="anim_express_afraid">
+		Susto
+	</string>
+	<string name="anim_express_anger">
+		Enfado
+	</string>
+	<string name="anim_away">
+		Ausente
+	</string>
+	<string name="anim_backflip">
+		Salto mortal atrás
+	</string>
+	<string name="anim_express_laugh">
+		Carcajada
+	</string>
+	<string name="anim_express_toothsmile">
+		Gran sonrisa
+	</string>
+	<string name="anim_blowkiss">
+		Mandar un beso
+	</string>
+	<string name="anim_express_bored">
+		Aburrimiento
+	</string>
+	<string name="anim_bow">
+		Reverencia
+	</string>
+	<string name="anim_clap">
+		Aplauso
+	</string>
+	<string name="anim_courtbow">
+		Reverencia floreada
+	</string>
+	<string name="anim_express_cry">
+		Llanto
+	</string>
+	<string name="anim_dance1">
+		Baile 1
+	</string>
+	<string name="anim_dance2">
+		Baile 2
+	</string>
+	<string name="anim_dance3">
+		Baile 3
+	</string>
+	<string name="anim_dance4">
+		Baile 4
+	</string>
+	<string name="anim_dance5">
+		Baile 5
+	</string>
+	<string name="anim_dance6">
+		Baile 6
+	</string>
+	<string name="anim_dance7">
+		Baile 7
+	</string>
+	<string name="anim_dance8">
+		Baile 8
+	</string>
+	<string name="anim_express_disdain">
+		Desdén
+	</string>
+	<string name="anim_drink">
+		Beber
+	</string>
+	<string name="anim_express_embarrased">
+		Azorarse
+	</string>
+	<string name="anim_angry_fingerwag">
+		Negar con el dedo
+	</string>
+	<string name="anim_fist_pump">
+		Éxito con el puño
+	</string>
+	<string name="anim_yoga_float">
+		Yoga flotando
+	</string>
+	<string name="anim_express_frown">
+		Fruncir el ceño
+	</string>
+	<string name="anim_impatient">
+		Impaciente
+	</string>
+	<string name="anim_jumpforjoy">
+		Salto de alegría
+	</string>
+	<string name="anim_kissmybutt">
+		Bésame el culo
+	</string>
+	<string name="anim_express_kiss">
+		Besar
+	</string>
+	<string name="anim_laugh_short">
+		Reír
+	</string>
+	<string name="anim_musclebeach">
+		Sacar músculo
+	</string>
+	<string name="anim_no_unhappy">
+		No (con enfado)
+	</string>
+	<string name="anim_no_head">
+		No
+	</string>
+	<string name="anim_nyanya">
+		Ña-Ña-Ña
+	</string>
+	<string name="anim_punch_onetwo">
+		Puñetazo uno-dos
+	</string>
+	<string name="anim_express_open_mouth">
+		Abrir la boca
+	</string>
+	<string name="anim_peace">
+		'V' con los dedos
+	</string>
+	<string name="anim_point_you">
+		Señalar a otro/a
+	</string>
+	<string name="anim_point_me">
+		Señalarse
+	</string>
+	<string name="anim_punch_l">
+		Puñetazo izquierdo
+	</string>
+	<string name="anim_punch_r">
+		Puñetazo derecho
+	</string>
+	<string name="anim_rps_countdown">
+		PPT cuenta
+	</string>
+	<string name="anim_rps_paper">
+		PPT papel
+	</string>
+	<string name="anim_rps_rock">
+		PPT piedra
+	</string>
+	<string name="anim_rps_scissors">
+		PPT tijera
+	</string>
+	<string name="anim_express_repulsed">
+		Repulsa
+	</string>
+	<string name="anim_kick_roundhouse_r">
+		Patada circular
+	</string>
+	<string name="anim_express_sad">
+		Triste
+	</string>
+	<string name="anim_salute">
+		Saludo militar
+	</string>
+	<string name="anim_shout">
+		Gritar
+	</string>
+	<string name="anim_express_shrug">
+		Encogerse de hombros
+	</string>
+	<string name="anim_express_smile">
+		Sonreír
+	</string>
+	<string name="anim_smoke_idle">
+		Fumar: en la mano
+	</string>
+	<string name="anim_smoke_inhale">
+		Fumar
+	</string>
+	<string name="anim_smoke_throw_down">
+		Fumar: tirar el cigarro
+	</string>
+	<string name="anim_express_surprise">
+		Sorpresa
+	</string>
+	<string name="anim_sword_strike_r">
+		Estocadas
+	</string>
+	<string name="anim_angry_tantrum">
+		Berrinche
+	</string>
+	<string name="anim_express_tongue_out">
+		Sacar la lengua
+	</string>
+	<string name="anim_hello">
+		Agitar la mano
+	</string>
+	<string name="anim_whisper">
+		Cuchichear
+	</string>
+	<string name="anim_whistle">
+		Pitar
+	</string>
+	<string name="anim_express_wink">
+		Guiño
+	</string>
+	<string name="anim_wink_hollywood">
+		Guiño (Hollywood)
+	</string>
+	<string name="anim_express_worry">
+		Preocuparse
+	</string>
+	<string name="anim_yes_happy">
+		Sí (contento)
+	</string>
+	<string name="anim_yes_head">
+		Sí
+	</string>
+	<string name="use_texture">
+		Usar textura
+	</string>
+	<string name="manip_hint1">
+		Pasa el cursor del ratón sobre la regla
+	</string>
+	<string name="manip_hint2">
+		para ajustar a la cuadrícula
+	</string>
+	<string name="texture_loading">
+		Cargando...
+	</string>
+	<string name="worldmap_offline">
+		Sin conexión
+	</string>
+	<string name="worldmap_item_tooltip_format">
+		[PRICE] L$ por [AREA] m²
+	</string>
+	<string name="worldmap_results_none_found">
+		No se ha encontrado.
+	</string>
+	<string name="Ok">
+		OK
+	</string>
+	<string name="Premature end of file">
+		Fin prematuro del archivo
+	</string>
+	<string name="ST_NO_JOINT">
+		No se puede encontrar ROOT o JOINT.
+	</string>
+	<string name="NearbyChatTitle">
+		Chat
+	</string>
+	<string name="NearbyChatLabel">
+		(Chat)
+	</string>
+	<string name="whisper">
+		susurra:
+	</string>
+	<string name="shout">
+		grita:
+	</string>
+	<string name="ringing">
+		Conectando al chat de voz...
+	</string>
+	<string name="connected">
+		Conectado
+	</string>
+	<string name="unavailable">
+		La voz no está disponible en su localización actual
+	</string>
+	<string name="hang_up">
+		Desconectado del chat de voz
+	</string>
+	<string name="reconnect_nearby">
+		Vas a ser reconectado al chat de voz con los cercanos
+	</string>
+	<string name="ScriptQuestionCautionChatGranted">
+		'[OBJECTNAME]', un objeto propiedad de '[OWNERNAME]', localizado en [REGIONNAME] con la posición [REGIONPOS], ha recibido permiso para: [PERMISSIONS].
+	</string>
+	<string name="ScriptQuestionCautionChatDenied">
+		A '[OBJECTNAME]', un objeto propiedad de '[OWNERNAME]', localizado en [REGIONNAME] con la posición [REGIONPOS], se le ha denegado el permiso para: [PERMISSIONS].
+	</string>
+	<string name="AdditionalPermissionsRequestHeader">
+		Si autorizas el acceso a tu cuenta, también permitirás al objeto:
+	</string>
+	<string name="ScriptTakeMoney">
+		Cogerle a usted dólares Linden (L$)
+	</string>
+	<string name="ActOnControlInputs">
+		Actuar en sus controles de entrada
+	</string>
+	<string name="RemapControlInputs">
+		Reconfigurar sus controles de entrada
+	</string>
+	<string name="AnimateYourAvatar">
+		Ejecutar animaciones en su avatar
+	</string>
+	<string name="AttachToYourAvatar">
+		Anexarse a su avatar
+	</string>
+	<string name="ReleaseOwnership">
+		Anular la propiedad y que pase a ser público
+	</string>
+	<string name="LinkAndDelink">
+		Enlazar y desenlazar de otros objetos
+	</string>
+	<string name="AddAndRemoveJoints">
+		Añadir y quitar uniones con otros objetos
+	</string>
+	<string name="ChangePermissions">
+		Cambiar sus permisos
+	</string>
+	<string name="TrackYourCamera">
+		Seguir su cámara
+	</string>
+	<string name="ControlYourCamera">
+		Controlar su cámara
+	</string>
+	<string name="TeleportYourAgent">
+		Teleportarte
+	</string>
+	<string name="ForceSitAvatar">
+		Forzar que el avatar se siente
+	</string>
+	<string name="ChangeEnvSettings">
+		Cambiar tu configuración del entorno
+	</string>
+	<string name="AgentNameSubst">
+		(Tú)
+	</string>
 	<string name="JoinAnExperience"/>
-	<string name="SilentlyManageEstateAccess">Suprimir alertas al gestionar las listas de acceso a un estado</string>
-	<string name="OverrideYourAnimations">Reemplazar tus animaciones predeterminadas</string>
-	<string name="ScriptReturnObjects">Devolver objetos en tu nombre</string>
-	<string name="UnknownScriptPermission">(desconocido)</string>
-	<string name="SIM_ACCESS_PG">General</string>
-	<string name="SIM_ACCESS_MATURE">Moderado</string>
-	<string name="SIM_ACCESS_ADULT">Adulto</string>
-	<string name="SIM_ACCESS_DOWN">Desconectado</string>
-	<string name="SIM_ACCESS_MIN">Desconocido</string>
-	<string name="land_type_unknown">(desconocido)</string>
-	<string name="Estate / Full Region">Estado /Región completa</string>
-	<string name="Estate / Homestead">Estado / Homestead</string>
-	<string name="Mainland / Homestead">Continente / Homestead</string>
-	<string name="Mainland / Full Region">Continente / Región completa</string>
-	<string name="all_files">Todos los archivos</string>
-	<string name="sound_files">Sonidos</string>
-	<string name="animation_files">Animaciones</string>
-	<string name="image_files">Imágenes</string>
-	<string name="save_file_verb">Guardar</string>
-	<string name="load_file_verb">Cargar</string>
-	<string name="targa_image_files">Imágenes Targa</string>
-	<string name="bitmap_image_files">Imágenes de mapa de bits</string>
-	<string name="png_image_files">Imágenes PNG</string>
-	<string name="save_texture_image_files">Imágenes Targa o PNG</string>
-	<string name="avi_movie_file">Archivo de película AVI</string>
-	<string name="xaf_animation_file">Archivo de anim. XAF</string>
-	<string name="xml_file">Archivo XML</string>
-	<string name="raw_file">Archivo RAW</string>
-	<string name="compressed_image_files">Imágenes comprimidas</string>
-	<string name="load_files">Cargar archivos</string>
-	<string name="choose_the_directory">Elegir directorio</string>
-	<string name="script_files">Scripts</string>
-	<string name="dictionary_files">Diccionarios</string>
-	<string name="shape">Forma</string>
-	<string name="skin">Piel</string>
-	<string name="hair">Pelo</string>
-	<string name="eyes">Ojos</string>
-	<string name="shirt">Camisa</string>
-	<string name="pants">Pantalón</string>
-	<string name="shoes">Zapatos</string>
-	<string name="socks">Calcetines</string>
-	<string name="jacket">Chaqueta</string>
-	<string name="gloves">Guantes</string>
-	<string name="undershirt">Camiseta</string>
-	<string name="underpants">Ropa interior</string>
-	<string name="skirt">Falda</string>
-	<string name="alpha">Alfa</string>
-	<string name="tattoo">Tatuaje</string>
-	<string name="universal">Universal</string>
-	<string name="physics">Física</string>
-	<string name="invalid">inválido/a</string>
-	<string name="none">ninguno</string>
-	<string name="shirt_not_worn">Camisa no puesta</string>
-	<string name="pants_not_worn">Pantalones no puestos</string>
-	<string name="shoes_not_worn">Zapatos no puestos</string>
-	<string name="socks_not_worn">Calcetines no puestos</string>
-	<string name="jacket_not_worn">Chaqueta no puesta</string>
-	<string name="gloves_not_worn">Guantes no puestos</string>
-	<string name="undershirt_not_worn">Camiseta no puesta</string>
-	<string name="underpants_not_worn">Ropa interior no puesta</string>
-	<string name="skirt_not_worn">Falda no puesta</string>
-	<string name="alpha_not_worn">Alfa no puesta</string>
-	<string name="tattoo_not_worn">Tatuaje no puesto</string>
-	<string name="universal_not_worn">Universal no puesto</string>
-	<string name="physics_not_worn">Física no puesta</string>
-	<string name="invalid_not_worn">no válido/a</string>
-	<string name="create_new_shape">Crear una anatomía nueva</string>
-	<string name="create_new_skin">Crear una piel nueva</string>
-	<string name="create_new_hair">Crear pelo nuevo</string>
-	<string name="create_new_eyes">Crear ojos nuevos</string>
-	<string name="create_new_shirt">Crear una camisa nueva</string>
-	<string name="create_new_pants">Crear unos pantalones nuevos</string>
-	<string name="create_new_shoes">Crear unos zapatos nuevos</string>
-	<string name="create_new_socks">Crear unos calcetines nuevos</string>
-	<string name="create_new_jacket">Crear una chaqueta nueva</string>
-	<string name="create_new_gloves">Crear unos guantes nuevos</string>
-	<string name="create_new_undershirt">Crear una camiseta nueva</string>
-	<string name="create_new_underpants">Crear ropa interior nueva</string>
-	<string name="create_new_skirt">Crear una falda nueva</string>
-	<string name="create_new_alpha">Crear una capa alfa nueva</string>
-	<string name="create_new_tattoo">Crear un tatuaje nuevo</string>
-	<string name="create_new_universal">Crear unos guantes nuevos</string>
-	<string name="create_new_physics">Crear nueva física</string>
-	<string name="create_new_invalid">no válido/a</string>
-	<string name="NewWearable">Nuevo [WEARABLE_ITEM]</string>
-	<string name="next">Siguiente</string>
-	<string name="ok">OK</string>
-	<string name="GroupNotifyGroupNotice">Aviso de grupo</string>
-	<string name="GroupNotifyGroupNotices">Avisos del grupo</string>
-	<string name="GroupNotifySentBy">Enviado por</string>
-	<string name="GroupNotifyAttached">Adjunto:</string>
-	<string name="GroupNotifyViewPastNotices">Ver los avisos pasados u optar por dejar de recibir aquí estos mensajes.</string>
-	<string name="GroupNotifyOpenAttachment">Abrir el adjunto</string>
-	<string name="GroupNotifySaveAttachment">Guardar el adjunto</string>
-	<string name="TeleportOffer">Ofrecimiento de teleporte</string>
-	<string name="StartUpNotifications">Llegaron avisos nuevos mientras estabas ausente...</string>
-	<string name="OverflowInfoChannelString">Tienes [%d] aviso/s más</string>
-	<string name="BodyPartsRightArm">Brazo der.</string>
-	<string name="BodyPartsHead">Cabeza</string>
-	<string name="BodyPartsLeftArm">Brazo izq.</string>
-	<string name="BodyPartsLeftLeg">Pierna izq.</string>
-	<string name="BodyPartsTorso">Torso</string>
-	<string name="BodyPartsRightLeg">Pierna der.</string>
-	<string name="BodyPartsEnhancedSkeleton">Esqueleto mejorado</string>
-	<string name="GraphicsQualityLow">Bajo</string>
-	<string name="GraphicsQualityMid">Medio</string>
-	<string name="GraphicsQualityHigh">Alto</string>
-	<string name="LeaveMouselook">Pulsa ESC para salir de la vista subjetiva</string>
-	<string name="InventoryNoMatchingItems">¿No encuentras lo que buscas? Prueba con [secondlife:///app/search/all/[SEARCH_TERM] Buscar].</string>
-	<string name="InventoryNoMatchingRecentItems">¿No encuentras lo que buscas? Intenta [secondlife:///app/inventory/filters Show filters].</string>
-	<string name="PlacesNoMatchingItems">¿No encuentras lo que buscas? Prueba con [secondlife:///app/search/places/[SEARCH_TERM] Buscar].</string>
-	<string name="FavoritesNoMatchingItems">Arrastra aquí un hito para tenerlo en tus favoritos.</string>
-	<string name="MarketplaceNoMatchingItems">No se han encontrado artículos. Comprueba si has escrito correctamente la cadena de búsqueda y vuelve a intentarlo.</string>
-	<string name="InventoryNoTexture">No tienes en tu inventario una copia de esta textura</string>
-	<string name="InventoryInboxNoItems">Aquí aparecerán algunos de los objetos que recibas, como los regalos Premium. Después puedes arrastrarlos a tu inventario.</string>
-	<string name="MarketplaceURL">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/</string>
-	<string name="MarketplaceURL_CreateStore">http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3</string>
-	<string name="MarketplaceURL_Dashboard">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard</string>
-	<string name="MarketplaceURL_Imports">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports</string>
-	<string name="MarketplaceURL_LearnMore">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more</string>
-	<string name="InventoryPlayAnimationTooltip">Abrir la ventana con las opciones del Juego</string>
-	<string name="InventoryPlayGestureTooltip">Realizar gesto seleccionado en el mundo.</string>
-	<string name="InventoryPlaySoundTooltip">Abrir la ventana con las opciones del Juego</string>
-	<string name="InventoryOutboxNotMerchantTitle">Cualquier usuario puede vender objetos en el mercado.</string>
+	<string name="SilentlyManageEstateAccess">
+		Suprimir alertas al gestionar las listas de acceso a un estado
+	</string>
+	<string name="OverrideYourAnimations">
+		Reemplazar tus animaciones predeterminadas
+	</string>
+	<string name="ScriptReturnObjects">
+		Devolver objetos en tu nombre
+	</string>
+	<string name="UnknownScriptPermission">
+		(desconocido)
+	</string>
+	<string name="SIM_ACCESS_PG">
+		General
+	</string>
+	<string name="SIM_ACCESS_MATURE">
+		Moderado
+	</string>
+	<string name="SIM_ACCESS_ADULT">
+		Adulto
+	</string>
+	<string name="SIM_ACCESS_DOWN">
+		Desconectado
+	</string>
+	<string name="SIM_ACCESS_MIN">
+		Desconocido
+	</string>
+	<string name="land_type_unknown">
+		(desconocido)
+	</string>
+	<string name="Estate / Full Region">
+		Estado /Región completa
+	</string>
+	<string name="Estate / Homestead">
+		Estado / Homestead
+	</string>
+	<string name="Mainland / Homestead">
+		Continente / Homestead
+	</string>
+	<string name="Mainland / Full Region">
+		Continente / Región completa
+	</string>
+	<string name="all_files">
+		Todos los archivos
+	</string>
+	<string name="sound_files">
+		Sonidos
+	</string>
+	<string name="animation_files">
+		Animaciones
+	</string>
+	<string name="image_files">
+		Imágenes
+	</string>
+	<string name="save_file_verb">
+		Guardar
+	</string>
+	<string name="load_file_verb">
+		Cargar
+	</string>
+	<string name="targa_image_files">
+		Imágenes Targa
+	</string>
+	<string name="bitmap_image_files">
+		Imágenes de mapa de bits
+	</string>
+	<string name="png_image_files">
+		Imágenes PNG
+	</string>
+	<string name="save_texture_image_files">
+		Imágenes Targa o PNG
+	</string>
+	<string name="avi_movie_file">
+		Archivo de película AVI
+	</string>
+	<string name="xaf_animation_file">
+		Archivo de anim. XAF
+	</string>
+	<string name="xml_file">
+		Archivo XML
+	</string>
+	<string name="raw_file">
+		Archivo RAW
+	</string>
+	<string name="compressed_image_files">
+		Imágenes comprimidas
+	</string>
+	<string name="load_files">
+		Cargar archivos
+	</string>
+	<string name="choose_the_directory">
+		Elegir directorio
+	</string>
+	<string name="script_files">
+		Scripts
+	</string>
+	<string name="dictionary_files">
+		Diccionarios
+	</string>
+	<string name="shape">
+		Forma
+	</string>
+	<string name="skin">
+		Piel
+	</string>
+	<string name="hair">
+		Pelo
+	</string>
+	<string name="eyes">
+		Ojos
+	</string>
+	<string name="shirt">
+		Camisa
+	</string>
+	<string name="pants">
+		Pantalón
+	</string>
+	<string name="shoes">
+		Zapatos
+	</string>
+	<string name="socks">
+		Calcetines
+	</string>
+	<string name="jacket">
+		Chaqueta
+	</string>
+	<string name="gloves">
+		Guantes
+	</string>
+	<string name="undershirt">
+		Camiseta
+	</string>
+	<string name="underpants">
+		Ropa interior
+	</string>
+	<string name="skirt">
+		Falda
+	</string>
+	<string name="alpha">
+		Alfa
+	</string>
+	<string name="tattoo">
+		Tatuaje
+	</string>
+	<string name="universal">
+		Universal
+	</string>
+	<string name="physics">
+		Física
+	</string>
+	<string name="invalid">
+		inválido/a
+	</string>
+	<string name="none">
+		ninguno
+	</string>
+	<string name="shirt_not_worn">
+		Camisa no puesta
+	</string>
+	<string name="pants_not_worn">
+		Pantalones no puestos
+	</string>
+	<string name="shoes_not_worn">
+		Zapatos no puestos
+	</string>
+	<string name="socks_not_worn">
+		Calcetines no puestos
+	</string>
+	<string name="jacket_not_worn">
+		Chaqueta no puesta
+	</string>
+	<string name="gloves_not_worn">
+		Guantes no puestos
+	</string>
+	<string name="undershirt_not_worn">
+		Camiseta no puesta
+	</string>
+	<string name="underpants_not_worn">
+		Ropa interior no puesta
+	</string>
+	<string name="skirt_not_worn">
+		Falda no puesta
+	</string>
+	<string name="alpha_not_worn">
+		Alfa no puesta
+	</string>
+	<string name="tattoo_not_worn">
+		Tatuaje no puesto
+	</string>
+	<string name="universal_not_worn">
+		Universal no puesto
+	</string>
+	<string name="physics_not_worn">
+		Física no puesta
+	</string>
+	<string name="invalid_not_worn">
+		no válido/a
+	</string>
+	<string name="create_new_shape">
+		Crear una anatomía nueva
+	</string>
+	<string name="create_new_skin">
+		Crear una piel nueva
+	</string>
+	<string name="create_new_hair">
+		Crear pelo nuevo
+	</string>
+	<string name="create_new_eyes">
+		Crear ojos nuevos
+	</string>
+	<string name="create_new_shirt">
+		Crear una camisa nueva
+	</string>
+	<string name="create_new_pants">
+		Crear unos pantalones nuevos
+	</string>
+	<string name="create_new_shoes">
+		Crear unos zapatos nuevos
+	</string>
+	<string name="create_new_socks">
+		Crear unos calcetines nuevos
+	</string>
+	<string name="create_new_jacket">
+		Crear una chaqueta nueva
+	</string>
+	<string name="create_new_gloves">
+		Crear unos guantes nuevos
+	</string>
+	<string name="create_new_undershirt">
+		Crear una camiseta nueva
+	</string>
+	<string name="create_new_underpants">
+		Crear ropa interior nueva
+	</string>
+	<string name="create_new_skirt">
+		Crear una falda nueva
+	</string>
+	<string name="create_new_alpha">
+		Crear una capa alfa nueva
+	</string>
+	<string name="create_new_tattoo">
+		Crear un tatuaje nuevo
+	</string>
+	<string name="create_new_universal">
+		Crear unos guantes nuevos
+	</string>
+	<string name="create_new_physics">
+		Crear nueva física
+	</string>
+	<string name="create_new_invalid">
+		no válido/a
+	</string>
+	<string name="NewWearable">
+		Nuevo [WEARABLE_ITEM]
+	</string>
+	<string name="next">
+		Siguiente
+	</string>
+	<string name="ok">
+		OK
+	</string>
+	<string name="GroupNotifyGroupNotice">
+		Aviso de grupo
+	</string>
+	<string name="GroupNotifyGroupNotices">
+		Avisos del grupo
+	</string>
+	<string name="GroupNotifySentBy">
+		Enviado por
+	</string>
+	<string name="GroupNotifyAttached">
+		Adjunto:
+	</string>
+	<string name="GroupNotifyViewPastNotices">
+		Ver los avisos pasados u optar por dejar de recibir aquí estos mensajes.
+	</string>
+	<string name="GroupNotifyOpenAttachment">
+		Abrir el adjunto
+	</string>
+	<string name="GroupNotifySaveAttachment">
+		Guardar el adjunto
+	</string>
+	<string name="TeleportOffer">
+		Ofrecimiento de teleporte
+	</string>
+	<string name="StartUpNotifications">
+		Llegaron avisos nuevos mientras estabas ausente...
+	</string>
+	<string name="OverflowInfoChannelString">
+		Tienes [%d] aviso/s más
+	</string>
+	<string name="BodyPartsRightArm">
+		Brazo der.
+	</string>
+	<string name="BodyPartsHead">
+		Cabeza
+	</string>
+	<string name="BodyPartsLeftArm">
+		Brazo izq.
+	</string>
+	<string name="BodyPartsLeftLeg">
+		Pierna izq.
+	</string>
+	<string name="BodyPartsTorso">
+		Torso
+	</string>
+	<string name="BodyPartsRightLeg">
+		Pierna der.
+	</string>
+	<string name="BodyPartsEnhancedSkeleton">
+		Esqueleto mejorado
+	</string>
+	<string name="GraphicsQualityLow">
+		Bajo
+	</string>
+	<string name="GraphicsQualityMid">
+		Medio
+	</string>
+	<string name="GraphicsQualityHigh">
+		Alto
+	</string>
+	<string name="LeaveMouselook">
+		Pulsa ESC para salir de la vista subjetiva
+	</string>
+	<string name="InventoryNoMatchingItems">
+		¿No encuentras lo que buscas? Prueba con [secondlife:///app/search/all/[SEARCH_TERM] Buscar].
+	</string>
+	<string name="InventoryNoMatchingRecentItems">
+		¿No encuentras lo que buscas? Intenta [secondlife:///app/inventory/filters Show filters].
+	</string>
+	<string name="PlacesNoMatchingItems">
+		¿No encuentras lo que buscas? Prueba con [secondlife:///app/search/places/[SEARCH_TERM] Buscar].
+	</string>
+	<string name="FavoritesNoMatchingItems">
+		Arrastra aquí un hito para tenerlo en tus favoritos.
+	</string>
+	<string name="MarketplaceNoMatchingItems">
+		No se han encontrado artículos. Comprueba si has escrito correctamente la cadena de búsqueda y vuelve a intentarlo.
+	</string>
+	<string name="InventoryNoTexture">
+		No tienes en tu inventario una copia de esta textura
+	</string>
+	<string name="InventoryInboxNoItems">
+		Aquí aparecerán algunos de los objetos que recibas, como los regalos Premium. Después puedes arrastrarlos a tu inventario.
+	</string>
+	<string name="MarketplaceURL">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/
+	</string>
+	<string name="MarketplaceURL_CreateStore">
+		http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3
+	</string>
+	<string name="MarketplaceURL_Dashboard">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard
+	</string>
+	<string name="MarketplaceURL_Imports">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports
+	</string>
+	<string name="MarketplaceURL_LearnMore">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more
+	</string>
+	<string name="InventoryPlayAnimationTooltip">
+		Abrir la ventana con las opciones del Juego
+	</string>
+	<string name="InventoryPlayGestureTooltip">
+		Realizar gesto seleccionado en el mundo.
+	</string>
+	<string name="InventoryPlaySoundTooltip">
+		Abrir la ventana con las opciones del Juego
+	</string>
+	<string name="InventoryOutboxNotMerchantTitle">
+		Cualquier usuario puede vender objetos en el mercado.
+	</string>
 	<string name="InventoryOutboxNotMerchantTooltip"/>
-	<string name="InventoryOutboxNotMerchant">Para hacerte comerciante debes [[MARKETPLACE_CREATE_STORE_URL] crear una tienda del Mercado].</string>
-	<string name="InventoryOutboxNoItemsTitle">El buzón de salida está vacío.</string>
+	<string name="InventoryOutboxNotMerchant">
+		Para hacerte comerciante debes [[MARKETPLACE_CREATE_STORE_URL] crear una tienda del Mercado].
+	</string>
+	<string name="InventoryOutboxNoItemsTitle">
+		El buzón de salida está vacío.
+	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
-	<string name="InventoryOutboxNoItems">Arrastra carpetas a esta sección y pulsa en &quot;Enviar al Mercado&quot; para incluirlas en la lista de venta del [[MARKETPLACE_DASHBOARD_URL] Mercado].</string>
-	<string name="InventoryOutboxInitializingTitle">Inicializando el Mercado.</string>
-	<string name="InventoryOutboxInitializing">Estamos accediendo a tu cuenta de la [[MARKETPLACE_CREATE_STORE_URL] tienda del Mercado].</string>
-	<string name="InventoryOutboxErrorTitle">Errores del Mercado.</string>
-	<string name="InventoryOutboxError">La [[MARKETPLACE_CREATE_STORE_URL] tienda del Mercado] devuelve errores.</string>
-	<string name="InventoryMarketplaceError">Se ha producido un error al abrir Artículos del Mercado.
-Si sigues recibiendo el mismo mensaje, solicita ayuda al personal de asistencia de Second Life en http://support.secondlife.com</string>
-	<string name="InventoryMarketplaceListingsNoItemsTitle">Tu carpeta Artículos del mercado está vacía.</string>
-	<string name="InventoryMarketplaceListingsNoItems">Arrastra carpetas a esta sección para incluirlas en la lista de venta del [[MARKETPLACE_DASHBOARD_URL] Mercado].</string>
-	<string name="InventoryItemsCount">( [ITEMS_COUNT] Objetos)</string>
-	<string name="Marketplace Validation Warning Stock">La carpeta de stock debe estar contenida en una carpeta de versión</string>
-	<string name="Marketplace Validation Error Mixed Stock">: Error: todos los artículos de una carpeta de stock deben ser del mismo tipo y que no se puedan copiar</string>
-	<string name="Marketplace Validation Error Subfolder In Stock">: Error: la carpeta de stock no puede contener subcarpetas</string>
-	<string name="Marketplace Validation Warning Empty">: Atención: la carpeta no contiene ningún artículo</string>
-	<string name="Marketplace Validation Warning Create Stock">: Atención: creando carpeta de stock</string>
-	<string name="Marketplace Validation Warning Create Version">: Atención: creando la carpeta de versión</string>
-	<string name="Marketplace Validation Warning Move">: Atención: moviendo artículos</string>
-	<string name="Marketplace Validation Warning Delete">: Atención: se ha transferido el contenido de la carpeta a la carpeta de stock, y se eliminará la carpeta vacía</string>
-	<string name="Marketplace Validation Error Stock Item">: Error: los artículos que no se pueden copiar deben estar contenidos en una carpeta de stock</string>
-	<string name="Marketplace Validation Warning Unwrapped Item">: Atención: los artículos deben estar contenidos en una carpeta de versión</string>
-	<string name="Marketplace Validation Error">: Error:</string>
-	<string name="Marketplace Validation Warning">: Atención:</string>
-	<string name="Marketplace Validation Error Empty Version">: Atención: la carpeta de versión debe contener al menos un artículo</string>
-	<string name="Marketplace Validation Error Empty Stock">: Atención: la carpeta de stock debe contener al menos un artículo</string>
-	<string name="Marketplace Validation No Error">No se han producido errores ni advertencias</string>
-	<string name="Marketplace Error None">Sin errores</string>
-	<string name="Marketplace Error Prefix">Error:</string>
-	<string name="Marketplace Error Not Merchant">Para poder enviar objetos al mercado, debes registrarte como comerciante (es gratis).</string>
-	<string name="Marketplace Error Not Accepted">No se puede mover el artículo a esa carpeta.</string>
-	<string name="Marketplace Error Unsellable Item">Este artículo no se puede vender en el Mercado.</string>
-	<string name="MarketplaceNoID">no Mkt ID</string>
-	<string name="MarketplaceLive">en la lista</string>
-	<string name="MarketplaceActive">activa</string>
-	<string name="MarketplaceMax">máx.</string>
-	<string name="MarketplaceStock">stock</string>
-	<string name="MarketplaceNoStock">existencias agotadas</string>
-	<string name="MarketplaceUpdating">actualizando...</string>
-	<string name="UploadFeeInfo">Las cuotas se basan en tu nivel de suscripcion. Niveles más altos tienen cuotas más bajas visita [https://secondlife.com/my/account/membership.php? para saber más]</string>
-	<string name="Open landmarks">Abrir puntos destacados</string>
-	<string name="Unconstrained">Sin Restricciones</string>
+	<string name="InventoryOutboxNoItems">
+		Arrastra carpetas a esta sección y pulsa en "Enviar al Mercado" para incluirlas en la lista de venta del [[MARKETPLACE_DASHBOARD_URL] Mercado].
+	</string>
+	<string name="InventoryOutboxInitializingTitle">
+		Inicializando el Mercado.
+	</string>
+	<string name="InventoryOutboxInitializing">
+		Estamos accediendo a tu cuenta de la [[MARKETPLACE_CREATE_STORE_URL] tienda del Mercado].
+	</string>
+	<string name="InventoryOutboxErrorTitle">
+		Errores del Mercado.
+	</string>
+	<string name="InventoryOutboxError">
+		La [[MARKETPLACE_CREATE_STORE_URL] tienda del Mercado] devuelve errores.
+	</string>
+	<string name="InventoryMarketplaceError">
+		Se ha producido un error al abrir Artículos del Mercado.
+Si sigues recibiendo el mismo mensaje, solicita ayuda al personal de asistencia de Second Life en http://support.secondlife.com
+	</string>
+	<string name="InventoryMarketplaceListingsNoItemsTitle">
+		Tu carpeta Artículos del mercado está vacía.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItems">
+		Arrastra carpetas a esta sección para incluirlas en la lista de venta del [[MARKETPLACE_DASHBOARD_URL] Mercado].
+	</string>
+	<string name="InventoryItemsCount">
+		( [ITEMS_COUNT] Objetos)
+	</string>
+	<string name="Marketplace Validation Warning Stock">
+		La carpeta de stock debe estar contenida en una carpeta de versión
+	</string>
+	<string name="Marketplace Validation Error Mixed Stock">
+		: Error: todos los artículos de una carpeta de stock deben ser del mismo tipo y que no se puedan copiar
+	</string>
+	<string name="Marketplace Validation Error Subfolder In Stock">
+		: Error: la carpeta de stock no puede contener subcarpetas
+	</string>
+	<string name="Marketplace Validation Warning Empty">
+		: Atención: la carpeta no contiene ningún artículo
+	</string>
+	<string name="Marketplace Validation Warning Create Stock">
+		: Atención: creando carpeta de stock
+	</string>
+	<string name="Marketplace Validation Warning Create Version">
+		: Atención: creando la carpeta de versión
+	</string>
+	<string name="Marketplace Validation Warning Move">
+		: Atención: moviendo artículos
+	</string>
+	<string name="Marketplace Validation Warning Delete">
+		: Atención: se ha transferido el contenido de la carpeta a la carpeta de stock, y se eliminará la carpeta vacía
+	</string>
+	<string name="Marketplace Validation Error Stock Item">
+		: Error: los artículos que no se pueden copiar deben estar contenidos en una carpeta de stock
+	</string>
+	<string name="Marketplace Validation Warning Unwrapped Item">
+		: Atención: los artículos deben estar contenidos en una carpeta de versión
+	</string>
+	<string name="Marketplace Validation Error">
+		: Error:
+	</string>
+	<string name="Marketplace Validation Warning">
+		: Atención:
+	</string>
+	<string name="Marketplace Validation Error Empty Version">
+		: Atención: la carpeta de versión debe contener al menos un artículo
+	</string>
+	<string name="Marketplace Validation Error Empty Stock">
+		: Atención: la carpeta de stock debe contener al menos un artículo
+	</string>
+	<string name="Marketplace Validation No Error">
+		No se han producido errores ni advertencias
+	</string>
+	<string name="Marketplace Error None">
+		Sin errores
+	</string>
+	<string name="Marketplace Error Prefix">
+		Error:
+	</string>
+	<string name="Marketplace Error Not Merchant">
+		Para poder enviar objetos al mercado, debes registrarte como comerciante (es gratis).
+	</string>
+	<string name="Marketplace Error Not Accepted">
+		No se puede mover el artículo a esa carpeta.
+	</string>
+	<string name="Marketplace Error Unsellable Item">
+		Este artículo no se puede vender en el Mercado.
+	</string>
+	<string name="MarketplaceNoID">
+		no Mkt ID
+	</string>
+	<string name="MarketplaceLive">
+		en la lista
+	</string>
+	<string name="MarketplaceActive">
+		activa
+	</string>
+	<string name="MarketplaceMax">
+		máx.
+	</string>
+	<string name="MarketplaceStock">
+		stock
+	</string>
+	<string name="MarketplaceNoStock">
+		existencias agotadas
+	</string>
+	<string name="MarketplaceUpdating">
+		actualizando...
+	</string>
+	<string name="UploadFeeInfo">
+		Las cuotas se basan en tu nivel de suscripcion. Niveles más altos tienen cuotas más bajas visita [https://secondlife.com/my/account/membership.php? para saber más]
+	</string>
+	<string name="Open landmarks">
+		Abrir puntos destacados
+	</string>
+	<string name="Unconstrained">
+		Sin Restricciones
+	</string>
 	<string name="no_transfer" value="(no transferible)"/>
 	<string name="no_modify" value="(no modificable)"/>
 	<string name="no_copy" value="(no copiable)"/>
 	<string name="worn" value="(puesto)"/>
 	<string name="link" value="(enlace)"/>
 	<string name="broken_link" value="(enlace roto)&quot;"/>
-	<string name="LoadingContents">Cargando el contenido...</string>
-	<string name="NoContents">No hay contenido</string>
+	<string name="LoadingContents">
+		Cargando el contenido...
+	</string>
+	<string name="NoContents">
+		No hay contenido
+	</string>
 	<string name="WornOnAttachmentPoint" value="(lo llevas en: [ATTACHMENT_POINT])"/>
 	<string name="AttachmentErrorMessage" value="([ATTACHMENT_ERROR])"/>
 	<string name="ActiveGesture" value="[GESLABEL] (activo)"/>
@@ -629,1418 +1681,4140 @@ Si sigues recibiendo el mismo mensaje, solicita ayuda al personal de asistencia 
 	<string name="Snapshots" value="Fotos,"/>
 	<string name="No Filters" value="No"/>
 	<string name="Since Logoff" value="- Desde la desconexión"/>
-	<string name="InvFolder My Inventory">Mi Inventario</string>
-	<string name="InvFolder Library">Biblioteca</string>
-	<string name="InvFolder Textures">Texturas</string>
-	<string name="InvFolder Sounds">Sonidos</string>
-	<string name="InvFolder Calling Cards">Tarjetas de visita</string>
-	<string name="InvFolder Landmarks">Hitos</string>
-	<string name="InvFolder Scripts">Scripts</string>
-	<string name="InvFolder Clothing">Ropa</string>
-	<string name="InvFolder Objects">Objetos</string>
-	<string name="InvFolder Notecards">Notas</string>
-	<string name="InvFolder New Folder">Carpeta nueva</string>
-	<string name="InvFolder Inventory">Inventario</string>
-	<string name="InvFolder Uncompressed Images">Imágenes sin comprimir</string>
-	<string name="InvFolder Body Parts">Partes del cuerpo</string>
-	<string name="InvFolder Trash">Papelera</string>
-	<string name="InvFolder Photo Album">Álbum de fotos</string>
-	<string name="InvFolder Lost And Found">Objetos Perdidos</string>
-	<string name="InvFolder Uncompressed Sounds">Sonidos sin comprimir</string>
-	<string name="InvFolder Animations">Animaciones</string>
-	<string name="InvFolder Gestures">Gestos</string>
-	<string name="InvFolder Favorite">Mis Favoritos</string>
-	<string name="InvFolder favorite">Mis Favoritos</string>
-	<string name="InvFolder Favorites">Mis Favoritos</string>
-	<string name="InvFolder favorites">Mis Favoritos</string>
-	<string name="InvFolder Current Outfit">Vestuario actual</string>
-	<string name="InvFolder Initial Outfits">Vestuario inicial</string>
-	<string name="InvFolder My Outfits">Mis vestuarios</string>
-	<string name="InvFolder Accessories">Accesorios</string>
-	<string name="InvFolder Meshes">Redes</string>
-	<string name="InvFolder Received Items">Objetos recibidos</string>
-	<string name="InvFolder Merchant Outbox">Buzón de salida de comerciante</string>
-	<string name="InvFolder Friends">Amigos</string>
-	<string name="InvFolder All">Todas</string>
-	<string name="no_attachments">No tienes puestos anexos</string>
-	<string name="Attachments remain">Anexos (quedan [COUNT] ranuras)</string>
-	<string name="Buy">Comprar</string>
-	<string name="BuyforL$">Comprar por L$</string>
-	<string name="Stone">Piedra</string>
-	<string name="Metal">Metal</string>
-	<string name="Glass">Cristal</string>
-	<string name="Wood">Madera</string>
-	<string name="Flesh">Carne</string>
-	<string name="Plastic">Plástico</string>
-	<string name="Rubber">Goma</string>
-	<string name="Light">Claridad</string>
-	<string name="KBShift">Mayúsculas</string>
-	<string name="KBCtrl">Ctrl</string>
-	<string name="Chest">Tórax</string>
-	<string name="Skull">Cráneo</string>
-	<string name="Left Shoulder">Hombro izquierdo</string>
-	<string name="Right Shoulder">Hombro derecho</string>
-	<string name="Left Hand">Mano izq.</string>
-	<string name="Right Hand">Mano der.</string>
-	<string name="Left Foot">Pie izq.</string>
-	<string name="Right Foot">Pie der.</string>
-	<string name="Spine">Columna</string>
-	<string name="Pelvis">Pelvis</string>
-	<string name="Mouth">Boca</string>
-	<string name="Chin">Barbilla</string>
-	<string name="Left Ear">Oreja izq.</string>
-	<string name="Right Ear">Oreja der.</string>
-	<string name="Left Eyeball">Ojo izq.</string>
-	<string name="Right Eyeball">Ojo der.</string>
-	<string name="Nose">Nariz</string>
-	<string name="R Upper Arm">Brazo der.</string>
-	<string name="R Forearm">Antebrazo der.</string>
-	<string name="L Upper Arm">Brazo izq.</string>
-	<string name="L Forearm">Antebrazo izq.</string>
-	<string name="Right Hip">Cadera der.</string>
-	<string name="R Upper Leg">Muslo der.</string>
-	<string name="R Lower Leg">Pantorrilla der.</string>
-	<string name="Left Hip">Cadera izq.</string>
-	<string name="L Upper Leg">Muslo izq.</string>
-	<string name="L Lower Leg">Pantorrilla izq.</string>
-	<string name="Stomach">Abdomen</string>
-	<string name="Left Pec">Pecho izquierdo</string>
-	<string name="Right Pec">Pecho derecho</string>
-	<string name="Neck">Cuello</string>
-	<string name="Avatar Center">Centro del avatar</string>
-	<string name="Left Ring Finger">Dedo anular izquierdo</string>
-	<string name="Right Ring Finger">Dedo anular derecho</string>
-	<string name="Tail Base">Base de la cola</string>
-	<string name="Tail Tip">Extremo de la cola</string>
-	<string name="Left Wing">Ala izquierda</string>
-	<string name="Right Wing">Ala derecha</string>
-	<string name="Jaw">Mandíbula</string>
-	<string name="Alt Left Ear">Oreja izquierda alternativa</string>
-	<string name="Alt Right Ear">Oreja derecha alternativa</string>
-	<string name="Alt Left Eye">Ojo izquierdo alternativo</string>
-	<string name="Alt Right Eye">Ojo derecho alternativo</string>
-	<string name="Tongue">Lengua</string>
-	<string name="Groin">Ingle</string>
-	<string name="Left Hind Foot">Pata trasera izquierda</string>
-	<string name="Right Hind Foot">Pata trasera derecha</string>
-	<string name="Invalid Attachment">Punto de colocación no válido</string>
-	<string name="ATTACHMENT_MISSING_ITEM">Error: falta un artículo</string>
-	<string name="ATTACHMENT_MISSING_BASE_ITEM">Error: falta el artículo de base</string>
-	<string name="ATTACHMENT_NOT_ATTACHED">Error: el objeto se encuentra en el vestuario actual, pero no está anexado</string>
-	<string name="YearsMonthsOld">[AGEYEARS] [AGEMONTHS] de edad</string>
-	<string name="YearsOld">[AGEYEARS] de edad</string>
-	<string name="MonthsOld">[AGEMONTHS] de edad</string>
-	<string name="WeeksOld">[AGEWEEKS] de edad</string>
-	<string name="DaysOld">[AGEDAYS] de edad</string>
-	<string name="TodayOld">Registrado hoy</string>
-	<string name="av_render_everyone_now">Ahora todos pueden verte.</string>
-	<string name="av_render_not_everyone">Es posible que no todos los que están próximos puedan renderizarte.</string>
-	<string name="av_render_over_half">Es posible que más de la mitad de los que están próximos no puedan renderizarte.</string>
-	<string name="av_render_most_of">Es posible que la mayoría de los que están próximos no puedan renderizarte.</string>
-	<string name="av_render_anyone">Es posible que ninguno de los que están próximos pueda renderizarte.</string>
-	<string name="hud_description_total">Tu HUD</string>
-	<string name="hud_name_with_joint">[OBJ_NAME] (lo llevas en [JNT_NAME])</string>
-	<string name="hud_render_memory_warning">[HUD_DETAILS] usa mucha memoria de textura</string>
-	<string name="hud_render_cost_warning">[HUD_DETAILS] contiene muchas texturas y objetos complicados</string>
-	<string name="hud_render_heavy_textures_warning">[HUD_DETAILS] contiene muchas texturas grandes</string>
-	<string name="hud_render_cramped_warning">[HUD_DETAILS] contiene demasiados objetos</string>
-	<string name="hud_render_textures_warning">[HUD_DETAILS] contiene demasiadas texturas</string>
-	<string name="AgeYearsA">[COUNT] año</string>
-	<string name="AgeYearsB">[COUNT] años</string>
-	<string name="AgeYearsC">[COUNT] años</string>
-	<string name="AgeMonthsA">[COUNT] mes</string>
-	<string name="AgeMonthsB">[COUNT] meses</string>
-	<string name="AgeMonthsC">[COUNT] meses</string>
-	<string name="AgeWeeksA">[COUNT] semana</string>
-	<string name="AgeWeeksB">[COUNT] semanas</string>
-	<string name="AgeWeeksC">[COUNT] semanas</string>
-	<string name="AgeDaysA">[COUNT] día</string>
-	<string name="AgeDaysB">[COUNT] días</string>
-	<string name="AgeDaysC">[COUNT] días</string>
-	<string name="GroupMembersA">[COUNT] miembro</string>
-	<string name="GroupMembersB">[COUNT] miembros</string>
-	<string name="GroupMembersC">[COUNT] miembros</string>
-	<string name="AcctTypeResident">Residente</string>
-	<string name="AcctTypeTrial">Prueba</string>
-	<string name="AcctTypeCharterMember">Miembro fundador</string>
-	<string name="AcctTypeEmployee">Empleado de Linden Lab</string>
-	<string name="PaymentInfoUsed">Ha usado información sobre la forma de pago</string>
-	<string name="PaymentInfoOnFile">Hay información archivada sobre la forma de pago</string>
-	<string name="NoPaymentInfoOnFile">No hay información archivada sobre la forma de pago</string>
-	<string name="AgeVerified">Edad verificada</string>
-	<string name="NotAgeVerified">Edad no verificada</string>
-	<string name="Center 2">Centro 2</string>
-	<string name="Top Right">Arriba der.</string>
-	<string name="Top">Arriba</string>
-	<string name="Top Left">Arriba izq.</string>
-	<string name="Center">Centro</string>
-	<string name="Bottom Left">Abajo izq.</string>
-	<string name="Bottom">Abajo</string>
-	<string name="Bottom Right">Abajo der.</string>
-	<string name="CompileQueueDownloadedCompiling">Descargado, compilándolo</string>
-	<string name="CompileQueueServiceUnavailable">El servicio de compilación de scripts no está disponible</string>
-	<string name="CompileQueueScriptNotFound">No se encuentra el script en el servidor.</string>
-	<string name="CompileQueueProblemDownloading">Problema al descargar</string>
-	<string name="CompileQueueInsufficientPermDownload">Permisos insuficientes para descargar un script.</string>
-	<string name="CompileQueueInsufficientPermFor">Permisos insuficientes para</string>
-	<string name="CompileQueueUnknownFailure">Fallo desconocido en la descarga</string>
-	<string name="CompileNoExperiencePerm">Omitiendo el script [SCRIPT] con la experiencia [EXPERIENCE].</string>
-	<string name="CompileQueueTitle">Recompilando</string>
-	<string name="CompileQueueStart">recompilar</string>
-	<string name="ResetQueueTitle">Progreso del reinicio</string>
-	<string name="ResetQueueStart">restaurar</string>
-	<string name="RunQueueTitle">Configurar según se ejecuta</string>
-	<string name="RunQueueStart">Configurando según se ejecuta</string>
-	<string name="NotRunQueueTitle">Configurar sin ejecutar</string>
-	<string name="NotRunQueueStart">Configurando sin ejecutarlo</string>
-	<string name="CompileSuccessful">¡Compilación correcta!</string>
-	<string name="CompileSuccessfulSaving">Compilación correcta, guardando...</string>
-	<string name="SaveComplete">Guardado.</string>
-	<string name="UploadFailed">Error al subir el archivo:</string>
-	<string name="ObjectOutOfRange">Script (objeto fuera de rango)</string>
-	<string name="ScriptWasDeleted">Script (eliminado del inventario)</string>
-	<string name="GodToolsObjectOwnedBy">El objeto [OBJECT] es propiedad de [OWNER]</string>
-	<string name="GroupsNone">ninguno</string>
+	<string name="InvFolder My Inventory">
+		Mi Inventario
+	</string>
+	<string name="InvFolder Library">
+		Biblioteca
+	</string>
+	<string name="InvFolder Textures">
+		Texturas
+	</string>
+	<string name="InvFolder Sounds">
+		Sonidos
+	</string>
+	<string name="InvFolder Calling Cards">
+		Tarjetas de visita
+	</string>
+	<string name="InvFolder Landmarks">
+		Hitos
+	</string>
+	<string name="InvFolder Scripts">
+		Scripts
+	</string>
+	<string name="InvFolder Clothing">
+		Ropa
+	</string>
+	<string name="InvFolder Objects">
+		Objetos
+	</string>
+	<string name="InvFolder Notecards">
+		Notas
+	</string>
+	<string name="InvFolder New Folder">
+		Carpeta nueva
+	</string>
+	<string name="InvFolder Inventory">
+		Inventario
+	</string>
+	<string name="InvFolder Uncompressed Images">
+		Imágenes sin comprimir
+	</string>
+	<string name="InvFolder Body Parts">
+		Partes del cuerpo
+	</string>
+	<string name="InvFolder Trash">
+		Papelera
+	</string>
+	<string name="InvFolder Photo Album">
+		Álbum de fotos
+	</string>
+	<string name="InvFolder Lost And Found">
+		Objetos Perdidos
+	</string>
+	<string name="InvFolder Uncompressed Sounds">
+		Sonidos sin comprimir
+	</string>
+	<string name="InvFolder Animations">
+		Animaciones
+	</string>
+	<string name="InvFolder Gestures">
+		Gestos
+	</string>
+	<string name="InvFolder Favorite">
+		Mis Favoritos
+	</string>
+	<string name="InvFolder favorite">
+		Mis Favoritos
+	</string>
+	<string name="InvFolder Favorites">
+		Mis Favoritos
+	</string>
+	<string name="InvFolder favorites">
+		Mis Favoritos
+	</string>
+	<string name="InvFolder Current Outfit">
+		Vestuario actual
+	</string>
+	<string name="InvFolder Initial Outfits">
+		Vestuario inicial
+	</string>
+	<string name="InvFolder My Outfits">
+		Mis vestuarios
+	</string>
+	<string name="InvFolder Accessories">
+		Accesorios
+	</string>
+	<string name="InvFolder Meshes">
+		Redes
+	</string>
+	<string name="InvFolder Received Items">
+		Objetos recibidos
+	</string>
+	<string name="InvFolder Merchant Outbox">
+		Buzón de salida de comerciante
+	</string>
+	<string name="InvFolder Friends">
+		Amigos
+	</string>
+	<string name="InvFolder All">
+		Todas
+	</string>
+	<string name="no_attachments">
+		No tienes puestos anexos
+	</string>
+	<string name="Attachments remain">
+		Anexos (quedan [COUNT] ranuras)
+	</string>
+	<string name="Buy">
+		Comprar
+	</string>
+	<string name="BuyforL$">
+		Comprar por L$
+	</string>
+	<string name="Stone">
+		Piedra
+	</string>
+	<string name="Metal">
+		Metal
+	</string>
+	<string name="Glass">
+		Cristal
+	</string>
+	<string name="Wood">
+		Madera
+	</string>
+	<string name="Flesh">
+		Carne
+	</string>
+	<string name="Plastic">
+		Plástico
+	</string>
+	<string name="Rubber">
+		Goma
+	</string>
+	<string name="Light">
+		Claridad
+	</string>
+	<string name="KBShift">
+		Mayúsculas
+	</string>
+	<string name="KBCtrl">
+		Ctrl
+	</string>
+	<string name="Chest">
+		Tórax
+	</string>
+	<string name="Skull">
+		Cráneo
+	</string>
+	<string name="Left Shoulder">
+		Hombro izquierdo
+	</string>
+	<string name="Right Shoulder">
+		Hombro derecho
+	</string>
+	<string name="Left Hand">
+		Mano izq.
+	</string>
+	<string name="Right Hand">
+		Mano der.
+	</string>
+	<string name="Left Foot">
+		Pie izq.
+	</string>
+	<string name="Right Foot">
+		Pie der.
+	</string>
+	<string name="Spine">
+		Columna
+	</string>
+	<string name="Pelvis">
+		Pelvis
+	</string>
+	<string name="Mouth">
+		Boca
+	</string>
+	<string name="Chin">
+		Barbilla
+	</string>
+	<string name="Left Ear">
+		Oreja izq.
+	</string>
+	<string name="Right Ear">
+		Oreja der.
+	</string>
+	<string name="Left Eyeball">
+		Ojo izq.
+	</string>
+	<string name="Right Eyeball">
+		Ojo der.
+	</string>
+	<string name="Nose">
+		Nariz
+	</string>
+	<string name="R Upper Arm">
+		Brazo der.
+	</string>
+	<string name="R Forearm">
+		Antebrazo der.
+	</string>
+	<string name="L Upper Arm">
+		Brazo izq.
+	</string>
+	<string name="L Forearm">
+		Antebrazo izq.
+	</string>
+	<string name="Right Hip">
+		Cadera der.
+	</string>
+	<string name="R Upper Leg">
+		Muslo der.
+	</string>
+	<string name="R Lower Leg">
+		Pantorrilla der.
+	</string>
+	<string name="Left Hip">
+		Cadera izq.
+	</string>
+	<string name="L Upper Leg">
+		Muslo izq.
+	</string>
+	<string name="L Lower Leg">
+		Pantorrilla izq.
+	</string>
+	<string name="Stomach">
+		Abdomen
+	</string>
+	<string name="Left Pec">
+		Pecho izquierdo
+	</string>
+	<string name="Right Pec">
+		Pecho derecho
+	</string>
+	<string name="Neck">
+		Cuello
+	</string>
+	<string name="Avatar Center">
+		Centro del avatar
+	</string>
+	<string name="Left Ring Finger">
+		Dedo anular izquierdo
+	</string>
+	<string name="Right Ring Finger">
+		Dedo anular derecho
+	</string>
+	<string name="Tail Base">
+		Base de la cola
+	</string>
+	<string name="Tail Tip">
+		Extremo de la cola
+	</string>
+	<string name="Left Wing">
+		Ala izquierda
+	</string>
+	<string name="Right Wing">
+		Ala derecha
+	</string>
+	<string name="Jaw">
+		Mandíbula
+	</string>
+	<string name="Alt Left Ear">
+		Oreja izquierda alternativa
+	</string>
+	<string name="Alt Right Ear">
+		Oreja derecha alternativa
+	</string>
+	<string name="Alt Left Eye">
+		Ojo izquierdo alternativo
+	</string>
+	<string name="Alt Right Eye">
+		Ojo derecho alternativo
+	</string>
+	<string name="Tongue">
+		Lengua
+	</string>
+	<string name="Groin">
+		Ingle
+	</string>
+	<string name="Left Hind Foot">
+		Pata trasera izquierda
+	</string>
+	<string name="Right Hind Foot">
+		Pata trasera derecha
+	</string>
+	<string name="Invalid Attachment">
+		Punto de colocación no válido
+	</string>
+	<string name="ATTACHMENT_MISSING_ITEM">
+		Error: falta un artículo
+	</string>
+	<string name="ATTACHMENT_MISSING_BASE_ITEM">
+		Error: falta el artículo de base
+	</string>
+	<string name="ATTACHMENT_NOT_ATTACHED">
+		Error: el objeto se encuentra en el vestuario actual, pero no está anexado
+	</string>
+	<string name="YearsMonthsOld">
+		[AGEYEARS] [AGEMONTHS] de edad
+	</string>
+	<string name="YearsOld">
+		[AGEYEARS] de edad
+	</string>
+	<string name="MonthsOld">
+		[AGEMONTHS] de edad
+	</string>
+	<string name="WeeksOld">
+		[AGEWEEKS] de edad
+	</string>
+	<string name="DaysOld">
+		[AGEDAYS] de edad
+	</string>
+	<string name="TodayOld">
+		Registrado hoy
+	</string>
+	<string name="av_render_everyone_now">
+		Ahora todos pueden verte.
+	</string>
+	<string name="av_render_not_everyone">
+		Es posible que no todos los que están próximos puedan renderizarte.
+	</string>
+	<string name="av_render_over_half">
+		Es posible que más de la mitad de los que están próximos no puedan renderizarte.
+	</string>
+	<string name="av_render_most_of">
+		Es posible que la mayoría de los que están próximos no puedan renderizarte.
+	</string>
+	<string name="av_render_anyone">
+		Es posible que ninguno de los que están próximos pueda renderizarte.
+	</string>
+	<string name="hud_description_total">
+		Tu HUD
+	</string>
+	<string name="hud_name_with_joint">
+		[OBJ_NAME] (lo llevas en [JNT_NAME])
+	</string>
+	<string name="hud_render_memory_warning">
+		[HUD_DETAILS] usa mucha memoria de textura
+	</string>
+	<string name="hud_render_cost_warning">
+		[HUD_DETAILS] contiene muchas texturas y objetos complicados
+	</string>
+	<string name="hud_render_heavy_textures_warning">
+		[HUD_DETAILS] contiene muchas texturas grandes
+	</string>
+	<string name="hud_render_cramped_warning">
+		[HUD_DETAILS] contiene demasiados objetos
+	</string>
+	<string name="hud_render_textures_warning">
+		[HUD_DETAILS] contiene demasiadas texturas
+	</string>
+	<string name="AgeYearsA">
+		[COUNT] año
+	</string>
+	<string name="AgeYearsB">
+		[COUNT] años
+	</string>
+	<string name="AgeYearsC">
+		[COUNT] años
+	</string>
+	<string name="AgeMonthsA">
+		[COUNT] mes
+	</string>
+	<string name="AgeMonthsB">
+		[COUNT] meses
+	</string>
+	<string name="AgeMonthsC">
+		[COUNT] meses
+	</string>
+	<string name="AgeWeeksA">
+		[COUNT] semana
+	</string>
+	<string name="AgeWeeksB">
+		[COUNT] semanas
+	</string>
+	<string name="AgeWeeksC">
+		[COUNT] semanas
+	</string>
+	<string name="AgeDaysA">
+		[COUNT] día
+	</string>
+	<string name="AgeDaysB">
+		[COUNT] días
+	</string>
+	<string name="AgeDaysC">
+		[COUNT] días
+	</string>
+	<string name="GroupMembersA">
+		[COUNT] miembro
+	</string>
+	<string name="GroupMembersB">
+		[COUNT] miembros
+	</string>
+	<string name="GroupMembersC">
+		[COUNT] miembros
+	</string>
+	<string name="AcctTypeResident">
+		Residente
+	</string>
+	<string name="AcctTypeTrial">
+		Prueba
+	</string>
+	<string name="AcctTypeCharterMember">
+		Miembro fundador
+	</string>
+	<string name="AcctTypeEmployee">
+		Empleado de Linden Lab
+	</string>
+	<string name="PaymentInfoUsed">
+		Ha usado información sobre la forma de pago
+	</string>
+	<string name="PaymentInfoOnFile">
+		Hay información archivada sobre la forma de pago
+	</string>
+	<string name="NoPaymentInfoOnFile">
+		No hay información archivada sobre la forma de pago
+	</string>
+	<string name="AgeVerified">
+		Edad verificada
+	</string>
+	<string name="NotAgeVerified">
+		Edad no verificada
+	</string>
+	<string name="Center 2">
+		Centro 2
+	</string>
+	<string name="Top Right">
+		Arriba der.
+	</string>
+	<string name="Top">
+		Arriba
+	</string>
+	<string name="Top Left">
+		Arriba izq.
+	</string>
+	<string name="Center">
+		Centro
+	</string>
+	<string name="Bottom Left">
+		Abajo izq.
+	</string>
+	<string name="Bottom">
+		Abajo
+	</string>
+	<string name="Bottom Right">
+		Abajo der.
+	</string>
+	<string name="CompileQueueDownloadedCompiling">
+		Descargado, compilándolo
+	</string>
+	<string name="CompileQueueServiceUnavailable">
+		El servicio de compilación de scripts no está disponible
+	</string>
+	<string name="CompileQueueScriptNotFound">
+		No se encuentra el script en el servidor.
+	</string>
+	<string name="CompileQueueProblemDownloading">
+		Problema al descargar
+	</string>
+	<string name="CompileQueueInsufficientPermDownload">
+		Permisos insuficientes para descargar un script.
+	</string>
+	<string name="CompileQueueInsufficientPermFor">
+		Permisos insuficientes para
+	</string>
+	<string name="CompileQueueUnknownFailure">
+		Fallo desconocido en la descarga
+	</string>
+	<string name="CompileNoExperiencePerm">
+		Omitiendo el script [SCRIPT] con la experiencia [EXPERIENCE].
+	</string>
+	<string name="CompileQueueTitle">
+		Recompilando
+	</string>
+	<string name="CompileQueueStart">
+		recompilar
+	</string>
+	<string name="ResetQueueTitle">
+		Progreso del reinicio
+	</string>
+	<string name="ResetQueueStart">
+		restaurar
+	</string>
+	<string name="RunQueueTitle">
+		Configurar según se ejecuta
+	</string>
+	<string name="RunQueueStart">
+		Configurando según se ejecuta
+	</string>
+	<string name="NotRunQueueTitle">
+		Configurar sin ejecutar
+	</string>
+	<string name="NotRunQueueStart">
+		Configurando sin ejecutarlo
+	</string>
+	<string name="CompileSuccessful">
+		¡Compilación correcta!
+	</string>
+	<string name="CompileSuccessfulSaving">
+		Compilación correcta, guardando...
+	</string>
+	<string name="SaveComplete">
+		Guardado.
+	</string>
+	<string name="UploadFailed">
+		Error al subir el archivo:
+	</string>
+	<string name="ObjectOutOfRange">
+		Script (objeto fuera de rango)
+	</string>
+	<string name="ScriptWasDeleted">
+		Script (eliminado del inventario)
+	</string>
+	<string name="GodToolsObjectOwnedBy">
+		El objeto [OBJECT] es propiedad de [OWNER]
+	</string>
+	<string name="GroupsNone">
+		ninguno
+	</string>
 	<string name="Group" value="(grupo)"/>
-	<string name="Unknown">(Desconocido)</string>
+	<string name="Unknown">
+		(Desconocido)
+	</string>
 	<string name="SummaryForTheWeek" value="Resumen de esta semana, empezando el "/>
 	<string name="NextStipendDay" value=". El próximo día de pago es el "/>
-	<string name="GroupPlanningDate">[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]</string>
+	<string name="GroupPlanningDate">
+		[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]
+	</string>
 	<string name="GroupIndividualShare" value="Grupo       Aportaciones individuales"/>
 	<string name="GroupColumn" value="Grupo"/>
-	<string name="Balance">Saldo</string>
-	<string name="Credits">Créditos</string>
-	<string name="Debits">Débitos</string>
-	<string name="Total">Total</string>
-	<string name="NoGroupDataFound">No se encontraron datos del grupo</string>
-	<string name="IMParentEstate">parent estate</string>
-	<string name="IMMainland">continente</string>
-	<string name="IMTeen">teen</string>
-	<string name="Anyone">cualquiera</string>
-	<string name="RegionInfoError">error</string>
-	<string name="RegionInfoAllEstatesOwnedBy">todos los estados propiedad de [OWNER]</string>
-	<string name="RegionInfoAllEstatesYouOwn">todos los estados que posees</string>
-	<string name="RegionInfoAllEstatesYouManage">todos los estados que administras para [OWNER]</string>
-	<string name="RegionInfoAllowedResidents">Siempre permitido: ([ALLOWEDAGENTS], de un máx. de [MAXACCESS])</string>
-	<string name="RegionInfoAllowedGroups">Grupos siempre permitidos: ([ALLOWEDGROUPS], de un máx. de [MAXACCESS])</string>
-	<string name="RegionInfoBannedResidents">Siempre prohibido: ([BANNEDAGENTS], de un máx. de [MAXBANNED])</string>
-	<string name="RegionInfoListTypeAllowedAgents">Siempre permitido</string>
-	<string name="RegionInfoListTypeBannedAgents">Siempre prohibido</string>
-	<string name="RegionInfoAllEstates">todos los estados</string>
-	<string name="RegionInfoManagedEstates">estados administrados</string>
-	<string name="RegionInfoThisEstate">este estado</string>
-	<string name="AndNMore">y [EXTRA_COUNT] más</string>
-	<string name="ScriptLimitsParcelScriptMemory">Memoria de los scripts de la parcela</string>
-	<string name="ScriptLimitsParcelsOwned">Parcelas listadas: [PARCELS]</string>
-	<string name="ScriptLimitsMemoryUsed">Memoria usada: [COUNT] kb de un máx de [MAX] kb; [AVAILABLE] kb disponibles</string>
-	<string name="ScriptLimitsMemoryUsedSimple">Memoria usada: [COUNT] kb</string>
-	<string name="ScriptLimitsParcelScriptURLs">URLs de los scripts de la parcela</string>
-	<string name="ScriptLimitsURLsUsed">URLs usadas: [COUNT] de un máx. de [MAX]; [AVAILABLE] disponibles</string>
-	<string name="ScriptLimitsURLsUsedSimple">URLs usadas: [COUNT]</string>
-	<string name="ScriptLimitsRequestError">Error al obtener la información</string>
-	<string name="ScriptLimitsRequestNoParcelSelected">No hay una parcela seleccionada</string>
-	<string name="ScriptLimitsRequestWrongRegion">Error: la información del script sólo está disponible en tu región actual</string>
-	<string name="ScriptLimitsRequestWaiting">Obteniendo la información...</string>
-	<string name="ScriptLimitsRequestDontOwnParcel">No tienes permiso para examinar esta parcela</string>
-	<string name="SITTING_ON">Sentado en</string>
-	<string name="ATTACH_CHEST">Tórax</string>
-	<string name="ATTACH_HEAD">Cráneo</string>
-	<string name="ATTACH_LSHOULDER">Hombro izquierdo</string>
-	<string name="ATTACH_RSHOULDER">Hombro derecho</string>
-	<string name="ATTACH_LHAND">Mano izq.</string>
-	<string name="ATTACH_RHAND">Mano der.</string>
-	<string name="ATTACH_LFOOT">Pie izq.</string>
-	<string name="ATTACH_RFOOT">Pie der.</string>
-	<string name="ATTACH_BACK">Columna</string>
-	<string name="ATTACH_PELVIS">Pelvis</string>
-	<string name="ATTACH_MOUTH">Boca</string>
-	<string name="ATTACH_CHIN">Barbilla</string>
-	<string name="ATTACH_LEAR">Oreja izq.</string>
-	<string name="ATTACH_REAR">Oreja der.</string>
-	<string name="ATTACH_LEYE">Ojo izq.</string>
-	<string name="ATTACH_REYE">Ojo der.</string>
-	<string name="ATTACH_NOSE">Nariz</string>
-	<string name="ATTACH_RUARM">Brazo der.</string>
-	<string name="ATTACH_RLARM">Antebrazo derecho</string>
-	<string name="ATTACH_LUARM">Brazo izq.</string>
-	<string name="ATTACH_LLARM">Antebrazo izquierdo</string>
-	<string name="ATTACH_RHIP">Cadera der.</string>
-	<string name="ATTACH_RULEG">Muslo der.</string>
-	<string name="ATTACH_RLLEG">Pantorrilla der.</string>
-	<string name="ATTACH_LHIP">Cadera izq.</string>
-	<string name="ATTACH_LULEG">Muslo izq.</string>
-	<string name="ATTACH_LLLEG">Pantorrilla izq.</string>
-	<string name="ATTACH_BELLY">Abdomen</string>
-	<string name="ATTACH_LEFT_PEC">Pectoral izquierdo</string>
-	<string name="ATTACH_RIGHT_PEC">Pectoral derecho</string>
-	<string name="ATTACH_HUD_CENTER_2">HUD: Centro 2</string>
-	<string name="ATTACH_HUD_TOP_RIGHT">HUD: arriba der.</string>
-	<string name="ATTACH_HUD_TOP_CENTER">HUD: arriba centro</string>
-	<string name="ATTACH_HUD_TOP_LEFT">HUD: arriba izq.</string>
-	<string name="ATTACH_HUD_CENTER_1">HUD: Centro 1</string>
-	<string name="ATTACH_HUD_BOTTOM_LEFT">HUD: abajo izq.</string>
-	<string name="ATTACH_HUD_BOTTOM">HUD: abajo</string>
-	<string name="ATTACH_HUD_BOTTOM_RIGHT">HUD: abajo der.</string>
-	<string name="ATTACH_NECK">Cuello</string>
-	<string name="ATTACH_AVATAR_CENTER">Centro del avatar</string>
-	<string name="ATTACH_LHAND_RING1">Dedo anular izquierdo</string>
-	<string name="ATTACH_RHAND_RING1">Dedo anular derecho</string>
-	<string name="ATTACH_TAIL_BASE">Base de la cola</string>
-	<string name="ATTACH_TAIL_TIP">Extremo de la cola</string>
-	<string name="ATTACH_LWING">Ala izquierda</string>
-	<string name="ATTACH_RWING">Ala derecha</string>
-	<string name="ATTACH_FACE_JAW">Mandíbula</string>
-	<string name="ATTACH_FACE_LEAR">Oreja izquierda alternativa</string>
-	<string name="ATTACH_FACE_REAR">Oreja derecha alternativa</string>
-	<string name="ATTACH_FACE_LEYE">Ojo izquierdo alternativo</string>
-	<string name="ATTACH_FACE_REYE">Ojo derecho alternativo</string>
-	<string name="ATTACH_FACE_TONGUE">Lengua</string>
-	<string name="ATTACH_GROIN">Ingle</string>
-	<string name="ATTACH_HIND_LFOOT">Pata trasera izquierda</string>
-	<string name="ATTACH_HIND_RFOOT">Pata trasera derecha</string>
-	<string name="CursorPos">Línea [LINE], Columna [COLUMN]</string>
-	<string name="PanelDirCountFound">[COUNT] resultados</string>
-	<string name="PanelContentsTooltip">Contenido del objeto</string>
-	<string name="PanelContentsNewScript">Script nuevo</string>
-	<string name="DoNotDisturbModeResponseDefault">Este residente tiene activado 'No molestar' y verá tu mensaje más tarde.</string>
-	<string name="MuteByName">(Por el nombre)</string>
-	<string name="MuteAgent">(Residente)</string>
-	<string name="MuteObject">(Objeto)</string>
-	<string name="MuteGroup">(Grupo)</string>
-	<string name="MuteExternal">(Externo)</string>
-	<string name="RegionNoCovenant">No se ha aportado un contrato para este estado.</string>
-	<string name="RegionNoCovenantOtherOwner">No se ha aportado un contrato para este estado. El terreno de este estado lo vende el propietario del estado, no Linden Lab.  Por favor, contacta con ese propietario para informarte sobre la venta.</string>
+	<string name="Balance">
+		Saldo
+	</string>
+	<string name="Credits">
+		Créditos
+	</string>
+	<string name="Debits">
+		Débitos
+	</string>
+	<string name="Total">
+		Total
+	</string>
+	<string name="NoGroupDataFound">
+		No se encontraron datos del grupo
+	</string>
+	<string name="IMParentEstate">
+		parent estate
+	</string>
+	<string name="IMMainland">
+		continente
+	</string>
+	<string name="IMTeen">
+		teen
+	</string>
+	<string name="Anyone">
+		cualquiera
+	</string>
+	<string name="RegionInfoError">
+		error
+	</string>
+	<string name="RegionInfoAllEstatesOwnedBy">
+		todos los estados propiedad de [OWNER]
+	</string>
+	<string name="RegionInfoAllEstatesYouOwn">
+		todos los estados que posees
+	</string>
+	<string name="RegionInfoAllEstatesYouManage">
+		todos los estados que administras para [OWNER]
+	</string>
+	<string name="RegionInfoAllowedResidents">
+		Siempre permitido: ([ALLOWEDAGENTS], de un máx. de [MAXACCESS])
+	</string>
+	<string name="RegionInfoAllowedGroups">
+		Grupos siempre permitidos: ([ALLOWEDGROUPS], de un máx. de [MAXACCESS])
+	</string>
+	<string name="RegionInfoBannedResidents">
+		Siempre prohibido: ([BANNEDAGENTS], de un máx. de [MAXBANNED])
+	</string>
+	<string name="RegionInfoListTypeAllowedAgents">
+		Siempre permitido
+	</string>
+	<string name="RegionInfoListTypeBannedAgents">
+		Siempre prohibido
+	</string>
+	<string name="RegionInfoAllEstates">
+		todos los estados
+	</string>
+	<string name="RegionInfoManagedEstates">
+		estados administrados
+	</string>
+	<string name="RegionInfoThisEstate">
+		este estado
+	</string>
+	<string name="AndNMore">
+		y [EXTRA_COUNT] más
+	</string>
+	<string name="ScriptLimitsParcelScriptMemory">
+		Memoria de los scripts de la parcela
+	</string>
+	<string name="ScriptLimitsParcelsOwned">
+		Parcelas listadas: [PARCELS]
+	</string>
+	<string name="ScriptLimitsMemoryUsed">
+		Memoria usada: [COUNT] kb de un máx de [MAX] kb; [AVAILABLE] kb disponibles
+	</string>
+	<string name="ScriptLimitsMemoryUsedSimple">
+		Memoria usada: [COUNT] kb
+	</string>
+	<string name="ScriptLimitsParcelScriptURLs">
+		URLs de los scripts de la parcela
+	</string>
+	<string name="ScriptLimitsURLsUsed">
+		URLs usadas: [COUNT] de un máx. de [MAX]; [AVAILABLE] disponibles
+	</string>
+	<string name="ScriptLimitsURLsUsedSimple">
+		URLs usadas: [COUNT]
+	</string>
+	<string name="ScriptLimitsRequestError">
+		Error al obtener la información
+	</string>
+	<string name="ScriptLimitsRequestNoParcelSelected">
+		No hay una parcela seleccionada
+	</string>
+	<string name="ScriptLimitsRequestWrongRegion">
+		Error: la información del script sólo está disponible en tu región actual
+	</string>
+	<string name="ScriptLimitsRequestWaiting">
+		Obteniendo la información...
+	</string>
+	<string name="ScriptLimitsRequestDontOwnParcel">
+		No tienes permiso para examinar esta parcela
+	</string>
+	<string name="SITTING_ON">
+		Sentado en
+	</string>
+	<string name="ATTACH_CHEST">
+		Tórax
+	</string>
+	<string name="ATTACH_HEAD">
+		Cráneo
+	</string>
+	<string name="ATTACH_LSHOULDER">
+		Hombro izquierdo
+	</string>
+	<string name="ATTACH_RSHOULDER">
+		Hombro derecho
+	</string>
+	<string name="ATTACH_LHAND">
+		Mano izq.
+	</string>
+	<string name="ATTACH_RHAND">
+		Mano der.
+	</string>
+	<string name="ATTACH_LFOOT">
+		Pie izq.
+	</string>
+	<string name="ATTACH_RFOOT">
+		Pie der.
+	</string>
+	<string name="ATTACH_BACK">
+		Columna
+	</string>
+	<string name="ATTACH_PELVIS">
+		Pelvis
+	</string>
+	<string name="ATTACH_MOUTH">
+		Boca
+	</string>
+	<string name="ATTACH_CHIN">
+		Barbilla
+	</string>
+	<string name="ATTACH_LEAR">
+		Oreja izq.
+	</string>
+	<string name="ATTACH_REAR">
+		Oreja der.
+	</string>
+	<string name="ATTACH_LEYE">
+		Ojo izq.
+	</string>
+	<string name="ATTACH_REYE">
+		Ojo der.
+	</string>
+	<string name="ATTACH_NOSE">
+		Nariz
+	</string>
+	<string name="ATTACH_RUARM">
+		Brazo der.
+	</string>
+	<string name="ATTACH_RLARM">
+		Antebrazo derecho
+	</string>
+	<string name="ATTACH_LUARM">
+		Brazo izq.
+	</string>
+	<string name="ATTACH_LLARM">
+		Antebrazo izquierdo
+	</string>
+	<string name="ATTACH_RHIP">
+		Cadera der.
+	</string>
+	<string name="ATTACH_RULEG">
+		Muslo der.
+	</string>
+	<string name="ATTACH_RLLEG">
+		Pantorrilla der.
+	</string>
+	<string name="ATTACH_LHIP">
+		Cadera izq.
+	</string>
+	<string name="ATTACH_LULEG">
+		Muslo izq.
+	</string>
+	<string name="ATTACH_LLLEG">
+		Pantorrilla izq.
+	</string>
+	<string name="ATTACH_BELLY">
+		Abdomen
+	</string>
+	<string name="ATTACH_LEFT_PEC">
+		Pectoral izquierdo
+	</string>
+	<string name="ATTACH_RIGHT_PEC">
+		Pectoral derecho
+	</string>
+	<string name="ATTACH_HUD_CENTER_2">
+		HUD: Centro 2
+	</string>
+	<string name="ATTACH_HUD_TOP_RIGHT">
+		HUD: arriba der.
+	</string>
+	<string name="ATTACH_HUD_TOP_CENTER">
+		HUD: arriba centro
+	</string>
+	<string name="ATTACH_HUD_TOP_LEFT">
+		HUD: arriba izq.
+	</string>
+	<string name="ATTACH_HUD_CENTER_1">
+		HUD: Centro 1
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_LEFT">
+		HUD: abajo izq.
+	</string>
+	<string name="ATTACH_HUD_BOTTOM">
+		HUD: abajo
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_RIGHT">
+		HUD: abajo der.
+	</string>
+	<string name="ATTACH_NECK">
+		Cuello
+	</string>
+	<string name="ATTACH_AVATAR_CENTER">
+		Centro del avatar
+	</string>
+	<string name="ATTACH_LHAND_RING1">
+		Dedo anular izquierdo
+	</string>
+	<string name="ATTACH_RHAND_RING1">
+		Dedo anular derecho
+	</string>
+	<string name="ATTACH_TAIL_BASE">
+		Base de la cola
+	</string>
+	<string name="ATTACH_TAIL_TIP">
+		Extremo de la cola
+	</string>
+	<string name="ATTACH_LWING">
+		Ala izquierda
+	</string>
+	<string name="ATTACH_RWING">
+		Ala derecha
+	</string>
+	<string name="ATTACH_FACE_JAW">
+		Mandíbula
+	</string>
+	<string name="ATTACH_FACE_LEAR">
+		Oreja izquierda alternativa
+	</string>
+	<string name="ATTACH_FACE_REAR">
+		Oreja derecha alternativa
+	</string>
+	<string name="ATTACH_FACE_LEYE">
+		Ojo izquierdo alternativo
+	</string>
+	<string name="ATTACH_FACE_REYE">
+		Ojo derecho alternativo
+	</string>
+	<string name="ATTACH_FACE_TONGUE">
+		Lengua
+	</string>
+	<string name="ATTACH_GROIN">
+		Ingle
+	</string>
+	<string name="ATTACH_HIND_LFOOT">
+		Pata trasera izquierda
+	</string>
+	<string name="ATTACH_HIND_RFOOT">
+		Pata trasera derecha
+	</string>
+	<string name="CursorPos">
+		Línea [LINE], Columna [COLUMN]
+	</string>
+	<string name="PanelDirCountFound">
+		[COUNT] resultados
+	</string>
+	<string name="PanelContentsTooltip">
+		Contenido del objeto
+	</string>
+	<string name="PanelContentsNewScript">
+		Script nuevo
+	</string>
+	<string name="DoNotDisturbModeResponseDefault">
+		Este residente tiene activado 'No molestar' y verá tu mensaje más tarde.
+	</string>
+	<string name="MuteByName">
+		(Por el nombre)
+	</string>
+	<string name="MuteAgent">
+		(Residente)
+	</string>
+	<string name="MuteObject">
+		(Objeto)
+	</string>
+	<string name="MuteGroup">
+		(Grupo)
+	</string>
+	<string name="MuteExternal">
+		(Externo)
+	</string>
+	<string name="RegionNoCovenant">
+		No se ha aportado un contrato para este estado.
+	</string>
+	<string name="RegionNoCovenantOtherOwner">
+		No se ha aportado un contrato para este estado. El terreno de este estado lo vende el propietario del estado, no Linden Lab.  Por favor, contacta con ese propietario para informarte sobre la venta.
+	</string>
 	<string name="covenant_last_modified" value="Última modificación: "/>
 	<string name="none_text" value="(no hay)"/>
 	<string name="never_text" value=" (nunca)"/>
-	<string name="GroupOwned">Propiedad del grupo</string>
-	<string name="Public">Público</string>
-	<string name="LocalSettings">Configuración local</string>
-	<string name="RegionSettings">Configuración de la región</string>
-	<string name="NoEnvironmentSettings">Esta región no es compatible con las opciones de entorno.</string>
-	<string name="EnvironmentSun">Sol</string>
-	<string name="EnvironmentMoon">Luna</string>
-	<string name="EnvironmentBloom">Florecimiento</string>
-	<string name="EnvironmentCloudNoise">Ruido de nubes</string>
-	<string name="EnvironmentNormalMap">Vista Normal</string>
-	<string name="EnvironmentTransparent">Transparente</string>
-	<string name="ClassifiedClicksTxt">Clics: [TELEPORT] teleportes, [MAP] mapa, [PROFILE] perfil</string>
-	<string name="ClassifiedUpdateAfterPublish">(se actualizará tras la publicación)</string>
-	<string name="NoPicksClassifiedsText">No has creado destacados ni clasificados. Pulsa el botón Más para crear uno.</string>
-	<string name="NoPicksText">No has creado destacados. Haz clic en el botón Más para crear uno.</string>
-	<string name="NoClassifiedsText">No has creado clasificados. Haz clic en el botón Nuevo para crear un anuncio clasificado.</string>
-	<string name="NoAvatarPicksClassifiedsText">El usuario no tiene clasificados ni destacados</string>
-	<string name="NoAvatarPicksText">El usuario no tiene destacados</string>
-	<string name="NoAvatarClassifiedsText">El usuario no tiene clasificados</string>
-	<string name="PicksClassifiedsLoadingText">Cargando...</string>
-	<string name="MultiPreviewTitle">Vista previa</string>
-	<string name="MultiPropertiesTitle">Propiedades</string>
-	<string name="InvOfferAnObjectNamed">Un objeto de nombre</string>
-	<string name="InvOfferOwnedByGroup">propiedad del grupo</string>
-	<string name="InvOfferOwnedByUnknownGroup">propiedad de un grupo desconocido</string>
-	<string name="InvOfferOwnedBy">propiedad de</string>
-	<string name="InvOfferOwnedByUnknownUser">propiedad de un usuario desconocido</string>
-	<string name="InvOfferGaveYou">te ha dado</string>
-	<string name="InvOfferDecline">Rechazas [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.</string>
-	<string name="GroupMoneyTotal">Total</string>
-	<string name="GroupMoneyBought">comprado</string>
-	<string name="GroupMoneyPaidYou">pagado a ti</string>
-	<string name="GroupMoneyPaidInto">pagado en</string>
-	<string name="GroupMoneyBoughtPassTo">pase comprado a</string>
-	<string name="GroupMoneyPaidFeeForEvent">cuotas pagadas para el evento</string>
-	<string name="GroupMoneyPaidPrizeForEvent">precio pagado por el evento</string>
-	<string name="GroupMoneyBalance">Saldo</string>
-	<string name="GroupMoneyCredits">Créditos</string>
-	<string name="GroupMoneyDebits">Débitos</string>
-	<string name="GroupMoneyDate">[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]</string>
-	<string name="AcquiredItems">Artículos adquiridos</string>
-	<string name="Cancel">Cancelar</string>
-	<string name="UploadingCosts">Subir [NAME] cuesta [AMOUNT] L$</string>
-	<string name="BuyingCosts">Comprar esto cuesta [AMOUNT] L$</string>
-	<string name="UnknownFileExtension">Extensión de archivo desconocida [.%s]
-Se esperaba .wav, .tga, .bmp, .jpg, .jpeg, o .bvh</string>
-	<string name="MuteObject2">Ignorar</string>
-	<string name="AddLandmarkNavBarMenu">Guardarme este hito...</string>
-	<string name="EditLandmarkNavBarMenu">Editar este hito...</string>
-	<string name="accel-mac-control">⌃</string>
-	<string name="accel-mac-command">⌘</string>
-	<string name="accel-mac-option">⌥</string>
-	<string name="accel-mac-shift">⇧</string>
-	<string name="accel-win-control">Ctrl+</string>
-	<string name="accel-win-alt">Alt+</string>
-	<string name="accel-win-shift">Mayús+</string>
-	<string name="FileSaved">Archivo guardado</string>
-	<string name="Receiving">Recibiendo</string>
-	<string name="AM">AM</string>
-	<string name="PM">PM</string>
-	<string name="PST">PST</string>
-	<string name="PDT">PDT</string>
-	<string name="Direction_Forward">Adelante</string>
-	<string name="Direction_Left">Izquierda</string>
-	<string name="Direction_Right">Derecha</string>
-	<string name="Direction_Back">Atrás</string>
-	<string name="Direction_North">Norte</string>
-	<string name="Direction_South">Sur</string>
-	<string name="Direction_West">Oeste</string>
-	<string name="Direction_East">Este</string>
-	<string name="Direction_Up">Arriba</string>
-	<string name="Direction_Down">Abajo</string>
-	<string name="Any Category">Cualquier categoría</string>
-	<string name="Shopping">Compras</string>
-	<string name="Land Rental">Terreno en alquiler</string>
-	<string name="Property Rental">Propiedad en alquiler</string>
-	<string name="Special Attraction">Atracción especial</string>
-	<string name="New Products">Nuevos productos</string>
-	<string name="Employment">Empleo</string>
-	<string name="Wanted">Se busca</string>
-	<string name="Service">Servicios</string>
-	<string name="Personal">Personal</string>
-	<string name="None">Ninguno</string>
-	<string name="Linden Location">Localización Linden</string>
-	<string name="Adult">Adulto</string>
-	<string name="Arts&amp;Culture">Arte y Cultura</string>
-	<string name="Business">Negocios</string>
-	<string name="Educational">Educativo</string>
-	<string name="Gaming">Juegos de azar</string>
-	<string name="Hangout">Entretenimiento</string>
-	<string name="Newcomer Friendly">Para recién llegados</string>
-	<string name="Parks&amp;Nature">Parques y Naturaleza</string>
-	<string name="Residential">Residencial</string>
-	<string name="Stage">Artes escénicas</string>
-	<string name="Other">Otra</string>
-	<string name="Rental">Terreno en alquiler</string>
-	<string name="Any">Cualquiera</string>
-	<string name="You">Tú</string>
-	<string name="Multiple Media">Múltiples medias</string>
-	<string name="Play Media">Play/Pausa los media</string>
-	<string name="IntelDriverPage">http://www.intel.com/p/en_US/support/detect/graphics</string>
-	<string name="NvidiaDriverPage">http://www.nvidia.com/Download/index.aspx?lang=es</string>
-	<string name="AMDDriverPage">http://support.amd.com/us/Pages/AMDSupportHub.aspx</string>
-	<string name="MBCmdLineError">Ha habido un error analizando la línea de comando.
+	<string name="GroupOwned">
+		Propiedad del grupo
+	</string>
+	<string name="Public">
+		Público
+	</string>
+	<string name="LocalSettings">
+		Configuración local
+	</string>
+	<string name="RegionSettings">
+		Configuración de la región
+	</string>
+	<string name="NoEnvironmentSettings">
+		Esta región no es compatible con las opciones de entorno.
+	</string>
+	<string name="EnvironmentSun">
+		Sol
+	</string>
+	<string name="EnvironmentMoon">
+		Luna
+	</string>
+	<string name="EnvironmentBloom">
+		Florecimiento
+	</string>
+	<string name="EnvironmentCloudNoise">
+		Ruido de nubes
+	</string>
+	<string name="EnvironmentNormalMap">
+		Vista Normal
+	</string>
+	<string name="EnvironmentTransparent">
+		Transparente
+	</string>
+	<string name="ClassifiedClicksTxt">
+		Clics: [TELEPORT] teleportes, [MAP] mapa, [PROFILE] perfil
+	</string>
+	<string name="ClassifiedUpdateAfterPublish">
+		(se actualizará tras la publicación)
+	</string>
+	<string name="NoPicksClassifiedsText">
+		No has creado destacados ni clasificados. Pulsa el botón Más para crear uno.
+	</string>
+	<string name="NoPicksText">
+		No has creado destacados. Haz clic en el botón Más para crear uno.
+	</string>
+	<string name="NoClassifiedsText">
+		No has creado clasificados. Haz clic en el botón Nuevo para crear un anuncio clasificado.
+	</string>
+	<string name="NoAvatarPicksClassifiedsText">
+		El usuario no tiene clasificados ni destacados
+	</string>
+	<string name="NoAvatarPicksText">
+		El usuario no tiene destacados
+	</string>
+	<string name="NoAvatarClassifiedsText">
+		El usuario no tiene clasificados
+	</string>
+	<string name="PicksClassifiedsLoadingText">
+		Cargando...
+	</string>
+	<string name="MultiPreviewTitle">
+		Vista previa
+	</string>
+	<string name="MultiPropertiesTitle">
+		Propiedades
+	</string>
+	<string name="InvOfferAnObjectNamed">
+		Un objeto de nombre
+	</string>
+	<string name="InvOfferOwnedByGroup">
+		propiedad del grupo
+	</string>
+	<string name="InvOfferOwnedByUnknownGroup">
+		propiedad de un grupo desconocido
+	</string>
+	<string name="InvOfferOwnedBy">
+		propiedad de
+	</string>
+	<string name="InvOfferOwnedByUnknownUser">
+		propiedad de un usuario desconocido
+	</string>
+	<string name="InvOfferGaveYou">
+		te ha dado
+	</string>
+	<string name="InvOfferDecline">
+		Rechazas [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.
+	</string>
+	<string name="GroupMoneyTotal">
+		Total
+	</string>
+	<string name="GroupMoneyBought">
+		comprado
+	</string>
+	<string name="GroupMoneyPaidYou">
+		pagado a ti
+	</string>
+	<string name="GroupMoneyPaidInto">
+		pagado en
+	</string>
+	<string name="GroupMoneyBoughtPassTo">
+		pase comprado a
+	</string>
+	<string name="GroupMoneyPaidFeeForEvent">
+		cuotas pagadas para el evento
+	</string>
+	<string name="GroupMoneyPaidPrizeForEvent">
+		precio pagado por el evento
+	</string>
+	<string name="GroupMoneyBalance">
+		Saldo
+	</string>
+	<string name="GroupMoneyCredits">
+		Créditos
+	</string>
+	<string name="GroupMoneyDebits">
+		Débitos
+	</string>
+	<string name="GroupMoneyDate">
+		[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]
+	</string>
+	<string name="AcquiredItems">
+		Artículos adquiridos
+	</string>
+	<string name="Cancel">
+		Cancelar
+	</string>
+	<string name="UploadingCosts">
+		Subir [NAME] cuesta [AMOUNT] L$
+	</string>
+	<string name="BuyingCosts">
+		Comprar esto cuesta [AMOUNT] L$
+	</string>
+	<string name="UnknownFileExtension">
+		Extensión de archivo desconocida [.%s]
+Se esperaba .wav, .tga, .bmp, .jpg, .jpeg, o .bvh
+	</string>
+	<string name="MuteObject2">
+		Ignorar
+	</string>
+	<string name="AddLandmarkNavBarMenu">
+		Guardarme este hito...
+	</string>
+	<string name="EditLandmarkNavBarMenu">
+		Editar este hito...
+	</string>
+	<string name="accel-mac-control">
+		⌃
+	</string>
+	<string name="accel-mac-command">
+		⌘
+	</string>
+	<string name="accel-mac-option">
+		⌥
+	</string>
+	<string name="accel-mac-shift">
+		⇧
+	</string>
+	<string name="accel-win-control">
+		Ctrl+
+	</string>
+	<string name="accel-win-alt">
+		Alt+
+	</string>
+	<string name="accel-win-shift">
+		Mayús+
+	</string>
+	<string name="FileSaved">
+		Archivo guardado
+	</string>
+	<string name="Receiving">
+		Recibiendo
+	</string>
+	<string name="AM">
+		AM
+	</string>
+	<string name="PM">
+		PM
+	</string>
+	<string name="PST">
+		PST
+	</string>
+	<string name="PDT">
+		PDT
+	</string>
+	<string name="Direction_Forward">
+		Adelante
+	</string>
+	<string name="Direction_Left">
+		Izquierda
+	</string>
+	<string name="Direction_Right">
+		Derecha
+	</string>
+	<string name="Direction_Back">
+		Atrás
+	</string>
+	<string name="Direction_North">
+		Norte
+	</string>
+	<string name="Direction_South">
+		Sur
+	</string>
+	<string name="Direction_West">
+		Oeste
+	</string>
+	<string name="Direction_East">
+		Este
+	</string>
+	<string name="Direction_Up">
+		Arriba
+	</string>
+	<string name="Direction_Down">
+		Abajo
+	</string>
+	<string name="Any Category">
+		Cualquier categoría
+	</string>
+	<string name="Shopping">
+		Compras
+	</string>
+	<string name="Land Rental">
+		Terreno en alquiler
+	</string>
+	<string name="Property Rental">
+		Propiedad en alquiler
+	</string>
+	<string name="Special Attraction">
+		Atracción especial
+	</string>
+	<string name="New Products">
+		Nuevos productos
+	</string>
+	<string name="Employment">
+		Empleo
+	</string>
+	<string name="Wanted">
+		Se busca
+	</string>
+	<string name="Service">
+		Servicios
+	</string>
+	<string name="Personal">
+		Personal
+	</string>
+	<string name="None">
+		Ninguno
+	</string>
+	<string name="Linden Location">
+		Localización Linden
+	</string>
+	<string name="Adult">
+		Adulto
+	</string>
+	<string name="Arts&amp;Culture">
+		Arte y Cultura
+	</string>
+	<string name="Business">
+		Negocios
+	</string>
+	<string name="Educational">
+		Educativo
+	</string>
+	<string name="Gaming">
+		Juegos de azar
+	</string>
+	<string name="Hangout">
+		Entretenimiento
+	</string>
+	<string name="Newcomer Friendly">
+		Para recién llegados
+	</string>
+	<string name="Parks&amp;Nature">
+		Parques y Naturaleza
+	</string>
+	<string name="Residential">
+		Residencial
+	</string>
+	<string name="Stage">
+		Artes escénicas
+	</string>
+	<string name="Other">
+		Otra
+	</string>
+	<string name="Rental">
+		Terreno en alquiler
+	</string>
+	<string name="Any">
+		Cualquiera
+	</string>
+	<string name="You">
+		Tú
+	</string>
+	<string name="Multiple Media">
+		Múltiples medias
+	</string>
+	<string name="Play Media">
+		Play/Pausa los media
+	</string>
+	<string name="IntelDriverPage">
+		http://www.intel.com/p/en_US/support/detect/graphics
+	</string>
+	<string name="NvidiaDriverPage">
+		http://www.nvidia.com/Download/index.aspx?lang=es
+	</string>
+	<string name="AMDDriverPage">
+		http://support.amd.com/us/Pages/AMDSupportHub.aspx
+	</string>
+	<string name="MBCmdLineError">
+		Ha habido un error analizando la línea de comando.
 Por favor, consulta: http://wiki.secondlife.com/wiki/Client_parameters
-Error:</string>
-	<string name="MBCmdLineUsg">[APP_NAME] Uso de línea de comando:</string>
-	<string name="MBUnableToAccessFile">[APP_NAME] no puede acceder a un archivo que necesita.
+Error:
+	</string>
+	<string name="MBCmdLineUsg">
+		[APP_NAME] Uso de línea de comando:
+	</string>
+	<string name="MBUnableToAccessFile">
+		[APP_NAME] no puede acceder a un archivo que necesita.
 
 Puede ser porque estés ejecutando varias copias, o porque tu sistema crea -equivocadamente- que el archivo está abierto.
 Si este mensaje persiste, reinicia tu ordenador y vuelve a intentarlo.
-Si aun así sigue apareciendo el mensaje, debes desinstalar completamente [APP_NAME] y reinstalarlo.</string>
-	<string name="MBFatalError">Error fatal</string>
-	<string name="MBRequiresAltiVec">[APP_NAME] requiere un procesador con AltiVec (G4 o posterior).</string>
-	<string name="MBAlreadyRunning">[APP_NAME] ya se está ejecutando.
+Si aun así sigue apareciendo el mensaje, debes desinstalar completamente [APP_NAME] y reinstalarlo.
+	</string>
+	<string name="MBFatalError">
+		Error fatal
+	</string>
+	<string name="MBRequiresAltiVec">
+		[APP_NAME] requiere un procesador con AltiVec (G4 o posterior).
+	</string>
+	<string name="MBAlreadyRunning">
+		[APP_NAME] ya se está ejecutando.
 Revisa tu barra de tareas para encontrar una copia minimizada del programa.
-Si este mensaje persiste, reinicia tu ordenador.</string>
-	<string name="MBFrozenCrashed">En su anterior ejecución, [APP_NAME] se congeló o se cayó.
-¿Quieres enviar un informe de caída?</string>
-	<string name="MBAlert">Alerta</string>
-	<string name="MBNoDirectX">[APP_NAME] no encuentra DirectX 9.0b o superior.
+Si este mensaje persiste, reinicia tu ordenador.
+	</string>
+	<string name="MBFrozenCrashed">
+		En su anterior ejecución, [APP_NAME] se congeló o se cayó.
+¿Quieres enviar un informe de caída?
+	</string>
+	<string name="MBAlert">
+		Alerta
+	</string>
+	<string name="MBNoDirectX">
+		[APP_NAME] no encuentra DirectX 9.0b o superior.
 [APP_NAME] usa DirectX para detectar el hardware o los drivers no actualizados que pueden provocar problemas de estabilidad, ejecución pobre y caídas.  Aunque puedes ejecutar [APP_NAME] sin él, recomendamos encarecidamente hacerlo con DirectX 9.0b.
 
-¿Quieres continuar?</string>
-	<string name="MBWarning">¡Atención!</string>
-	<string name="MBNoAutoUpdate">Las actualizaciones automáticas no están todavía implementadas para Linux.
-Por favor, descarga la última versión desde www.secondlife.com.</string>
-	<string name="MBRegClassFailed">Fallo en RegisterClass</string>
-	<string name="MBError">Error</string>
-	<string name="MBFullScreenErr">No puede ejecutarse a pantalla completa de [WIDTH] x [HEIGHT].
-Ejecutándose en una ventana.</string>
-	<string name="MBDestroyWinFailed">Error Shutdown destruyendo la ventana (DestroyWindow() failed)</string>
-	<string name="MBShutdownErr">Error Shutdown</string>
-	<string name="MBDevContextErr">No se puede construir el 'GL device context'</string>
-	<string name="MBPixelFmtErr">No se puede encontrar un formato adecuado de píxel</string>
-	<string name="MBPixelFmtDescErr">No se puede conseguir la descripción del formato de píxel</string>
-	<string name="MBTrueColorWindow">Para ejecutarse, [APP_NAME] necesita True Color (32-bit).
-Por favor, en las configuraciones de tu ordenador ajusta el modo de color a 32-bit.</string>
-	<string name="MBAlpha">[APP_NAME] no puede ejecutarse porque no puede obtener un canal alpha de 8 bit.  Generalmente, se debe a alguna cuestión de los drivers de la tarjeta de vídeo.
+¿Quieres continuar?
+	</string>
+	<string name="MBWarning">
+		¡Atención!
+	</string>
+	<string name="MBNoAutoUpdate">
+		Las actualizaciones automáticas no están todavía implementadas para Linux.
+Por favor, descarga la última versión desde www.secondlife.com.
+	</string>
+	<string name="MBRegClassFailed">
+		Fallo en RegisterClass
+	</string>
+	<string name="MBError">
+		Error
+	</string>
+	<string name="MBFullScreenErr">
+		No puede ejecutarse a pantalla completa de [WIDTH] x [HEIGHT].
+Ejecutándose en una ventana.
+	</string>
+	<string name="MBDestroyWinFailed">
+		Error Shutdown destruyendo la ventana (DestroyWindow() failed)
+	</string>
+	<string name="MBShutdownErr">
+		Error Shutdown
+	</string>
+	<string name="MBDevContextErr">
+		No se puede construir el 'GL device context'
+	</string>
+	<string name="MBPixelFmtErr">
+		No se puede encontrar un formato adecuado de píxel
+	</string>
+	<string name="MBPixelFmtDescErr">
+		No se puede conseguir la descripción del formato de píxel
+	</string>
+	<string name="MBTrueColorWindow">
+		Para ejecutarse, [APP_NAME] necesita True Color (32-bit).
+Por favor, en las configuraciones de tu ordenador ajusta el modo de color a 32-bit.
+	</string>
+	<string name="MBAlpha">
+		[APP_NAME] no puede ejecutarse porque no puede obtener un canal alpha de 8 bit.  Generalmente, se debe a alguna cuestión de los drivers de la tarjeta de vídeo.
 Por favor, comprueba que tienes instalados los últimos drivers para tu tarjeta de vídeo.
 Comprueba también que tu monitor esta configurado para True Color (32-bit) en Panel de Control &gt; Apariencia y temas &gt; Pantalla.
-Si sigues recibiendo este mensaje, contacta con [SUPPORT_SITE].</string>
-	<string name="MBPixelFmtSetErr">No se puede configurar el formato de píxel</string>
-	<string name="MBGLContextErr">No se puede crear el 'GL rendering context'</string>
-	<string name="MBGLContextActErr">No se puede activar el 'GL rendering context'</string>
-	<string name="MBVideoDrvErr">[APP_NAME] no puede ejecutarse porque los drivers de tu tarjeta de vídeo o no están bien instalados, o no están actualizados, o son para hardware no admitido. Por favor, comprueba que tienes los drivers más actuales para tu tarjeta de vídeo, y, aunque los tengas, intenta reinstalarlos.
+Si sigues recibiendo este mensaje, contacta con [SUPPORT_SITE].
+	</string>
+	<string name="MBPixelFmtSetErr">
+		No se puede configurar el formato de píxel
+	</string>
+	<string name="MBGLContextErr">
+		No se puede crear el 'GL rendering context'
+	</string>
+	<string name="MBGLContextActErr">
+		No se puede activar el 'GL rendering context'
+	</string>
+	<string name="MBVideoDrvErr">
+		[APP_NAME] no puede ejecutarse porque los drivers de tu tarjeta de vídeo o no están bien instalados, o no están actualizados, o son para hardware no admitido. Por favor, comprueba que tienes los drivers más actuales para tu tarjeta de vídeo, y, aunque los tengas, intenta reinstalarlos.
 
-Si sigues recibiendo este mensaje, contacta con [SUPPORT_SITE].</string>
-	<string name="5 O'Clock Shadow">Barba del día</string>
-	<string name="All White">Blanco del todo</string>
-	<string name="Anime Eyes">Ojos de cómic</string>
-	<string name="Arced">Arqueadas</string>
-	<string name="Arm Length">Brazos: longitud</string>
-	<string name="Attached">Cortos</string>
-	<string name="Attached Earlobes">Lóbulos</string>
-	<string name="Back Fringe">Nuca: largo</string>
-	<string name="Baggy">Marcadas</string>
-	<string name="Bangs">Bangs</string>
-	<string name="Beady Eyes">Ojos pequeños</string>
-	<string name="Belly Size">Barriga: tamaño</string>
-	<string name="Big">Grande</string>
-	<string name="Big Butt">Culo grande</string>
-	<string name="Big Hair Back">Pelo: moño</string>
-	<string name="Big Hair Front">Pelo: tupé</string>
-	<string name="Big Hair Top">Pelo: melena alta</string>
-	<string name="Big Head">Cabeza grande</string>
-	<string name="Big Pectorals">Grandes pectorales</string>
-	<string name="Big Spikes">Crestas grandes</string>
-	<string name="Black">Negro</string>
-	<string name="Blonde">Rubio</string>
-	<string name="Blonde Hair">Pelo rubio</string>
-	<string name="Blush">Colorete</string>
-	<string name="Blush Color">Color del colorete</string>
-	<string name="Blush Opacity">Opacidad del colorete</string>
-	<string name="Body Definition">Definición del cuerpo</string>
-	<string name="Body Fat">Cuerpo: gordura</string>
-	<string name="Body Freckles">Pecas del cuerpo</string>
-	<string name="Body Thick">Cuerpo grueso</string>
-	<string name="Body Thickness">Cuerpo: grosor</string>
-	<string name="Body Thin">Cuerpo delgado</string>
-	<string name="Bow Legged">Abiertas</string>
-	<string name="Breast Buoyancy">Busto: firmeza</string>
-	<string name="Breast Cleavage">Busto: canalillo</string>
-	<string name="Breast Size">Busto: tamaño</string>
-	<string name="Bridge Width">Puente: ancho</string>
-	<string name="Broad">Aumentar</string>
-	<string name="Brow Size">Arco ciliar</string>
-	<string name="Bug Eyes">Bug Eyes</string>
-	<string name="Bugged Eyes">Ojos saltones</string>
-	<string name="Bulbous">Bulbosa</string>
-	<string name="Bulbous Nose">Nariz de porra</string>
-	<string name="Breast Physics Mass">Masa del busto</string>
-	<string name="Breast Physics Smoothing">Suavizado del busto</string>
-	<string name="Breast Physics Gravity">Gravedad del busto</string>
-	<string name="Breast Physics Drag">Aerodinámica del busto</string>
-	<string name="Breast Physics InOut Max Effect">Efecto máx.</string>
-	<string name="Breast Physics InOut Spring">Elasticidad</string>
-	<string name="Breast Physics InOut Gain">Ganancia</string>
-	<string name="Breast Physics InOut Damping">Amortiguación</string>
-	<string name="Breast Physics UpDown Max Effect">Efecto máx.</string>
-	<string name="Breast Physics UpDown Spring">Elasticidad</string>
-	<string name="Breast Physics UpDown Gain">Ganancia</string>
-	<string name="Breast Physics UpDown Damping">Amortiguación</string>
-	<string name="Breast Physics LeftRight Max Effect">Efecto máx.</string>
-	<string name="Breast Physics LeftRight Spring">Elasticidad</string>
-	<string name="Breast Physics LeftRight Gain">Ganancia</string>
-	<string name="Breast Physics LeftRight Damping">Amortiguación</string>
-	<string name="Belly Physics Mass">Masa de la barriga</string>
-	<string name="Belly Physics Smoothing">Suavizado de la barriga</string>
-	<string name="Belly Physics Gravity">Gravedad de la barriga</string>
-	<string name="Belly Physics Drag">Aerodinámica de la barriga</string>
-	<string name="Belly Physics UpDown Max Effect">Efecto máx.</string>
-	<string name="Belly Physics UpDown Spring">Elasticidad</string>
-	<string name="Belly Physics UpDown Gain">Ganancia</string>
-	<string name="Belly Physics UpDown Damping">Amortiguación</string>
-	<string name="Butt Physics Mass">Masa del culo</string>
-	<string name="Butt Physics Smoothing">Suavizado del culo</string>
-	<string name="Butt Physics Gravity">Gravedad del culo</string>
-	<string name="Butt Physics Drag">Aerodinámica del culo</string>
-	<string name="Butt Physics UpDown Max Effect">Efecto máx.</string>
-	<string name="Butt Physics UpDown Spring">Elasticidad</string>
-	<string name="Butt Physics UpDown Gain">Ganancia</string>
-	<string name="Butt Physics UpDown Damping">Amortiguación</string>
-	<string name="Butt Physics LeftRight Max Effect">Efecto máx.</string>
-	<string name="Butt Physics LeftRight Spring">Elasticidad</string>
-	<string name="Butt Physics LeftRight Gain">Ganancia</string>
-	<string name="Butt Physics LeftRight Damping">Amortiguación</string>
-	<string name="Bushy Eyebrows">Cejijuntas</string>
-	<string name="Bushy Hair">Pelo tupido</string>
-	<string name="Butt Size">Culo: tamaño</string>
-	<string name="Butt Gravity">Gravedad del culo</string>
-	<string name="bustle skirt">Polisón</string>
-	<string name="no bustle">Sin polisón</string>
-	<string name="more bustle">Con polisón</string>
-	<string name="Chaplin">Cortito</string>
-	<string name="Cheek Bones">Pómulos</string>
-	<string name="Chest Size">Tórax: tamaño</string>
-	<string name="Chin Angle">Barbilla: ángulo</string>
-	<string name="Chin Cleft">Barbilla: contorno</string>
-	<string name="Chin Curtains">Barba en collar</string>
-	<string name="Chin Depth">Barbilla: largo</string>
-	<string name="Chin Heavy">Hacia la barbilla</string>
-	<string name="Chin In">Barbilla retraída</string>
-	<string name="Chin Out">Barbilla prominente</string>
-	<string name="Chin-Neck">Papada</string>
-	<string name="Clear">Transparente</string>
-	<string name="Cleft">Remarcar</string>
-	<string name="Close Set Eyes">Ojos juntos</string>
-	<string name="Closed">Cerrar</string>
-	<string name="Closed Back">Trasera cerrada</string>
-	<string name="Closed Front">Frontal cerrado</string>
-	<string name="Closed Left">Cerrada</string>
-	<string name="Closed Right">Cerrada</string>
-	<string name="Coin Purse">Poco abultada</string>
-	<string name="Collar Back">Espalda</string>
-	<string name="Collar Front">Escote</string>
-	<string name="Corner Down">Hacia abajo</string>
-	<string name="Corner Up">Hacia arriba</string>
-	<string name="Creased">Caídos</string>
-	<string name="Crooked Nose">Nariz torcida</string>
-	<string name="Cuff Flare">Acampanado</string>
-	<string name="Dark">Oscuridad</string>
-	<string name="Dark Green">Verde oscuro</string>
-	<string name="Darker">Más oscuros</string>
-	<string name="Deep">Remarcar</string>
-	<string name="Default Heels">Tacones por defecto</string>
-	<string name="Dense">Densas</string>
-	<string name="Double Chin">Mucha papada</string>
-	<string name="Downturned">Poco</string>
-	<string name="Duffle Bag">Muy abultada</string>
-	<string name="Ear Angle">Orejas: ángulo</string>
-	<string name="Ear Size">Orejas: tamaño</string>
-	<string name="Ear Tips">Orejas: forma</string>
-	<string name="Egg Head">Cabeza: ahuevada</string>
-	<string name="Eye Bags">Ojos: bolsas</string>
-	<string name="Eye Color">Ojos: color</string>
-	<string name="Eye Depth">Ojos: profundidad</string>
-	<string name="Eye Lightness">Ojos: brillo</string>
-	<string name="Eye Opening">Ojos: apertura</string>
-	<string name="Eye Pop">Ojos: simetría</string>
-	<string name="Eye Size">Ojos: tamaño</string>
-	<string name="Eye Spacing">Ojos: separación</string>
-	<string name="Eyebrow Arc">Cejas: arco</string>
-	<string name="Eyebrow Density">Cejas: densidad</string>
-	<string name="Eyebrow Height">Cejas: altura</string>
-	<string name="Eyebrow Points">Cejas: en V</string>
-	<string name="Eyebrow Size">Cejas: tamaño</string>
-	<string name="Eyelash Length">Pestañas: longitud</string>
-	<string name="Eyeliner">Contorno de ojos</string>
-	<string name="Eyeliner Color">Contorno de ojos: color</string>
-	<string name="Eyes Bugged">Eyes Bugged</string>
-	<string name="Face Shear">Cara: simetría</string>
-	<string name="Facial Definition">Rasgos marcados</string>
-	<string name="Far Set Eyes">Ojos separados</string>
-	<string name="Fat Lips">Prominentes</string>
-	<string name="Female">Mujer</string>
-	<string name="Fingerless">Sin dedos</string>
-	<string name="Fingers">Con dedos</string>
-	<string name="Flared Cuffs">Campana</string>
-	<string name="Flat">Redondeadas</string>
-	<string name="Flat Butt">Culo plano</string>
-	<string name="Flat Head">Cabeza plana</string>
-	<string name="Flat Toe">Empeine bajo</string>
-	<string name="Foot Size">Pie: tamaño</string>
-	<string name="Forehead Angle">Frente: ángulo</string>
-	<string name="Forehead Heavy">Hacia la frente</string>
-	<string name="Freckles">Pecas</string>
-	<string name="Front Fringe">Flequillo</string>
-	<string name="Full Back">Sin cortar</string>
-	<string name="Full Eyeliner">Contorno completo</string>
-	<string name="Full Front">Sin cortar</string>
-	<string name="Full Hair Sides">Pelo: volumen a los lados</string>
-	<string name="Full Sides">Volumen total</string>
-	<string name="Glossy">Con brillo</string>
-	<string name="Glove Fingers">Guantes: dedos</string>
-	<string name="Glove Length">Guantes: largo</string>
-	<string name="Hair">Pelo</string>
-	<string name="Hair Back">Pelo: nuca</string>
-	<string name="Hair Front">Pelo: delante</string>
-	<string name="Hair Sides">Pelo: lados</string>
-	<string name="Hair Sweep">Peinado: dirección</string>
-	<string name="Hair Thickess">Pelo: espesor</string>
-	<string name="Hair Thickness">Pelo: espesor</string>
-	<string name="Hair Tilt">Pelo: inclinación</string>
-	<string name="Hair Tilted Left">A la izq.</string>
-	<string name="Hair Tilted Right">A la der.</string>
-	<string name="Hair Volume">Pelo: volumen</string>
-	<string name="Hand Size">Manos: tamaño</string>
-	<string name="Handlebars">Muy largo</string>
-	<string name="Head Length">Cabeza: longitud</string>
-	<string name="Head Shape">Cabeza: forma</string>
-	<string name="Head Size">Cabeza: tamaño</string>
-	<string name="Head Stretch">Cabeza: estiramiento</string>
-	<string name="Heel Height">Tacón: altura</string>
-	<string name="Heel Shape">Tacón: forma</string>
-	<string name="Height">Altura</string>
-	<string name="High">Subir</string>
-	<string name="High Heels">Tacones altos</string>
-	<string name="High Jaw">Mandíbula alta</string>
-	<string name="High Platforms">Suela gorda</string>
-	<string name="High and Tight">Pegada</string>
-	<string name="Higher">Arrriba</string>
-	<string name="Hip Length">Cadera: altura</string>
-	<string name="Hip Width">Cadera: ancho</string>
-	<string name="Hover">Pasa el cursor</string>
-	<string name="In">Pegadas</string>
-	<string name="In Shdw Color">Línea de ojos: color</string>
-	<string name="In Shdw Opacity">Línea de ojos: opacidad</string>
-	<string name="Inner Eye Corner">Ojos: lagrimal</string>
-	<string name="Inner Eye Shadow">Inner Eye Shadow</string>
-	<string name="Inner Shadow">Línea de ojos</string>
-	<string name="Jacket Length">Chaqueta: largo</string>
-	<string name="Jacket Wrinkles">Chaqueta: arrugas</string>
-	<string name="Jaw Angle">Mandíbula: ángulo</string>
-	<string name="Jaw Jut">Maxilar inferior</string>
-	<string name="Jaw Shape">Mandíbula: forma</string>
-	<string name="Join">Más junto</string>
-	<string name="Jowls">Mofletes</string>
-	<string name="Knee Angle">Rodillas: ángulo</string>
-	<string name="Knock Kneed">Zambas</string>
-	<string name="Large">Aumentar</string>
-	<string name="Large Hands">Manos grandes</string>
-	<string name="Left Part">Raya: izq.</string>
-	<string name="Leg Length">Piernas: longitud</string>
-	<string name="Leg Muscles">Piernas: musculatura</string>
-	<string name="Less">Menos</string>
-	<string name="Less Body Fat">Menos gordura</string>
-	<string name="Less Curtains">Menos tupida</string>
-	<string name="Less Freckles">Menos pecas</string>
-	<string name="Less Full">Menos grosor</string>
-	<string name="Less Gravity">Más levantado</string>
-	<string name="Less Love">Menos michelines</string>
-	<string name="Less Muscles">Pocos músculos</string>
-	<string name="Less Muscular">Poca musculatura</string>
-	<string name="Less Rosy">Menos sonrosada</string>
-	<string name="Less Round">Menos redondeada</string>
-	<string name="Less Saddle">Menos cartucheras</string>
-	<string name="Less Square">Menos cuadrada</string>
-	<string name="Less Volume">Menos volumen</string>
-	<string name="Less soul">Pequeña</string>
-	<string name="Lighter">Más luminosos</string>
-	<string name="Lip Cleft">Labio: hoyuelo</string>
-	<string name="Lip Cleft Depth">Hoyuelo marcado</string>
-	<string name="Lip Fullness">Labios: grosor</string>
-	<string name="Lip Pinkness">Labios sonrosados</string>
-	<string name="Lip Ratio">Labios: ratio</string>
-	<string name="Lip Thickness">Labios: prominencia</string>
-	<string name="Lip Width">Labios: ancho</string>
-	<string name="Lipgloss">Brillo de labios</string>
-	<string name="Lipstick">Barra de labios</string>
-	<string name="Lipstick Color">Barra de labios: color</string>
-	<string name="Long">Más</string>
-	<string name="Long Head">Cabeza alargada</string>
-	<string name="Long Hips">Cadera larga</string>
-	<string name="Long Legs">Piernas largas</string>
-	<string name="Long Neck">Cuello largo</string>
-	<string name="Long Pigtails">Coletas largas</string>
-	<string name="Long Ponytail">Cola de caballo larga</string>
-	<string name="Long Torso">Torso largo</string>
-	<string name="Long arms">Brazos largos</string>
-	<string name="Loose Pants">Pantalón suelto</string>
-	<string name="Loose Shirt">Camiseta suelta</string>
-	<string name="Loose Sleeves">Puños anchos</string>
-	<string name="Love Handles">Michelines</string>
-	<string name="Low">Bajar</string>
-	<string name="Low Heels">Tacones bajos</string>
-	<string name="Low Jaw">Mandíbula baja</string>
-	<string name="Low Platforms">Suela fina</string>
-	<string name="Low and Loose">Suelta</string>
-	<string name="Lower">Abajo</string>
-	<string name="Lower Bridge">Puente: abajo</string>
-	<string name="Lower Cheeks">Mejillas: abajo</string>
-	<string name="Male">Varón</string>
-	<string name="Middle Part">Raya: en medio</string>
-	<string name="More">Más</string>
-	<string name="More Blush">Más colorete</string>
-	<string name="More Body Fat">Más gordura</string>
-	<string name="More Curtains">Más tupida</string>
-	<string name="More Eyeshadow">Más</string>
-	<string name="More Freckles">Más pecas</string>
-	<string name="More Full">Más grosor</string>
-	<string name="More Gravity">Menos levantado</string>
-	<string name="More Lipstick">Más barra de labios</string>
-	<string name="More Love">Más michelines</string>
-	<string name="More Lower Lip">Más el inferior</string>
-	<string name="More Muscles">Más músculos</string>
-	<string name="More Muscular">Más musculatura</string>
-	<string name="More Rosy">Más sonrosada</string>
-	<string name="More Round">Más redondeada</string>
-	<string name="More Saddle">Más cartucheras</string>
-	<string name="More Sloped">Más inclinada</string>
-	<string name="More Square">Más cuadrada</string>
-	<string name="More Upper Lip">Más el superior</string>
-	<string name="More Vertical">Más recta</string>
-	<string name="More Volume">Más volumen</string>
-	<string name="More soul">Grande</string>
-	<string name="Moustache">Bigote</string>
-	<string name="Mouth Corner">Comisuras</string>
-	<string name="Mouth Position">Boca: posición</string>
-	<string name="Mowhawk">Rapado</string>
-	<string name="Muscular">Muscular</string>
-	<string name="Mutton Chops">Patillas largas</string>
-	<string name="Nail Polish">Uñas pintadas</string>
-	<string name="Nail Polish Color">Uñas pintadas: color</string>
-	<string name="Narrow">Disminuir</string>
-	<string name="Narrow Back">Rapada</string>
-	<string name="Narrow Front">Entradas</string>
-	<string name="Narrow Lips">Labios estrechos</string>
-	<string name="Natural">Natural</string>
-	<string name="Neck Length">Cuello: longitud</string>
-	<string name="Neck Thickness">Cuello: grosor</string>
-	<string name="No Blush">Sin colorete</string>
-	<string name="No Eyeliner">Sin contorno</string>
-	<string name="No Eyeshadow">Menos</string>
-	<string name="No Lipgloss">Sin brillo</string>
-	<string name="No Lipstick">Sin barra de labios</string>
-	<string name="No Part">Sin raya</string>
-	<string name="No Polish">Sin pintar</string>
-	<string name="No Red">Nada</string>
-	<string name="No Spikes">Sin crestas</string>
-	<string name="No White">Sin blanco</string>
-	<string name="No Wrinkles">Sin arrugas</string>
-	<string name="Normal Lower">Normal Lower</string>
-	<string name="Normal Upper">Normal Upper</string>
-	<string name="Nose Left">Nariz a la izq.</string>
-	<string name="Nose Right">Nariz a la der.</string>
-	<string name="Nose Size">Nariz: tamaño</string>
-	<string name="Nose Thickness">Nariz: grosor</string>
-	<string name="Nose Tip Angle">Nariz: respingona</string>
-	<string name="Nose Tip Shape">Nariz: punta</string>
-	<string name="Nose Width">Nariz: ancho</string>
-	<string name="Nostril Division">Ventana: altura</string>
-	<string name="Nostril Width">Ventana: ancho</string>
-	<string name="Opaque">Opaco</string>
-	<string name="Open">Abrir</string>
-	<string name="Open Back">Apertura trasera</string>
-	<string name="Open Front">Apertura frontal</string>
-	<string name="Open Left">Abierta</string>
-	<string name="Open Right">Abierta</string>
-	<string name="Orange">Anaranjado</string>
-	<string name="Out">De soplillo</string>
-	<string name="Out Shdw Color">Sombra de ojos: color</string>
-	<string name="Out Shdw Opacity">Sombra de ojos: opacidad</string>
-	<string name="Outer Eye Corner">Ojos: comisura</string>
-	<string name="Outer Eye Shadow">Outer Eye Shadow</string>
-	<string name="Outer Shadow">Sombra de ojos</string>
-	<string name="Overbite">Retraído</string>
-	<string name="Package">Pubis</string>
-	<string name="Painted Nails">Pintadas</string>
-	<string name="Pale">Pálida</string>
-	<string name="Pants Crotch">Pantalón: cruz</string>
-	<string name="Pants Fit">Ceñido</string>
-	<string name="Pants Length">Pernera: largo</string>
-	<string name="Pants Waist">Caja</string>
-	<string name="Pants Wrinkles">Pantalón: arrugas</string>
-	<string name="Part">Raya</string>
-	<string name="Part Bangs">Flequillo partido</string>
-	<string name="Pectorals">Pectorales</string>
-	<string name="Pigment">Tono</string>
-	<string name="Pigtails">Coletas</string>
-	<string name="Pink">Rosa</string>
-	<string name="Pinker">Más sonrosados</string>
-	<string name="Platform Height">Suela: altura</string>
-	<string name="Platform Width">Suela: ancho</string>
-	<string name="Pointy">En punta</string>
-	<string name="Pointy Heels">De aguja</string>
-	<string name="Ponytail">Cola de caballo</string>
-	<string name="Poofy Skirt">Con vuelo</string>
-	<string name="Pop Left Eye">Izquierdo más grande</string>
-	<string name="Pop Right Eye">Derecho más grande</string>
-	<string name="Puffy">Hinchadas</string>
-	<string name="Puffy Eyelids">Ojeras</string>
-	<string name="Rainbow Color">Irisación</string>
-	<string name="Red Hair">Pelirrojo</string>
-	<string name="Regular">Regular</string>
-	<string name="Right Part">Raya: der.</string>
-	<string name="Rosy Complexion">Tez sonrosada</string>
-	<string name="Round">Redondear</string>
-	<string name="Ruddiness">Rubicundez</string>
-	<string name="Ruddy">Rojiza</string>
-	<string name="Rumpled Hair">Pelo encrespado</string>
-	<string name="Saddle Bags">Cartucheras</string>
-	<string name="Scrawny Leg">Piernas flacas</string>
-	<string name="Separate">Más ancho</string>
-	<string name="Shallow">Sin marcar</string>
-	<string name="Shear Back">Nuca: corte</string>
-	<string name="Shear Face">Shear Face</string>
-	<string name="Shear Front">Shear Front</string>
-	<string name="Shear Left Up">Arriba - izq.</string>
-	<string name="Shear Right Up">Arriba - der.</string>
-	<string name="Sheared Back">Rapada</string>
-	<string name="Sheared Front">Rapada</string>
-	<string name="Shift Left">A la izq.</string>
-	<string name="Shift Mouth">Boca: ladeada</string>
-	<string name="Shift Right">A la der.</string>
-	<string name="Shirt Bottom">Alto de cintura</string>
-	<string name="Shirt Fit">Ceñido</string>
-	<string name="Shirt Wrinkles">Camisa: arrugas</string>
-	<string name="Shoe Height">Caña: altura</string>
-	<string name="Short">Menos</string>
-	<string name="Short Arms">Brazos cortos</string>
-	<string name="Short Legs">Piernas cortas</string>
-	<string name="Short Neck">Cuello corto</string>
-	<string name="Short Pigtails">Coletas cortas</string>
-	<string name="Short Ponytail">Cola de caballo corta</string>
-	<string name="Short Sideburns">Patillas cortas</string>
-	<string name="Short Torso">Torso corto</string>
-	<string name="Short hips">Cadera corta</string>
-	<string name="Shoulders">Hombros</string>
-	<string name="Side Fringe">Lados: franja</string>
-	<string name="Sideburns">Patillas</string>
-	<string name="Sides Hair">Pelo: lados</string>
-	<string name="Sides Hair Down">Bajar lados del pelo</string>
-	<string name="Sides Hair Up">Subir lados del pelo</string>
-	<string name="Skinny Neck">Cuello estrecho</string>
-	<string name="Skirt Fit">Falda: vuelo</string>
-	<string name="Skirt Length">Falda: largo</string>
-	<string name="Slanted Forehead">Slanted Forehead</string>
-	<string name="Sleeve Length">Largo de manga</string>
-	<string name="Sleeve Looseness">Ancho de puños</string>
-	<string name="Slit Back">Raja trasera</string>
-	<string name="Slit Front">Raja frontal</string>
-	<string name="Slit Left">Raja a la izq.</string>
-	<string name="Slit Right">Raja a la der.</string>
-	<string name="Small">Disminuir</string>
-	<string name="Small Hands">Manos pequeñas</string>
-	<string name="Small Head">Cabeza pequeña</string>
-	<string name="Smooth">Leves</string>
-	<string name="Smooth Hair">Pelo liso</string>
-	<string name="Socks Length">Calcetines: largo</string>
-	<string name="Soulpatch">Perilla</string>
-	<string name="Sparse">Depiladas</string>
-	<string name="Spiked Hair">Crestas</string>
-	<string name="Square">Cuadrada</string>
-	<string name="Square Toe">Punta cuadrada</string>
-	<string name="Squash Head">Cabeza aplastada</string>
-	<string name="Stretch Head">Cabeza estirada</string>
-	<string name="Sunken">Chupadas</string>
-	<string name="Sunken Chest">Estrecho de pecho</string>
-	<string name="Sunken Eyes">Ojos hundidos</string>
-	<string name="Sweep Back">Sweep Back</string>
-	<string name="Sweep Forward">Sweep Forward</string>
-	<string name="Tall">Más</string>
-	<string name="Taper Back">Cubierta trasera</string>
-	<string name="Taper Front">Cubierta frontal</string>
-	<string name="Thick Heels">Tacones grandes</string>
-	<string name="Thick Neck">Cuello ancho</string>
-	<string name="Thick Toe">Empeine alto</string>
-	<string name="Thin">Delgadas</string>
-	<string name="Thin Eyebrows">Cejas finas</string>
-	<string name="Thin Lips">Hacia dentro</string>
-	<string name="Thin Nose">Nariz fina</string>
-	<string name="Tight Chin">Poca papada</string>
-	<string name="Tight Cuffs">Sin campana</string>
-	<string name="Tight Pants">Pantalón ceñido</string>
-	<string name="Tight Shirt">Camisa ceñida</string>
-	<string name="Tight Skirt">Falda ceñida</string>
-	<string name="Tight Sleeves">Puños ceñidos</string>
-	<string name="Toe Shape">Punta: forma</string>
-	<string name="Toe Thickness">Empeine</string>
-	<string name="Torso Length">Torso: longitud</string>
-	<string name="Torso Muscles">Torso: musculatura</string>
-	<string name="Torso Scrawny">Torso flacucho</string>
-	<string name="Unattached">Largos</string>
-	<string name="Uncreased">Abiertos</string>
-	<string name="Underbite">Prognatismo</string>
-	<string name="Unnatural">No natural</string>
-	<string name="Upper Bridge">Puente: arriba</string>
-	<string name="Upper Cheeks">Mejillas: arriba</string>
-	<string name="Upper Chin Cleft">Barbilla: prominencia</string>
-	<string name="Upper Eyelid Fold">Párpados</string>
-	<string name="Upturned">Mucho</string>
-	<string name="Very Red">Del todo</string>
-	<string name="Waist Height">Cintura</string>
-	<string name="Well-Fed">Mofletes</string>
-	<string name="White Hair">Pelo blanco</string>
-	<string name="Wide">Aumentar</string>
-	<string name="Wide Back">Completa</string>
-	<string name="Wide Front">Completa</string>
-	<string name="Wide Lips">Labios anchos</string>
-	<string name="Wild">Total</string>
-	<string name="Wrinkles">Arrugas</string>
-	<string name="LocationCtrlAddLandmarkTooltip">Añadir a mis hitos</string>
-	<string name="LocationCtrlEditLandmarkTooltip">Editar mis hitos</string>
-	<string name="LocationCtrlInfoBtnTooltip">Ver más información de esta localización</string>
-	<string name="LocationCtrlComboBtnTooltip">Historial de mis localizaciones</string>
-	<string name="LocationCtrlForSaleTooltip">Comprar este terreno</string>
-	<string name="LocationCtrlAdultIconTooltip">Región Adulta</string>
-	<string name="LocationCtrlModerateIconTooltip">Región Moderada</string>
-	<string name="LocationCtrlGeneralIconTooltip">Región General</string>
-	<string name="LocationCtrlSeeAVsTooltip">Los avatares que están en esta parcela no pueden ser vistos ni escuchados por los que están fuera de ella</string>
-	<string name="LocationCtrlPathfindingDirtyTooltip">Los objetos que se mueven pueden presentar un comportamiento incorrecto en la región hasta que ésta se recargue.</string>
-	<string name="LocationCtrlPathfindingDisabledTooltip">Esta región no tiene activado el pathfinding dinámico.</string>
-	<string name="UpdaterWindowTitle">Actualizar [APP_NAME]</string>
-	<string name="UpdaterNowUpdating">Actualizando [APP_NAME]...</string>
-	<string name="UpdaterNowInstalling">Instalando [APP_NAME]...</string>
-	<string name="UpdaterUpdatingDescriptive">Tu visor [APP_NAME] se está actualizando a la última versión.  Llevará algún tiempo, paciencia.</string>
-	<string name="UpdaterProgressBarTextWithEllipses">Descargando la actualización...</string>
-	<string name="UpdaterProgressBarText">Descargando la actualización</string>
-	<string name="UpdaterFailDownloadTitle">Fallo en la descarga de la actualización</string>
-	<string name="UpdaterFailUpdateDescriptive">Ha habido un error actualizando [APP_NAME]. Por favor, descarga la última versión desde www.secondlife.com.</string>
-	<string name="UpdaterFailInstallTitle">Fallo al instalar la actualización</string>
-	<string name="UpdaterFailStartTitle">Fallo al iniciar el visor</string>
-	<string name="ItemsComingInTooFastFrom">[APP_NAME]: Los ítems se reciben muy rápido de [FROM_NAME]; desactivada la vista previa automática durante [TIME] sgs.</string>
-	<string name="ItemsComingInTooFast">[APP_NAME]: Los ítems se reciben muy rápido; desactivada la vista previa automática durante [TIME] sgs.</string>
-	<string name="IM_logging_string">-- Activado el registro de los mensajes instantáneos --</string>
-	<string name="IM_typing_start_string">[NAME] está escribiendo...</string>
-	<string name="Unnamed">(sin nombre)</string>
-	<string name="IM_moderated_chat_label">(Moderado: por defecto, desactivada la voz)</string>
-	<string name="IM_unavailable_text_label">Para esta llamada no está disponible el chat de texto.</string>
-	<string name="IM_muted_text_label">Un moderador del grupo ha desactivado tu chat de texto.</string>
-	<string name="IM_default_text_label">Pulsa aquí para enviar un mensaje instantáneo.</string>
-	<string name="IM_to_label">A</string>
-	<string name="IM_moderator_label">(Moderador)</string>
-	<string name="Saved_message">(Guardado [LONG_TIMESTAMP])</string>
-	<string name="OnlineStatus">Conectado/a</string>
-	<string name="OfflineStatus">Desconectado/a</string>
-	<string name="not_online_msg">El usuario no está conectado: el mensaje se almacenará para entregárselo más tarde.</string>
-	<string name="not_online_inventory">El usuario no está conectado: el inventario se ha guardado.</string>
-	<string name="answered_call">Han respondido a tu llamada</string>
-	<string name="you_started_call">Has iniciado una llamada de voz</string>
-	<string name="you_joined_call">Has entrado en la llamada de voz</string>
-	<string name="you_auto_rejected_call-im">Rechazaste la llamada de voz automáticamente porque estaba activado 'No molestar'.</string>
-	<string name="name_started_call">[NAME] inició una llamada de voz</string>
-	<string name="ringing-im">Haciendo la llamada de voz...</string>
-	<string name="connected-im">Conectado, pulsa Colgar para salir</string>
-	<string name="hang_up-im">Se colgó la llamada de voz</string>
-	<string name="conference-title">Chat multi-persona</string>
-	<string name="conference-title-incoming">Conferencia con [AGENT_NAME]</string>
-	<string name="inventory_item_offered-im">Ítem del inventario '[ITEM_NAME]' ofrecido</string>
-	<string name="inventory_folder_offered-im">Carpeta del inventario '[ITEM_NAME]' ofrecida</string>
+Si sigues recibiendo este mensaje, contacta con [SUPPORT_SITE].
+	</string>
+	<string name="5 O'Clock Shadow">
+		Barba del día
+	</string>
+	<string name="All White">
+		Blanco del todo
+	</string>
+	<string name="Anime Eyes">
+		Ojos de cómic
+	</string>
+	<string name="Arced">
+		Arqueadas
+	</string>
+	<string name="Arm Length">
+		Brazos: longitud
+	</string>
+	<string name="Attached">
+		Cortos
+	</string>
+	<string name="Attached Earlobes">
+		Lóbulos
+	</string>
+	<string name="Back Fringe">
+		Nuca: largo
+	</string>
+	<string name="Baggy">
+		Marcadas
+	</string>
+	<string name="Bangs">
+		Bangs
+	</string>
+	<string name="Beady Eyes">
+		Ojos pequeños
+	</string>
+	<string name="Belly Size">
+		Barriga: tamaño
+	</string>
+	<string name="Big">
+		Grande
+	</string>
+	<string name="Big Butt">
+		Culo grande
+	</string>
+	<string name="Big Hair Back">
+		Pelo: moño
+	</string>
+	<string name="Big Hair Front">
+		Pelo: tupé
+	</string>
+	<string name="Big Hair Top">
+		Pelo: melena alta
+	</string>
+	<string name="Big Head">
+		Cabeza grande
+	</string>
+	<string name="Big Pectorals">
+		Grandes pectorales
+	</string>
+	<string name="Big Spikes">
+		Crestas grandes
+	</string>
+	<string name="Black">
+		Negro
+	</string>
+	<string name="Blonde">
+		Rubio
+	</string>
+	<string name="Blonde Hair">
+		Pelo rubio
+	</string>
+	<string name="Blush">
+		Colorete
+	</string>
+	<string name="Blush Color">
+		Color del colorete
+	</string>
+	<string name="Blush Opacity">
+		Opacidad del colorete
+	</string>
+	<string name="Body Definition">
+		Definición del cuerpo
+	</string>
+	<string name="Body Fat">
+		Cuerpo: gordura
+	</string>
+	<string name="Body Freckles">
+		Pecas del cuerpo
+	</string>
+	<string name="Body Thick">
+		Cuerpo grueso
+	</string>
+	<string name="Body Thickness">
+		Cuerpo: grosor
+	</string>
+	<string name="Body Thin">
+		Cuerpo delgado
+	</string>
+	<string name="Bow Legged">
+		Abiertas
+	</string>
+	<string name="Breast Buoyancy">
+		Busto: firmeza
+	</string>
+	<string name="Breast Cleavage">
+		Busto: canalillo
+	</string>
+	<string name="Breast Size">
+		Busto: tamaño
+	</string>
+	<string name="Bridge Width">
+		Puente: ancho
+	</string>
+	<string name="Broad">
+		Aumentar
+	</string>
+	<string name="Brow Size">
+		Arco ciliar
+	</string>
+	<string name="Bug Eyes">
+		Bug Eyes
+	</string>
+	<string name="Bugged Eyes">
+		Ojos saltones
+	</string>
+	<string name="Bulbous">
+		Bulbosa
+	</string>
+	<string name="Bulbous Nose">
+		Nariz de porra
+	</string>
+	<string name="Breast Physics Mass">
+		Masa del busto
+	</string>
+	<string name="Breast Physics Smoothing">
+		Suavizado del busto
+	</string>
+	<string name="Breast Physics Gravity">
+		Gravedad del busto
+	</string>
+	<string name="Breast Physics Drag">
+		Aerodinámica del busto
+	</string>
+	<string name="Breast Physics InOut Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Breast Physics InOut Spring">
+		Elasticidad
+	</string>
+	<string name="Breast Physics InOut Gain">
+		Ganancia
+	</string>
+	<string name="Breast Physics InOut Damping">
+		Amortiguación
+	</string>
+	<string name="Breast Physics UpDown Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Breast Physics UpDown Spring">
+		Elasticidad
+	</string>
+	<string name="Breast Physics UpDown Gain">
+		Ganancia
+	</string>
+	<string name="Breast Physics UpDown Damping">
+		Amortiguación
+	</string>
+	<string name="Breast Physics LeftRight Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Breast Physics LeftRight Spring">
+		Elasticidad
+	</string>
+	<string name="Breast Physics LeftRight Gain">
+		Ganancia
+	</string>
+	<string name="Breast Physics LeftRight Damping">
+		Amortiguación
+	</string>
+	<string name="Belly Physics Mass">
+		Masa de la barriga
+	</string>
+	<string name="Belly Physics Smoothing">
+		Suavizado de la barriga
+	</string>
+	<string name="Belly Physics Gravity">
+		Gravedad de la barriga
+	</string>
+	<string name="Belly Physics Drag">
+		Aerodinámica de la barriga
+	</string>
+	<string name="Belly Physics UpDown Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Belly Physics UpDown Spring">
+		Elasticidad
+	</string>
+	<string name="Belly Physics UpDown Gain">
+		Ganancia
+	</string>
+	<string name="Belly Physics UpDown Damping">
+		Amortiguación
+	</string>
+	<string name="Butt Physics Mass">
+		Masa del culo
+	</string>
+	<string name="Butt Physics Smoothing">
+		Suavizado del culo
+	</string>
+	<string name="Butt Physics Gravity">
+		Gravedad del culo
+	</string>
+	<string name="Butt Physics Drag">
+		Aerodinámica del culo
+	</string>
+	<string name="Butt Physics UpDown Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Butt Physics UpDown Spring">
+		Elasticidad
+	</string>
+	<string name="Butt Physics UpDown Gain">
+		Ganancia
+	</string>
+	<string name="Butt Physics UpDown Damping">
+		Amortiguación
+	</string>
+	<string name="Butt Physics LeftRight Max Effect">
+		Efecto máx.
+	</string>
+	<string name="Butt Physics LeftRight Spring">
+		Elasticidad
+	</string>
+	<string name="Butt Physics LeftRight Gain">
+		Ganancia
+	</string>
+	<string name="Butt Physics LeftRight Damping">
+		Amortiguación
+	</string>
+	<string name="Bushy Eyebrows">
+		Cejijuntas
+	</string>
+	<string name="Bushy Hair">
+		Pelo tupido
+	</string>
+	<string name="Butt Size">
+		Culo: tamaño
+	</string>
+	<string name="Butt Gravity">
+		Gravedad del culo
+	</string>
+	<string name="bustle skirt">
+		Polisón
+	</string>
+	<string name="no bustle">
+		Sin polisón
+	</string>
+	<string name="more bustle">
+		Con polisón
+	</string>
+	<string name="Chaplin">
+		Cortito
+	</string>
+	<string name="Cheek Bones">
+		Pómulos
+	</string>
+	<string name="Chest Size">
+		Tórax: tamaño
+	</string>
+	<string name="Chin Angle">
+		Barbilla: ángulo
+	</string>
+	<string name="Chin Cleft">
+		Barbilla: contorno
+	</string>
+	<string name="Chin Curtains">
+		Barba en collar
+	</string>
+	<string name="Chin Depth">
+		Barbilla: largo
+	</string>
+	<string name="Chin Heavy">
+		Hacia la barbilla
+	</string>
+	<string name="Chin In">
+		Barbilla retraída
+	</string>
+	<string name="Chin Out">
+		Barbilla prominente
+	</string>
+	<string name="Chin-Neck">
+		Papada
+	</string>
+	<string name="Clear">
+		Transparente
+	</string>
+	<string name="Cleft">
+		Remarcar
+	</string>
+	<string name="Close Set Eyes">
+		Ojos juntos
+	</string>
+	<string name="Closed">
+		Cerrar
+	</string>
+	<string name="Closed Back">
+		Trasera cerrada
+	</string>
+	<string name="Closed Front">
+		Frontal cerrado
+	</string>
+	<string name="Closed Left">
+		Cerrada
+	</string>
+	<string name="Closed Right">
+		Cerrada
+	</string>
+	<string name="Coin Purse">
+		Poco abultada
+	</string>
+	<string name="Collar Back">
+		Espalda
+	</string>
+	<string name="Collar Front">
+		Escote
+	</string>
+	<string name="Corner Down">
+		Hacia abajo
+	</string>
+	<string name="Corner Up">
+		Hacia arriba
+	</string>
+	<string name="Creased">
+		Caídos
+	</string>
+	<string name="Crooked Nose">
+		Nariz torcida
+	</string>
+	<string name="Cuff Flare">
+		Acampanado
+	</string>
+	<string name="Dark">
+		Oscuridad
+	</string>
+	<string name="Dark Green">
+		Verde oscuro
+	</string>
+	<string name="Darker">
+		Más oscuros
+	</string>
+	<string name="Deep">
+		Remarcar
+	</string>
+	<string name="Default Heels">
+		Tacones por defecto
+	</string>
+	<string name="Dense">
+		Densas
+	</string>
+	<string name="Double Chin">
+		Mucha papada
+	</string>
+	<string name="Downturned">
+		Poco
+	</string>
+	<string name="Duffle Bag">
+		Muy abultada
+	</string>
+	<string name="Ear Angle">
+		Orejas: ángulo
+	</string>
+	<string name="Ear Size">
+		Orejas: tamaño
+	</string>
+	<string name="Ear Tips">
+		Orejas: forma
+	</string>
+	<string name="Egg Head">
+		Cabeza: ahuevada
+	</string>
+	<string name="Eye Bags">
+		Ojos: bolsas
+	</string>
+	<string name="Eye Color">
+		Ojos: color
+	</string>
+	<string name="Eye Depth">
+		Ojos: profundidad
+	</string>
+	<string name="Eye Lightness">
+		Ojos: brillo
+	</string>
+	<string name="Eye Opening">
+		Ojos: apertura
+	</string>
+	<string name="Eye Pop">
+		Ojos: simetría
+	</string>
+	<string name="Eye Size">
+		Ojos: tamaño
+	</string>
+	<string name="Eye Spacing">
+		Ojos: separación
+	</string>
+	<string name="Eyebrow Arc">
+		Cejas: arco
+	</string>
+	<string name="Eyebrow Density">
+		Cejas: densidad
+	</string>
+	<string name="Eyebrow Height">
+		Cejas: altura
+	</string>
+	<string name="Eyebrow Points">
+		Cejas: en V
+	</string>
+	<string name="Eyebrow Size">
+		Cejas: tamaño
+	</string>
+	<string name="Eyelash Length">
+		Pestañas: longitud
+	</string>
+	<string name="Eyeliner">
+		Contorno de ojos
+	</string>
+	<string name="Eyeliner Color">
+		Contorno de ojos: color
+	</string>
+	<string name="Eyes Bugged">
+		Eyes Bugged
+	</string>
+	<string name="Face Shear">
+		Cara: simetría
+	</string>
+	<string name="Facial Definition">
+		Rasgos marcados
+	</string>
+	<string name="Far Set Eyes">
+		Ojos separados
+	</string>
+	<string name="Fat Lips">
+		Prominentes
+	</string>
+	<string name="Female">
+		Mujer
+	</string>
+	<string name="Fingerless">
+		Sin dedos
+	</string>
+	<string name="Fingers">
+		Con dedos
+	</string>
+	<string name="Flared Cuffs">
+		Campana
+	</string>
+	<string name="Flat">
+		Redondeadas
+	</string>
+	<string name="Flat Butt">
+		Culo plano
+	</string>
+	<string name="Flat Head">
+		Cabeza plana
+	</string>
+	<string name="Flat Toe">
+		Empeine bajo
+	</string>
+	<string name="Foot Size">
+		Pie: tamaño
+	</string>
+	<string name="Forehead Angle">
+		Frente: ángulo
+	</string>
+	<string name="Forehead Heavy">
+		Hacia la frente
+	</string>
+	<string name="Freckles">
+		Pecas
+	</string>
+	<string name="Front Fringe">
+		Flequillo
+	</string>
+	<string name="Full Back">
+		Sin cortar
+	</string>
+	<string name="Full Eyeliner">
+		Contorno completo
+	</string>
+	<string name="Full Front">
+		Sin cortar
+	</string>
+	<string name="Full Hair Sides">
+		Pelo: volumen a los lados
+	</string>
+	<string name="Full Sides">
+		Volumen total
+	</string>
+	<string name="Glossy">
+		Con brillo
+	</string>
+	<string name="Glove Fingers">
+		Guantes: dedos
+	</string>
+	<string name="Glove Length">
+		Guantes: largo
+	</string>
+	<string name="Hair">
+		Pelo
+	</string>
+	<string name="Hair Back">
+		Pelo: nuca
+	</string>
+	<string name="Hair Front">
+		Pelo: delante
+	</string>
+	<string name="Hair Sides">
+		Pelo: lados
+	</string>
+	<string name="Hair Sweep">
+		Peinado: dirección
+	</string>
+	<string name="Hair Thickess">
+		Pelo: espesor
+	</string>
+	<string name="Hair Thickness">
+		Pelo: espesor
+	</string>
+	<string name="Hair Tilt">
+		Pelo: inclinación
+	</string>
+	<string name="Hair Tilted Left">
+		A la izq.
+	</string>
+	<string name="Hair Tilted Right">
+		A la der.
+	</string>
+	<string name="Hair Volume">
+		Pelo: volumen
+	</string>
+	<string name="Hand Size">
+		Manos: tamaño
+	</string>
+	<string name="Handlebars">
+		Muy largo
+	</string>
+	<string name="Head Length">
+		Cabeza: longitud
+	</string>
+	<string name="Head Shape">
+		Cabeza: forma
+	</string>
+	<string name="Head Size">
+		Cabeza: tamaño
+	</string>
+	<string name="Head Stretch">
+		Cabeza: estiramiento
+	</string>
+	<string name="Heel Height">
+		Tacón: altura
+	</string>
+	<string name="Heel Shape">
+		Tacón: forma
+	</string>
+	<string name="Height">
+		Altura
+	</string>
+	<string name="High">
+		Subir
+	</string>
+	<string name="High Heels">
+		Tacones altos
+	</string>
+	<string name="High Jaw">
+		Mandíbula alta
+	</string>
+	<string name="High Platforms">
+		Suela gorda
+	</string>
+	<string name="High and Tight">
+		Pegada
+	</string>
+	<string name="Higher">
+		Arrriba
+	</string>
+	<string name="Hip Length">
+		Cadera: altura
+	</string>
+	<string name="Hip Width">
+		Cadera: ancho
+	</string>
+	<string name="Hover">
+		Pasa el cursor
+	</string>
+	<string name="In">
+		Pegadas
+	</string>
+	<string name="In Shdw Color">
+		Línea de ojos: color
+	</string>
+	<string name="In Shdw Opacity">
+		Línea de ojos: opacidad
+	</string>
+	<string name="Inner Eye Corner">
+		Ojos: lagrimal
+	</string>
+	<string name="Inner Eye Shadow">
+		Inner Eye Shadow
+	</string>
+	<string name="Inner Shadow">
+		Línea de ojos
+	</string>
+	<string name="Jacket Length">
+		Chaqueta: largo
+	</string>
+	<string name="Jacket Wrinkles">
+		Chaqueta: arrugas
+	</string>
+	<string name="Jaw Angle">
+		Mandíbula: ángulo
+	</string>
+	<string name="Jaw Jut">
+		Maxilar inferior
+	</string>
+	<string name="Jaw Shape">
+		Mandíbula: forma
+	</string>
+	<string name="Join">
+		Más junto
+	</string>
+	<string name="Jowls">
+		Mofletes
+	</string>
+	<string name="Knee Angle">
+		Rodillas: ángulo
+	</string>
+	<string name="Knock Kneed">
+		Zambas
+	</string>
+	<string name="Large">
+		Aumentar
+	</string>
+	<string name="Large Hands">
+		Manos grandes
+	</string>
+	<string name="Left Part">
+		Raya: izq.
+	</string>
+	<string name="Leg Length">
+		Piernas: longitud
+	</string>
+	<string name="Leg Muscles">
+		Piernas: musculatura
+	</string>
+	<string name="Less">
+		Menos
+	</string>
+	<string name="Less Body Fat">
+		Menos gordura
+	</string>
+	<string name="Less Curtains">
+		Menos tupida
+	</string>
+	<string name="Less Freckles">
+		Menos pecas
+	</string>
+	<string name="Less Full">
+		Menos grosor
+	</string>
+	<string name="Less Gravity">
+		Más levantado
+	</string>
+	<string name="Less Love">
+		Menos michelines
+	</string>
+	<string name="Less Muscles">
+		Pocos músculos
+	</string>
+	<string name="Less Muscular">
+		Poca musculatura
+	</string>
+	<string name="Less Rosy">
+		Menos sonrosada
+	</string>
+	<string name="Less Round">
+		Menos redondeada
+	</string>
+	<string name="Less Saddle">
+		Menos cartucheras
+	</string>
+	<string name="Less Square">
+		Menos cuadrada
+	</string>
+	<string name="Less Volume">
+		Menos volumen
+	</string>
+	<string name="Less soul">
+		Pequeña
+	</string>
+	<string name="Lighter">
+		Más luminosos
+	</string>
+	<string name="Lip Cleft">
+		Labio: hoyuelo
+	</string>
+	<string name="Lip Cleft Depth">
+		Hoyuelo marcado
+	</string>
+	<string name="Lip Fullness">
+		Labios: grosor
+	</string>
+	<string name="Lip Pinkness">
+		Labios sonrosados
+	</string>
+	<string name="Lip Ratio">
+		Labios: ratio
+	</string>
+	<string name="Lip Thickness">
+		Labios: prominencia
+	</string>
+	<string name="Lip Width">
+		Labios: ancho
+	</string>
+	<string name="Lipgloss">
+		Brillo de labios
+	</string>
+	<string name="Lipstick">
+		Barra de labios
+	</string>
+	<string name="Lipstick Color">
+		Barra de labios: color
+	</string>
+	<string name="Long">
+		Más
+	</string>
+	<string name="Long Head">
+		Cabeza alargada
+	</string>
+	<string name="Long Hips">
+		Cadera larga
+	</string>
+	<string name="Long Legs">
+		Piernas largas
+	</string>
+	<string name="Long Neck">
+		Cuello largo
+	</string>
+	<string name="Long Pigtails">
+		Coletas largas
+	</string>
+	<string name="Long Ponytail">
+		Cola de caballo larga
+	</string>
+	<string name="Long Torso">
+		Torso largo
+	</string>
+	<string name="Long arms">
+		Brazos largos
+	</string>
+	<string name="Loose Pants">
+		Pantalón suelto
+	</string>
+	<string name="Loose Shirt">
+		Camiseta suelta
+	</string>
+	<string name="Loose Sleeves">
+		Puños anchos
+	</string>
+	<string name="Love Handles">
+		Michelines
+	</string>
+	<string name="Low">
+		Bajar
+	</string>
+	<string name="Low Heels">
+		Tacones bajos
+	</string>
+	<string name="Low Jaw">
+		Mandíbula baja
+	</string>
+	<string name="Low Platforms">
+		Suela fina
+	</string>
+	<string name="Low and Loose">
+		Suelta
+	</string>
+	<string name="Lower">
+		Abajo
+	</string>
+	<string name="Lower Bridge">
+		Puente: abajo
+	</string>
+	<string name="Lower Cheeks">
+		Mejillas: abajo
+	</string>
+	<string name="Male">
+		Varón
+	</string>
+	<string name="Middle Part">
+		Raya: en medio
+	</string>
+	<string name="More">
+		Más
+	</string>
+	<string name="More Blush">
+		Más colorete
+	</string>
+	<string name="More Body Fat">
+		Más gordura
+	</string>
+	<string name="More Curtains">
+		Más tupida
+	</string>
+	<string name="More Eyeshadow">
+		Más
+	</string>
+	<string name="More Freckles">
+		Más pecas
+	</string>
+	<string name="More Full">
+		Más grosor
+	</string>
+	<string name="More Gravity">
+		Menos levantado
+	</string>
+	<string name="More Lipstick">
+		Más barra de labios
+	</string>
+	<string name="More Love">
+		Más michelines
+	</string>
+	<string name="More Lower Lip">
+		Más el inferior
+	</string>
+	<string name="More Muscles">
+		Más músculos
+	</string>
+	<string name="More Muscular">
+		Más musculatura
+	</string>
+	<string name="More Rosy">
+		Más sonrosada
+	</string>
+	<string name="More Round">
+		Más redondeada
+	</string>
+	<string name="More Saddle">
+		Más cartucheras
+	</string>
+	<string name="More Sloped">
+		Más inclinada
+	</string>
+	<string name="More Square">
+		Más cuadrada
+	</string>
+	<string name="More Upper Lip">
+		Más el superior
+	</string>
+	<string name="More Vertical">
+		Más recta
+	</string>
+	<string name="More Volume">
+		Más volumen
+	</string>
+	<string name="More soul">
+		Grande
+	</string>
+	<string name="Moustache">
+		Bigote
+	</string>
+	<string name="Mouth Corner">
+		Comisuras
+	</string>
+	<string name="Mouth Position">
+		Boca: posición
+	</string>
+	<string name="Mowhawk">
+		Rapado
+	</string>
+	<string name="Muscular">
+		Muscular
+	</string>
+	<string name="Mutton Chops">
+		Patillas largas
+	</string>
+	<string name="Nail Polish">
+		Uñas pintadas
+	</string>
+	<string name="Nail Polish Color">
+		Uñas pintadas: color
+	</string>
+	<string name="Narrow">
+		Disminuir
+	</string>
+	<string name="Narrow Back">
+		Rapada
+	</string>
+	<string name="Narrow Front">
+		Entradas
+	</string>
+	<string name="Narrow Lips">
+		Labios estrechos
+	</string>
+	<string name="Natural">
+		Natural
+	</string>
+	<string name="Neck Length">
+		Cuello: longitud
+	</string>
+	<string name="Neck Thickness">
+		Cuello: grosor
+	</string>
+	<string name="No Blush">
+		Sin colorete
+	</string>
+	<string name="No Eyeliner">
+		Sin contorno
+	</string>
+	<string name="No Eyeshadow">
+		Menos
+	</string>
+	<string name="No Lipgloss">
+		Sin brillo
+	</string>
+	<string name="No Lipstick">
+		Sin barra de labios
+	</string>
+	<string name="No Part">
+		Sin raya
+	</string>
+	<string name="No Polish">
+		Sin pintar
+	</string>
+	<string name="No Red">
+		Nada
+	</string>
+	<string name="No Spikes">
+		Sin crestas
+	</string>
+	<string name="No White">
+		Sin blanco
+	</string>
+	<string name="No Wrinkles">
+		Sin arrugas
+	</string>
+	<string name="Normal Lower">
+		Normal Lower
+	</string>
+	<string name="Normal Upper">
+		Normal Upper
+	</string>
+	<string name="Nose Left">
+		Nariz a la izq.
+	</string>
+	<string name="Nose Right">
+		Nariz a la der.
+	</string>
+	<string name="Nose Size">
+		Nariz: tamaño
+	</string>
+	<string name="Nose Thickness">
+		Nariz: grosor
+	</string>
+	<string name="Nose Tip Angle">
+		Nariz: respingona
+	</string>
+	<string name="Nose Tip Shape">
+		Nariz: punta
+	</string>
+	<string name="Nose Width">
+		Nariz: ancho
+	</string>
+	<string name="Nostril Division">
+		Ventana: altura
+	</string>
+	<string name="Nostril Width">
+		Ventana: ancho
+	</string>
+	<string name="Opaque">
+		Opaco
+	</string>
+	<string name="Open">
+		Abrir
+	</string>
+	<string name="Open Back">
+		Apertura trasera
+	</string>
+	<string name="Open Front">
+		Apertura frontal
+	</string>
+	<string name="Open Left">
+		Abierta
+	</string>
+	<string name="Open Right">
+		Abierta
+	</string>
+	<string name="Orange">
+		Anaranjado
+	</string>
+	<string name="Out">
+		De soplillo
+	</string>
+	<string name="Out Shdw Color">
+		Sombra de ojos: color
+	</string>
+	<string name="Out Shdw Opacity">
+		Sombra de ojos: opacidad
+	</string>
+	<string name="Outer Eye Corner">
+		Ojos: comisura
+	</string>
+	<string name="Outer Eye Shadow">
+		Outer Eye Shadow
+	</string>
+	<string name="Outer Shadow">
+		Sombra de ojos
+	</string>
+	<string name="Overbite">
+		Retraído
+	</string>
+	<string name="Package">
+		Pubis
+	</string>
+	<string name="Painted Nails">
+		Pintadas
+	</string>
+	<string name="Pale">
+		Pálida
+	</string>
+	<string name="Pants Crotch">
+		Pantalón: cruz
+	</string>
+	<string name="Pants Fit">
+		Ceñido
+	</string>
+	<string name="Pants Length">
+		Pernera: largo
+	</string>
+	<string name="Pants Waist">
+		Caja
+	</string>
+	<string name="Pants Wrinkles">
+		Pantalón: arrugas
+	</string>
+	<string name="Part">
+		Raya
+	</string>
+	<string name="Part Bangs">
+		Flequillo partido
+	</string>
+	<string name="Pectorals">
+		Pectorales
+	</string>
+	<string name="Pigment">
+		Tono
+	</string>
+	<string name="Pigtails">
+		Coletas
+	</string>
+	<string name="Pink">
+		Rosa
+	</string>
+	<string name="Pinker">
+		Más sonrosados
+	</string>
+	<string name="Platform Height">
+		Suela: altura
+	</string>
+	<string name="Platform Width">
+		Suela: ancho
+	</string>
+	<string name="Pointy">
+		En punta
+	</string>
+	<string name="Pointy Heels">
+		De aguja
+	</string>
+	<string name="Ponytail">
+		Cola de caballo
+	</string>
+	<string name="Poofy Skirt">
+		Con vuelo
+	</string>
+	<string name="Pop Left Eye">
+		Izquierdo más grande
+	</string>
+	<string name="Pop Right Eye">
+		Derecho más grande
+	</string>
+	<string name="Puffy">
+		Hinchadas
+	</string>
+	<string name="Puffy Eyelids">
+		Ojeras
+	</string>
+	<string name="Rainbow Color">
+		Irisación
+	</string>
+	<string name="Red Hair">
+		Pelirrojo
+	</string>
+	<string name="Regular">
+		Regular
+	</string>
+	<string name="Right Part">
+		Raya: der.
+	</string>
+	<string name="Rosy Complexion">
+		Tez sonrosada
+	</string>
+	<string name="Round">
+		Redondear
+	</string>
+	<string name="Ruddiness">
+		Rubicundez
+	</string>
+	<string name="Ruddy">
+		Rojiza
+	</string>
+	<string name="Rumpled Hair">
+		Pelo encrespado
+	</string>
+	<string name="Saddle Bags">
+		Cartucheras
+	</string>
+	<string name="Scrawny Leg">
+		Piernas flacas
+	</string>
+	<string name="Separate">
+		Más ancho
+	</string>
+	<string name="Shallow">
+		Sin marcar
+	</string>
+	<string name="Shear Back">
+		Nuca: corte
+	</string>
+	<string name="Shear Face">
+		Shear Face
+	</string>
+	<string name="Shear Front">
+		Shear Front
+	</string>
+	<string name="Shear Left Up">
+		Arriba - izq.
+	</string>
+	<string name="Shear Right Up">
+		Arriba - der.
+	</string>
+	<string name="Sheared Back">
+		Rapada
+	</string>
+	<string name="Sheared Front">
+		Rapada
+	</string>
+	<string name="Shift Left">
+		A la izq.
+	</string>
+	<string name="Shift Mouth">
+		Boca: ladeada
+	</string>
+	<string name="Shift Right">
+		A la der.
+	</string>
+	<string name="Shirt Bottom">
+		Alto de cintura
+	</string>
+	<string name="Shirt Fit">
+		Ceñido
+	</string>
+	<string name="Shirt Wrinkles">
+		Camisa: arrugas
+	</string>
+	<string name="Shoe Height">
+		Caña: altura
+	</string>
+	<string name="Short">
+		Menos
+	</string>
+	<string name="Short Arms">
+		Brazos cortos
+	</string>
+	<string name="Short Legs">
+		Piernas cortas
+	</string>
+	<string name="Short Neck">
+		Cuello corto
+	</string>
+	<string name="Short Pigtails">
+		Coletas cortas
+	</string>
+	<string name="Short Ponytail">
+		Cola de caballo corta
+	</string>
+	<string name="Short Sideburns">
+		Patillas cortas
+	</string>
+	<string name="Short Torso">
+		Torso corto
+	</string>
+	<string name="Short hips">
+		Cadera corta
+	</string>
+	<string name="Shoulders">
+		Hombros
+	</string>
+	<string name="Side Fringe">
+		Lados: franja
+	</string>
+	<string name="Sideburns">
+		Patillas
+	</string>
+	<string name="Sides Hair">
+		Pelo: lados
+	</string>
+	<string name="Sides Hair Down">
+		Bajar lados del pelo
+	</string>
+	<string name="Sides Hair Up">
+		Subir lados del pelo
+	</string>
+	<string name="Skinny Neck">
+		Cuello estrecho
+	</string>
+	<string name="Skirt Fit">
+		Falda: vuelo
+	</string>
+	<string name="Skirt Length">
+		Falda: largo
+	</string>
+	<string name="Slanted Forehead">
+		Slanted Forehead
+	</string>
+	<string name="Sleeve Length">
+		Largo de manga
+	</string>
+	<string name="Sleeve Looseness">
+		Ancho de puños
+	</string>
+	<string name="Slit Back">
+		Raja trasera
+	</string>
+	<string name="Slit Front">
+		Raja frontal
+	</string>
+	<string name="Slit Left">
+		Raja a la izq.
+	</string>
+	<string name="Slit Right">
+		Raja a la der.
+	</string>
+	<string name="Small">
+		Disminuir
+	</string>
+	<string name="Small Hands">
+		Manos pequeñas
+	</string>
+	<string name="Small Head">
+		Cabeza pequeña
+	</string>
+	<string name="Smooth">
+		Leves
+	</string>
+	<string name="Smooth Hair">
+		Pelo liso
+	</string>
+	<string name="Socks Length">
+		Calcetines: largo
+	</string>
+	<string name="Soulpatch">
+		Perilla
+	</string>
+	<string name="Sparse">
+		Depiladas
+	</string>
+	<string name="Spiked Hair">
+		Crestas
+	</string>
+	<string name="Square">
+		Cuadrada
+	</string>
+	<string name="Square Toe">
+		Punta cuadrada
+	</string>
+	<string name="Squash Head">
+		Cabeza aplastada
+	</string>
+	<string name="Stretch Head">
+		Cabeza estirada
+	</string>
+	<string name="Sunken">
+		Chupadas
+	</string>
+	<string name="Sunken Chest">
+		Estrecho de pecho
+	</string>
+	<string name="Sunken Eyes">
+		Ojos hundidos
+	</string>
+	<string name="Sweep Back">
+		Sweep Back
+	</string>
+	<string name="Sweep Forward">
+		Sweep Forward
+	</string>
+	<string name="Tall">
+		Más
+	</string>
+	<string name="Taper Back">
+		Cubierta trasera
+	</string>
+	<string name="Taper Front">
+		Cubierta frontal
+	</string>
+	<string name="Thick Heels">
+		Tacones grandes
+	</string>
+	<string name="Thick Neck">
+		Cuello ancho
+	</string>
+	<string name="Thick Toe">
+		Empeine alto
+	</string>
+	<string name="Thin">
+		Delgadas
+	</string>
+	<string name="Thin Eyebrows">
+		Cejas finas
+	</string>
+	<string name="Thin Lips">
+		Hacia dentro
+	</string>
+	<string name="Thin Nose">
+		Nariz fina
+	</string>
+	<string name="Tight Chin">
+		Poca papada
+	</string>
+	<string name="Tight Cuffs">
+		Sin campana
+	</string>
+	<string name="Tight Pants">
+		Pantalón ceñido
+	</string>
+	<string name="Tight Shirt">
+		Camisa ceñida
+	</string>
+	<string name="Tight Skirt">
+		Falda ceñida
+	</string>
+	<string name="Tight Sleeves">
+		Puños ceñidos
+	</string>
+	<string name="Toe Shape">
+		Punta: forma
+	</string>
+	<string name="Toe Thickness">
+		Empeine
+	</string>
+	<string name="Torso Length">
+		Torso: longitud
+	</string>
+	<string name="Torso Muscles">
+		Torso: musculatura
+	</string>
+	<string name="Torso Scrawny">
+		Torso flacucho
+	</string>
+	<string name="Unattached">
+		Largos
+	</string>
+	<string name="Uncreased">
+		Abiertos
+	</string>
+	<string name="Underbite">
+		Prognatismo
+	</string>
+	<string name="Unnatural">
+		No natural
+	</string>
+	<string name="Upper Bridge">
+		Puente: arriba
+	</string>
+	<string name="Upper Cheeks">
+		Mejillas: arriba
+	</string>
+	<string name="Upper Chin Cleft">
+		Barbilla: prominencia
+	</string>
+	<string name="Upper Eyelid Fold">
+		Párpados
+	</string>
+	<string name="Upturned">
+		Mucho
+	</string>
+	<string name="Very Red">
+		Del todo
+	</string>
+	<string name="Waist Height">
+		Cintura
+	</string>
+	<string name="Well-Fed">
+		Mofletes
+	</string>
+	<string name="White Hair">
+		Pelo blanco
+	</string>
+	<string name="Wide">
+		Aumentar
+	</string>
+	<string name="Wide Back">
+		Completa
+	</string>
+	<string name="Wide Front">
+		Completa
+	</string>
+	<string name="Wide Lips">
+		Labios anchos
+	</string>
+	<string name="Wild">
+		Total
+	</string>
+	<string name="Wrinkles">
+		Arrugas
+	</string>
+	<string name="LocationCtrlAddLandmarkTooltip">
+		Añadir a mis hitos
+	</string>
+	<string name="LocationCtrlEditLandmarkTooltip">
+		Editar mis hitos
+	</string>
+	<string name="LocationCtrlInfoBtnTooltip">
+		Ver más información de esta localización
+	</string>
+	<string name="LocationCtrlComboBtnTooltip">
+		Historial de mis localizaciones
+	</string>
+	<string name="LocationCtrlForSaleTooltip">
+		Comprar este terreno
+	</string>
+	<string name="LocationCtrlAdultIconTooltip">
+		Región Adulta
+	</string>
+	<string name="LocationCtrlModerateIconTooltip">
+		Región Moderada
+	</string>
+	<string name="LocationCtrlGeneralIconTooltip">
+		Región General
+	</string>
+	<string name="LocationCtrlSeeAVsTooltip">
+		Los avatares que están en esta parcela no pueden ser vistos ni escuchados por los que están fuera de ella
+	</string>
+	<string name="LocationCtrlPathfindingDirtyTooltip">
+		Los objetos que se mueven pueden presentar un comportamiento incorrecto en la región hasta que ésta se recargue.
+	</string>
+	<string name="LocationCtrlPathfindingDisabledTooltip">
+		Esta región no tiene activado el pathfinding dinámico.
+	</string>
+	<string name="UpdaterWindowTitle">
+		Actualizar [APP_NAME]
+	</string>
+	<string name="UpdaterNowUpdating">
+		Actualizando [APP_NAME]...
+	</string>
+	<string name="UpdaterNowInstalling">
+		Instalando [APP_NAME]...
+	</string>
+	<string name="UpdaterUpdatingDescriptive">
+		Tu visor [APP_NAME] se está actualizando a la última versión.  Llevará algún tiempo, paciencia.
+	</string>
+	<string name="UpdaterProgressBarTextWithEllipses">
+		Descargando la actualización...
+	</string>
+	<string name="UpdaterProgressBarText">
+		Descargando la actualización
+	</string>
+	<string name="UpdaterFailDownloadTitle">
+		Fallo en la descarga de la actualización
+	</string>
+	<string name="UpdaterFailUpdateDescriptive">
+		Ha habido un error actualizando [APP_NAME]. Por favor, descarga la última versión desde www.secondlife.com.
+	</string>
+	<string name="UpdaterFailInstallTitle">
+		Fallo al instalar la actualización
+	</string>
+	<string name="UpdaterFailStartTitle">
+		Fallo al iniciar el visor
+	</string>
+	<string name="ItemsComingInTooFastFrom">
+		[APP_NAME]: Los ítems se reciben muy rápido de [FROM_NAME]; desactivada la vista previa automática durante [TIME] sgs.
+	</string>
+	<string name="ItemsComingInTooFast">
+		[APP_NAME]: Los ítems se reciben muy rápido; desactivada la vista previa automática durante [TIME] sgs.
+	</string>
+	<string name="IM_logging_string">
+		-- Activado el registro de los mensajes instantáneos --
+	</string>
+	<string name="IM_typing_start_string">
+		[NAME] está escribiendo...
+	</string>
+	<string name="Unnamed">
+		(sin nombre)
+	</string>
+	<string name="IM_moderated_chat_label">
+		(Moderado: por defecto, desactivada la voz)
+	</string>
+	<string name="IM_unavailable_text_label">
+		Para esta llamada no está disponible el chat de texto.
+	</string>
+	<string name="IM_muted_text_label">
+		Un moderador del grupo ha desactivado tu chat de texto.
+	</string>
+	<string name="IM_default_text_label">
+		Pulsa aquí para enviar un mensaje instantáneo.
+	</string>
+	<string name="IM_to_label">
+		A
+	</string>
+	<string name="IM_moderator_label">
+		(Moderador)
+	</string>
+	<string name="Saved_message">
+		(Guardado [LONG_TIMESTAMP])
+	</string>
+	<string name="OnlineStatus">
+		Conectado/a
+	</string>
+	<string name="OfflineStatus">
+		Desconectado/a
+	</string>
+	<string name="not_online_msg">
+		El usuario no está conectado: el mensaje se almacenará para entregárselo más tarde.
+	</string>
+	<string name="not_online_inventory">
+		El usuario no está conectado: el inventario se ha guardado.
+	</string>
+	<string name="answered_call">
+		Han respondido a tu llamada
+	</string>
+	<string name="you_started_call">
+		Has iniciado una llamada de voz
+	</string>
+	<string name="you_joined_call">
+		Has entrado en la llamada de voz
+	</string>
+	<string name="you_auto_rejected_call-im">
+		Rechazaste la llamada de voz automáticamente porque estaba activado 'No molestar'.
+	</string>
+	<string name="name_started_call">
+		[NAME] inició una llamada de voz
+	</string>
+	<string name="ringing-im">
+		Haciendo la llamada de voz...
+	</string>
+	<string name="connected-im">
+		Conectado, pulsa Colgar para salir
+	</string>
+	<string name="hang_up-im">
+		Se colgó la llamada de voz
+	</string>
+	<string name="conference-title">
+		Chat multi-persona
+	</string>
+	<string name="conference-title-incoming">
+		Conferencia con [AGENT_NAME]
+	</string>
+	<string name="inventory_item_offered-im">
+		Ítem del inventario '[ITEM_NAME]' ofrecido
+	</string>
+	<string name="inventory_folder_offered-im">
+		Carpeta del inventario '[ITEM_NAME]' ofrecida
+	</string>
 	<string name="bot_warning">
-Estás conversando con un bot, [NAME]. No compartas información personal.
+		Estás conversando con un bot, [NAME]. No compartas información personal.
 Más información en https://second.life/scripted-agents.
 	</string>
-	<string name="share_alert">Arrastra los ítems desde el invenbtario hasta aquí</string>
-	<string name="facebook_post_success">Has publicado en Facebook.</string>
-	<string name="flickr_post_success">Has publicado en Flickr.</string>
-	<string name="twitter_post_success">Has publicado en Twitter.</string>
-	<string name="no_session_message">(La sesión de MI no existe)</string>
-	<string name="only_user_message">Usted es el único usuario en esta sesión.</string>
-	<string name="offline_message">[NAME] está desconectado.</string>
-	<string name="invite_message">Pulse el botón [BUTTON NAME] para aceptar/conectar este chat de voz.</string>
-	<string name="muted_message">Has ignorado a este residente. Enviándole un mensaje, automáticamente dejarás de ignorarle.</string>
-	<string name="generic">Error en lo solicitado, por favor, inténtalo más tarde.</string>
-	<string name="generic_request_error">Error al hacer lo solicitado; por favor, inténtelo más tarde.</string>
-	<string name="insufficient_perms_error">Usted no tiene permisos suficientes.</string>
-	<string name="session_does_not_exist_error">La sesión ya acabó</string>
-	<string name="no_ability_error">Usted no tiene esa capacidad.</string>
-	<string name="no_ability">Usted no tiene esa capacidad.</string>
-	<string name="not_a_mod_error">Usted no es un moderador de la sesión.</string>
-	<string name="muted">Un moderador del grupo ha desactivado tu chat de texto.</string>
-	<string name="muted_error">Un moderador del grupo le ha desactivado el chat de texto.</string>
-	<string name="add_session_event">No se ha podido añadir usuarios a la sesión de chat con [RECIPIENT].</string>
-	<string name="message">No se ha podido enviar tu mensaje a la sesión de chat con [RECIPIENT].</string>
-	<string name="message_session_event">No se ha podido enviar su mensaje a la sesión de chat con [RECIPIENT].</string>
-	<string name="mute">Error moderando.</string>
-	<string name="removed">Se te ha sacado del grupo.</string>
-	<string name="removed_from_group">Ha sido eliminado del grupo.</string>
-	<string name="close_on_no_ability">Usted ya no tendrá más la capacidad de estar en la sesión de chat.</string>
-	<string name="unread_chat_single">[SOURCES] ha dicho algo nuevo</string>
-	<string name="unread_chat_multiple">[SOURCES] ha dicho algo nuevo</string>
-	<string name="session_initialization_timed_out_error">Se ha agotado el tiempo del inicio de sesión</string>
-	<string name="Home position set.">Posición inicial establecida.</string>
-	<string name="voice_morphing_url">https://secondlife.com/destination/voice-island</string>
-	<string name="premium_voice_morphing_url">https://secondlife.com/destination/voice-morphing-premium</string>
-	<string name="paid_you_ldollars">[NAME] te ha pagado [AMOUNT] L$ [REASON].</string>
-	<string name="paid_you_ldollars_gift">[NAME] te ha pagado [AMOUNT] L$: [REASON]</string>
-	<string name="paid_you_ldollars_no_reason">[NAME] te ha pagado [AMOUNT] L$.</string>
-	<string name="you_paid_ldollars">Has pagado [AMOUNT] L$ a [NAME] por [REASON].</string>
-	<string name="you_paid_ldollars_gift">Has pagado [AMOUNT] L$ a [NAME]: [REASON]</string>
-	<string name="you_paid_ldollars_no_info">Has pagado[AMOUNT] L$</string>
-	<string name="you_paid_ldollars_no_reason">Has pagado [AMOUNT] L$ a [NAME].</string>
-	<string name="you_paid_ldollars_no_name">Has pagado [AMOUNT] L$ por [REASON].</string>
-	<string name="you_paid_failure_ldollars">No has pagado a [NAME] [AMOUNT] L$ [REASON].</string>
-	<string name="you_paid_failure_ldollars_gift">No has pagado a [NAME] [AMOUNT] L$: [REASON]</string>
-	<string name="you_paid_failure_ldollars_no_info">No has pagado [AMOUNT] L$.</string>
-	<string name="you_paid_failure_ldollars_no_reason">No has pagado a [NAME] [AMOUNT] L$.</string>
-	<string name="you_paid_failure_ldollars_no_name">No has pagado [AMOUNT] L$ [REASON].</string>
-	<string name="for item">para [ITEM]</string>
-	<string name="for a parcel of land">para una parcela de terreno</string>
-	<string name="for a land access pass">para un pase de acceso a terrenos</string>
-	<string name="for deeding land">for deeding land</string>
-	<string name="to create a group">para crear un grupo</string>
-	<string name="to join a group">para entrar a un grupo</string>
-	<string name="to upload">to upload</string>
-	<string name="to publish a classified ad">para publicar un anuncio clasificado</string>
-	<string name="giving">Dando [AMOUNT] L$</string>
-	<string name="uploading_costs">Subir esto cuesta [AMOUNT] L$</string>
-	<string name="this_costs">Esto cuesta [AMOUNT] L$</string>
-	<string name="buying_selected_land">Compra del terreno seleccionado por [AMOUNT] L$</string>
-	<string name="this_object_costs">Este objeto cuesta [AMOUNT] L$</string>
-	<string name="group_role_everyone">Todos</string>
-	<string name="group_role_officers">Oficiales</string>
-	<string name="group_role_owners">Propietarios</string>
-	<string name="group_member_status_online">Conectado/a</string>
-	<string name="uploading_abuse_report">Subiendo...
+	<string name="share_alert">
+		Arrastra los ítems desde el invenbtario hasta aquí
+	</string>
+	<string name="facebook_post_success">
+		Has publicado en Facebook.
+	</string>
+	<string name="flickr_post_success">
+		Has publicado en Flickr.
+	</string>
+	<string name="twitter_post_success">
+		Has publicado en Twitter.
+	</string>
+	<string name="no_session_message">
+		(La sesión de MI no existe)
+	</string>
+	<string name="only_user_message">
+		Usted es el único usuario en esta sesión.
+	</string>
+	<string name="offline_message">
+		[NAME] está desconectado.
+	</string>
+	<string name="invite_message">
+		Pulse el botón [BUTTON NAME] para aceptar/conectar este chat de voz.
+	</string>
+	<string name="muted_message">
+		Has ignorado a este residente. Enviándole un mensaje, automáticamente dejarás de ignorarle.
+	</string>
+	<string name="generic">
+		Error en lo solicitado, por favor, inténtalo más tarde.
+	</string>
+	<string name="generic_request_error">
+		Error al hacer lo solicitado; por favor, inténtelo más tarde.
+	</string>
+	<string name="insufficient_perms_error">
+		Usted no tiene permisos suficientes.
+	</string>
+	<string name="session_does_not_exist_error">
+		La sesión ya acabó
+	</string>
+	<string name="no_ability_error">
+		Usted no tiene esa capacidad.
+	</string>
+	<string name="no_ability">
+		Usted no tiene esa capacidad.
+	</string>
+	<string name="not_a_mod_error">
+		Usted no es un moderador de la sesión.
+	</string>
+	<string name="muted">
+		Un moderador del grupo ha desactivado tu chat de texto.
+	</string>
+	<string name="muted_error">
+		Un moderador del grupo le ha desactivado el chat de texto.
+	</string>
+	<string name="add_session_event">
+		No se ha podido añadir usuarios a la sesión de chat con [RECIPIENT].
+	</string>
+	<string name="message">
+		No se ha podido enviar tu mensaje a la sesión de chat con [RECIPIENT].
+	</string>
+	<string name="message_session_event">
+		No se ha podido enviar su mensaje a la sesión de chat con [RECIPIENT].
+	</string>
+	<string name="mute">
+		Error moderando.
+	</string>
+	<string name="removed">
+		Se te ha sacado del grupo.
+	</string>
+	<string name="removed_from_group">
+		Ha sido eliminado del grupo.
+	</string>
+	<string name="close_on_no_ability">
+		Usted ya no tendrá más la capacidad de estar en la sesión de chat.
+	</string>
+	<string name="unread_chat_single">
+		[SOURCES] ha dicho algo nuevo
+	</string>
+	<string name="unread_chat_multiple">
+		[SOURCES] ha dicho algo nuevo
+	</string>
+	<string name="session_initialization_timed_out_error">
+		Se ha agotado el tiempo del inicio de sesión
+	</string>
+	<string name="Home position set.">
+		Posición inicial establecida.
+	</string>
+	<string name="voice_morphing_url">
+		https://secondlife.com/destination/voice-island
+	</string>
+	<string name="premium_voice_morphing_url">
+		https://secondlife.com/destination/voice-morphing-premium
+	</string>
+	<string name="paid_you_ldollars">
+		[NAME] te ha pagado [AMOUNT] L$ [REASON].
+	</string>
+	<string name="paid_you_ldollars_gift">
+		[NAME] te ha pagado [AMOUNT] L$: [REASON]
+	</string>
+	<string name="paid_you_ldollars_no_reason">
+		[NAME] te ha pagado [AMOUNT] L$.
+	</string>
+	<string name="you_paid_ldollars">
+		Has pagado [AMOUNT] L$ a [NAME] por [REASON].
+	</string>
+	<string name="you_paid_ldollars_gift">
+		Has pagado [AMOUNT] L$ a [NAME]: [REASON]
+	</string>
+	<string name="you_paid_ldollars_no_info">
+		Has pagado[AMOUNT] L$
+	</string>
+	<string name="you_paid_ldollars_no_reason">
+		Has pagado [AMOUNT] L$ a [NAME].
+	</string>
+	<string name="you_paid_ldollars_no_name">
+		Has pagado [AMOUNT] L$ por [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars">
+		No has pagado a [NAME] [AMOUNT] L$ [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars_gift">
+		No has pagado a [NAME] [AMOUNT] L$: [REASON]
+	</string>
+	<string name="you_paid_failure_ldollars_no_info">
+		No has pagado [AMOUNT] L$.
+	</string>
+	<string name="you_paid_failure_ldollars_no_reason">
+		No has pagado a [NAME] [AMOUNT] L$.
+	</string>
+	<string name="you_paid_failure_ldollars_no_name">
+		No has pagado [AMOUNT] L$ [REASON].
+	</string>
+	<string name="for item">
+		para [ITEM]
+	</string>
+	<string name="for a parcel of land">
+		para una parcela de terreno
+	</string>
+	<string name="for a land access pass">
+		para un pase de acceso a terrenos
+	</string>
+	<string name="for deeding land">
+		for deeding land
+	</string>
+	<string name="to create a group">
+		para crear un grupo
+	</string>
+	<string name="to join a group">
+		para entrar a un grupo
+	</string>
+	<string name="to upload">
+		to upload
+	</string>
+	<string name="to publish a classified ad">
+		para publicar un anuncio clasificado
+	</string>
+	<string name="giving">
+		Dando [AMOUNT] L$
+	</string>
+	<string name="uploading_costs">
+		Subir esto cuesta [AMOUNT] L$
+	</string>
+	<string name="this_costs">
+		Esto cuesta [AMOUNT] L$
+	</string>
+	<string name="buying_selected_land">
+		Compra del terreno seleccionado por [AMOUNT] L$
+	</string>
+	<string name="this_object_costs">
+		Este objeto cuesta [AMOUNT] L$
+	</string>
+	<string name="group_role_everyone">
+		Todos
+	</string>
+	<string name="group_role_officers">
+		Oficiales
+	</string>
+	<string name="group_role_owners">
+		Propietarios
+	</string>
+	<string name="group_member_status_online">
+		Conectado/a
+	</string>
+	<string name="uploading_abuse_report">
+		Subiendo...
 
-Denuncia de infracción</string>
-	<string name="New Shape">Anatomía nueva</string>
-	<string name="New Skin">Piel nueva</string>
-	<string name="New Hair">Pelo nuevo</string>
-	<string name="New Eyes">Ojos nuevos</string>
-	<string name="New Shirt">Camisa nueva</string>
-	<string name="New Pants">Pantalón nuevo</string>
-	<string name="New Shoes">Zapatos nuevos</string>
-	<string name="New Socks">Calcetines nuevos</string>
-	<string name="New Jacket">Chaqueta nueva</string>
-	<string name="New Gloves">Guantes nuevos</string>
-	<string name="New Undershirt">Camiseta nueva</string>
-	<string name="New Underpants">Ropa interior nueva</string>
-	<string name="New Skirt">Falda nueva</string>
-	<string name="New Alpha">Nueva Alfa</string>
-	<string name="New Tattoo">Tatuaje nuevo</string>
-	<string name="New Universal">Nuevo Universal</string>
-	<string name="New Physics">Nueva física</string>
-	<string name="Invalid Wearable">No se puede poner</string>
-	<string name="New Gesture">Gesto nuevo</string>
-	<string name="New Script">Script nuevo</string>
-	<string name="New Note">Nota nueva</string>
-	<string name="New Folder">Carpeta nueva</string>
-	<string name="Contents">Contenidos</string>
-	<string name="Gesture">Gestos</string>
-	<string name="Male Gestures">Gestos de hombre</string>
-	<string name="Female Gestures">Gestos de mujer</string>
-	<string name="Other Gestures">Otros gestos</string>
-	<string name="Speech Gestures">Gestos al hablar</string>
-	<string name="Common Gestures">Gestos corrientes</string>
-	<string name="Male - Excuse me">Varón - Disculpa</string>
-	<string name="Male - Get lost">Varón – Déjame en paz</string>
-	<string name="Male - Blow kiss">Varón - Lanzar un beso</string>
-	<string name="Male - Boo">Varón - Abucheo</string>
-	<string name="Male - Bored">Varón - Aburrido</string>
-	<string name="Male - Hey">Varón – ¡Eh!</string>
-	<string name="Male - Laugh">Varón - Risa</string>
-	<string name="Male - Repulsed">Varón - Rechazo</string>
-	<string name="Male - Shrug">Varón - Encogimiento de hombros</string>
-	<string name="Male - Stick tougue out">Hombre - Sacando la lengua</string>
-	<string name="Male - Wow">Varón - Admiración</string>
-	<string name="Female - Chuckle">Mujer - Risa suave</string>
-	<string name="Female - Cry">Mujer - Llorar</string>
-	<string name="Female - Embarrassed">Mujer - Ruborizada</string>
-	<string name="Female - Excuse me">Mujer - Disculpa</string>
-	<string name="Female - Get lost">Mujer – Déjame en paz</string>
-	<string name="Female - Blow kiss">Mujer - Lanzar un beso</string>
-	<string name="Female - Boo">Mujer - Abucheo</string>
-	<string name="Female - Bored">Mujer - Aburrida</string>
-	<string name="Female - Hey">Mujer - ¡Eh!</string>
-	<string name="Female - Hey baby">Mujer - ¡Eh, encanto!</string>
-	<string name="Female - Laugh">Mujer - Risa</string>
-	<string name="Female - Looking good">Mujer - Buen aspecto</string>
-	<string name="Female - Over here">Mujer - Por aquí</string>
-	<string name="Female - Please">Mujer - Por favor</string>
-	<string name="Female - Repulsed">Mujer - Rechazo</string>
-	<string name="Female - Shrug">Mujer - Encogimiento de hombros</string>
-	<string name="Female - Stick tougue out">Mujer - Sacando la lengua</string>
-	<string name="Female - Wow">Mujer - Admiración</string>
-	<string name="New Daycycle">Nuevo Ciclo del día</string>
-	<string name="New Water">Nueva Agua</string>
-	<string name="New Sky">Nuevo Cielo</string>
-	<string name="/bow">/reverencia</string>
-	<string name="/clap">/aplaudir</string>
-	<string name="/count">/contar</string>
-	<string name="/extinguish">/apagar</string>
-	<string name="/kmb">/bmc</string>
-	<string name="/muscle">/músculo</string>
-	<string name="/no">/no</string>
-	<string name="/no!">/¡no!</string>
-	<string name="/paper">/papel</string>
-	<string name="/pointme">/señalarme</string>
-	<string name="/pointyou">/señalarte</string>
-	<string name="/rock">/piedra</string>
-	<string name="/scissor">/tijera</string>
-	<string name="/smoke">/fumar</string>
-	<string name="/stretch">/estirar</string>
-	<string name="/whistle">/silbar</string>
-	<string name="/yes">/sí</string>
-	<string name="/yes!">/¡sí!</string>
-	<string name="afk">ausente</string>
-	<string name="dance1">baile1</string>
-	<string name="dance2">baile2</string>
-	<string name="dance3">baile3</string>
-	<string name="dance4">baile4</string>
-	<string name="dance5">baile5</string>
-	<string name="dance6">baile6</string>
-	<string name="dance7">baile7</string>
-	<string name="dance8">baile8</string>
-	<string name="AvatarBirthDateFormat">[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]</string>
-	<string name="DefaultMimeType">ninguno/ninguno</string>
-	<string name="texture_load_dimensions_error">No se puede subir imágenes mayores de [WIDTH]*[HEIGHT]</string>
-	<string name="outfit_photo_load_dimensions_error">La foto del vestuario puede tener como máx. un tamaño de [WIDTH]*[HEIGHT]. Cambia el tamaño o utiliza otra imagen</string>
-	<string name="outfit_photo_select_dimensions_error">La foto del vestuario puede tener como máx. un tamaño de [WIDTH]*[HEIGHT]. Selecciona otra textura</string>
-	<string name="outfit_photo_verify_dimensions_error">No se pueden verificar las dimensiones de la foto. Espera hasta que aparezca el tamaño de la foto en el selector</string>
+Denuncia de infracción
+	</string>
+	<string name="New Shape">
+		Anatomía nueva
+	</string>
+	<string name="New Skin">
+		Piel nueva
+	</string>
+	<string name="New Hair">
+		Pelo nuevo
+	</string>
+	<string name="New Eyes">
+		Ojos nuevos
+	</string>
+	<string name="New Shirt">
+		Camisa nueva
+	</string>
+	<string name="New Pants">
+		Pantalón nuevo
+	</string>
+	<string name="New Shoes">
+		Zapatos nuevos
+	</string>
+	<string name="New Socks">
+		Calcetines nuevos
+	</string>
+	<string name="New Jacket">
+		Chaqueta nueva
+	</string>
+	<string name="New Gloves">
+		Guantes nuevos
+	</string>
+	<string name="New Undershirt">
+		Camiseta nueva
+	</string>
+	<string name="New Underpants">
+		Ropa interior nueva
+	</string>
+	<string name="New Skirt">
+		Falda nueva
+	</string>
+	<string name="New Alpha">
+		Nueva Alfa
+	</string>
+	<string name="New Tattoo">
+		Tatuaje nuevo
+	</string>
+	<string name="New Universal">
+		Nuevo Universal
+	</string>
+	<string name="New Physics">
+		Nueva física
+	</string>
+	<string name="Invalid Wearable">
+		No se puede poner
+	</string>
+	<string name="New Gesture">
+		Gesto nuevo
+	</string>
+	<string name="New Script">
+		Script nuevo
+	</string>
+	<string name="New Note">
+		Nota nueva
+	</string>
+	<string name="New Folder">
+		Carpeta nueva
+	</string>
+	<string name="Contents">
+		Contenidos
+	</string>
+	<string name="Gesture">
+		Gestos
+	</string>
+	<string name="Male Gestures">
+		Gestos de hombre
+	</string>
+	<string name="Female Gestures">
+		Gestos de mujer
+	</string>
+	<string name="Other Gestures">
+		Otros gestos
+	</string>
+	<string name="Speech Gestures">
+		Gestos al hablar
+	</string>
+	<string name="Common Gestures">
+		Gestos corrientes
+	</string>
+	<string name="Male - Excuse me">
+		Varón - Disculpa
+	</string>
+	<string name="Male - Get lost">
+		Varón – Déjame en paz
+	</string>
+	<string name="Male - Blow kiss">
+		Varón - Lanzar un beso
+	</string>
+	<string name="Male - Boo">
+		Varón - Abucheo
+	</string>
+	<string name="Male - Bored">
+		Varón - Aburrido
+	</string>
+	<string name="Male - Hey">
+		Varón – ¡Eh!
+	</string>
+	<string name="Male - Laugh">
+		Varón - Risa
+	</string>
+	<string name="Male - Repulsed">
+		Varón - Rechazo
+	</string>
+	<string name="Male - Shrug">
+		Varón - Encogimiento de hombros
+	</string>
+	<string name="Male - Stick tougue out">
+		Hombre - Sacando la lengua
+	</string>
+	<string name="Male - Wow">
+		Varón - Admiración
+	</string>
+	<string name="Female - Chuckle">
+		Mujer - Risa suave
+	</string>
+	<string name="Female - Cry">
+		Mujer - Llorar
+	</string>
+	<string name="Female - Embarrassed">
+		Mujer - Ruborizada
+	</string>
+	<string name="Female - Excuse me">
+		Mujer - Disculpa
+	</string>
+	<string name="Female - Get lost">
+		Mujer – Déjame en paz
+	</string>
+	<string name="Female - Blow kiss">
+		Mujer - Lanzar un beso
+	</string>
+	<string name="Female - Boo">
+		Mujer - Abucheo
+	</string>
+	<string name="Female - Bored">
+		Mujer - Aburrida
+	</string>
+	<string name="Female - Hey">
+		Mujer - ¡Eh!
+	</string>
+	<string name="Female - Hey baby">
+		Mujer - ¡Eh, encanto!
+	</string>
+	<string name="Female - Laugh">
+		Mujer - Risa
+	</string>
+	<string name="Female - Looking good">
+		Mujer - Buen aspecto
+	</string>
+	<string name="Female - Over here">
+		Mujer - Por aquí
+	</string>
+	<string name="Female - Please">
+		Mujer - Por favor
+	</string>
+	<string name="Female - Repulsed">
+		Mujer - Rechazo
+	</string>
+	<string name="Female - Shrug">
+		Mujer - Encogimiento de hombros
+	</string>
+	<string name="Female - Stick tougue out">
+		Mujer - Sacando la lengua
+	</string>
+	<string name="Female - Wow">
+		Mujer - Admiración
+	</string>
+	<string name="New Daycycle">
+		Nuevo Ciclo del día
+	</string>
+	<string name="New Water">
+		Nueva Agua
+	</string>
+	<string name="New Sky">
+		Nuevo Cielo
+	</string>
+	<string name="/bow">
+		/reverencia
+	</string>
+	<string name="/clap">
+		/aplaudir
+	</string>
+	<string name="/count">
+		/contar
+	</string>
+	<string name="/extinguish">
+		/apagar
+	</string>
+	<string name="/kmb">
+		/bmc
+	</string>
+	<string name="/muscle">
+		/músculo
+	</string>
+	<string name="/no">
+		/no
+	</string>
+	<string name="/no!">
+		/¡no!
+	</string>
+	<string name="/paper">
+		/papel
+	</string>
+	<string name="/pointme">
+		/señalarme
+	</string>
+	<string name="/pointyou">
+		/señalarte
+	</string>
+	<string name="/rock">
+		/piedra
+	</string>
+	<string name="/scissor">
+		/tijera
+	</string>
+	<string name="/smoke">
+		/fumar
+	</string>
+	<string name="/stretch">
+		/estirar
+	</string>
+	<string name="/whistle">
+		/silbar
+	</string>
+	<string name="/yes">
+		/sí
+	</string>
+	<string name="/yes!">
+		/¡sí!
+	</string>
+	<string name="afk">
+		ausente
+	</string>
+	<string name="dance1">
+		baile1
+	</string>
+	<string name="dance2">
+		baile2
+	</string>
+	<string name="dance3">
+		baile3
+	</string>
+	<string name="dance4">
+		baile4
+	</string>
+	<string name="dance5">
+		baile5
+	</string>
+	<string name="dance6">
+		baile6
+	</string>
+	<string name="dance7">
+		baile7
+	</string>
+	<string name="dance8">
+		baile8
+	</string>
+	<string name="AvatarBirthDateFormat">
+		[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]
+	</string>
+	<string name="DefaultMimeType">
+		ninguno/ninguno
+	</string>
+	<string name="texture_load_dimensions_error">
+		No se puede subir imágenes mayores de [WIDTH]*[HEIGHT]
+	</string>
+	<string name="outfit_photo_load_dimensions_error">
+		La foto del vestuario puede tener como máx. un tamaño de [WIDTH]*[HEIGHT]. Cambia el tamaño o utiliza otra imagen
+	</string>
+	<string name="outfit_photo_select_dimensions_error">
+		La foto del vestuario puede tener como máx. un tamaño de [WIDTH]*[HEIGHT]. Selecciona otra textura
+	</string>
+	<string name="outfit_photo_verify_dimensions_error">
+		No se pueden verificar las dimensiones de la foto. Espera hasta que aparezca el tamaño de la foto en el selector
+	</string>
 	<string name="words_separator" value=","/>
-	<string name="server_is_down">Parece que hay algún problema que ha escapado a nuestros controles.
+	<string name="server_is_down">
+		Parece que hay algún problema que ha escapado a nuestros controles.
 
 Visita http://status.secondlifegrid.net para ver si hay alguna incidencia conocida que esté afectando al servicio.
-        Si sigues teniendo problemas, comprueba la configuración de la red y del servidor de seguridad.</string>
-	<string name="dateTimeWeekdaysNames">Domingo:Lunes:Martes:Miércoles:Jueves:Viernes:Sábado</string>
-	<string name="dateTimeWeekdaysShortNames">Dom:Lun:Mar:Mié:Jue:Vie:Sáb</string>
-	<string name="dateTimeMonthNames">Enero:Febrero:Marzo:Abril:Mayo:Junio:Julio:Agosto:Septiembre:Octubre:Noviembre:Diciembre</string>
-	<string name="dateTimeMonthShortNames">Ene:Feb:Mar:Abr:May:Jun:Jul:Ago:Sep:Oct:Nov:Dic</string>
-	<string name="dateTimeDayFormat">[MDAY]</string>
-	<string name="dateTimeAM">AM</string>
-	<string name="dateTimePM">PM</string>
-	<string name="LocalEstimateUSD">[AMOUNT] US$</string>
-	<string name="Group Ban">Expulsión de grupo</string>
-	<string name="Membership">Membresía</string>
-	<string name="Roles">Roles</string>
-	<string name="Group Identity">Indentidad de grupo</string>
-	<string name="Parcel Management">Gestión de la parcela</string>
-	<string name="Parcel Identity">Identidad de la parcela</string>
-	<string name="Parcel Settings">Configuración de la parcela</string>
-	<string name="Parcel Powers">Poder de la parcela</string>
-	<string name="Parcel Access">Acceso a la parcela</string>
-	<string name="Parcel Content">Contenido de la parcela</string>
-	<string name="Object Management">Manejo de objetos</string>
-	<string name="Accounting">Contabilidad</string>
-	<string name="Notices">Avisos</string>
-	<string name="Chat" value="Chat :">Chat</string>
-	<string name="DeleteItems">¿Deseas eliminar los elementos seleccionados?</string>
-	<string name="DeleteItem">¿Deseas eliminar el elemento seleccionado?</string>
-	<string name="EmptyOutfitText">No hay elementos en este vestuario</string>
-	<string name="ExternalEditorNotSet">Selecciona un editor mediante la configuración de ExternalEditor.</string>
-	<string name="ExternalEditorNotFound">No se encuentra el editor externo especificado.
+        Si sigues teniendo problemas, comprueba la configuración de la red y del servidor de seguridad.
+	</string>
+	<string name="dateTimeWeekdaysNames">
+		Domingo:Lunes:Martes:Miércoles:Jueves:Viernes:Sábado
+	</string>
+	<string name="dateTimeWeekdaysShortNames">
+		Dom:Lun:Mar:Mié:Jue:Vie:Sáb
+	</string>
+	<string name="dateTimeMonthNames">
+		Enero:Febrero:Marzo:Abril:Mayo:Junio:Julio:Agosto:Septiembre:Octubre:Noviembre:Diciembre
+	</string>
+	<string name="dateTimeMonthShortNames">
+		Ene:Feb:Mar:Abr:May:Jun:Jul:Ago:Sep:Oct:Nov:Dic
+	</string>
+	<string name="dateTimeDayFormat">
+		[MDAY]
+	</string>
+	<string name="dateTimeAM">
+		AM
+	</string>
+	<string name="dateTimePM">
+		PM
+	</string>
+	<string name="LocalEstimateUSD">
+		[AMOUNT] US$
+	</string>
+	<string name="Group Ban">
+		Expulsión de grupo
+	</string>
+	<string name="Membership">
+		Membresía
+	</string>
+	<string name="Roles">
+		Roles
+	</string>
+	<string name="Group Identity">
+		Indentidad de grupo
+	</string>
+	<string name="Parcel Management">
+		Gestión de la parcela
+	</string>
+	<string name="Parcel Identity">
+		Identidad de la parcela
+	</string>
+	<string name="Parcel Settings">
+		Configuración de la parcela
+	</string>
+	<string name="Parcel Powers">
+		Poder de la parcela
+	</string>
+	<string name="Parcel Access">
+		Acceso a la parcela
+	</string>
+	<string name="Parcel Content">
+		Contenido de la parcela
+	</string>
+	<string name="Object Management">
+		Manejo de objetos
+	</string>
+	<string name="Accounting">
+		Contabilidad
+	</string>
+	<string name="Notices">
+		Avisos
+	</string>
+	<string name="Chat" value="Chat :">
+		Chat
+	</string>
+	<string name="DeleteItems">
+		¿Deseas eliminar los elementos seleccionados?
+	</string>
+	<string name="DeleteItem">
+		¿Deseas eliminar el elemento seleccionado?
+	</string>
+	<string name="EmptyOutfitText">
+		No hay elementos en este vestuario
+	</string>
+	<string name="ExternalEditorNotSet">
+		Selecciona un editor mediante la configuración de ExternalEditor.
+	</string>
+	<string name="ExternalEditorNotFound">
+		No se encuentra el editor externo especificado.
 Inténtalo incluyendo la ruta de acceso al editor entre comillas
-(por ejemplo, &quot;/ruta a mi/editor&quot; &quot;%s&quot;).</string>
-	<string name="ExternalEditorCommandParseError">Error al analizar el comando de editor externo.</string>
-	<string name="ExternalEditorFailedToRun">Error al ejecutar el editor externo.</string>
-	<string name="TranslationFailed">Error al traducir: [REASON]</string>
-	<string name="TranslationResponseParseError">Error al analizar la respuesta de la traducción.</string>
-	<string name="Esc">Esc</string>
-	<string name="Space">Space</string>
-	<string name="Enter">Enter</string>
-	<string name="Tab">Tab</string>
-	<string name="Ins">Ins</string>
-	<string name="Del">Del</string>
-	<string name="Backsp">Backsp</string>
-	<string name="Shift">Shift</string>
-	<string name="Ctrl">Ctrl</string>
-	<string name="Alt">Alt</string>
-	<string name="CapsLock">CapsLock</string>
-	<string name="Home">Base</string>
-	<string name="End">End</string>
-	<string name="PgUp">PgUp</string>
-	<string name="PgDn">PgDn</string>
-	<string name="F1">F1</string>
-	<string name="F2">F2</string>
-	<string name="F3">F3</string>
-	<string name="F4">F4</string>
-	<string name="F5">F5</string>
-	<string name="F6">F6</string>
-	<string name="F7">F7</string>
-	<string name="F8">F8</string>
-	<string name="F9">F9</string>
-	<string name="F10">F10</string>
-	<string name="F11">F11</string>
-	<string name="F12">F12</string>
-	<string name="Add">Añadir</string>
-	<string name="Subtract">Restar</string>
-	<string name="Multiply">Multiplicar</string>
-	<string name="Divide">Dividir</string>
-	<string name="PAD_DIVIDE">PAD_DIVIDE</string>
-	<string name="PAD_LEFT">PAD_LEFT</string>
-	<string name="PAD_RIGHT">PAD_RIGHT</string>
-	<string name="PAD_DOWN">PAD_DOWN</string>
-	<string name="PAD_UP">PAD_UP</string>
-	<string name="PAD_HOME">PAD_HOME</string>
-	<string name="PAD_END">PAD_END</string>
-	<string name="PAD_PGUP">PAD_PGUP</string>
-	<string name="PAD_PGDN">PAD_PGDN</string>
-	<string name="PAD_CENTER">PAD_CENTER</string>
-	<string name="PAD_INS">PAD_INS</string>
-	<string name="PAD_DEL">PAD_DEL</string>
-	<string name="PAD_Enter">PAD_Enter</string>
-	<string name="PAD_BUTTON0">PAD_BUTTON0</string>
-	<string name="PAD_BUTTON1">PAD_BUTTON1</string>
-	<string name="PAD_BUTTON2">PAD_BUTTON2</string>
-	<string name="PAD_BUTTON3">PAD_BUTTON3</string>
-	<string name="PAD_BUTTON4">PAD_BUTTON4</string>
-	<string name="PAD_BUTTON5">PAD_BUTTON5</string>
-	<string name="PAD_BUTTON6">PAD_BUTTON6</string>
-	<string name="PAD_BUTTON7">PAD_BUTTON7</string>
-	<string name="PAD_BUTTON8">PAD_BUTTON8</string>
-	<string name="PAD_BUTTON9">PAD_BUTTON9</string>
-	<string name="PAD_BUTTON10">PAD_BUTTON10</string>
-	<string name="PAD_BUTTON11">PAD_BUTTON11</string>
-	<string name="PAD_BUTTON12">PAD_BUTTON12</string>
-	<string name="PAD_BUTTON13">PAD_BUTTON13</string>
-	<string name="PAD_BUTTON14">PAD_BUTTON14</string>
-	<string name="PAD_BUTTON15">PAD_BUTTON15</string>
-	<string name="-">-</string>
-	<string name="=">=</string>
-	<string name="`">`</string>
-	<string name=";">;</string>
-	<string name="[">[</string>
-	<string name="]">]</string>
-	<string name="\">\</string>
-	<string name="0">0</string>
-	<string name="1">1</string>
-	<string name="2">2</string>
-	<string name="3">3</string>
-	<string name="4">4</string>
-	<string name="5">5</string>
-	<string name="6">6</string>
-	<string name="7">7</string>
-	<string name="8">8</string>
-	<string name="9">9</string>
-	<string name="A">A</string>
-	<string name="B">B</string>
-	<string name="C">C</string>
-	<string name="D">D</string>
-	<string name="E">E</string>
-	<string name="F">F</string>
-	<string name="G">G</string>
-	<string name="H">H</string>
-	<string name="I">I</string>
-	<string name="J">J</string>
-	<string name="K">K</string>
-	<string name="L">L</string>
-	<string name="M">M</string>
-	<string name="N">N</string>
-	<string name="O">O</string>
-	<string name="P">P</string>
-	<string name="Q">Q</string>
-	<string name="R">R</string>
-	<string name="S">S</string>
-	<string name="T">T</string>
-	<string name="U">U</string>
-	<string name="V">V</string>
-	<string name="W">W</string>
-	<string name="X">X</string>
-	<string name="Y">Y</string>
-	<string name="Z">Z</string>
-	<string name="BeaconParticle">Viendo balizas de partículas (azules)</string>
-	<string name="BeaconPhysical">Viendo balizas de objetos materiales (verdes)</string>
-	<string name="BeaconScripted">Viendo balizas de objetos con script (rojas)</string>
-	<string name="BeaconScriptedTouch">Viendo el objeto con script con balizas de función táctil (rojas)</string>
-	<string name="BeaconSound">Viendo balizas de sonido (amarillas)</string>
-	<string name="BeaconMedia">Viendo balizas de medios (blancas)</string>
-	<string name="BeaconSun">Visualización de la baliza de dirección del sol (naranja)</string>
-	<string name="BeaconMoon">Visualización de la baliza de dirección de la luna (violeta)</string>
-	<string name="ParticleHiding">Ocultando las partículas</string>
-	<string name="Command_AboutLand_Label">Acerca del terreno</string>
-	<string name="Command_Appearance_Label">Apariencia</string>
-	<string name="Command_Avatar_Label">Avatar</string>
-	<string name="Command_Build_Label">Construir</string>
-	<string name="Command_Chat_Label">Chat</string>
-	<string name="Command_Conversations_Label">Conversaciones</string>
-	<string name="Command_Compass_Label">Brújula</string>
-	<string name="Command_Destinations_Label">Destinos</string>
-	<string name="Command_Environments_Label">Mis entornos</string>
-	<string name="Command_Facebook_Label">Facebook</string>
-	<string name="Command_Flickr_Label">Flickr</string>
-	<string name="Command_Gestures_Label">Gestos</string>
-	<string name="Command_Grid_Status_Label">Estado del Grid</string>
-	<string name="Command_HowTo_Label">Cómo</string>
-	<string name="Command_Inventory_Label">Inventario</string>
-	<string name="Command_Map_Label">Mapa</string>
-	<string name="Command_Marketplace_Label">Mercado</string>
-	<string name="Command_MarketplaceListings_Label">Mercado</string>
-	<string name="Command_MiniMap_Label">Minimapa</string>
-	<string name="Command_Move_Label">Caminar / Correr / Volar</string>
-	<string name="Command_Outbox_Label">Buzón de salida de comerciante</string>
-	<string name="Command_People_Label">Gente</string>
-	<string name="Command_Picks_Label">Destacados</string>
-	<string name="Command_Places_Label">Lugares</string>
-	<string name="Command_Preferences_Label">Preferencias</string>
-	<string name="Command_Profile_Label">Perfil</string>
-	<string name="Command_Report_Abuse_Label">Denunciar una infracción</string>
-	<string name="Command_Search_Label">Buscar</string>
-	<string name="Command_Snapshot_Label">Foto</string>
-	<string name="Command_Speak_Label">Hablar</string>
-	<string name="Command_Twitter_Label">Twitter</string>
-	<string name="Command_View_Label">Controles de la cámara</string>
-	<string name="Command_Voice_Label">Configuración de voz</string>
-	<string name="Command_AboutLand_Tooltip">Información sobre el terreno que vas a visitar</string>
-	<string name="Command_Appearance_Tooltip">Cambiar tu avatar</string>
-	<string name="Command_Avatar_Tooltip">Elegir un avatar completo</string>
-	<string name="Command_Build_Tooltip">Construir objetos y modificar la forma del terreno</string>
-	<string name="Command_Chat_Tooltip">Habla por chat de texto con las personas próximas</string>
-	<string name="Command_Conversations_Tooltip">Conversar con todos</string>
-	<string name="Command_Compass_Tooltip">Brújula</string>
-	<string name="Command_Destinations_Tooltip">Destinos de interés</string>
-	<string name="Command_Environments_Tooltip">Mis entornos</string>
-	<string name="Command_Facebook_Tooltip">Publicar en Facebook</string>
-	<string name="Command_Flickr_Tooltip">Subir a Flickr</string>
-	<string name="Command_Gestures_Tooltip">Gestos para tu avatar</string>
-	<string name="Command_Grid_Status_Tooltip">Mostrar el estado actual del Grid</string>
-	<string name="Command_HowTo_Tooltip">Cómo hacer las tareas habituales</string>
-	<string name="Command_Inventory_Tooltip">Ver y usar tus pertenencias</string>
-	<string name="Command_Map_Tooltip">Mapa del mundo</string>
-	<string name="Command_Marketplace_Tooltip">Ir de compras</string>
-	<string name="Command_MarketplaceListings_Tooltip">Vende tu creación</string>
-	<string name="Command_MiniMap_Tooltip">Mostrar la gente que está cerca</string>
-	<string name="Command_Move_Tooltip">Desplazando el avatar</string>
-	<string name="Command_Outbox_Tooltip">Transfiere objetos a tu mercado para venderlos</string>
-	<string name="Command_People_Tooltip">Amigos, grupos y personas próximas</string>
-	<string name="Command_Picks_Tooltip">Lugares que se mostrarán como favoritos en tu perfil</string>
-	<string name="Command_Places_Tooltip">Lugares que has guardado</string>
-	<string name="Command_Preferences_Tooltip">Preferencias</string>
-	<string name="Command_Profile_Tooltip">Consulta o edita tu perfil</string>
-	<string name="Command_Report_Abuse_Tooltip">Denunciar una infracción</string>
-	<string name="Command_Search_Tooltip">Buscar lugares, eventos y personas</string>
-	<string name="Command_Snapshot_Tooltip">Tomar una fotografía</string>
-	<string name="Command_Speak_Tooltip">Utiliza el micrófono para hablar con las personas próximas</string>
-	<string name="Command_Twitter_Tooltip">Twitter</string>
-	<string name="Command_View_Tooltip">Cambiando el ángulo de la cámara</string>
-	<string name="Command_Voice_Tooltip">Controles de volumen para las llamadas y la gente que se encuentre cerca de ti en el mundo virtual</string>
-	<string name="Toolbar_Bottom_Tooltip">actualmente en tu barra de herramientas inferior</string>
-	<string name="Toolbar_Left_Tooltip">actualmente en tu barra de herramientas izquierda</string>
-	<string name="Toolbar_Right_Tooltip">actualmente en tu barra de herramientas derecha</string>
-	<string name="Retain%">% retención</string>
-	<string name="Detail">Detalle</string>
-	<string name="Better Detail">Mejor detalle</string>
-	<string name="Surface">Superficie</string>
-	<string name="Solid">Sólido</string>
-	<string name="Wrap">Envoltura</string>
-	<string name="Preview">Vista previa</string>
-	<string name="Normal">Normal</string>
-	<string name="Pathfinding_Wiki_URL">http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer</string>
-	<string name="Pathfinding_Object_Attr_None">Ninguno</string>
-	<string name="Pathfinding_Object_Attr_Permanent">Afecta al navmesh</string>
-	<string name="Pathfinding_Object_Attr_Character">Personaje</string>
-	<string name="Pathfinding_Object_Attr_MultiSelect">(Múltiple)</string>
-	<string name="snapshot_quality_very_low">Muy bajo</string>
-	<string name="snapshot_quality_low">Bajo</string>
-	<string name="snapshot_quality_medium">Medio</string>
-	<string name="snapshot_quality_high">Alto</string>
-	<string name="snapshot_quality_very_high">Muy alto</string>
-	<string name="TeleportMaturityExceeded">El Residente no puede visitar esta región.</string>
-	<string name="UserDictionary">[Usuario]</string>
-	<string name="experience_tools_experience">Experiencia</string>
-	<string name="ExperienceNameNull">(sin experiencia)</string>
-	<string name="ExperienceNameUntitled">(experiencia sin título)</string>
-	<string name="Land-Scope">Activa en el terreno</string>
-	<string name="Grid-Scope">Activa en el Grid</string>
-	<string name="Allowed_Experiences_Tab">PERMITIDO</string>
-	<string name="Blocked_Experiences_Tab">BLOQUEADO</string>
-	<string name="Contrib_Experiences_Tab">COLABORADOR</string>
-	<string name="Admin_Experiences_Tab">ADMIN.</string>
-	<string name="Recent_Experiences_Tab">RECIENTE</string>
-	<string name="Owned_Experiences_Tab">PROPIEDAD</string>
-	<string name="ExperiencesCounter">([EXPERIENCES], máx. [MAXEXPERIENCES])</string>
-	<string name="ExperiencePermission1">hacerte con tus controles</string>
-	<string name="ExperiencePermission3">activar animaciones en tu avatar</string>
-	<string name="ExperiencePermission4">anexar a tu avatar</string>
-	<string name="ExperiencePermission9">seguimiento de la cámara</string>
-	<string name="ExperiencePermission10">controlar tu cámara</string>
-	<string name="ExperiencePermission11">teleportarte</string>
-	<string name="ExperiencePermission12">aceptar automáticamente permisos de experiencias</string>
-	<string name="ExperiencePermission16">forzar que el avatar se siente</string>
-	<string name="ExperiencePermission17">cambiar tu configuración del entorno</string>
-	<string name="ExperiencePermissionShortUnknown">realizar una operación desconocida: [Permission]</string>
-	<string name="ExperiencePermissionShort1">Ponerte al mando</string>
-	<string name="ExperiencePermissionShort3">Activar animaciones</string>
-	<string name="ExperiencePermissionShort4">Anexar</string>
-	<string name="ExperiencePermissionShort9">Seguir la cámara</string>
-	<string name="ExperiencePermissionShort10">Controlar la cámara</string>
-	<string name="ExperiencePermissionShort11">Teleporte</string>
-	<string name="ExperiencePermissionShort12">Otorgar permisos</string>
-	<string name="ExperiencePermissionShort16">Sentarte</string>
-	<string name="ExperiencePermissionShort17">Entorno</string>
-	<string name="logging_calls_disabled_log_empty">No se están registrando las conversaciones. Para empezar a grabar un registro, elige &quot;Guardar: Solo registro&quot; o &quot;Guardar: Registro y transcripciones&quot; en Preferencias &gt; Chat.</string>
-	<string name="logging_calls_disabled_log_not_empty">No se registrarán más conversaciones. Para reanudar la grabación de un registro, elige &quot;Guardar: Solo registro&quot; o &quot;Guardar: Registro y transcripciones&quot; en Preferencias &gt; Chat.</string>
-	<string name="logging_calls_enabled_log_empty">No hay conversaciones grabadas. Después de contactar con una persona, o de que alguien contacte contigo, aquí se mostrará una entrada de registro.</string>
-	<string name="loading_chat_logs">Cargando...</string>
-	<string name="na">n/c</string>
-	<string name="preset_combo_label">-Lista vacía-</string>
-	<string name="Default">Predeterminado</string>
-	<string name="none_paren_cap">(ninguno)</string>
-	<string name="no_limit">Sin límite</string>
-	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">La forma física contiene triángulos demasiado pequeños. Intenta simplificar el modelo físico.</string>
-	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">La forma física contiene datos de confirmación erróneos. Intenta corregir el modelo físico.</string>
-	<string name="Mav_Details_MAV_UNKNOWN_VERSION">La versión de la forma física no es correcta. Configura la versión correcta del modelo físico.</string>
-	<string name="couldnt_resolve_host">Error de DNS al resolver el nombre del host([HOSTNAME]). 
+(por ejemplo, "/ruta a mi/editor" "%s").
+	</string>
+	<string name="ExternalEditorCommandParseError">
+		Error al analizar el comando de editor externo.
+	</string>
+	<string name="ExternalEditorFailedToRun">
+		Error al ejecutar el editor externo.
+	</string>
+	<string name="TranslationFailed">
+		Error al traducir: [REASON]
+	</string>
+	<string name="TranslationResponseParseError">
+		Error al analizar la respuesta de la traducción.
+	</string>
+	<string name="Esc">
+		Esc
+	</string>
+	<string name="Space">
+		Space
+	</string>
+	<string name="Enter">
+		Enter
+	</string>
+	<string name="Tab">
+		Tab
+	</string>
+	<string name="Ins">
+		Ins
+	</string>
+	<string name="Del">
+		Del
+	</string>
+	<string name="Backsp">
+		Backsp
+	</string>
+	<string name="Shift">
+		Shift
+	</string>
+	<string name="Ctrl">
+		Ctrl
+	</string>
+	<string name="Alt">
+		Alt
+	</string>
+	<string name="CapsLock">
+		CapsLock
+	</string>
+	<string name="Home">
+		Base
+	</string>
+	<string name="End">
+		End
+	</string>
+	<string name="PgUp">
+		PgUp
+	</string>
+	<string name="PgDn">
+		PgDn
+	</string>
+	<string name="F1">
+		F1
+	</string>
+	<string name="F2">
+		F2
+	</string>
+	<string name="F3">
+		F3
+	</string>
+	<string name="F4">
+		F4
+	</string>
+	<string name="F5">
+		F5
+	</string>
+	<string name="F6">
+		F6
+	</string>
+	<string name="F7">
+		F7
+	</string>
+	<string name="F8">
+		F8
+	</string>
+	<string name="F9">
+		F9
+	</string>
+	<string name="F10">
+		F10
+	</string>
+	<string name="F11">
+		F11
+	</string>
+	<string name="F12">
+		F12
+	</string>
+	<string name="Add">
+		Añadir
+	</string>
+	<string name="Subtract">
+		Restar
+	</string>
+	<string name="Multiply">
+		Multiplicar
+	</string>
+	<string name="Divide">
+		Dividir
+	</string>
+	<string name="PAD_DIVIDE">
+		PAD_DIVIDE
+	</string>
+	<string name="PAD_LEFT">
+		PAD_LEFT
+	</string>
+	<string name="PAD_RIGHT">
+		PAD_RIGHT
+	</string>
+	<string name="PAD_DOWN">
+		PAD_DOWN
+	</string>
+	<string name="PAD_UP">
+		PAD_UP
+	</string>
+	<string name="PAD_HOME">
+		PAD_HOME
+	</string>
+	<string name="PAD_END">
+		PAD_END
+	</string>
+	<string name="PAD_PGUP">
+		PAD_PGUP
+	</string>
+	<string name="PAD_PGDN">
+		PAD_PGDN
+	</string>
+	<string name="PAD_CENTER">
+		PAD_CENTER
+	</string>
+	<string name="PAD_INS">
+		PAD_INS
+	</string>
+	<string name="PAD_DEL">
+		PAD_DEL
+	</string>
+	<string name="PAD_Enter">
+		PAD_Enter
+	</string>
+	<string name="PAD_BUTTON0">
+		PAD_BUTTON0
+	</string>
+	<string name="PAD_BUTTON1">
+		PAD_BUTTON1
+	</string>
+	<string name="PAD_BUTTON2">
+		PAD_BUTTON2
+	</string>
+	<string name="PAD_BUTTON3">
+		PAD_BUTTON3
+	</string>
+	<string name="PAD_BUTTON4">
+		PAD_BUTTON4
+	</string>
+	<string name="PAD_BUTTON5">
+		PAD_BUTTON5
+	</string>
+	<string name="PAD_BUTTON6">
+		PAD_BUTTON6
+	</string>
+	<string name="PAD_BUTTON7">
+		PAD_BUTTON7
+	</string>
+	<string name="PAD_BUTTON8">
+		PAD_BUTTON8
+	</string>
+	<string name="PAD_BUTTON9">
+		PAD_BUTTON9
+	</string>
+	<string name="PAD_BUTTON10">
+		PAD_BUTTON10
+	</string>
+	<string name="PAD_BUTTON11">
+		PAD_BUTTON11
+	</string>
+	<string name="PAD_BUTTON12">
+		PAD_BUTTON12
+	</string>
+	<string name="PAD_BUTTON13">
+		PAD_BUTTON13
+	</string>
+	<string name="PAD_BUTTON14">
+		PAD_BUTTON14
+	</string>
+	<string name="PAD_BUTTON15">
+		PAD_BUTTON15
+	</string>
+	<string name="-">
+		-
+	</string>
+	<string name="=">
+		=
+	</string>
+	<string name="`">
+		`
+	</string>
+	<string name=";">
+		;
+	</string>
+	<string name="[">
+		[
+	</string>
+	<string name="]">
+		]
+	</string>
+	<string name="\">
+		\
+	</string>
+	<string name="0">
+		0
+	</string>
+	<string name="1">
+		1
+	</string>
+	<string name="2">
+		2
+	</string>
+	<string name="3">
+		3
+	</string>
+	<string name="4">
+		4
+	</string>
+	<string name="5">
+		5
+	</string>
+	<string name="6">
+		6
+	</string>
+	<string name="7">
+		7
+	</string>
+	<string name="8">
+		8
+	</string>
+	<string name="9">
+		9
+	</string>
+	<string name="A">
+		A
+	</string>
+	<string name="B">
+		B
+	</string>
+	<string name="C">
+		C
+	</string>
+	<string name="D">
+		D
+	</string>
+	<string name="E">
+		E
+	</string>
+	<string name="F">
+		F
+	</string>
+	<string name="G">
+		G
+	</string>
+	<string name="H">
+		H
+	</string>
+	<string name="I">
+		I
+	</string>
+	<string name="J">
+		J
+	</string>
+	<string name="K">
+		K
+	</string>
+	<string name="L">
+		L
+	</string>
+	<string name="M">
+		M
+	</string>
+	<string name="N">
+		N
+	</string>
+	<string name="O">
+		O
+	</string>
+	<string name="P">
+		P
+	</string>
+	<string name="Q">
+		Q
+	</string>
+	<string name="R">
+		R
+	</string>
+	<string name="S">
+		S
+	</string>
+	<string name="T">
+		T
+	</string>
+	<string name="U">
+		U
+	</string>
+	<string name="V">
+		V
+	</string>
+	<string name="W">
+		W
+	</string>
+	<string name="X">
+		X
+	</string>
+	<string name="Y">
+		Y
+	</string>
+	<string name="Z">
+		Z
+	</string>
+	<string name="BeaconParticle">
+		Viendo balizas de partículas (azules)
+	</string>
+	<string name="BeaconPhysical">
+		Viendo balizas de objetos materiales (verdes)
+	</string>
+	<string name="BeaconScripted">
+		Viendo balizas de objetos con script (rojas)
+	</string>
+	<string name="BeaconScriptedTouch">
+		Viendo el objeto con script con balizas de función táctil (rojas)
+	</string>
+	<string name="BeaconSound">
+		Viendo balizas de sonido (amarillas)
+	</string>
+	<string name="BeaconMedia">
+		Viendo balizas de medios (blancas)
+	</string>
+	<string name="BeaconSun">
+		Visualización de la baliza de dirección del sol (naranja)
+	</string>
+	<string name="BeaconMoon">
+		Visualización de la baliza de dirección de la luna (violeta)
+	</string>
+	<string name="ParticleHiding">
+		Ocultando las partículas
+	</string>
+	<string name="Command_AboutLand_Label">
+		Acerca del terreno
+	</string>
+	<string name="Command_Appearance_Label">
+		Apariencia
+	</string>
+	<string name="Command_Avatar_Label">
+		Avatar
+	</string>
+	<string name="Command_Build_Label">
+		Construir
+	</string>
+	<string name="Command_Chat_Label">
+		Chat
+	</string>
+	<string name="Command_Conversations_Label">
+		Conversaciones
+	</string>
+	<string name="Command_Compass_Label">
+		Brújula
+	</string>
+	<string name="Command_Destinations_Label">
+		Destinos
+	</string>
+	<string name="Command_Environments_Label">
+		Mis entornos
+	</string>
+	<string name="Command_Facebook_Label">
+		Facebook
+	</string>
+	<string name="Command_Flickr_Label">
+		Flickr
+	</string>
+	<string name="Command_Gestures_Label">
+		Gestos
+	</string>
+	<string name="Command_Grid_Status_Label">
+		Estado del Grid
+	</string>
+	<string name="Command_HowTo_Label">
+		Cómo
+	</string>
+	<string name="Command_Inventory_Label">
+		Inventario
+	</string>
+	<string name="Command_Map_Label">
+		Mapa
+	</string>
+	<string name="Command_Marketplace_Label">
+		Mercado
+	</string>
+	<string name="Command_MarketplaceListings_Label">
+		Mercado
+	</string>
+	<string name="Command_MiniMap_Label">
+		Minimapa
+	</string>
+	<string name="Command_Move_Label">
+		Caminar / Correr / Volar
+	</string>
+	<string name="Command_Outbox_Label">
+		Buzón de salida de comerciante
+	</string>
+	<string name="Command_People_Label">
+		Gente
+	</string>
+	<string name="Command_Picks_Label">
+		Destacados
+	</string>
+	<string name="Command_Places_Label">
+		Lugares
+	</string>
+	<string name="Command_Preferences_Label">
+		Preferencias
+	</string>
+	<string name="Command_Profile_Label">
+		Perfil
+	</string>
+	<string name="Command_Report_Abuse_Label">
+		Denunciar una infracción
+	</string>
+	<string name="Command_Search_Label">
+		Buscar
+	</string>
+	<string name="Command_Snapshot_Label">
+		Foto
+	</string>
+	<string name="Command_Speak_Label">
+		Hablar
+	</string>
+	<string name="Command_Twitter_Label">
+		Twitter
+	</string>
+	<string name="Command_View_Label">
+		Controles de la cámara
+	</string>
+	<string name="Command_Voice_Label">
+		Configuración de voz
+	</string>
+	<string name="Command_AboutLand_Tooltip">
+		Información sobre el terreno que vas a visitar
+	</string>
+	<string name="Command_Appearance_Tooltip">
+		Cambiar tu avatar
+	</string>
+	<string name="Command_Avatar_Tooltip">
+		Elegir un avatar completo
+	</string>
+	<string name="Command_Build_Tooltip">
+		Construir objetos y modificar la forma del terreno
+	</string>
+	<string name="Command_Chat_Tooltip">
+		Habla por chat de texto con las personas próximas
+	</string>
+	<string name="Command_Conversations_Tooltip">
+		Conversar con todos
+	</string>
+	<string name="Command_Compass_Tooltip">
+		Brújula
+	</string>
+	<string name="Command_Destinations_Tooltip">
+		Destinos de interés
+	</string>
+	<string name="Command_Environments_Tooltip">
+		Mis entornos
+	</string>
+	<string name="Command_Facebook_Tooltip">
+		Publicar en Facebook
+	</string>
+	<string name="Command_Flickr_Tooltip">
+		Subir a Flickr
+	</string>
+	<string name="Command_Gestures_Tooltip">
+		Gestos para tu avatar
+	</string>
+	<string name="Command_Grid_Status_Tooltip">
+		Mostrar el estado actual del Grid
+	</string>
+	<string name="Command_HowTo_Tooltip">
+		Cómo hacer las tareas habituales
+	</string>
+	<string name="Command_Inventory_Tooltip">
+		Ver y usar tus pertenencias
+	</string>
+	<string name="Command_Map_Tooltip">
+		Mapa del mundo
+	</string>
+	<string name="Command_Marketplace_Tooltip">
+		Ir de compras
+	</string>
+	<string name="Command_MarketplaceListings_Tooltip">
+		Vende tu creación
+	</string>
+	<string name="Command_MiniMap_Tooltip">
+		Mostrar la gente que está cerca
+	</string>
+	<string name="Command_Move_Tooltip">
+		Desplazando el avatar
+	</string>
+	<string name="Command_Outbox_Tooltip">
+		Transfiere objetos a tu mercado para venderlos
+	</string>
+	<string name="Command_People_Tooltip">
+		Amigos, grupos y personas próximas
+	</string>
+	<string name="Command_Picks_Tooltip">
+		Lugares que se mostrarán como favoritos en tu perfil
+	</string>
+	<string name="Command_Places_Tooltip">
+		Lugares que has guardado
+	</string>
+	<string name="Command_Preferences_Tooltip">
+		Preferencias
+	</string>
+	<string name="Command_Profile_Tooltip">
+		Consulta o edita tu perfil
+	</string>
+	<string name="Command_Report_Abuse_Tooltip">
+		Denunciar una infracción
+	</string>
+	<string name="Command_Search_Tooltip">
+		Buscar lugares, eventos y personas
+	</string>
+	<string name="Command_Snapshot_Tooltip">
+		Tomar una fotografía
+	</string>
+	<string name="Command_Speak_Tooltip">
+		Utiliza el micrófono para hablar con las personas próximas
+	</string>
+	<string name="Command_Twitter_Tooltip">
+		Twitter
+	</string>
+	<string name="Command_View_Tooltip">
+		Cambiando el ángulo de la cámara
+	</string>
+	<string name="Command_Voice_Tooltip">
+		Controles de volumen para las llamadas y la gente que se encuentre cerca de ti en el mundo virtual
+	</string>
+	<string name="Toolbar_Bottom_Tooltip">
+		actualmente en tu barra de herramientas inferior
+	</string>
+	<string name="Toolbar_Left_Tooltip">
+		actualmente en tu barra de herramientas izquierda
+	</string>
+	<string name="Toolbar_Right_Tooltip">
+		actualmente en tu barra de herramientas derecha
+	</string>
+	<string name="Retain%">
+		% retención
+	</string>
+	<string name="Detail">
+		Detalle
+	</string>
+	<string name="Better Detail">
+		Mejor detalle
+	</string>
+	<string name="Surface">
+		Superficie
+	</string>
+	<string name="Solid">
+		Sólido
+	</string>
+	<string name="Wrap">
+		Envoltura
+	</string>
+	<string name="Preview">
+		Vista previa
+	</string>
+	<string name="Normal">
+		Normal
+	</string>
+	<string name="Pathfinding_Wiki_URL">
+		http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer
+	</string>
+	<string name="Pathfinding_Object_Attr_None">
+		Ninguno
+	</string>
+	<string name="Pathfinding_Object_Attr_Permanent">
+		Afecta al navmesh
+	</string>
+	<string name="Pathfinding_Object_Attr_Character">
+		Personaje
+	</string>
+	<string name="Pathfinding_Object_Attr_MultiSelect">
+		(Múltiple)
+	</string>
+	<string name="snapshot_quality_very_low">
+		Muy bajo
+	</string>
+	<string name="snapshot_quality_low">
+		Bajo
+	</string>
+	<string name="snapshot_quality_medium">
+		Medio
+	</string>
+	<string name="snapshot_quality_high">
+		Alto
+	</string>
+	<string name="snapshot_quality_very_high">
+		Muy alto
+	</string>
+	<string name="TeleportMaturityExceeded">
+		El Residente no puede visitar esta región.
+	</string>
+	<string name="UserDictionary">
+		[Usuario]
+	</string>
+	<string name="experience_tools_experience">
+		Experiencia
+	</string>
+	<string name="ExperienceNameNull">
+		(sin experiencia)
+	</string>
+	<string name="ExperienceNameUntitled">
+		(experiencia sin título)
+	</string>
+	<string name="Land-Scope">
+		Activa en el terreno
+	</string>
+	<string name="Grid-Scope">
+		Activa en el Grid
+	</string>
+	<string name="Allowed_Experiences_Tab">
+		PERMITIDO
+	</string>
+	<string name="Blocked_Experiences_Tab">
+		BLOQUEADO
+	</string>
+	<string name="Contrib_Experiences_Tab">
+		COLABORADOR
+	</string>
+	<string name="Admin_Experiences_Tab">
+		ADMIN.
+	</string>
+	<string name="Recent_Experiences_Tab">
+		RECIENTE
+	</string>
+	<string name="Owned_Experiences_Tab">
+		PROPIEDAD
+	</string>
+	<string name="ExperiencesCounter">
+		([EXPERIENCES], máx. [MAXEXPERIENCES])
+	</string>
+	<string name="ExperiencePermission1">
+		hacerte con tus controles
+	</string>
+	<string name="ExperiencePermission3">
+		activar animaciones en tu avatar
+	</string>
+	<string name="ExperiencePermission4">
+		anexar a tu avatar
+	</string>
+	<string name="ExperiencePermission9">
+		seguimiento de la cámara
+	</string>
+	<string name="ExperiencePermission10">
+		controlar tu cámara
+	</string>
+	<string name="ExperiencePermission11">
+		teleportarte
+	</string>
+	<string name="ExperiencePermission12">
+		aceptar automáticamente permisos de experiencias
+	</string>
+	<string name="ExperiencePermission16">
+		forzar que el avatar se siente
+	</string>
+	<string name="ExperiencePermission17">
+		cambiar tu configuración del entorno
+	</string>
+	<string name="ExperiencePermissionShortUnknown">
+		realizar una operación desconocida: [Permission]
+	</string>
+	<string name="ExperiencePermissionShort1">
+		Ponerte al mando
+	</string>
+	<string name="ExperiencePermissionShort3">
+		Activar animaciones
+	</string>
+	<string name="ExperiencePermissionShort4">
+		Anexar
+	</string>
+	<string name="ExperiencePermissionShort9">
+		Seguir la cámara
+	</string>
+	<string name="ExperiencePermissionShort10">
+		Controlar la cámara
+	</string>
+	<string name="ExperiencePermissionShort11">
+		Teleporte
+	</string>
+	<string name="ExperiencePermissionShort12">
+		Otorgar permisos
+	</string>
+	<string name="ExperiencePermissionShort16">
+		Sentarte
+	</string>
+	<string name="ExperiencePermissionShort17">
+		Entorno
+	</string>
+	<string name="logging_calls_disabled_log_empty">
+		No se están registrando las conversaciones. Para empezar a grabar un registro, elige "Guardar: Solo registro" o "Guardar: Registro y transcripciones" en Preferencias &gt; Chat.
+	</string>
+	<string name="logging_calls_disabled_log_not_empty">
+		No se registrarán más conversaciones. Para reanudar la grabación de un registro, elige "Guardar: Solo registro" o "Guardar: Registro y transcripciones" en Preferencias &gt; Chat.
+	</string>
+	<string name="logging_calls_enabled_log_empty">
+		No hay conversaciones grabadas. Después de contactar con una persona, o de que alguien contacte contigo, aquí se mostrará una entrada de registro.
+	</string>
+	<string name="loading_chat_logs">
+		Cargando...
+	</string>
+	<string name="na">
+		n/c
+	</string>
+	<string name="preset_combo_label">
+		-Lista vacía-
+	</string>
+	<string name="Default">
+		Predeterminado
+	</string>
+	<string name="none_paren_cap">
+		(ninguno)
+	</string>
+	<string name="no_limit">
+		Sin límite
+	</string>
+	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">
+		La forma física contiene triángulos demasiado pequeños. Intenta simplificar el modelo físico.
+	</string>
+	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">
+		La forma física contiene datos de confirmación erróneos. Intenta corregir el modelo físico.
+	</string>
+	<string name="Mav_Details_MAV_UNKNOWN_VERSION">
+		La versión de la forma física no es correcta. Configura la versión correcta del modelo físico.
+	</string>
+	<string name="couldnt_resolve_host">
+		Error de DNS al resolver el nombre del host([HOSTNAME]). 
 Por favor verifica si puedes conectarte al sitio web www.secondlife.com. 
 Si puedes conectarte, pero aún recibes este error, por favor accede a 
-la sección Soporte y genera un informe del problema.</string>
-	<string name="ssl_peer_certificate">El servidor de inicio de sesión no pudo verificarse vía SSL. 
+la sección Soporte y genera un informe del problema.
+	</string>
+	<string name="ssl_peer_certificate">
+		El servidor de inicio de sesión no pudo verificarse vía SSL. 
 Si aún recibes este error, por favor accede a 
 la sección Soporte del sitio web Secondlife.com 
-y genera un informe del problema.</string>
-	<string name="ssl_connect_error">En general esto significa que el horario de tu computadora no está bien configurado. 
+y genera un informe del problema.
+	</string>
+	<string name="ssl_connect_error">
+		En general esto significa que el horario de tu computadora no está bien configurado. 
 Por favor accede al Panel de control y asegúrate de que la hora y la fecha estén 
 bien configurados. Verifica también que tu red y tu cortafuegos estén bien 
 configurados. Si aún recibes este error, por favor accede a la sección Soporte 
 del sitio web Secondlife.com y genera un informe del problema. 
 
-[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de conocimientos]</string>
+[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de conocimientos]
+	</string>
 </strings>

--- a/indra/newview/skins/default/xui/es/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/es/teleport_strings.xml
@@ -1,39 +1,95 @@
 <?xml version="1.0" ?>
 <teleport_messages>
 	<message_set name="errors">
-		<message name="invalid_tport">Ha habido un problema al procesar tu petición de teleporte. Debes volver a iniciar sesión antes de poder teleportarte de nuevo.
-Si sigues recibiendo este mensaje, por favor, acude al [SUPPORT_SITE].</message>
-		<message name="invalid_region_handoff">Ha habido un problema al procesar tu paso a otra región. Debes volver a iniciar sesión para poder pasar de región a región.
-Si sigues recibiendo este mensaje, por favor, acude al [SUPPORT_SITE].</message>
-		<message name="blocked_tport">Lo sentimos, en estos momentos los teleportes están bloqueados. Vuelve a intentarlo en un momento. Si sigues sin poder teleportarte, desconéctate y vuelve a iniciar sesión para solucionar el problema.</message>
-		<message name="nolandmark_tport">Lo sentimos, pero el sistema no ha podido localizar el destino de este hito.</message>
-		<message name="timeout_tport">Lo sentimos, pero el sistema no ha podido completar el teleporte.
-Vuelva a intentarlo en un momento.</message>
-		<message name="NoHelpIslandTP">No te puedes volver a teleportar a la isla de bienvenida.
-Para repetir el tutorial, visita la isla de bienvenida pública.</message>
-		<message name="noaccess_tport">Lo sentimos, pero no tienes acceso al destino de este teleporte.</message>
-		<message name="missing_attach_tport">Aún no han llegado tus objetos anexados. Espera unos segundos más o desconéctate y vuelve a iniciar sesión antes de teleportarte.</message>
-		<message name="too_many_uploads_tport">La cola de espera en esta región está actualmente obstruida, por lo que tu petición de teleporte no se atenderá en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos o ve a una zona menos ocupada.</message>
-		<message name="expired_tport">Lo sentimos, pero el sistema no ha podido atender a tu petición de teleporte en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos.</message>
-		<message name="expired_region_handoff">Lo sentimos, pero el sistema no ha podido completar tu paso a otra región en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos.</message>
-		<message name="no_host">Ha sido imposible encontrar el destino del teleporte: o está desactivado temporalmente o ya no existe. Por favor, vuelve a intentarlo en unos minutos.</message>
-		<message name="no_inventory_host">En estos momentos no está disponible el sistema del inventario.</message>
-		<message name="MustGetAgeRegion">Solo pueden acceder a esta región los mayores de 18 años.</message>
-		<message name="RegionTPSpecialUsageBlocked">No puedes entrar en la región. '[REGION_NAME]' es una región de juegos de habilidad, y debes cumplir determinados criterios para poder entrar en ella. Consulta los detalles en las [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life P+F de juegos de habilidad].</message>
-		<message name="preexisting_tport">Lo sentimos, pero el sistema no pudo comenzar tu teleportacion. Por favor inténtalo de nuevo en unos minutos</message>
+		<message name="invalid_tport">
+			Ha habido un problema al procesar tu petición de teleporte. Debes volver a iniciar sesión antes de poder teleportarte de nuevo.
+Si sigues recibiendo este mensaje, por favor, acude al [SUPPORT_SITE].
+		</message>
+		<message name="invalid_region_handoff">
+			Ha habido un problema al procesar tu paso a otra región. Debes volver a iniciar sesión para poder pasar de región a región.
+Si sigues recibiendo este mensaje, por favor, acude al [SUPPORT_SITE].
+		</message>
+		<message name="blocked_tport">
+			Lo sentimos, en estos momentos los teleportes están bloqueados. Vuelve a intentarlo en un momento. Si sigues sin poder teleportarte, desconéctate y vuelve a iniciar sesión para solucionar el problema.
+		</message>
+		<message name="nolandmark_tport">
+			Lo sentimos, pero el sistema no ha podido localizar el destino de este hito.
+		</message>
+		<message name="timeout_tport">
+			Lo sentimos, pero el sistema no ha podido completar el teleporte.
+Vuelva a intentarlo en un momento.
+		</message>
+		<message name="NoHelpIslandTP">
+			No te puedes volver a teleportar a la isla de bienvenida.
+Para repetir el tutorial, visita la isla de bienvenida pública.
+		</message>
+		<message name="noaccess_tport">
+			Lo sentimos, pero no tienes acceso al destino de este teleporte.
+		</message>
+		<message name="missing_attach_tport">
+			Aún no han llegado tus objetos anexados. Espera unos segundos más o desconéctate y vuelve a iniciar sesión antes de teleportarte.
+		</message>
+		<message name="too_many_uploads_tport">
+			La cola de espera en esta región está actualmente obstruida, por lo que tu petición de teleporte no se atenderá en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos o ve a una zona menos ocupada.
+		</message>
+		<message name="expired_tport">
+			Lo sentimos, pero el sistema no ha podido atender a tu petición de teleporte en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos.
+		</message>
+		<message name="expired_region_handoff">
+			Lo sentimos, pero el sistema no ha podido completar tu paso a otra región en un tiempo prudencial. Por favor, vuelve a intentarlo en unos minutos.
+		</message>
+		<message name="no_host">
+			Ha sido imposible encontrar el destino del teleporte: o está desactivado temporalmente o ya no existe. Por favor, vuelve a intentarlo en unos minutos.
+		</message>
+		<message name="no_inventory_host">
+			En estos momentos no está disponible el sistema del inventario.
+		</message>
+		<message name="MustGetAgeRegion">
+			Solo pueden acceder a esta región los mayores de 18 años.
+		</message>
+		<message name="RegionTPSpecialUsageBlocked">
+			No puedes entrar en la región. '[REGION_NAME]' es una región de juegos de habilidad, y debes cumplir determinados criterios para poder entrar en ella. Consulta los detalles en las [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life P+F de juegos de habilidad].
+		</message>
+		<message name="preexisting_tport">
+			Lo sentimos, pero el sistema no pudo comenzar tu teleportacion. Por favor inténtalo de nuevo en unos minutos
+		</message>
 	</message_set>
 	<message_set name="progress">
-		<message name="sending_dest">Llevando al destino.</message>
-		<message name="redirecting">Redireccionando a una posición diferente.</message>
-		<message name="relaying">Reorientando el destino.</message>
-		<message name="sending_home">Enviando la petición de posición de la Base.</message>
-		<message name="sending_landmark">Enviando la petición de posición del hito.</message>
-		<message name="completing">Completando el teleporte.</message>
-		<message name="completed_from">Teleporte realizado desde [T_SLURL]</message>
-		<message name="resolving">Especificando el destino.</message>
-		<message name="contacting">Contactando con la nueva región.</message>
-		<message name="arriving">Llegando...</message>
-		<message name="requesting">Solicitando teleporte...</message>
-		<message name="pending">Teleporte pendiente...</message>
+		<message name="sending_dest">
+			Llevando al destino.
+		</message>
+		<message name="redirecting">
+			Redireccionando a una posición diferente.
+		</message>
+		<message name="relaying">
+			Reorientando el destino.
+		</message>
+		<message name="sending_home">
+			Enviando la petición de posición de la Base.
+		</message>
+		<message name="sending_landmark">
+			Enviando la petición de posición del hito.
+		</message>
+		<message name="completing">
+			Completando el teleporte.
+		</message>
+		<message name="completed_from">
+			Teleporte realizado desde [T_SLURL]
+		</message>
+		<message name="resolving">
+			Especificando el destino.
+		</message>
+		<message name="contacting">
+			Contactando con la nueva región.
+		</message>
+		<message name="arriving">
+			Llegando...
+		</message>
+		<message name="requesting">
+			Solicitando teleporte...
+		</message>
+		<message name="pending">
+			Teleporte pendiente...
+		</message>
 	</message_set>
 </teleport_messages>

--- a/indra/newview/skins/default/xui/fr/strings.xml
+++ b/indra/newview/skins/default/xui/fr/strings.xml
@@ -1,619 +1,1687 @@
 <?xml version="1.0" ?>
 <strings>
-	<string name="SECOND_LIFE">Second Life</string>
-	<string name="APP_NAME">Second Life</string>
-	<string name="CAPITALIZED_APP_NAME">SECOND LIFE</string>
-	<string name="SECOND_LIFE_GRID">Grille de Second Life</string>
-	<string name="SUPPORT_SITE">Portail Assistance Second Life</string>
-	<string name="StartupDetectingHardware">Détection du matériel...</string>
-	<string name="StartupLoading">Chargement de [APP_NAME]...</string>
-	<string name="StartupClearingCache">Vidage du cache...</string>
-	<string name="StartupInitializingTextureCache">Initialisation du cache des textures...</string>
-	<string name="StartupRequireDriverUpdate">Échec d'initialisation des graphiques. Veuillez mettre votre pilote graphique à jour.</string>
-	<string name="AboutHeader">[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
-[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]</string>
-	<string name="BuildConfig">Configuration de la construction [BUILD_CONFIG]</string>
-	<string name="AboutPosition">Vous êtes à [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] dans [REGION], se trouvant à &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+	<string name="SECOND_LIFE">
+		Second Life
+	</string>
+	<string name="APP_NAME">
+		Second Life
+	</string>
+	<string name="CAPITALIZED_APP_NAME">
+		SECOND LIFE
+	</string>
+	<string name="SECOND_LIFE_GRID">
+		Grille de Second Life
+	</string>
+	<string name="SUPPORT_SITE">
+		Portail Assistance Second Life
+	</string>
+	<string name="StartupDetectingHardware">
+		Détection du matériel...
+	</string>
+	<string name="StartupLoading">
+		Chargement de [APP_NAME]...
+	</string>
+	<string name="StartupClearingCache">
+		Vidage du cache...
+	</string>
+	<string name="StartupInitializingTextureCache">
+		Initialisation du cache des textures...
+	</string>
+	<string name="StartupRequireDriverUpdate">
+		Échec d'initialisation des graphiques. Veuillez mettre votre pilote graphique à jour.
+	</string>
+	<string name="AboutHeader">
+		[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
+[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
+	</string>
+	<string name="BuildConfig">
+		Configuration de la construction [BUILD_CONFIG]
+	</string>
+	<string name="AboutPosition">
+		Vous êtes à [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] dans [REGION], se trouvant à &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL : &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (coordonnées globales [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
-[SERVER_RELEASE_NOTES_URL]</string>
-	<string name="AboutSystem">CPU : [CPU]
+[SERVER_RELEASE_NOTES_URL]
+	</string>
+	<string name="AboutSystem">
+		CPU : [CPU]
 Mémoire : [MEMORY_MB] Mo
 Version OS : [OS_VERSION]
 Distributeur de cartes graphiques : [GRAPHICS_CARD_VENDOR]
-Carte graphique : [GRAPHICS_CARD]</string>
-	<string name="AboutDriver">Version Windows Graphics Driver : [GRAPHICS_DRIVER_VERSION]</string>
-	<string name="AboutOGL">Version OpenGL : [OPENGL_VERSION]</string>
-	<string name="AboutSettings">Taille de la fenêtre: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+Carte graphique : [GRAPHICS_CARD]
+	</string>
+	<string name="AboutDriver">
+		Version Windows Graphics Driver : [GRAPHICS_DRIVER_VERSION]
+	</string>
+	<string name="AboutOGL">
+		Version OpenGL : [OPENGL_VERSION]
+	</string>
+	<string name="AboutSettings">
+		Taille de la fenêtre: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Ajustement de la taille de la police : [FONT_SIZE_ADJUSTMENT]pt
 Échelle de l’interface : [UI_SCALE]
 Distance de dessin : [DRAW_DISTANCE]m
 Bande passante : [NET_BANDWITH] kbit/s
 Facteur LOD (niveau de détail) : [LOD_FACTOR]
 Qualité de rendu : [RENDER_QUALITY]
-Mémoire textures : [TEXTURE_MEMORY] Mo</string>
-	<string name="AboutOSXHiDPI">Mode d'affichage HiDPI : [HIDPI]</string>
-	<string name="AboutLibs">J2C Decoder Version: [J2C_VERSION] 
+Mémoire textures : [TEXTURE_MEMORY] Mo
+	</string>
+	<string name="AboutOSXHiDPI">
+		Mode d'affichage HiDPI : [HIDPI]
+	</string>
+	<string name="AboutLibs">
+		J2C Decoder Version: [J2C_VERSION] 
 Audio Driver Version: [AUDIO_DRIVER_VERSION] 
 [LIBCEF_VERSION] 
 LibVLC Version: [LIBVLC_VERSION] 
-Voice Server Version: [VOICE_VERSION]</string>
-	<string name="AboutTraffic">Paquets perdus : [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)</string>
-	<string name="AboutTime">[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]</string>
-	<string name="ErrorFetchingServerReleaseNotesURL">Erreur lors de la récupération de l'URL des notes de version du serveur.</string>
-	<string name="BuildConfiguration">Configuration de la construction</string>
-	<string name="ProgressRestoring">Restauration...</string>
-	<string name="ProgressChangingResolution">Changement de la résolution...</string>
-	<string name="Fullbright">Fullbright (Legacy)</string>
-	<string name="LoginInProgress">La connexion à [APP_NAME] apparaît peut-être comme étant gelée. Veuillez patienter.</string>
-	<string name="LoginInProgressNoFrozen">Connexion...</string>
-	<string name="LoginAuthenticating">Authentification en cours</string>
-	<string name="LoginMaintenance">Maintenance du compte en cours…</string>
-	<string name="LoginAttempt">La tentative de connexion précédente a échoué. Connexion, esssai [NUMBER]</string>
-	<string name="LoginPrecaching">Monde en cours de chargement…</string>
-	<string name="LoginInitializingBrowser">Navigateur Web incorporé en cours d'initialisation…</string>
-	<string name="LoginInitializingMultimedia">Multimédia en cours d'initialisation…</string>
-	<string name="LoginInitializingFonts">Chargement des polices en cours...</string>
-	<string name="LoginVerifyingCache">Fichiers du cache en cours de vérification (peut prendre 60-90 s)...</string>
-	<string name="LoginProcessingResponse">Réponse en cours de traitement…</string>
-	<string name="LoginInitializingWorld">Monde en cours d'initialisation…</string>
-	<string name="LoginDecodingImages">Décodage des images en cours...</string>
-	<string name="LoginInitializingQuicktime">Quicktime en cours d'initialisation</string>
-	<string name="LoginQuicktimeNotFound">Quicktime introuvable, impossible de procéder à l'initialisation.</string>
-	<string name="LoginQuicktimeOK">Initialisation de Quicktime réussie.</string>
-	<string name="LoginRequestSeedCapGrant">Capacités de la région demandées...</string>
-	<string name="LoginRetrySeedCapGrant">Capacités de la région demandées... Tentative n° [NUMBER].</string>
-	<string name="LoginWaitingForRegionHandshake">Liaison avec la région en cours de création...</string>
-	<string name="LoginConnectingToRegion">Connexion avec la région en cours...</string>
-	<string name="LoginDownloadingClothing">Habits en cours de téléchargement...</string>
-	<string name="InvalidCertificate">Certificat non valide ou corrompu renvoyé par le serveur. Contactez l'administrateur de la grille.</string>
-	<string name="CertInvalidHostname">Nom d'hôte non valide utilisé pour accéder au serveur. Vérifiez votre nom d'hôte de grille ou SLURL.</string>
-	<string name="CertExpired">Il semble que le certificat renvoyé par la grille ait expiré.  Vérifiez votre horloge système ou contactez l'administrateur de la grille.</string>
-	<string name="CertKeyUsage">Impossible d'utiliser le certificat renvoyé par le serveur pour SSL. Contactez l'administrateur de la grille.</string>
-	<string name="CertBasicConstraints">Certificats trop nombreux dans la chaîne des certificats du serveur. Contactez l'administrateur de la grille.</string>
-	<string name="CertInvalidSignature">Impossible de vérifier la signature de certificat renvoyée par le serveur de la grille.  Contactez l'administrateur de la grille.</string>
-	<string name="LoginFailedNoNetwork">Erreur réseau : impossible d'établir la connexion. Veuillez vérifier votre connexion réseau.</string>
-	<string name="LoginFailedHeader">Échec de la connexion.</string>
-	<string name="Quit">Quitter</string>
-	<string name="create_account_url">http://join.secondlife.com/?sourceid=[sourceid]</string>
-	<string name="AgniGridLabel">Grille principale de Second Life (Agni)</string>
-	<string name="AditiGridLabel">Grille de test bêta Second Life (Aditi)</string>
-	<string name="ViewerDownloadURL">http://secondlife.com/download</string>
-	<string name="LoginFailedViewerNotPermitted">Le client que vous utilisez ne permet plus d'accéder à Second Life. Téléchargez un nouveau client à la page suivante :
+Voice Server Version: [VOICE_VERSION]
+	</string>
+	<string name="AboutTraffic">
+		Paquets perdus : [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)
+	</string>
+	<string name="AboutTime">
+		[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
+	</string>
+	<string name="ErrorFetchingServerReleaseNotesURL">
+		Erreur lors de la récupération de l'URL des notes de version du serveur.
+	</string>
+	<string name="BuildConfiguration">
+		Configuration de la construction
+	</string>
+	<string name="ProgressRestoring">
+		Restauration...
+	</string>
+	<string name="ProgressChangingResolution">
+		Changement de la résolution...
+	</string>
+	<string name="Fullbright">
+		Fullbright (Legacy)
+	</string>
+	<string name="LoginInProgress">
+		La connexion à [APP_NAME] apparaît peut-être comme étant gelée. Veuillez patienter.
+	</string>
+	<string name="LoginInProgressNoFrozen">
+		Connexion...
+	</string>
+	<string name="LoginAuthenticating">
+		Authentification en cours
+	</string>
+	<string name="LoginMaintenance">
+		Maintenance du compte en cours…
+	</string>
+	<string name="LoginAttempt">
+		La tentative de connexion précédente a échoué. Connexion, esssai [NUMBER]
+	</string>
+	<string name="LoginPrecaching">
+		Monde en cours de chargement…
+	</string>
+	<string name="LoginInitializingBrowser">
+		Navigateur Web incorporé en cours d'initialisation…
+	</string>
+	<string name="LoginInitializingMultimedia">
+		Multimédia en cours d'initialisation…
+	</string>
+	<string name="LoginInitializingFonts">
+		Chargement des polices en cours...
+	</string>
+	<string name="LoginVerifyingCache">
+		Fichiers du cache en cours de vérification (peut prendre 60-90 s)...
+	</string>
+	<string name="LoginProcessingResponse">
+		Réponse en cours de traitement…
+	</string>
+	<string name="LoginInitializingWorld">
+		Monde en cours d'initialisation…
+	</string>
+	<string name="LoginDecodingImages">
+		Décodage des images en cours...
+	</string>
+	<string name="LoginInitializingQuicktime">
+		Quicktime en cours d'initialisation
+	</string>
+	<string name="LoginQuicktimeNotFound">
+		Quicktime introuvable, impossible de procéder à l'initialisation.
+	</string>
+	<string name="LoginQuicktimeOK">
+		Initialisation de Quicktime réussie.
+	</string>
+	<string name="LoginRequestSeedCapGrant">
+		Capacités de la région demandées...
+	</string>
+	<string name="LoginRetrySeedCapGrant">
+		Capacités de la région demandées... Tentative n° [NUMBER].
+	</string>
+	<string name="LoginWaitingForRegionHandshake">
+		Liaison avec la région en cours de création...
+	</string>
+	<string name="LoginConnectingToRegion">
+		Connexion avec la région en cours...
+	</string>
+	<string name="LoginDownloadingClothing">
+		Habits en cours de téléchargement...
+	</string>
+	<string name="InvalidCertificate">
+		Certificat non valide ou corrompu renvoyé par le serveur. Contactez l'administrateur de la grille.
+	</string>
+	<string name="CertInvalidHostname">
+		Nom d'hôte non valide utilisé pour accéder au serveur. Vérifiez votre nom d'hôte de grille ou SLURL.
+	</string>
+	<string name="CertExpired">
+		Il semble que le certificat renvoyé par la grille ait expiré.  Vérifiez votre horloge système ou contactez l'administrateur de la grille.
+	</string>
+	<string name="CertKeyUsage">
+		Impossible d'utiliser le certificat renvoyé par le serveur pour SSL. Contactez l'administrateur de la grille.
+	</string>
+	<string name="CertBasicConstraints">
+		Certificats trop nombreux dans la chaîne des certificats du serveur. Contactez l'administrateur de la grille.
+	</string>
+	<string name="CertInvalidSignature">
+		Impossible de vérifier la signature de certificat renvoyée par le serveur de la grille.  Contactez l'administrateur de la grille.
+	</string>
+	<string name="LoginFailedNoNetwork">
+		Erreur réseau : impossible d'établir la connexion. Veuillez vérifier votre connexion réseau.
+	</string>
+	<string name="LoginFailedHeader">
+		Échec de la connexion.
+	</string>
+	<string name="Quit">
+		Quitter
+	</string>
+	<string name="create_account_url">
+		http://join.secondlife.com/?sourceid=[sourceid]
+	</string>
+	<string name="AgniGridLabel">
+		Grille principale de Second Life (Agni)
+	</string>
+	<string name="AditiGridLabel">
+		Grille de test bêta Second Life (Aditi)
+	</string>
+	<string name="ViewerDownloadURL">
+		http://secondlife.com/download
+	</string>
+	<string name="LoginFailedViewerNotPermitted">
+		Le client que vous utilisez ne permet plus d'accéder à Second Life. Téléchargez un nouveau client à la page suivante :
 http://secondlife.com/download
 
 Pour plus d'informations, consultez la page FAQ ci-dessous :
-http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginIntermediateOptionalUpdateAvailable">Mise à jour facultative du client disponible : [VERSION]</string>
-	<string name="LoginFailedRequiredUpdate">Mise à jour du client requise : [VERSION]</string>
-	<string name="LoginFailedAlreadyLoggedIn">L'agent est déjà connecté.</string>
-	<string name="LoginFailedAuthenticationFailed">Désolé ! La connexion a échoué.
+http://secondlife.com/viewer-access-faq
+	</string>
+	<string name="LoginIntermediateOptionalUpdateAvailable">
+		Mise à jour facultative du client disponible : [VERSION]
+	</string>
+	<string name="LoginFailedRequiredUpdate">
+		Mise à jour du client requise : [VERSION]
+	</string>
+	<string name="LoginFailedAlreadyLoggedIn">
+		L'agent est déjà connecté.
+	</string>
+	<string name="LoginFailedAuthenticationFailed">
+		Désolé ! La connexion a échoué.
 Veuillez vérifier que les éléments ci-dessous ont été correctement saisis :
     * Nom d'utilisateur (par exemple, bobsmith12 ou steller.sunshine)
     * Mot de passe
-Assurez-vous également que la touche Verr. maj n'est pas activée.</string>
-	<string name="LoginFailedPasswordChanged">Votre mot de passe a été modifié pour des raisons de sécurité.
+Assurez-vous également que la touche Verr. maj n'est pas activée.
+	</string>
+	<string name="LoginFailedPasswordChanged">
+		Votre mot de passe a été modifié pour des raisons de sécurité.
 Veuillez accéder à votre compte à la page http://secondlife.com/password
 et répondre à la question de sécurité afin de réinitialiser votre mot de passe.
-Nous vous prions de nous excuser pour la gêne occasionnée.</string>
-	<string name="LoginFailedPasswordReset">Vous allez devoir réinitialiser votre mot de passe suite à quelques changements effectués sur notre système.
+Nous vous prions de nous excuser pour la gêne occasionnée.
+	</string>
+	<string name="LoginFailedPasswordReset">
+		Vous allez devoir réinitialiser votre mot de passe suite à quelques changements effectués sur notre système.
 Pour cela, accédez à votre compte à la page http://secondlife.com/password
 et répondez à la question de sécurité. Votre mot de passe sera réinitialisé.
-Nous vous prions de nous excuser pour la gêne occasionnée.</string>
-	<string name="LoginFailedEmployeesOnly">Second Life est temporairement fermé pour des raisons de maintenance.
+Nous vous prions de nous excuser pour la gêne occasionnée.
+	</string>
+	<string name="LoginFailedEmployeesOnly">
+		Second Life est temporairement fermé pour des raisons de maintenance.
 Seuls les employés peuvent actuellement y accéder.
-Consultez la page www.secondlife.com/status pour plus d'informations.</string>
-	<string name="LoginFailedPremiumOnly">Les connexions à Second Life sont temporairement limitées afin de s'assurer que l'expérience des utilisateurs présents dans le monde virtuel soit optimale.
+Consultez la page www.secondlife.com/status pour plus d'informations.
+	</string>
+	<string name="LoginFailedPremiumOnly">
+		Les connexions à Second Life sont temporairement limitées afin de s'assurer que l'expérience des utilisateurs présents dans le monde virtuel soit optimale.
 
-Les personnes disposant de comptes gratuits ne pourront pas accéder à Second Life pendant ce temps afin de permettre à celles qui ont payé pour pouvoir utiliser Second Life de le faire.</string>
-	<string name="LoginFailedComputerProhibited">Impossible d'accéder à Second Life depuis cet ordinateur.
+Les personnes disposant de comptes gratuits ne pourront pas accéder à Second Life pendant ce temps afin de permettre à celles qui ont payé pour pouvoir utiliser Second Life de le faire.
+	</string>
+	<string name="LoginFailedComputerProhibited">
+		Impossible d'accéder à Second Life depuis cet ordinateur.
 Si vous pensez qu'il s'agit d'une erreur, contactez
-l'Assistance à l'adresse suivante : support@secondlife.com.</string>
-	<string name="LoginFailedAcountSuspended">Votre compte est inaccessible jusqu'à
-[TIME], heure du Pacifique.</string>
-	<string name="LoginFailedAccountDisabled">Impossible de traiter votre demande à l'heure actuelle. 
-Pour obtenir de l'aide, veuillez contacter l'Assistance Second Life à la page suivante : http://support.secondlife.com.</string>
-	<string name="LoginFailedTransformError">Incohérence des données lors de la connexion.
-Veuillez contacter support@secondlife.com.</string>
-	<string name="LoginFailedAccountMaintenance">Des opérations de maintenance mineures sont actuellement effectuées sur votre compte.
+l'Assistance à l'adresse suivante : support@secondlife.com.
+	</string>
+	<string name="LoginFailedAcountSuspended">
+		Votre compte est inaccessible jusqu'à
+[TIME], heure du Pacifique.
+	</string>
+	<string name="LoginFailedAccountDisabled">
+		Impossible de traiter votre demande à l'heure actuelle. 
+Pour obtenir de l'aide, veuillez contacter l'Assistance Second Life à la page suivante : http://support.secondlife.com.
+	</string>
+	<string name="LoginFailedTransformError">
+		Incohérence des données lors de la connexion.
+Veuillez contacter support@secondlife.com.
+	</string>
+	<string name="LoginFailedAccountMaintenance">
+		Des opérations de maintenance mineures sont actuellement effectuées sur votre compte.
 Votre compte est inaccessible jusqu'à
 [TIME], heure du Pacifique.
-Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com</string>
-	<string name="LoginFailedPendingLogoutFault">Le simulateur a renvoyé une erreur en réponse à la demande de déconnexion.</string>
-	<string name="LoginFailedPendingLogout">Le système est en train de vous déconnecter. 
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LoginFailedUnableToCreateSession">Impossible de créer de session valide.</string>
-	<string name="LoginFailedUnableToConnectToSimulator">Impossible de se connecter à un simulateur.</string>
-	<string name="LoginFailedRestrictedHours">Votre compte permet uniquement d'accéder à Second Life
+Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com
+	</string>
+	<string name="LoginFailedPendingLogoutFault">
+		Le simulateur a renvoyé une erreur en réponse à la demande de déconnexion.
+	</string>
+	<string name="LoginFailedPendingLogout">
+		Le système est en train de vous déconnecter. 
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LoginFailedUnableToCreateSession">
+		Impossible de créer de session valide.
+	</string>
+	<string name="LoginFailedUnableToConnectToSimulator">
+		Impossible de se connecter à un simulateur.
+	</string>
+	<string name="LoginFailedRestrictedHours">
+		Votre compte permet uniquement d'accéder à Second Life
 entre [START] et [END], heure du Pacifique.
 Veuillez réessayer au cours de la période indiquée.
-Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com</string>
-	<string name="LoginFailedIncorrectParameters">Paramètres incorrects.
-Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com</string>
-	<string name="LoginFailedFirstNameNotAlphanumeric">Le paramètre Prénom doit être alphanumérique.
-Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com</string>
-	<string name="LoginFailedLastNameNotAlphanumeric">Le paramètre Nom doit être alphanumérique.
-Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com</string>
-	<string name="LogoutFailedRegionGoingOffline">La région est en train d'être mise hors ligne.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutFailedAgentNotInRegion">Agent absent de la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutFailedPendingLogin">Une autre session était en cours d'ouverture au sein de la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutFailedLoggingOut">La session précédente était en cours de fermeture au sein de la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutFailedStillLoggingOut">Fermeture de la session précédente toujours en cours pour la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutSucceeded">Dernière session fermée au sein de la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LogoutFailedLogoutBegun">Processus de déconnexion commencé pour la région.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="LoginFailedLoggingOutSession">Le système a commencé à fermer votre dernière session.
-Veuillez réessayer de vous connecter dans une minute.</string>
-	<string name="AgentLostConnection">Il y a peut-être des problèmes techniques dans cette région.  Veuillez vérifier votre connexion Internet.</string>
-	<string name="SavingSettings">Enregistrement des paramètres...</string>
-	<string name="LoggingOut">Déconnexion...</string>
-	<string name="ShuttingDown">Arrêt en cours...</string>
-	<string name="YouHaveBeenDisconnected">Vous avez été déconnecté de la région où vous étiez.</string>
-	<string name="SentToInvalidRegion">Vous avez été transféré vers une région non valide.</string>
-	<string name="TestingDisconnect">Test de déconnexion du client</string>
-	<string name="SocialFacebookConnecting">Connexion à Facebook…</string>
-	<string name="SocialFacebookPosting">Publication…</string>
-	<string name="SocialFacebookDisconnecting">Déconnexion de Facebook…</string>
-	<string name="SocialFacebookErrorConnecting">Un problème est survenu lors de la connexion à Facebook.</string>
-	<string name="SocialFacebookErrorPosting">Un problème est survenu lors de la publication sur Facebook.</string>
-	<string name="SocialFacebookErrorDisconnecting">Un problème est survenu lors de la déconnexion à Facebook.</string>
-	<string name="SocialFlickrConnecting">Connexion à Flickr...</string>
-	<string name="SocialFlickrPosting">Publication…</string>
-	<string name="SocialFlickrDisconnecting">Déconnexion de Flickr...</string>
-	<string name="SocialFlickrErrorConnecting">Un problème est survenu lors de la connexion à Flickr.</string>
-	<string name="SocialFlickrErrorPosting">Un problème est survenu lors de la publication sur Flickr.</string>
-	<string name="SocialFlickrErrorDisconnecting">Un problème est survenu lors de la déconnexion de Flickr.</string>
-	<string name="SocialTwitterConnecting">Connexion à Twitter...</string>
-	<string name="SocialTwitterPosting">Publication…</string>
-	<string name="SocialTwitterDisconnecting">Déconnexion de Twitter...</string>
-	<string name="SocialTwitterErrorConnecting">Un problème est survenu lors de la connexion à Twitter.</string>
-	<string name="SocialTwitterErrorPosting">Un problème est survenu lors de la publication sur Twitter.</string>
-	<string name="SocialTwitterErrorDisconnecting">Un problème est survenu lors de la déconnexion de Twitter.</string>
-	<string name="BlackAndWhite">Noir et blanc</string>
-	<string name="Colors1970">Couleurs des années 1970</string>
-	<string name="Intense">Intense</string>
-	<string name="Newspaper">Presse</string>
-	<string name="Sepia">Sépia</string>
-	<string name="Spotlight">Projecteur</string>
-	<string name="Video">Vidéo</string>
-	<string name="Autocontrast">Contraste automatique</string>
-	<string name="LensFlare">Halo</string>
-	<string name="Miniature">Miniature</string>
-	<string name="Toycamera">Toy Camera</string>
-	<string name="TooltipPerson">Personne</string>
-	<string name="TooltipNoName">(pas de nom)</string>
-	<string name="TooltipOwner">Propriétaire :</string>
-	<string name="TooltipPublic">Public</string>
-	<string name="TooltipIsGroup">(Groupe)</string>
-	<string name="TooltipForSaleL$">À vendre : [AMOUNT] L$</string>
-	<string name="TooltipFlagGroupBuild">Contruction de groupe</string>
-	<string name="TooltipFlagNoBuild">Pas de construction</string>
-	<string name="TooltipFlagNoEdit">Contruction de groupe</string>
-	<string name="TooltipFlagNotSafe">Non sécurisé</string>
-	<string name="TooltipFlagNoFly">Interdiction de voler</string>
-	<string name="TooltipFlagGroupScripts">Scripts de groupe</string>
-	<string name="TooltipFlagNoScripts">Pas de scripts</string>
-	<string name="TooltipLand">Terrain :</string>
-	<string name="TooltipMustSingleDrop">Impossible de faire glisser plus d'un objet ici</string>
-	<string name="TooltipTooManyWearables">Vous ne pouvez pas porter un dossier contenant plus de [AMOUNT] articles.  Vous pouvez modifier cette limite dans Avancé &gt; Afficher les paramètres de débogage &gt; WearFolderLimit.</string>
+Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com
+	</string>
+	<string name="LoginFailedIncorrectParameters">
+		Paramètres incorrects.
+Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com
+	</string>
+	<string name="LoginFailedFirstNameNotAlphanumeric">
+		Le paramètre Prénom doit être alphanumérique.
+Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com
+	</string>
+	<string name="LoginFailedLastNameNotAlphanumeric">
+		Le paramètre Nom doit être alphanumérique.
+Si vous pensez qu'il s'agit d'une erreur, contactez l'Assistance à l'adresse suivante : support@secondlife.com
+	</string>
+	<string name="LogoutFailedRegionGoingOffline">
+		La région est en train d'être mise hors ligne.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutFailedAgentNotInRegion">
+		Agent absent de la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutFailedPendingLogin">
+		Une autre session était en cours d'ouverture au sein de la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutFailedLoggingOut">
+		La session précédente était en cours de fermeture au sein de la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutFailedStillLoggingOut">
+		Fermeture de la session précédente toujours en cours pour la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutSucceeded">
+		Dernière session fermée au sein de la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LogoutFailedLogoutBegun">
+		Processus de déconnexion commencé pour la région.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="LoginFailedLoggingOutSession">
+		Le système a commencé à fermer votre dernière session.
+Veuillez réessayer de vous connecter dans une minute.
+	</string>
+	<string name="AgentLostConnection">
+		Il y a peut-être des problèmes techniques dans cette région.  Veuillez vérifier votre connexion Internet.
+	</string>
+	<string name="SavingSettings">
+		Enregistrement des paramètres...
+	</string>
+	<string name="LoggingOut">
+		Déconnexion...
+	</string>
+	<string name="ShuttingDown">
+		Arrêt en cours...
+	</string>
+	<string name="YouHaveBeenDisconnected">
+		Vous avez été déconnecté de la région où vous étiez.
+	</string>
+	<string name="SentToInvalidRegion">
+		Vous avez été transféré vers une région non valide.
+	</string>
+	<string name="TestingDisconnect">
+		Test de déconnexion du client
+	</string>
+	<string name="SocialFacebookConnecting">
+		Connexion à Facebook…
+	</string>
+	<string name="SocialFacebookPosting">
+		Publication…
+	</string>
+	<string name="SocialFacebookDisconnecting">
+		Déconnexion de Facebook…
+	</string>
+	<string name="SocialFacebookErrorConnecting">
+		Un problème est survenu lors de la connexion à Facebook.
+	</string>
+	<string name="SocialFacebookErrorPosting">
+		Un problème est survenu lors de la publication sur Facebook.
+	</string>
+	<string name="SocialFacebookErrorDisconnecting">
+		Un problème est survenu lors de la déconnexion à Facebook.
+	</string>
+	<string name="SocialFlickrConnecting">
+		Connexion à Flickr...
+	</string>
+	<string name="SocialFlickrPosting">
+		Publication…
+	</string>
+	<string name="SocialFlickrDisconnecting">
+		Déconnexion de Flickr...
+	</string>
+	<string name="SocialFlickrErrorConnecting">
+		Un problème est survenu lors de la connexion à Flickr.
+	</string>
+	<string name="SocialFlickrErrorPosting">
+		Un problème est survenu lors de la publication sur Flickr.
+	</string>
+	<string name="SocialFlickrErrorDisconnecting">
+		Un problème est survenu lors de la déconnexion de Flickr.
+	</string>
+	<string name="SocialTwitterConnecting">
+		Connexion à Twitter...
+	</string>
+	<string name="SocialTwitterPosting">
+		Publication…
+	</string>
+	<string name="SocialTwitterDisconnecting">
+		Déconnexion de Twitter...
+	</string>
+	<string name="SocialTwitterErrorConnecting">
+		Un problème est survenu lors de la connexion à Twitter.
+	</string>
+	<string name="SocialTwitterErrorPosting">
+		Un problème est survenu lors de la publication sur Twitter.
+	</string>
+	<string name="SocialTwitterErrorDisconnecting">
+		Un problème est survenu lors de la déconnexion de Twitter.
+	</string>
+	<string name="BlackAndWhite">
+		Noir et blanc
+	</string>
+	<string name="Colors1970">
+		Couleurs des années 1970
+	</string>
+	<string name="Intense">
+		Intense
+	</string>
+	<string name="Newspaper">
+		Presse
+	</string>
+	<string name="Sepia">
+		Sépia
+	</string>
+	<string name="Spotlight">
+		Projecteur
+	</string>
+	<string name="Video">
+		Vidéo
+	</string>
+	<string name="Autocontrast">
+		Contraste automatique
+	</string>
+	<string name="LensFlare">
+		Halo
+	</string>
+	<string name="Miniature">
+		Miniature
+	</string>
+	<string name="Toycamera">
+		Toy Camera
+	</string>
+	<string name="TooltipPerson">
+		Personne
+	</string>
+	<string name="TooltipNoName">
+		(pas de nom)
+	</string>
+	<string name="TooltipOwner">
+		Propriétaire :
+	</string>
+	<string name="TooltipPublic">
+		Public
+	</string>
+	<string name="TooltipIsGroup">
+		(Groupe)
+	</string>
+	<string name="TooltipForSaleL$">
+		À vendre : [AMOUNT] L$
+	</string>
+	<string name="TooltipFlagGroupBuild">
+		Contruction de groupe
+	</string>
+	<string name="TooltipFlagNoBuild">
+		Pas de construction
+	</string>
+	<string name="TooltipFlagNoEdit">
+		Contruction de groupe
+	</string>
+	<string name="TooltipFlagNotSafe">
+		Non sécurisé
+	</string>
+	<string name="TooltipFlagNoFly">
+		Interdiction de voler
+	</string>
+	<string name="TooltipFlagGroupScripts">
+		Scripts de groupe
+	</string>
+	<string name="TooltipFlagNoScripts">
+		Pas de scripts
+	</string>
+	<string name="TooltipLand">
+		Terrain :
+	</string>
+	<string name="TooltipMustSingleDrop">
+		Impossible de faire glisser plus d'un objet ici
+	</string>
+	<string name="TooltipTooManyWearables">
+		Vous ne pouvez pas porter un dossier contenant plus de [AMOUNT] articles.  Vous pouvez modifier cette limite dans Avancé &gt; Afficher les paramètres de débogage &gt; WearFolderLimit.
+	</string>
 	<string name="TooltipPrice" value="[AMOUNT] L$ :"/>
-	<string name="TooltipSLIcon">Il s’agit d’un lien vers une page dans le domaine officiel SecondLife.com ou LindenLab.com.</string>
-	<string name="TooltipOutboxDragToWorld">Vous ne pouvez pas rezzer (charger) des articles du dossier Annonces de la Place de marché</string>
-	<string name="TooltipOutboxWorn">Vous ne pouvez pas mettre d'articles que vous portez dans le dossier Annonces de la Place du marché</string>
-	<string name="TooltipOutboxFolderLevels">Le niveau de dossiers imbriqués dépasse [AMOUNT]. Diminuez le nombre de niveaux de dossiers imbriqués dans d'autres dossiers. Si nécessaire, placez certains articles dans une boîte.</string>
-	<string name="TooltipOutboxTooManyFolders">Le nombre de sous-dossiers dépasse [AMOUNT]. Diminuez le nombre de sous-dossiers dans votre annonce. Si nécessaire, placez certains articles dans une boîte.</string>
-	<string name="TooltipOutboxTooManyObjects">Le nombre d'articles dépasse [AMOUNT]. Pour pouvoir vendre plus de [AMOUNT] articles au sein d'une même annonce, vous devez placer certains de ces articles dans une boîte.</string>
-	<string name="TooltipOutboxTooManyStockItems">Le nombre d'articles de stock dépasse [AMOUNT].</string>
-	<string name="TooltipOutboxCannotDropOnRoot">Vous pouvez uniquement déposer des articles ou des dossiers dans les onglets TOUS ou NON ASSOCIÉS. Sélectionnez l’un de ces onglets et déplacez à nouveau votre ou vos article ou dossiers.</string>
-	<string name="TooltipOutboxNoTransfer">Impossible de vendre ou de transférer un ou plusieurs de ces objets</string>
-	<string name="TooltipOutboxNotInInventory">Vous ne pouvez mettre sur la Place du marché que des articles de votre inventaire</string>
-	<string name="TooltipOutboxLinked">Vous ne pouvez pas mettre des articles ou dossiers liés sur la Place du marché</string>
-	<string name="TooltipOutboxCallingCard">Vous ne pouvez pas mettre des cartes de visite sur la Place du marché</string>
-	<string name="TooltipOutboxDragActive">vous ne pouvez pas déplacer une annonce publiée</string>
-	<string name="TooltipOutboxCannotMoveRoot">Vous ne pouvez pas déplacer le dossier racine des annonces de la Place du marché</string>
-	<string name="TooltipOutboxMixedStock">tous les articles d'un dossier de stock doivent avoir le même type et droit</string>
-	<string name="TooltipDragOntoOwnChild">Impossible de déplacer un dossier vers son enfant</string>
-	<string name="TooltipDragOntoSelf">Impossible de déplacer un dossier vers lui-même</string>
-	<string name="TooltipHttpUrl">Cliquez pour afficher cette page web</string>
-	<string name="TooltipSLURL">Cliquez pour en savoir plus sur cet endroit</string>
-	<string name="TooltipAgentUrl">Cliquez pour afficher le profil de ce résident</string>
-	<string name="TooltipAgentInspect">En savoir plus sur ce résident</string>
-	<string name="TooltipAgentMute">Cliquer pour ignorer ce résident</string>
-	<string name="TooltipAgentUnmute">Cliquer pour ne plus ignorer ce résident</string>
-	<string name="TooltipAgentIM">Cliquer pour envoyer un IM à ce résident</string>
-	<string name="TooltipAgentPay">Cliquer pour payer ce résident</string>
-	<string name="TooltipAgentOfferTeleport">Cliquer pour proposer une téléportation à ce résident</string>
-	<string name="TooltipAgentRequestFriend">Cliquer pour demander à ce résident d'être votre ami</string>
-	<string name="TooltipGroupUrl">Cliquez pour afficher la description de ce groupe</string>
-	<string name="TooltipEventUrl">Cliquez pour afficher la description de cet événement</string>
-	<string name="TooltipClassifiedUrl">Cliquez pour afficher cette petite annonce</string>
-	<string name="TooltipParcelUrl">Cliquez pour afficher la description de cette parcelle</string>
-	<string name="TooltipTeleportUrl">Cliquez pour vous téléporter à cet endroit</string>
-	<string name="TooltipObjectIMUrl">Cliquez pour afficher la description de cet objet</string>
-	<string name="TooltipMapUrl">Cliquez pour voir cet emplacement sur la carte</string>
-	<string name="TooltipSLAPP">Cliquez pour exécuter la commande secondlife://</string>
+	<string name="TooltipSLIcon">
+		Il s’agit d’un lien vers une page dans le domaine officiel SecondLife.com ou LindenLab.com.
+	</string>
+	<string name="TooltipOutboxDragToWorld">
+		Vous ne pouvez pas rezzer (charger) des articles du dossier Annonces de la Place de marché
+	</string>
+	<string name="TooltipOutboxWorn">
+		Vous ne pouvez pas mettre d'articles que vous portez dans le dossier Annonces de la Place du marché
+	</string>
+	<string name="TooltipOutboxFolderLevels">
+		Le niveau de dossiers imbriqués dépasse [AMOUNT]. Diminuez le nombre de niveaux de dossiers imbriqués dans d'autres dossiers. Si nécessaire, placez certains articles dans une boîte.
+	</string>
+	<string name="TooltipOutboxTooManyFolders">
+		Le nombre de sous-dossiers dépasse [AMOUNT]. Diminuez le nombre de sous-dossiers dans votre annonce. Si nécessaire, placez certains articles dans une boîte.
+	</string>
+	<string name="TooltipOutboxTooManyObjects">
+		Le nombre d'articles dépasse [AMOUNT]. Pour pouvoir vendre plus de [AMOUNT] articles au sein d'une même annonce, vous devez placer certains de ces articles dans une boîte.
+	</string>
+	<string name="TooltipOutboxTooManyStockItems">
+		Le nombre d'articles de stock dépasse [AMOUNT].
+	</string>
+	<string name="TooltipOutboxCannotDropOnRoot">
+		Vous pouvez uniquement déposer des articles ou des dossiers dans les onglets TOUS ou NON ASSOCIÉS. Sélectionnez l’un de ces onglets et déplacez à nouveau votre ou vos article ou dossiers.
+	</string>
+	<string name="TooltipOutboxNoTransfer">
+		Impossible de vendre ou de transférer un ou plusieurs de ces objets
+	</string>
+	<string name="TooltipOutboxNotInInventory">
+		Vous ne pouvez mettre sur la Place du marché que des articles de votre inventaire
+	</string>
+	<string name="TooltipOutboxLinked">
+		Vous ne pouvez pas mettre des articles ou dossiers liés sur la Place du marché
+	</string>
+	<string name="TooltipOutboxCallingCard">
+		Vous ne pouvez pas mettre des cartes de visite sur la Place du marché
+	</string>
+	<string name="TooltipOutboxDragActive">
+		vous ne pouvez pas déplacer une annonce publiée
+	</string>
+	<string name="TooltipOutboxCannotMoveRoot">
+		Vous ne pouvez pas déplacer le dossier racine des annonces de la Place du marché
+	</string>
+	<string name="TooltipOutboxMixedStock">
+		tous les articles d'un dossier de stock doivent avoir le même type et droit
+	</string>
+	<string name="TooltipDragOntoOwnChild">
+		Impossible de déplacer un dossier vers son enfant
+	</string>
+	<string name="TooltipDragOntoSelf">
+		Impossible de déplacer un dossier vers lui-même
+	</string>
+	<string name="TooltipHttpUrl">
+		Cliquez pour afficher cette page web
+	</string>
+	<string name="TooltipSLURL">
+		Cliquez pour en savoir plus sur cet endroit
+	</string>
+	<string name="TooltipAgentUrl">
+		Cliquez pour afficher le profil de ce résident
+	</string>
+	<string name="TooltipAgentInspect">
+		En savoir plus sur ce résident
+	</string>
+	<string name="TooltipAgentMute">
+		Cliquer pour ignorer ce résident
+	</string>
+	<string name="TooltipAgentUnmute">
+		Cliquer pour ne plus ignorer ce résident
+	</string>
+	<string name="TooltipAgentIM">
+		Cliquer pour envoyer un IM à ce résident
+	</string>
+	<string name="TooltipAgentPay">
+		Cliquer pour payer ce résident
+	</string>
+	<string name="TooltipAgentOfferTeleport">
+		Cliquer pour proposer une téléportation à ce résident
+	</string>
+	<string name="TooltipAgentRequestFriend">
+		Cliquer pour demander à ce résident d'être votre ami
+	</string>
+	<string name="TooltipGroupUrl">
+		Cliquez pour afficher la description de ce groupe
+	</string>
+	<string name="TooltipEventUrl">
+		Cliquez pour afficher la description de cet événement
+	</string>
+	<string name="TooltipClassifiedUrl">
+		Cliquez pour afficher cette petite annonce
+	</string>
+	<string name="TooltipParcelUrl">
+		Cliquez pour afficher la description de cette parcelle
+	</string>
+	<string name="TooltipTeleportUrl">
+		Cliquez pour vous téléporter à cet endroit
+	</string>
+	<string name="TooltipObjectIMUrl">
+		Cliquez pour afficher la description de cet objet
+	</string>
+	<string name="TooltipMapUrl">
+		Cliquez pour voir cet emplacement sur la carte
+	</string>
+	<string name="TooltipSLAPP">
+		Cliquez pour exécuter la commande secondlife://
+	</string>
 	<string name="CurrentURL" value=" URL actuelle : [CurrentURL]"/>
-	<string name="TooltipEmail">Cliquez pour composer un message</string>
-	<string name="SLurlLabelTeleport">Me téléporter vers</string>
-	<string name="SLurlLabelShowOnMap">Afficher la carte pour</string>
-	<string name="SLappAgentMute">Ignorer</string>
-	<string name="SLappAgentUnmute">Ne plus ignorer</string>
-	<string name="SLappAgentIM">IM</string>
-	<string name="SLappAgentPay">Payer</string>
-	<string name="SLappAgentOfferTeleport">Proposer une téléportation à</string>
-	<string name="SLappAgentRequestFriend">Demande d'amitié</string>
-	<string name="SLappAgentRemoveFriend">Suppression d'un ami</string>
-	<string name="BUTTON_CLOSE_DARWIN">Fermer (⌘W)</string>
-	<string name="BUTTON_CLOSE_WIN">Fermer (Ctrl+W)</string>
-	<string name="BUTTON_CLOSE_CHROME">Fermer</string>
-	<string name="BUTTON_RESTORE">Restaurer</string>
-	<string name="BUTTON_MINIMIZE">Minimiser</string>
-	<string name="BUTTON_TEAR_OFF">Réduire</string>
-	<string name="BUTTON_DOCK">Attacher</string>
-	<string name="BUTTON_HELP">Afficher l'aide</string>
-	<string name="TooltipNotecardNotAllowedTypeDrop">Les éléments de ce type ne peuvent pas être attachés 
-aux notes de cette région.</string>
-	<string name="TooltipNotecardOwnerRestrictedDrop">Seuls des éléments avec des autorisation 
+	<string name="TooltipEmail">
+		Cliquez pour composer un message
+	</string>
+	<string name="SLurlLabelTeleport">
+		Me téléporter vers
+	</string>
+	<string name="SLurlLabelShowOnMap">
+		Afficher la carte pour
+	</string>
+	<string name="SLappAgentMute">
+		Ignorer
+	</string>
+	<string name="SLappAgentUnmute">
+		Ne plus ignorer
+	</string>
+	<string name="SLappAgentIM">
+		IM
+	</string>
+	<string name="SLappAgentPay">
+		Payer
+	</string>
+	<string name="SLappAgentOfferTeleport">
+		Proposer une téléportation à
+	</string>
+	<string name="SLappAgentRequestFriend">
+		Demande d'amitié
+	</string>
+	<string name="SLappAgentRemoveFriend">
+		Suppression d'un ami
+	</string>
+	<string name="BUTTON_CLOSE_DARWIN">
+		Fermer (⌘W)
+	</string>
+	<string name="BUTTON_CLOSE_WIN">
+		Fermer (Ctrl+W)
+	</string>
+	<string name="BUTTON_CLOSE_CHROME">
+		Fermer
+	</string>
+	<string name="BUTTON_RESTORE">
+		Restaurer
+	</string>
+	<string name="BUTTON_MINIMIZE">
+		Minimiser
+	</string>
+	<string name="BUTTON_TEAR_OFF">
+		Réduire
+	</string>
+	<string name="BUTTON_DOCK">
+		Attacher
+	</string>
+	<string name="BUTTON_HELP">
+		Afficher l'aide
+	</string>
+	<string name="TooltipNotecardNotAllowedTypeDrop">
+		Les éléments de ce type ne peuvent pas être attachés 
+aux notes de cette région.
+	</string>
+	<string name="TooltipNotecardOwnerRestrictedDrop">
+		Seuls des éléments avec des autorisation 
 illimitées pour le 'prochain propriétaire' 
-peuvent être joints aux notes.</string>
-	<string name="Searching">Recherche...</string>
-	<string name="NoneFound">Aucun résultat.</string>
-	<string name="RetrievingData">En cours d'extraction...</string>
-	<string name="ReleaseNotes">Notes de version</string>
-	<string name="RELEASE_NOTES_BASE_URL">https://releasenotes.secondlife.com/viewer/</string>
-	<string name="LoadingData">Chargement...</string>
-	<string name="AvatarNameNobody">(personne)</string>
-	<string name="AvatarNameWaiting">(en attente)</string>
-	<string name="AvatarNameMultiple">(multiple)</string>
-	<string name="GroupNameNone">(aucun)</string>
-	<string name="AssetErrorNone">Aucune erreur</string>
-	<string name="AssetErrorRequestFailed">Requête de l'actif : échec</string>
-	<string name="AssetErrorNonexistentFile">Requête de l'actif : fichier inexistant</string>
-	<string name="AssetErrorNotInDatabase">Requête de l'actif : actif introuvable dans la base de données</string>
-	<string name="AssetErrorEOF">Fin du ficher</string>
-	<string name="AssetErrorCannotOpenFile">Impossible d'ouvrir le fichier</string>
-	<string name="AssetErrorFileNotFound">Fichier introuvable</string>
-	<string name="AssetErrorTCPTimeout">Délai d'attente du transfert du fichier dépassé</string>
-	<string name="AssetErrorCircuitGone">Disparition du circuit</string>
-	<string name="AssetErrorPriceMismatch">Il y a une différence de prix entre le client et le serveur</string>
-	<string name="AssetErrorUnknownStatus">Statut inconnu</string>
-	<string name="AssetUploadServerUnreacheble">Service inaccessible.</string>
-	<string name="AssetUploadServerDifficulties">Le serveur rencontres des difficultés imprévues.</string>
-	<string name="AssetUploadServerUnavaliable">Services non disponible ou la durée du chargement est dépassée.</string>
-	<string name="AssetUploadRequestInvalid">Erreur dans la demande de chargement. Veuillez consulter le site : 
-http://secondlife.com/support pour vous aider à résoudre ce problème.</string>
-	<string name="SettingValidationError">Échec de la validation pour l'importation des paramètres [NAME]</string>
-	<string name="SettingImportFileError">Impossible d'ouvre le fichier [FILE]</string>
-	<string name="SettingParseFileError">Impossible d'ouvre le fichier [FILE]</string>
-	<string name="SettingTranslateError">Impossible de traduit les paramètres windlight hérités [NAME]</string>
-	<string name="texture">texture</string>
-	<string name="sound">son</string>
-	<string name="calling card">carte de visite</string>
-	<string name="landmark">repère</string>
-	<string name="legacy script">script (ancienne version)</string>
-	<string name="clothing">habits</string>
-	<string name="object">objet</string>
-	<string name="note card">note</string>
-	<string name="folder">dossier</string>
-	<string name="root">racine</string>
-	<string name="lsl2 script">script LSL2</string>
-	<string name="lsl bytecode">bytecode LSL</string>
-	<string name="tga texture">texture tga</string>
-	<string name="body part">partie du corps</string>
-	<string name="snapshot">photo</string>
-	<string name="lost and found">Objets trouvés</string>
-	<string name="targa image">image targa</string>
-	<string name="trash">Corbeille</string>
-	<string name="jpeg image">image jpeg</string>
-	<string name="animation">animation</string>
-	<string name="gesture">geste</string>
-	<string name="simstate">simstate</string>
-	<string name="favorite">favori</string>
-	<string name="symbolic link">lien</string>
-	<string name="symbolic folder link">lien du dossier</string>
-	<string name="settings blob">paramètres</string>
-	<string name="mesh">maillage</string>
-	<string name="AvatarEditingAppearance">(Apparence en cours de modification)</string>
-	<string name="AvatarAway">Absent</string>
-	<string name="AvatarDoNotDisturb">Ne pas déranger</string>
-	<string name="AvatarMuted">Bloqué(e)</string>
-	<string name="anim_express_afraid">Effrayé</string>
-	<string name="anim_express_anger">En colère</string>
-	<string name="anim_away">Absent</string>
-	<string name="anim_backflip">Salto arrière</string>
-	<string name="anim_express_laugh">Rire en se tenant le ventre</string>
-	<string name="anim_express_toothsmile">Grand sourire</string>
-	<string name="anim_blowkiss">Envoyer un baiser</string>
-	<string name="anim_express_bored">Bailler d'ennui</string>
-	<string name="anim_bow">S'incliner</string>
-	<string name="anim_clap">Applaudir</string>
-	<string name="anim_courtbow">Révérence de cour</string>
-	<string name="anim_express_cry">Pleurer</string>
-	<string name="anim_dance1">Danse 1</string>
-	<string name="anim_dance2">Danse 2</string>
-	<string name="anim_dance3">Danse 3</string>
-	<string name="anim_dance4">Danse 4</string>
-	<string name="anim_dance5">Danse 5</string>
-	<string name="anim_dance6">Danse 6</string>
-	<string name="anim_dance7">Danse 7</string>
-	<string name="anim_dance8">Danse 8</string>
-	<string name="anim_express_disdain">Mépris</string>
-	<string name="anim_drink">Boire</string>
-	<string name="anim_express_embarrased">Gêne</string>
-	<string name="anim_angry_fingerwag">Désapprobation</string>
-	<string name="anim_fist_pump">Victoire</string>
-	<string name="anim_yoga_float">Yoga</string>
-	<string name="anim_express_frown">Froncer les sourcils</string>
-	<string name="anim_impatient">Impatient</string>
-	<string name="anim_jumpforjoy">Sauter de joie</string>
-	<string name="anim_kissmybutt">Va te faire voir !</string>
-	<string name="anim_express_kiss">Envoyer un baiser</string>
-	<string name="anim_laugh_short">Rire</string>
-	<string name="anim_musclebeach">Montrer ses muscles</string>
-	<string name="anim_no_unhappy">Non (mécontent)</string>
-	<string name="anim_no_head">Non</string>
-	<string name="anim_nyanya">Na na na na nère</string>
-	<string name="anim_punch_onetwo">Gauche-droite</string>
-	<string name="anim_express_open_mouth">Bouche ouverte</string>
-	<string name="anim_peace">Paix</string>
-	<string name="anim_point_you">Montrer quelqu'un du doigt</string>
-	<string name="anim_point_me">Se montrer du doigt</string>
-	<string name="anim_punch_l">Gauche</string>
-	<string name="anim_punch_r">Droite</string>
-	<string name="anim_rps_countdown">Compter (pierre-papier-ciseaux)</string>
-	<string name="anim_rps_paper">Papier (pierre-papier-ciseaux)</string>
-	<string name="anim_rps_rock">Pierre (pierre-papier-ciseaux)</string>
-	<string name="anim_rps_scissors">Ciseaux (pierre-papier-ciseaux)</string>
-	<string name="anim_express_repulsed">Dégoût</string>
-	<string name="anim_kick_roundhouse_r">Coup de pied circulaire</string>
-	<string name="anim_express_sad">Triste</string>
-	<string name="anim_salute">Salut</string>
-	<string name="anim_shout">Crier</string>
-	<string name="anim_express_shrug">Hausser les épaules</string>
-	<string name="anim_express_smile">Sourire</string>
-	<string name="anim_smoke_idle">Fumer, immobile</string>
-	<string name="anim_smoke_inhale">Fumer, prendre une bouffée</string>
-	<string name="anim_smoke_throw_down">Fumer, jeter son mégot</string>
-	<string name="anim_express_surprise">Surprise</string>
-	<string name="anim_sword_strike_r">Coup d'épée</string>
-	<string name="anim_angry_tantrum">Caprice</string>
-	<string name="anim_express_tongue_out">Tirer la langue</string>
-	<string name="anim_hello">Faire signe</string>
-	<string name="anim_whisper">Chuchoter</string>
-	<string name="anim_whistle">Siffler</string>
-	<string name="anim_express_wink">Clin d'œil</string>
-	<string name="anim_wink_hollywood">Clin d'œil (Hollywood)</string>
-	<string name="anim_express_worry">Soucis</string>
-	<string name="anim_yes_happy">Oui (Joie)</string>
-	<string name="anim_yes_head">Oui</string>
-	<string name="multiple_textures">Multiples</string>
-	<string name="use_texture">Utiliser la texture</string>
-	<string name="manip_hint1">Faites glisser le curseur sur l'axe</string>
-	<string name="manip_hint2">pour le fixer sur la grille</string>
-	<string name="texture_loading">Chargement...</string>
-	<string name="worldmap_offline">Hors ligne</string>
-	<string name="worldmap_item_tooltip_format">[AREA] m² [PRICE] L$</string>
-	<string name="worldmap_results_none_found">Aucun résultat.</string>
-	<string name="Ok">OK</string>
-	<string name="Premature end of file">Fichier incomplet</string>
-	<string name="ST_NO_JOINT">Impossible de trouver ROOT ou JOINT.</string>
-	<string name="NearbyChatTitle">Chat près de moi</string>
-	<string name="NearbyChatLabel">(Chat près de moi)</string>
-	<string name="whisper">chuchote :</string>
-	<string name="shout">crie :</string>
-	<string name="ringing">Connexion au chat vocal du Monde en cours…</string>
-	<string name="connected">Connecté(e)</string>
-	<string name="unavailable">Voix non disponible à l'endroit où vous êtes</string>
-	<string name="hang_up">Déconnecté du chat vocal</string>
-	<string name="reconnect_nearby">Vous allez maintenant être reconnecté(e) au chat vocal près de vous.</string>
-	<string name="ScriptQuestionCautionChatGranted">'[OBJECTNAME]', un objet appartenant à [OWNERNAME], situé dans [REGIONNAME] à [REGIONPOS], a reçu le droit de : [PERMISSIONS].</string>
-	<string name="ScriptQuestionCautionChatDenied">'[OBJECTNAME]', un objet appartenant à [OWNERNAME], situé dans [REGIONNAME] à [REGIONPOS], n'a pas reçu le droit de : [PERMISSIONS].</string>
-	<string name="AdditionalPermissionsRequestHeader">Si vous autorisez un accès à votre compte, vous autorisez également l'objet à :</string>
-	<string name="ScriptTakeMoney">Débiter vos Linden dollars (L$)</string>
-	<string name="ActOnControlInputs">Utiliser vos touches de commandes</string>
-	<string name="RemapControlInputs">Reconfigurer vos touches de commandes</string>
-	<string name="AnimateYourAvatar">Animer votre avatar</string>
-	<string name="AttachToYourAvatar">Attacher à votre avatar</string>
-	<string name="ReleaseOwnership">Passer l'objet dans le domaine public (sans propriétaire)</string>
-	<string name="LinkAndDelink">Lier et délier d'autres objets</string>
-	<string name="AddAndRemoveJoints">Créer et supprimer des liens avec d'autres objets</string>
-	<string name="ChangePermissions">Modifier ses droits</string>
-	<string name="TrackYourCamera">Suivre votre caméra</string>
-	<string name="ControlYourCamera">Contrôler votre caméra</string>
-	<string name="TeleportYourAgent">Vous téléporter</string>
-	<string name="ForceSitAvatar">Forcez votre avatar à s’asseoir</string>
-	<string name="ChangeEnvSettings">Changer vos paramètres d'environnement</string>
-	<string name="NotConnected">Pas connecté(e)</string>
-	<string name="AgentNameSubst">(Vous)</string>
+peuvent être joints aux notes.
+	</string>
+	<string name="Searching">
+		Recherche...
+	</string>
+	<string name="NoneFound">
+		Aucun résultat.
+	</string>
+	<string name="RetrievingData">
+		En cours d'extraction...
+	</string>
+	<string name="ReleaseNotes">
+		Notes de version
+	</string>
+	<string name="RELEASE_NOTES_BASE_URL">
+		https://releasenotes.secondlife.com/viewer/
+	</string>
+	<string name="LoadingData">
+		Chargement...
+	</string>
+	<string name="AvatarNameNobody">
+		(personne)
+	</string>
+	<string name="AvatarNameWaiting">
+		(en attente)
+	</string>
+	<string name="AvatarNameMultiple">
+		(multiple)
+	</string>
+	<string name="GroupNameNone">
+		(aucun)
+	</string>
+	<string name="AssetErrorNone">
+		Aucune erreur
+	</string>
+	<string name="AssetErrorRequestFailed">
+		Requête de l'actif : échec
+	</string>
+	<string name="AssetErrorNonexistentFile">
+		Requête de l'actif : fichier inexistant
+	</string>
+	<string name="AssetErrorNotInDatabase">
+		Requête de l'actif : actif introuvable dans la base de données
+	</string>
+	<string name="AssetErrorEOF">
+		Fin du ficher
+	</string>
+	<string name="AssetErrorCannotOpenFile">
+		Impossible d'ouvrir le fichier
+	</string>
+	<string name="AssetErrorFileNotFound">
+		Fichier introuvable
+	</string>
+	<string name="AssetErrorTCPTimeout">
+		Délai d'attente du transfert du fichier dépassé
+	</string>
+	<string name="AssetErrorCircuitGone">
+		Disparition du circuit
+	</string>
+	<string name="AssetErrorPriceMismatch">
+		Il y a une différence de prix entre le client et le serveur
+	</string>
+	<string name="AssetErrorUnknownStatus">
+		Statut inconnu
+	</string>
+	<string name="AssetUploadServerUnreacheble">
+		Service inaccessible.
+	</string>
+	<string name="AssetUploadServerDifficulties">
+		Le serveur rencontres des difficultés imprévues.
+	</string>
+	<string name="AssetUploadServerUnavaliable">
+		Services non disponible ou la durée du chargement est dépassée.
+	</string>
+	<string name="AssetUploadRequestInvalid">
+		Erreur dans la demande de chargement. Veuillez consulter le site : 
+http://secondlife.com/support pour vous aider à résoudre ce problème.
+	</string>
+	<string name="SettingValidationError">
+		Échec de la validation pour l'importation des paramètres [NAME]
+	</string>
+	<string name="SettingImportFileError">
+		Impossible d'ouvre le fichier [FILE]
+	</string>
+	<string name="SettingParseFileError">
+		Impossible d'ouvre le fichier [FILE]
+	</string>
+	<string name="SettingTranslateError">
+		Impossible de traduit les paramètres windlight hérités [NAME]
+	</string>
+	<string name="texture">
+		texture
+	</string>
+	<string name="sound">
+		son
+	</string>
+	<string name="calling card">
+		carte de visite
+	</string>
+	<string name="landmark">
+		repère
+	</string>
+	<string name="legacy script">
+		script (ancienne version)
+	</string>
+	<string name="clothing">
+		habits
+	</string>
+	<string name="object">
+		objet
+	</string>
+	<string name="note card">
+		note
+	</string>
+	<string name="folder">
+		dossier
+	</string>
+	<string name="root">
+		racine
+	</string>
+	<string name="lsl2 script">
+		script LSL2
+	</string>
+	<string name="lsl bytecode">
+		bytecode LSL
+	</string>
+	<string name="tga texture">
+		texture tga
+	</string>
+	<string name="body part">
+		partie du corps
+	</string>
+	<string name="snapshot">
+		photo
+	</string>
+	<string name="lost and found">
+		Objets trouvés
+	</string>
+	<string name="targa image">
+		image targa
+	</string>
+	<string name="trash">
+		Corbeille
+	</string>
+	<string name="jpeg image">
+		image jpeg
+	</string>
+	<string name="animation">
+		animation
+	</string>
+	<string name="gesture">
+		geste
+	</string>
+	<string name="simstate">
+		simstate
+	</string>
+	<string name="favorite">
+		favori
+	</string>
+	<string name="symbolic link">
+		lien
+	</string>
+	<string name="symbolic folder link">
+		lien du dossier
+	</string>
+	<string name="settings blob">
+		paramètres
+	</string>
+	<string name="mesh">
+		maillage
+	</string>
+	<string name="AvatarEditingAppearance">
+		(Apparence en cours de modification)
+	</string>
+	<string name="AvatarAway">
+		Absent
+	</string>
+	<string name="AvatarDoNotDisturb">
+		Ne pas déranger
+	</string>
+	<string name="AvatarMuted">
+		Bloqué(e)
+	</string>
+	<string name="anim_express_afraid">
+		Effrayé
+	</string>
+	<string name="anim_express_anger">
+		En colère
+	</string>
+	<string name="anim_away">
+		Absent
+	</string>
+	<string name="anim_backflip">
+		Salto arrière
+	</string>
+	<string name="anim_express_laugh">
+		Rire en se tenant le ventre
+	</string>
+	<string name="anim_express_toothsmile">
+		Grand sourire
+	</string>
+	<string name="anim_blowkiss">
+		Envoyer un baiser
+	</string>
+	<string name="anim_express_bored">
+		Bailler d'ennui
+	</string>
+	<string name="anim_bow">
+		S'incliner
+	</string>
+	<string name="anim_clap">
+		Applaudir
+	</string>
+	<string name="anim_courtbow">
+		Révérence de cour
+	</string>
+	<string name="anim_express_cry">
+		Pleurer
+	</string>
+	<string name="anim_dance1">
+		Danse 1
+	</string>
+	<string name="anim_dance2">
+		Danse 2
+	</string>
+	<string name="anim_dance3">
+		Danse 3
+	</string>
+	<string name="anim_dance4">
+		Danse 4
+	</string>
+	<string name="anim_dance5">
+		Danse 5
+	</string>
+	<string name="anim_dance6">
+		Danse 6
+	</string>
+	<string name="anim_dance7">
+		Danse 7
+	</string>
+	<string name="anim_dance8">
+		Danse 8
+	</string>
+	<string name="anim_express_disdain">
+		Mépris
+	</string>
+	<string name="anim_drink">
+		Boire
+	</string>
+	<string name="anim_express_embarrased">
+		Gêne
+	</string>
+	<string name="anim_angry_fingerwag">
+		Désapprobation
+	</string>
+	<string name="anim_fist_pump">
+		Victoire
+	</string>
+	<string name="anim_yoga_float">
+		Yoga
+	</string>
+	<string name="anim_express_frown">
+		Froncer les sourcils
+	</string>
+	<string name="anim_impatient">
+		Impatient
+	</string>
+	<string name="anim_jumpforjoy">
+		Sauter de joie
+	</string>
+	<string name="anim_kissmybutt">
+		Va te faire voir !
+	</string>
+	<string name="anim_express_kiss">
+		Envoyer un baiser
+	</string>
+	<string name="anim_laugh_short">
+		Rire
+	</string>
+	<string name="anim_musclebeach">
+		Montrer ses muscles
+	</string>
+	<string name="anim_no_unhappy">
+		Non (mécontent)
+	</string>
+	<string name="anim_no_head">
+		Non
+	</string>
+	<string name="anim_nyanya">
+		Na na na na nère
+	</string>
+	<string name="anim_punch_onetwo">
+		Gauche-droite
+	</string>
+	<string name="anim_express_open_mouth">
+		Bouche ouverte
+	</string>
+	<string name="anim_peace">
+		Paix
+	</string>
+	<string name="anim_point_you">
+		Montrer quelqu'un du doigt
+	</string>
+	<string name="anim_point_me">
+		Se montrer du doigt
+	</string>
+	<string name="anim_punch_l">
+		Gauche
+	</string>
+	<string name="anim_punch_r">
+		Droite
+	</string>
+	<string name="anim_rps_countdown">
+		Compter (pierre-papier-ciseaux)
+	</string>
+	<string name="anim_rps_paper">
+		Papier (pierre-papier-ciseaux)
+	</string>
+	<string name="anim_rps_rock">
+		Pierre (pierre-papier-ciseaux)
+	</string>
+	<string name="anim_rps_scissors">
+		Ciseaux (pierre-papier-ciseaux)
+	</string>
+	<string name="anim_express_repulsed">
+		Dégoût
+	</string>
+	<string name="anim_kick_roundhouse_r">
+		Coup de pied circulaire
+	</string>
+	<string name="anim_express_sad">
+		Triste
+	</string>
+	<string name="anim_salute">
+		Salut
+	</string>
+	<string name="anim_shout">
+		Crier
+	</string>
+	<string name="anim_express_shrug">
+		Hausser les épaules
+	</string>
+	<string name="anim_express_smile">
+		Sourire
+	</string>
+	<string name="anim_smoke_idle">
+		Fumer, immobile
+	</string>
+	<string name="anim_smoke_inhale">
+		Fumer, prendre une bouffée
+	</string>
+	<string name="anim_smoke_throw_down">
+		Fumer, jeter son mégot
+	</string>
+	<string name="anim_express_surprise">
+		Surprise
+	</string>
+	<string name="anim_sword_strike_r">
+		Coup d'épée
+	</string>
+	<string name="anim_angry_tantrum">
+		Caprice
+	</string>
+	<string name="anim_express_tongue_out">
+		Tirer la langue
+	</string>
+	<string name="anim_hello">
+		Faire signe
+	</string>
+	<string name="anim_whisper">
+		Chuchoter
+	</string>
+	<string name="anim_whistle">
+		Siffler
+	</string>
+	<string name="anim_express_wink">
+		Clin d'œil
+	</string>
+	<string name="anim_wink_hollywood">
+		Clin d'œil (Hollywood)
+	</string>
+	<string name="anim_express_worry">
+		Soucis
+	</string>
+	<string name="anim_yes_happy">
+		Oui (Joie)
+	</string>
+	<string name="anim_yes_head">
+		Oui
+	</string>
+	<string name="multiple_textures">
+		Multiples
+	</string>
+	<string name="use_texture">
+		Utiliser la texture
+	</string>
+	<string name="manip_hint1">
+		Faites glisser le curseur sur l'axe
+	</string>
+	<string name="manip_hint2">
+		pour le fixer sur la grille
+	</string>
+	<string name="texture_loading">
+		Chargement...
+	</string>
+	<string name="worldmap_offline">
+		Hors ligne
+	</string>
+	<string name="worldmap_item_tooltip_format">
+		[AREA] m² [PRICE] L$
+	</string>
+	<string name="worldmap_results_none_found">
+		Aucun résultat.
+	</string>
+	<string name="Ok">
+		OK
+	</string>
+	<string name="Premature end of file">
+		Fichier incomplet
+	</string>
+	<string name="ST_NO_JOINT">
+		Impossible de trouver ROOT ou JOINT.
+	</string>
+	<string name="NearbyChatTitle">
+		Chat près de moi
+	</string>
+	<string name="NearbyChatLabel">
+		(Chat près de moi)
+	</string>
+	<string name="whisper">
+		chuchote :
+	</string>
+	<string name="shout">
+		crie :
+	</string>
+	<string name="ringing">
+		Connexion au chat vocal du Monde en cours…
+	</string>
+	<string name="connected">
+		Connecté(e)
+	</string>
+	<string name="unavailable">
+		Voix non disponible à l'endroit où vous êtes
+	</string>
+	<string name="hang_up">
+		Déconnecté du chat vocal
+	</string>
+	<string name="reconnect_nearby">
+		Vous allez maintenant être reconnecté(e) au chat vocal près de vous.
+	</string>
+	<string name="ScriptQuestionCautionChatGranted">
+		'[OBJECTNAME]', un objet appartenant à [OWNERNAME], situé dans [REGIONNAME] à [REGIONPOS], a reçu le droit de : [PERMISSIONS].
+	</string>
+	<string name="ScriptQuestionCautionChatDenied">
+		'[OBJECTNAME]', un objet appartenant à [OWNERNAME], situé dans [REGIONNAME] à [REGIONPOS], n'a pas reçu le droit de : [PERMISSIONS].
+	</string>
+	<string name="AdditionalPermissionsRequestHeader">
+		Si vous autorisez un accès à votre compte, vous autorisez également l'objet à :
+	</string>
+	<string name="ScriptTakeMoney">
+		Débiter vos Linden dollars (L$)
+	</string>
+	<string name="ActOnControlInputs">
+		Utiliser vos touches de commandes
+	</string>
+	<string name="RemapControlInputs">
+		Reconfigurer vos touches de commandes
+	</string>
+	<string name="AnimateYourAvatar">
+		Animer votre avatar
+	</string>
+	<string name="AttachToYourAvatar">
+		Attacher à votre avatar
+	</string>
+	<string name="ReleaseOwnership">
+		Passer l'objet dans le domaine public (sans propriétaire)
+	</string>
+	<string name="LinkAndDelink">
+		Lier et délier d'autres objets
+	</string>
+	<string name="AddAndRemoveJoints">
+		Créer et supprimer des liens avec d'autres objets
+	</string>
+	<string name="ChangePermissions">
+		Modifier ses droits
+	</string>
+	<string name="TrackYourCamera">
+		Suivre votre caméra
+	</string>
+	<string name="ControlYourCamera">
+		Contrôler votre caméra
+	</string>
+	<string name="TeleportYourAgent">
+		Vous téléporter
+	</string>
+	<string name="ForceSitAvatar">
+		Forcez votre avatar à s’asseoir
+	</string>
+	<string name="ChangeEnvSettings">
+		Changer vos paramètres d'environnement
+	</string>
+	<string name="NotConnected">
+		Pas connecté(e)
+	</string>
+	<string name="AgentNameSubst">
+		(Vous)
+	</string>
 	<string name="JoinAnExperience"/>
-	<string name="SilentlyManageEstateAccess">Supprimer les alertes lors de la gestion des listes d'accès aux domaines</string>
-	<string name="OverrideYourAnimations">Remplacer vos animations par défaut</string>
-	<string name="ScriptReturnObjects">Renvoyer les objets de votre part</string>
-	<string name="UnknownScriptPermission">(inconnu)</string>
-	<string name="SIM_ACCESS_PG">Général</string>
-	<string name="SIM_ACCESS_MATURE">Modéré</string>
-	<string name="SIM_ACCESS_ADULT">Adulte</string>
-	<string name="SIM_ACCESS_DOWN">Hors ligne</string>
-	<string name="SIM_ACCESS_MIN">Inconnu</string>
-	<string name="land_type_unknown">(inconnu)</string>
-	<string name="Estate / Full Region">Domaine / Région entière</string>
-	<string name="Estate / Homestead">Domaine / Homestead</string>
-	<string name="Mainland / Homestead">Continent / Homestead</string>
-	<string name="Mainland / Full Region">Continent / Région entière</string>
-	<string name="all_files">Tous fichiers</string>
-	<string name="sound_files">Sons</string>
-	<string name="animation_files">Animations</string>
-	<string name="image_files">Images</string>
-	<string name="save_file_verb">Enregistrer</string>
-	<string name="load_file_verb">Charger</string>
-	<string name="targa_image_files">Images Targa</string>
-	<string name="bitmap_image_files">Images Bitmap</string>
-	<string name="png_image_files">Images PNG</string>
-	<string name="save_texture_image_files">Images Targa ou PNG</string>
-	<string name="avi_movie_file">Fichier de film AVI</string>
-	<string name="xaf_animation_file">Fichier d'animation XAF</string>
-	<string name="xml_file">Fichier XML</string>
-	<string name="raw_file">Fichier RAW</string>
-	<string name="compressed_image_files">Images compressées</string>
-	<string name="load_files">Charger des fichiers</string>
-	<string name="choose_the_directory">Choisir le répertoire</string>
-	<string name="script_files">Scripts</string>
-	<string name="dictionary_files">Dictionnaires</string>
-	<string name="shape">Silhouette</string>
-	<string name="skin">Peau</string>
-	<string name="hair">Cheveux</string>
-	<string name="eyes">Yeux</string>
-	<string name="shirt">Chemise</string>
-	<string name="pants">Pantalon</string>
-	<string name="shoes">Chaussures</string>
-	<string name="socks">Chaussettes</string>
-	<string name="jacket">Veste</string>
-	<string name="gloves">Gants</string>
-	<string name="undershirt">Débardeur</string>
-	<string name="underpants">Caleçon</string>
-	<string name="skirt">Jupe</string>
-	<string name="alpha">Alpha</string>
-	<string name="tattoo">Tatouage</string>
-	<string name="universal">Universel</string>
-	<string name="physics">Propriétés physiques</string>
-	<string name="invalid">non valide</string>
-	<string name="none">aucun</string>
-	<string name="shirt_not_worn">Chemise non portée</string>
-	<string name="pants_not_worn">Pantalon non porté</string>
-	<string name="shoes_not_worn">Chaussures non portées</string>
-	<string name="socks_not_worn">Chaussettes non portées</string>
-	<string name="jacket_not_worn">Veste non portée</string>
-	<string name="gloves_not_worn">Gants non portés</string>
-	<string name="undershirt_not_worn">Débardeur non porté</string>
-	<string name="underpants_not_worn">Caleçon non porté</string>
-	<string name="skirt_not_worn">Jupe non portée</string>
-	<string name="alpha_not_worn">Alpha non porté</string>
-	<string name="tattoo_not_worn">Tatouage non porté</string>
-	<string name="universal_not_worn">Universel non porté</string>
-	<string name="physics_not_worn">Propriétés physiques non portées</string>
-	<string name="invalid_not_worn">non valide</string>
-	<string name="create_new_shape">Créer une nouvelle silhouette</string>
-	<string name="create_new_skin">Créer une nouvelle peau</string>
-	<string name="create_new_hair">Créer de nouveaux cheveux</string>
-	<string name="create_new_eyes">Créer de nouveaux yeux</string>
-	<string name="create_new_shirt">Créer une nouvelle chemise</string>
-	<string name="create_new_pants">Créer un nouveau pantalon</string>
-	<string name="create_new_shoes">Créer de nouvelles chaussures</string>
-	<string name="create_new_socks">Créer de nouvelles chaussettes</string>
-	<string name="create_new_jacket">Créer une nouvelle veste</string>
-	<string name="create_new_gloves">Créer de nouveaux gants</string>
-	<string name="create_new_undershirt">Créer un nouveau débardeur</string>
-	<string name="create_new_underpants">Créer un nouveau caleçon</string>
-	<string name="create_new_skirt">Créer une nouvelle jupe</string>
-	<string name="create_new_alpha">Créer un nouvel alpha</string>
-	<string name="create_new_tattoo">Créer un nouveau tatouage</string>
-	<string name="create_new_universal">Créer un nouvel environnement universel</string>
-	<string name="create_new_physics">Créer de nouvelles propriétés physiques</string>
-	<string name="create_new_invalid">non valide</string>
-	<string name="NewWearable">Nouv. [WEARABLE_ITEM]</string>
-	<string name="next">Suivant</string>
-	<string name="ok">OK</string>
-	<string name="GroupNotifyGroupNotice">Note au groupe</string>
-	<string name="GroupNotifyGroupNotices">Notices au groupe</string>
-	<string name="GroupNotifySentBy">Envoyée par</string>
-	<string name="GroupNotifyAttached">Pièce(s) jointe(s) :</string>
-	<string name="GroupNotifyViewPastNotices">Consultez les notices précédentes ou choisissez de ne plus recevoir ces messages ici.</string>
-	<string name="GroupNotifyOpenAttachment">Ouvrir pièce jointe</string>
-	<string name="GroupNotifySaveAttachment">Enregistrer la pièce jointe</string>
-	<string name="TeleportOffer">Offre de téléportation</string>
-	<string name="StartUpNotifications">De nouvelles notifications sont arrivées en votre absence.</string>
-	<string name="OverflowInfoChannelString">Vous avez %d notification(s) supplémentaire(s)</string>
-	<string name="BodyPartsRightArm">Bras droit</string>
-	<string name="BodyPartsHead">Tête</string>
-	<string name="BodyPartsLeftArm">Bras gauche</string>
-	<string name="BodyPartsLeftLeg">Jambe gauche</string>
-	<string name="BodyPartsTorso">Torse</string>
-	<string name="BodyPartsRightLeg">Jambe droite</string>
-	<string name="BodyPartsEnhancedSkeleton">Squelette amélioré</string>
-	<string name="GraphicsQualityLow">Faible</string>
-	<string name="GraphicsQualityMid">Moyen</string>
-	<string name="GraphicsQualityHigh">Élevé</string>
-	<string name="LeaveMouselook">Appuyez sur ESC pour quitter la vue subjective</string>
-	<string name="InventoryNoMatchingItems">Vous n'avez pas trouvé ce que vous cherchiez ? Essayez [secondlife:///app/search/all/[SEARCH_TERM] Rechercher].</string>
-	<string name="InventoryNoMatchingRecentItems">Avez-vous trouvé ce que vous cherchiez ? Essayez [secondlife:///app/inventory/filters Show filters].</string>
-	<string name="PlacesNoMatchingItems">Vous n'avez pas trouvé ce que vous cherchiez ? Essayez [secondlife:///app/search/places/[SEARCH_TERM] Rechercher].</string>
-	<string name="FavoritesNoMatchingItems">Faites glisser un repère ici pour l'ajouter à vos Favoris.</string>
-	<string name="MarketplaceNoMatchingItems">Aucun article trouvé. Vérifiez l'orthographe de votre chaîne de recherche et réessayez.</string>
-	<string name="InventoryNoTexture">Vous n'avez pas de copie de cette texture dans votre inventaire</string>
-	<string name="InventoryInboxNoItems">Les achats que vous avez effectués sur la Place du marché s'affichent ici. Vous pouvez alors les faire glisser vers votre inventaire afin de les utiliser.</string>
-	<string name="MarketplaceURL">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/</string>
-	<string name="MarketplaceURL_CreateStore">http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3</string>
-	<string name="MarketplaceURL_Dashboard">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard</string>
-	<string name="MarketplaceURL_Imports">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports</string>
-	<string name="MarketplaceURL_LearnMore">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more</string>
-	<string name="InventoryPlayAnimationTooltip">Ouvrir la fenêtre avec les options Jeu</string>
-	<string name="InventoryPlayGestureTooltip">Exécuter le geste sélectionné dans le monde virtuel.</string>
-	<string name="InventoryPlaySoundTooltip">Ouvrir la fenêtre avec les options Jeu</string>
-	<string name="InventoryOutboxNotMerchantTitle">Tout le monde peut vendre des articles sur la Place du marché.</string>
+	<string name="SilentlyManageEstateAccess">
+		Supprimer les alertes lors de la gestion des listes d'accès aux domaines
+	</string>
+	<string name="OverrideYourAnimations">
+		Remplacer vos animations par défaut
+	</string>
+	<string name="ScriptReturnObjects">
+		Renvoyer les objets de votre part
+	</string>
+	<string name="UnknownScriptPermission">
+		(inconnu)
+	</string>
+	<string name="SIM_ACCESS_PG">
+		Général
+	</string>
+	<string name="SIM_ACCESS_MATURE">
+		Modéré
+	</string>
+	<string name="SIM_ACCESS_ADULT">
+		Adulte
+	</string>
+	<string name="SIM_ACCESS_DOWN">
+		Hors ligne
+	</string>
+	<string name="SIM_ACCESS_MIN">
+		Inconnu
+	</string>
+	<string name="land_type_unknown">
+		(inconnu)
+	</string>
+	<string name="Estate / Full Region">
+		Domaine / Région entière
+	</string>
+	<string name="Estate / Homestead">
+		Domaine / Homestead
+	</string>
+	<string name="Mainland / Homestead">
+		Continent / Homestead
+	</string>
+	<string name="Mainland / Full Region">
+		Continent / Région entière
+	</string>
+	<string name="all_files">
+		Tous fichiers
+	</string>
+	<string name="sound_files">
+		Sons
+	</string>
+	<string name="animation_files">
+		Animations
+	</string>
+	<string name="image_files">
+		Images
+	</string>
+	<string name="save_file_verb">
+		Enregistrer
+	</string>
+	<string name="load_file_verb">
+		Charger
+	</string>
+	<string name="targa_image_files">
+		Images Targa
+	</string>
+	<string name="bitmap_image_files">
+		Images Bitmap
+	</string>
+	<string name="png_image_files">
+		Images PNG
+	</string>
+	<string name="save_texture_image_files">
+		Images Targa ou PNG
+	</string>
+	<string name="avi_movie_file">
+		Fichier de film AVI
+	</string>
+	<string name="xaf_animation_file">
+		Fichier d'animation XAF
+	</string>
+	<string name="xml_file">
+		Fichier XML
+	</string>
+	<string name="raw_file">
+		Fichier RAW
+	</string>
+	<string name="compressed_image_files">
+		Images compressées
+	</string>
+	<string name="load_files">
+		Charger des fichiers
+	</string>
+	<string name="choose_the_directory">
+		Choisir le répertoire
+	</string>
+	<string name="script_files">
+		Scripts
+	</string>
+	<string name="dictionary_files">
+		Dictionnaires
+	</string>
+	<string name="shape">
+		Silhouette
+	</string>
+	<string name="skin">
+		Peau
+	</string>
+	<string name="hair">
+		Cheveux
+	</string>
+	<string name="eyes">
+		Yeux
+	</string>
+	<string name="shirt">
+		Chemise
+	</string>
+	<string name="pants">
+		Pantalon
+	</string>
+	<string name="shoes">
+		Chaussures
+	</string>
+	<string name="socks">
+		Chaussettes
+	</string>
+	<string name="jacket">
+		Veste
+	</string>
+	<string name="gloves">
+		Gants
+	</string>
+	<string name="undershirt">
+		Débardeur
+	</string>
+	<string name="underpants">
+		Caleçon
+	</string>
+	<string name="skirt">
+		Jupe
+	</string>
+	<string name="alpha">
+		Alpha
+	</string>
+	<string name="tattoo">
+		Tatouage
+	</string>
+	<string name="universal">
+		Universel
+	</string>
+	<string name="physics">
+		Propriétés physiques
+	</string>
+	<string name="invalid">
+		non valide
+	</string>
+	<string name="none">
+		aucun
+	</string>
+	<string name="shirt_not_worn">
+		Chemise non portée
+	</string>
+	<string name="pants_not_worn">
+		Pantalon non porté
+	</string>
+	<string name="shoes_not_worn">
+		Chaussures non portées
+	</string>
+	<string name="socks_not_worn">
+		Chaussettes non portées
+	</string>
+	<string name="jacket_not_worn">
+		Veste non portée
+	</string>
+	<string name="gloves_not_worn">
+		Gants non portés
+	</string>
+	<string name="undershirt_not_worn">
+		Débardeur non porté
+	</string>
+	<string name="underpants_not_worn">
+		Caleçon non porté
+	</string>
+	<string name="skirt_not_worn">
+		Jupe non portée
+	</string>
+	<string name="alpha_not_worn">
+		Alpha non porté
+	</string>
+	<string name="tattoo_not_worn">
+		Tatouage non porté
+	</string>
+	<string name="universal_not_worn">
+		Universel non porté
+	</string>
+	<string name="physics_not_worn">
+		Propriétés physiques non portées
+	</string>
+	<string name="invalid_not_worn">
+		non valide
+	</string>
+	<string name="create_new_shape">
+		Créer une nouvelle silhouette
+	</string>
+	<string name="create_new_skin">
+		Créer une nouvelle peau
+	</string>
+	<string name="create_new_hair">
+		Créer de nouveaux cheveux
+	</string>
+	<string name="create_new_eyes">
+		Créer de nouveaux yeux
+	</string>
+	<string name="create_new_shirt">
+		Créer une nouvelle chemise
+	</string>
+	<string name="create_new_pants">
+		Créer un nouveau pantalon
+	</string>
+	<string name="create_new_shoes">
+		Créer de nouvelles chaussures
+	</string>
+	<string name="create_new_socks">
+		Créer de nouvelles chaussettes
+	</string>
+	<string name="create_new_jacket">
+		Créer une nouvelle veste
+	</string>
+	<string name="create_new_gloves">
+		Créer de nouveaux gants
+	</string>
+	<string name="create_new_undershirt">
+		Créer un nouveau débardeur
+	</string>
+	<string name="create_new_underpants">
+		Créer un nouveau caleçon
+	</string>
+	<string name="create_new_skirt">
+		Créer une nouvelle jupe
+	</string>
+	<string name="create_new_alpha">
+		Créer un nouvel alpha
+	</string>
+	<string name="create_new_tattoo">
+		Créer un nouveau tatouage
+	</string>
+	<string name="create_new_universal">
+		Créer un nouvel environnement universel
+	</string>
+	<string name="create_new_physics">
+		Créer de nouvelles propriétés physiques
+	</string>
+	<string name="create_new_invalid">
+		non valide
+	</string>
+	<string name="NewWearable">
+		Nouv. [WEARABLE_ITEM]
+	</string>
+	<string name="next">
+		Suivant
+	</string>
+	<string name="ok">
+		OK
+	</string>
+	<string name="GroupNotifyGroupNotice">
+		Note au groupe
+	</string>
+	<string name="GroupNotifyGroupNotices">
+		Notices au groupe
+	</string>
+	<string name="GroupNotifySentBy">
+		Envoyée par
+	</string>
+	<string name="GroupNotifyAttached">
+		Pièce(s) jointe(s) :
+	</string>
+	<string name="GroupNotifyViewPastNotices">
+		Consultez les notices précédentes ou choisissez de ne plus recevoir ces messages ici.
+	</string>
+	<string name="GroupNotifyOpenAttachment">
+		Ouvrir pièce jointe
+	</string>
+	<string name="GroupNotifySaveAttachment">
+		Enregistrer la pièce jointe
+	</string>
+	<string name="TeleportOffer">
+		Offre de téléportation
+	</string>
+	<string name="StartUpNotifications">
+		De nouvelles notifications sont arrivées en votre absence.
+	</string>
+	<string name="OverflowInfoChannelString">
+		Vous avez %d notification(s) supplémentaire(s)
+	</string>
+	<string name="BodyPartsRightArm">
+		Bras droit
+	</string>
+	<string name="BodyPartsHead">
+		Tête
+	</string>
+	<string name="BodyPartsLeftArm">
+		Bras gauche
+	</string>
+	<string name="BodyPartsLeftLeg">
+		Jambe gauche
+	</string>
+	<string name="BodyPartsTorso">
+		Torse
+	</string>
+	<string name="BodyPartsRightLeg">
+		Jambe droite
+	</string>
+	<string name="BodyPartsEnhancedSkeleton">
+		Squelette amélioré
+	</string>
+	<string name="GraphicsQualityLow">
+		Faible
+	</string>
+	<string name="GraphicsQualityMid">
+		Moyen
+	</string>
+	<string name="GraphicsQualityHigh">
+		Élevé
+	</string>
+	<string name="LeaveMouselook">
+		Appuyez sur ESC pour quitter la vue subjective
+	</string>
+	<string name="InventoryNoMatchingItems">
+		Vous n'avez pas trouvé ce que vous cherchiez ? Essayez [secondlife:///app/search/all/[SEARCH_TERM] Rechercher].
+	</string>
+	<string name="InventoryNoMatchingRecentItems">
+		Avez-vous trouvé ce que vous cherchiez ? Essayez [secondlife:///app/inventory/filters Show filters].
+	</string>
+	<string name="PlacesNoMatchingItems">
+		Vous n'avez pas trouvé ce que vous cherchiez ? Essayez [secondlife:///app/search/places/[SEARCH_TERM] Rechercher].
+	</string>
+	<string name="FavoritesNoMatchingItems">
+		Faites glisser un repère ici pour l'ajouter à vos Favoris.
+	</string>
+	<string name="MarketplaceNoMatchingItems">
+		Aucun article trouvé. Vérifiez l'orthographe de votre chaîne de recherche et réessayez.
+	</string>
+	<string name="InventoryNoTexture">
+		Vous n'avez pas de copie de cette texture dans votre inventaire
+	</string>
+	<string name="InventoryInboxNoItems">
+		Les achats que vous avez effectués sur la Place du marché s'affichent ici. Vous pouvez alors les faire glisser vers votre inventaire afin de les utiliser.
+	</string>
+	<string name="MarketplaceURL">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/
+	</string>
+	<string name="MarketplaceURL_CreateStore">
+		http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3
+	</string>
+	<string name="MarketplaceURL_Dashboard">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard
+	</string>
+	<string name="MarketplaceURL_Imports">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports
+	</string>
+	<string name="MarketplaceURL_LearnMore">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more
+	</string>
+	<string name="InventoryPlayAnimationTooltip">
+		Ouvrir la fenêtre avec les options Jeu
+	</string>
+	<string name="InventoryPlayGestureTooltip">
+		Exécuter le geste sélectionné dans le monde virtuel.
+	</string>
+	<string name="InventoryPlaySoundTooltip">
+		Ouvrir la fenêtre avec les options Jeu
+	</string>
+	<string name="InventoryOutboxNotMerchantTitle">
+		Tout le monde peut vendre des articles sur la Place du marché.
+	</string>
 	<string name="InventoryOutboxNotMerchantTooltip"/>
-	<string name="InventoryOutboxNotMerchant">Pour devenir vendeur, vous devez [[MARKETPLACE_CREATE_STORE_URL] créer une boutique sur la Place du marché].</string>
-	<string name="InventoryOutboxNoItemsTitle">Votre boîte d'envoi est vide.</string>
+	<string name="InventoryOutboxNotMerchant">
+		Pour devenir vendeur, vous devez [[MARKETPLACE_CREATE_STORE_URL] créer une boutique sur la Place du marché].
+	</string>
+	<string name="InventoryOutboxNoItemsTitle">
+		Votre boîte d'envoi est vide.
+	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
-	<string name="InventoryOutboxNoItems">Pour mettre des dossiers en vente sur la [[MARKETPLACE_DASHBOARD_URL] Place du marché], faites-les glisser vers cette zone et cliquez sur &quot;Envoyer vers la Place du marché&quot;.</string>
-	<string name="InventoryOutboxInitializingTitle">Initialisation de la Place du marché...</string>
-	<string name="InventoryOutboxInitializing">Nous sommes en train d'accéder à votre compte dans la [[MARKETPLACE_CREATE_STORE_URL] boutique de la Place du marché].</string>
-	<string name="InventoryOutboxErrorTitle">Erreurs de la Place du marché.</string>
-	<string name="InventoryOutboxError">La [[MARKETPLACE_CREATE_STORE_URL] boutique de la Place du marché] renvoie des erreurs.</string>
-	<string name="InventoryMarketplaceError">Une erreur est survenue lors de l’ouverture des annonces de la Place du marché.
-Si vous continuez de recevoir ce message, contactez l’assistance Second Life à http://support.secondlife.com pour obtenir de l’aide.</string>
-	<string name="InventoryMarketplaceListingsNoItemsTitle">Votre dossier Annonces de la Place du marché est vide.</string>
-	<string name="InventoryMarketplaceListingsNoItems">Pour mettre des dossiers en vente sur la [[MARKETPLACE_DASHBOARD_URL] Place du marché], faites-les glisser vers cette zone.</string>
-	<string name="InventoryItemsCount">( [ITEMS_COUNT] Articles )</string>
-	<string name="Marketplace Validation Warning Stock">le dossier de stock doit être contenu dans un dossier de version</string>
-	<string name="Marketplace Validation Error Mixed Stock">: Erreur : tous les articles d'un dossier de stock doivent être non reproductibles et de même type</string>
-	<string name="Marketplace Validation Error Subfolder In Stock">: Erreur : un dossier de stock ne peut pas contenir de sous-dossiers</string>
-	<string name="Marketplace Validation Warning Empty">: Avertissement : le dossier ne contient aucun article</string>
-	<string name="Marketplace Validation Warning Create Stock">: Avertissement : création du dossier de stock</string>
-	<string name="Marketplace Validation Warning Create Version">: Avertissement : création du dossier de version</string>
-	<string name="Marketplace Validation Warning Move">: Avertissement : déplacement d'articles</string>
-	<string name="Marketplace Validation Warning Delete">: Avertissement : contenu du dossier transféré vers le dossier de stock, suppression du dossier vide</string>
-	<string name="Marketplace Validation Error Stock Item">: Erreur : les articles non reproductibles doivent être contenus dans un dossier de stock</string>
-	<string name="Marketplace Validation Warning Unwrapped Item">: Avertissement : les articles doivent être contenus dans un dossier de version</string>
-	<string name="Marketplace Validation Error">: Erreur :</string>
-	<string name="Marketplace Validation Warning">: Avertissement :</string>
-	<string name="Marketplace Validation Error Empty Version">: Avertissement : le dossier de version doit contenir au moins 1 article</string>
-	<string name="Marketplace Validation Error Empty Stock">: Avertissement : le dossier de stock doit contenir au moins 1 article</string>
-	<string name="Marketplace Validation No Error">Pas d'erreur ni d'avertissement à signaler</string>
-	<string name="Marketplace Error None">Aucune erreur</string>
-	<string name="Marketplace Error Prefix">Erreur :</string>
-	<string name="Marketplace Error Not Merchant">Avant d'envoyer des articles vers la Place du marché, vous devez vous configurer comme vendeur (gratuit).</string>
-	<string name="Marketplace Error Not Accepted">Impossible de déplacer l'article dans ce dossier.</string>
-	<string name="Marketplace Error Unsellable Item">Cet article ne peut pas être vendu sur la Place du marché.</string>
-	<string name="MarketplaceNoID">no Mkt ID</string>
-	<string name="MarketplaceLive">publié</string>
-	<string name="MarketplaceActive">actif</string>
-	<string name="MarketplaceMax">max.</string>
-	<string name="MarketplaceStock">stock</string>
-	<string name="MarketplaceNoStock">rupture de stock</string>
-	<string name="MarketplaceUpdating">mise à jour...</string>
-	<string name="UploadFeeInfo">Les frais dépendent de votre niveau d'abonnement. Les niveaux supérieurs sont soumis à des frais moins élevés. [https://secondlife.com/my/account/membership.php? En savoir plus]</string>
-	<string name="Open landmarks">Points de repère ouverts</string>
-	<string name="Unconstrained">Sans contrainte</string>
+	<string name="InventoryOutboxNoItems">
+		Pour mettre des dossiers en vente sur la [[MARKETPLACE_DASHBOARD_URL] Place du marché], faites-les glisser vers cette zone et cliquez sur "Envoyer vers la Place du marché".
+	</string>
+	<string name="InventoryOutboxInitializingTitle">
+		Initialisation de la Place du marché...
+	</string>
+	<string name="InventoryOutboxInitializing">
+		Nous sommes en train d'accéder à votre compte dans la [[MARKETPLACE_CREATE_STORE_URL] boutique de la Place du marché].
+	</string>
+	<string name="InventoryOutboxErrorTitle">
+		Erreurs de la Place du marché.
+	</string>
+	<string name="InventoryOutboxError">
+		La [[MARKETPLACE_CREATE_STORE_URL] boutique de la Place du marché] renvoie des erreurs.
+	</string>
+	<string name="InventoryMarketplaceError">
+		Une erreur est survenue lors de l’ouverture des annonces de la Place du marché.
+Si vous continuez de recevoir ce message, contactez l’assistance Second Life à http://support.secondlife.com pour obtenir de l’aide.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItemsTitle">
+		Votre dossier Annonces de la Place du marché est vide.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItems">
+		Pour mettre des dossiers en vente sur la [[MARKETPLACE_DASHBOARD_URL] Place du marché], faites-les glisser vers cette zone.
+	</string>
+	<string name="InventoryItemsCount">
+		( [ITEMS_COUNT] Articles )
+	</string>
+	<string name="Marketplace Validation Warning Stock">
+		le dossier de stock doit être contenu dans un dossier de version
+	</string>
+	<string name="Marketplace Validation Error Mixed Stock">
+		: Erreur : tous les articles d'un dossier de stock doivent être non reproductibles et de même type
+	</string>
+	<string name="Marketplace Validation Error Subfolder In Stock">
+		: Erreur : un dossier de stock ne peut pas contenir de sous-dossiers
+	</string>
+	<string name="Marketplace Validation Warning Empty">
+		: Avertissement : le dossier ne contient aucun article
+	</string>
+	<string name="Marketplace Validation Warning Create Stock">
+		: Avertissement : création du dossier de stock
+	</string>
+	<string name="Marketplace Validation Warning Create Version">
+		: Avertissement : création du dossier de version
+	</string>
+	<string name="Marketplace Validation Warning Move">
+		: Avertissement : déplacement d'articles
+	</string>
+	<string name="Marketplace Validation Warning Delete">
+		: Avertissement : contenu du dossier transféré vers le dossier de stock, suppression du dossier vide
+	</string>
+	<string name="Marketplace Validation Error Stock Item">
+		: Erreur : les articles non reproductibles doivent être contenus dans un dossier de stock
+	</string>
+	<string name="Marketplace Validation Warning Unwrapped Item">
+		: Avertissement : les articles doivent être contenus dans un dossier de version
+	</string>
+	<string name="Marketplace Validation Error">
+		: Erreur :
+	</string>
+	<string name="Marketplace Validation Warning">
+		: Avertissement :
+	</string>
+	<string name="Marketplace Validation Error Empty Version">
+		: Avertissement : le dossier de version doit contenir au moins 1 article
+	</string>
+	<string name="Marketplace Validation Error Empty Stock">
+		: Avertissement : le dossier de stock doit contenir au moins 1 article
+	</string>
+	<string name="Marketplace Validation No Error">
+		Pas d'erreur ni d'avertissement à signaler
+	</string>
+	<string name="Marketplace Error None">
+		Aucune erreur
+	</string>
+	<string name="Marketplace Error Prefix">
+		Erreur :
+	</string>
+	<string name="Marketplace Error Not Merchant">
+		Avant d'envoyer des articles vers la Place du marché, vous devez vous configurer comme vendeur (gratuit).
+	</string>
+	<string name="Marketplace Error Not Accepted">
+		Impossible de déplacer l'article dans ce dossier.
+	</string>
+	<string name="Marketplace Error Unsellable Item">
+		Cet article ne peut pas être vendu sur la Place du marché.
+	</string>
+	<string name="MarketplaceNoID">
+		no Mkt ID
+	</string>
+	<string name="MarketplaceLive">
+		publié
+	</string>
+	<string name="MarketplaceActive">
+		actif
+	</string>
+	<string name="MarketplaceMax">
+		max.
+	</string>
+	<string name="MarketplaceStock">
+		stock
+	</string>
+	<string name="MarketplaceNoStock">
+		rupture de stock
+	</string>
+	<string name="MarketplaceUpdating">
+		mise à jour...
+	</string>
+	<string name="UploadFeeInfo">
+		Les frais dépendent de votre niveau d'abonnement. Les niveaux supérieurs sont soumis à des frais moins élevés. [https://secondlife.com/my/account/membership.php? En savoir plus]
+	</string>
+	<string name="Open landmarks">
+		Points de repère ouverts
+	</string>
+	<string name="Unconstrained">
+		Sans contrainte
+	</string>
 	<string name="no_transfer" value=" (pas de transfert)"/>
 	<string name="no_modify" value=" (pas de modification)"/>
 	<string name="no_copy" value=" (pas de copie)"/>
 	<string name="worn" value=" (porté)"/>
 	<string name="link" value=" (lien)"/>
 	<string name="broken_link" value=" (broken_link)"/>
-	<string name="LoadingContents">chargement des contenus en cours...</string>
-	<string name="NoContents">Aucun contenu</string>
+	<string name="LoadingContents">
+		chargement des contenus en cours...
+	</string>
+	<string name="NoContents">
+		Aucun contenu
+	</string>
 	<string name="WornOnAttachmentPoint" value=" (porté sur [ATTACHMENT_POINT])"/>
 	<string name="AttachmentErrorMessage" value="([ATTACHMENT_ERROR])"/>
 	<string name="ActiveGesture" value="[GESLABEL] (actif)"/>
-	<string name="PermYes">Oui</string>
-	<string name="PermNo">Non</string>
+	<string name="PermYes">
+		Oui
+	</string>
+	<string name="PermNo">
+		Non
+	</string>
 	<string name="Chat Message" value="Chat :"/>
 	<string name="Sound" value=" Son :"/>
 	<string name="Wait" value=" --- Attendre :"/>
@@ -637,1443 +1705,4215 @@ Si vous continuez de recevoir ce message, contactez l’assistance Second Life �
 	<string name="Snapshots" value=" Photos,"/>
 	<string name="No Filters" value="Non "/>
 	<string name="Since Logoff" value="depuis la déconnexion"/>
-	<string name="InvFolder My Inventory">Mon inventaire</string>
-	<string name="InvFolder Library">Bibliothèque</string>
-	<string name="InvFolder Textures">Textures</string>
-	<string name="InvFolder Sounds">Sons</string>
-	<string name="InvFolder Calling Cards">Cartes de visite</string>
-	<string name="InvFolder Landmarks">Repères</string>
-	<string name="InvFolder Scripts">Scripts</string>
-	<string name="InvFolder Clothing">Habits</string>
-	<string name="InvFolder Objects">Objets</string>
-	<string name="InvFolder Notecards">Notes</string>
-	<string name="InvFolder New Folder">Nouveau dossier</string>
-	<string name="InvFolder Inventory">Inventaire</string>
-	<string name="InvFolder Uncompressed Images">Images non compressées</string>
-	<string name="InvFolder Body Parts">Parties du corps</string>
-	<string name="InvFolder Trash">Corbeille</string>
-	<string name="InvFolder Photo Album">Albums photo</string>
-	<string name="InvFolder Lost And Found">Objets trouvés</string>
-	<string name="InvFolder Uncompressed Sounds">Sons non compressés</string>
-	<string name="InvFolder Animations">Animations</string>
-	<string name="InvFolder Gestures">Gestes</string>
-	<string name="InvFolder Favorite">Mes Favoris</string>
-	<string name="InvFolder favorite">Mes Favoris</string>
-	<string name="InvFolder Favorites">Mes favoris</string>
-	<string name="InvFolder favorites">Mes favoris</string>
-	<string name="InvFolder Current Outfit">Tenue actuelle</string>
-	<string name="InvFolder Initial Outfits">Tenues initiales</string>
-	<string name="InvFolder My Outfits">Mes tenues</string>
-	<string name="InvFolder Accessories">Accessoires</string>
-	<string name="InvFolder Meshes">Maillages</string>
-	<string name="InvFolder Received Items">Articles reçus</string>
-	<string name="InvFolder Merchant Outbox">Boîte d'envoi vendeur</string>
-	<string name="InvFolder Friends">Amis</string>
-	<string name="InvFolder All">Tout</string>
-	<string name="no_attachments">Aucun élément attaché porté</string>
-	<string name="Attachments remain">Éléments attachés ([COUNT] emplacements restants)</string>
-	<string name="Buy">Acheter</string>
-	<string name="BuyforL$">Acheter des L$</string>
-	<string name="Stone">Pierre</string>
-	<string name="Metal">Métal</string>
-	<string name="Glass">Verre</string>
-	<string name="Wood">Bois</string>
-	<string name="Flesh">Chair</string>
-	<string name="Plastic">Plastique</string>
-	<string name="Rubber">Caoutchouc</string>
-	<string name="Light">Léger</string>
-	<string name="KBShift">Maj-</string>
-	<string name="KBCtrl">Ctrl</string>
-	<string name="Chest">Poitrine</string>
-	<string name="Skull">Crâne</string>
-	<string name="Left Shoulder">Épaule gauche</string>
-	<string name="Right Shoulder">Épaule droite</string>
-	<string name="Left Hand">Main gauche</string>
-	<string name="Right Hand">Main droite</string>
-	<string name="Left Foot">Pied gauche</string>
-	<string name="Right Foot">Pied droit</string>
-	<string name="Spine">Colonne</string>
-	<string name="Pelvis">Bassin</string>
-	<string name="Mouth">Bouche</string>
-	<string name="Chin">Menton</string>
-	<string name="Left Ear">Oreille gauche</string>
-	<string name="Right Ear">Oreille droite</string>
-	<string name="Left Eyeball">Globe oculaire gauche</string>
-	<string name="Right Eyeball">Globe oculaire droit</string>
-	<string name="Nose">Nez</string>
-	<string name="R Upper Arm">Bras D</string>
-	<string name="R Forearm">Avant-bras D</string>
-	<string name="L Upper Arm">Bras G</string>
-	<string name="L Forearm">Avant-bras G</string>
-	<string name="Right Hip">Hanche droite</string>
-	<string name="R Upper Leg">Cuisse D</string>
-	<string name="R Lower Leg">Jambe D</string>
-	<string name="Left Hip">Hanche gauche</string>
-	<string name="L Upper Leg">Cuisse G</string>
-	<string name="L Lower Leg">Jambe G</string>
-	<string name="Stomach">Estomac</string>
-	<string name="Left Pec">Pectoral gauche</string>
-	<string name="Right Pec">Pectoral droit</string>
-	<string name="Neck">Cou</string>
-	<string name="Avatar Center">Centre de l'avatar</string>
-	<string name="Left Ring Finger">Annulaire gauche</string>
-	<string name="Right Ring Finger">Annulaire droit</string>
-	<string name="Tail Base">Base de la queue</string>
-	<string name="Tail Tip">Bout de la queue</string>
-	<string name="Left Wing">Aile gauche</string>
-	<string name="Right Wing">Aile droite</string>
-	<string name="Jaw">Mâchoire</string>
-	<string name="Alt Left Ear">Oreille gauche différente</string>
-	<string name="Alt Right Ear">Oreille droite différente</string>
-	<string name="Alt Left Eye">Œil gauche différent</string>
-	<string name="Alt Right Eye">Œil droit différent</string>
-	<string name="Tongue">Langue</string>
-	<string name="Groin">Aine</string>
-	<string name="Left Hind Foot">Pied arrière gauche</string>
-	<string name="Right Hind Foot">Pied arrière droit</string>
-	<string name="Invalid Attachment">Point d'attache non valide</string>
-	<string name="ATTACHMENT_MISSING_ITEM">Erreur : article manquant</string>
-	<string name="ATTACHMENT_MISSING_BASE_ITEM">Erreur : article de base manquant</string>
-	<string name="ATTACHMENT_NOT_ATTACHED">Erreur : l'objet est dans une tenue actuelle, mais il n'est pas attaché</string>
-	<string name="YearsMonthsOld">[AGEYEARS] [AGEMONTHS]</string>
-	<string name="YearsOld">[AGEYEARS]</string>
-	<string name="MonthsOld">[AGEMONTHS]</string>
-	<string name="WeeksOld">[AGEWEEKS]</string>
-	<string name="DaysOld">[AGEDAYS]</string>
-	<string name="TodayOld">Inscrit aujourd'hui</string>
-	<string name="av_render_everyone_now">Désormais, tout le monde peut vous voir.</string>
-	<string name="av_render_not_everyone">Vous risquez de ne pas être rendu par tous les gens qui vous entourent.</string>
-	<string name="av_render_over_half">Vous risquez de ne pas être rendu par plus de la moitié des gens qui vous entourent.</string>
-	<string name="av_render_most_of">Vous risquez de ne pas être rendu par la plupart des gens qui vous entourent.</string>
-	<string name="av_render_anyone">Vous risquez de n’être rendu par aucune des personnes qui vous entourent.</string>
-	<string name="hud_description_total">Votre HUD</string>
-	<string name="hud_name_with_joint">[OBJ_NAME] (porté sur [JNT_NAME])</string>
-	<string name="hud_render_memory_warning">[HUD_DETAILS] utilise beaucoup de mémoire textures</string>
-	<string name="hud_render_cost_warning">[HUD_DETAILS] contient beaucoup de textures et d’objets volumineux</string>
-	<string name="hud_render_heavy_textures_warning">[HUD_DETAILS] contient beaucoup de textures volumineuses</string>
-	<string name="hud_render_cramped_warning">[HUD_DETAILS] contient trop d’objets</string>
-	<string name="hud_render_textures_warning">[HUD_DETAILS] contient trop de textures</string>
-	<string name="AgeYearsA">[COUNT] an</string>
-	<string name="AgeYearsB">[COUNT] ans</string>
-	<string name="AgeYearsC">[COUNT] ans</string>
-	<string name="AgeMonthsA">[COUNT] mois</string>
-	<string name="AgeMonthsB">[COUNT] mois</string>
-	<string name="AgeMonthsC">[COUNT] mois</string>
-	<string name="AgeWeeksA">[COUNT] semaine</string>
-	<string name="AgeWeeksB">[COUNT] semaines</string>
-	<string name="AgeWeeksC">[COUNT] semaines</string>
-	<string name="AgeDaysA">[COUNT] jour</string>
-	<string name="AgeDaysB">[COUNT] jours</string>
-	<string name="AgeDaysC">[COUNT] jours</string>
-	<string name="GroupMembersA">[COUNT] membre</string>
-	<string name="GroupMembersB">[COUNT] membres</string>
-	<string name="GroupMembersC">[COUNT] membres</string>
-	<string name="AcctTypeResident">Résident</string>
-	<string name="AcctTypeTrial">Essai</string>
-	<string name="AcctTypeCharterMember">Membre originaire</string>
-	<string name="AcctTypeEmployee">Employé(e) de Linden Lab</string>
-	<string name="PaymentInfoUsed">Infos de paiement utilisées</string>
-	<string name="PaymentInfoOnFile">Infos de paiement enregistrées</string>
-	<string name="NoPaymentInfoOnFile">Aucune info de paiement enregistrée</string>
-	<string name="AgeVerified">Personne dont l'âge a été vérifié</string>
-	<string name="NotAgeVerified">Personne dont l'âge n'a pas été vérifié</string>
-	<string name="Center 2">Centre 2</string>
-	<string name="Top Right">En haut à droite</string>
-	<string name="Top">En haut</string>
-	<string name="Top Left">En haut à gauche</string>
-	<string name="Center">Centre</string>
-	<string name="Bottom Left">En bas à gauche</string>
-	<string name="Bottom">Bas</string>
-	<string name="Bottom Right">En bas à droite</string>
-	<string name="CompileQueueDownloadedCompiling">Téléchargé, compilation en cours</string>
-	<string name="CompileQueueServiceUnavailable">Service de compilation de script indisponible.</string>
-	<string name="CompileQueueScriptNotFound">Script introuvable sur le serveur.</string>
-	<string name="CompileQueueProblemDownloading">Problème lors du téléchargement</string>
-	<string name="CompileQueueInsufficientPermDownload">Droits insuffisants pour télécharger un script.</string>
-	<string name="CompileQueueInsufficientPermFor">Droits insuffisants pour</string>
-	<string name="CompileQueueUnknownFailure">Échec du téléchargement, erreur inconnue</string>
-	<string name="CompileNoExperiencePerm">En train d’ignorer le script [SCRIPT] avec l’expérience [EXPERIENCE].</string>
-	<string name="CompileQueueTitle">Recompilation - progrès</string>
-	<string name="CompileQueueStart">recompiler</string>
-	<string name="ResetQueueTitle">Réinitialiser les progrès</string>
-	<string name="ResetQueueStart">réinitialiser</string>
-	<string name="RunQueueTitle">Lancer</string>
-	<string name="RunQueueStart">lancer</string>
-	<string name="NotRunQueueTitle">Arrêter</string>
-	<string name="NotRunQueueStart">arrêter</string>
-	<string name="CompileSuccessful">Compilation réussie !</string>
-	<string name="CompileSuccessfulSaving">Compilation réussie, enregistrement en cours...</string>
-	<string name="SaveComplete">Enregistrement terminé.</string>
-	<string name="UploadFailed">Échec du chargement de fichier :</string>
-	<string name="ObjectOutOfRange">Script (objet hors de portée)</string>
-	<string name="ScriptWasDeleted">Script (supprimé de l’inventaire)</string>
-	<string name="GodToolsObjectOwnedBy">Objet [OBJECT] appartenant à [OWNER]</string>
-	<string name="GroupsNone">aucun</string>
+	<string name="InvFolder My Inventory">
+		Mon inventaire
+	</string>
+	<string name="InvFolder Library">
+		Bibliothèque
+	</string>
+	<string name="InvFolder Textures">
+		Textures
+	</string>
+	<string name="InvFolder Sounds">
+		Sons
+	</string>
+	<string name="InvFolder Calling Cards">
+		Cartes de visite
+	</string>
+	<string name="InvFolder Landmarks">
+		Repères
+	</string>
+	<string name="InvFolder Scripts">
+		Scripts
+	</string>
+	<string name="InvFolder Clothing">
+		Habits
+	</string>
+	<string name="InvFolder Objects">
+		Objets
+	</string>
+	<string name="InvFolder Notecards">
+		Notes
+	</string>
+	<string name="InvFolder New Folder">
+		Nouveau dossier
+	</string>
+	<string name="InvFolder Inventory">
+		Inventaire
+	</string>
+	<string name="InvFolder Uncompressed Images">
+		Images non compressées
+	</string>
+	<string name="InvFolder Body Parts">
+		Parties du corps
+	</string>
+	<string name="InvFolder Trash">
+		Corbeille
+	</string>
+	<string name="InvFolder Photo Album">
+		Albums photo
+	</string>
+	<string name="InvFolder Lost And Found">
+		Objets trouvés
+	</string>
+	<string name="InvFolder Uncompressed Sounds">
+		Sons non compressés
+	</string>
+	<string name="InvFolder Animations">
+		Animations
+	</string>
+	<string name="InvFolder Gestures">
+		Gestes
+	</string>
+	<string name="InvFolder Favorite">
+		Mes Favoris
+	</string>
+	<string name="InvFolder favorite">
+		Mes Favoris
+	</string>
+	<string name="InvFolder Favorites">
+		Mes favoris
+	</string>
+	<string name="InvFolder favorites">
+		Mes favoris
+	</string>
+	<string name="InvFolder Current Outfit">
+		Tenue actuelle
+	</string>
+	<string name="InvFolder Initial Outfits">
+		Tenues initiales
+	</string>
+	<string name="InvFolder My Outfits">
+		Mes tenues
+	</string>
+	<string name="InvFolder Accessories">
+		Accessoires
+	</string>
+	<string name="InvFolder Meshes">
+		Maillages
+	</string>
+	<string name="InvFolder Received Items">
+		Articles reçus
+	</string>
+	<string name="InvFolder Merchant Outbox">
+		Boîte d'envoi vendeur
+	</string>
+	<string name="InvFolder Friends">
+		Amis
+	</string>
+	<string name="InvFolder All">
+		Tout
+	</string>
+	<string name="no_attachments">
+		Aucun élément attaché porté
+	</string>
+	<string name="Attachments remain">
+		Éléments attachés ([COUNT] emplacements restants)
+	</string>
+	<string name="Buy">
+		Acheter
+	</string>
+	<string name="BuyforL$">
+		Acheter des L$
+	</string>
+	<string name="Stone">
+		Pierre
+	</string>
+	<string name="Metal">
+		Métal
+	</string>
+	<string name="Glass">
+		Verre
+	</string>
+	<string name="Wood">
+		Bois
+	</string>
+	<string name="Flesh">
+		Chair
+	</string>
+	<string name="Plastic">
+		Plastique
+	</string>
+	<string name="Rubber">
+		Caoutchouc
+	</string>
+	<string name="Light">
+		Léger
+	</string>
+	<string name="KBShift">
+		Maj-
+	</string>
+	<string name="KBCtrl">
+		Ctrl
+	</string>
+	<string name="Chest">
+		Poitrine
+	</string>
+	<string name="Skull">
+		Crâne
+	</string>
+	<string name="Left Shoulder">
+		Épaule gauche
+	</string>
+	<string name="Right Shoulder">
+		Épaule droite
+	</string>
+	<string name="Left Hand">
+		Main gauche
+	</string>
+	<string name="Right Hand">
+		Main droite
+	</string>
+	<string name="Left Foot">
+		Pied gauche
+	</string>
+	<string name="Right Foot">
+		Pied droit
+	</string>
+	<string name="Spine">
+		Colonne
+	</string>
+	<string name="Pelvis">
+		Bassin
+	</string>
+	<string name="Mouth">
+		Bouche
+	</string>
+	<string name="Chin">
+		Menton
+	</string>
+	<string name="Left Ear">
+		Oreille gauche
+	</string>
+	<string name="Right Ear">
+		Oreille droite
+	</string>
+	<string name="Left Eyeball">
+		Globe oculaire gauche
+	</string>
+	<string name="Right Eyeball">
+		Globe oculaire droit
+	</string>
+	<string name="Nose">
+		Nez
+	</string>
+	<string name="R Upper Arm">
+		Bras D
+	</string>
+	<string name="R Forearm">
+		Avant-bras D
+	</string>
+	<string name="L Upper Arm">
+		Bras G
+	</string>
+	<string name="L Forearm">
+		Avant-bras G
+	</string>
+	<string name="Right Hip">
+		Hanche droite
+	</string>
+	<string name="R Upper Leg">
+		Cuisse D
+	</string>
+	<string name="R Lower Leg">
+		Jambe D
+	</string>
+	<string name="Left Hip">
+		Hanche gauche
+	</string>
+	<string name="L Upper Leg">
+		Cuisse G
+	</string>
+	<string name="L Lower Leg">
+		Jambe G
+	</string>
+	<string name="Stomach">
+		Estomac
+	</string>
+	<string name="Left Pec">
+		Pectoral gauche
+	</string>
+	<string name="Right Pec">
+		Pectoral droit
+	</string>
+	<string name="Neck">
+		Cou
+	</string>
+	<string name="Avatar Center">
+		Centre de l'avatar
+	</string>
+	<string name="Left Ring Finger">
+		Annulaire gauche
+	</string>
+	<string name="Right Ring Finger">
+		Annulaire droit
+	</string>
+	<string name="Tail Base">
+		Base de la queue
+	</string>
+	<string name="Tail Tip">
+		Bout de la queue
+	</string>
+	<string name="Left Wing">
+		Aile gauche
+	</string>
+	<string name="Right Wing">
+		Aile droite
+	</string>
+	<string name="Jaw">
+		Mâchoire
+	</string>
+	<string name="Alt Left Ear">
+		Oreille gauche différente
+	</string>
+	<string name="Alt Right Ear">
+		Oreille droite différente
+	</string>
+	<string name="Alt Left Eye">
+		Œil gauche différent
+	</string>
+	<string name="Alt Right Eye">
+		Œil droit différent
+	</string>
+	<string name="Tongue">
+		Langue
+	</string>
+	<string name="Groin">
+		Aine
+	</string>
+	<string name="Left Hind Foot">
+		Pied arrière gauche
+	</string>
+	<string name="Right Hind Foot">
+		Pied arrière droit
+	</string>
+	<string name="Invalid Attachment">
+		Point d'attache non valide
+	</string>
+	<string name="ATTACHMENT_MISSING_ITEM">
+		Erreur : article manquant
+	</string>
+	<string name="ATTACHMENT_MISSING_BASE_ITEM">
+		Erreur : article de base manquant
+	</string>
+	<string name="ATTACHMENT_NOT_ATTACHED">
+		Erreur : l'objet est dans une tenue actuelle, mais il n'est pas attaché
+	</string>
+	<string name="YearsMonthsOld">
+		[AGEYEARS] [AGEMONTHS]
+	</string>
+	<string name="YearsOld">
+		[AGEYEARS]
+	</string>
+	<string name="MonthsOld">
+		[AGEMONTHS]
+	</string>
+	<string name="WeeksOld">
+		[AGEWEEKS]
+	</string>
+	<string name="DaysOld">
+		[AGEDAYS]
+	</string>
+	<string name="TodayOld">
+		Inscrit aujourd'hui
+	</string>
+	<string name="av_render_everyone_now">
+		Désormais, tout le monde peut vous voir.
+	</string>
+	<string name="av_render_not_everyone">
+		Vous risquez de ne pas être rendu par tous les gens qui vous entourent.
+	</string>
+	<string name="av_render_over_half">
+		Vous risquez de ne pas être rendu par plus de la moitié des gens qui vous entourent.
+	</string>
+	<string name="av_render_most_of">
+		Vous risquez de ne pas être rendu par la plupart des gens qui vous entourent.
+	</string>
+	<string name="av_render_anyone">
+		Vous risquez de n’être rendu par aucune des personnes qui vous entourent.
+	</string>
+	<string name="hud_description_total">
+		Votre HUD
+	</string>
+	<string name="hud_name_with_joint">
+		[OBJ_NAME] (porté sur [JNT_NAME])
+	</string>
+	<string name="hud_render_memory_warning">
+		[HUD_DETAILS] utilise beaucoup de mémoire textures
+	</string>
+	<string name="hud_render_cost_warning">
+		[HUD_DETAILS] contient beaucoup de textures et d’objets volumineux
+	</string>
+	<string name="hud_render_heavy_textures_warning">
+		[HUD_DETAILS] contient beaucoup de textures volumineuses
+	</string>
+	<string name="hud_render_cramped_warning">
+		[HUD_DETAILS] contient trop d’objets
+	</string>
+	<string name="hud_render_textures_warning">
+		[HUD_DETAILS] contient trop de textures
+	</string>
+	<string name="AgeYearsA">
+		[COUNT] an
+	</string>
+	<string name="AgeYearsB">
+		[COUNT] ans
+	</string>
+	<string name="AgeYearsC">
+		[COUNT] ans
+	</string>
+	<string name="AgeMonthsA">
+		[COUNT] mois
+	</string>
+	<string name="AgeMonthsB">
+		[COUNT] mois
+	</string>
+	<string name="AgeMonthsC">
+		[COUNT] mois
+	</string>
+	<string name="AgeWeeksA">
+		[COUNT] semaine
+	</string>
+	<string name="AgeWeeksB">
+		[COUNT] semaines
+	</string>
+	<string name="AgeWeeksC">
+		[COUNT] semaines
+	</string>
+	<string name="AgeDaysA">
+		[COUNT] jour
+	</string>
+	<string name="AgeDaysB">
+		[COUNT] jours
+	</string>
+	<string name="AgeDaysC">
+		[COUNT] jours
+	</string>
+	<string name="GroupMembersA">
+		[COUNT] membre
+	</string>
+	<string name="GroupMembersB">
+		[COUNT] membres
+	</string>
+	<string name="GroupMembersC">
+		[COUNT] membres
+	</string>
+	<string name="AcctTypeResident">
+		Résident
+	</string>
+	<string name="AcctTypeTrial">
+		Essai
+	</string>
+	<string name="AcctTypeCharterMember">
+		Membre originaire
+	</string>
+	<string name="AcctTypeEmployee">
+		Employé(e) de Linden Lab
+	</string>
+	<string name="PaymentInfoUsed">
+		Infos de paiement utilisées
+	</string>
+	<string name="PaymentInfoOnFile">
+		Infos de paiement enregistrées
+	</string>
+	<string name="NoPaymentInfoOnFile">
+		Aucune info de paiement enregistrée
+	</string>
+	<string name="AgeVerified">
+		Personne dont l'âge a été vérifié
+	</string>
+	<string name="NotAgeVerified">
+		Personne dont l'âge n'a pas été vérifié
+	</string>
+	<string name="Center 2">
+		Centre 2
+	</string>
+	<string name="Top Right">
+		En haut à droite
+	</string>
+	<string name="Top">
+		En haut
+	</string>
+	<string name="Top Left">
+		En haut à gauche
+	</string>
+	<string name="Center">
+		Centre
+	</string>
+	<string name="Bottom Left">
+		En bas à gauche
+	</string>
+	<string name="Bottom">
+		Bas
+	</string>
+	<string name="Bottom Right">
+		En bas à droite
+	</string>
+	<string name="CompileQueueDownloadedCompiling">
+		Téléchargé, compilation en cours
+	</string>
+	<string name="CompileQueueServiceUnavailable">
+		Service de compilation de script indisponible.
+	</string>
+	<string name="CompileQueueScriptNotFound">
+		Script introuvable sur le serveur.
+	</string>
+	<string name="CompileQueueProblemDownloading">
+		Problème lors du téléchargement
+	</string>
+	<string name="CompileQueueInsufficientPermDownload">
+		Droits insuffisants pour télécharger un script.
+	</string>
+	<string name="CompileQueueInsufficientPermFor">
+		Droits insuffisants pour
+	</string>
+	<string name="CompileQueueUnknownFailure">
+		Échec du téléchargement, erreur inconnue
+	</string>
+	<string name="CompileNoExperiencePerm">
+		En train d’ignorer le script [SCRIPT] avec l’expérience [EXPERIENCE].
+	</string>
+	<string name="CompileQueueTitle">
+		Recompilation - progrès
+	</string>
+	<string name="CompileQueueStart">
+		recompiler
+	</string>
+	<string name="ResetQueueTitle">
+		Réinitialiser les progrès
+	</string>
+	<string name="ResetQueueStart">
+		réinitialiser
+	</string>
+	<string name="RunQueueTitle">
+		Lancer
+	</string>
+	<string name="RunQueueStart">
+		lancer
+	</string>
+	<string name="NotRunQueueTitle">
+		Arrêter
+	</string>
+	<string name="NotRunQueueStart">
+		arrêter
+	</string>
+	<string name="CompileSuccessful">
+		Compilation réussie !
+	</string>
+	<string name="CompileSuccessfulSaving">
+		Compilation réussie, enregistrement en cours...
+	</string>
+	<string name="SaveComplete">
+		Enregistrement terminé.
+	</string>
+	<string name="UploadFailed">
+		Échec du chargement de fichier :
+	</string>
+	<string name="ObjectOutOfRange">
+		Script (objet hors de portée)
+	</string>
+	<string name="ScriptWasDeleted">
+		Script (supprimé de l’inventaire)
+	</string>
+	<string name="GodToolsObjectOwnedBy">
+		Objet [OBJECT] appartenant à [OWNER]
+	</string>
+	<string name="GroupsNone">
+		aucun
+	</string>
 	<string name="Group" value=" (groupe)"/>
-	<string name="Unknown">(Inconnu)</string>
+	<string name="Unknown">
+		(Inconnu)
+	</string>
 	<string name="SummaryForTheWeek" value="Récapitulatif de la semaine, début le "/>
 	<string name="NextStipendDay" value=". Prochaine prime le "/>
-	<string name="GroupPlanningDate">[day,datetime,utc]/[mthnum,datetime,utc]/[year,datetime,utc]</string>
+	<string name="GroupPlanningDate">
+		[day,datetime,utc]/[mthnum,datetime,utc]/[year,datetime,utc]
+	</string>
 	<string name="GroupIndividualShare" value="                      Groupe    Part individuelle"/>
 	<string name="GroupColumn" value="Groupe"/>
-	<string name="Balance">Solde</string>
-	<string name="Credits">Crédits</string>
-	<string name="Debits">Débits</string>
-	<string name="Total">Total</string>
-	<string name="NoGroupDataFound">Aucune donnée trouvée pour le groupe</string>
-	<string name="IMParentEstate">domaine parent</string>
-	<string name="IMMainland">continent</string>
-	<string name="IMTeen">teen</string>
-	<string name="Anyone">n'importe qui</string>
-	<string name="RegionInfoError">erreur</string>
-	<string name="RegionInfoAllEstatesOwnedBy">tous les domaines appartenant à [OWNER]</string>
-	<string name="RegionInfoAllEstatesYouOwn">tous les domaines vous appartenant</string>
-	<string name="RegionInfoAllEstatesYouManage">tous les domaines que vous gérez pour [OWNER]</string>
-	<string name="RegionInfoAllowedResidents">Toujours autorisé : ([ALLOWEDAGENTS], max [MAXACCESS])</string>
-	<string name="RegionInfoAllowedGroups">Groupes toujours autorisés : [ALLOWEDGROUPS], max [MAXACCESS])</string>
-	<string name="RegionInfoBannedResidents">Toujours interdits : ([BANNEDAGENTS], max. [MAXBANNED])</string>
-	<string name="RegionInfoListTypeAllowedAgents">Toujours autorisé</string>
-	<string name="RegionInfoListTypeBannedAgents">Toujours interdit</string>
-	<string name="RegionInfoAllEstates">tous les domaines</string>
-	<string name="RegionInfoManagedEstates">domaines gérés</string>
-	<string name="RegionInfoThisEstate">ce domaine</string>
-	<string name="AndNMore">et [EXTRA_COUNT] plus</string>
-	<string name="ScriptLimitsParcelScriptMemory">Mémoire des scripts de parcelles</string>
-	<string name="ScriptLimitsParcelsOwned">Parcelles répertoriées : [PARCELS]</string>
-	<string name="ScriptLimitsMemoryUsed">Mémoire utilisée : [COUNT] Ko sur [MAX] ; [AVAILABLE] Ko disponibles</string>
-	<string name="ScriptLimitsMemoryUsedSimple">Mémoire utilisée : [COUNT] Ko</string>
-	<string name="ScriptLimitsParcelScriptURLs">URL des scripts de parcelles</string>
-	<string name="ScriptLimitsURLsUsed">URL utilisées : [COUNT] sur [MAX] ; [AVAILABLE] disponible(s)</string>
-	<string name="ScriptLimitsURLsUsedSimple">URL utilisées : [COUNT]</string>
-	<string name="ScriptLimitsRequestError">Une erreur est survenue pendant la requête d'informations.</string>
-	<string name="ScriptLimitsRequestNoParcelSelected">Aucune parcelle sélectionnée</string>
-	<string name="ScriptLimitsRequestWrongRegion">Erreur : les informations de script ne sont disponibles que dans votre région actuelle.</string>
-	<string name="ScriptLimitsRequestWaiting">Extraction des informations en cours...</string>
-	<string name="ScriptLimitsRequestDontOwnParcel">Vous n'avez pas le droit d'examiner cette parcelle.</string>
-	<string name="SITTING_ON">Assis(e) dessus</string>
-	<string name="ATTACH_CHEST">Poitrine</string>
-	<string name="ATTACH_HEAD">Crâne</string>
-	<string name="ATTACH_LSHOULDER">Épaule gauche</string>
-	<string name="ATTACH_RSHOULDER">Épaule droite</string>
-	<string name="ATTACH_LHAND">Main gauche</string>
-	<string name="ATTACH_RHAND">Main droite</string>
-	<string name="ATTACH_LFOOT">Pied gauche</string>
-	<string name="ATTACH_RFOOT">Pied droit</string>
-	<string name="ATTACH_BACK">Colonne vertébrale</string>
-	<string name="ATTACH_PELVIS">Bassin</string>
-	<string name="ATTACH_MOUTH">Bouche</string>
-	<string name="ATTACH_CHIN">Menton</string>
-	<string name="ATTACH_LEAR">Oreille gauche</string>
-	<string name="ATTACH_REAR">Oreille droite</string>
-	<string name="ATTACH_LEYE">Œil gauche</string>
-	<string name="ATTACH_REYE">Œil droit</string>
-	<string name="ATTACH_NOSE">Nez</string>
-	<string name="ATTACH_RUARM">Bras droit</string>
-	<string name="ATTACH_RLARM">Avant-bras droit</string>
-	<string name="ATTACH_LUARM">Bras gauche</string>
-	<string name="ATTACH_LLARM">Avant-bras gauche</string>
-	<string name="ATTACH_RHIP">Hanche droite</string>
-	<string name="ATTACH_RULEG">Cuisse droite</string>
-	<string name="ATTACH_RLLEG">Jambe droite</string>
-	<string name="ATTACH_LHIP">Hanche gauche</string>
-	<string name="ATTACH_LULEG">Cuisse gauche</string>
-	<string name="ATTACH_LLLEG">Jambe gauche</string>
-	<string name="ATTACH_BELLY">Estomac</string>
-	<string name="ATTACH_LEFT_PEC">Pectoral gauche</string>
-	<string name="ATTACH_RIGHT_PEC">Pectoral droit</string>
-	<string name="ATTACH_HUD_CENTER_2">HUD centre 2</string>
-	<string name="ATTACH_HUD_TOP_RIGHT">HUD en haut à droite</string>
-	<string name="ATTACH_HUD_TOP_CENTER">HUD en haut au centre</string>
-	<string name="ATTACH_HUD_TOP_LEFT">HUD en haut à gauche</string>
-	<string name="ATTACH_HUD_CENTER_1">HUD centre 1</string>
-	<string name="ATTACH_HUD_BOTTOM_LEFT">HUD en bas à gauche</string>
-	<string name="ATTACH_HUD_BOTTOM">HUD en bas</string>
-	<string name="ATTACH_HUD_BOTTOM_RIGHT">HUD en bas à droite</string>
-	<string name="ATTACH_NECK">Cou</string>
-	<string name="ATTACH_AVATAR_CENTER">Centre de l'avatar</string>
-	<string name="ATTACH_LHAND_RING1">Annulaire gauche</string>
-	<string name="ATTACH_RHAND_RING1">Annulaire droit</string>
-	<string name="ATTACH_TAIL_BASE">Base de la queue</string>
-	<string name="ATTACH_TAIL_TIP">Bout de la queue</string>
-	<string name="ATTACH_LWING">Aile gauche</string>
-	<string name="ATTACH_RWING">Aile droite</string>
-	<string name="ATTACH_FACE_JAW">Mâchoire</string>
-	<string name="ATTACH_FACE_LEAR">Oreille gauche différente</string>
-	<string name="ATTACH_FACE_REAR">Oreille droite différente</string>
-	<string name="ATTACH_FACE_LEYE">Œil gauche différent</string>
-	<string name="ATTACH_FACE_REYE">Œil droit différent</string>
-	<string name="ATTACH_FACE_TONGUE">Langue</string>
-	<string name="ATTACH_GROIN">Aine</string>
-	<string name="ATTACH_HIND_LFOOT">Pied arrière gauche</string>
-	<string name="ATTACH_HIND_RFOOT">Pied arrière droit</string>
-	<string name="CursorPos">Ligne [LINE], colonne [COLUMN]</string>
-	<string name="PanelDirCountFound">[COUNT] trouvé(s)</string>
-	<string name="PanelDirTimeStr">[hour12,datetime,slt]:[min,datetime,slt] [ampm,datetime,slt]</string>
-	<string name="PanelDirEventsDateText">[mthnum,datetime,slt]/[day,datetime,slt]</string>
-	<string name="PanelContentsTooltip">Contenu de l'objet</string>
-	<string name="PanelContentsNewScript">Nouveau script</string>
-	<string name="DoNotDisturbModeResponseDefault">Ce résident a activé Ne pas déranger et verra votre message plus tard.</string>
-	<string name="MuteByName">(par nom)</string>
-	<string name="MuteAgent">(résident)</string>
-	<string name="MuteObject">(objet)</string>
-	<string name="MuteGroup">(groupe)</string>
-	<string name="MuteExternal">(externe)</string>
-	<string name="RegionNoCovenant">Il n'y a aucun règlement pour ce domaine.</string>
-	<string name="RegionNoCovenantOtherOwner">Il n'y a aucun règlement pour ce domaine. Le terrain sur ce domaine est vendu par le propriétaire, non par Linden Lab.  Pour en savoir plus, veuillez contacter le propriétaire.</string>
+	<string name="Balance">
+		Solde
+	</string>
+	<string name="Credits">
+		Crédits
+	</string>
+	<string name="Debits">
+		Débits
+	</string>
+	<string name="Total">
+		Total
+	</string>
+	<string name="NoGroupDataFound">
+		Aucune donnée trouvée pour le groupe
+	</string>
+	<string name="IMParentEstate">
+		domaine parent
+	</string>
+	<string name="IMMainland">
+		continent
+	</string>
+	<string name="IMTeen">
+		teen
+	</string>
+	<string name="Anyone">
+		n'importe qui
+	</string>
+	<string name="RegionInfoError">
+		erreur
+	</string>
+	<string name="RegionInfoAllEstatesOwnedBy">
+		tous les domaines appartenant à [OWNER]
+	</string>
+	<string name="RegionInfoAllEstatesYouOwn">
+		tous les domaines vous appartenant
+	</string>
+	<string name="RegionInfoAllEstatesYouManage">
+		tous les domaines que vous gérez pour [OWNER]
+	</string>
+	<string name="RegionInfoAllowedResidents">
+		Toujours autorisé : ([ALLOWEDAGENTS], max [MAXACCESS])
+	</string>
+	<string name="RegionInfoAllowedGroups">
+		Groupes toujours autorisés : [ALLOWEDGROUPS], max [MAXACCESS])
+	</string>
+	<string name="RegionInfoBannedResidents">
+		Toujours interdits : ([BANNEDAGENTS], max. [MAXBANNED])
+	</string>
+	<string name="RegionInfoListTypeAllowedAgents">
+		Toujours autorisé
+	</string>
+	<string name="RegionInfoListTypeBannedAgents">
+		Toujours interdit
+	</string>
+	<string name="RegionInfoAllEstates">
+		tous les domaines
+	</string>
+	<string name="RegionInfoManagedEstates">
+		domaines gérés
+	</string>
+	<string name="RegionInfoThisEstate">
+		ce domaine
+	</string>
+	<string name="AndNMore">
+		et [EXTRA_COUNT] plus
+	</string>
+	<string name="ScriptLimitsParcelScriptMemory">
+		Mémoire des scripts de parcelles
+	</string>
+	<string name="ScriptLimitsParcelsOwned">
+		Parcelles répertoriées : [PARCELS]
+	</string>
+	<string name="ScriptLimitsMemoryUsed">
+		Mémoire utilisée : [COUNT] Ko sur [MAX] ; [AVAILABLE] Ko disponibles
+	</string>
+	<string name="ScriptLimitsMemoryUsedSimple">
+		Mémoire utilisée : [COUNT] Ko
+	</string>
+	<string name="ScriptLimitsParcelScriptURLs">
+		URL des scripts de parcelles
+	</string>
+	<string name="ScriptLimitsURLsUsed">
+		URL utilisées : [COUNT] sur [MAX] ; [AVAILABLE] disponible(s)
+	</string>
+	<string name="ScriptLimitsURLsUsedSimple">
+		URL utilisées : [COUNT]
+	</string>
+	<string name="ScriptLimitsRequestError">
+		Une erreur est survenue pendant la requête d'informations.
+	</string>
+	<string name="ScriptLimitsRequestNoParcelSelected">
+		Aucune parcelle sélectionnée
+	</string>
+	<string name="ScriptLimitsRequestWrongRegion">
+		Erreur : les informations de script ne sont disponibles que dans votre région actuelle.
+	</string>
+	<string name="ScriptLimitsRequestWaiting">
+		Extraction des informations en cours...
+	</string>
+	<string name="ScriptLimitsRequestDontOwnParcel">
+		Vous n'avez pas le droit d'examiner cette parcelle.
+	</string>
+	<string name="SITTING_ON">
+		Assis(e) dessus
+	</string>
+	<string name="ATTACH_CHEST">
+		Poitrine
+	</string>
+	<string name="ATTACH_HEAD">
+		Crâne
+	</string>
+	<string name="ATTACH_LSHOULDER">
+		Épaule gauche
+	</string>
+	<string name="ATTACH_RSHOULDER">
+		Épaule droite
+	</string>
+	<string name="ATTACH_LHAND">
+		Main gauche
+	</string>
+	<string name="ATTACH_RHAND">
+		Main droite
+	</string>
+	<string name="ATTACH_LFOOT">
+		Pied gauche
+	</string>
+	<string name="ATTACH_RFOOT">
+		Pied droit
+	</string>
+	<string name="ATTACH_BACK">
+		Colonne vertébrale
+	</string>
+	<string name="ATTACH_PELVIS">
+		Bassin
+	</string>
+	<string name="ATTACH_MOUTH">
+		Bouche
+	</string>
+	<string name="ATTACH_CHIN">
+		Menton
+	</string>
+	<string name="ATTACH_LEAR">
+		Oreille gauche
+	</string>
+	<string name="ATTACH_REAR">
+		Oreille droite
+	</string>
+	<string name="ATTACH_LEYE">
+		Œil gauche
+	</string>
+	<string name="ATTACH_REYE">
+		Œil droit
+	</string>
+	<string name="ATTACH_NOSE">
+		Nez
+	</string>
+	<string name="ATTACH_RUARM">
+		Bras droit
+	</string>
+	<string name="ATTACH_RLARM">
+		Avant-bras droit
+	</string>
+	<string name="ATTACH_LUARM">
+		Bras gauche
+	</string>
+	<string name="ATTACH_LLARM">
+		Avant-bras gauche
+	</string>
+	<string name="ATTACH_RHIP">
+		Hanche droite
+	</string>
+	<string name="ATTACH_RULEG">
+		Cuisse droite
+	</string>
+	<string name="ATTACH_RLLEG">
+		Jambe droite
+	</string>
+	<string name="ATTACH_LHIP">
+		Hanche gauche
+	</string>
+	<string name="ATTACH_LULEG">
+		Cuisse gauche
+	</string>
+	<string name="ATTACH_LLLEG">
+		Jambe gauche
+	</string>
+	<string name="ATTACH_BELLY">
+		Estomac
+	</string>
+	<string name="ATTACH_LEFT_PEC">
+		Pectoral gauche
+	</string>
+	<string name="ATTACH_RIGHT_PEC">
+		Pectoral droit
+	</string>
+	<string name="ATTACH_HUD_CENTER_2">
+		HUD centre 2
+	</string>
+	<string name="ATTACH_HUD_TOP_RIGHT">
+		HUD en haut à droite
+	</string>
+	<string name="ATTACH_HUD_TOP_CENTER">
+		HUD en haut au centre
+	</string>
+	<string name="ATTACH_HUD_TOP_LEFT">
+		HUD en haut à gauche
+	</string>
+	<string name="ATTACH_HUD_CENTER_1">
+		HUD centre 1
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_LEFT">
+		HUD en bas à gauche
+	</string>
+	<string name="ATTACH_HUD_BOTTOM">
+		HUD en bas
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_RIGHT">
+		HUD en bas à droite
+	</string>
+	<string name="ATTACH_NECK">
+		Cou
+	</string>
+	<string name="ATTACH_AVATAR_CENTER">
+		Centre de l'avatar
+	</string>
+	<string name="ATTACH_LHAND_RING1">
+		Annulaire gauche
+	</string>
+	<string name="ATTACH_RHAND_RING1">
+		Annulaire droit
+	</string>
+	<string name="ATTACH_TAIL_BASE">
+		Base de la queue
+	</string>
+	<string name="ATTACH_TAIL_TIP">
+		Bout de la queue
+	</string>
+	<string name="ATTACH_LWING">
+		Aile gauche
+	</string>
+	<string name="ATTACH_RWING">
+		Aile droite
+	</string>
+	<string name="ATTACH_FACE_JAW">
+		Mâchoire
+	</string>
+	<string name="ATTACH_FACE_LEAR">
+		Oreille gauche différente
+	</string>
+	<string name="ATTACH_FACE_REAR">
+		Oreille droite différente
+	</string>
+	<string name="ATTACH_FACE_LEYE">
+		Œil gauche différent
+	</string>
+	<string name="ATTACH_FACE_REYE">
+		Œil droit différent
+	</string>
+	<string name="ATTACH_FACE_TONGUE">
+		Langue
+	</string>
+	<string name="ATTACH_GROIN">
+		Aine
+	</string>
+	<string name="ATTACH_HIND_LFOOT">
+		Pied arrière gauche
+	</string>
+	<string name="ATTACH_HIND_RFOOT">
+		Pied arrière droit
+	</string>
+	<string name="CursorPos">
+		Ligne [LINE], colonne [COLUMN]
+	</string>
+	<string name="PanelDirCountFound">
+		[COUNT] trouvé(s)
+	</string>
+	<string name="PanelDirTimeStr">
+		[hour12,datetime,slt]:[min,datetime,slt] [ampm,datetime,slt]
+	</string>
+	<string name="PanelDirEventsDateText">
+		[mthnum,datetime,slt]/[day,datetime,slt]
+	</string>
+	<string name="PanelContentsTooltip">
+		Contenu de l'objet
+	</string>
+	<string name="PanelContentsNewScript">
+		Nouveau script
+	</string>
+	<string name="DoNotDisturbModeResponseDefault">
+		Ce résident a activé Ne pas déranger et verra votre message plus tard.
+	</string>
+	<string name="MuteByName">
+		(par nom)
+	</string>
+	<string name="MuteAgent">
+		(résident)
+	</string>
+	<string name="MuteObject">
+		(objet)
+	</string>
+	<string name="MuteGroup">
+		(groupe)
+	</string>
+	<string name="MuteExternal">
+		(externe)
+	</string>
+	<string name="RegionNoCovenant">
+		Il n'y a aucun règlement pour ce domaine.
+	</string>
+	<string name="RegionNoCovenantOtherOwner">
+		Il n'y a aucun règlement pour ce domaine. Le terrain sur ce domaine est vendu par le propriétaire, non par Linden Lab.  Pour en savoir plus, veuillez contacter le propriétaire.
+	</string>
 	<string name="covenant_last_modified" value="Dernière modification :"/>
 	<string name="none_text" value=" (aucun)"/>
 	<string name="never_text" value=" (jamais)"/>
-	<string name="GroupOwned">Propriété du groupe</string>
-	<string name="Public">Public</string>
-	<string name="LocalSettings">Réglages locaux</string>
-	<string name="RegionSettings">Réglages de la région</string>
-	<string name="NoEnvironmentSettings">Cette région ne prend pas en charge les paramètres environnementaux.</string>
-	<string name="EnvironmentSun">Soleil</string>
-	<string name="EnvironmentMoon">Lune</string>
-	<string name="EnvironmentBloom">Éclat</string>
-	<string name="EnvironmentCloudNoise">Bruit du nuage</string>
-	<string name="EnvironmentNormalMap">Carte normale</string>
-	<string name="EnvironmentTransparent">Transparent</string>
-	<string name="ClassifiedClicksTxt">Clics : [TELEPORT] téléportation, [MAP] carte, [PROFILE] profil</string>
-	<string name="ClassifiedUpdateAfterPublish">(mise à jour après la publication)</string>
-	<string name="NoPicksClassifiedsText">Vous n'avez pas créé de favoris ni de petites annonces Cliquez sur le bouton Plus pour créer un favori ou une petite annonce.</string>
-	<string name="NoPicksText">Vous n'avez pas créé de favoris Cliquer sur le bouton Nouveau pour créer un favori</string>
-	<string name="NoClassifiedsText">Vous n'avez pas créé de petites annonces Cliquer sur le bouton Nouveau pour créer une petite annonce.</string>
-	<string name="NoAvatarPicksClassifiedsText">L'utilisateur n'a ni favoris ni petites annonces.</string>
-	<string name="NoAvatarPicksText">L'utilisateur n'a pas de favoris</string>
-	<string name="NoAvatarClassifiedsText">L'utilisateur n'a pas de petites annonces</string>
-	<string name="PicksClassifiedsLoadingText">Chargement...</string>
-	<string name="MultiPreviewTitle">Prévisualiser</string>
-	<string name="MultiPropertiesTitle">Propriétés</string>
-	<string name="InvOfferAnObjectNamed">Un objet appelé</string>
-	<string name="InvOfferOwnedByGroup">possédé par le groupe</string>
-	<string name="InvOfferOwnedByUnknownGroup">possédé par un groupe inconnu</string>
-	<string name="InvOfferOwnedBy">possédé par</string>
-	<string name="InvOfferOwnedByUnknownUser">possédé par un résident inconnu</string>
-	<string name="InvOfferGaveYou">vous a donné</string>
-	<string name="InvOfferDecline">Vous refusez l'offre [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.</string>
-	<string name="GroupMoneyTotal">Total</string>
-	<string name="GroupMoneyBought">acheté</string>
-	<string name="GroupMoneyPaidYou">vous a payé</string>
-	<string name="GroupMoneyPaidInto">payé</string>
-	<string name="GroupMoneyBoughtPassTo">a acheté un pass à</string>
-	<string name="GroupMoneyPaidFeeForEvent">a payé des frais pour un événement</string>
-	<string name="GroupMoneyPaidPrizeForEvent">a payé un prix pour un événement</string>
-	<string name="GroupMoneyBalance">Solde</string>
-	<string name="GroupMoneyCredits">Crédits</string>
-	<string name="GroupMoneyDebits">Débits</string>
-	<string name="GroupMoneyDate">[weekday,datetime,utc] [day,datetime,utc] [mth,datetime,utc] [year,datetime,utc]</string>
-	<string name="AcquiredItems">Objets acquis</string>
-	<string name="Cancel">Annuler</string>
-	<string name="UploadingCosts">Le chargement de [NAME] coûte [AMOUNT] L$</string>
-	<string name="BuyingCosts">Cet achat coûte [AMOUNT] L$</string>
-	<string name="UnknownFileExtension">Extension de fichier inconnue .%s
-.wav, .tga, .bmp, .jpg, .jpeg, ou .bvh acceptés</string>
-	<string name="MuteObject2">Ignorer</string>
-	<string name="MuteAvatar">Ignorer</string>
-	<string name="UnmuteObject">Ne plus ignorer</string>
-	<string name="UnmuteAvatar">Ne plus ignorer</string>
-	<string name="AddLandmarkNavBarMenu">Ajouter à mes repères...</string>
-	<string name="EditLandmarkNavBarMenu">Modifier mon repère...</string>
-	<string name="accel-mac-control">⌃</string>
-	<string name="accel-mac-command">⌘</string>
-	<string name="accel-mac-option">⌥</string>
-	<string name="accel-mac-shift">⇧</string>
-	<string name="accel-win-control">Ctrl+</string>
-	<string name="accel-win-alt">Alt+</string>
-	<string name="accel-win-shift">Maj+</string>
-	<string name="FileSaved">Fichier enregistré</string>
-	<string name="Receiving">Réception</string>
-	<string name="AM">Matin</string>
-	<string name="PM">Après-midi</string>
-	<string name="PST">PST</string>
-	<string name="PDT">PDT</string>
-	<string name="Direction_Forward">Avant</string>
-	<string name="Direction_Left">Gauche</string>
-	<string name="Direction_Right">Droite</string>
-	<string name="Direction_Back">Arrière</string>
-	<string name="Direction_North">Nord</string>
-	<string name="Direction_South">Sud</string>
-	<string name="Direction_West">Ouest</string>
-	<string name="Direction_East">Est</string>
-	<string name="Direction_Up">Haut</string>
-	<string name="Direction_Down">Bas</string>
-	<string name="Any Category">Toutes catégories</string>
-	<string name="Shopping">Shopping</string>
-	<string name="Land Rental">Terrains à louer</string>
-	<string name="Property Rental">Propriétés à louer</string>
-	<string name="Special Attraction">Divertissements</string>
-	<string name="New Products">Nouveaux produits</string>
-	<string name="Employment">Emplois</string>
-	<string name="Wanted">Offres</string>
-	<string name="Service">Services</string>
-	<string name="Personal">Divers</string>
-	<string name="None">Aucun</string>
-	<string name="Linden Location">Appartenant aux Lindens</string>
-	<string name="Adult">Adulte</string>
-	<string name="Arts&amp;Culture">Arts et culture</string>
-	<string name="Business">Business</string>
-	<string name="Educational">Éducation</string>
-	<string name="Gaming">Jeux</string>
-	<string name="Hangout">Favoris</string>
-	<string name="Newcomer Friendly">Accueil pour les nouveaux</string>
-	<string name="Parks&amp;Nature">Parcs et nature</string>
-	<string name="Residential">Résidentiel</string>
-	<string name="Stage">Phase</string>
-	<string name="Other">Autre</string>
-	<string name="Rental">Location</string>
-	<string name="Any">Aucun</string>
-	<string name="You">Vous</string>
-	<string name=":">:</string>
-	<string name=",">,</string>
-	<string name="...">...</string>
-	<string name="***">***</string>
-	<string name="(">(</string>
-	<string name=")">)</string>
-	<string name=".">.</string>
-	<string name="'">'</string>
-	<string name="---">---</string>
-	<string name="Multiple Media">Médias multiples</string>
-	<string name="Play Media">Lire/pauser le média</string>
-	<string name="IntelDriverPage">http://www.intel.com/p/fr_FR/support/detect/graphics</string>
-	<string name="NvidiaDriverPage">http://www.nvidia.com/Download/index.aspx?lang=fr</string>
-	<string name="AMDDriverPage">http://support.amd.com/us/Pages/AMDSupportHub.aspx</string>
-	<string name="MBCmdLineError">Une erreur est survenue lors de la lecture de la ligne de commande.
+	<string name="GroupOwned">
+		Propriété du groupe
+	</string>
+	<string name="Public">
+		Public
+	</string>
+	<string name="LocalSettings">
+		Réglages locaux
+	</string>
+	<string name="RegionSettings">
+		Réglages de la région
+	</string>
+	<string name="NoEnvironmentSettings">
+		Cette région ne prend pas en charge les paramètres environnementaux.
+	</string>
+	<string name="EnvironmentSun">
+		Soleil
+	</string>
+	<string name="EnvironmentMoon">
+		Lune
+	</string>
+	<string name="EnvironmentBloom">
+		Éclat
+	</string>
+	<string name="EnvironmentCloudNoise">
+		Bruit du nuage
+	</string>
+	<string name="EnvironmentNormalMap">
+		Carte normale
+	</string>
+	<string name="EnvironmentTransparent">
+		Transparent
+	</string>
+	<string name="ClassifiedClicksTxt">
+		Clics : [TELEPORT] téléportation, [MAP] carte, [PROFILE] profil
+	</string>
+	<string name="ClassifiedUpdateAfterPublish">
+		(mise à jour après la publication)
+	</string>
+	<string name="NoPicksClassifiedsText">
+		Vous n'avez pas créé de favoris ni de petites annonces Cliquez sur le bouton Plus pour créer un favori ou une petite annonce.
+	</string>
+	<string name="NoPicksText">
+		Vous n'avez pas créé de favoris Cliquer sur le bouton Nouveau pour créer un favori
+	</string>
+	<string name="NoClassifiedsText">
+		Vous n'avez pas créé de petites annonces Cliquer sur le bouton Nouveau pour créer une petite annonce.
+	</string>
+	<string name="NoAvatarPicksClassifiedsText">
+		L'utilisateur n'a ni favoris ni petites annonces.
+	</string>
+	<string name="NoAvatarPicksText">
+		L'utilisateur n'a pas de favoris
+	</string>
+	<string name="NoAvatarClassifiedsText">
+		L'utilisateur n'a pas de petites annonces
+	</string>
+	<string name="PicksClassifiedsLoadingText">
+		Chargement...
+	</string>
+	<string name="MultiPreviewTitle">
+		Prévisualiser
+	</string>
+	<string name="MultiPropertiesTitle">
+		Propriétés
+	</string>
+	<string name="InvOfferAnObjectNamed">
+		Un objet appelé
+	</string>
+	<string name="InvOfferOwnedByGroup">
+		possédé par le groupe
+	</string>
+	<string name="InvOfferOwnedByUnknownGroup">
+		possédé par un groupe inconnu
+	</string>
+	<string name="InvOfferOwnedBy">
+		possédé par
+	</string>
+	<string name="InvOfferOwnedByUnknownUser">
+		possédé par un résident inconnu
+	</string>
+	<string name="InvOfferGaveYou">
+		vous a donné
+	</string>
+	<string name="InvOfferDecline">
+		Vous refusez l'offre [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.
+	</string>
+	<string name="GroupMoneyTotal">
+		Total
+	</string>
+	<string name="GroupMoneyBought">
+		acheté
+	</string>
+	<string name="GroupMoneyPaidYou">
+		vous a payé
+	</string>
+	<string name="GroupMoneyPaidInto">
+		payé
+	</string>
+	<string name="GroupMoneyBoughtPassTo">
+		a acheté un pass à
+	</string>
+	<string name="GroupMoneyPaidFeeForEvent">
+		a payé des frais pour un événement
+	</string>
+	<string name="GroupMoneyPaidPrizeForEvent">
+		a payé un prix pour un événement
+	</string>
+	<string name="GroupMoneyBalance">
+		Solde
+	</string>
+	<string name="GroupMoneyCredits">
+		Crédits
+	</string>
+	<string name="GroupMoneyDebits">
+		Débits
+	</string>
+	<string name="GroupMoneyDate">
+		[weekday,datetime,utc] [day,datetime,utc] [mth,datetime,utc] [year,datetime,utc]
+	</string>
+	<string name="AcquiredItems">
+		Objets acquis
+	</string>
+	<string name="Cancel">
+		Annuler
+	</string>
+	<string name="UploadingCosts">
+		Le chargement de [NAME] coûte [AMOUNT] L$
+	</string>
+	<string name="BuyingCosts">
+		Cet achat coûte [AMOUNT] L$
+	</string>
+	<string name="UnknownFileExtension">
+		Extension de fichier inconnue .%s
+.wav, .tga, .bmp, .jpg, .jpeg, ou .bvh acceptés
+	</string>
+	<string name="MuteObject2">
+		Ignorer
+	</string>
+	<string name="MuteAvatar">
+		Ignorer
+	</string>
+	<string name="UnmuteObject">
+		Ne plus ignorer
+	</string>
+	<string name="UnmuteAvatar">
+		Ne plus ignorer
+	</string>
+	<string name="AddLandmarkNavBarMenu">
+		Ajouter à mes repères...
+	</string>
+	<string name="EditLandmarkNavBarMenu">
+		Modifier mon repère...
+	</string>
+	<string name="accel-mac-control">
+		⌃
+	</string>
+	<string name="accel-mac-command">
+		⌘
+	</string>
+	<string name="accel-mac-option">
+		⌥
+	</string>
+	<string name="accel-mac-shift">
+		⇧
+	</string>
+	<string name="accel-win-control">
+		Ctrl+
+	</string>
+	<string name="accel-win-alt">
+		Alt+
+	</string>
+	<string name="accel-win-shift">
+		Maj+
+	</string>
+	<string name="FileSaved">
+		Fichier enregistré
+	</string>
+	<string name="Receiving">
+		Réception
+	</string>
+	<string name="AM">
+		Matin
+	</string>
+	<string name="PM">
+		Après-midi
+	</string>
+	<string name="PST">
+		PST
+	</string>
+	<string name="PDT">
+		PDT
+	</string>
+	<string name="Direction_Forward">
+		Avant
+	</string>
+	<string name="Direction_Left">
+		Gauche
+	</string>
+	<string name="Direction_Right">
+		Droite
+	</string>
+	<string name="Direction_Back">
+		Arrière
+	</string>
+	<string name="Direction_North">
+		Nord
+	</string>
+	<string name="Direction_South">
+		Sud
+	</string>
+	<string name="Direction_West">
+		Ouest
+	</string>
+	<string name="Direction_East">
+		Est
+	</string>
+	<string name="Direction_Up">
+		Haut
+	</string>
+	<string name="Direction_Down">
+		Bas
+	</string>
+	<string name="Any Category">
+		Toutes catégories
+	</string>
+	<string name="Shopping">
+		Shopping
+	</string>
+	<string name="Land Rental">
+		Terrains à louer
+	</string>
+	<string name="Property Rental">
+		Propriétés à louer
+	</string>
+	<string name="Special Attraction">
+		Divertissements
+	</string>
+	<string name="New Products">
+		Nouveaux produits
+	</string>
+	<string name="Employment">
+		Emplois
+	</string>
+	<string name="Wanted">
+		Offres
+	</string>
+	<string name="Service">
+		Services
+	</string>
+	<string name="Personal">
+		Divers
+	</string>
+	<string name="None">
+		Aucun
+	</string>
+	<string name="Linden Location">
+		Appartenant aux Lindens
+	</string>
+	<string name="Adult">
+		Adulte
+	</string>
+	<string name="Arts&amp;Culture">
+		Arts et culture
+	</string>
+	<string name="Business">
+		Business
+	</string>
+	<string name="Educational">
+		Éducation
+	</string>
+	<string name="Gaming">
+		Jeux
+	</string>
+	<string name="Hangout">
+		Favoris
+	</string>
+	<string name="Newcomer Friendly">
+		Accueil pour les nouveaux
+	</string>
+	<string name="Parks&amp;Nature">
+		Parcs et nature
+	</string>
+	<string name="Residential">
+		Résidentiel
+	</string>
+	<string name="Stage">
+		Phase
+	</string>
+	<string name="Other">
+		Autre
+	</string>
+	<string name="Rental">
+		Location
+	</string>
+	<string name="Any">
+		Aucun
+	</string>
+	<string name="You">
+		Vous
+	</string>
+	<string name=":">
+		:
+	</string>
+	<string name=",">
+		,
+	</string>
+	<string name="...">
+		...
+	</string>
+	<string name="***">
+		***
+	</string>
+	<string name="(">
+		(
+	</string>
+	<string name=")">
+		)
+	</string>
+	<string name=".">
+		.
+	</string>
+	<string name="'">
+		'
+	</string>
+	<string name="---">
+		---
+	</string>
+	<string name="Multiple Media">
+		Médias multiples
+	</string>
+	<string name="Play Media">
+		Lire/pauser le média
+	</string>
+	<string name="IntelDriverPage">
+		http://www.intel.com/p/fr_FR/support/detect/graphics
+	</string>
+	<string name="NvidiaDriverPage">
+		http://www.nvidia.com/Download/index.aspx?lang=fr
+	</string>
+	<string name="AMDDriverPage">
+		http://support.amd.com/us/Pages/AMDSupportHub.aspx
+	</string>
+	<string name="MBCmdLineError">
+		Une erreur est survenue lors de la lecture de la ligne de commande.
 Merci de consulter : http://wiki.secondlife.com/wiki/Client_parameters
-Erreur :</string>
-	<string name="MBCmdLineUsg">[APP_NAME] - Utilisation de la ligne de commande :</string>
-	<string name="MBUnableToAccessFile">[APP_NAME] ne peut accéder à un fichier requis.
+Erreur :
+	</string>
+	<string name="MBCmdLineUsg">
+		[APP_NAME] - Utilisation de la ligne de commande :
+	</string>
+	<string name="MBUnableToAccessFile">
+		[APP_NAME] ne peut accéder à un fichier requis.
 
 Cela vient du fait que quelqu'un a ouvert plusieurs copies ou que votre système pense qu'un fichier est ouvert.
 Si ce message persiste, veuillez redémarrer votre ordinateur.
-Si le problème persiste, vous devrez peut-être complètement désinstaller puis réinstaller [APP_NAME].</string>
-	<string name="MBFatalError">Erreur fatale</string>
-	<string name="MBRequiresAltiVec">[APP_NAME] nécessite un microprocesseur AltiVec (version G4 ou antérieure).</string>
-	<string name="MBAlreadyRunning">[APP_NAME] est déjà en cours d'exécution.
+Si le problème persiste, vous devrez peut-être complètement désinstaller puis réinstaller [APP_NAME].
+	</string>
+	<string name="MBFatalError">
+		Erreur fatale
+	</string>
+	<string name="MBRequiresAltiVec">
+		[APP_NAME] nécessite un microprocesseur AltiVec (version G4 ou antérieure).
+	</string>
+	<string name="MBAlreadyRunning">
+		[APP_NAME] est déjà en cours d'exécution.
 Vérifiez si une version minimisée du programme apparaît dans votre barre de tâches.
-Si ce message persiste, redémarrez votre ordinateur.</string>
-	<string name="MBFrozenCrashed">[APP_NAME] semble avoir crashé lors de l'utilisation précédente.
-Voulez-vous envoyer un rapport de crash ?</string>
-	<string name="MBAlert">Notification</string>
-	<string name="MBNoDirectX">[APP_NAME] ne peut détecter DirectX 9.0b ou une version supérieure.
+Si ce message persiste, redémarrez votre ordinateur.
+	</string>
+	<string name="MBFrozenCrashed">
+		[APP_NAME] semble avoir crashé lors de l'utilisation précédente.
+Voulez-vous envoyer un rapport de crash ?
+	</string>
+	<string name="MBAlert">
+		Notification
+	</string>
+	<string name="MBNoDirectX">
+		[APP_NAME] ne peut détecter DirectX 9.0b ou une version supérieure.
 [APP_NAME] utilise DirectX pour détecter les matériels et/ou les pilotes qui ne sont pas à jour et peuvent causer des problèmes de stabilité, de performance ou des plantages.  Bien que vous puissiez utiliser [APP_NAME] sans DirectX, nous vous recommandons de l'utiliser avec DirectX 9.0b.
 
-Voulez-vous continuer ?</string>
-	<string name="MBWarning">Avertissement</string>
-	<string name="MBNoAutoUpdate">Les mises à jour automatiques n'existent pas encore pour Linux.
-Veuillez télécharger la dernière version sur www.secondlife.com.</string>
-	<string name="MBRegClassFailed">RegisterClass a échoué</string>
-	<string name="MBError">Erreur</string>
-	<string name="MBFullScreenErr">Impossible d'ouvrir le mode plein écran à [WIDTH] x [HEIGHT].
-Utilisation du mode fenêtré.</string>
-	<string name="MBDestroyWinFailed">Erreur de fermeture lors de la destruction de la fenêtre (DestroyWindow() a échoué)</string>
-	<string name="MBShutdownErr">Erreur de fermeture</string>
-	<string name="MBDevContextErr">Impossible de créer le contexte GL</string>
-	<string name="MBPixelFmtErr">Impossible de trouver le format pixel approprié</string>
-	<string name="MBPixelFmtDescErr">Impossible de trouver la description du format pixel</string>
-	<string name="MBTrueColorWindow">[APP_NAME] nécessite True Color (32 bits) pour s'exécuter.
-Accédez aux paramètres d'affichage de votre ordinateur et réglez le mode couleur sur 32 bits.</string>
-	<string name="MBAlpha">[APP_NAME] ne peut pas s'exécuter, car il n'y pas de canal alpha 8 bits accessible.  En général, ceci vient de problèmes avec le pilote de la carte vidéo.
+Voulez-vous continuer ?
+	</string>
+	<string name="MBWarning">
+		Avertissement
+	</string>
+	<string name="MBNoAutoUpdate">
+		Les mises à jour automatiques n'existent pas encore pour Linux.
+Veuillez télécharger la dernière version sur www.secondlife.com.
+	</string>
+	<string name="MBRegClassFailed">
+		RegisterClass a échoué
+	</string>
+	<string name="MBError">
+		Erreur
+	</string>
+	<string name="MBFullScreenErr">
+		Impossible d'ouvrir le mode plein écran à [WIDTH] x [HEIGHT].
+Utilisation du mode fenêtré.
+	</string>
+	<string name="MBDestroyWinFailed">
+		Erreur de fermeture lors de la destruction de la fenêtre (DestroyWindow() a échoué)
+	</string>
+	<string name="MBShutdownErr">
+		Erreur de fermeture
+	</string>
+	<string name="MBDevContextErr">
+		Impossible de créer le contexte GL
+	</string>
+	<string name="MBPixelFmtErr">
+		Impossible de trouver le format pixel approprié
+	</string>
+	<string name="MBPixelFmtDescErr">
+		Impossible de trouver la description du format pixel
+	</string>
+	<string name="MBTrueColorWindow">
+		[APP_NAME] nécessite True Color (32 bits) pour s'exécuter.
+Accédez aux paramètres d'affichage de votre ordinateur et réglez le mode couleur sur 32 bits.
+	</string>
+	<string name="MBAlpha">
+		[APP_NAME] ne peut pas s'exécuter, car il n'y pas de canal alpha 8 bits accessible.  En général, ceci vient de problèmes avec le pilote de la carte vidéo.
 Assurez-vous d'avoir installé le pilote de carte vidéo le plus récent possible.
 Assurez-vous aussi que votre écran est réglé sur True Color (32 bits) sous Panneau de configuration &gt; Affichage &gt; Paramètres.
-Si ce message persiste, veuillez aller sur la page [SUPPORT_SITE].</string>
-	<string name="MBPixelFmtSetErr">Impossible de trouver le format pixel approprié</string>
-	<string name="MBGLContextErr">Impossible de créer le contexte de rendu GL</string>
-	<string name="MBGLContextActErr">Impossible d'activer le contexte de rendu GL</string>
-	<string name="MBVideoDrvErr">[APP_NAME] ne peut pas s'exécuter car les pilotes de votre carte vidéo n'ont pas été installés correctement, ne sont pas à jour, ou sont pour du matériel non pris en charge. Assurez-vous d'avoir des pilotes de cartes vidéos récents, et même si vous avez les plus récents, réinstallez-les.
+Si ce message persiste, veuillez aller sur la page [SUPPORT_SITE].
+	</string>
+	<string name="MBPixelFmtSetErr">
+		Impossible de trouver le format pixel approprié
+	</string>
+	<string name="MBGLContextErr">
+		Impossible de créer le contexte de rendu GL
+	</string>
+	<string name="MBGLContextActErr">
+		Impossible d'activer le contexte de rendu GL
+	</string>
+	<string name="MBVideoDrvErr">
+		[APP_NAME] ne peut pas s'exécuter car les pilotes de votre carte vidéo n'ont pas été installés correctement, ne sont pas à jour, ou sont pour du matériel non pris en charge. Assurez-vous d'avoir des pilotes de cartes vidéos récents, et même si vous avez les plus récents, réinstallez-les.
 
-Si ce message persiste, veuillez aller sur la page [SUPPORT_SITE].</string>
-	<string name="5 O'Clock Shadow">Peu</string>
-	<string name="All White">Tout blancs</string>
-	<string name="Anime Eyes">Grand yeux</string>
-	<string name="Arced">Arqués</string>
-	<string name="Arm Length">Longueur des bras</string>
-	<string name="Attached">Attachés</string>
-	<string name="Attached Earlobes">Lobes</string>
-	<string name="Back Fringe">Mèches de derrière</string>
-	<string name="Baggy">Plus</string>
-	<string name="Bangs">Frange</string>
-	<string name="Beady Eyes">Yeux perçants</string>
-	<string name="Belly Size">Taille du ventre</string>
-	<string name="Big">Plus</string>
-	<string name="Big Butt">Grosses fesses</string>
-	<string name="Big Hair Back">Volume : Derrière</string>
-	<string name="Big Hair Front">Volume : Devant</string>
-	<string name="Big Hair Top">Volume : Haut</string>
-	<string name="Big Head">Plus</string>
-	<string name="Big Pectorals">Gros pectoraux</string>
-	<string name="Big Spikes">Spikes</string>
-	<string name="Black">Noir</string>
-	<string name="Blonde">Blond</string>
-	<string name="Blonde Hair">Cheveux blonds</string>
-	<string name="Blush">Blush</string>
-	<string name="Blush Color">Couleur du blush</string>
-	<string name="Blush Opacity">Opacité du blush</string>
-	<string name="Body Definition">Contour du corps</string>
-	<string name="Body Fat">Graisse</string>
-	<string name="Body Freckles">Grains de beauté</string>
-	<string name="Body Thick">Plus</string>
-	<string name="Body Thickness">Épaisseur du corps</string>
-	<string name="Body Thin">Moins</string>
-	<string name="Bow Legged">Jambes arquées</string>
-	<string name="Breast Buoyancy">Hauteur des seins</string>
-	<string name="Breast Cleavage">Clivage</string>
-	<string name="Breast Size">Taille des seins</string>
-	<string name="Bridge Width">Arête du nez</string>
-	<string name="Broad">Large</string>
-	<string name="Brow Size">Taille du front</string>
-	<string name="Bug Eyes">Yeux globuleux</string>
-	<string name="Bugged Eyes">Yeux globuleux</string>
-	<string name="Bulbous">En bulbe</string>
-	<string name="Bulbous Nose">Nez en bulbe</string>
-	<string name="Breast Physics Mass">Masse des seins</string>
-	<string name="Breast Physics Smoothing">Lissage des seins</string>
-	<string name="Breast Physics Gravity">Gravité des seins</string>
-	<string name="Breast Physics Drag">Résistance de l'air sur les seins</string>
-	<string name="Breast Physics InOut Max Effect">Effet max.</string>
-	<string name="Breast Physics InOut Spring">Élasticité</string>
-	<string name="Breast Physics InOut Gain">Amplification</string>
-	<string name="Breast Physics InOut Damping">Amortissement</string>
-	<string name="Breast Physics UpDown Max Effect">Effet max.</string>
-	<string name="Breast Physics UpDown Spring">Élasticité</string>
-	<string name="Breast Physics UpDown Gain">Amplification</string>
-	<string name="Breast Physics UpDown Damping">Amortissement</string>
-	<string name="Breast Physics LeftRight Max Effect">Effet max.</string>
-	<string name="Breast Physics LeftRight Spring">Élasticité</string>
-	<string name="Breast Physics LeftRight Gain">Amplification</string>
-	<string name="Breast Physics LeftRight Damping">Amortissement</string>
-	<string name="Belly Physics Mass">Masse du ventre</string>
-	<string name="Belly Physics Smoothing">Lissage du ventre</string>
-	<string name="Belly Physics Gravity">Gravité du ventre</string>
-	<string name="Belly Physics Drag">Résistance de l'air sur le ventre</string>
-	<string name="Belly Physics UpDown Max Effect">Effet max.</string>
-	<string name="Belly Physics UpDown Spring">Élasticité</string>
-	<string name="Belly Physics UpDown Gain">Amplification</string>
-	<string name="Belly Physics UpDown Damping">Amortissement</string>
-	<string name="Butt Physics Mass">Masse des fesses</string>
-	<string name="Butt Physics Smoothing">Lissage des fesses</string>
-	<string name="Butt Physics Gravity">Gravité des fesses</string>
-	<string name="Butt Physics Drag">Résistance de l'air sur les fesses</string>
-	<string name="Butt Physics UpDown Max Effect">Effet max.</string>
-	<string name="Butt Physics UpDown Spring">Élasticité</string>
-	<string name="Butt Physics UpDown Gain">Amplification</string>
-	<string name="Butt Physics UpDown Damping">Amortissement</string>
-	<string name="Butt Physics LeftRight Max Effect">Effet max.</string>
-	<string name="Butt Physics LeftRight Spring">Élasticité</string>
-	<string name="Butt Physics LeftRight Gain">Amplification</string>
-	<string name="Butt Physics LeftRight Damping">Amortissement</string>
-	<string name="Bushy Eyebrows">Sourcils touffus</string>
-	<string name="Bushy Hair">Beaucoup</string>
-	<string name="Butt Size">Taille des fesses</string>
-	<string name="Butt Gravity">Gravité des fesses</string>
-	<string name="bustle skirt">Jupe gonflante</string>
-	<string name="no bustle">Pas gonflante</string>
-	<string name="more bustle">Plus gonflante</string>
-	<string name="Chaplin">Moins</string>
-	<string name="Cheek Bones">Pommettes</string>
-	<string name="Chest Size">Taille de la poitrine</string>
-	<string name="Chin Angle">Angle du menton</string>
-	<string name="Chin Cleft">Fente du menton</string>
-	<string name="Chin Curtains">Favoris</string>
-	<string name="Chin Depth">Profondeur</string>
-	<string name="Chin Heavy">Menton lourd</string>
-	<string name="Chin In">Menton rentré</string>
-	<string name="Chin Out">Menton sorti</string>
-	<string name="Chin-Neck">Menton-cou</string>
-	<string name="Clear">Clair</string>
-	<string name="Cleft">Fendu</string>
-	<string name="Close Set Eyes">Yeux rapprochés</string>
-	<string name="Closed">Fermé(s)</string>
-	<string name="Closed Back">Fermé à l'arrière</string>
-	<string name="Closed Front">Fermé devant</string>
-	<string name="Closed Left">Fermé à gauche</string>
-	<string name="Closed Right">Fermé à droite</string>
-	<string name="Coin Purse">Mini</string>
-	<string name="Collar Back">Col arrière</string>
-	<string name="Collar Front">Col devant</string>
-	<string name="Corner Down">Coin vers le bas</string>
-	<string name="Corner Up">Coin vers le haut</string>
-	<string name="Creased">Fripée</string>
-	<string name="Crooked Nose">Déviation du nez</string>
-	<string name="Cuff Flare">Jambes</string>
-	<string name="Dark">Sombre</string>
-	<string name="Dark Green">Vert foncé</string>
-	<string name="Darker">Plus foncé</string>
-	<string name="Deep">Profonde</string>
-	<string name="Default Heels">Talons par défaut</string>
-	<string name="Dense">Dense</string>
-	<string name="Double Chin">Double menton</string>
-	<string name="Downturned">Pointant vers le bas</string>
-	<string name="Duffle Bag">Maxi</string>
-	<string name="Ear Angle">Angle de l'oreille</string>
-	<string name="Ear Size">Taille</string>
-	<string name="Ear Tips">Extrémités</string>
-	<string name="Egg Head">Proéminence</string>
-	<string name="Eye Bags">Cernes</string>
-	<string name="Eye Color">Couleur des yeux</string>
-	<string name="Eye Depth">Profondeur</string>
-	<string name="Eye Lightness">Clarté</string>
-	<string name="Eye Opening">Ouverture</string>
-	<string name="Eye Pop">Œil proéminent</string>
-	<string name="Eye Size">Taille de l'œil</string>
-	<string name="Eye Spacing">Espacement</string>
-	<string name="Eyebrow Arc">Arc</string>
-	<string name="Eyebrow Density">Épaisseur sourcils</string>
-	<string name="Eyebrow Height">Hauteur</string>
-	<string name="Eyebrow Points">Direction</string>
-	<string name="Eyebrow Size">Taille</string>
-	<string name="Eyelash Length">Longueur des cils</string>
-	<string name="Eyeliner">Eyeliner</string>
-	<string name="Eyeliner Color">Couleur de l'eyeliner</string>
-	<string name="Eyes Bugged">Yeux globuleux</string>
-	<string name="Face Shear">Visage</string>
-	<string name="Facial Definition">Définition</string>
-	<string name="Far Set Eyes">Yeux écartés</string>
-	<string name="Fat Lips">Lèvres épaisses</string>
-	<string name="Female">Femme</string>
-	<string name="Fingerless">Sans doigts</string>
-	<string name="Fingers">Doigts</string>
-	<string name="Flared Cuffs">Jambes larges</string>
-	<string name="Flat">Moins</string>
-	<string name="Flat Butt">Fesses plates</string>
-	<string name="Flat Head">Tête plate</string>
-	<string name="Flat Toe">Orteil plat</string>
-	<string name="Foot Size">Pointure</string>
-	<string name="Forehead Angle">Angle du front</string>
-	<string name="Forehead Heavy">Front lourd</string>
-	<string name="Freckles">Tâches de rousseur</string>
-	<string name="Front Fringe">Mèches de devant</string>
-	<string name="Full Back">Arrière touffu</string>
-	<string name="Full Eyeliner">Eyeliner marqué</string>
-	<string name="Full Front">Devant touffu</string>
-	<string name="Full Hair Sides">Côtés touffus</string>
-	<string name="Full Sides">Côtés touffus</string>
-	<string name="Glossy">Brillant</string>
-	<string name="Glove Fingers">Gants avec doigts</string>
-	<string name="Glove Length">Longueur</string>
-	<string name="Hair">Cheveux</string>
-	<string name="Hair Back">Cheveux : Derrière</string>
-	<string name="Hair Front">Cheveux : Devant</string>
-	<string name="Hair Sides">Cheveux : Côtés</string>
-	<string name="Hair Sweep">Sens de la coiffure</string>
-	<string name="Hair Thickess">Épaisseur cheveux</string>
-	<string name="Hair Thickness">Épaisseur cheveux</string>
-	<string name="Hair Tilt">Inclinaison</string>
-	<string name="Hair Tilted Left">Vers la gauche</string>
-	<string name="Hair Tilted Right">Vers la droite</string>
-	<string name="Hair Volume">Cheveux : Volume</string>
-	<string name="Hand Size">Taille de la main</string>
-	<string name="Handlebars">Plus</string>
-	<string name="Head Length">Longueur</string>
-	<string name="Head Shape">Forme</string>
-	<string name="Head Size">Taille</string>
-	<string name="Head Stretch">Allongement</string>
-	<string name="Heel Height">Talons</string>
-	<string name="Heel Shape">Forme des talons</string>
-	<string name="Height">Taille</string>
-	<string name="High">Haut</string>
-	<string name="High Heels">Talons hauts</string>
-	<string name="High Jaw">Haut</string>
-	<string name="High Platforms">Haute</string>
-	<string name="High and Tight">Haut et serré</string>
-	<string name="Higher">Plus élevé</string>
-	<string name="Hip Length">Longueur hanche</string>
-	<string name="Hip Width">Largeur hanche</string>
-	<string name="Hover">Survol</string>
-	<string name="In">Rentré</string>
-	<string name="In Shdw Color">Couleur ombre interne</string>
-	<string name="In Shdw Opacity">Opacité ombre interne</string>
-	<string name="Inner Eye Corner">Coin interne</string>
-	<string name="Inner Eye Shadow">Ombre de l'œil interne</string>
-	<string name="Inner Shadow">Ombre interne</string>
-	<string name="Jacket Length">Longueur de la veste</string>
-	<string name="Jacket Wrinkles">Plis de la veste</string>
-	<string name="Jaw Angle">Angle mâchoire</string>
-	<string name="Jaw Jut">Saillie mâchoire</string>
-	<string name="Jaw Shape">Mâchoire</string>
-	<string name="Join">Rapprochés</string>
-	<string name="Jowls">Bajoues</string>
-	<string name="Knee Angle">Angle du genou</string>
-	<string name="Knock Kneed">Genoux rapprochés</string>
-	<string name="Large">Plus</string>
-	<string name="Large Hands">Grandes mains</string>
-	<string name="Left Part">Raie à gauche</string>
-	<string name="Leg Length">Longueur</string>
-	<string name="Leg Muscles">Muscles</string>
-	<string name="Less">Moins</string>
-	<string name="Less Body Fat">Moins</string>
-	<string name="Less Curtains">Moins</string>
-	<string name="Less Freckles">Moins</string>
-	<string name="Less Full">Moins</string>
-	<string name="Less Gravity">Moins</string>
-	<string name="Less Love">Moins</string>
-	<string name="Less Muscles">Moins</string>
-	<string name="Less Muscular">Moins</string>
-	<string name="Less Rosy">Moins</string>
-	<string name="Less Round">Moins ronde</string>
-	<string name="Less Saddle">Moins</string>
-	<string name="Less Square">Moins carrée</string>
-	<string name="Less Volume">Moins</string>
-	<string name="Less soul">Moins</string>
-	<string name="Lighter">Plus léger</string>
-	<string name="Lip Cleft">Fente labiale</string>
-	<string name="Lip Cleft Depth">Prof. fente labiale</string>
-	<string name="Lip Fullness">Volume des lèvres</string>
-	<string name="Lip Pinkness">Rougeur des lèvres</string>
-	<string name="Lip Ratio">Proportion des lèvres</string>
-	<string name="Lip Thickness">Épaisseur</string>
-	<string name="Lip Width">Largeur</string>
-	<string name="Lipgloss">Brillant à lèvres</string>
-	<string name="Lipstick">Rouge à lèvres</string>
-	<string name="Lipstick Color">Couleur du rouge à lèvres</string>
-	<string name="Long">Plus</string>
-	<string name="Long Head">Tête longue</string>
-	<string name="Long Hips">Hanches longues</string>
-	<string name="Long Legs">Jambes longues</string>
-	<string name="Long Neck">Long cou</string>
-	<string name="Long Pigtails">Longues couettes</string>
-	<string name="Long Ponytail">Longue queue de cheval</string>
-	<string name="Long Torso">Torse long</string>
-	<string name="Long arms">Bras longs</string>
-	<string name="Loose Pants">Pantalons amples</string>
-	<string name="Loose Shirt">Chemise ample</string>
-	<string name="Loose Sleeves">Manches amples</string>
-	<string name="Love Handles">Poignées d'amour</string>
-	<string name="Low">Bas</string>
-	<string name="Low Heels">Talons bas</string>
-	<string name="Low Jaw">Bas</string>
-	<string name="Low Platforms">Basse</string>
-	<string name="Low and Loose">Bas et ample</string>
-	<string name="Lower">Abaisser</string>
-	<string name="Lower Bridge">Arête inférieure</string>
-	<string name="Lower Cheeks">Joue inférieure</string>
-	<string name="Male">Homme</string>
-	<string name="Middle Part">Raie au milieu</string>
-	<string name="More">Plus</string>
-	<string name="More Blush">Plus</string>
-	<string name="More Body Fat">Plus</string>
-	<string name="More Curtains">Plus</string>
-	<string name="More Eyeshadow">Plus</string>
-	<string name="More Freckles">Plus</string>
-	<string name="More Full">Plus</string>
-	<string name="More Gravity">Plus</string>
-	<string name="More Lipstick">Plus</string>
-	<string name="More Love">Plus</string>
-	<string name="More Lower Lip">Inférieure plus grosse</string>
-	<string name="More Muscles">Plus</string>
-	<string name="More Muscular">Plus</string>
-	<string name="More Rosy">Plus</string>
-	<string name="More Round">Plus</string>
-	<string name="More Saddle">Plus</string>
-	<string name="More Sloped">Plus</string>
-	<string name="More Square">Plus</string>
-	<string name="More Upper Lip">Supérieure plus grosse</string>
-	<string name="More Vertical">Plus</string>
-	<string name="More Volume">Plus</string>
-	<string name="More soul">Plus</string>
-	<string name="Moustache">Moustache</string>
-	<string name="Mouth Corner">Coin de la bouche</string>
-	<string name="Mouth Position">Position</string>
-	<string name="Mowhawk">Mowhawk</string>
-	<string name="Muscular">Musclé</string>
-	<string name="Mutton Chops">Longs</string>
-	<string name="Nail Polish">Vernis à ongles</string>
-	<string name="Nail Polish Color">Couleur du vernis</string>
-	<string name="Narrow">Moins</string>
-	<string name="Narrow Back">Arrière étroit</string>
-	<string name="Narrow Front">Devant étroit</string>
-	<string name="Narrow Lips">Lèvres étroites</string>
-	<string name="Natural">Naturel</string>
-	<string name="Neck Length">Longueur du cou</string>
-	<string name="Neck Thickness">Épaisseur du cou</string>
-	<string name="No Blush">Pas de blush</string>
-	<string name="No Eyeliner">Pas d'eyeliner</string>
-	<string name="No Eyeshadow">Pas d'ombre à paupières</string>
-	<string name="No Lipgloss">Pas de brillant à lèvres</string>
-	<string name="No Lipstick">Pas de rouge à lèvres</string>
-	<string name="No Part">Pas de raie</string>
-	<string name="No Polish">Pas de vernis</string>
-	<string name="No Red">Pas de rouge</string>
-	<string name="No Spikes">Pas de spikes</string>
-	<string name="No White">Pas de blanc</string>
-	<string name="No Wrinkles">Pas de rides</string>
-	<string name="Normal Lower">Normal plus bas</string>
-	<string name="Normal Upper">Normal plus haut</string>
-	<string name="Nose Left">Nez à gauche</string>
-	<string name="Nose Right">Nez à droite</string>
-	<string name="Nose Size">Taille du nez</string>
-	<string name="Nose Thickness">Épaisseur du nez</string>
-	<string name="Nose Tip Angle">Angle bout du nez</string>
-	<string name="Nose Tip Shape">Forme bout du nez</string>
-	<string name="Nose Width">Largeur du nez</string>
-	<string name="Nostril Division">Division narines</string>
-	<string name="Nostril Width">Largeur narines</string>
-	<string name="Opaque">Opaque</string>
-	<string name="Open">Ouvert</string>
-	<string name="Open Back">Derrière ouvert</string>
-	<string name="Open Front">Devant ouvert</string>
-	<string name="Open Left">Ouvert à gauche</string>
-	<string name="Open Right">Ouvert à droite</string>
-	<string name="Orange">Orange</string>
-	<string name="Out">Sorti</string>
-	<string name="Out Shdw Color">Couleur de l'ombre externe</string>
-	<string name="Out Shdw Opacity">Opacité de l'ombre externe</string>
-	<string name="Outer Eye Corner">Coin externe</string>
-	<string name="Outer Eye Shadow">Ombre de l'œil externe</string>
-	<string name="Outer Shadow">Ombre externe</string>
-	<string name="Overbite">Rentrée</string>
-	<string name="Package">Parties</string>
-	<string name="Painted Nails">Ongles vernis</string>
-	<string name="Pale">Pâle</string>
-	<string name="Pants Crotch">Entrejambe</string>
-	<string name="Pants Fit">Taille</string>
-	<string name="Pants Length">Longueur</string>
-	<string name="Pants Waist">Taille</string>
-	<string name="Pants Wrinkles">Plis</string>
-	<string name="Part">Raie</string>
-	<string name="Part Bangs">Séparation frange</string>
-	<string name="Pectorals">Pectoraux</string>
-	<string name="Pigment">Pigmentation</string>
-	<string name="Pigtails">Couettes</string>
-	<string name="Pink">Rose</string>
-	<string name="Pinker">Plus rose</string>
-	<string name="Platform Height">Platef. (hauteur)</string>
-	<string name="Platform Width">Platef. (largeur)</string>
-	<string name="Pointy">Pointue</string>
-	<string name="Pointy Heels">Talons pointus</string>
-	<string name="Ponytail">Queue de cheval</string>
-	<string name="Poofy Skirt">Jupe bouffante</string>
-	<string name="Pop Left Eye">Œil gauche saillant</string>
-	<string name="Pop Right Eye">Œil droit saillant</string>
-	<string name="Puffy">Plus</string>
-	<string name="Puffy Eyelids">Paup. gonflées</string>
-	<string name="Rainbow Color">Couleur arc en ciel</string>
-	<string name="Red Hair">Cheveux roux</string>
-	<string name="Regular">Standard</string>
-	<string name="Right Part">Raie à droite</string>
-	<string name="Rosy Complexion">Teint rosé</string>
-	<string name="Round">Rond</string>
-	<string name="Ruddiness">Rougeur</string>
-	<string name="Ruddy">Rouge</string>
-	<string name="Rumpled Hair">Texture</string>
-	<string name="Saddle Bags">Culotte de cheval</string>
-	<string name="Scrawny Leg">Jambes maigres</string>
-	<string name="Separate">Séparés</string>
-	<string name="Shallow">Creux</string>
-	<string name="Shear Back">Coupe derrière</string>
-	<string name="Shear Face">Visage</string>
-	<string name="Shear Front">Front</string>
-	<string name="Shear Left Up">Haut gauche décalé</string>
-	<string name="Shear Right Up">Haut droit décalé</string>
-	<string name="Sheared Back">Dégagé derrière</string>
-	<string name="Sheared Front">Dégagé devant</string>
-	<string name="Shift Left">Vers la gauche</string>
-	<string name="Shift Mouth">Déplacement</string>
-	<string name="Shift Right">Vers la droite</string>
-	<string name="Shirt Bottom">Chemise</string>
-	<string name="Shirt Fit">Taille</string>
-	<string name="Shirt Wrinkles">Plis</string>
-	<string name="Shoe Height">Hauteur</string>
-	<string name="Short">Moins</string>
-	<string name="Short Arms">Bras courts</string>
-	<string name="Short Legs">Jambes courtes</string>
-	<string name="Short Neck">Petit cou</string>
-	<string name="Short Pigtails">Couettes courtes</string>
-	<string name="Short Ponytail">Queue de cheval courte</string>
-	<string name="Short Sideburns">Court</string>
-	<string name="Short Torso">Torse court</string>
-	<string name="Short hips">Hanches courtes</string>
-	<string name="Shoulders">Épaules</string>
-	<string name="Side Fringe">Mèches sur le côté</string>
-	<string name="Sideburns">Favoris</string>
-	<string name="Sides Hair">Cheveux sur le côté</string>
-	<string name="Sides Hair Down">Cheveux sur le côté en bas</string>
-	<string name="Sides Hair Up">Cheveux sur le côté en haut</string>
-	<string name="Skinny Neck">Cou maigre</string>
-	<string name="Skirt Fit">Taille jupe</string>
-	<string name="Skirt Length">Longueur jupe</string>
-	<string name="Slanted Forehead">Front incliné</string>
-	<string name="Sleeve Length">Longueur manche</string>
-	<string name="Sleeve Looseness">Ampleur manche</string>
-	<string name="Slit Back">Fente : Derrière</string>
-	<string name="Slit Front">Fente : Devant</string>
-	<string name="Slit Left">Fente : Gauche</string>
-	<string name="Slit Right">Fente : Droite</string>
-	<string name="Small">Moins</string>
-	<string name="Small Hands">Petites mains</string>
-	<string name="Small Head">Moins</string>
-	<string name="Smooth">Moins</string>
-	<string name="Smooth Hair">Cheveux lisses</string>
-	<string name="Socks Length">Longueur</string>
-	<string name="Soulpatch">Barbichette</string>
-	<string name="Sparse">Rares</string>
-	<string name="Spiked Hair">Mèches en pointe</string>
-	<string name="Square">Carrée</string>
-	<string name="Square Toe">Orteil carré</string>
-	<string name="Squash Head">Écraser la tête</string>
-	<string name="Stretch Head">Allonger la tête</string>
-	<string name="Sunken">Saillante</string>
-	<string name="Sunken Chest">Poitrine enfoncée</string>
-	<string name="Sunken Eyes">Yeux enfoncés</string>
-	<string name="Sweep Back">En arrière</string>
-	<string name="Sweep Forward">Vers l'avant</string>
-	<string name="Tall">Plus</string>
-	<string name="Taper Back">Arrière</string>
-	<string name="Taper Front">Avant</string>
-	<string name="Thick Heels">Talons épais</string>
-	<string name="Thick Neck">Cou épais</string>
-	<string name="Thick Toe">Orteil épais</string>
-	<string name="Thin">Mince</string>
-	<string name="Thin Eyebrows">Sourcils fins</string>
-	<string name="Thin Lips">Lèvres fines</string>
-	<string name="Thin Nose">Nez fin</string>
-	<string name="Tight Chin">Menton fin</string>
-	<string name="Tight Cuffs">Jambes serrées</string>
-	<string name="Tight Pants">Pantalons serrés</string>
-	<string name="Tight Shirt">Chemise serrée</string>
-	<string name="Tight Skirt">Jupe serrée</string>
-	<string name="Tight Sleeves">Manches serrées</string>
-	<string name="Toe Shape">Forme de l'orteil</string>
-	<string name="Toe Thickness">Épaisseur orteil</string>
-	<string name="Torso Length">Longueur du torse</string>
-	<string name="Torso Muscles">Muscles du torse</string>
-	<string name="Torso Scrawny">Torse maigre</string>
-	<string name="Unattached">Séparés</string>
-	<string name="Uncreased">Lisse</string>
-	<string name="Underbite">Sortie</string>
-	<string name="Unnatural">Artificiel</string>
-	<string name="Upper Bridge">Arête supérieure</string>
-	<string name="Upper Cheeks">Joue supérieure</string>
-	<string name="Upper Chin Cleft">Menton supérieur</string>
-	<string name="Upper Eyelid Fold">Paupière sup.</string>
-	<string name="Upturned">En trompette</string>
-	<string name="Very Red">Très rouge</string>
-	<string name="Waist Height">Hauteur taille</string>
-	<string name="Well-Fed">Ronde</string>
-	<string name="White Hair">Cheveux blancs</string>
-	<string name="Wide">Plus</string>
-	<string name="Wide Back">Derrière large</string>
-	<string name="Wide Front">Devant large</string>
-	<string name="Wide Lips">Lèvres larges</string>
-	<string name="Wild">Artificiel</string>
-	<string name="Wrinkles">Rides</string>
-	<string name="LocationCtrlAddLandmarkTooltip">Ajouter à mes repères</string>
-	<string name="LocationCtrlEditLandmarkTooltip">Modifier mon repère</string>
-	<string name="LocationCtrlInfoBtnTooltip">En savoir plus sur l'emplacement actuel</string>
-	<string name="LocationCtrlComboBtnTooltip">Historique de mes emplacements</string>
-	<string name="LocationCtrlForSaleTooltip">Acheter ce terrain</string>
-	<string name="LocationCtrlVoiceTooltip">Chat vocal indisponible ici</string>
-	<string name="LocationCtrlFlyTooltip">Vol interdit</string>
-	<string name="LocationCtrlPushTooltip">Pas de bousculades</string>
-	<string name="LocationCtrlBuildTooltip">Construction/placement d'objets interdit</string>
-	<string name="LocationCtrlScriptsTooltip">Scripts interdits</string>
-	<string name="LocationCtrlDamageTooltip">Santé</string>
-	<string name="LocationCtrlAdultIconTooltip">Région de type Adulte</string>
-	<string name="LocationCtrlModerateIconTooltip">Région de type Modéré</string>
-	<string name="LocationCtrlGeneralIconTooltip">Région de type Général</string>
-	<string name="LocationCtrlSeeAVsTooltip">Les avatars à l'extérieur de cette parcelle ne peuvent pas voir ni entendre les avatars qui se trouvent à l'intérieur.</string>
-	<string name="LocationCtrlPathfindingDirtyTooltip">Les objets mobiles risquent de ne pas se comporter correctement dans cette région tant qu'elle n'est pas refigée.</string>
-	<string name="LocationCtrlPathfindingDisabledTooltip">La recherche de chemin dynamique n'est pas activée dans cette région.</string>
-	<string name="UpdaterWindowTitle">[APP_NAME] - Mise à jour</string>
-	<string name="UpdaterNowUpdating">Mise à jour de [APP_NAME]...</string>
-	<string name="UpdaterNowInstalling">Installation de [APP_NAME]...</string>
-	<string name="UpdaterUpdatingDescriptive">Le client [APP_NAME] est en train d'être mis à jour.  Cela peut prendre un certain temps, merci de votre patience.</string>
-	<string name="UpdaterProgressBarTextWithEllipses">Mise à jour en cours...</string>
-	<string name="UpdaterProgressBarText">Mise à jour en cours</string>
-	<string name="UpdaterFailDownloadTitle">Le téléchargement de la mise à jour a échoué</string>
-	<string name="UpdaterFailUpdateDescriptive">Une erreur est survenue lors de la mise à jour de [APP_NAME]. Veuillez télécharger la dernière version sur www.secondlife.com.</string>
-	<string name="UpdaterFailInstallTitle">L'installation de la mise à jour a échoué</string>
-	<string name="UpdaterFailStartTitle">Impossible de lancer le client</string>
-	<string name="ItemsComingInTooFastFrom">[APP_NAME] : transfert trop rapide des articles de [FROM_NAME] ; aperçu automatique désactivé pendant [TIME] secondes</string>
-	<string name="ItemsComingInTooFast">[APP_NAME] : transfert trop rapide des articles ; aperçu automatique désactivé pendant [TIME] secondes</string>
-	<string name="IM_logging_string">-- Archivage des IM activé --</string>
-	<string name="IM_typing_start_string">[NAME] est en train d'écrire...</string>
-	<string name="Unnamed">(sans nom)</string>
-	<string name="IM_moderated_chat_label">(Modéré : Voix désactivées par défaut)</string>
-	<string name="IM_unavailable_text_label">Le chat écrit n'est pas disponible pour cet appel.</string>
-	<string name="IM_muted_text_label">Votre chat écrit a été désactivé par un modérateur de groupe.</string>
-	<string name="IM_default_text_label">Cliquez ici pour envoyer un message instantané.</string>
-	<string name="IM_to_label">À</string>
-	<string name="IM_moderator_label">(Modérateur)</string>
-	<string name="Saved_message">(Enregistrement : [LONG_TIMESTAMP])</string>
-	<string name="IM_unblock_only_groups_friends">Pour afficher ce message, vous devez désactiver la case Seuls mes amis et groupes peuvent m'appeler ou m'envoyer un IM, sous Préférences/Confidentialité.</string>
-	<string name="OnlineStatus">En ligne</string>
-	<string name="OfflineStatus">Hors ligne</string>
-	<string name="not_online_msg">Utilisateur non connecté -  le message sera enregistré et livré plus tard.</string>
-	<string name="not_online_inventory">Utilisateur non connecté - l'inventaire a été enregistré</string>
-	<string name="answered_call">Votre appel a fait l'objet d'une réponse</string>
-	<string name="you_started_call">Vous appelez.</string>
-	<string name="you_joined_call">Vous avez rejoint l'appel</string>
-	<string name="you_auto_rejected_call-im">Vous avez automatiquement refusé l'appel vocal quand le mode Ne pas déranger était activé.</string>
-	<string name="name_started_call">[NAME] appelle.</string>
-	<string name="ringing-im">En train de rejoindre l'appel...</string>
-	<string name="connected-im">Connecté(e), cliquez sur Quitter l'appel pour raccrocher</string>
-	<string name="hang_up-im">A quitté l'appel</string>
-	<string name="answering-im">Connexion en cours...</string>
-	<string name="conference-title">Chat à plusieurs</string>
-	<string name="conference-title-incoming">Conférence avec [AGENT_NAME]</string>
-	<string name="inventory_item_offered-im">Objet de l’inventaire [ITEM_NAME] offert</string>
-	<string name="inventory_folder_offered-im">Dossier de l’inventaire [ITEM_NAME] offert</string>
+Si ce message persiste, veuillez aller sur la page [SUPPORT_SITE].
+	</string>
+	<string name="5 O'Clock Shadow">
+		Peu
+	</string>
+	<string name="All White">
+		Tout blancs
+	</string>
+	<string name="Anime Eyes">
+		Grand yeux
+	</string>
+	<string name="Arced">
+		Arqués
+	</string>
+	<string name="Arm Length">
+		Longueur des bras
+	</string>
+	<string name="Attached">
+		Attachés
+	</string>
+	<string name="Attached Earlobes">
+		Lobes
+	</string>
+	<string name="Back Fringe">
+		Mèches de derrière
+	</string>
+	<string name="Baggy">
+		Plus
+	</string>
+	<string name="Bangs">
+		Frange
+	</string>
+	<string name="Beady Eyes">
+		Yeux perçants
+	</string>
+	<string name="Belly Size">
+		Taille du ventre
+	</string>
+	<string name="Big">
+		Plus
+	</string>
+	<string name="Big Butt">
+		Grosses fesses
+	</string>
+	<string name="Big Hair Back">
+		Volume : Derrière
+	</string>
+	<string name="Big Hair Front">
+		Volume : Devant
+	</string>
+	<string name="Big Hair Top">
+		Volume : Haut
+	</string>
+	<string name="Big Head">
+		Plus
+	</string>
+	<string name="Big Pectorals">
+		Gros pectoraux
+	</string>
+	<string name="Big Spikes">
+		Spikes
+	</string>
+	<string name="Black">
+		Noir
+	</string>
+	<string name="Blonde">
+		Blond
+	</string>
+	<string name="Blonde Hair">
+		Cheveux blonds
+	</string>
+	<string name="Blush">
+		Blush
+	</string>
+	<string name="Blush Color">
+		Couleur du blush
+	</string>
+	<string name="Blush Opacity">
+		Opacité du blush
+	</string>
+	<string name="Body Definition">
+		Contour du corps
+	</string>
+	<string name="Body Fat">
+		Graisse
+	</string>
+	<string name="Body Freckles">
+		Grains de beauté
+	</string>
+	<string name="Body Thick">
+		Plus
+	</string>
+	<string name="Body Thickness">
+		Épaisseur du corps
+	</string>
+	<string name="Body Thin">
+		Moins
+	</string>
+	<string name="Bow Legged">
+		Jambes arquées
+	</string>
+	<string name="Breast Buoyancy">
+		Hauteur des seins
+	</string>
+	<string name="Breast Cleavage">
+		Clivage
+	</string>
+	<string name="Breast Size">
+		Taille des seins
+	</string>
+	<string name="Bridge Width">
+		Arête du nez
+	</string>
+	<string name="Broad">
+		Large
+	</string>
+	<string name="Brow Size">
+		Taille du front
+	</string>
+	<string name="Bug Eyes">
+		Yeux globuleux
+	</string>
+	<string name="Bugged Eyes">
+		Yeux globuleux
+	</string>
+	<string name="Bulbous">
+		En bulbe
+	</string>
+	<string name="Bulbous Nose">
+		Nez en bulbe
+	</string>
+	<string name="Breast Physics Mass">
+		Masse des seins
+	</string>
+	<string name="Breast Physics Smoothing">
+		Lissage des seins
+	</string>
+	<string name="Breast Physics Gravity">
+		Gravité des seins
+	</string>
+	<string name="Breast Physics Drag">
+		Résistance de l'air sur les seins
+	</string>
+	<string name="Breast Physics InOut Max Effect">
+		Effet max.
+	</string>
+	<string name="Breast Physics InOut Spring">
+		Élasticité
+	</string>
+	<string name="Breast Physics InOut Gain">
+		Amplification
+	</string>
+	<string name="Breast Physics InOut Damping">
+		Amortissement
+	</string>
+	<string name="Breast Physics UpDown Max Effect">
+		Effet max.
+	</string>
+	<string name="Breast Physics UpDown Spring">
+		Élasticité
+	</string>
+	<string name="Breast Physics UpDown Gain">
+		Amplification
+	</string>
+	<string name="Breast Physics UpDown Damping">
+		Amortissement
+	</string>
+	<string name="Breast Physics LeftRight Max Effect">
+		Effet max.
+	</string>
+	<string name="Breast Physics LeftRight Spring">
+		Élasticité
+	</string>
+	<string name="Breast Physics LeftRight Gain">
+		Amplification
+	</string>
+	<string name="Breast Physics LeftRight Damping">
+		Amortissement
+	</string>
+	<string name="Belly Physics Mass">
+		Masse du ventre
+	</string>
+	<string name="Belly Physics Smoothing">
+		Lissage du ventre
+	</string>
+	<string name="Belly Physics Gravity">
+		Gravité du ventre
+	</string>
+	<string name="Belly Physics Drag">
+		Résistance de l'air sur le ventre
+	</string>
+	<string name="Belly Physics UpDown Max Effect">
+		Effet max.
+	</string>
+	<string name="Belly Physics UpDown Spring">
+		Élasticité
+	</string>
+	<string name="Belly Physics UpDown Gain">
+		Amplification
+	</string>
+	<string name="Belly Physics UpDown Damping">
+		Amortissement
+	</string>
+	<string name="Butt Physics Mass">
+		Masse des fesses
+	</string>
+	<string name="Butt Physics Smoothing">
+		Lissage des fesses
+	</string>
+	<string name="Butt Physics Gravity">
+		Gravité des fesses
+	</string>
+	<string name="Butt Physics Drag">
+		Résistance de l'air sur les fesses
+	</string>
+	<string name="Butt Physics UpDown Max Effect">
+		Effet max.
+	</string>
+	<string name="Butt Physics UpDown Spring">
+		Élasticité
+	</string>
+	<string name="Butt Physics UpDown Gain">
+		Amplification
+	</string>
+	<string name="Butt Physics UpDown Damping">
+		Amortissement
+	</string>
+	<string name="Butt Physics LeftRight Max Effect">
+		Effet max.
+	</string>
+	<string name="Butt Physics LeftRight Spring">
+		Élasticité
+	</string>
+	<string name="Butt Physics LeftRight Gain">
+		Amplification
+	</string>
+	<string name="Butt Physics LeftRight Damping">
+		Amortissement
+	</string>
+	<string name="Bushy Eyebrows">
+		Sourcils touffus
+	</string>
+	<string name="Bushy Hair">
+		Beaucoup
+	</string>
+	<string name="Butt Size">
+		Taille des fesses
+	</string>
+	<string name="Butt Gravity">
+		Gravité des fesses
+	</string>
+	<string name="bustle skirt">
+		Jupe gonflante
+	</string>
+	<string name="no bustle">
+		Pas gonflante
+	</string>
+	<string name="more bustle">
+		Plus gonflante
+	</string>
+	<string name="Chaplin">
+		Moins
+	</string>
+	<string name="Cheek Bones">
+		Pommettes
+	</string>
+	<string name="Chest Size">
+		Taille de la poitrine
+	</string>
+	<string name="Chin Angle">
+		Angle du menton
+	</string>
+	<string name="Chin Cleft">
+		Fente du menton
+	</string>
+	<string name="Chin Curtains">
+		Favoris
+	</string>
+	<string name="Chin Depth">
+		Profondeur
+	</string>
+	<string name="Chin Heavy">
+		Menton lourd
+	</string>
+	<string name="Chin In">
+		Menton rentré
+	</string>
+	<string name="Chin Out">
+		Menton sorti
+	</string>
+	<string name="Chin-Neck">
+		Menton-cou
+	</string>
+	<string name="Clear">
+		Clair
+	</string>
+	<string name="Cleft">
+		Fendu
+	</string>
+	<string name="Close Set Eyes">
+		Yeux rapprochés
+	</string>
+	<string name="Closed">
+		Fermé(s)
+	</string>
+	<string name="Closed Back">
+		Fermé à l'arrière
+	</string>
+	<string name="Closed Front">
+		Fermé devant
+	</string>
+	<string name="Closed Left">
+		Fermé à gauche
+	</string>
+	<string name="Closed Right">
+		Fermé à droite
+	</string>
+	<string name="Coin Purse">
+		Mini
+	</string>
+	<string name="Collar Back">
+		Col arrière
+	</string>
+	<string name="Collar Front">
+		Col devant
+	</string>
+	<string name="Corner Down">
+		Coin vers le bas
+	</string>
+	<string name="Corner Up">
+		Coin vers le haut
+	</string>
+	<string name="Creased">
+		Fripée
+	</string>
+	<string name="Crooked Nose">
+		Déviation du nez
+	</string>
+	<string name="Cuff Flare">
+		Jambes
+	</string>
+	<string name="Dark">
+		Sombre
+	</string>
+	<string name="Dark Green">
+		Vert foncé
+	</string>
+	<string name="Darker">
+		Plus foncé
+	</string>
+	<string name="Deep">
+		Profonde
+	</string>
+	<string name="Default Heels">
+		Talons par défaut
+	</string>
+	<string name="Dense">
+		Dense
+	</string>
+	<string name="Double Chin">
+		Double menton
+	</string>
+	<string name="Downturned">
+		Pointant vers le bas
+	</string>
+	<string name="Duffle Bag">
+		Maxi
+	</string>
+	<string name="Ear Angle">
+		Angle de l'oreille
+	</string>
+	<string name="Ear Size">
+		Taille
+	</string>
+	<string name="Ear Tips">
+		Extrémités
+	</string>
+	<string name="Egg Head">
+		Proéminence
+	</string>
+	<string name="Eye Bags">
+		Cernes
+	</string>
+	<string name="Eye Color">
+		Couleur des yeux
+	</string>
+	<string name="Eye Depth">
+		Profondeur
+	</string>
+	<string name="Eye Lightness">
+		Clarté
+	</string>
+	<string name="Eye Opening">
+		Ouverture
+	</string>
+	<string name="Eye Pop">
+		Œil proéminent
+	</string>
+	<string name="Eye Size">
+		Taille de l'œil
+	</string>
+	<string name="Eye Spacing">
+		Espacement
+	</string>
+	<string name="Eyebrow Arc">
+		Arc
+	</string>
+	<string name="Eyebrow Density">
+		Épaisseur sourcils
+	</string>
+	<string name="Eyebrow Height">
+		Hauteur
+	</string>
+	<string name="Eyebrow Points">
+		Direction
+	</string>
+	<string name="Eyebrow Size">
+		Taille
+	</string>
+	<string name="Eyelash Length">
+		Longueur des cils
+	</string>
+	<string name="Eyeliner">
+		Eyeliner
+	</string>
+	<string name="Eyeliner Color">
+		Couleur de l'eyeliner
+	</string>
+	<string name="Eyes Bugged">
+		Yeux globuleux
+	</string>
+	<string name="Face Shear">
+		Visage
+	</string>
+	<string name="Facial Definition">
+		Définition
+	</string>
+	<string name="Far Set Eyes">
+		Yeux écartés
+	</string>
+	<string name="Fat Lips">
+		Lèvres épaisses
+	</string>
+	<string name="Female">
+		Femme
+	</string>
+	<string name="Fingerless">
+		Sans doigts
+	</string>
+	<string name="Fingers">
+		Doigts
+	</string>
+	<string name="Flared Cuffs">
+		Jambes larges
+	</string>
+	<string name="Flat">
+		Moins
+	</string>
+	<string name="Flat Butt">
+		Fesses plates
+	</string>
+	<string name="Flat Head">
+		Tête plate
+	</string>
+	<string name="Flat Toe">
+		Orteil plat
+	</string>
+	<string name="Foot Size">
+		Pointure
+	</string>
+	<string name="Forehead Angle">
+		Angle du front
+	</string>
+	<string name="Forehead Heavy">
+		Front lourd
+	</string>
+	<string name="Freckles">
+		Tâches de rousseur
+	</string>
+	<string name="Front Fringe">
+		Mèches de devant
+	</string>
+	<string name="Full Back">
+		Arrière touffu
+	</string>
+	<string name="Full Eyeliner">
+		Eyeliner marqué
+	</string>
+	<string name="Full Front">
+		Devant touffu
+	</string>
+	<string name="Full Hair Sides">
+		Côtés touffus
+	</string>
+	<string name="Full Sides">
+		Côtés touffus
+	</string>
+	<string name="Glossy">
+		Brillant
+	</string>
+	<string name="Glove Fingers">
+		Gants avec doigts
+	</string>
+	<string name="Glove Length">
+		Longueur
+	</string>
+	<string name="Hair">
+		Cheveux
+	</string>
+	<string name="Hair Back">
+		Cheveux : Derrière
+	</string>
+	<string name="Hair Front">
+		Cheveux : Devant
+	</string>
+	<string name="Hair Sides">
+		Cheveux : Côtés
+	</string>
+	<string name="Hair Sweep">
+		Sens de la coiffure
+	</string>
+	<string name="Hair Thickess">
+		Épaisseur cheveux
+	</string>
+	<string name="Hair Thickness">
+		Épaisseur cheveux
+	</string>
+	<string name="Hair Tilt">
+		Inclinaison
+	</string>
+	<string name="Hair Tilted Left">
+		Vers la gauche
+	</string>
+	<string name="Hair Tilted Right">
+		Vers la droite
+	</string>
+	<string name="Hair Volume">
+		Cheveux : Volume
+	</string>
+	<string name="Hand Size">
+		Taille de la main
+	</string>
+	<string name="Handlebars">
+		Plus
+	</string>
+	<string name="Head Length">
+		Longueur
+	</string>
+	<string name="Head Shape">
+		Forme
+	</string>
+	<string name="Head Size">
+		Taille
+	</string>
+	<string name="Head Stretch">
+		Allongement
+	</string>
+	<string name="Heel Height">
+		Talons
+	</string>
+	<string name="Heel Shape">
+		Forme des talons
+	</string>
+	<string name="Height">
+		Taille
+	</string>
+	<string name="High">
+		Haut
+	</string>
+	<string name="High Heels">
+		Talons hauts
+	</string>
+	<string name="High Jaw">
+		Haut
+	</string>
+	<string name="High Platforms">
+		Haute
+	</string>
+	<string name="High and Tight">
+		Haut et serré
+	</string>
+	<string name="Higher">
+		Plus élevé
+	</string>
+	<string name="Hip Length">
+		Longueur hanche
+	</string>
+	<string name="Hip Width">
+		Largeur hanche
+	</string>
+	<string name="Hover">
+		Survol
+	</string>
+	<string name="In">
+		Rentré
+	</string>
+	<string name="In Shdw Color">
+		Couleur ombre interne
+	</string>
+	<string name="In Shdw Opacity">
+		Opacité ombre interne
+	</string>
+	<string name="Inner Eye Corner">
+		Coin interne
+	</string>
+	<string name="Inner Eye Shadow">
+		Ombre de l'œil interne
+	</string>
+	<string name="Inner Shadow">
+		Ombre interne
+	</string>
+	<string name="Jacket Length">
+		Longueur de la veste
+	</string>
+	<string name="Jacket Wrinkles">
+		Plis de la veste
+	</string>
+	<string name="Jaw Angle">
+		Angle mâchoire
+	</string>
+	<string name="Jaw Jut">
+		Saillie mâchoire
+	</string>
+	<string name="Jaw Shape">
+		Mâchoire
+	</string>
+	<string name="Join">
+		Rapprochés
+	</string>
+	<string name="Jowls">
+		Bajoues
+	</string>
+	<string name="Knee Angle">
+		Angle du genou
+	</string>
+	<string name="Knock Kneed">
+		Genoux rapprochés
+	</string>
+	<string name="Large">
+		Plus
+	</string>
+	<string name="Large Hands">
+		Grandes mains
+	</string>
+	<string name="Left Part">
+		Raie à gauche
+	</string>
+	<string name="Leg Length">
+		Longueur
+	</string>
+	<string name="Leg Muscles">
+		Muscles
+	</string>
+	<string name="Less">
+		Moins
+	</string>
+	<string name="Less Body Fat">
+		Moins
+	</string>
+	<string name="Less Curtains">
+		Moins
+	</string>
+	<string name="Less Freckles">
+		Moins
+	</string>
+	<string name="Less Full">
+		Moins
+	</string>
+	<string name="Less Gravity">
+		Moins
+	</string>
+	<string name="Less Love">
+		Moins
+	</string>
+	<string name="Less Muscles">
+		Moins
+	</string>
+	<string name="Less Muscular">
+		Moins
+	</string>
+	<string name="Less Rosy">
+		Moins
+	</string>
+	<string name="Less Round">
+		Moins ronde
+	</string>
+	<string name="Less Saddle">
+		Moins
+	</string>
+	<string name="Less Square">
+		Moins carrée
+	</string>
+	<string name="Less Volume">
+		Moins
+	</string>
+	<string name="Less soul">
+		Moins
+	</string>
+	<string name="Lighter">
+		Plus léger
+	</string>
+	<string name="Lip Cleft">
+		Fente labiale
+	</string>
+	<string name="Lip Cleft Depth">
+		Prof. fente labiale
+	</string>
+	<string name="Lip Fullness">
+		Volume des lèvres
+	</string>
+	<string name="Lip Pinkness">
+		Rougeur des lèvres
+	</string>
+	<string name="Lip Ratio">
+		Proportion des lèvres
+	</string>
+	<string name="Lip Thickness">
+		Épaisseur
+	</string>
+	<string name="Lip Width">
+		Largeur
+	</string>
+	<string name="Lipgloss">
+		Brillant à lèvres
+	</string>
+	<string name="Lipstick">
+		Rouge à lèvres
+	</string>
+	<string name="Lipstick Color">
+		Couleur du rouge à lèvres
+	</string>
+	<string name="Long">
+		Plus
+	</string>
+	<string name="Long Head">
+		Tête longue
+	</string>
+	<string name="Long Hips">
+		Hanches longues
+	</string>
+	<string name="Long Legs">
+		Jambes longues
+	</string>
+	<string name="Long Neck">
+		Long cou
+	</string>
+	<string name="Long Pigtails">
+		Longues couettes
+	</string>
+	<string name="Long Ponytail">
+		Longue queue de cheval
+	</string>
+	<string name="Long Torso">
+		Torse long
+	</string>
+	<string name="Long arms">
+		Bras longs
+	</string>
+	<string name="Loose Pants">
+		Pantalons amples
+	</string>
+	<string name="Loose Shirt">
+		Chemise ample
+	</string>
+	<string name="Loose Sleeves">
+		Manches amples
+	</string>
+	<string name="Love Handles">
+		Poignées d'amour
+	</string>
+	<string name="Low">
+		Bas
+	</string>
+	<string name="Low Heels">
+		Talons bas
+	</string>
+	<string name="Low Jaw">
+		Bas
+	</string>
+	<string name="Low Platforms">
+		Basse
+	</string>
+	<string name="Low and Loose">
+		Bas et ample
+	</string>
+	<string name="Lower">
+		Abaisser
+	</string>
+	<string name="Lower Bridge">
+		Arête inférieure
+	</string>
+	<string name="Lower Cheeks">
+		Joue inférieure
+	</string>
+	<string name="Male">
+		Homme
+	</string>
+	<string name="Middle Part">
+		Raie au milieu
+	</string>
+	<string name="More">
+		Plus
+	</string>
+	<string name="More Blush">
+		Plus
+	</string>
+	<string name="More Body Fat">
+		Plus
+	</string>
+	<string name="More Curtains">
+		Plus
+	</string>
+	<string name="More Eyeshadow">
+		Plus
+	</string>
+	<string name="More Freckles">
+		Plus
+	</string>
+	<string name="More Full">
+		Plus
+	</string>
+	<string name="More Gravity">
+		Plus
+	</string>
+	<string name="More Lipstick">
+		Plus
+	</string>
+	<string name="More Love">
+		Plus
+	</string>
+	<string name="More Lower Lip">
+		Inférieure plus grosse
+	</string>
+	<string name="More Muscles">
+		Plus
+	</string>
+	<string name="More Muscular">
+		Plus
+	</string>
+	<string name="More Rosy">
+		Plus
+	</string>
+	<string name="More Round">
+		Plus
+	</string>
+	<string name="More Saddle">
+		Plus
+	</string>
+	<string name="More Sloped">
+		Plus
+	</string>
+	<string name="More Square">
+		Plus
+	</string>
+	<string name="More Upper Lip">
+		Supérieure plus grosse
+	</string>
+	<string name="More Vertical">
+		Plus
+	</string>
+	<string name="More Volume">
+		Plus
+	</string>
+	<string name="More soul">
+		Plus
+	</string>
+	<string name="Moustache">
+		Moustache
+	</string>
+	<string name="Mouth Corner">
+		Coin de la bouche
+	</string>
+	<string name="Mouth Position">
+		Position
+	</string>
+	<string name="Mowhawk">
+		Mowhawk
+	</string>
+	<string name="Muscular">
+		Musclé
+	</string>
+	<string name="Mutton Chops">
+		Longs
+	</string>
+	<string name="Nail Polish">
+		Vernis à ongles
+	</string>
+	<string name="Nail Polish Color">
+		Couleur du vernis
+	</string>
+	<string name="Narrow">
+		Moins
+	</string>
+	<string name="Narrow Back">
+		Arrière étroit
+	</string>
+	<string name="Narrow Front">
+		Devant étroit
+	</string>
+	<string name="Narrow Lips">
+		Lèvres étroites
+	</string>
+	<string name="Natural">
+		Naturel
+	</string>
+	<string name="Neck Length">
+		Longueur du cou
+	</string>
+	<string name="Neck Thickness">
+		Épaisseur du cou
+	</string>
+	<string name="No Blush">
+		Pas de blush
+	</string>
+	<string name="No Eyeliner">
+		Pas d'eyeliner
+	</string>
+	<string name="No Eyeshadow">
+		Pas d'ombre à paupières
+	</string>
+	<string name="No Lipgloss">
+		Pas de brillant à lèvres
+	</string>
+	<string name="No Lipstick">
+		Pas de rouge à lèvres
+	</string>
+	<string name="No Part">
+		Pas de raie
+	</string>
+	<string name="No Polish">
+		Pas de vernis
+	</string>
+	<string name="No Red">
+		Pas de rouge
+	</string>
+	<string name="No Spikes">
+		Pas de spikes
+	</string>
+	<string name="No White">
+		Pas de blanc
+	</string>
+	<string name="No Wrinkles">
+		Pas de rides
+	</string>
+	<string name="Normal Lower">
+		Normal plus bas
+	</string>
+	<string name="Normal Upper">
+		Normal plus haut
+	</string>
+	<string name="Nose Left">
+		Nez à gauche
+	</string>
+	<string name="Nose Right">
+		Nez à droite
+	</string>
+	<string name="Nose Size">
+		Taille du nez
+	</string>
+	<string name="Nose Thickness">
+		Épaisseur du nez
+	</string>
+	<string name="Nose Tip Angle">
+		Angle bout du nez
+	</string>
+	<string name="Nose Tip Shape">
+		Forme bout du nez
+	</string>
+	<string name="Nose Width">
+		Largeur du nez
+	</string>
+	<string name="Nostril Division">
+		Division narines
+	</string>
+	<string name="Nostril Width">
+		Largeur narines
+	</string>
+	<string name="Opaque">
+		Opaque
+	</string>
+	<string name="Open">
+		Ouvert
+	</string>
+	<string name="Open Back">
+		Derrière ouvert
+	</string>
+	<string name="Open Front">
+		Devant ouvert
+	</string>
+	<string name="Open Left">
+		Ouvert à gauche
+	</string>
+	<string name="Open Right">
+		Ouvert à droite
+	</string>
+	<string name="Orange">
+		Orange
+	</string>
+	<string name="Out">
+		Sorti
+	</string>
+	<string name="Out Shdw Color">
+		Couleur de l'ombre externe
+	</string>
+	<string name="Out Shdw Opacity">
+		Opacité de l'ombre externe
+	</string>
+	<string name="Outer Eye Corner">
+		Coin externe
+	</string>
+	<string name="Outer Eye Shadow">
+		Ombre de l'œil externe
+	</string>
+	<string name="Outer Shadow">
+		Ombre externe
+	</string>
+	<string name="Overbite">
+		Rentrée
+	</string>
+	<string name="Package">
+		Parties
+	</string>
+	<string name="Painted Nails">
+		Ongles vernis
+	</string>
+	<string name="Pale">
+		Pâle
+	</string>
+	<string name="Pants Crotch">
+		Entrejambe
+	</string>
+	<string name="Pants Fit">
+		Taille
+	</string>
+	<string name="Pants Length">
+		Longueur
+	</string>
+	<string name="Pants Waist">
+		Taille
+	</string>
+	<string name="Pants Wrinkles">
+		Plis
+	</string>
+	<string name="Part">
+		Raie
+	</string>
+	<string name="Part Bangs">
+		Séparation frange
+	</string>
+	<string name="Pectorals">
+		Pectoraux
+	</string>
+	<string name="Pigment">
+		Pigmentation
+	</string>
+	<string name="Pigtails">
+		Couettes
+	</string>
+	<string name="Pink">
+		Rose
+	</string>
+	<string name="Pinker">
+		Plus rose
+	</string>
+	<string name="Platform Height">
+		Platef. (hauteur)
+	</string>
+	<string name="Platform Width">
+		Platef. (largeur)
+	</string>
+	<string name="Pointy">
+		Pointue
+	</string>
+	<string name="Pointy Heels">
+		Talons pointus
+	</string>
+	<string name="Ponytail">
+		Queue de cheval
+	</string>
+	<string name="Poofy Skirt">
+		Jupe bouffante
+	</string>
+	<string name="Pop Left Eye">
+		Œil gauche saillant
+	</string>
+	<string name="Pop Right Eye">
+		Œil droit saillant
+	</string>
+	<string name="Puffy">
+		Plus
+	</string>
+	<string name="Puffy Eyelids">
+		Paup. gonflées
+	</string>
+	<string name="Rainbow Color">
+		Couleur arc en ciel
+	</string>
+	<string name="Red Hair">
+		Cheveux roux
+	</string>
+	<string name="Regular">
+		Standard
+	</string>
+	<string name="Right Part">
+		Raie à droite
+	</string>
+	<string name="Rosy Complexion">
+		Teint rosé
+	</string>
+	<string name="Round">
+		Rond
+	</string>
+	<string name="Ruddiness">
+		Rougeur
+	</string>
+	<string name="Ruddy">
+		Rouge
+	</string>
+	<string name="Rumpled Hair">
+		Texture
+	</string>
+	<string name="Saddle Bags">
+		Culotte de cheval
+	</string>
+	<string name="Scrawny Leg">
+		Jambes maigres
+	</string>
+	<string name="Separate">
+		Séparés
+	</string>
+	<string name="Shallow">
+		Creux
+	</string>
+	<string name="Shear Back">
+		Coupe derrière
+	</string>
+	<string name="Shear Face">
+		Visage
+	</string>
+	<string name="Shear Front">
+		Front
+	</string>
+	<string name="Shear Left Up">
+		Haut gauche décalé
+	</string>
+	<string name="Shear Right Up">
+		Haut droit décalé
+	</string>
+	<string name="Sheared Back">
+		Dégagé derrière
+	</string>
+	<string name="Sheared Front">
+		Dégagé devant
+	</string>
+	<string name="Shift Left">
+		Vers la gauche
+	</string>
+	<string name="Shift Mouth">
+		Déplacement
+	</string>
+	<string name="Shift Right">
+		Vers la droite
+	</string>
+	<string name="Shirt Bottom">
+		Chemise
+	</string>
+	<string name="Shirt Fit">
+		Taille
+	</string>
+	<string name="Shirt Wrinkles">
+		Plis
+	</string>
+	<string name="Shoe Height">
+		Hauteur
+	</string>
+	<string name="Short">
+		Moins
+	</string>
+	<string name="Short Arms">
+		Bras courts
+	</string>
+	<string name="Short Legs">
+		Jambes courtes
+	</string>
+	<string name="Short Neck">
+		Petit cou
+	</string>
+	<string name="Short Pigtails">
+		Couettes courtes
+	</string>
+	<string name="Short Ponytail">
+		Queue de cheval courte
+	</string>
+	<string name="Short Sideburns">
+		Court
+	</string>
+	<string name="Short Torso">
+		Torse court
+	</string>
+	<string name="Short hips">
+		Hanches courtes
+	</string>
+	<string name="Shoulders">
+		Épaules
+	</string>
+	<string name="Side Fringe">
+		Mèches sur le côté
+	</string>
+	<string name="Sideburns">
+		Favoris
+	</string>
+	<string name="Sides Hair">
+		Cheveux sur le côté
+	</string>
+	<string name="Sides Hair Down">
+		Cheveux sur le côté en bas
+	</string>
+	<string name="Sides Hair Up">
+		Cheveux sur le côté en haut
+	</string>
+	<string name="Skinny Neck">
+		Cou maigre
+	</string>
+	<string name="Skirt Fit">
+		Taille jupe
+	</string>
+	<string name="Skirt Length">
+		Longueur jupe
+	</string>
+	<string name="Slanted Forehead">
+		Front incliné
+	</string>
+	<string name="Sleeve Length">
+		Longueur manche
+	</string>
+	<string name="Sleeve Looseness">
+		Ampleur manche
+	</string>
+	<string name="Slit Back">
+		Fente : Derrière
+	</string>
+	<string name="Slit Front">
+		Fente : Devant
+	</string>
+	<string name="Slit Left">
+		Fente : Gauche
+	</string>
+	<string name="Slit Right">
+		Fente : Droite
+	</string>
+	<string name="Small">
+		Moins
+	</string>
+	<string name="Small Hands">
+		Petites mains
+	</string>
+	<string name="Small Head">
+		Moins
+	</string>
+	<string name="Smooth">
+		Moins
+	</string>
+	<string name="Smooth Hair">
+		Cheveux lisses
+	</string>
+	<string name="Socks Length">
+		Longueur
+	</string>
+	<string name="Soulpatch">
+		Barbichette
+	</string>
+	<string name="Sparse">
+		Rares
+	</string>
+	<string name="Spiked Hair">
+		Mèches en pointe
+	</string>
+	<string name="Square">
+		Carrée
+	</string>
+	<string name="Square Toe">
+		Orteil carré
+	</string>
+	<string name="Squash Head">
+		Écraser la tête
+	</string>
+	<string name="Stretch Head">
+		Allonger la tête
+	</string>
+	<string name="Sunken">
+		Saillante
+	</string>
+	<string name="Sunken Chest">
+		Poitrine enfoncée
+	</string>
+	<string name="Sunken Eyes">
+		Yeux enfoncés
+	</string>
+	<string name="Sweep Back">
+		En arrière
+	</string>
+	<string name="Sweep Forward">
+		Vers l'avant
+	</string>
+	<string name="Tall">
+		Plus
+	</string>
+	<string name="Taper Back">
+		Arrière
+	</string>
+	<string name="Taper Front">
+		Avant
+	</string>
+	<string name="Thick Heels">
+		Talons épais
+	</string>
+	<string name="Thick Neck">
+		Cou épais
+	</string>
+	<string name="Thick Toe">
+		Orteil épais
+	</string>
+	<string name="Thin">
+		Mince
+	</string>
+	<string name="Thin Eyebrows">
+		Sourcils fins
+	</string>
+	<string name="Thin Lips">
+		Lèvres fines
+	</string>
+	<string name="Thin Nose">
+		Nez fin
+	</string>
+	<string name="Tight Chin">
+		Menton fin
+	</string>
+	<string name="Tight Cuffs">
+		Jambes serrées
+	</string>
+	<string name="Tight Pants">
+		Pantalons serrés
+	</string>
+	<string name="Tight Shirt">
+		Chemise serrée
+	</string>
+	<string name="Tight Skirt">
+		Jupe serrée
+	</string>
+	<string name="Tight Sleeves">
+		Manches serrées
+	</string>
+	<string name="Toe Shape">
+		Forme de l'orteil
+	</string>
+	<string name="Toe Thickness">
+		Épaisseur orteil
+	</string>
+	<string name="Torso Length">
+		Longueur du torse
+	</string>
+	<string name="Torso Muscles">
+		Muscles du torse
+	</string>
+	<string name="Torso Scrawny">
+		Torse maigre
+	</string>
+	<string name="Unattached">
+		Séparés
+	</string>
+	<string name="Uncreased">
+		Lisse
+	</string>
+	<string name="Underbite">
+		Sortie
+	</string>
+	<string name="Unnatural">
+		Artificiel
+	</string>
+	<string name="Upper Bridge">
+		Arête supérieure
+	</string>
+	<string name="Upper Cheeks">
+		Joue supérieure
+	</string>
+	<string name="Upper Chin Cleft">
+		Menton supérieur
+	</string>
+	<string name="Upper Eyelid Fold">
+		Paupière sup.
+	</string>
+	<string name="Upturned">
+		En trompette
+	</string>
+	<string name="Very Red">
+		Très rouge
+	</string>
+	<string name="Waist Height">
+		Hauteur taille
+	</string>
+	<string name="Well-Fed">
+		Ronde
+	</string>
+	<string name="White Hair">
+		Cheveux blancs
+	</string>
+	<string name="Wide">
+		Plus
+	</string>
+	<string name="Wide Back">
+		Derrière large
+	</string>
+	<string name="Wide Front">
+		Devant large
+	</string>
+	<string name="Wide Lips">
+		Lèvres larges
+	</string>
+	<string name="Wild">
+		Artificiel
+	</string>
+	<string name="Wrinkles">
+		Rides
+	</string>
+	<string name="LocationCtrlAddLandmarkTooltip">
+		Ajouter à mes repères
+	</string>
+	<string name="LocationCtrlEditLandmarkTooltip">
+		Modifier mon repère
+	</string>
+	<string name="LocationCtrlInfoBtnTooltip">
+		En savoir plus sur l'emplacement actuel
+	</string>
+	<string name="LocationCtrlComboBtnTooltip">
+		Historique de mes emplacements
+	</string>
+	<string name="LocationCtrlForSaleTooltip">
+		Acheter ce terrain
+	</string>
+	<string name="LocationCtrlVoiceTooltip">
+		Chat vocal indisponible ici
+	</string>
+	<string name="LocationCtrlFlyTooltip">
+		Vol interdit
+	</string>
+	<string name="LocationCtrlPushTooltip">
+		Pas de bousculades
+	</string>
+	<string name="LocationCtrlBuildTooltip">
+		Construction/placement d'objets interdit
+	</string>
+	<string name="LocationCtrlScriptsTooltip">
+		Scripts interdits
+	</string>
+	<string name="LocationCtrlDamageTooltip">
+		Santé
+	</string>
+	<string name="LocationCtrlAdultIconTooltip">
+		Région de type Adulte
+	</string>
+	<string name="LocationCtrlModerateIconTooltip">
+		Région de type Modéré
+	</string>
+	<string name="LocationCtrlGeneralIconTooltip">
+		Région de type Général
+	</string>
+	<string name="LocationCtrlSeeAVsTooltip">
+		Les avatars à l'extérieur de cette parcelle ne peuvent pas voir ni entendre les avatars qui se trouvent à l'intérieur.
+	</string>
+	<string name="LocationCtrlPathfindingDirtyTooltip">
+		Les objets mobiles risquent de ne pas se comporter correctement dans cette région tant qu'elle n'est pas refigée.
+	</string>
+	<string name="LocationCtrlPathfindingDisabledTooltip">
+		La recherche de chemin dynamique n'est pas activée dans cette région.
+	</string>
+	<string name="UpdaterWindowTitle">
+		[APP_NAME] - Mise à jour
+	</string>
+	<string name="UpdaterNowUpdating">
+		Mise à jour de [APP_NAME]...
+	</string>
+	<string name="UpdaterNowInstalling">
+		Installation de [APP_NAME]...
+	</string>
+	<string name="UpdaterUpdatingDescriptive">
+		Le client [APP_NAME] est en train d'être mis à jour.  Cela peut prendre un certain temps, merci de votre patience.
+	</string>
+	<string name="UpdaterProgressBarTextWithEllipses">
+		Mise à jour en cours...
+	</string>
+	<string name="UpdaterProgressBarText">
+		Mise à jour en cours
+	</string>
+	<string name="UpdaterFailDownloadTitle">
+		Le téléchargement de la mise à jour a échoué
+	</string>
+	<string name="UpdaterFailUpdateDescriptive">
+		Une erreur est survenue lors de la mise à jour de [APP_NAME]. Veuillez télécharger la dernière version sur www.secondlife.com.
+	</string>
+	<string name="UpdaterFailInstallTitle">
+		L'installation de la mise à jour a échoué
+	</string>
+	<string name="UpdaterFailStartTitle">
+		Impossible de lancer le client
+	</string>
+	<string name="ItemsComingInTooFastFrom">
+		[APP_NAME] : transfert trop rapide des articles de [FROM_NAME] ; aperçu automatique désactivé pendant [TIME] secondes
+	</string>
+	<string name="ItemsComingInTooFast">
+		[APP_NAME] : transfert trop rapide des articles ; aperçu automatique désactivé pendant [TIME] secondes
+	</string>
+	<string name="IM_logging_string">
+		-- Archivage des IM activé --
+	</string>
+	<string name="IM_typing_start_string">
+		[NAME] est en train d'écrire...
+	</string>
+	<string name="Unnamed">
+		(sans nom)
+	</string>
+	<string name="IM_moderated_chat_label">
+		(Modéré : Voix désactivées par défaut)
+	</string>
+	<string name="IM_unavailable_text_label">
+		Le chat écrit n'est pas disponible pour cet appel.
+	</string>
+	<string name="IM_muted_text_label">
+		Votre chat écrit a été désactivé par un modérateur de groupe.
+	</string>
+	<string name="IM_default_text_label">
+		Cliquez ici pour envoyer un message instantané.
+	</string>
+	<string name="IM_to_label">
+		À
+	</string>
+	<string name="IM_moderator_label">
+		(Modérateur)
+	</string>
+	<string name="Saved_message">
+		(Enregistrement : [LONG_TIMESTAMP])
+	</string>
+	<string name="IM_unblock_only_groups_friends">
+		Pour afficher ce message, vous devez désactiver la case Seuls mes amis et groupes peuvent m'appeler ou m'envoyer un IM, sous Préférences/Confidentialité.
+	</string>
+	<string name="OnlineStatus">
+		En ligne
+	</string>
+	<string name="OfflineStatus">
+		Hors ligne
+	</string>
+	<string name="not_online_msg">
+		Utilisateur non connecté -  le message sera enregistré et livré plus tard.
+	</string>
+	<string name="not_online_inventory">
+		Utilisateur non connecté - l'inventaire a été enregistré
+	</string>
+	<string name="answered_call">
+		Votre appel a fait l'objet d'une réponse
+	</string>
+	<string name="you_started_call">
+		Vous appelez.
+	</string>
+	<string name="you_joined_call">
+		Vous avez rejoint l'appel
+	</string>
+	<string name="you_auto_rejected_call-im">
+		Vous avez automatiquement refusé l'appel vocal quand le mode Ne pas déranger était activé.
+	</string>
+	<string name="name_started_call">
+		[NAME] appelle.
+	</string>
+	<string name="ringing-im">
+		En train de rejoindre l'appel...
+	</string>
+	<string name="connected-im">
+		Connecté(e), cliquez sur Quitter l'appel pour raccrocher
+	</string>
+	<string name="hang_up-im">
+		A quitté l'appel
+	</string>
+	<string name="answering-im">
+		Connexion en cours...
+	</string>
+	<string name="conference-title">
+		Chat à plusieurs
+	</string>
+	<string name="conference-title-incoming">
+		Conférence avec [AGENT_NAME]
+	</string>
+	<string name="inventory_item_offered-im">
+		Objet de l’inventaire [ITEM_NAME] offert
+	</string>
+	<string name="inventory_folder_offered-im">
+		Dossier de l’inventaire [ITEM_NAME] offert
+	</string>
 	<string name="bot_warning">
-Vous discutez avec un bot, [NAME]. Ne partagez pas d’informations personnelles.
+		Vous discutez avec un bot, [NAME]. Ne partagez pas d’informations personnelles.
 En savoir plus sur https://second.life/scripted-agents.
 	</string>
-	<string name="share_alert">Faire glisser les objets de l'inventaire ici</string>
-	<string name="facebook_post_success">Vous avez publié sur Facebook.</string>
-	<string name="flickr_post_success">Vous avez publié sur Flickr.</string>
-	<string name="twitter_post_success">Vous avez publié sur Twitter.</string>
-	<string name="no_session_message">(Session IM inexistante)</string>
-	<string name="only_user_message">Vous êtes le seul participant à cette session.</string>
-	<string name="offline_message">[NAME] est hors ligne.</string>
-	<string name="invite_message">Pour accepter ce chat vocal/vous connecter, cliquez sur le bouton [BUTTON NAME].</string>
-	<string name="muted_message">Vous ignorez ce résident. Si vous lui envoyez un message, il ne sera plus ignoré.</string>
-	<string name="generic">Erreur lors de la requête, veuillez réessayer ultérieurement.</string>
-	<string name="generic_request_error">Erreur lors de la requête, veuillez réessayer ultérieurement.</string>
-	<string name="insufficient_perms_error">Vous n'avez pas les droits requis.</string>
-	<string name="session_does_not_exist_error">La session a expiré</string>
-	<string name="no_ability_error">Vous n'avez pas ce pouvoir.</string>
-	<string name="no_ability">Vous n'avez pas ce pouvoir.</string>
-	<string name="not_a_mod_error">Vous n'êtes pas modérateur de session.</string>
-	<string name="muted">Un modérateur de groupe a désactivé votre chat écrit.</string>
-	<string name="muted_error">Un modérateur de groupe a désactivé votre chat écrit.</string>
-	<string name="add_session_event">Impossible d'ajouter des participants à la session de chat avec [RECIPIENT].</string>
-	<string name="message">Impossible d'envoyer votre message à la session de chat avec [RECIPIENT].</string>
-	<string name="message_session_event">Impossible d'envoyer votre message à la session de chat avec [RECIPIENT].</string>
-	<string name="mute">Erreur lors de la modération.</string>
-	<string name="removed">Vous avez été supprimé du groupe.</string>
-	<string name="removed_from_group">Vous avez été supprimé du groupe.</string>
-	<string name="close_on_no_ability">Vous ne pouvez plus participer à la session de chat.</string>
-	<string name="unread_chat_single">[SOURCES] a dit quelque chose de nouveau</string>
-	<string name="unread_chat_multiple">[SOURCES] ont dit quelque chose de nouveau</string>
-	<string name="session_initialization_timed_out_error">Expiration du délai d'initialisation de la session</string>
-	<string name="Home position set.">Emplacement du domicile défini.</string>
-	<string name="voice_morphing_url">https://secondlife.com/destination/voice-island</string>
-	<string name="premium_voice_morphing_url">https://secondlife.com/destination/voice-morphing-premium</string>
-	<string name="paid_you_ldollars">[NAME] vous a payé [AMOUNT] L$ [REASON].</string>
-	<string name="paid_you_ldollars_gift">[NAME] vous a payé [AMOUNT] L$ : [REASON]</string>
-	<string name="paid_you_ldollars_no_reason">[NAME] vous a payé [AMOUNT] L$.</string>
-	<string name="you_paid_ldollars">Vous avez payé à [AMOUNT] L$ [REASON].</string>
-	<string name="you_paid_ldollars_gift">Vous avez payé à [NAME] [AMOUNT] L$ : [REASON]</string>
-	<string name="you_paid_ldollars_no_info">Vous avez payé [AMOUNT] L$.</string>
-	<string name="you_paid_ldollars_no_reason">Vous avez payé à [NAME] [AMOUNT] L$.</string>
-	<string name="you_paid_ldollars_no_name">Vous avez payé à [AMOUNT] L$ [REASON].</string>
-	<string name="you_paid_failure_ldollars">Votre paiement de [AMOUNT] L$ à [NAME] [REASON] a échoué.</string>
-	<string name="you_paid_failure_ldollars_gift">Votre paiement de [AMOUNT] L$ à [NAME] a échoué : [REASON]</string>
-	<string name="you_paid_failure_ldollars_no_info">Votre paiement de [AMOUNT] L$ a échoué.</string>
-	<string name="you_paid_failure_ldollars_no_reason">Votre paiement de [AMOUNT] L$ à [NAME] a échoué.</string>
-	<string name="you_paid_failure_ldollars_no_name">Votre paiement de [AMOUNT] L$ [REASON] a échoué.</string>
-	<string name="for item">pour l'article suivant : [ITEM]</string>
-	<string name="for a parcel of land">pour une parcelle de terrain</string>
-	<string name="for a land access pass">pour un pass d'accès au terrain</string>
-	<string name="for deeding land">pour une cession de terrain</string>
-	<string name="to create a group">pour créer un groupe</string>
-	<string name="to join a group">pour rejoindre un groupe</string>
-	<string name="to upload">pour charger</string>
-	<string name="to publish a classified ad">pour publier une petite annonce</string>
-	<string name="giving">Donner [AMOUNT] L$</string>
-	<string name="uploading_costs">Le chargement coûte [AMOUNT] L$</string>
-	<string name="this_costs">Cela coûte [AMOUNT] L$</string>
-	<string name="buying_selected_land">Achat du terrain sélectionné pour [AMOUNT] L$</string>
-	<string name="this_object_costs">Cet objet coûte [AMOUNT] L$</string>
-	<string name="group_role_everyone">Tous</string>
-	<string name="group_role_officers">Officiers</string>
-	<string name="group_role_owners">Propriétaires</string>
-	<string name="group_member_status_online">En ligne</string>
-	<string name="uploading_abuse_report">Chargement...
+	<string name="share_alert">
+		Faire glisser les objets de l'inventaire ici
+	</string>
+	<string name="facebook_post_success">
+		Vous avez publié sur Facebook.
+	</string>
+	<string name="flickr_post_success">
+		Vous avez publié sur Flickr.
+	</string>
+	<string name="twitter_post_success">
+		Vous avez publié sur Twitter.
+	</string>
+	<string name="no_session_message">
+		(Session IM inexistante)
+	</string>
+	<string name="only_user_message">
+		Vous êtes le seul participant à cette session.
+	</string>
+	<string name="offline_message">
+		[NAME] est hors ligne.
+	</string>
+	<string name="invite_message">
+		Pour accepter ce chat vocal/vous connecter, cliquez sur le bouton [BUTTON NAME].
+	</string>
+	<string name="muted_message">
+		Vous ignorez ce résident. Si vous lui envoyez un message, il ne sera plus ignoré.
+	</string>
+	<string name="generic">
+		Erreur lors de la requête, veuillez réessayer ultérieurement.
+	</string>
+	<string name="generic_request_error">
+		Erreur lors de la requête, veuillez réessayer ultérieurement.
+	</string>
+	<string name="insufficient_perms_error">
+		Vous n'avez pas les droits requis.
+	</string>
+	<string name="session_does_not_exist_error">
+		La session a expiré
+	</string>
+	<string name="no_ability_error">
+		Vous n'avez pas ce pouvoir.
+	</string>
+	<string name="no_ability">
+		Vous n'avez pas ce pouvoir.
+	</string>
+	<string name="not_a_mod_error">
+		Vous n'êtes pas modérateur de session.
+	</string>
+	<string name="muted">
+		Un modérateur de groupe a désactivé votre chat écrit.
+	</string>
+	<string name="muted_error">
+		Un modérateur de groupe a désactivé votre chat écrit.
+	</string>
+	<string name="add_session_event">
+		Impossible d'ajouter des participants à la session de chat avec [RECIPIENT].
+	</string>
+	<string name="message">
+		Impossible d'envoyer votre message à la session de chat avec [RECIPIENT].
+	</string>
+	<string name="message_session_event">
+		Impossible d'envoyer votre message à la session de chat avec [RECIPIENT].
+	</string>
+	<string name="mute">
+		Erreur lors de la modération.
+	</string>
+	<string name="removed">
+		Vous avez été supprimé du groupe.
+	</string>
+	<string name="removed_from_group">
+		Vous avez été supprimé du groupe.
+	</string>
+	<string name="close_on_no_ability">
+		Vous ne pouvez plus participer à la session de chat.
+	</string>
+	<string name="unread_chat_single">
+		[SOURCES] a dit quelque chose de nouveau
+	</string>
+	<string name="unread_chat_multiple">
+		[SOURCES] ont dit quelque chose de nouveau
+	</string>
+	<string name="session_initialization_timed_out_error">
+		Expiration du délai d'initialisation de la session
+	</string>
+	<string name="Home position set.">
+		Emplacement du domicile défini.
+	</string>
+	<string name="voice_morphing_url">
+		https://secondlife.com/destination/voice-island
+	</string>
+	<string name="premium_voice_morphing_url">
+		https://secondlife.com/destination/voice-morphing-premium
+	</string>
+	<string name="paid_you_ldollars">
+		[NAME] vous a payé [AMOUNT] L$ [REASON].
+	</string>
+	<string name="paid_you_ldollars_gift">
+		[NAME] vous a payé [AMOUNT] L$ : [REASON]
+	</string>
+	<string name="paid_you_ldollars_no_reason">
+		[NAME] vous a payé [AMOUNT] L$.
+	</string>
+	<string name="you_paid_ldollars">
+		Vous avez payé à [AMOUNT] L$ [REASON].
+	</string>
+	<string name="you_paid_ldollars_gift">
+		Vous avez payé à [NAME] [AMOUNT] L$ : [REASON]
+	</string>
+	<string name="you_paid_ldollars_no_info">
+		Vous avez payé [AMOUNT] L$.
+	</string>
+	<string name="you_paid_ldollars_no_reason">
+		Vous avez payé à [NAME] [AMOUNT] L$.
+	</string>
+	<string name="you_paid_ldollars_no_name">
+		Vous avez payé à [AMOUNT] L$ [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars">
+		Votre paiement de [AMOUNT] L$ à [NAME] [REASON] a échoué.
+	</string>
+	<string name="you_paid_failure_ldollars_gift">
+		Votre paiement de [AMOUNT] L$ à [NAME] a échoué : [REASON]
+	</string>
+	<string name="you_paid_failure_ldollars_no_info">
+		Votre paiement de [AMOUNT] L$ a échoué.
+	</string>
+	<string name="you_paid_failure_ldollars_no_reason">
+		Votre paiement de [AMOUNT] L$ à [NAME] a échoué.
+	</string>
+	<string name="you_paid_failure_ldollars_no_name">
+		Votre paiement de [AMOUNT] L$ [REASON] a échoué.
+	</string>
+	<string name="for item">
+		pour l'article suivant : [ITEM]
+	</string>
+	<string name="for a parcel of land">
+		pour une parcelle de terrain
+	</string>
+	<string name="for a land access pass">
+		pour un pass d'accès au terrain
+	</string>
+	<string name="for deeding land">
+		pour une cession de terrain
+	</string>
+	<string name="to create a group">
+		pour créer un groupe
+	</string>
+	<string name="to join a group">
+		pour rejoindre un groupe
+	</string>
+	<string name="to upload">
+		pour charger
+	</string>
+	<string name="to publish a classified ad">
+		pour publier une petite annonce
+	</string>
+	<string name="giving">
+		Donner [AMOUNT] L$
+	</string>
+	<string name="uploading_costs">
+		Le chargement coûte [AMOUNT] L$
+	</string>
+	<string name="this_costs">
+		Cela coûte [AMOUNT] L$
+	</string>
+	<string name="buying_selected_land">
+		Achat du terrain sélectionné pour [AMOUNT] L$
+	</string>
+	<string name="this_object_costs">
+		Cet objet coûte [AMOUNT] L$
+	</string>
+	<string name="group_role_everyone">
+		Tous
+	</string>
+	<string name="group_role_officers">
+		Officiers
+	</string>
+	<string name="group_role_owners">
+		Propriétaires
+	</string>
+	<string name="group_member_status_online">
+		En ligne
+	</string>
+	<string name="uploading_abuse_report">
+		Chargement...
 
-du rapport d'infraction</string>
-	<string name="New Shape">Nouvelle silhouette</string>
-	<string name="New Skin">Nouvelle peau</string>
-	<string name="New Hair">Nouveaux cheveux</string>
-	<string name="New Eyes">Nouveaux yeux</string>
-	<string name="New Shirt">Nouvelle chemise</string>
-	<string name="New Pants">Nouveau pantalon</string>
-	<string name="New Shoes">Nouvelles chaussures</string>
-	<string name="New Socks">Nouvelles chaussettes</string>
-	<string name="New Jacket">Nouvelle veste</string>
-	<string name="New Gloves">Nouveaux gants</string>
-	<string name="New Undershirt">Nouveau débardeur</string>
-	<string name="New Underpants">Nouveau caleçon</string>
-	<string name="New Skirt">Nouvelle jupe</string>
-	<string name="New Alpha">Nouvel alpha</string>
-	<string name="New Tattoo">Nouveau tatouage</string>
-	<string name="New Universal">Nouvel environnement universel</string>
-	<string name="New Physics">Nouvelles propriétés physiques</string>
-	<string name="Invalid Wearable">Objet à porter non valide</string>
-	<string name="New Gesture">Nouveau geste</string>
-	<string name="New Script">Nouveau script</string>
-	<string name="New Note">Nouvelle note</string>
-	<string name="New Folder">Nouveau dossier</string>
-	<string name="Contents">Contenus</string>
-	<string name="Gesture">Geste</string>
-	<string name="Male Gestures">Gestes masculins</string>
-	<string name="Female Gestures">Gestes féminins</string>
-	<string name="Other Gestures">Autres gestes</string>
-	<string name="Speech Gestures">Gestes liés à la parole</string>
-	<string name="Common Gestures">Gestes communs</string>
-	<string name="Male - Excuse me">Homme - Demander pardon</string>
-	<string name="Male - Get lost">Homme - Get lost</string>
-	<string name="Male - Blow kiss">Homme - Envoyer un baiser</string>
-	<string name="Male - Boo">Homme - Hou !</string>
-	<string name="Male - Bored">Homme - Ennui</string>
-	<string name="Male - Hey">Homme - Hé !</string>
-	<string name="Male - Laugh">Homme - Rire</string>
-	<string name="Male - Repulsed">Homme - Dégoût</string>
-	<string name="Male - Shrug">Homme - Hausser les épaules</string>
-	<string name="Male - Stick tougue out">Homme - Tirer la langue</string>
-	<string name="Male - Wow">Homme - Ouah !</string>
-	<string name="Female - Chuckle">Femme - Glousser</string>
-	<string name="Female - Cry">Femme - Pleurer</string>
-	<string name="Female - Embarrassed">Femme - Gêne</string>
-	<string name="Female - Excuse me">Femme - Demander pardon</string>
-	<string name="Female - Get lost">Femme - Get lost</string>
-	<string name="Female - Blow kiss">Femme - Envoyer un baiser</string>
-	<string name="Female - Boo">Femme - Hou !</string>
-	<string name="Female - Bored">Femme - Ennui</string>
-	<string name="Female - Hey">Femme - Hé !</string>
-	<string name="Female - Hey baby">Femme - Hey baby</string>
-	<string name="Female - Laugh">Femme - Rire</string>
-	<string name="Female - Looking good">Femme - Looking good</string>
-	<string name="Female - Over here">Femme - Over here</string>
-	<string name="Female - Please">Femme - Please</string>
-	<string name="Female - Repulsed">Femme - Dégoût</string>
-	<string name="Female - Shrug">Femme - Hausser les épaules</string>
-	<string name="Female - Stick tougue out">Femme - Tirer la langue</string>
-	<string name="Female - Wow">Femme - Ouah !</string>
-	<string name="New Daycycle">Nouveau cycle du jour</string>
-	<string name="New Water">Nouvelle eau</string>
-	<string name="New Sky">Nouveau ciel</string>
-	<string name="/bow">/s'incliner</string>
-	<string name="/clap">/applaudir</string>
-	<string name="/count">/compter</string>
-	<string name="/extinguish">/éteindre</string>
-	<string name="/kmb">/vatefairevoir</string>
-	<string name="/muscle">/montrersesmuscles</string>
-	<string name="/no">/non</string>
-	<string name="/no!">/non !</string>
-	<string name="/paper">/papier</string>
-	<string name="/pointme">/memontrerdudoigt</string>
-	<string name="/pointyou">/montrerl'autredudoigt</string>
-	<string name="/rock">/pierre</string>
-	<string name="/scissor">/ciseaux</string>
-	<string name="/smoke">/fumer</string>
-	<string name="/stretch">/bailler</string>
-	<string name="/whistle">/siffler</string>
-	<string name="/yes">/oui</string>
-	<string name="/yes!">/oui !</string>
-	<string name="afk">absent</string>
-	<string name="dance1">danse1</string>
-	<string name="dance2">danse2</string>
-	<string name="dance3">danse3</string>
-	<string name="dance4">danse4</string>
-	<string name="dance5">danse5</string>
-	<string name="dance6">danse6</string>
-	<string name="dance7">danse7</string>
-	<string name="dance8">danse8</string>
-	<string name="AvatarBirthDateFormat">[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]</string>
-	<string name="DefaultMimeType">aucun/aucun</string>
-	<string name="texture_load_dimensions_error">Impossible de charger des images de taille supérieure à [WIDTH]*[HEIGHT]</string>
-	<string name="outfit_photo_load_dimensions_error">Taille max. de la photo de la tenue : [WIDTH]*[HEIGHT]. Redimensionnez l’image ou utilisez-en une autre.</string>
-	<string name="outfit_photo_select_dimensions_error">Taille max. de la photo de la tenue : [WIDTH]*[HEIGHT]. Sélectionnez une autre texture.</string>
-	<string name="outfit_photo_verify_dimensions_error">Impossible de vérifier les dimensions de la photo. Attendez que la taille de la photo s’affiche dans le sélecteur.</string>
+du rapport d'infraction
+	</string>
+	<string name="New Shape">
+		Nouvelle silhouette
+	</string>
+	<string name="New Skin">
+		Nouvelle peau
+	</string>
+	<string name="New Hair">
+		Nouveaux cheveux
+	</string>
+	<string name="New Eyes">
+		Nouveaux yeux
+	</string>
+	<string name="New Shirt">
+		Nouvelle chemise
+	</string>
+	<string name="New Pants">
+		Nouveau pantalon
+	</string>
+	<string name="New Shoes">
+		Nouvelles chaussures
+	</string>
+	<string name="New Socks">
+		Nouvelles chaussettes
+	</string>
+	<string name="New Jacket">
+		Nouvelle veste
+	</string>
+	<string name="New Gloves">
+		Nouveaux gants
+	</string>
+	<string name="New Undershirt">
+		Nouveau débardeur
+	</string>
+	<string name="New Underpants">
+		Nouveau caleçon
+	</string>
+	<string name="New Skirt">
+		Nouvelle jupe
+	</string>
+	<string name="New Alpha">
+		Nouvel alpha
+	</string>
+	<string name="New Tattoo">
+		Nouveau tatouage
+	</string>
+	<string name="New Universal">
+		Nouvel environnement universel
+	</string>
+	<string name="New Physics">
+		Nouvelles propriétés physiques
+	</string>
+	<string name="Invalid Wearable">
+		Objet à porter non valide
+	</string>
+	<string name="New Gesture">
+		Nouveau geste
+	</string>
+	<string name="New Script">
+		Nouveau script
+	</string>
+	<string name="New Note">
+		Nouvelle note
+	</string>
+	<string name="New Folder">
+		Nouveau dossier
+	</string>
+	<string name="Contents">
+		Contenus
+	</string>
+	<string name="Gesture">
+		Geste
+	</string>
+	<string name="Male Gestures">
+		Gestes masculins
+	</string>
+	<string name="Female Gestures">
+		Gestes féminins
+	</string>
+	<string name="Other Gestures">
+		Autres gestes
+	</string>
+	<string name="Speech Gestures">
+		Gestes liés à la parole
+	</string>
+	<string name="Common Gestures">
+		Gestes communs
+	</string>
+	<string name="Male - Excuse me">
+		Homme - Demander pardon
+	</string>
+	<string name="Male - Get lost">
+		Homme - Get lost
+	</string>
+	<string name="Male - Blow kiss">
+		Homme - Envoyer un baiser
+	</string>
+	<string name="Male - Boo">
+		Homme - Hou !
+	</string>
+	<string name="Male - Bored">
+		Homme - Ennui
+	</string>
+	<string name="Male - Hey">
+		Homme - Hé !
+	</string>
+	<string name="Male - Laugh">
+		Homme - Rire
+	</string>
+	<string name="Male - Repulsed">
+		Homme - Dégoût
+	</string>
+	<string name="Male - Shrug">
+		Homme - Hausser les épaules
+	</string>
+	<string name="Male - Stick tougue out">
+		Homme - Tirer la langue
+	</string>
+	<string name="Male - Wow">
+		Homme - Ouah !
+	</string>
+	<string name="Female - Chuckle">
+		Femme - Glousser
+	</string>
+	<string name="Female - Cry">
+		Femme - Pleurer
+	</string>
+	<string name="Female - Embarrassed">
+		Femme - Gêne
+	</string>
+	<string name="Female - Excuse me">
+		Femme - Demander pardon
+	</string>
+	<string name="Female - Get lost">
+		Femme - Get lost
+	</string>
+	<string name="Female - Blow kiss">
+		Femme - Envoyer un baiser
+	</string>
+	<string name="Female - Boo">
+		Femme - Hou !
+	</string>
+	<string name="Female - Bored">
+		Femme - Ennui
+	</string>
+	<string name="Female - Hey">
+		Femme - Hé !
+	</string>
+	<string name="Female - Hey baby">
+		Femme - Hey baby
+	</string>
+	<string name="Female - Laugh">
+		Femme - Rire
+	</string>
+	<string name="Female - Looking good">
+		Femme - Looking good
+	</string>
+	<string name="Female - Over here">
+		Femme - Over here
+	</string>
+	<string name="Female - Please">
+		Femme - Please
+	</string>
+	<string name="Female - Repulsed">
+		Femme - Dégoût
+	</string>
+	<string name="Female - Shrug">
+		Femme - Hausser les épaules
+	</string>
+	<string name="Female - Stick tougue out">
+		Femme - Tirer la langue
+	</string>
+	<string name="Female - Wow">
+		Femme - Ouah !
+	</string>
+	<string name="New Daycycle">
+		Nouveau cycle du jour
+	</string>
+	<string name="New Water">
+		Nouvelle eau
+	</string>
+	<string name="New Sky">
+		Nouveau ciel
+	</string>
+	<string name="/bow">
+		/s'incliner
+	</string>
+	<string name="/clap">
+		/applaudir
+	</string>
+	<string name="/count">
+		/compter
+	</string>
+	<string name="/extinguish">
+		/éteindre
+	</string>
+	<string name="/kmb">
+		/vatefairevoir
+	</string>
+	<string name="/muscle">
+		/montrersesmuscles
+	</string>
+	<string name="/no">
+		/non
+	</string>
+	<string name="/no!">
+		/non !
+	</string>
+	<string name="/paper">
+		/papier
+	</string>
+	<string name="/pointme">
+		/memontrerdudoigt
+	</string>
+	<string name="/pointyou">
+		/montrerl'autredudoigt
+	</string>
+	<string name="/rock">
+		/pierre
+	</string>
+	<string name="/scissor">
+		/ciseaux
+	</string>
+	<string name="/smoke">
+		/fumer
+	</string>
+	<string name="/stretch">
+		/bailler
+	</string>
+	<string name="/whistle">
+		/siffler
+	</string>
+	<string name="/yes">
+		/oui
+	</string>
+	<string name="/yes!">
+		/oui !
+	</string>
+	<string name="afk">
+		absent
+	</string>
+	<string name="dance1">
+		danse1
+	</string>
+	<string name="dance2">
+		danse2
+	</string>
+	<string name="dance3">
+		danse3
+	</string>
+	<string name="dance4">
+		danse4
+	</string>
+	<string name="dance5">
+		danse5
+	</string>
+	<string name="dance6">
+		danse6
+	</string>
+	<string name="dance7">
+		danse7
+	</string>
+	<string name="dance8">
+		danse8
+	</string>
+	<string name="AvatarBirthDateFormat">
+		[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]
+	</string>
+	<string name="DefaultMimeType">
+		aucun/aucun
+	</string>
+	<string name="texture_load_dimensions_error">
+		Impossible de charger des images de taille supérieure à [WIDTH]*[HEIGHT]
+	</string>
+	<string name="outfit_photo_load_dimensions_error">
+		Taille max. de la photo de la tenue : [WIDTH]*[HEIGHT]. Redimensionnez l’image ou utilisez-en une autre.
+	</string>
+	<string name="outfit_photo_select_dimensions_error">
+		Taille max. de la photo de la tenue : [WIDTH]*[HEIGHT]. Sélectionnez une autre texture.
+	</string>
+	<string name="outfit_photo_verify_dimensions_error">
+		Impossible de vérifier les dimensions de la photo. Attendez que la taille de la photo s’affiche dans le sélecteur.
+	</string>
 	<string name="words_separator" value=","/>
-	<string name="server_is_down">Malgré nos efforts, une erreur inattendue s’est produite.
+	<string name="server_is_down">
+		Malgré nos efforts, une erreur inattendue s’est produite.
 
 Veuillez vous reporter à http://status.secondlifegrid.net afin de déterminer si un problème connu existe avec ce service.
-        Si le problème persiste, vérifiez la configuration de votre réseau et de votre pare-feu.</string>
-	<string name="dateTimeWeekdaysNames">Sunday:Monday:Tuesday:Wednesday:Thursday:Friday:Saturday</string>
-	<string name="dateTimeWeekdaysShortNames">Sun:Mon:Tue:Wed:Thu:Fri:Sat</string>
-	<string name="dateTimeMonthNames">January:February:March:April:May:June:July:August:September:October:November:December</string>
-	<string name="dateTimeMonthShortNames">Jan:Feb:Mar:Apr:May:Jun:Jul:Aug:Sep:Oct:Nov:Dec</string>
-	<string name="dateTimeDayFormat">[MDAY]</string>
-	<string name="dateTimeAM">AM</string>
-	<string name="dateTimePM">PM</string>
-	<string name="LocalEstimateUSD">[AMOUNT] US$</string>
-	<string name="Group Ban">Bannissement de groupe</string>
-	<string name="Membership">Inscription</string>
-	<string name="Roles">Rôles</string>
-	<string name="Group Identity">Identité du groupe</string>
-	<string name="Parcel Management">Gestion des parcelles</string>
-	<string name="Parcel Identity">Identité des parcelles</string>
-	<string name="Parcel Settings">Paramètres des parcelles</string>
-	<string name="Parcel Powers">Pouvoirs sur les parcelles</string>
-	<string name="Parcel Access">Accès aux parcelles</string>
-	<string name="Parcel Content">Contenu des parcelles</string>
-	<string name="Object Management">Gestion des objets</string>
-	<string name="Accounting">Comptabilité</string>
-	<string name="Notices">Notices</string>
-	<string name="Chat" value=" Chat :">Chat</string>
-	<string name="BaseMembership">Base</string>
-	<string name="PremiumMembership">Premium</string>
-	<string name="Premium_PlusMembership">Premium Plus</string>
-	<string name="DeleteItems">Supprimer les articles sélectionnés ?</string>
-	<string name="DeleteItem">Supprimer l'article sélectionné ?</string>
-	<string name="EmptyOutfitText">Cette tenue ne contient aucun article.</string>
-	<string name="ExternalEditorNotSet">Sélectionnez un éditeur à l'aide du paramètre ExternalEditor.</string>
-	<string name="ExternalEditorNotFound">Éditeur externe spécifié introuvable.
+        Si le problème persiste, vérifiez la configuration de votre réseau et de votre pare-feu.
+	</string>
+	<string name="dateTimeWeekdaysNames">
+		Sunday:Monday:Tuesday:Wednesday:Thursday:Friday:Saturday
+	</string>
+	<string name="dateTimeWeekdaysShortNames">
+		Sun:Mon:Tue:Wed:Thu:Fri:Sat
+	</string>
+	<string name="dateTimeMonthNames">
+		January:February:March:April:May:June:July:August:September:October:November:December
+	</string>
+	<string name="dateTimeMonthShortNames">
+		Jan:Feb:Mar:Apr:May:Jun:Jul:Aug:Sep:Oct:Nov:Dec
+	</string>
+	<string name="dateTimeDayFormat">
+		[MDAY]
+	</string>
+	<string name="dateTimeAM">
+		AM
+	</string>
+	<string name="dateTimePM">
+		PM
+	</string>
+	<string name="LocalEstimateUSD">
+		[AMOUNT] US$
+	</string>
+	<string name="Group Ban">
+		Bannissement de groupe
+	</string>
+	<string name="Membership">
+		Inscription
+	</string>
+	<string name="Roles">
+		Rôles
+	</string>
+	<string name="Group Identity">
+		Identité du groupe
+	</string>
+	<string name="Parcel Management">
+		Gestion des parcelles
+	</string>
+	<string name="Parcel Identity">
+		Identité des parcelles
+	</string>
+	<string name="Parcel Settings">
+		Paramètres des parcelles
+	</string>
+	<string name="Parcel Powers">
+		Pouvoirs sur les parcelles
+	</string>
+	<string name="Parcel Access">
+		Accès aux parcelles
+	</string>
+	<string name="Parcel Content">
+		Contenu des parcelles
+	</string>
+	<string name="Object Management">
+		Gestion des objets
+	</string>
+	<string name="Accounting">
+		Comptabilité
+	</string>
+	<string name="Notices">
+		Notices
+	</string>
+	<string name="Chat" value=" Chat :">
+		Chat
+	</string>
+	<string name="BaseMembership">
+		Base
+	</string>
+	<string name="PremiumMembership">
+		Premium
+	</string>
+	<string name="Premium_PlusMembership">
+		Premium Plus
+	</string>
+	<string name="DeleteItems">
+		Supprimer les articles sélectionnés ?
+	</string>
+	<string name="DeleteItem">
+		Supprimer l'article sélectionné ?
+	</string>
+	<string name="EmptyOutfitText">
+		Cette tenue ne contient aucun article.
+	</string>
+	<string name="ExternalEditorNotSet">
+		Sélectionnez un éditeur à l'aide du paramètre ExternalEditor.
+	</string>
+	<string name="ExternalEditorNotFound">
+		Éditeur externe spécifié introuvable.
 Essayez avec le chemin d'accès à l'éditeur entre guillemets doubles
-(par ex. : &quot;/chemin_accès/editor&quot; &quot;%s&quot;).</string>
-	<string name="ExternalEditorCommandParseError">Erreur lors de l'analyse de la commande d'éditeur externe.</string>
-	<string name="ExternalEditorFailedToRun">Échec d'exécution de l'éditeur externe.</string>
-	<string name="TranslationFailed">Échec de traduction : [REASON]</string>
-	<string name="TranslationResponseParseError">Erreur lors de l'analyse de la réponse relative à la traduction.</string>
-	<string name="Esc">Échap</string>
-	<string name="Space">Space</string>
-	<string name="Enter">Enter</string>
-	<string name="Tab">Tab</string>
-	<string name="Ins">Ins</string>
-	<string name="Del">Del</string>
-	<string name="Backsp">Backsp</string>
-	<string name="Shift">Maj</string>
-	<string name="Ctrl">Ctrl</string>
-	<string name="Alt">Alt</string>
-	<string name="CapsLock">CapsLock</string>
-	<string name="Home">Début</string>
-	<string name="End">End</string>
-	<string name="PgUp">PgUp</string>
-	<string name="PgDn">PgDn</string>
-	<string name="F1">F1</string>
-	<string name="F2">F2</string>
-	<string name="F3">F3</string>
-	<string name="F4">F4</string>
-	<string name="F5">F5</string>
-	<string name="F6">F6</string>
-	<string name="F7">F7</string>
-	<string name="F8">F8</string>
-	<string name="F9">F9</string>
-	<string name="F10">F10</string>
-	<string name="F11">F11</string>
-	<string name="F12">F12</string>
-	<string name="Add">Ajouter</string>
-	<string name="Subtract">Soustraire</string>
-	<string name="Multiply">Multiplier</string>
-	<string name="Divide">Diviser</string>
-	<string name="PAD_DIVIDE">PAD_DIVIDE</string>
-	<string name="PAD_LEFT">PAD_LEFT</string>
-	<string name="PAD_RIGHT">PAD_RIGHT</string>
-	<string name="PAD_DOWN">PAD_DOWN</string>
-	<string name="PAD_UP">PAD_UP</string>
-	<string name="PAD_HOME">PAD_HOME</string>
-	<string name="PAD_END">PAD_END</string>
-	<string name="PAD_PGUP">PAD_PGUP</string>
-	<string name="PAD_PGDN">PAD_PGDN</string>
-	<string name="PAD_CENTER">PAD_CENTER</string>
-	<string name="PAD_INS">PAD_INS</string>
-	<string name="PAD_DEL">PAD_DEL</string>
-	<string name="PAD_Enter">PAD_Enter</string>
-	<string name="PAD_BUTTON0">PAD_BUTTON0</string>
-	<string name="PAD_BUTTON1">PAD_BUTTON1</string>
-	<string name="PAD_BUTTON2">PAD_BUTTON2</string>
-	<string name="PAD_BUTTON3">PAD_BUTTON3</string>
-	<string name="PAD_BUTTON4">PAD_BUTTON4</string>
-	<string name="PAD_BUTTON5">PAD_BUTTON5</string>
-	<string name="PAD_BUTTON6">PAD_BUTTON6</string>
-	<string name="PAD_BUTTON7">PAD_BUTTON7</string>
-	<string name="PAD_BUTTON8">PAD_BUTTON8</string>
-	<string name="PAD_BUTTON9">PAD_BUTTON9</string>
-	<string name="PAD_BUTTON10">PAD_BUTTON10</string>
-	<string name="PAD_BUTTON11">PAD_BUTTON11</string>
-	<string name="PAD_BUTTON12">PAD_BUTTON12</string>
-	<string name="PAD_BUTTON13">PAD_BUTTON13</string>
-	<string name="PAD_BUTTON14">PAD_BUTTON14</string>
-	<string name="PAD_BUTTON15">PAD_BUTTON15</string>
-	<string name="-">-</string>
-	<string name="=">=</string>
-	<string name="`">`</string>
-	<string name=";">;</string>
-	<string name="[">[</string>
-	<string name="]">]</string>
-	<string name="\">\</string>
-	<string name="0">0</string>
-	<string name="1">1</string>
-	<string name="2">2</string>
-	<string name="3">3</string>
-	<string name="4">4</string>
-	<string name="5">5</string>
-	<string name="6">6</string>
-	<string name="7">7</string>
-	<string name="8">8</string>
-	<string name="9">9</string>
-	<string name="A">A</string>
-	<string name="B">B</string>
-	<string name="C">C</string>
-	<string name="D">D</string>
-	<string name="E">E</string>
-	<string name="F">F</string>
-	<string name="G">G</string>
-	<string name="H">H</string>
-	<string name="I">I</string>
-	<string name="J">J</string>
-	<string name="K">K</string>
-	<string name="L">L</string>
-	<string name="M">M</string>
-	<string name="N">N</string>
-	<string name="O">O</string>
-	<string name="P">P</string>
-	<string name="Q">Q</string>
-	<string name="R">R</string>
-	<string name="S">S</string>
-	<string name="T">T</string>
-	<string name="U">U</string>
-	<string name="V">V</string>
-	<string name="W">W</string>
-	<string name="X">X</string>
-	<string name="Y">Y</string>
-	<string name="Z">Z</string>
-	<string name="BeaconParticle">Affichage des balises de particule (bleu)</string>
-	<string name="BeaconPhysical">Affichage des balises d'objet physique (vert)</string>
-	<string name="BeaconScripted">Affichage des balises d'objet scripté (rouge)</string>
-	<string name="BeaconScriptedTouch">Affichage des balises d'objet scripté avec fonction de toucher (rouge)</string>
-	<string name="BeaconSound">Affichage des balises de son (jaune)</string>
-	<string name="BeaconMedia">Affichage des balises de média (blanc)</string>
-	<string name="BeaconSun">Balise de visibilité du soleil (orange)</string>
-	<string name="BeaconMoon">Observation de la balise de direction de la lune (violet)</string>
-	<string name="ParticleHiding">Masquage des particules</string>
-	<string name="Command_AboutLand_Label">À propos du terrain</string>
-	<string name="Command_Appearance_Label">Apparence</string>
-	<string name="Command_Avatar_Label">Avatar</string>
-	<string name="Command_Build_Label">Construire</string>
-	<string name="Command_Chat_Label">Chat</string>
-	<string name="Command_Conversations_Label">Conversations</string>
-	<string name="Command_Compass_Label">Boussole</string>
-	<string name="Command_Destinations_Label">Destinations</string>
-	<string name="Command_Environments_Label">Mes environnements</string>
-	<string name="Command_Facebook_Label">Facebook</string>
-	<string name="Command_Flickr_Label">Flickr</string>
-	<string name="Command_Gestures_Label">Gestes</string>
-	<string name="Command_Grid_Status_Label">État de la grille</string>
-	<string name="Command_HowTo_Label">Aide rapide</string>
-	<string name="Command_Inventory_Label">Inventaire</string>
-	<string name="Command_Map_Label">Carte</string>
-	<string name="Command_Marketplace_Label">Place du marché</string>
-	<string name="Command_MarketplaceListings_Label">Place du marché</string>
-	<string name="Command_MiniMap_Label">Mini-carte</string>
-	<string name="Command_Move_Label">Marcher / Courir / Voler</string>
-	<string name="Command_Outbox_Label">Boîte d'envoi vendeur</string>
-	<string name="Command_People_Label">Personnes</string>
-	<string name="Command_Picks_Label">Favoris</string>
-	<string name="Command_Places_Label">Lieux</string>
-	<string name="Command_Preferences_Label">Préférences</string>
-	<string name="Command_Profile_Label">Profil</string>
-	<string name="Command_Report_Abuse_Label">Signaler une infraction</string>
-	<string name="Command_Search_Label">Recherche</string>
-	<string name="Command_Snapshot_Label">Photo</string>
-	<string name="Command_Speak_Label">Parler</string>
-	<string name="Command_Twitter_Label">Twitter</string>
-	<string name="Command_View_Label">Caméra</string>
-	<string name="Command_Voice_Label">Paramètres vocaux</string>
-	<string name="Command_AboutLand_Tooltip">Information sur le terrain que vous visitez</string>
-	<string name="Command_Appearance_Tooltip">Modifier votre avatar</string>
-	<string name="Command_Avatar_Tooltip">Choisir un avatar complet</string>
-	<string name="Command_Build_Tooltip">Construction d'objets et remodelage du terrain</string>
-	<string name="Command_Chat_Tooltip">Parler aux personnes près de vous par chat écrit</string>
-	<string name="Command_Conversations_Tooltip">Parler à quelqu'un</string>
-	<string name="Command_Compass_Tooltip">Boussole</string>
-	<string name="Command_Destinations_Tooltip">Destinations intéressantes</string>
-	<string name="Command_Environments_Tooltip">Mes environnements</string>
-	<string name="Command_Facebook_Tooltip">Publier sur Facebook</string>
-	<string name="Command_Flickr_Tooltip">Charger sur Flickr</string>
-	<string name="Command_Gestures_Tooltip">Gestes de votre avatar</string>
-	<string name="Command_Grid_Status_Tooltip">Afficher l’état actuel de la grille</string>
-	<string name="Command_HowTo_Tooltip">Comment effectuer les opérations courantes</string>
-	<string name="Command_Inventory_Tooltip">Afficher et utiliser vos possessions</string>
-	<string name="Command_Map_Tooltip">Carte du monde</string>
-	<string name="Command_Marketplace_Tooltip">Faire du shopping</string>
-	<string name="Command_MarketplaceListings_Tooltip">Vendez votre création</string>
-	<string name="Command_MiniMap_Tooltip">Afficher les personnes près de vous</string>
-	<string name="Command_Move_Tooltip">Faire bouger votre avatar</string>
-	<string name="Command_Outbox_Tooltip">Transférer des articles vers votre place de marché afin de les vendre.</string>
-	<string name="Command_People_Tooltip">Amis, groupes et personnes près de vous</string>
-	<string name="Command_Picks_Tooltip">Lieux à afficher comme favoris dans votre profil</string>
-	<string name="Command_Places_Tooltip">Lieux enregistrés</string>
-	<string name="Command_Preferences_Tooltip">Préférences</string>
-	<string name="Command_Profile_Tooltip">Modifier ou afficher votre profil</string>
-	<string name="Command_Report_Abuse_Tooltip">Signaler une infraction</string>
-	<string name="Command_Search_Tooltip">Trouver des lieux, personnes, événements</string>
-	<string name="Command_Snapshot_Tooltip">Prendre une photo</string>
-	<string name="Command_Speak_Tooltip">Parler aux personnes près de vous en utilisant votre micro</string>
-	<string name="Command_Twitter_Tooltip">Twitter</string>
-	<string name="Command_View_Tooltip">Changer l'angle de la caméra</string>
-	<string name="Command_Voice_Tooltip">Commandes de réglage du volume des appels et des personnes près de vous dans Second Life.</string>
-	<string name="Toolbar_Bottom_Tooltip">actuellement dans la barre d'outils du bas</string>
-	<string name="Toolbar_Left_Tooltip">actuellement dans la barre d'outils de gauche</string>
-	<string name="Toolbar_Right_Tooltip">actuellement dans la barre d'outils de droite</string>
-	<string name="Retain%">Garder%</string>
-	<string name="Detail">Détail</string>
-	<string name="Better Detail">Meilleur détail</string>
-	<string name="Surface">Surface</string>
-	<string name="Solid">Solide</string>
-	<string name="Wrap">Wrap</string>
-	<string name="Preview">Aperçu</string>
-	<string name="Normal">Normal</string>
-	<string name="Pathfinding_Wiki_URL">http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer</string>
-	<string name="Pathfinding_Object_Attr_None">Aucun</string>
-	<string name="Pathfinding_Object_Attr_Permanent">Maillage de navigation affecté</string>
-	<string name="Pathfinding_Object_Attr_Character">Personnage</string>
-	<string name="Pathfinding_Object_Attr_MultiSelect">(Multiple)</string>
-	<string name="snapshot_quality_very_low">Très faible</string>
-	<string name="snapshot_quality_low">Faible</string>
-	<string name="snapshot_quality_medium">Moyenne</string>
-	<string name="snapshot_quality_high">Élevée</string>
-	<string name="snapshot_quality_very_high">Très élevée</string>
-	<string name="TeleportMaturityExceeded">Le résident ne peut pas visiter cette région.</string>
-	<string name="UserDictionary">[User]</string>
-	<string name="experience_tools_experience">Expérience</string>
-	<string name="ExperienceNameNull">(aucune expérience)</string>
-	<string name="ExperienceNameUntitled">(expérience sans titre)</string>
-	<string name="Land-Scope">À l’échelle des terrains</string>
-	<string name="Grid-Scope">À l’échelle de la grille</string>
-	<string name="Allowed_Experiences_Tab">AUTORISÉE</string>
-	<string name="Blocked_Experiences_Tab">BLOQUÉE</string>
-	<string name="Contrib_Experiences_Tab">CONTRIBUTEUR</string>
-	<string name="Admin_Experiences_Tab">ADMIN</string>
-	<string name="Recent_Experiences_Tab">RÉCENTE</string>
-	<string name="Owned_Experiences_Tab">AVEC PROPRIÉTAIRE</string>
-	<string name="ExperiencesCounter">([EXPERIENCES], [MAXEXPERIENCES] max.)</string>
-	<string name="ExperiencePermission1">assumer vos contrôles</string>
-	<string name="ExperiencePermission3">déclencher des animations pour votre avatar</string>
-	<string name="ExperiencePermission4">attacher à votre avatar</string>
-	<string name="ExperiencePermission9">suivre votre caméra</string>
-	<string name="ExperiencePermission10">contrôler votre caméra</string>
-	<string name="ExperiencePermission11">vous téléporter</string>
-	<string name="ExperiencePermission12">accepter automatiquement les permissions d’expérience</string>
-	<string name="ExperiencePermission16">forcez votre avatar à s’asseoir</string>
-	<string name="ExperiencePermission17">changer vos paramètres d'environnement</string>
-	<string name="ExperiencePermissionShortUnknown">a effectué une opération inconnue : [Permission]</string>
-	<string name="ExperiencePermissionShort1">Prendre le contrôle</string>
-	<string name="ExperiencePermissionShort3">Déclencher des animations</string>
-	<string name="ExperiencePermissionShort4">Attacher</string>
-	<string name="ExperiencePermissionShort9">Suivre la caméra</string>
-	<string name="ExperiencePermissionShort10">Contrôler la caméra</string>
-	<string name="ExperiencePermissionShort11">Téléportation</string>
-	<string name="ExperiencePermissionShort12">Permission</string>
-	<string name="ExperiencePermissionShort16">M'asseoir</string>
-	<string name="ExperiencePermissionShort17">Environnement</string>
-	<string name="logging_calls_disabled_log_empty">Les conversations ne sont pas archivées. Pour commencer à tenir un journal, choisissez Enregistrer : Journal seul ou Enregistrer : Journal et transcriptions sous Préférences &gt; Chat.</string>
-	<string name="logging_calls_disabled_log_not_empty">Aucune conversation ne sera plus enregistrée. Pour recommencer à tenir un journal, choisissez Enregistrer : Journal seul ou Enregistrer : Journal et transcriptions sous Préférences &gt; Chat.</string>
-	<string name="logging_calls_enabled_log_empty">Il n'y a aucune conversation enregistrée. Quand quelqu'un vous contacte ou quand vous contactez quelqu'un, une entrée de journal s'affiche ici.</string>
-	<string name="loading_chat_logs">Chargement...</string>
-	<string name="na">s.o.</string>
-	<string name="preset_combo_label">-Liste vide-</string>
-	<string name="Default">Valeur par défaut</string>
-	<string name="none_paren_cap">(Aucun/Aucune)</string>
-	<string name="no_limit">Aucune limite</string>
-	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">La forme physique contient des triangles trop petits. Essayez de simplifier le modèle physique.</string>
-	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">La forme physique contient de mauvaises données de confirmation. Essayez de corriger le modèle physique.</string>
-	<string name="Mav_Details_MAV_UNKNOWN_VERSION">La forme physique n’a pas la version correcte. Configurez la version correcte pour le modèle physique.</string>
-	<string name="couldnt_resolve_host">DNS n'a pas pu résoudre le nom d'hôte([HOSTNAME]). 
+(par ex. : "/chemin_accès/editor" "%s").
+	</string>
+	<string name="ExternalEditorCommandParseError">
+		Erreur lors de l'analyse de la commande d'éditeur externe.
+	</string>
+	<string name="ExternalEditorFailedToRun">
+		Échec d'exécution de l'éditeur externe.
+	</string>
+	<string name="TranslationFailed">
+		Échec de traduction : [REASON]
+	</string>
+	<string name="TranslationResponseParseError">
+		Erreur lors de l'analyse de la réponse relative à la traduction.
+	</string>
+	<string name="Esc">
+		Échap
+	</string>
+	<string name="Space">
+		Space
+	</string>
+	<string name="Enter">
+		Enter
+	</string>
+	<string name="Tab">
+		Tab
+	</string>
+	<string name="Ins">
+		Ins
+	</string>
+	<string name="Del">
+		Del
+	</string>
+	<string name="Backsp">
+		Backsp
+	</string>
+	<string name="Shift">
+		Maj
+	</string>
+	<string name="Ctrl">
+		Ctrl
+	</string>
+	<string name="Alt">
+		Alt
+	</string>
+	<string name="CapsLock">
+		CapsLock
+	</string>
+	<string name="Home">
+		Début
+	</string>
+	<string name="End">
+		End
+	</string>
+	<string name="PgUp">
+		PgUp
+	</string>
+	<string name="PgDn">
+		PgDn
+	</string>
+	<string name="F1">
+		F1
+	</string>
+	<string name="F2">
+		F2
+	</string>
+	<string name="F3">
+		F3
+	</string>
+	<string name="F4">
+		F4
+	</string>
+	<string name="F5">
+		F5
+	</string>
+	<string name="F6">
+		F6
+	</string>
+	<string name="F7">
+		F7
+	</string>
+	<string name="F8">
+		F8
+	</string>
+	<string name="F9">
+		F9
+	</string>
+	<string name="F10">
+		F10
+	</string>
+	<string name="F11">
+		F11
+	</string>
+	<string name="F12">
+		F12
+	</string>
+	<string name="Add">
+		Ajouter
+	</string>
+	<string name="Subtract">
+		Soustraire
+	</string>
+	<string name="Multiply">
+		Multiplier
+	</string>
+	<string name="Divide">
+		Diviser
+	</string>
+	<string name="PAD_DIVIDE">
+		PAD_DIVIDE
+	</string>
+	<string name="PAD_LEFT">
+		PAD_LEFT
+	</string>
+	<string name="PAD_RIGHT">
+		PAD_RIGHT
+	</string>
+	<string name="PAD_DOWN">
+		PAD_DOWN
+	</string>
+	<string name="PAD_UP">
+		PAD_UP
+	</string>
+	<string name="PAD_HOME">
+		PAD_HOME
+	</string>
+	<string name="PAD_END">
+		PAD_END
+	</string>
+	<string name="PAD_PGUP">
+		PAD_PGUP
+	</string>
+	<string name="PAD_PGDN">
+		PAD_PGDN
+	</string>
+	<string name="PAD_CENTER">
+		PAD_CENTER
+	</string>
+	<string name="PAD_INS">
+		PAD_INS
+	</string>
+	<string name="PAD_DEL">
+		PAD_DEL
+	</string>
+	<string name="PAD_Enter">
+		PAD_Enter
+	</string>
+	<string name="PAD_BUTTON0">
+		PAD_BUTTON0
+	</string>
+	<string name="PAD_BUTTON1">
+		PAD_BUTTON1
+	</string>
+	<string name="PAD_BUTTON2">
+		PAD_BUTTON2
+	</string>
+	<string name="PAD_BUTTON3">
+		PAD_BUTTON3
+	</string>
+	<string name="PAD_BUTTON4">
+		PAD_BUTTON4
+	</string>
+	<string name="PAD_BUTTON5">
+		PAD_BUTTON5
+	</string>
+	<string name="PAD_BUTTON6">
+		PAD_BUTTON6
+	</string>
+	<string name="PAD_BUTTON7">
+		PAD_BUTTON7
+	</string>
+	<string name="PAD_BUTTON8">
+		PAD_BUTTON8
+	</string>
+	<string name="PAD_BUTTON9">
+		PAD_BUTTON9
+	</string>
+	<string name="PAD_BUTTON10">
+		PAD_BUTTON10
+	</string>
+	<string name="PAD_BUTTON11">
+		PAD_BUTTON11
+	</string>
+	<string name="PAD_BUTTON12">
+		PAD_BUTTON12
+	</string>
+	<string name="PAD_BUTTON13">
+		PAD_BUTTON13
+	</string>
+	<string name="PAD_BUTTON14">
+		PAD_BUTTON14
+	</string>
+	<string name="PAD_BUTTON15">
+		PAD_BUTTON15
+	</string>
+	<string name="-">
+		-
+	</string>
+	<string name="=">
+		=
+	</string>
+	<string name="`">
+		`
+	</string>
+	<string name=";">
+		;
+	</string>
+	<string name="[">
+		[
+	</string>
+	<string name="]">
+		]
+	</string>
+	<string name="\">
+		\
+	</string>
+	<string name="0">
+		0
+	</string>
+	<string name="1">
+		1
+	</string>
+	<string name="2">
+		2
+	</string>
+	<string name="3">
+		3
+	</string>
+	<string name="4">
+		4
+	</string>
+	<string name="5">
+		5
+	</string>
+	<string name="6">
+		6
+	</string>
+	<string name="7">
+		7
+	</string>
+	<string name="8">
+		8
+	</string>
+	<string name="9">
+		9
+	</string>
+	<string name="A">
+		A
+	</string>
+	<string name="B">
+		B
+	</string>
+	<string name="C">
+		C
+	</string>
+	<string name="D">
+		D
+	</string>
+	<string name="E">
+		E
+	</string>
+	<string name="F">
+		F
+	</string>
+	<string name="G">
+		G
+	</string>
+	<string name="H">
+		H
+	</string>
+	<string name="I">
+		I
+	</string>
+	<string name="J">
+		J
+	</string>
+	<string name="K">
+		K
+	</string>
+	<string name="L">
+		L
+	</string>
+	<string name="M">
+		M
+	</string>
+	<string name="N">
+		N
+	</string>
+	<string name="O">
+		O
+	</string>
+	<string name="P">
+		P
+	</string>
+	<string name="Q">
+		Q
+	</string>
+	<string name="R">
+		R
+	</string>
+	<string name="S">
+		S
+	</string>
+	<string name="T">
+		T
+	</string>
+	<string name="U">
+		U
+	</string>
+	<string name="V">
+		V
+	</string>
+	<string name="W">
+		W
+	</string>
+	<string name="X">
+		X
+	</string>
+	<string name="Y">
+		Y
+	</string>
+	<string name="Z">
+		Z
+	</string>
+	<string name="BeaconParticle">
+		Affichage des balises de particule (bleu)
+	</string>
+	<string name="BeaconPhysical">
+		Affichage des balises d'objet physique (vert)
+	</string>
+	<string name="BeaconScripted">
+		Affichage des balises d'objet scripté (rouge)
+	</string>
+	<string name="BeaconScriptedTouch">
+		Affichage des balises d'objet scripté avec fonction de toucher (rouge)
+	</string>
+	<string name="BeaconSound">
+		Affichage des balises de son (jaune)
+	</string>
+	<string name="BeaconMedia">
+		Affichage des balises de média (blanc)
+	</string>
+	<string name="BeaconSun">
+		Balise de visibilité du soleil (orange)
+	</string>
+	<string name="BeaconMoon">
+		Observation de la balise de direction de la lune (violet)
+	</string>
+	<string name="ParticleHiding">
+		Masquage des particules
+	</string>
+	<string name="Command_AboutLand_Label">
+		À propos du terrain
+	</string>
+	<string name="Command_Appearance_Label">
+		Apparence
+	</string>
+	<string name="Command_Avatar_Label">
+		Avatar
+	</string>
+	<string name="Command_Build_Label">
+		Construire
+	</string>
+	<string name="Command_Chat_Label">
+		Chat
+	</string>
+	<string name="Command_Conversations_Label">
+		Conversations
+	</string>
+	<string name="Command_Compass_Label">
+		Boussole
+	</string>
+	<string name="Command_Destinations_Label">
+		Destinations
+	</string>
+	<string name="Command_Environments_Label">
+		Mes environnements
+	</string>
+	<string name="Command_Facebook_Label">
+		Facebook
+	</string>
+	<string name="Command_Flickr_Label">
+		Flickr
+	</string>
+	<string name="Command_Gestures_Label">
+		Gestes
+	</string>
+	<string name="Command_Grid_Status_Label">
+		État de la grille
+	</string>
+	<string name="Command_HowTo_Label">
+		Aide rapide
+	</string>
+	<string name="Command_Inventory_Label">
+		Inventaire
+	</string>
+	<string name="Command_Map_Label">
+		Carte
+	</string>
+	<string name="Command_Marketplace_Label">
+		Place du marché
+	</string>
+	<string name="Command_MarketplaceListings_Label">
+		Place du marché
+	</string>
+	<string name="Command_MiniMap_Label">
+		Mini-carte
+	</string>
+	<string name="Command_Move_Label">
+		Marcher / Courir / Voler
+	</string>
+	<string name="Command_Outbox_Label">
+		Boîte d'envoi vendeur
+	</string>
+	<string name="Command_People_Label">
+		Personnes
+	</string>
+	<string name="Command_Picks_Label">
+		Favoris
+	</string>
+	<string name="Command_Places_Label">
+		Lieux
+	</string>
+	<string name="Command_Preferences_Label">
+		Préférences
+	</string>
+	<string name="Command_Profile_Label">
+		Profil
+	</string>
+	<string name="Command_Report_Abuse_Label">
+		Signaler une infraction
+	</string>
+	<string name="Command_Search_Label">
+		Recherche
+	</string>
+	<string name="Command_Snapshot_Label">
+		Photo
+	</string>
+	<string name="Command_Speak_Label">
+		Parler
+	</string>
+	<string name="Command_Twitter_Label">
+		Twitter
+	</string>
+	<string name="Command_View_Label">
+		Caméra
+	</string>
+	<string name="Command_Voice_Label">
+		Paramètres vocaux
+	</string>
+	<string name="Command_AboutLand_Tooltip">
+		Information sur le terrain que vous visitez
+	</string>
+	<string name="Command_Appearance_Tooltip">
+		Modifier votre avatar
+	</string>
+	<string name="Command_Avatar_Tooltip">
+		Choisir un avatar complet
+	</string>
+	<string name="Command_Build_Tooltip">
+		Construction d'objets et remodelage du terrain
+	</string>
+	<string name="Command_Chat_Tooltip">
+		Parler aux personnes près de vous par chat écrit
+	</string>
+	<string name="Command_Conversations_Tooltip">
+		Parler à quelqu'un
+	</string>
+	<string name="Command_Compass_Tooltip">
+		Boussole
+	</string>
+	<string name="Command_Destinations_Tooltip">
+		Destinations intéressantes
+	</string>
+	<string name="Command_Environments_Tooltip">
+		Mes environnements
+	</string>
+	<string name="Command_Facebook_Tooltip">
+		Publier sur Facebook
+	</string>
+	<string name="Command_Flickr_Tooltip">
+		Charger sur Flickr
+	</string>
+	<string name="Command_Gestures_Tooltip">
+		Gestes de votre avatar
+	</string>
+	<string name="Command_Grid_Status_Tooltip">
+		Afficher l’état actuel de la grille
+	</string>
+	<string name="Command_HowTo_Tooltip">
+		Comment effectuer les opérations courantes
+	</string>
+	<string name="Command_Inventory_Tooltip">
+		Afficher et utiliser vos possessions
+	</string>
+	<string name="Command_Map_Tooltip">
+		Carte du monde
+	</string>
+	<string name="Command_Marketplace_Tooltip">
+		Faire du shopping
+	</string>
+	<string name="Command_MarketplaceListings_Tooltip">
+		Vendez votre création
+	</string>
+	<string name="Command_MiniMap_Tooltip">
+		Afficher les personnes près de vous
+	</string>
+	<string name="Command_Move_Tooltip">
+		Faire bouger votre avatar
+	</string>
+	<string name="Command_Outbox_Tooltip">
+		Transférer des articles vers votre place de marché afin de les vendre.
+	</string>
+	<string name="Command_People_Tooltip">
+		Amis, groupes et personnes près de vous
+	</string>
+	<string name="Command_Picks_Tooltip">
+		Lieux à afficher comme favoris dans votre profil
+	</string>
+	<string name="Command_Places_Tooltip">
+		Lieux enregistrés
+	</string>
+	<string name="Command_Preferences_Tooltip">
+		Préférences
+	</string>
+	<string name="Command_Profile_Tooltip">
+		Modifier ou afficher votre profil
+	</string>
+	<string name="Command_Report_Abuse_Tooltip">
+		Signaler une infraction
+	</string>
+	<string name="Command_Search_Tooltip">
+		Trouver des lieux, personnes, événements
+	</string>
+	<string name="Command_Snapshot_Tooltip">
+		Prendre une photo
+	</string>
+	<string name="Command_Speak_Tooltip">
+		Parler aux personnes près de vous en utilisant votre micro
+	</string>
+	<string name="Command_Twitter_Tooltip">
+		Twitter
+	</string>
+	<string name="Command_View_Tooltip">
+		Changer l'angle de la caméra
+	</string>
+	<string name="Command_Voice_Tooltip">
+		Commandes de réglage du volume des appels et des personnes près de vous dans Second Life.
+	</string>
+	<string name="Toolbar_Bottom_Tooltip">
+		actuellement dans la barre d'outils du bas
+	</string>
+	<string name="Toolbar_Left_Tooltip">
+		actuellement dans la barre d'outils de gauche
+	</string>
+	<string name="Toolbar_Right_Tooltip">
+		actuellement dans la barre d'outils de droite
+	</string>
+	<string name="Retain%">
+		Garder%
+	</string>
+	<string name="Detail">
+		Détail
+	</string>
+	<string name="Better Detail">
+		Meilleur détail
+	</string>
+	<string name="Surface">
+		Surface
+	</string>
+	<string name="Solid">
+		Solide
+	</string>
+	<string name="Wrap">
+		Wrap
+	</string>
+	<string name="Preview">
+		Aperçu
+	</string>
+	<string name="Normal">
+		Normal
+	</string>
+	<string name="Pathfinding_Wiki_URL">
+		http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer
+	</string>
+	<string name="Pathfinding_Object_Attr_None">
+		Aucun
+	</string>
+	<string name="Pathfinding_Object_Attr_Permanent">
+		Maillage de navigation affecté
+	</string>
+	<string name="Pathfinding_Object_Attr_Character">
+		Personnage
+	</string>
+	<string name="Pathfinding_Object_Attr_MultiSelect">
+		(Multiple)
+	</string>
+	<string name="snapshot_quality_very_low">
+		Très faible
+	</string>
+	<string name="snapshot_quality_low">
+		Faible
+	</string>
+	<string name="snapshot_quality_medium">
+		Moyenne
+	</string>
+	<string name="snapshot_quality_high">
+		Élevée
+	</string>
+	<string name="snapshot_quality_very_high">
+		Très élevée
+	</string>
+	<string name="TeleportMaturityExceeded">
+		Le résident ne peut pas visiter cette région.
+	</string>
+	<string name="UserDictionary">
+		[User]
+	</string>
+	<string name="experience_tools_experience">
+		Expérience
+	</string>
+	<string name="ExperienceNameNull">
+		(aucune expérience)
+	</string>
+	<string name="ExperienceNameUntitled">
+		(expérience sans titre)
+	</string>
+	<string name="Land-Scope">
+		À l’échelle des terrains
+	</string>
+	<string name="Grid-Scope">
+		À l’échelle de la grille
+	</string>
+	<string name="Allowed_Experiences_Tab">
+		AUTORISÉE
+	</string>
+	<string name="Blocked_Experiences_Tab">
+		BLOQUÉE
+	</string>
+	<string name="Contrib_Experiences_Tab">
+		CONTRIBUTEUR
+	</string>
+	<string name="Admin_Experiences_Tab">
+		ADMIN
+	</string>
+	<string name="Recent_Experiences_Tab">
+		RÉCENTE
+	</string>
+	<string name="Owned_Experiences_Tab">
+		AVEC PROPRIÉTAIRE
+	</string>
+	<string name="ExperiencesCounter">
+		([EXPERIENCES], [MAXEXPERIENCES] max.)
+	</string>
+	<string name="ExperiencePermission1">
+		assumer vos contrôles
+	</string>
+	<string name="ExperiencePermission3">
+		déclencher des animations pour votre avatar
+	</string>
+	<string name="ExperiencePermission4">
+		attacher à votre avatar
+	</string>
+	<string name="ExperiencePermission9">
+		suivre votre caméra
+	</string>
+	<string name="ExperiencePermission10">
+		contrôler votre caméra
+	</string>
+	<string name="ExperiencePermission11">
+		vous téléporter
+	</string>
+	<string name="ExperiencePermission12">
+		accepter automatiquement les permissions d’expérience
+	</string>
+	<string name="ExperiencePermission16">
+		forcez votre avatar à s’asseoir
+	</string>
+	<string name="ExperiencePermission17">
+		changer vos paramètres d'environnement
+	</string>
+	<string name="ExperiencePermissionShortUnknown">
+		a effectué une opération inconnue : [Permission]
+	</string>
+	<string name="ExperiencePermissionShort1">
+		Prendre le contrôle
+	</string>
+	<string name="ExperiencePermissionShort3">
+		Déclencher des animations
+	</string>
+	<string name="ExperiencePermissionShort4">
+		Attacher
+	</string>
+	<string name="ExperiencePermissionShort9">
+		Suivre la caméra
+	</string>
+	<string name="ExperiencePermissionShort10">
+		Contrôler la caméra
+	</string>
+	<string name="ExperiencePermissionShort11">
+		Téléportation
+	</string>
+	<string name="ExperiencePermissionShort12">
+		Permission
+	</string>
+	<string name="ExperiencePermissionShort16">
+		M'asseoir
+	</string>
+	<string name="ExperiencePermissionShort17">
+		Environnement
+	</string>
+	<string name="logging_calls_disabled_log_empty">
+		Les conversations ne sont pas archivées. Pour commencer à tenir un journal, choisissez Enregistrer : Journal seul ou Enregistrer : Journal et transcriptions sous Préférences &gt; Chat.
+	</string>
+	<string name="logging_calls_disabled_log_not_empty">
+		Aucune conversation ne sera plus enregistrée. Pour recommencer à tenir un journal, choisissez Enregistrer : Journal seul ou Enregistrer : Journal et transcriptions sous Préférences &gt; Chat.
+	</string>
+	<string name="logging_calls_enabled_log_empty">
+		Il n'y a aucune conversation enregistrée. Quand quelqu'un vous contacte ou quand vous contactez quelqu'un, une entrée de journal s'affiche ici.
+	</string>
+	<string name="loading_chat_logs">
+		Chargement...
+	</string>
+	<string name="na">
+		s.o.
+	</string>
+	<string name="preset_combo_label">
+		-Liste vide-
+	</string>
+	<string name="Default">
+		Valeur par défaut
+	</string>
+	<string name="none_paren_cap">
+		(Aucun/Aucune)
+	</string>
+	<string name="no_limit">
+		Aucune limite
+	</string>
+	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">
+		La forme physique contient des triangles trop petits. Essayez de simplifier le modèle physique.
+	</string>
+	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">
+		La forme physique contient de mauvaises données de confirmation. Essayez de corriger le modèle physique.
+	</string>
+	<string name="Mav_Details_MAV_UNKNOWN_VERSION">
+		La forme physique n’a pas la version correcte. Configurez la version correcte pour le modèle physique.
+	</string>
+	<string name="couldnt_resolve_host">
+		DNS n'a pas pu résoudre le nom d'hôte([HOSTNAME]). 
 Veuillez vérifier que vous parvenez à vous connecter au site www.secondlife.com. 
 Si c'est le cas, et que vous continuez à recevoir ce message d'erreur, veuillez vous 
-rendre à la section Support et signaler ce problème</string>
-	<string name="ssl_peer_certificate">Le serveur d'identification a rencontré une erreur de connexion SSL. 
+rendre à la section Support et signaler ce problème
+	</string>
+	<string name="ssl_peer_certificate">
+		Le serveur d'identification a rencontré une erreur de connexion SSL. 
 Si vous continuez à recevoir ce message d'erreur, 
 veuillez vous rendre à la section Support du site web 
-SecondLife.com et signaler ce problème</string>
-	<string name="ssl_connect_error">Ceci est souvent dû à un mauvais réglage de l'horloge de votre ordinateur. 
+SecondLife.com et signaler ce problème
+	</string>
+	<string name="ssl_connect_error">
+		Ceci est souvent dû à un mauvais réglage de l'horloge de votre ordinateur. 
 Veuillez aller à Tableaux de bord et assurez-vous que l'heure et la date sont réglés 
 correctement. Vérifiez également que votre réseau et votre pare-feu sont configurés 
 correctement. Si vous continuez à recevoir ce message d'erreur, veuillez vous rendre 
 à la section Support du site web SecondLife.com et signaler ce problème. 
 
-[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de connaissances]</string>
+[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de connaissances]
+	</string>
 </strings>

--- a/indra/newview/skins/default/xui/fr/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/fr/teleport_strings.xml
@@ -1,40 +1,96 @@
 <?xml version="1.0" ?>
 <teleport_messages>
 	<message_set name="errors">
-		<message name="invalid_tport">Nous avons rencontré des problèmes en essayant de vous téléporter. Vous devrez peut-être vous reconnecter avant de pouvoir vous téléporter.
-Si ce message persiste, veuillez consulter la page [SUPPORT_SITE].</message>
-		<message name="invalid_region_handoff">Nous avons rencontré des problèmes en essayant de vous téléporter. Vous devrez peut-être vous reconnecter avant de pouvoir traverser des régions.
-Si ce message persiste, veuillez consulter la page [SUPPORT_SITE].</message>
-		<message name="blocked_tport">Désolé, la téléportation est bloquée actuellement. Veuillez réessayer dans un moment.
-Si vous ne parvenez toujours pas à être téléporté, déconnectez-vous puis reconnectez-vous pour résoudre le problème.</message>
-		<message name="nolandmark_tport">Désolé, le système n'a pas réussi à localiser la destination de votre repère.</message>
-		<message name="timeout_tport">Désolé, la connexion vers votre lieu de téléportation n'a pas abouti.
-Veuillez réessayer dans un moment.</message>
-		<message name="NoHelpIslandTP">Vous ne pouvez pas vous téléporter à nouveau vers Welcome Island.
-Pour recommencer le didacticiel, accédez à Welcome Island Public.</message>
-		<message name="noaccess_tport">Désolé, vous n'avez pas accès à cette destination.</message>
-		<message name="missing_attach_tport">Vos pieces-jointes ne sont pas encore arrivées. Attendez quelques secondes de plus ou déconnectez-vous puis reconnectez-vous avant d'essayer de vous téléporter.</message>
-		<message name="too_many_uploads_tport">Le trafic vers cette région est bouché en ce moment. Votre téléportation ne pourra pas avoir lieu immédiatement. Veuillez réessayer dans quelques minutes ou bien aller dans une zone moins fréquentée.</message>
-		<message name="expired_tport">Désolé, votre demande de téléportation n'a pas abouti assez rapidement. Veuillez réessayer dans quelques minutes.</message>
-		<message name="expired_region_handoff">Désolé, votre demande pour passer dans une autre région n'a pas abouti assez rapidement. Veuillez réessayer dans quelques minutes.</message>
-		<message name="no_host">Impossible de trouver la destination de la téléportation. Il est possible que cette destination soit temporairement indisponible ou qu'elle n'existe plus. Veuillez réessayer dans quelques minutes.</message>
-		<message name="no_inventory_host">L'inventaire est temporairement indisponible.</message>
-		<message name="MustGetAgeRegion">Pour accéder à cette région, vous devez avoir au moins 18 ans.</message>
-		<message name="RegionTPSpecialUsageBlocked">Impossible de pénétrer dans la région. « [REGION_NAME] » est une région de jeux d'adresse et vous devez satisfaire à certains critères pour y pénétrer. Pour en savoir plus, consultez la page [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life FAQ sur les jeux d'adresse].</message>
-		<message name="preexisting_tport">Désolé, mais le système n'a pas pu démarrer votre téléport. Veuillez réessayer dans quelques minutes.</message>
+		<message name="invalid_tport">
+			Nous avons rencontré des problèmes en essayant de vous téléporter. Vous devrez peut-être vous reconnecter avant de pouvoir vous téléporter.
+Si ce message persiste, veuillez consulter la page [SUPPORT_SITE].
+		</message>
+		<message name="invalid_region_handoff">
+			Nous avons rencontré des problèmes en essayant de vous téléporter. Vous devrez peut-être vous reconnecter avant de pouvoir traverser des régions.
+Si ce message persiste, veuillez consulter la page [SUPPORT_SITE].
+		</message>
+		<message name="blocked_tport">
+			Désolé, la téléportation est bloquée actuellement. Veuillez réessayer dans un moment.
+Si vous ne parvenez toujours pas à être téléporté, déconnectez-vous puis reconnectez-vous pour résoudre le problème.
+		</message>
+		<message name="nolandmark_tport">
+			Désolé, le système n'a pas réussi à localiser la destination de votre repère.
+		</message>
+		<message name="timeout_tport">
+			Désolé, la connexion vers votre lieu de téléportation n'a pas abouti.
+Veuillez réessayer dans un moment.
+		</message>
+		<message name="NoHelpIslandTP">
+			Vous ne pouvez pas vous téléporter à nouveau vers Welcome Island.
+Pour recommencer le didacticiel, accédez à Welcome Island Public.
+		</message>
+		<message name="noaccess_tport">
+			Désolé, vous n'avez pas accès à cette destination.
+		</message>
+		<message name="missing_attach_tport">
+			Vos pieces-jointes ne sont pas encore arrivées. Attendez quelques secondes de plus ou déconnectez-vous puis reconnectez-vous avant d'essayer de vous téléporter.
+		</message>
+		<message name="too_many_uploads_tport">
+			Le trafic vers cette région est bouché en ce moment. Votre téléportation ne pourra pas avoir lieu immédiatement. Veuillez réessayer dans quelques minutes ou bien aller dans une zone moins fréquentée.
+		</message>
+		<message name="expired_tport">
+			Désolé, votre demande de téléportation n'a pas abouti assez rapidement. Veuillez réessayer dans quelques minutes.
+		</message>
+		<message name="expired_region_handoff">
+			Désolé, votre demande pour passer dans une autre région n'a pas abouti assez rapidement. Veuillez réessayer dans quelques minutes.
+		</message>
+		<message name="no_host">
+			Impossible de trouver la destination de la téléportation. Il est possible que cette destination soit temporairement indisponible ou qu'elle n'existe plus. Veuillez réessayer dans quelques minutes.
+		</message>
+		<message name="no_inventory_host">
+			L'inventaire est temporairement indisponible.
+		</message>
+		<message name="MustGetAgeRegion">
+			Pour accéder à cette région, vous devez avoir au moins 18 ans.
+		</message>
+		<message name="RegionTPSpecialUsageBlocked">
+			Impossible de pénétrer dans la région. « [REGION_NAME] » est une région de jeux d'adresse et vous devez satisfaire à certains critères pour y pénétrer. Pour en savoir plus, consultez la page [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life FAQ sur les jeux d'adresse].
+		</message>
+		<message name="preexisting_tport">
+			Désolé, mais le système n'a pas pu démarrer votre téléport. Veuillez réessayer dans quelques minutes.
+		</message>
 	</message_set>
 	<message_set name="progress">
-		<message name="sending_dest">Envoi vers la destination en cours.</message>
-		<message name="redirecting">Redirection vers un emplacement différent en cours.</message>
-		<message name="relaying">Relai vers la destination en cours.</message>
-		<message name="sending_home">Requête de la demande d'envoi vers votre domicile en cours.</message>
-		<message name="sending_landmark">Requête de la demande d'envoi vers le repère en cours.</message>
-		<message name="completing">Téléportation sur le point d'aboutir.</message>
-		<message name="completed_from">Téléportation depuis [T_SLURL] terminée</message>
-		<message name="resolving">Destination en cours de résolution.</message>
-		<message name="contacting">Contact avec la nouvelle région en cours.</message>
-		<message name="arriving">Vous arrivez...</message>
-		<message name="requesting">Demande de téléportation en cours...</message>
-		<message name="pending">En attente de téléportation...</message>
+		<message name="sending_dest">
+			Envoi vers la destination en cours.
+		</message>
+		<message name="redirecting">
+			Redirection vers un emplacement différent en cours.
+		</message>
+		<message name="relaying">
+			Relai vers la destination en cours.
+		</message>
+		<message name="sending_home">
+			Requête de la demande d'envoi vers votre domicile en cours.
+		</message>
+		<message name="sending_landmark">
+			Requête de la demande d'envoi vers le repère en cours.
+		</message>
+		<message name="completing">
+			Téléportation sur le point d'aboutir.
+		</message>
+		<message name="completed_from">
+			Téléportation depuis [T_SLURL] terminée
+		</message>
+		<message name="resolving">
+			Destination en cours de résolution.
+		</message>
+		<message name="contacting">
+			Contact avec la nouvelle région en cours.
+		</message>
+		<message name="arriving">
+			Vous arrivez...
+		</message>
+		<message name="requesting">
+			Demande de téléportation en cours...
+		</message>
+		<message name="pending">
+			En attente de téléportation...
+		</message>
 	</message_set>
 </teleport_messages>

--- a/indra/newview/skins/default/xui/it/strings.xml
+++ b/indra/newview/skins/default/xui/it/strings.xml
@@ -1,610 +1,1668 @@
 <?xml version="1.0" ?>
 <strings>
-	<string name="SECOND_LIFE">Second Life</string>
-	<string name="APP_NAME">Second Life</string>
-	<string name="CAPITALIZED_APP_NAME">SECOND LIFE</string>
-	<string name="SUPPORT_SITE">Portale di supporto di Second Life</string>
-	<string name="StartupDetectingHardware">Ricerca hardware...</string>
-	<string name="StartupLoading">Caricamento di [APP_NAME]...</string>
-	<string name="StartupClearingCache">Pulizia della cache...</string>
-	<string name="StartupInitializingTextureCache">Inizializzazione della cache texture...</string>
-	<string name="StartupRequireDriverUpdate">Inizializzazione grafica non riuscita. Aggiorna il driver della scheda grafica!</string>
-	<string name="AboutHeader">[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
-[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]</string>
-	<string name="BuildConfig">Configurazione struttura [BUILD_CONFIG]</string>
-	<string name="AboutPosition">Tu sei a [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] in [REGION] che si trova a &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+	<string name="SECOND_LIFE">
+		Second Life
+	</string>
+	<string name="APP_NAME">
+		Second Life
+	</string>
+	<string name="CAPITALIZED_APP_NAME">
+		SECOND LIFE
+	</string>
+	<string name="SUPPORT_SITE">
+		Portale di supporto di Second Life
+	</string>
+	<string name="StartupDetectingHardware">
+		Ricerca hardware...
+	</string>
+	<string name="StartupLoading">
+		Caricamento di [APP_NAME]...
+	</string>
+	<string name="StartupClearingCache">
+		Pulizia della cache...
+	</string>
+	<string name="StartupInitializingTextureCache">
+		Inizializzazione della cache texture...
+	</string>
+	<string name="StartupRequireDriverUpdate">
+		Inizializzazione grafica non riuscita. Aggiorna il driver della scheda grafica!
+	</string>
+	<string name="AboutHeader">
+		[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
+[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
+	</string>
+	<string name="BuildConfig">
+		Configurazione struttura [BUILD_CONFIG]
+	</string>
+	<string name="AboutPosition">
+		Tu sei a [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] in [REGION] che si trova a &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (coordinate globali [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
-[SERVER_RELEASE_NOTES_URL]</string>
-	<string name="AboutSystem">CPU: [CPU]
+[SERVER_RELEASE_NOTES_URL]
+	</string>
+	<string name="AboutSystem">
+		CPU: [CPU]
 Memoria: [MEMORY_MB] MB
 Versione sistema operativo: [OS_VERSION]
 Venditore scheda grafica: [GRAPHICS_CARD_VENDOR]
-Scheda grafica: [GRAPHICS_CARD]</string>
-	<string name="AboutDriver">Versione driver Windows per grafica: [GRAPHICS_DRIVER_VERSION]</string>
-	<string name="AboutOGL">Versione OpenGL: [OPENGL_VERSION]</string>
-	<string name="AboutSettings">Dimensione finestra: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+Scheda grafica: [GRAPHICS_CARD]
+	</string>
+	<string name="AboutDriver">
+		Versione driver Windows per grafica: [GRAPHICS_DRIVER_VERSION]
+	</string>
+	<string name="AboutOGL">
+		Versione OpenGL: [OPENGL_VERSION]
+	</string>
+	<string name="AboutSettings">
+		Dimensione finestra: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Regolazione dimensioni carattere: [FONT_SIZE_ADJUSTMENT]pt
 Scala UI: [UI_SCALE]
 Distanza visualizzazione: [DRAW_DISTANCE]m
 Larghezza banda: [NET_BANDWITH]kbit/s
 Fattore livello di dettaglio: [LOD_FACTOR]
 Qualità di rendering: [RENDER_QUALITY]
-Memoria texture: [TEXTURE_MEMORY]MB</string>
-	<string name="AboutOSXHiDPI">Modalità display HiDPI: [HIDPI]</string>
-	<string name="AboutLibs">J2C Versione decoder: [J2C_VERSION] 
+Memoria texture: [TEXTURE_MEMORY]MB
+	</string>
+	<string name="AboutOSXHiDPI">
+		Modalità display HiDPI: [HIDPI]
+	</string>
+	<string name="AboutLibs">
+		J2C Versione decoder: [J2C_VERSION] 
 Versione del driver audio: [AUDIO_DRIVER_VERSION][LIBCEF_VERSION]
 Versione LibVLC: [LIBVLC_VERSION] 
-Versione server voce: [VOICE_VERSION]</string>
-	<string name="AboutTraffic">Pacchetti perduti: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)</string>
-	<string name="AboutTime">[day, datetime, slt] [month, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]</string>
-	<string name="ErrorFetchingServerReleaseNotesURL">Errore nel recupero URL note rilascio versione</string>
-	<string name="BuildConfiguration">Costruisci configurazione</string>
-	<string name="ProgressRestoring">Ripristino in corso...</string>
-	<string name="ProgressChangingResolution">Modifica della risoluzione...</string>
-	<string name="Fullbright">Luminosità massima (vers. precedente)</string>
-	<string name="LoginInProgress">In connessione. [APP_NAME] può sembrare rallentata.  Attendi.</string>
-	<string name="LoginInProgressNoFrozen">Accesso in corso...</string>
-	<string name="LoginAuthenticating">In autenticazione</string>
-	<string name="LoginMaintenance">Aggiornamento account in corso...</string>
-	<string name="LoginAttempt">Un precedente tentativo di login è fallito. Tentativo di connessione [NUMBER]</string>
-	<string name="LoginPrecaching">Sto caricando [SECOND_LIFE]...</string>
-	<string name="LoginInitializingBrowser">Inizializzazione del browser web incorporato...</string>
-	<string name="LoginInitializingMultimedia">Inizializzazione dati multimediali...</string>
-	<string name="LoginInitializingFonts">Caricamento caratteri...</string>
-	<string name="LoginVerifyingCache">Verifica file della cache (tempo previsto 60-90 secondi)...</string>
-	<string name="LoginProcessingResponse">Elaborazione risposta...</string>
-	<string name="LoginInitializingWorld">Inizializzazione mondo...</string>
-	<string name="LoginDecodingImages">Decodifica immagini...</string>
-	<string name="LoginInitializingQuicktime">Inizializzazione QuickTime...</string>
-	<string name="LoginQuicktimeNotFound">QuickTime non trovato - impossibile inizializzare.</string>
-	<string name="LoginQuicktimeOK">QuickTime configurato con successo.</string>
-	<string name="LoginRequestSeedCapGrant">Richiesta capacità regione...</string>
-	<string name="LoginRetrySeedCapGrant">Richiesta capacità regione, tentativo [NUMBER]...</string>
-	<string name="LoginWaitingForRegionHandshake">In attesa della risposta della regione...</string>
-	<string name="LoginConnectingToRegion">Connessione alla regione...</string>
-	<string name="LoginDownloadingClothing">Sto caricando i vestiti...</string>
-	<string name="InvalidCertificate">Il server ha inviato un certificato non valido o errato. Rivolgiti all'amministratore della griglia.</string>
-	<string name="CertInvalidHostname">Per accedere al server è stato utilizzato un nome host non valido; controlla lo SLURL o il nome host della griglia.</string>
-	<string name="CertExpired">Il certificato inviato dalla griglia sembra essere scaduto.  Controlla l'orologio del sistema o rivolgiti all'amministratore della griglia.</string>
-	<string name="CertKeyUsage">Impossibile utilizzare per SSl il certificato inviato dal server.  Rivolgiti all'amministratore della griglia.</string>
-	<string name="CertBasicConstraints">Nella catena dei certificati del server erano presenti troppi certificati.  Rivolgiti all'amministratore della griglia.</string>
-	<string name="CertInvalidSignature">Impossibile verificare la firma del certificato inviato dal server della griglia.  Rivolgiti all'amministratore della griglia.</string>
-	<string name="LoginFailedNoNetwork">Errore di rete: Non è stato possibile stabilire un collegamento, controlla la tua connessione.</string>
-	<string name="LoginFailedHeader">Accesso non riuscito.</string>
-	<string name="Quit">Esci</string>
-	<string name="create_account_url">http://join.secondlife.com/?sourceid=[sourceid]</string>
-	<string name="AgniGridLabel">Griglia principale di Second Life (Agni)</string>
-	<string name="AditiGridLabel">Griglia per beta test di Second Life (Aditi)</string>
-	<string name="ViewerDownloadURL">http://secondlife.com/download.</string>
-	<string name="LoginFailedViewerNotPermitted">Il viewer utilizzato non è più in grado di accedere a Second Life. Visita la parina seguente per scaricare un nuovo viewer:
+Versione server voce: [VOICE_VERSION]
+	</string>
+	<string name="AboutTraffic">
+		Pacchetti perduti: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)
+	</string>
+	<string name="AboutTime">
+		[day, datetime, slt] [month, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
+	</string>
+	<string name="ErrorFetchingServerReleaseNotesURL">
+		Errore nel recupero URL note rilascio versione
+	</string>
+	<string name="BuildConfiguration">
+		Costruisci configurazione
+	</string>
+	<string name="ProgressRestoring">
+		Ripristino in corso...
+	</string>
+	<string name="ProgressChangingResolution">
+		Modifica della risoluzione...
+	</string>
+	<string name="Fullbright">
+		Luminosità massima (vers. precedente)
+	</string>
+	<string name="LoginInProgress">
+		In connessione. [APP_NAME] può sembrare rallentata.  Attendi.
+	</string>
+	<string name="LoginInProgressNoFrozen">
+		Accesso in corso...
+	</string>
+	<string name="LoginAuthenticating">
+		In autenticazione
+	</string>
+	<string name="LoginMaintenance">
+		Aggiornamento account in corso...
+	</string>
+	<string name="LoginAttempt">
+		Un precedente tentativo di login è fallito. Tentativo di connessione [NUMBER]
+	</string>
+	<string name="LoginPrecaching">
+		Sto caricando [SECOND_LIFE]...
+	</string>
+	<string name="LoginInitializingBrowser">
+		Inizializzazione del browser web incorporato...
+	</string>
+	<string name="LoginInitializingMultimedia">
+		Inizializzazione dati multimediali...
+	</string>
+	<string name="LoginInitializingFonts">
+		Caricamento caratteri...
+	</string>
+	<string name="LoginVerifyingCache">
+		Verifica file della cache (tempo previsto 60-90 secondi)...
+	</string>
+	<string name="LoginProcessingResponse">
+		Elaborazione risposta...
+	</string>
+	<string name="LoginInitializingWorld">
+		Inizializzazione mondo...
+	</string>
+	<string name="LoginDecodingImages">
+		Decodifica immagini...
+	</string>
+	<string name="LoginInitializingQuicktime">
+		Inizializzazione QuickTime...
+	</string>
+	<string name="LoginQuicktimeNotFound">
+		QuickTime non trovato - impossibile inizializzare.
+	</string>
+	<string name="LoginQuicktimeOK">
+		QuickTime configurato con successo.
+	</string>
+	<string name="LoginRequestSeedCapGrant">
+		Richiesta capacità regione...
+	</string>
+	<string name="LoginRetrySeedCapGrant">
+		Richiesta capacità regione, tentativo [NUMBER]...
+	</string>
+	<string name="LoginWaitingForRegionHandshake">
+		In attesa della risposta della regione...
+	</string>
+	<string name="LoginConnectingToRegion">
+		Connessione alla regione...
+	</string>
+	<string name="LoginDownloadingClothing">
+		Sto caricando i vestiti...
+	</string>
+	<string name="InvalidCertificate">
+		Il server ha inviato un certificato non valido o errato. Rivolgiti all'amministratore della griglia.
+	</string>
+	<string name="CertInvalidHostname">
+		Per accedere al server è stato utilizzato un nome host non valido; controlla lo SLURL o il nome host della griglia.
+	</string>
+	<string name="CertExpired">
+		Il certificato inviato dalla griglia sembra essere scaduto.  Controlla l'orologio del sistema o rivolgiti all'amministratore della griglia.
+	</string>
+	<string name="CertKeyUsage">
+		Impossibile utilizzare per SSl il certificato inviato dal server.  Rivolgiti all'amministratore della griglia.
+	</string>
+	<string name="CertBasicConstraints">
+		Nella catena dei certificati del server erano presenti troppi certificati.  Rivolgiti all'amministratore della griglia.
+	</string>
+	<string name="CertInvalidSignature">
+		Impossibile verificare la firma del certificato inviato dal server della griglia.  Rivolgiti all'amministratore della griglia.
+	</string>
+	<string name="LoginFailedNoNetwork">
+		Errore di rete: Non è stato possibile stabilire un collegamento, controlla la tua connessione.
+	</string>
+	<string name="LoginFailedHeader">
+		Accesso non riuscito.
+	</string>
+	<string name="Quit">
+		Esci
+	</string>
+	<string name="create_account_url">
+		http://join.secondlife.com/?sourceid=[sourceid]
+	</string>
+	<string name="AgniGridLabel">
+		Griglia principale di Second Life (Agni)
+	</string>
+	<string name="AditiGridLabel">
+		Griglia per beta test di Second Life (Aditi)
+	</string>
+	<string name="ViewerDownloadURL">
+		http://secondlife.com/download.
+	</string>
+	<string name="LoginFailedViewerNotPermitted">
+		Il viewer utilizzato non è più in grado di accedere a Second Life. Visita la parina seguente per scaricare un nuovo viewer:
 http://secondlife.com/download.
 
 Per maggiori informazioni, consulta le domande frequenti alla pagina seguente:
-http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginIntermediateOptionalUpdateAvailable">Disponibile aggiornamento facoltativo viewer: [VERSION]</string>
-	<string name="LoginFailedRequiredUpdate">Aggernamento viewer richiesto: [VERSION]</string>
-	<string name="LoginFailedAlreadyLoggedIn">Questo agente ha già eseguito il login.</string>
-	<string name="LoginFailedAuthenticationFailed">Siamo spiacenti. Il tentativo di accesso non è riuscito.
+http://secondlife.com/viewer-access-faq
+	</string>
+	<string name="LoginIntermediateOptionalUpdateAvailable">
+		Disponibile aggiornamento facoltativo viewer: [VERSION]
+	</string>
+	<string name="LoginFailedRequiredUpdate">
+		Aggernamento viewer richiesto: [VERSION]
+	</string>
+	<string name="LoginFailedAlreadyLoggedIn">
+		Questo agente ha già eseguito il login.
+	</string>
+	<string name="LoginFailedAuthenticationFailed">
+		Siamo spiacenti. Il tentativo di accesso non è riuscito.
 Verifica di avere inserito correttamente
     * Nome utente (come robby12 o Stella Soleggiato)
     * Password
-Verifica anche che il blocco delle maiuscole non sia attivato.</string>
-	<string name="LoginFailedPasswordChanged">Come misura precauzionale, la tua password è stata cambiata.
+Verifica anche che il blocco delle maiuscole non sia attivato.
+	</string>
+	<string name="LoginFailedPasswordChanged">
+		Come misura precauzionale, la tua password è stata cambiata.
 Visita la pagina del tuo account a http://secondlife.com/password
 e rispondi alla domanda di sicurezza per reimpostare la password.
-Ci scusiamo per l'inconveniente.</string>
-	<string name="LoginFailedPasswordReset">Abbiamo effettuato delle modifiche al sistema che richiedono di reimpostare la password.
+Ci scusiamo per l'inconveniente.
+	</string>
+	<string name="LoginFailedPasswordReset">
+		Abbiamo effettuato delle modifiche al sistema che richiedono di reimpostare la password.
 Visita la pagina del tuo account a http://secondlife.com/password
 e rispondi alla domanda di sicurezza per reimpostare la password.
-Ci scusiamo per l'inconveniente.</string>
-	<string name="LoginFailedEmployeesOnly">Second Life è chiuso temporaneamente per manutenzione.
+Ci scusiamo per l'inconveniente.
+	</string>
+	<string name="LoginFailedEmployeesOnly">
+		Second Life è chiuso temporaneamente per manutenzione.
 Al momento, solo i dipendenti possono eseguire l'accesso.
-Visita www.secondlife.com/status per aggiornamenti.</string>
-	<string name="LoginFailedPremiumOnly">L'accesso a Second Life è temporaneamente limitato per garantire che chi è nel mondo virtuale abbia la migliore esperienza possibile.
+Visita www.secondlife.com/status per aggiornamenti.
+	</string>
+	<string name="LoginFailedPremiumOnly">
+		L'accesso a Second Life è temporaneamente limitato per garantire che chi è nel mondo virtuale abbia la migliore esperienza possibile.
 
-Le persone con account gratuiti non potranno accedere a Second Life durante questo periodo, per lasciare spazio alle persone che hanno pagato per Second Life.</string>
-	<string name="LoginFailedComputerProhibited">Non si può accedere a Second Life da questo computer.
+Le persone con account gratuiti non potranno accedere a Second Life durante questo periodo, per lasciare spazio alle persone che hanno pagato per Second Life.
+	</string>
+	<string name="LoginFailedComputerProhibited">
+		Non si può accedere a Second Life da questo computer.
 Se ritieni che si tratta di un errore, contatta
-support@secondlife.com.</string>
-	<string name="LoginFailedAcountSuspended">Il tuo account non è accessibile fino alle
-[TIME] fuso orario del Pacifico.</string>
-	<string name="LoginFailedAccountDisabled">Non siamo attualmente in grado di completare la tua richiesta. 
-Contatta l'assistenza Second Life alla pagina http://support.secondlife.com.</string>
-	<string name="LoginFailedTransformError">Dati incompatibili rilevati durante l'accesso.
-Contattare support@secondlife.com.</string>
-	<string name="LoginFailedAccountMaintenance">Il tuo account è in fase di leggera manutenzione.
+support@secondlife.com.
+	</string>
+	<string name="LoginFailedAcountSuspended">
+		Il tuo account non è accessibile fino alle
+[TIME] fuso orario del Pacifico.
+	</string>
+	<string name="LoginFailedAccountDisabled">
+		Non siamo attualmente in grado di completare la tua richiesta. 
+Contatta l'assistenza Second Life alla pagina http://support.secondlife.com.
+	</string>
+	<string name="LoginFailedTransformError">
+		Dati incompatibili rilevati durante l'accesso.
+Contattare support@secondlife.com.
+	</string>
+	<string name="LoginFailedAccountMaintenance">
+		Il tuo account è in fase di leggera manutenzione.
 Il tuo account non è accessibile fino alle
 [TIME] fuso orario del Pacifico.
-Se ritieni che si tratta di un errore, contatta support@secondlife.com.</string>
-	<string name="LoginFailedPendingLogoutFault">Errore del simulatore in seguito alla richiesta di logout.</string>
-	<string name="LoginFailedPendingLogout">Il sistema sta eseguendo il logout in questo momento. 
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LoginFailedUnableToCreateSession">Non è possibile creare una sessione valida.</string>
-	<string name="LoginFailedUnableToConnectToSimulator">Non è possibile collegarsi a un simulatore.</string>
-	<string name="LoginFailedRestrictedHours">Il tuo account può accedere a Second Life solo
+Se ritieni che si tratta di un errore, contatta support@secondlife.com.
+	</string>
+	<string name="LoginFailedPendingLogoutFault">
+		Errore del simulatore in seguito alla richiesta di logout.
+	</string>
+	<string name="LoginFailedPendingLogout">
+		Il sistema sta eseguendo il logout in questo momento. 
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LoginFailedUnableToCreateSession">
+		Non è possibile creare una sessione valida.
+	</string>
+	<string name="LoginFailedUnableToConnectToSimulator">
+		Non è possibile collegarsi a un simulatore.
+	</string>
+	<string name="LoginFailedRestrictedHours">
+		Il tuo account può accedere a Second Life solo
 tra le [START] e le [END] fuso orario del Pacifico.
 Torna durante quell'orario.
-Se ritieni che si tratta di un errore, contatta support@secondlife.com.</string>
-	<string name="LoginFailedIncorrectParameters">Parametri errati.
-Se ritieni che si tratta di un errore, contatta support@secondlife.com.</string>
-	<string name="LoginFailedFirstNameNotAlphanumeric">Il parametro Nome deve includere solo caratteri alfanumerici.
-Se ritieni che si tratta di un errore, contatta support@secondlife.com.</string>
-	<string name="LoginFailedLastNameNotAlphanumeric">Il parametro Cognome deve includere solo caratteri alfanumerici.
-Se ritieni che si tratta di un errore, contatta support@secondlife.com.</string>
-	<string name="LogoutFailedRegionGoingOffline">La regione sta passando allo stato non in linea.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutFailedAgentNotInRegion">L'agente non è nella regione.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutFailedPendingLogin">La regione ha eseguito l'accesso in un'altre sessione.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutFailedLoggingOut">La regione stava eseguendo il logout della sessione precedente.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutFailedStillLoggingOut">La regione sta ancora eseguendo il logout della sessione precedente.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutSucceeded">La regione ha eseguito il logout dell'ultima sessione.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LogoutFailedLogoutBegun">La regione ha iniziato la procedura di logout.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="LoginFailedLoggingOutSession">Il sistema ha iniziato il logout dell'ultima sessione.
-Prova ad accedere nuovamente tra un minuto.</string>
-	<string name="AgentLostConnection">Questa regione sta avendo problemi.  Verifica la tua connessione a Internet.</string>
-	<string name="SavingSettings">Salvataggio delle impostazioni...</string>
-	<string name="LoggingOut">Uscita...</string>
-	<string name="ShuttingDown">Chiusura...</string>
-	<string name="YouHaveBeenDisconnected">Sei scollegato dalla regione in cui ti trovavi.</string>
-	<string name="SentToInvalidRegion">Sei stato indirizzato in una regione non valida.</string>
-	<string name="TestingDisconnect">Verifica scollegamento viewer</string>
-	<string name="SocialFacebookConnecting">Connessione a Facebook in corso...</string>
-	<string name="SocialFacebookPosting">Caricamento post...</string>
-	<string name="SocialFacebookDisconnecting">Disconnessione da Facebook in corso...</string>
-	<string name="SocialFacebookErrorConnecting">Problemi con la connessione a Facebook</string>
-	<string name="SocialFacebookErrorPosting">Problemi con la connessione a Facebook</string>
-	<string name="SocialFacebookErrorDisconnecting">Problemi con la disconnessione da Facebook</string>
-	<string name="SocialFlickrConnecting">Collegamento a Flickr...</string>
-	<string name="SocialFlickrPosting">Caricamento post...</string>
-	<string name="SocialFlickrDisconnecting">Interruzione del collegamento con Flickr...</string>
-	<string name="SocialFlickrErrorConnecting">Problema nel collegamento a Flickr</string>
-	<string name="SocialFlickrErrorPosting">Problema nel caricamento post su Flickr</string>
-	<string name="SocialFlickrErrorDisconnecting">Problema nell'interruzione del collegamento da Flickr</string>
-	<string name="SocialTwitterConnecting">Collegamento a Twitter...</string>
-	<string name="SocialTwitterPosting">Caricamento post...</string>
-	<string name="SocialTwitterDisconnecting">Interruzione del collegamento con Twitter...</string>
-	<string name="SocialTwitterErrorConnecting">Problema nel collegamento a Twitter</string>
-	<string name="SocialTwitterErrorPosting">Problema nel caricamento post su Twitter</string>
-	<string name="SocialTwitterErrorDisconnecting">Problema nell'interruzione del collegamento da Twitter</string>
-	<string name="BlackAndWhite">Bianco e nero</string>
-	<string name="Colors1970">Colori anni '70</string>
-	<string name="Intense">Intenso</string>
-	<string name="Newspaper">Giornale</string>
-	<string name="Sepia">Seppia</string>
-	<string name="Spotlight">Faretto</string>
-	<string name="Video">Video</string>
-	<string name="Autocontrast">Auto contrasto</string>
-	<string name="LensFlare">Bagliore</string>
-	<string name="Miniature">Miniatura</string>
-	<string name="Toycamera">Toy camera</string>
-	<string name="TooltipPerson">Persona</string>
-	<string name="TooltipNoName">(nessun nome)</string>
-	<string name="TooltipOwner">Proprietario:</string>
-	<string name="TooltipPublic">Pubblico</string>
-	<string name="TooltipIsGroup">(Gruppo)</string>
-	<string name="TooltipForSaleL$">In Vendita: [AMOUNT]L$</string>
-	<string name="TooltipFlagGroupBuild">Costruzione solo con gruppo</string>
-	<string name="TooltipFlagNoBuild">Divieto di Costruire</string>
-	<string name="TooltipFlagNoEdit">Costruzione solo con gruppo</string>
-	<string name="TooltipFlagNotSafe">Non Sicuro</string>
-	<string name="TooltipFlagNoFly">Divieto di Volare</string>
-	<string name="TooltipFlagGroupScripts">Script solo con gruppo</string>
-	<string name="TooltipFlagNoScripts">Script vietati</string>
-	<string name="TooltipLand">Terreno:</string>
-	<string name="TooltipMustSingleDrop">Solo un singolo oggetto può essere creato qui</string>
-	<string name="TooltipTooManyWearables">Non puoi indossare una cartella che contiene più di [AMOUNT] elementi. Per modificare questo limite, accedi ad Avanzate &gt; Mostra impostazioni di debug &gt; WearFolderLimit.</string>
+Se ritieni che si tratta di un errore, contatta support@secondlife.com.
+	</string>
+	<string name="LoginFailedIncorrectParameters">
+		Parametri errati.
+Se ritieni che si tratta di un errore, contatta support@secondlife.com.
+	</string>
+	<string name="LoginFailedFirstNameNotAlphanumeric">
+		Il parametro Nome deve includere solo caratteri alfanumerici.
+Se ritieni che si tratta di un errore, contatta support@secondlife.com.
+	</string>
+	<string name="LoginFailedLastNameNotAlphanumeric">
+		Il parametro Cognome deve includere solo caratteri alfanumerici.
+Se ritieni che si tratta di un errore, contatta support@secondlife.com.
+	</string>
+	<string name="LogoutFailedRegionGoingOffline">
+		La regione sta passando allo stato non in linea.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutFailedAgentNotInRegion">
+		L'agente non è nella regione.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutFailedPendingLogin">
+		La regione ha eseguito l'accesso in un'altre sessione.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutFailedLoggingOut">
+		La regione stava eseguendo il logout della sessione precedente.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutFailedStillLoggingOut">
+		La regione sta ancora eseguendo il logout della sessione precedente.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutSucceeded">
+		La regione ha eseguito il logout dell'ultima sessione.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LogoutFailedLogoutBegun">
+		La regione ha iniziato la procedura di logout.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="LoginFailedLoggingOutSession">
+		Il sistema ha iniziato il logout dell'ultima sessione.
+Prova ad accedere nuovamente tra un minuto.
+	</string>
+	<string name="AgentLostConnection">
+		Questa regione sta avendo problemi.  Verifica la tua connessione a Internet.
+	</string>
+	<string name="SavingSettings">
+		Salvataggio delle impostazioni...
+	</string>
+	<string name="LoggingOut">
+		Uscita...
+	</string>
+	<string name="ShuttingDown">
+		Chiusura...
+	</string>
+	<string name="YouHaveBeenDisconnected">
+		Sei scollegato dalla regione in cui ti trovavi.
+	</string>
+	<string name="SentToInvalidRegion">
+		Sei stato indirizzato in una regione non valida.
+	</string>
+	<string name="TestingDisconnect">
+		Verifica scollegamento viewer
+	</string>
+	<string name="SocialFacebookConnecting">
+		Connessione a Facebook in corso...
+	</string>
+	<string name="SocialFacebookPosting">
+		Caricamento post...
+	</string>
+	<string name="SocialFacebookDisconnecting">
+		Disconnessione da Facebook in corso...
+	</string>
+	<string name="SocialFacebookErrorConnecting">
+		Problemi con la connessione a Facebook
+	</string>
+	<string name="SocialFacebookErrorPosting">
+		Problemi con la connessione a Facebook
+	</string>
+	<string name="SocialFacebookErrorDisconnecting">
+		Problemi con la disconnessione da Facebook
+	</string>
+	<string name="SocialFlickrConnecting">
+		Collegamento a Flickr...
+	</string>
+	<string name="SocialFlickrPosting">
+		Caricamento post...
+	</string>
+	<string name="SocialFlickrDisconnecting">
+		Interruzione del collegamento con Flickr...
+	</string>
+	<string name="SocialFlickrErrorConnecting">
+		Problema nel collegamento a Flickr
+	</string>
+	<string name="SocialFlickrErrorPosting">
+		Problema nel caricamento post su Flickr
+	</string>
+	<string name="SocialFlickrErrorDisconnecting">
+		Problema nell'interruzione del collegamento da Flickr
+	</string>
+	<string name="SocialTwitterConnecting">
+		Collegamento a Twitter...
+	</string>
+	<string name="SocialTwitterPosting">
+		Caricamento post...
+	</string>
+	<string name="SocialTwitterDisconnecting">
+		Interruzione del collegamento con Twitter...
+	</string>
+	<string name="SocialTwitterErrorConnecting">
+		Problema nel collegamento a Twitter
+	</string>
+	<string name="SocialTwitterErrorPosting">
+		Problema nel caricamento post su Twitter
+	</string>
+	<string name="SocialTwitterErrorDisconnecting">
+		Problema nell'interruzione del collegamento da Twitter
+	</string>
+	<string name="BlackAndWhite">
+		Bianco e nero
+	</string>
+	<string name="Colors1970">
+		Colori anni '70
+	</string>
+	<string name="Intense">
+		Intenso
+	</string>
+	<string name="Newspaper">
+		Giornale
+	</string>
+	<string name="Sepia">
+		Seppia
+	</string>
+	<string name="Spotlight">
+		Faretto
+	</string>
+	<string name="Video">
+		Video
+	</string>
+	<string name="Autocontrast">
+		Auto contrasto
+	</string>
+	<string name="LensFlare">
+		Bagliore
+	</string>
+	<string name="Miniature">
+		Miniatura
+	</string>
+	<string name="Toycamera">
+		Toy camera
+	</string>
+	<string name="TooltipPerson">
+		Persona
+	</string>
+	<string name="TooltipNoName">
+		(nessun nome)
+	</string>
+	<string name="TooltipOwner">
+		Proprietario:
+	</string>
+	<string name="TooltipPublic">
+		Pubblico
+	</string>
+	<string name="TooltipIsGroup">
+		(Gruppo)
+	</string>
+	<string name="TooltipForSaleL$">
+		In Vendita: [AMOUNT]L$
+	</string>
+	<string name="TooltipFlagGroupBuild">
+		Costruzione solo con gruppo
+	</string>
+	<string name="TooltipFlagNoBuild">
+		Divieto di Costruire
+	</string>
+	<string name="TooltipFlagNoEdit">
+		Costruzione solo con gruppo
+	</string>
+	<string name="TooltipFlagNotSafe">
+		Non Sicuro
+	</string>
+	<string name="TooltipFlagNoFly">
+		Divieto di Volare
+	</string>
+	<string name="TooltipFlagGroupScripts">
+		Script solo con gruppo
+	</string>
+	<string name="TooltipFlagNoScripts">
+		Script vietati
+	</string>
+	<string name="TooltipLand">
+		Terreno:
+	</string>
+	<string name="TooltipMustSingleDrop">
+		Solo un singolo oggetto può essere creato qui
+	</string>
+	<string name="TooltipTooManyWearables">
+		Non puoi indossare una cartella che contiene più di [AMOUNT] elementi. Per modificare questo limite, accedi ad Avanzate &gt; Mostra impostazioni di debug &gt; WearFolderLimit.
+	</string>
 	<string name="TooltipPrice" value="L$ [AMOUNT]:"/>
-	<string name="TooltipSLIcon">Questo link porta a una pagina nel dominio ufficiale SecondLife.com o LindenLab.com.</string>
-	<string name="TooltipOutboxDragToWorld">Non puoi rezzare articoli dalla cartella degli annunci di Marketplace</string>
-	<string name="TooltipOutboxWorn">Non puoi inserire nella cartella degli annunci in Marketplace gli articoli che indossi</string>
-	<string name="TooltipOutboxFolderLevels">La profondità delle caselle nidificate è maggiore di [AMOUNT]. Diminuisci la profondità delle cartelle nidificate; se necessario, raggruppa gli articoli.</string>
-	<string name="TooltipOutboxTooManyFolders">Il numero di sottocartelle è maggiore di [AMOUNT]. Diminuisci il numero delle cartelle nel tuo annuncio; se necessario, raggruppa gli articoli.</string>
-	<string name="TooltipOutboxTooManyObjects">Il numero di articoli è maggiore di [AMOUNT]. Per vendere più di [AMOUNT] articoli in un annuncio, devi raggruppare alcuni di essi.</string>
-	<string name="TooltipOutboxTooManyStockItems">Il numero di articoli in magazzino è maggiore di [AMOUNT].</string>
-	<string name="TooltipOutboxCannotDropOnRoot">Puoi trascinare elementi o cartelle solo nelle schede TUTTI o NON ASSOCIATO. Seleziona una di quelle schede e sposta nuovamente gli elementi o le cartelle.</string>
-	<string name="TooltipOutboxNoTransfer">Almeno uno di questi oggetti non può essere venduto o trasferito</string>
-	<string name="TooltipOutboxNotInInventory">Puoi aggiungere a Marketplace solo gli articoli nel tuo inventario</string>
-	<string name="TooltipOutboxLinked">Non puoi inserire cartelle o articoli collegati tramite link nel Marketplace</string>
-	<string name="TooltipOutboxCallingCard">Non puoi inserire biglietti da visita in Marketplace</string>
-	<string name="TooltipOutboxDragActive">non puoi muovere un annuncio attivo</string>
-	<string name="TooltipOutboxCannotMoveRoot">Non puoi spostare la cartella principale degli annunci di Marketplace</string>
-	<string name="TooltipOutboxMixedStock">Tutti gli articoli in una cartella di magazzino devono essere dello stesso tipo e con le stesse autorizzazioni</string>
-	<string name="TooltipDragOntoOwnChild">Non puoi spostare una cartella nella relativa cartella secondaria</string>
-	<string name="TooltipDragOntoSelf">Non puoi spostare una cartella in se stessa</string>
-	<string name="TooltipHttpUrl">Clicca per visitare questa pagina web</string>
-	<string name="TooltipSLURL">Clicca per avere maggiori informazioni sul luogo</string>
-	<string name="TooltipAgentUrl">Clicca per vedere il profilo di questo residente</string>
-	<string name="TooltipAgentInspect">Ulteriori informazioni su questo Residente</string>
-	<string name="TooltipAgentMute">Clicca per disattivare l'audio di questo residente</string>
-	<string name="TooltipAgentUnmute">Clicca per attivare l'audio del residente</string>
-	<string name="TooltipAgentIM">Clicca per inviare un IM a questo residente</string>
-	<string name="TooltipAgentPay">Clicca per pagare il residente</string>
-	<string name="TooltipAgentOfferTeleport">Fai clic per inviare un'offerta di teleport al residente</string>
-	<string name="TooltipAgentRequestFriend">Fai clic per inviare una richiesta di amicizia al residente</string>
-	<string name="TooltipGroupUrl">Clicca per vedere la descrizione del gruppo</string>
-	<string name="TooltipEventUrl">Clicca per vedere la descrizione dell'evento</string>
-	<string name="TooltipClassifiedUrl">Clicca per vedere questa inserzione</string>
-	<string name="TooltipParcelUrl">Clicca per vedere la descrizione del lotto</string>
-	<string name="TooltipTeleportUrl">Clicca per effettuare il teleport a questa destinazione</string>
-	<string name="TooltipObjectIMUrl">Clicca per vedere la descrizione dell'oggetto</string>
-	<string name="TooltipMapUrl">Clicca per vedere questo posto sulla mappa</string>
-	<string name="TooltipSLAPP">Clicca per avviare il comando secondlife://</string>
+	<string name="TooltipSLIcon">
+		Questo link porta a una pagina nel dominio ufficiale SecondLife.com o LindenLab.com.
+	</string>
+	<string name="TooltipOutboxDragToWorld">
+		Non puoi rezzare articoli dalla cartella degli annunci di Marketplace
+	</string>
+	<string name="TooltipOutboxWorn">
+		Non puoi inserire nella cartella degli annunci in Marketplace gli articoli che indossi
+	</string>
+	<string name="TooltipOutboxFolderLevels">
+		La profondità delle caselle nidificate è maggiore di [AMOUNT]. Diminuisci la profondità delle cartelle nidificate; se necessario, raggruppa gli articoli.
+	</string>
+	<string name="TooltipOutboxTooManyFolders">
+		Il numero di sottocartelle è maggiore di [AMOUNT]. Diminuisci il numero delle cartelle nel tuo annuncio; se necessario, raggruppa gli articoli.
+	</string>
+	<string name="TooltipOutboxTooManyObjects">
+		Il numero di articoli è maggiore di [AMOUNT]. Per vendere più di [AMOUNT] articoli in un annuncio, devi raggruppare alcuni di essi.
+	</string>
+	<string name="TooltipOutboxTooManyStockItems">
+		Il numero di articoli in magazzino è maggiore di [AMOUNT].
+	</string>
+	<string name="TooltipOutboxCannotDropOnRoot">
+		Puoi trascinare elementi o cartelle solo nelle schede TUTTI o NON ASSOCIATO. Seleziona una di quelle schede e sposta nuovamente gli elementi o le cartelle.
+	</string>
+	<string name="TooltipOutboxNoTransfer">
+		Almeno uno di questi oggetti non può essere venduto o trasferito
+	</string>
+	<string name="TooltipOutboxNotInInventory">
+		Puoi aggiungere a Marketplace solo gli articoli nel tuo inventario
+	</string>
+	<string name="TooltipOutboxLinked">
+		Non puoi inserire cartelle o articoli collegati tramite link nel Marketplace
+	</string>
+	<string name="TooltipOutboxCallingCard">
+		Non puoi inserire biglietti da visita in Marketplace
+	</string>
+	<string name="TooltipOutboxDragActive">
+		non puoi muovere un annuncio attivo
+	</string>
+	<string name="TooltipOutboxCannotMoveRoot">
+		Non puoi spostare la cartella principale degli annunci di Marketplace
+	</string>
+	<string name="TooltipOutboxMixedStock">
+		Tutti gli articoli in una cartella di magazzino devono essere dello stesso tipo e con le stesse autorizzazioni
+	</string>
+	<string name="TooltipDragOntoOwnChild">
+		Non puoi spostare una cartella nella relativa cartella secondaria
+	</string>
+	<string name="TooltipDragOntoSelf">
+		Non puoi spostare una cartella in se stessa
+	</string>
+	<string name="TooltipHttpUrl">
+		Clicca per visitare questa pagina web
+	</string>
+	<string name="TooltipSLURL">
+		Clicca per avere maggiori informazioni sul luogo
+	</string>
+	<string name="TooltipAgentUrl">
+		Clicca per vedere il profilo di questo residente
+	</string>
+	<string name="TooltipAgentInspect">
+		Ulteriori informazioni su questo Residente
+	</string>
+	<string name="TooltipAgentMute">
+		Clicca per disattivare l'audio di questo residente
+	</string>
+	<string name="TooltipAgentUnmute">
+		Clicca per attivare l'audio del residente
+	</string>
+	<string name="TooltipAgentIM">
+		Clicca per inviare un IM a questo residente
+	</string>
+	<string name="TooltipAgentPay">
+		Clicca per pagare il residente
+	</string>
+	<string name="TooltipAgentOfferTeleport">
+		Fai clic per inviare un'offerta di teleport al residente
+	</string>
+	<string name="TooltipAgentRequestFriend">
+		Fai clic per inviare una richiesta di amicizia al residente
+	</string>
+	<string name="TooltipGroupUrl">
+		Clicca per vedere la descrizione del gruppo
+	</string>
+	<string name="TooltipEventUrl">
+		Clicca per vedere la descrizione dell'evento
+	</string>
+	<string name="TooltipClassifiedUrl">
+		Clicca per vedere questa inserzione
+	</string>
+	<string name="TooltipParcelUrl">
+		Clicca per vedere la descrizione del lotto
+	</string>
+	<string name="TooltipTeleportUrl">
+		Clicca per effettuare il teleport a questa destinazione
+	</string>
+	<string name="TooltipObjectIMUrl">
+		Clicca per vedere la descrizione dell'oggetto
+	</string>
+	<string name="TooltipMapUrl">
+		Clicca per vedere questo posto sulla mappa
+	</string>
+	<string name="TooltipSLAPP">
+		Clicca per avviare il comando secondlife://
+	</string>
 	<string name="CurrentURL" value="URL attuale: [CurrentURL]"/>
-	<string name="TooltipEmail">Fai clic per comporre un'email</string>
-	<string name="SLurlLabelTeleport">Teleportati a</string>
-	<string name="SLurlLabelShowOnMap">Mostra la mappa per</string>
-	<string name="SLappAgentMute">Disattiva audio</string>
-	<string name="SLappAgentUnmute">Riattiva audio</string>
-	<string name="SLappAgentIM">IM</string>
-	<string name="SLappAgentPay">Paga</string>
-	<string name="SLappAgentOfferTeleport">Offri teleport a</string>
-	<string name="SLappAgentRequestFriend">Richiesta di amicizia</string>
-	<string name="SLappAgentRemoveFriend">Rimozione amico</string>
-	<string name="BUTTON_CLOSE_DARWIN">Chiudi (⌘W)</string>
-	<string name="BUTTON_CLOSE_WIN">Chiudi (Ctrl+W)</string>
-	<string name="BUTTON_CLOSE_CHROME">Chiudi</string>
-	<string name="BUTTON_RESTORE">Ripristina</string>
-	<string name="BUTTON_MINIMIZE">Minimizza</string>
-	<string name="BUTTON_TEAR_OFF">Distacca</string>
-	<string name="BUTTON_DOCK">Àncora</string>
-	<string name="BUTTON_HELP">Mostra Aiuto</string>
-	<string name="TooltipNotecardNotAllowedTypeDrop">Oggetti di questo tipo non possono essere allegati ai 
-biglietti in questa regione.</string>
-	<string name="TooltipNotecardOwnerRestrictedDrop">Solamente gli oggetti con autorizzazioni 
+	<string name="TooltipEmail">
+		Fai clic per comporre un'email
+	</string>
+	<string name="SLurlLabelTeleport">
+		Teleportati a
+	</string>
+	<string name="SLurlLabelShowOnMap">
+		Mostra la mappa per
+	</string>
+	<string name="SLappAgentMute">
+		Disattiva audio
+	</string>
+	<string name="SLappAgentUnmute">
+		Riattiva audio
+	</string>
+	<string name="SLappAgentIM">
+		IM
+	</string>
+	<string name="SLappAgentPay">
+		Paga
+	</string>
+	<string name="SLappAgentOfferTeleport">
+		Offri teleport a
+	</string>
+	<string name="SLappAgentRequestFriend">
+		Richiesta di amicizia
+	</string>
+	<string name="SLappAgentRemoveFriend">
+		Rimozione amico
+	</string>
+	<string name="BUTTON_CLOSE_DARWIN">
+		Chiudi (⌘W)
+	</string>
+	<string name="BUTTON_CLOSE_WIN">
+		Chiudi (Ctrl+W)
+	</string>
+	<string name="BUTTON_CLOSE_CHROME">
+		Chiudi
+	</string>
+	<string name="BUTTON_RESTORE">
+		Ripristina
+	</string>
+	<string name="BUTTON_MINIMIZE">
+		Minimizza
+	</string>
+	<string name="BUTTON_TEAR_OFF">
+		Distacca
+	</string>
+	<string name="BUTTON_DOCK">
+		Àncora
+	</string>
+	<string name="BUTTON_HELP">
+		Mostra Aiuto
+	</string>
+	<string name="TooltipNotecardNotAllowedTypeDrop">
+		Oggetti di questo tipo non possono essere allegati ai 
+biglietti in questa regione.
+	</string>
+	<string name="TooltipNotecardOwnerRestrictedDrop">
+		Solamente gli oggetti con autorizzazioni 
 illimitate al “proprietario successivo” 
-possono essere allegati ai biglietti.</string>
-	<string name="Searching">Ricerca in corso...</string>
-	<string name="NoneFound">Nessun risultato.</string>
-	<string name="RetrievingData">Recupero dati in corso...</string>
-	<string name="ReleaseNotes">Note sulla versione</string>
-	<string name="RELEASE_NOTES_BASE_URL">https://releasenotes.secondlife.com/viewer/</string>
-	<string name="LoadingData">In caricamento...</string>
-	<string name="AvatarNameNobody">(nessuno)</string>
-	<string name="AvatarNameWaiting">(in attesa)</string>
-	<string name="GroupNameNone">(nessuno)</string>
-	<string name="AssetErrorNone">Nessun errore</string>
-	<string name="AssetErrorRequestFailed">Richiesta risorsa: fallita</string>
-	<string name="AssetErrorNonexistentFile">Richiesta risorsa: file non esistente</string>
-	<string name="AssetErrorNotInDatabase">Richiesta risorsa: risorsa non trovata nel database</string>
-	<string name="AssetErrorEOF">Fine del file</string>
-	<string name="AssetErrorCannotOpenFile">Apertura del file non possibile</string>
-	<string name="AssetErrorFileNotFound">File non trovato</string>
-	<string name="AssetErrorTCPTimeout">Tempo esaurito per il trasferimento file</string>
-	<string name="AssetErrorCircuitGone">Circuito perso</string>
-	<string name="AssetErrorPriceMismatch">Il programma e il server non combaciano nel prezzo</string>
-	<string name="AssetErrorUnknownStatus">Stato sconosciuto</string>
-	<string name="AssetUploadServerUnreacheble">Servizio non raggiungibile.</string>
-	<string name="AssetUploadServerDifficulties">Il servizio sta riscontrando difficoltà inaspettate.</string>
-	<string name="AssetUploadServerUnavaliable">Servizio non disponibile o limite di tempo per il caricamento raggiunto.</string>
-	<string name="AssetUploadRequestInvalid">Errore nella richiesta di caricamento. Vai alla pagina 
-http://secondlife.com/support per risolvere il problema.</string>
-	<string name="SettingValidationError">Impossibile convalidare le impostazioni importate [NAME]</string>
-	<string name="SettingImportFileError">Impossibile aprire il file [FILE]</string>
-	<string name="SettingParseFileError">Impossibile aprire il file [FILE]</string>
-	<string name="SettingTranslateError">Impossibile tradurre la legacy vento e luce [NAME]</string>
-	<string name="texture">texture</string>
-	<string name="sound">suono</string>
-	<string name="calling card">biglietto da visita</string>
-	<string name="landmark">punto di riferimento</string>
-	<string name="legacy script">script (vecchia versione)</string>
-	<string name="clothing">vestiario</string>
-	<string name="object">oggetto</string>
-	<string name="note card">biglietto</string>
-	<string name="folder">cartella</string>
-	<string name="root">cartella principale</string>
-	<string name="lsl2 script">script LSL2</string>
-	<string name="lsl bytecode">bytecode LSL</string>
-	<string name="tga texture">tga texture</string>
-	<string name="body part">parte del corpo</string>
-	<string name="snapshot">fotografia</string>
-	<string name="lost and found">oggetti smarriti</string>
-	<string name="targa image">immagine targa</string>
-	<string name="trash">Cestino</string>
-	<string name="jpeg image">immagine jpeg</string>
-	<string name="animation">animazione</string>
-	<string name="gesture">gesture</string>
-	<string name="simstate">simstate</string>
-	<string name="favorite">preferiti</string>
-	<string name="symbolic link">link</string>
-	<string name="symbolic folder link">link alla cartella</string>
-	<string name="settings blob">impostazioni</string>
-	<string name="mesh">reticolo</string>
-	<string name="AvatarEditingAppearance">(Modifica Aspetto)</string>
-	<string name="AvatarAway">Assente</string>
-	<string name="AvatarDoNotDisturb">Non disturbare</string>
-	<string name="AvatarMuted">Mutato</string>
-	<string name="anim_express_afraid">Dispiaciuto</string>
-	<string name="anim_express_anger">Arrabbiato</string>
-	<string name="anim_away">Assente</string>
-	<string name="anim_backflip">Salto all'indietro</string>
-	<string name="anim_express_laugh">Ridere a crepapelle</string>
-	<string name="anim_express_toothsmile">Gran sorriso</string>
-	<string name="anim_blowkiss">Lancia un bacio</string>
-	<string name="anim_express_bored">Noia</string>
-	<string name="anim_bow">Inchino</string>
-	<string name="anim_clap">Applauso</string>
-	<string name="anim_courtbow">Inchino a corte</string>
-	<string name="anim_express_cry">Pianto</string>
-	<string name="anim_dance1">Ballo 1</string>
-	<string name="anim_dance2">Ballo 2</string>
-	<string name="anim_dance3">Ballo 3</string>
-	<string name="anim_dance4">Ballo 4</string>
-	<string name="anim_dance5">Ballo 5</string>
-	<string name="anim_dance6">Ballo 6</string>
-	<string name="anim_dance7">Ballo 7</string>
-	<string name="anim_dance8">Dance 8</string>
-	<string name="anim_express_disdain">Sdegno</string>
-	<string name="anim_drink">Bere</string>
-	<string name="anim_express_embarrased">Imbarazzo</string>
-	<string name="anim_angry_fingerwag">Negare col dito</string>
-	<string name="anim_fist_pump">Esultare con pugno</string>
-	<string name="anim_yoga_float">Yoga fluttuante</string>
-	<string name="anim_express_frown">Acciglio</string>
-	<string name="anim_impatient">Impazienza</string>
-	<string name="anim_jumpforjoy">Salto di gioia</string>
-	<string name="anim_kissmybutt">Baciami il sedere</string>
-	<string name="anim_express_kiss">Bacio</string>
-	<string name="anim_laugh_short">Risata</string>
-	<string name="anim_musclebeach">Muscoli da spiaggia</string>
-	<string name="anim_no_unhappy">No (Scontento)</string>
-	<string name="anim_no_head">No</string>
-	<string name="anim_nyanya">Na-na-na</string>
-	<string name="anim_punch_onetwo">Uno-due pugno</string>
-	<string name="anim_express_open_mouth">Bocca aperta</string>
-	<string name="anim_peace">Pace</string>
-	<string name="anim_point_you">Indicare altri</string>
-	<string name="anim_point_me">Indicare te stesso</string>
-	<string name="anim_punch_l">Pugno a sinistra</string>
-	<string name="anim_punch_r">Pugno a destra</string>
-	<string name="anim_rps_countdown">Contare nella morra cinese</string>
-	<string name="anim_rps_paper">Carta nella morra cinese</string>
-	<string name="anim_rps_rock">Sasso nella morra cinese</string>
-	<string name="anim_rps_scissors">Forbici nella morra cinese</string>
-	<string name="anim_express_repulsed">Repulsione</string>
-	<string name="anim_kick_roundhouse_r">Calcio con rotazione</string>
-	<string name="anim_express_sad">Triste</string>
-	<string name="anim_salute">Saluto</string>
-	<string name="anim_shout">Urlo</string>
-	<string name="anim_express_shrug">Spallucce</string>
-	<string name="anim_express_smile">Sorriso</string>
-	<string name="anim_smoke_idle">Fumare</string>
-	<string name="anim_smoke_inhale">Fumare inspirazione</string>
-	<string name="anim_smoke_throw_down">Fumare mandando giù</string>
-	<string name="anim_express_surprise">Sorpresa</string>
-	<string name="anim_sword_strike_r">Colpo di spada</string>
-	<string name="anim_angry_tantrum">Collera</string>
-	<string name="anim_express_tongue_out">Linguaccia</string>
-	<string name="anim_hello">Saluto con mano</string>
-	<string name="anim_whisper">Sussurro</string>
-	<string name="anim_whistle">Fischio</string>
-	<string name="anim_express_wink">Ammicca</string>
-	<string name="anim_wink_hollywood">Ammicca (Hollywood)</string>
-	<string name="anim_express_worry">Preoccupato</string>
-	<string name="anim_yes_happy">Si (Felice)</string>
-	<string name="anim_yes_head">Si</string>
-	<string name="multiple_textures">Multiple</string>
-	<string name="use_texture">Usa texture</string>
-	<string name="manip_hint1">Sposta il cursore sul righello</string>
-	<string name="manip_hint2">per bloccare sulla griglia</string>
-	<string name="texture_loading">Caricamento in corso...</string>
-	<string name="worldmap_offline">Offline</string>
-	<string name="worldmap_item_tooltip_format">L$ [PRICE] - [AREA] m²</string>
-	<string name="worldmap_results_none_found">Nessun risultato.</string>
-	<string name="Ok">OK</string>
-	<string name="Premature end of file">Fine prematura del file</string>
-	<string name="ST_NO_JOINT">Impossibile trovare ROOT o JOINT.</string>
-	<string name="NearbyChatTitle">Chat nei dintorni</string>
-	<string name="NearbyChatLabel">(Chat nei dintorni)</string>
-	<string name="whisper">sussurra:</string>
-	<string name="shout">grida:</string>
-	<string name="ringing">In connessione alla Voice Chat in-world...</string>
-	<string name="connected">Connesso</string>
-	<string name="unavailable">Il voice non è disponibile nel posto dove ti trovi ora</string>
-	<string name="hang_up">Disconnesso dalla Voice Chat in-world</string>
-	<string name="reconnect_nearby">Sarai riconnesso alla chat vocale nei dintorni</string>
-	<string name="ScriptQuestionCautionChatGranted">A '[OBJECTNAME]', un oggetto di proprietà di '[OWNERNAME]', situato in [REGIONNAME] [REGIONPOS], è stato concesso il permesso di: [PERMISSIONS].</string>
-	<string name="ScriptQuestionCautionChatDenied">A '[OBJECTNAME]', un oggetto di proprietà di '[OWNERNAME]', situato in [REGIONNAME] [REGIONPOS], è stato negato il permesso di: [PERMISSIONS].</string>
-	<string name="AdditionalPermissionsRequestHeader">Se consenti l'accesso al tuo account, consentirai anche all'oggetto di:</string>
-	<string name="ScriptTakeMoney">Prendere dollari Linden (L$) da te</string>
-	<string name="ActOnControlInputs">Agire sul tuo controllo degli input</string>
-	<string name="RemapControlInputs">Rimappare il tuo controllo degli input</string>
-	<string name="AnimateYourAvatar">Animare il tuo avatar</string>
-	<string name="AttachToYourAvatar">Far indossare al tuo avatar</string>
-	<string name="ReleaseOwnership">Rilasciare la propietà è far diventare pubblico.</string>
-	<string name="LinkAndDelink">Collegare e scollegare dagli altri oggetti</string>
-	<string name="AddAndRemoveJoints">Aggiungere e rimuovere le giunzioni insieme con gli altri oggetti</string>
-	<string name="ChangePermissions">Cambiare i permessi</string>
-	<string name="TrackYourCamera">Tracciare la fotocamera</string>
-	<string name="ControlYourCamera">Controllare la tua fotocamera</string>
-	<string name="TeleportYourAgent">Teleportarti</string>
-	<string name="ForceSitAvatar">Forza l'avatar a sedersi</string>
-	<string name="ChangeEnvSettings">Cambia le impostazioni dell’ambiente</string>
-	<string name="AgentNameSubst">(Tu)</string>
+possono essere allegati ai biglietti.
+	</string>
+	<string name="Searching">
+		Ricerca in corso...
+	</string>
+	<string name="NoneFound">
+		Nessun risultato.
+	</string>
+	<string name="RetrievingData">
+		Recupero dati in corso...
+	</string>
+	<string name="ReleaseNotes">
+		Note sulla versione
+	</string>
+	<string name="RELEASE_NOTES_BASE_URL">
+		https://releasenotes.secondlife.com/viewer/
+	</string>
+	<string name="LoadingData">
+		In caricamento...
+	</string>
+	<string name="AvatarNameNobody">
+		(nessuno)
+	</string>
+	<string name="AvatarNameWaiting">
+		(in attesa)
+	</string>
+	<string name="GroupNameNone">
+		(nessuno)
+	</string>
+	<string name="AssetErrorNone">
+		Nessun errore
+	</string>
+	<string name="AssetErrorRequestFailed">
+		Richiesta risorsa: fallita
+	</string>
+	<string name="AssetErrorNonexistentFile">
+		Richiesta risorsa: file non esistente
+	</string>
+	<string name="AssetErrorNotInDatabase">
+		Richiesta risorsa: risorsa non trovata nel database
+	</string>
+	<string name="AssetErrorEOF">
+		Fine del file
+	</string>
+	<string name="AssetErrorCannotOpenFile">
+		Apertura del file non possibile
+	</string>
+	<string name="AssetErrorFileNotFound">
+		File non trovato
+	</string>
+	<string name="AssetErrorTCPTimeout">
+		Tempo esaurito per il trasferimento file
+	</string>
+	<string name="AssetErrorCircuitGone">
+		Circuito perso
+	</string>
+	<string name="AssetErrorPriceMismatch">
+		Il programma e il server non combaciano nel prezzo
+	</string>
+	<string name="AssetErrorUnknownStatus">
+		Stato sconosciuto
+	</string>
+	<string name="AssetUploadServerUnreacheble">
+		Servizio non raggiungibile.
+	</string>
+	<string name="AssetUploadServerDifficulties">
+		Il servizio sta riscontrando difficoltà inaspettate.
+	</string>
+	<string name="AssetUploadServerUnavaliable">
+		Servizio non disponibile o limite di tempo per il caricamento raggiunto.
+	</string>
+	<string name="AssetUploadRequestInvalid">
+		Errore nella richiesta di caricamento. Vai alla pagina 
+http://secondlife.com/support per risolvere il problema.
+	</string>
+	<string name="SettingValidationError">
+		Impossibile convalidare le impostazioni importate [NAME]
+	</string>
+	<string name="SettingImportFileError">
+		Impossibile aprire il file [FILE]
+	</string>
+	<string name="SettingParseFileError">
+		Impossibile aprire il file [FILE]
+	</string>
+	<string name="SettingTranslateError">
+		Impossibile tradurre la legacy vento e luce [NAME]
+	</string>
+	<string name="texture">
+		texture
+	</string>
+	<string name="sound">
+		suono
+	</string>
+	<string name="calling card">
+		biglietto da visita
+	</string>
+	<string name="landmark">
+		punto di riferimento
+	</string>
+	<string name="legacy script">
+		script (vecchia versione)
+	</string>
+	<string name="clothing">
+		vestiario
+	</string>
+	<string name="object">
+		oggetto
+	</string>
+	<string name="note card">
+		biglietto
+	</string>
+	<string name="folder">
+		cartella
+	</string>
+	<string name="root">
+		cartella principale
+	</string>
+	<string name="lsl2 script">
+		script LSL2
+	</string>
+	<string name="lsl bytecode">
+		bytecode LSL
+	</string>
+	<string name="tga texture">
+		tga texture
+	</string>
+	<string name="body part">
+		parte del corpo
+	</string>
+	<string name="snapshot">
+		fotografia
+	</string>
+	<string name="lost and found">
+		oggetti smarriti
+	</string>
+	<string name="targa image">
+		immagine targa
+	</string>
+	<string name="trash">
+		Cestino
+	</string>
+	<string name="jpeg image">
+		immagine jpeg
+	</string>
+	<string name="animation">
+		animazione
+	</string>
+	<string name="gesture">
+		gesture
+	</string>
+	<string name="simstate">
+		simstate
+	</string>
+	<string name="favorite">
+		preferiti
+	</string>
+	<string name="symbolic link">
+		link
+	</string>
+	<string name="symbolic folder link">
+		link alla cartella
+	</string>
+	<string name="settings blob">
+		impostazioni
+	</string>
+	<string name="mesh">
+		reticolo
+	</string>
+	<string name="AvatarEditingAppearance">
+		(Modifica Aspetto)
+	</string>
+	<string name="AvatarAway">
+		Assente
+	</string>
+	<string name="AvatarDoNotDisturb">
+		Non disturbare
+	</string>
+	<string name="AvatarMuted">
+		Mutato
+	</string>
+	<string name="anim_express_afraid">
+		Dispiaciuto
+	</string>
+	<string name="anim_express_anger">
+		Arrabbiato
+	</string>
+	<string name="anim_away">
+		Assente
+	</string>
+	<string name="anim_backflip">
+		Salto all'indietro
+	</string>
+	<string name="anim_express_laugh">
+		Ridere a crepapelle
+	</string>
+	<string name="anim_express_toothsmile">
+		Gran sorriso
+	</string>
+	<string name="anim_blowkiss">
+		Lancia un bacio
+	</string>
+	<string name="anim_express_bored">
+		Noia
+	</string>
+	<string name="anim_bow">
+		Inchino
+	</string>
+	<string name="anim_clap">
+		Applauso
+	</string>
+	<string name="anim_courtbow">
+		Inchino a corte
+	</string>
+	<string name="anim_express_cry">
+		Pianto
+	</string>
+	<string name="anim_dance1">
+		Ballo 1
+	</string>
+	<string name="anim_dance2">
+		Ballo 2
+	</string>
+	<string name="anim_dance3">
+		Ballo 3
+	</string>
+	<string name="anim_dance4">
+		Ballo 4
+	</string>
+	<string name="anim_dance5">
+		Ballo 5
+	</string>
+	<string name="anim_dance6">
+		Ballo 6
+	</string>
+	<string name="anim_dance7">
+		Ballo 7
+	</string>
+	<string name="anim_dance8">
+		Dance 8
+	</string>
+	<string name="anim_express_disdain">
+		Sdegno
+	</string>
+	<string name="anim_drink">
+		Bere
+	</string>
+	<string name="anim_express_embarrased">
+		Imbarazzo
+	</string>
+	<string name="anim_angry_fingerwag">
+		Negare col dito
+	</string>
+	<string name="anim_fist_pump">
+		Esultare con pugno
+	</string>
+	<string name="anim_yoga_float">
+		Yoga fluttuante
+	</string>
+	<string name="anim_express_frown">
+		Acciglio
+	</string>
+	<string name="anim_impatient">
+		Impazienza
+	</string>
+	<string name="anim_jumpforjoy">
+		Salto di gioia
+	</string>
+	<string name="anim_kissmybutt">
+		Baciami il sedere
+	</string>
+	<string name="anim_express_kiss">
+		Bacio
+	</string>
+	<string name="anim_laugh_short">
+		Risata
+	</string>
+	<string name="anim_musclebeach">
+		Muscoli da spiaggia
+	</string>
+	<string name="anim_no_unhappy">
+		No (Scontento)
+	</string>
+	<string name="anim_no_head">
+		No
+	</string>
+	<string name="anim_nyanya">
+		Na-na-na
+	</string>
+	<string name="anim_punch_onetwo">
+		Uno-due pugno
+	</string>
+	<string name="anim_express_open_mouth">
+		Bocca aperta
+	</string>
+	<string name="anim_peace">
+		Pace
+	</string>
+	<string name="anim_point_you">
+		Indicare altri
+	</string>
+	<string name="anim_point_me">
+		Indicare te stesso
+	</string>
+	<string name="anim_punch_l">
+		Pugno a sinistra
+	</string>
+	<string name="anim_punch_r">
+		Pugno a destra
+	</string>
+	<string name="anim_rps_countdown">
+		Contare nella morra cinese
+	</string>
+	<string name="anim_rps_paper">
+		Carta nella morra cinese
+	</string>
+	<string name="anim_rps_rock">
+		Sasso nella morra cinese
+	</string>
+	<string name="anim_rps_scissors">
+		Forbici nella morra cinese
+	</string>
+	<string name="anim_express_repulsed">
+		Repulsione
+	</string>
+	<string name="anim_kick_roundhouse_r">
+		Calcio con rotazione
+	</string>
+	<string name="anim_express_sad">
+		Triste
+	</string>
+	<string name="anim_salute">
+		Saluto
+	</string>
+	<string name="anim_shout">
+		Urlo
+	</string>
+	<string name="anim_express_shrug">
+		Spallucce
+	</string>
+	<string name="anim_express_smile">
+		Sorriso
+	</string>
+	<string name="anim_smoke_idle">
+		Fumare
+	</string>
+	<string name="anim_smoke_inhale">
+		Fumare inspirazione
+	</string>
+	<string name="anim_smoke_throw_down">
+		Fumare mandando giù
+	</string>
+	<string name="anim_express_surprise">
+		Sorpresa
+	</string>
+	<string name="anim_sword_strike_r">
+		Colpo di spada
+	</string>
+	<string name="anim_angry_tantrum">
+		Collera
+	</string>
+	<string name="anim_express_tongue_out">
+		Linguaccia
+	</string>
+	<string name="anim_hello">
+		Saluto con mano
+	</string>
+	<string name="anim_whisper">
+		Sussurro
+	</string>
+	<string name="anim_whistle">
+		Fischio
+	</string>
+	<string name="anim_express_wink">
+		Ammicca
+	</string>
+	<string name="anim_wink_hollywood">
+		Ammicca (Hollywood)
+	</string>
+	<string name="anim_express_worry">
+		Preoccupato
+	</string>
+	<string name="anim_yes_happy">
+		Si (Felice)
+	</string>
+	<string name="anim_yes_head">
+		Si
+	</string>
+	<string name="multiple_textures">
+		Multiple
+	</string>
+	<string name="use_texture">
+		Usa texture
+	</string>
+	<string name="manip_hint1">
+		Sposta il cursore sul righello
+	</string>
+	<string name="manip_hint2">
+		per bloccare sulla griglia
+	</string>
+	<string name="texture_loading">
+		Caricamento in corso...
+	</string>
+	<string name="worldmap_offline">
+		Offline
+	</string>
+	<string name="worldmap_item_tooltip_format">
+		L$ [PRICE] - [AREA] m²
+	</string>
+	<string name="worldmap_results_none_found">
+		Nessun risultato.
+	</string>
+	<string name="Ok">
+		OK
+	</string>
+	<string name="Premature end of file">
+		Fine prematura del file
+	</string>
+	<string name="ST_NO_JOINT">
+		Impossibile trovare ROOT o JOINT.
+	</string>
+	<string name="NearbyChatTitle">
+		Chat nei dintorni
+	</string>
+	<string name="NearbyChatLabel">
+		(Chat nei dintorni)
+	</string>
+	<string name="whisper">
+		sussurra:
+	</string>
+	<string name="shout">
+		grida:
+	</string>
+	<string name="ringing">
+		In connessione alla Voice Chat in-world...
+	</string>
+	<string name="connected">
+		Connesso
+	</string>
+	<string name="unavailable">
+		Il voice non è disponibile nel posto dove ti trovi ora
+	</string>
+	<string name="hang_up">
+		Disconnesso dalla Voice Chat in-world
+	</string>
+	<string name="reconnect_nearby">
+		Sarai riconnesso alla chat vocale nei dintorni
+	</string>
+	<string name="ScriptQuestionCautionChatGranted">
+		A '[OBJECTNAME]', un oggetto di proprietà di '[OWNERNAME]', situato in [REGIONNAME] [REGIONPOS], è stato concesso il permesso di: [PERMISSIONS].
+	</string>
+	<string name="ScriptQuestionCautionChatDenied">
+		A '[OBJECTNAME]', un oggetto di proprietà di '[OWNERNAME]', situato in [REGIONNAME] [REGIONPOS], è stato negato il permesso di: [PERMISSIONS].
+	</string>
+	<string name="AdditionalPermissionsRequestHeader">
+		Se consenti l'accesso al tuo account, consentirai anche all'oggetto di:
+	</string>
+	<string name="ScriptTakeMoney">
+		Prendere dollari Linden (L$) da te
+	</string>
+	<string name="ActOnControlInputs">
+		Agire sul tuo controllo degli input
+	</string>
+	<string name="RemapControlInputs">
+		Rimappare il tuo controllo degli input
+	</string>
+	<string name="AnimateYourAvatar">
+		Animare il tuo avatar
+	</string>
+	<string name="AttachToYourAvatar">
+		Far indossare al tuo avatar
+	</string>
+	<string name="ReleaseOwnership">
+		Rilasciare la propietà è far diventare pubblico.
+	</string>
+	<string name="LinkAndDelink">
+		Collegare e scollegare dagli altri oggetti
+	</string>
+	<string name="AddAndRemoveJoints">
+		Aggiungere e rimuovere le giunzioni insieme con gli altri oggetti
+	</string>
+	<string name="ChangePermissions">
+		Cambiare i permessi
+	</string>
+	<string name="TrackYourCamera">
+		Tracciare la fotocamera
+	</string>
+	<string name="ControlYourCamera">
+		Controllare la tua fotocamera
+	</string>
+	<string name="TeleportYourAgent">
+		Teleportarti
+	</string>
+	<string name="ForceSitAvatar">
+		Forza l'avatar a sedersi
+	</string>
+	<string name="ChangeEnvSettings">
+		Cambia le impostazioni dell’ambiente
+	</string>
+	<string name="AgentNameSubst">
+		(Tu)
+	</string>
 	<string name="JoinAnExperience"/>
-	<string name="SilentlyManageEstateAccess">Omette gli avvisi durante la gestione degli elenchi di accesso alle proprietà immobiliari</string>
-	<string name="OverrideYourAnimations">Sostituisce le animazioni predefinite</string>
-	<string name="ScriptReturnObjects">Restituisce oggetti per conto tuo</string>
-	<string name="UnknownScriptPermission">(sconosciuto)!</string>
-	<string name="SIM_ACCESS_PG">Generale</string>
-	<string name="SIM_ACCESS_MATURE">Moderato</string>
-	<string name="SIM_ACCESS_ADULT">Adulti</string>
-	<string name="SIM_ACCESS_DOWN">Offline</string>
-	<string name="SIM_ACCESS_MIN">Sconosciuto</string>
-	<string name="land_type_unknown">(sconosciuto)</string>
-	<string name="Estate / Full Region">Proprietà immobiliare / Regione completa</string>
-	<string name="Estate / Homestead">Proprietà immobiliare / Homestead</string>
-	<string name="Mainland / Homestead">Continente / Homestead</string>
-	<string name="Mainland / Full Region">Continente / Regione completa</string>
-	<string name="all_files">Tutti i file</string>
-	<string name="sound_files">Suoni</string>
-	<string name="animation_files">Animazioni</string>
-	<string name="image_files">Immagini</string>
-	<string name="save_file_verb">Salva</string>
-	<string name="load_file_verb">Carica</string>
-	<string name="targa_image_files">Immagini Targa</string>
-	<string name="bitmap_image_files">Immagini Bitmap</string>
-	<string name="png_image_files">Immagini PNG</string>
-	<string name="save_texture_image_files">Immagini Targa o PNG</string>
-	<string name="avi_movie_file">File video AVI</string>
-	<string name="xaf_animation_file">File animazione XAF</string>
-	<string name="xml_file">File XML</string>
-	<string name="raw_file">File RAW</string>
-	<string name="compressed_image_files">Immagini compresse</string>
-	<string name="load_files">Carica i file</string>
-	<string name="choose_the_directory">Scegli la cartella</string>
-	<string name="script_files">Script</string>
-	<string name="dictionary_files">Dizionari</string>
-	<string name="shape">Figura corporea</string>
-	<string name="skin">Pelle</string>
-	<string name="hair">Capigliature</string>
-	<string name="eyes">Occhi</string>
-	<string name="shirt">Camicia</string>
-	<string name="pants">Pantaloni</string>
-	<string name="shoes">Scarpe</string>
-	<string name="socks">Calzini</string>
-	<string name="jacket">Giacca</string>
-	<string name="gloves">Guanti</string>
-	<string name="undershirt">Maglietta intima</string>
-	<string name="underpants">Slip</string>
-	<string name="skirt">Gonna</string>
-	<string name="alpha">Alfa (Trasparenza)</string>
-	<string name="tattoo">Tatuaggio</string>
-	<string name="universal">Universale</string>
-	<string name="physics">Fisica</string>
-	<string name="invalid">non valido</string>
-	<string name="none">nessuno</string>
-	<string name="shirt_not_worn">Camicia non indossata</string>
-	<string name="pants_not_worn">Pantaloni non indossati</string>
-	<string name="shoes_not_worn">Scarpe non indossate</string>
-	<string name="socks_not_worn">Calzini non indossati</string>
-	<string name="jacket_not_worn">Giacca non indossata</string>
-	<string name="gloves_not_worn">Guanti non indossati</string>
-	<string name="undershirt_not_worn">Maglietta intima non indossata</string>
-	<string name="underpants_not_worn">Slip non indossati</string>
-	<string name="skirt_not_worn">Gonna non indossata</string>
-	<string name="alpha_not_worn">Alpha non portato</string>
-	<string name="tattoo_not_worn">Tatuaggio non portato</string>
-	<string name="universal_not_worn">Universale non indossato</string>
-	<string name="physics_not_worn">Fisica non indossata</string>
-	<string name="invalid_not_worn">non valido</string>
-	<string name="create_new_shape">Crea nuova figura corporea</string>
-	<string name="create_new_skin">Crea nuova pelle</string>
-	<string name="create_new_hair">Crea nuovi capelli</string>
-	<string name="create_new_eyes">Crea nuovi occhi</string>
-	<string name="create_new_shirt">Crea nuova camicia</string>
-	<string name="create_new_pants">Crea nuovi pantaloni</string>
-	<string name="create_new_shoes">Crea nuove scarpe</string>
-	<string name="create_new_socks">Crea nuove calze</string>
-	<string name="create_new_jacket">Crea nuova giacca</string>
-	<string name="create_new_gloves">Crea nuovi guanti</string>
-	<string name="create_new_undershirt">Crea nuova maglietta intima</string>
-	<string name="create_new_underpants">Crea nuovi slip</string>
-	<string name="create_new_skirt">Crea nuova gonna</string>
-	<string name="create_new_alpha">Crea nuovo Alpha</string>
-	<string name="create_new_tattoo">Crea un nuovo tatuaggio</string>
-	<string name="create_new_universal">Crea nuovo universale</string>
-	<string name="create_new_physics">Crea nuova fisica</string>
-	<string name="create_new_invalid">non valido</string>
-	<string name="NewWearable">Nuovo [WEARABLE_ITEM]</string>
-	<string name="next">Avanti</string>
-	<string name="ok">OK</string>
-	<string name="GroupNotifyGroupNotice">Avviso di gruppo</string>
-	<string name="GroupNotifyGroupNotices">Avvisi di gruppo</string>
-	<string name="GroupNotifySentBy">Inviato da</string>
-	<string name="GroupNotifyAttached">Allegato:</string>
-	<string name="GroupNotifyViewPastNotices">Visualizza gli avvisi precedenti o scegli qui di non riceverne.</string>
-	<string name="GroupNotifyOpenAttachment">Apri l'allegato</string>
-	<string name="GroupNotifySaveAttachment">Salva l'allegato</string>
-	<string name="TeleportOffer">Offerta di Teleport</string>
-	<string name="StartUpNotifications">Mentre eri assente sono arrivate nuove notifiche...</string>
-	<string name="OverflowInfoChannelString">Hai ancora [%d] notifiche</string>
-	<string name="BodyPartsRightArm">Braccio destro</string>
-	<string name="BodyPartsHead">Testa</string>
-	<string name="BodyPartsLeftArm">Braccio sinistro</string>
-	<string name="BodyPartsLeftLeg">Gamba sinistra</string>
-	<string name="BodyPartsTorso">Torace</string>
-	<string name="BodyPartsRightLeg">Gamba destra</string>
-	<string name="BodyPartsEnhancedSkeleton">Scheletro avanzato</string>
-	<string name="GraphicsQualityLow">Basso</string>
-	<string name="GraphicsQualityMid">Medio</string>
-	<string name="GraphicsQualityHigh">Alto</string>
-	<string name="LeaveMouselook">Premi ESC per tornare in visualizzazione normale</string>
-	<string name="InventoryNoMatchingItems">Non riesci a trovare quello che cerchi? Prova [secondlife:///app/search/all/[SEARCH_TERM] Cerca].</string>
-	<string name="InventoryNoMatchingRecentItems">Non hai trovato ció che cercavi? Prova [secondlife:///app/inventory/filters Show filters].</string>
-	<string name="PlacesNoMatchingItems">Non riesci a trovare quello che cerchi? Prova [secondlife:///app/search/places/[SEARCH_TERM] Cerca].</string>
-	<string name="FavoritesNoMatchingItems">Trascina qui un punto di riferimento per aggiungerlo ai Preferiti.</string>
-	<string name="MarketplaceNoMatchingItems">Nessun articolo trovato. Controlla di aver digitato la stringa di ricerca correttamente e riprova.</string>
-	<string name="InventoryNoTexture">Non hai una copia di questa texture nel tuo inventario</string>
-	<string name="InventoryInboxNoItems">Gli acquissti dal mercato verranno mostrati qui. Potrai quindi trascinarli nel tuo inventario per usarli.</string>
-	<string name="MarketplaceURL">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/</string>
-	<string name="MarketplaceURL_CreateStore">http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3</string>
-	<string name="MarketplaceURL_Dashboard">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard</string>
-	<string name="MarketplaceURL_Imports">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports</string>
-	<string name="MarketplaceURL_LearnMore">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more</string>
-	<string name="InventoryPlayAnimationTooltip">Apri finestra con opzioni di Gioco.</string>
-	<string name="InventoryPlayGestureTooltip">Esegui il movimento selezionato nel mondo virtuale.</string>
-	<string name="InventoryPlaySoundTooltip">Apri finestra con opzioni di Gioco.</string>
-	<string name="InventoryOutboxNotMerchantTitle">Chiunque può vendere oggetti nel Marketplace.</string>
+	<string name="SilentlyManageEstateAccess">
+		Omette gli avvisi durante la gestione degli elenchi di accesso alle proprietà immobiliari
+	</string>
+	<string name="OverrideYourAnimations">
+		Sostituisce le animazioni predefinite
+	</string>
+	<string name="ScriptReturnObjects">
+		Restituisce oggetti per conto tuo
+	</string>
+	<string name="UnknownScriptPermission">
+		(sconosciuto)!
+	</string>
+	<string name="SIM_ACCESS_PG">
+		Generale
+	</string>
+	<string name="SIM_ACCESS_MATURE">
+		Moderato
+	</string>
+	<string name="SIM_ACCESS_ADULT">
+		Adulti
+	</string>
+	<string name="SIM_ACCESS_DOWN">
+		Offline
+	</string>
+	<string name="SIM_ACCESS_MIN">
+		Sconosciuto
+	</string>
+	<string name="land_type_unknown">
+		(sconosciuto)
+	</string>
+	<string name="Estate / Full Region">
+		Proprietà immobiliare / Regione completa
+	</string>
+	<string name="Estate / Homestead">
+		Proprietà immobiliare / Homestead
+	</string>
+	<string name="Mainland / Homestead">
+		Continente / Homestead
+	</string>
+	<string name="Mainland / Full Region">
+		Continente / Regione completa
+	</string>
+	<string name="all_files">
+		Tutti i file
+	</string>
+	<string name="sound_files">
+		Suoni
+	</string>
+	<string name="animation_files">
+		Animazioni
+	</string>
+	<string name="image_files">
+		Immagini
+	</string>
+	<string name="save_file_verb">
+		Salva
+	</string>
+	<string name="load_file_verb">
+		Carica
+	</string>
+	<string name="targa_image_files">
+		Immagini Targa
+	</string>
+	<string name="bitmap_image_files">
+		Immagini Bitmap
+	</string>
+	<string name="png_image_files">
+		Immagini PNG
+	</string>
+	<string name="save_texture_image_files">
+		Immagini Targa o PNG
+	</string>
+	<string name="avi_movie_file">
+		File video AVI
+	</string>
+	<string name="xaf_animation_file">
+		File animazione XAF
+	</string>
+	<string name="xml_file">
+		File XML
+	</string>
+	<string name="raw_file">
+		File RAW
+	</string>
+	<string name="compressed_image_files">
+		Immagini compresse
+	</string>
+	<string name="load_files">
+		Carica i file
+	</string>
+	<string name="choose_the_directory">
+		Scegli la cartella
+	</string>
+	<string name="script_files">
+		Script
+	</string>
+	<string name="dictionary_files">
+		Dizionari
+	</string>
+	<string name="shape">
+		Figura corporea
+	</string>
+	<string name="skin">
+		Pelle
+	</string>
+	<string name="hair">
+		Capigliature
+	</string>
+	<string name="eyes">
+		Occhi
+	</string>
+	<string name="shirt">
+		Camicia
+	</string>
+	<string name="pants">
+		Pantaloni
+	</string>
+	<string name="shoes">
+		Scarpe
+	</string>
+	<string name="socks">
+		Calzini
+	</string>
+	<string name="jacket">
+		Giacca
+	</string>
+	<string name="gloves">
+		Guanti
+	</string>
+	<string name="undershirt">
+		Maglietta intima
+	</string>
+	<string name="underpants">
+		Slip
+	</string>
+	<string name="skirt">
+		Gonna
+	</string>
+	<string name="alpha">
+		Alfa (Trasparenza)
+	</string>
+	<string name="tattoo">
+		Tatuaggio
+	</string>
+	<string name="universal">
+		Universale
+	</string>
+	<string name="physics">
+		Fisica
+	</string>
+	<string name="invalid">
+		non valido
+	</string>
+	<string name="none">
+		nessuno
+	</string>
+	<string name="shirt_not_worn">
+		Camicia non indossata
+	</string>
+	<string name="pants_not_worn">
+		Pantaloni non indossati
+	</string>
+	<string name="shoes_not_worn">
+		Scarpe non indossate
+	</string>
+	<string name="socks_not_worn">
+		Calzini non indossati
+	</string>
+	<string name="jacket_not_worn">
+		Giacca non indossata
+	</string>
+	<string name="gloves_not_worn">
+		Guanti non indossati
+	</string>
+	<string name="undershirt_not_worn">
+		Maglietta intima non indossata
+	</string>
+	<string name="underpants_not_worn">
+		Slip non indossati
+	</string>
+	<string name="skirt_not_worn">
+		Gonna non indossata
+	</string>
+	<string name="alpha_not_worn">
+		Alpha non portato
+	</string>
+	<string name="tattoo_not_worn">
+		Tatuaggio non portato
+	</string>
+	<string name="universal_not_worn">
+		Universale non indossato
+	</string>
+	<string name="physics_not_worn">
+		Fisica non indossata
+	</string>
+	<string name="invalid_not_worn">
+		non valido
+	</string>
+	<string name="create_new_shape">
+		Crea nuova figura corporea
+	</string>
+	<string name="create_new_skin">
+		Crea nuova pelle
+	</string>
+	<string name="create_new_hair">
+		Crea nuovi capelli
+	</string>
+	<string name="create_new_eyes">
+		Crea nuovi occhi
+	</string>
+	<string name="create_new_shirt">
+		Crea nuova camicia
+	</string>
+	<string name="create_new_pants">
+		Crea nuovi pantaloni
+	</string>
+	<string name="create_new_shoes">
+		Crea nuove scarpe
+	</string>
+	<string name="create_new_socks">
+		Crea nuove calze
+	</string>
+	<string name="create_new_jacket">
+		Crea nuova giacca
+	</string>
+	<string name="create_new_gloves">
+		Crea nuovi guanti
+	</string>
+	<string name="create_new_undershirt">
+		Crea nuova maglietta intima
+	</string>
+	<string name="create_new_underpants">
+		Crea nuovi slip
+	</string>
+	<string name="create_new_skirt">
+		Crea nuova gonna
+	</string>
+	<string name="create_new_alpha">
+		Crea nuovo Alpha
+	</string>
+	<string name="create_new_tattoo">
+		Crea un nuovo tatuaggio
+	</string>
+	<string name="create_new_universal">
+		Crea nuovo universale
+	</string>
+	<string name="create_new_physics">
+		Crea nuova fisica
+	</string>
+	<string name="create_new_invalid">
+		non valido
+	</string>
+	<string name="NewWearable">
+		Nuovo [WEARABLE_ITEM]
+	</string>
+	<string name="next">
+		Avanti
+	</string>
+	<string name="ok">
+		OK
+	</string>
+	<string name="GroupNotifyGroupNotice">
+		Avviso di gruppo
+	</string>
+	<string name="GroupNotifyGroupNotices">
+		Avvisi di gruppo
+	</string>
+	<string name="GroupNotifySentBy">
+		Inviato da
+	</string>
+	<string name="GroupNotifyAttached">
+		Allegato:
+	</string>
+	<string name="GroupNotifyViewPastNotices">
+		Visualizza gli avvisi precedenti o scegli qui di non riceverne.
+	</string>
+	<string name="GroupNotifyOpenAttachment">
+		Apri l'allegato
+	</string>
+	<string name="GroupNotifySaveAttachment">
+		Salva l'allegato
+	</string>
+	<string name="TeleportOffer">
+		Offerta di Teleport
+	</string>
+	<string name="StartUpNotifications">
+		Mentre eri assente sono arrivate nuove notifiche...
+	</string>
+	<string name="OverflowInfoChannelString">
+		Hai ancora [%d] notifiche
+	</string>
+	<string name="BodyPartsRightArm">
+		Braccio destro
+	</string>
+	<string name="BodyPartsHead">
+		Testa
+	</string>
+	<string name="BodyPartsLeftArm">
+		Braccio sinistro
+	</string>
+	<string name="BodyPartsLeftLeg">
+		Gamba sinistra
+	</string>
+	<string name="BodyPartsTorso">
+		Torace
+	</string>
+	<string name="BodyPartsRightLeg">
+		Gamba destra
+	</string>
+	<string name="BodyPartsEnhancedSkeleton">
+		Scheletro avanzato
+	</string>
+	<string name="GraphicsQualityLow">
+		Basso
+	</string>
+	<string name="GraphicsQualityMid">
+		Medio
+	</string>
+	<string name="GraphicsQualityHigh">
+		Alto
+	</string>
+	<string name="LeaveMouselook">
+		Premi ESC per tornare in visualizzazione normale
+	</string>
+	<string name="InventoryNoMatchingItems">
+		Non riesci a trovare quello che cerchi? Prova [secondlife:///app/search/all/[SEARCH_TERM] Cerca].
+	</string>
+	<string name="InventoryNoMatchingRecentItems">
+		Non hai trovato ció che cercavi? Prova [secondlife:///app/inventory/filters Show filters].
+	</string>
+	<string name="PlacesNoMatchingItems">
+		Non riesci a trovare quello che cerchi? Prova [secondlife:///app/search/places/[SEARCH_TERM] Cerca].
+	</string>
+	<string name="FavoritesNoMatchingItems">
+		Trascina qui un punto di riferimento per aggiungerlo ai Preferiti.
+	</string>
+	<string name="MarketplaceNoMatchingItems">
+		Nessun articolo trovato. Controlla di aver digitato la stringa di ricerca correttamente e riprova.
+	</string>
+	<string name="InventoryNoTexture">
+		Non hai una copia di questa texture nel tuo inventario
+	</string>
+	<string name="InventoryInboxNoItems">
+		Gli acquissti dal mercato verranno mostrati qui. Potrai quindi trascinarli nel tuo inventario per usarli.
+	</string>
+	<string name="MarketplaceURL">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/
+	</string>
+	<string name="MarketplaceURL_CreateStore">
+		http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3
+	</string>
+	<string name="MarketplaceURL_Dashboard">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard
+	</string>
+	<string name="MarketplaceURL_Imports">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports
+	</string>
+	<string name="MarketplaceURL_LearnMore">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more
+	</string>
+	<string name="InventoryPlayAnimationTooltip">
+		Apri finestra con opzioni di Gioco.
+	</string>
+	<string name="InventoryPlayGestureTooltip">
+		Esegui il movimento selezionato nel mondo virtuale.
+	</string>
+	<string name="InventoryPlaySoundTooltip">
+		Apri finestra con opzioni di Gioco.
+	</string>
+	<string name="InventoryOutboxNotMerchantTitle">
+		Chiunque può vendere oggetti nel Marketplace.
+	</string>
 	<string name="InventoryOutboxNotMerchantTooltip"/>
-	<string name="InventoryOutboxNotMerchant">Per diventare un venditore, devi [[MARKETPLACE_CREATE_STORE_URL] creare un negozio nel Marketplace].</string>
-	<string name="InventoryOutboxNoItemsTitle">La tua casella in uscita è vuota.</string>
+	<string name="InventoryOutboxNotMerchant">
+		Per diventare un venditore, devi [[MARKETPLACE_CREATE_STORE_URL] creare un negozio nel Marketplace].
+	</string>
+	<string name="InventoryOutboxNoItemsTitle">
+		La tua casella in uscita è vuota.
+	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
-	<string name="InventoryOutboxNoItems">Trascina le cartelle in questa area e clicca su &quot;Invia a Marketplace&quot; per metterle in vendita su [[MARKETPLACE_DASHBOARD_URL] Marketplace].</string>
-	<string name="InventoryOutboxInitializingTitle">Inizializzazione Marketplace.in corso</string>
-	<string name="InventoryOutboxInitializing">Stiamo eseguendo l'accesso al tuo account sul [[MARKETPLACE_CREATE_STORE_URL] negozio Marketplace].</string>
-	<string name="InventoryOutboxErrorTitle">Errori in Marketplace.</string>
-	<string name="InventoryOutboxError">Il [[MARKETPLACE_CREATE_STORE_URL] negozio nel Marketplace] ha riportato errori.</string>
-	<string name="InventoryMarketplaceError">Errore nell'apertura degli annunci di Marketplace.
-Se continui a ricevere questo messaggio, contatta l'assistenza Second Life su http://support.secondlife.com.</string>
-	<string name="InventoryMarketplaceListingsNoItemsTitle">La cartella degli annunci di Marketplace è vuota.</string>
-	<string name="InventoryMarketplaceListingsNoItems">Trascina le cartelle in questa area per metterle in vendita su [[MARKETPLACE_DASHBOARD_URL] Marketplace].</string>
-	<string name="InventoryItemsCount">( [ITEMS_COUNT] oggetti )</string>
-	<string name="Marketplace Validation Warning Stock">la cartella di magazzino deve essere inclusa in una cartella di versione</string>
-	<string name="Marketplace Validation Error Mixed Stock">: Errore: tutti gli articoli un una cartella di magazzino devono essere non copiabili e dello stesso tipo</string>
-	<string name="Marketplace Validation Error Subfolder In Stock">: Errore: la cartella di magazzino non può contenere sottocartelle</string>
-	<string name="Marketplace Validation Warning Empty">: Avviso: la cartella non contiene alcun articolo</string>
-	<string name="Marketplace Validation Warning Create Stock">: Avviso: creazione cartella di magazzino in corso</string>
-	<string name="Marketplace Validation Warning Create Version">: Avviso: creazione cartella di versione in corso</string>
-	<string name="Marketplace Validation Warning Move">: Avviso: spostamento articoli in corso</string>
-	<string name="Marketplace Validation Warning Delete">: Avviso: il contenuto della cartella è stato trasferito alla cartella di magazzino e la cartella vuota sta per essere rimossa</string>
-	<string name="Marketplace Validation Error Stock Item">: Errore: gli articoli di cui non è permessa la copia devono essere all'interno di una cartella di magazzino</string>
-	<string name="Marketplace Validation Warning Unwrapped Item">: Avviso: gli articoli devono essere inclusi in una cartella di versione</string>
-	<string name="Marketplace Validation Error">: Errore:</string>
-	<string name="Marketplace Validation Warning">: Avviso:</string>
-	<string name="Marketplace Validation Error Empty Version">: Avviso: la cartella di versione deve contenere almeno 1 articolo</string>
-	<string name="Marketplace Validation Error Empty Stock">: Avviso: la cartella di magazzino deve contenere almeno 1 articolo</string>
-	<string name="Marketplace Validation No Error">Nessun errore o avviso da segnalare</string>
-	<string name="Marketplace Error None">Nessun errore</string>
-	<string name="Marketplace Error Prefix">Errore:</string>
-	<string name="Marketplace Error Not Merchant">Prima di inviare gli articoli al Marketplace devi essere impostato come rivenditore (gratis).</string>
-	<string name="Marketplace Error Not Accepted">L'articolo non può essere spostato in quella cartella.</string>
-	<string name="Marketplace Error Unsellable Item">Questo articolo non può essere venduto nel Marketplace.</string>
-	<string name="MarketplaceNoID">no Mkt ID</string>
-	<string name="MarketplaceLive">in elenco</string>
-	<string name="MarketplaceActive">attivi</string>
-	<string name="MarketplaceMax">massimo</string>
-	<string name="MarketplaceStock">magazzino</string>
-	<string name="MarketplaceNoStock">non in magazzino</string>
-	<string name="MarketplaceUpdating">in aggiornamento...</string>
-	<string name="UploadFeeInfo">La tariffa è basata sul tuo livello di membership. Più alto è il livello più bassa sarà la tariffa. [https://secondlife.com/my/account/membership.php? Per saperne di più]</string>
-	<string name="Open landmarks">Luoghi aperti</string>
-	<string name="Unconstrained">Senza limitazioni</string>
+	<string name="InventoryOutboxNoItems">
+		Trascina le cartelle in questa area e clicca su "Invia a Marketplace" per metterle in vendita su [[MARKETPLACE_DASHBOARD_URL] Marketplace].
+	</string>
+	<string name="InventoryOutboxInitializingTitle">
+		Inizializzazione Marketplace.in corso
+	</string>
+	<string name="InventoryOutboxInitializing">
+		Stiamo eseguendo l'accesso al tuo account sul [[MARKETPLACE_CREATE_STORE_URL] negozio Marketplace].
+	</string>
+	<string name="InventoryOutboxErrorTitle">
+		Errori in Marketplace.
+	</string>
+	<string name="InventoryOutboxError">
+		Il [[MARKETPLACE_CREATE_STORE_URL] negozio nel Marketplace] ha riportato errori.
+	</string>
+	<string name="InventoryMarketplaceError">
+		Errore nell'apertura degli annunci di Marketplace.
+Se continui a ricevere questo messaggio, contatta l'assistenza Second Life su http://support.secondlife.com.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItemsTitle">
+		La cartella degli annunci di Marketplace è vuota.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItems">
+		Trascina le cartelle in questa area per metterle in vendita su [[MARKETPLACE_DASHBOARD_URL] Marketplace].
+	</string>
+	<string name="InventoryItemsCount">
+		( [ITEMS_COUNT] oggetti )
+	</string>
+	<string name="Marketplace Validation Warning Stock">
+		la cartella di magazzino deve essere inclusa in una cartella di versione
+	</string>
+	<string name="Marketplace Validation Error Mixed Stock">
+		: Errore: tutti gli articoli un una cartella di magazzino devono essere non copiabili e dello stesso tipo
+	</string>
+	<string name="Marketplace Validation Error Subfolder In Stock">
+		: Errore: la cartella di magazzino non può contenere sottocartelle
+	</string>
+	<string name="Marketplace Validation Warning Empty">
+		: Avviso: la cartella non contiene alcun articolo
+	</string>
+	<string name="Marketplace Validation Warning Create Stock">
+		: Avviso: creazione cartella di magazzino in corso
+	</string>
+	<string name="Marketplace Validation Warning Create Version">
+		: Avviso: creazione cartella di versione in corso
+	</string>
+	<string name="Marketplace Validation Warning Move">
+		: Avviso: spostamento articoli in corso
+	</string>
+	<string name="Marketplace Validation Warning Delete">
+		: Avviso: il contenuto della cartella è stato trasferito alla cartella di magazzino e la cartella vuota sta per essere rimossa
+	</string>
+	<string name="Marketplace Validation Error Stock Item">
+		: Errore: gli articoli di cui non è permessa la copia devono essere all'interno di una cartella di magazzino
+	</string>
+	<string name="Marketplace Validation Warning Unwrapped Item">
+		: Avviso: gli articoli devono essere inclusi in una cartella di versione
+	</string>
+	<string name="Marketplace Validation Error">
+		: Errore:
+	</string>
+	<string name="Marketplace Validation Warning">
+		: Avviso:
+	</string>
+	<string name="Marketplace Validation Error Empty Version">
+		: Avviso: la cartella di versione deve contenere almeno 1 articolo
+	</string>
+	<string name="Marketplace Validation Error Empty Stock">
+		: Avviso: la cartella di magazzino deve contenere almeno 1 articolo
+	</string>
+	<string name="Marketplace Validation No Error">
+		Nessun errore o avviso da segnalare
+	</string>
+	<string name="Marketplace Error None">
+		Nessun errore
+	</string>
+	<string name="Marketplace Error Prefix">
+		Errore:
+	</string>
+	<string name="Marketplace Error Not Merchant">
+		Prima di inviare gli articoli al Marketplace devi essere impostato come rivenditore (gratis).
+	</string>
+	<string name="Marketplace Error Not Accepted">
+		L'articolo non può essere spostato in quella cartella.
+	</string>
+	<string name="Marketplace Error Unsellable Item">
+		Questo articolo non può essere venduto nel Marketplace.
+	</string>
+	<string name="MarketplaceNoID">
+		no Mkt ID
+	</string>
+	<string name="MarketplaceLive">
+		in elenco
+	</string>
+	<string name="MarketplaceActive">
+		attivi
+	</string>
+	<string name="MarketplaceMax">
+		massimo
+	</string>
+	<string name="MarketplaceStock">
+		magazzino
+	</string>
+	<string name="MarketplaceNoStock">
+		non in magazzino
+	</string>
+	<string name="MarketplaceUpdating">
+		in aggiornamento...
+	</string>
+	<string name="UploadFeeInfo">
+		La tariffa è basata sul tuo livello di membership. Più alto è il livello più bassa sarà la tariffa. [https://secondlife.com/my/account/membership.php? Per saperne di più]
+	</string>
+	<string name="Open landmarks">
+		Luoghi aperti
+	</string>
+	<string name="Unconstrained">
+		Senza limitazioni
+	</string>
 	<string name="no_transfer" value="(nessun trasferimento)"/>
 	<string name="no_modify" value="(nessuna modifica)"/>
 	<string name="no_copy" value="(nessuna copia)"/>
 	<string name="worn" value="(indossato)"/>
 	<string name="link" value="(link)"/>
 	<string name="broken_link" value="(broken_link)&quot;"/>
-	<string name="LoadingContents">Caricamento del contenuto...</string>
-	<string name="NoContents">Nessun contenuto</string>
+	<string name="LoadingContents">
+		Caricamento del contenuto...
+	</string>
+	<string name="NoContents">
+		Nessun contenuto
+	</string>
 	<string name="WornOnAttachmentPoint" value="(indossato su [ATTACHMENT_POINT])"/>
 	<string name="AttachmentErrorMessage" value="([ATTACHMENT_ERROR])"/>
 	<string name="ActiveGesture" value="[GESLABEL] (attivo)"/>
@@ -631,1420 +1689,4146 @@ Se continui a ricevere questo messaggio, contatta l'assistenza Second Life su ht
 	<string name="Snapshots" value="Fotografie,"/>
 	<string name="No Filters" value="No"/>
 	<string name="Since Logoff" value="- Dall'uscita"/>
-	<string name="InvFolder My Inventory">Il mio inventario</string>
-	<string name="InvFolder Library">Libreria</string>
-	<string name="InvFolder Textures">Texture</string>
-	<string name="InvFolder Sounds">Suoni</string>
-	<string name="InvFolder Calling Cards">Biglietti da visita</string>
-	<string name="InvFolder Landmarks">Punti di riferimento</string>
-	<string name="InvFolder Scripts">Script</string>
-	<string name="InvFolder Clothing">Vestiario</string>
-	<string name="InvFolder Objects">Oggetti</string>
-	<string name="InvFolder Notecards">Biglietti</string>
-	<string name="InvFolder New Folder">Nuova cartella</string>
-	<string name="InvFolder Inventory">Inventario</string>
-	<string name="InvFolder Uncompressed Images">Immagini non compresse</string>
-	<string name="InvFolder Body Parts">Parti del corpo</string>
-	<string name="InvFolder Trash">Cestino</string>
-	<string name="InvFolder Photo Album">Album fotografico</string>
-	<string name="InvFolder Lost And Found">Oggetti smarriti</string>
-	<string name="InvFolder Uncompressed Sounds">Suoni non compressi</string>
-	<string name="InvFolder Animations">Animazioni</string>
-	<string name="InvFolder Gestures">Gesture</string>
-	<string name="InvFolder Favorite">I miei preferiti</string>
-	<string name="InvFolder favorite">I miei preferiti</string>
-	<string name="InvFolder Favorites">I miei preferiti</string>
-	<string name="InvFolder favorites">I miei preferiti</string>
-	<string name="InvFolder Current Outfit">Abbigliamento attuale</string>
-	<string name="InvFolder Initial Outfits">Vestiario iniziale</string>
-	<string name="InvFolder My Outfits">Il mio vestiario</string>
-	<string name="InvFolder Accessories">Accessori</string>
-	<string name="InvFolder Meshes">Reticoli</string>
-	<string name="InvFolder Received Items">Oggetti ricevuti</string>
-	<string name="InvFolder Merchant Outbox">Casella venditore in uscita</string>
-	<string name="InvFolder Friends">Amici</string>
-	<string name="InvFolder All">Tutto</string>
-	<string name="no_attachments">Nessun allegato indossato</string>
-	<string name="Attachments remain">Allegati ([COUNT] spazi restanti)</string>
-	<string name="Buy">Acquista</string>
-	<string name="BuyforL$">Acquista per L$</string>
-	<string name="Stone">Pietra</string>
-	<string name="Metal">Metallo</string>
-	<string name="Glass">Vetro</string>
-	<string name="Wood">Legno</string>
-	<string name="Flesh">Carne</string>
-	<string name="Plastic">Plastica</string>
-	<string name="Rubber">Gomma</string>
-	<string name="Light">Luce</string>
-	<string name="KBShift">Maiusc</string>
-	<string name="KBCtrl">Ctrl</string>
-	<string name="Chest">Petto</string>
-	<string name="Skull">Cranio</string>
-	<string name="Left Shoulder">Spalla sinistra</string>
-	<string name="Right Shoulder">Spalla destra</string>
-	<string name="Left Hand">Mano sinistra</string>
-	<string name="Right Hand">Mano destra</string>
-	<string name="Left Foot">Piede sinisto</string>
-	<string name="Right Foot">Piede destro</string>
-	<string name="Spine">Spina dorsale</string>
-	<string name="Pelvis">Pelvi</string>
-	<string name="Mouth">Bocca</string>
-	<string name="Chin">Mento</string>
-	<string name="Left Ear">Orecchio sinistro</string>
-	<string name="Right Ear">Orecchio destro</string>
-	<string name="Left Eyeball">Bulbo sinistro</string>
-	<string name="Right Eyeball">Bulbo destro</string>
-	<string name="Nose">Naso</string>
-	<string name="R Upper Arm">Avambraccio destro</string>
-	<string name="R Forearm">Braccio destro</string>
-	<string name="L Upper Arm">Avambraccio sinistro</string>
-	<string name="L Forearm">Braccio sinistro</string>
-	<string name="Right Hip">Anca destra</string>
-	<string name="R Upper Leg">Coscia destra</string>
-	<string name="R Lower Leg">Gamba destra</string>
-	<string name="Left Hip">Anca sinista</string>
-	<string name="L Upper Leg">Coscia sinistra</string>
-	<string name="L Lower Leg">Gamba sinistra</string>
-	<string name="Stomach">Stomaco</string>
-	<string name="Left Pec">Petto sinistro</string>
-	<string name="Right Pec">Petto destro</string>
-	<string name="Neck">Collo</string>
-	<string name="Avatar Center">Centro avatar</string>
-	<string name="Left Ring Finger">Anulare sinistro</string>
-	<string name="Right Ring Finger">Anulare destro</string>
-	<string name="Tail Base">Base della coda</string>
-	<string name="Tail Tip">Punta della coda</string>
-	<string name="Left Wing">Ala sinistra</string>
-	<string name="Right Wing">Ala destra</string>
-	<string name="Jaw">Mandibola</string>
-	<string name="Alt Left Ear">Altro orecchio sinistro</string>
-	<string name="Alt Right Ear">Altro orecchio destro</string>
-	<string name="Alt Left Eye">Altro occhio sinistro</string>
-	<string name="Alt Right Eye">Altro occhio destro</string>
-	<string name="Tongue">Lingua</string>
-	<string name="Groin">Inguine</string>
-	<string name="Left Hind Foot">Piede posteriore sinistro</string>
-	<string name="Right Hind Foot">Piede posteriore destro</string>
-	<string name="Invalid Attachment">Punto di collegamento non valido</string>
-	<string name="ATTACHMENT_MISSING_ITEM">Errore: articolo mancante</string>
-	<string name="ATTACHMENT_MISSING_BASE_ITEM">Errore: articolo di base mancante</string>
-	<string name="ATTACHMENT_NOT_ATTACHED">Errore: l'oggetto è nel vestiario corrente ma non è collegato</string>
-	<string name="YearsMonthsOld">Nato da [AGEYEARS] [AGEMONTHS]</string>
-	<string name="YearsOld">Nato da [AGEYEARS]</string>
-	<string name="MonthsOld">Nato da [AGEMONTHS]</string>
-	<string name="WeeksOld">Nato da [AGEWEEKS]</string>
-	<string name="DaysOld">Nato da [AGEDAYS]</string>
-	<string name="TodayOld">Iscritto oggi</string>
-	<string name="av_render_everyone_now">Ora ti possono vedere tutti.</string>
-	<string name="av_render_not_everyone">Alcune persone vicine a te potrebbero non eseguire il tuo rendering.</string>
-	<string name="av_render_over_half">La maggioranza delle persone vicine a te potrebbe non eseguire il tuo rendering.</string>
-	<string name="av_render_most_of">La gran parte delle persone vicine a te potrebbe non eseguire il tuo rendering.</string>
-	<string name="av_render_anyone">Tutte le persone vicine a te potrebbero non eseguire il tuo rendering.</string>
-	<string name="hud_description_total">Il tuo HUD</string>
-	<string name="hud_name_with_joint">[OBJ_NAME] (indossato su [JNT_NAME])</string>
-	<string name="hud_render_memory_warning">[HUD_DETAILS] fa uso di molta memoria texture</string>
-	<string name="hud_render_cost_warning">[HUD_DETAILS] contiene molti oggetti e texture che occupano una grande quantità di risorse</string>
-	<string name="hud_render_heavy_textures_warning">[HUD_DETAILS] contiene molte texture di grandi dimensioni</string>
-	<string name="hud_render_cramped_warning">[HUD_DETAILS] contiene troppi oggetti</string>
-	<string name="hud_render_textures_warning">[HUD_DETAILS] contiene troppe texture</string>
-	<string name="AgeYearsA">[COUNT] anno</string>
-	<string name="AgeYearsB">[COUNT] anni</string>
-	<string name="AgeYearsC">[COUNT] anni</string>
-	<string name="AgeMonthsA">[COUNT] mese</string>
-	<string name="AgeMonthsB">[COUNT] mesi</string>
-	<string name="AgeMonthsC">[COUNT] mesi</string>
-	<string name="AgeWeeksA">[COUNT] settimana</string>
-	<string name="AgeWeeksB">[COUNT] settimane</string>
-	<string name="AgeWeeksC">[COUNT] settimane</string>
-	<string name="AgeDaysA">[COUNT] giorno</string>
-	<string name="AgeDaysB">[COUNT] giorni</string>
-	<string name="AgeDaysC">[COUNT] giorni</string>
-	<string name="GroupMembersA">[COUNT] iscritto</string>
-	<string name="GroupMembersB">[COUNT] iscritti</string>
-	<string name="GroupMembersC">[COUNT] iscritti</string>
-	<string name="AcctTypeResident">Residente</string>
-	<string name="AcctTypeTrial">In prova</string>
-	<string name="AcctTypeCharterMember">Socio onorario</string>
-	<string name="AcctTypeEmployee">Dipendente Linden Lab</string>
-	<string name="PaymentInfoUsed">Informazioni di pagamento usate</string>
-	<string name="PaymentInfoOnFile">Informazioni di pagamento registrate</string>
-	<string name="NoPaymentInfoOnFile">Nessuna informazione di pagamento disponibile</string>
-	<string name="AgeVerified">Età verificata</string>
-	<string name="NotAgeVerified">Età non verificata</string>
-	<string name="Center 2">Centro 2</string>
-	<string name="Top Right">In alto a destra</string>
-	<string name="Top">in  alto</string>
-	<string name="Top Left">In alto a sinistra</string>
-	<string name="Center">Al centro</string>
-	<string name="Bottom Left">In basso a sinistra</string>
-	<string name="Bottom">In basso</string>
-	<string name="Bottom Right">In basso a destra</string>
-	<string name="CompileQueueDownloadedCompiling">Scaricato, in compilazione</string>
-	<string name="CompileQueueServiceUnavailable">Il servizio di compilazione degli script non è disponibile</string>
-	<string name="CompileQueueScriptNotFound">Script non trovato sul server.</string>
-	<string name="CompileQueueProblemDownloading">Problema nel download</string>
-	<string name="CompileQueueInsufficientPermDownload">Permessi insufficenti per scaricare lo script.</string>
-	<string name="CompileQueueInsufficientPermFor">Permessi insufficenti per</string>
-	<string name="CompileQueueUnknownFailure">Errore di dowload sconosciuto</string>
-	<string name="CompileNoExperiencePerm">Saltato lo script [SCRIPT] con l'esperienza [EXPERIENCE].</string>
-	<string name="CompileQueueTitle">Avanzamento ricompilazione</string>
-	<string name="CompileQueueStart">ricompila</string>
-	<string name="ResetQueueTitle">Azzera avanzamento</string>
-	<string name="ResetQueueStart">azzera</string>
-	<string name="RunQueueTitle">Attiva avanzamento</string>
-	<string name="RunQueueStart">attiva</string>
-	<string name="NotRunQueueTitle">Disattiva avanzamento</string>
-	<string name="NotRunQueueStart">disattiva</string>
-	<string name="CompileSuccessful">Compilazione riuscita!</string>
-	<string name="CompileSuccessfulSaving">Compilazione riuscita, in salvataggio...</string>
-	<string name="SaveComplete">Salvataggio completato.</string>
-	<string name="UploadFailed">Caricamento file non riuscito:</string>
-	<string name="ObjectOutOfRange">Script (oggetto fuori portata)</string>
-	<string name="ScriptWasDeleted">Script (eliminato da inventario)</string>
-	<string name="GodToolsObjectOwnedBy">Oggetto [OBJECT] di proprietà di [OWNER]</string>
-	<string name="GroupsNone">nessuno</string>
+	<string name="InvFolder My Inventory">
+		Il mio inventario
+	</string>
+	<string name="InvFolder Library">
+		Libreria
+	</string>
+	<string name="InvFolder Textures">
+		Texture
+	</string>
+	<string name="InvFolder Sounds">
+		Suoni
+	</string>
+	<string name="InvFolder Calling Cards">
+		Biglietti da visita
+	</string>
+	<string name="InvFolder Landmarks">
+		Punti di riferimento
+	</string>
+	<string name="InvFolder Scripts">
+		Script
+	</string>
+	<string name="InvFolder Clothing">
+		Vestiario
+	</string>
+	<string name="InvFolder Objects">
+		Oggetti
+	</string>
+	<string name="InvFolder Notecards">
+		Biglietti
+	</string>
+	<string name="InvFolder New Folder">
+		Nuova cartella
+	</string>
+	<string name="InvFolder Inventory">
+		Inventario
+	</string>
+	<string name="InvFolder Uncompressed Images">
+		Immagini non compresse
+	</string>
+	<string name="InvFolder Body Parts">
+		Parti del corpo
+	</string>
+	<string name="InvFolder Trash">
+		Cestino
+	</string>
+	<string name="InvFolder Photo Album">
+		Album fotografico
+	</string>
+	<string name="InvFolder Lost And Found">
+		Oggetti smarriti
+	</string>
+	<string name="InvFolder Uncompressed Sounds">
+		Suoni non compressi
+	</string>
+	<string name="InvFolder Animations">
+		Animazioni
+	</string>
+	<string name="InvFolder Gestures">
+		Gesture
+	</string>
+	<string name="InvFolder Favorite">
+		I miei preferiti
+	</string>
+	<string name="InvFolder favorite">
+		I miei preferiti
+	</string>
+	<string name="InvFolder Favorites">
+		I miei preferiti
+	</string>
+	<string name="InvFolder favorites">
+		I miei preferiti
+	</string>
+	<string name="InvFolder Current Outfit">
+		Abbigliamento attuale
+	</string>
+	<string name="InvFolder Initial Outfits">
+		Vestiario iniziale
+	</string>
+	<string name="InvFolder My Outfits">
+		Il mio vestiario
+	</string>
+	<string name="InvFolder Accessories">
+		Accessori
+	</string>
+	<string name="InvFolder Meshes">
+		Reticoli
+	</string>
+	<string name="InvFolder Received Items">
+		Oggetti ricevuti
+	</string>
+	<string name="InvFolder Merchant Outbox">
+		Casella venditore in uscita
+	</string>
+	<string name="InvFolder Friends">
+		Amici
+	</string>
+	<string name="InvFolder All">
+		Tutto
+	</string>
+	<string name="no_attachments">
+		Nessun allegato indossato
+	</string>
+	<string name="Attachments remain">
+		Allegati ([COUNT] spazi restanti)
+	</string>
+	<string name="Buy">
+		Acquista
+	</string>
+	<string name="BuyforL$">
+		Acquista per L$
+	</string>
+	<string name="Stone">
+		Pietra
+	</string>
+	<string name="Metal">
+		Metallo
+	</string>
+	<string name="Glass">
+		Vetro
+	</string>
+	<string name="Wood">
+		Legno
+	</string>
+	<string name="Flesh">
+		Carne
+	</string>
+	<string name="Plastic">
+		Plastica
+	</string>
+	<string name="Rubber">
+		Gomma
+	</string>
+	<string name="Light">
+		Luce
+	</string>
+	<string name="KBShift">
+		Maiusc
+	</string>
+	<string name="KBCtrl">
+		Ctrl
+	</string>
+	<string name="Chest">
+		Petto
+	</string>
+	<string name="Skull">
+		Cranio
+	</string>
+	<string name="Left Shoulder">
+		Spalla sinistra
+	</string>
+	<string name="Right Shoulder">
+		Spalla destra
+	</string>
+	<string name="Left Hand">
+		Mano sinistra
+	</string>
+	<string name="Right Hand">
+		Mano destra
+	</string>
+	<string name="Left Foot">
+		Piede sinisto
+	</string>
+	<string name="Right Foot">
+		Piede destro
+	</string>
+	<string name="Spine">
+		Spina dorsale
+	</string>
+	<string name="Pelvis">
+		Pelvi
+	</string>
+	<string name="Mouth">
+		Bocca
+	</string>
+	<string name="Chin">
+		Mento
+	</string>
+	<string name="Left Ear">
+		Orecchio sinistro
+	</string>
+	<string name="Right Ear">
+		Orecchio destro
+	</string>
+	<string name="Left Eyeball">
+		Bulbo sinistro
+	</string>
+	<string name="Right Eyeball">
+		Bulbo destro
+	</string>
+	<string name="Nose">
+		Naso
+	</string>
+	<string name="R Upper Arm">
+		Avambraccio destro
+	</string>
+	<string name="R Forearm">
+		Braccio destro
+	</string>
+	<string name="L Upper Arm">
+		Avambraccio sinistro
+	</string>
+	<string name="L Forearm">
+		Braccio sinistro
+	</string>
+	<string name="Right Hip">
+		Anca destra
+	</string>
+	<string name="R Upper Leg">
+		Coscia destra
+	</string>
+	<string name="R Lower Leg">
+		Gamba destra
+	</string>
+	<string name="Left Hip">
+		Anca sinista
+	</string>
+	<string name="L Upper Leg">
+		Coscia sinistra
+	</string>
+	<string name="L Lower Leg">
+		Gamba sinistra
+	</string>
+	<string name="Stomach">
+		Stomaco
+	</string>
+	<string name="Left Pec">
+		Petto sinistro
+	</string>
+	<string name="Right Pec">
+		Petto destro
+	</string>
+	<string name="Neck">
+		Collo
+	</string>
+	<string name="Avatar Center">
+		Centro avatar
+	</string>
+	<string name="Left Ring Finger">
+		Anulare sinistro
+	</string>
+	<string name="Right Ring Finger">
+		Anulare destro
+	</string>
+	<string name="Tail Base">
+		Base della coda
+	</string>
+	<string name="Tail Tip">
+		Punta della coda
+	</string>
+	<string name="Left Wing">
+		Ala sinistra
+	</string>
+	<string name="Right Wing">
+		Ala destra
+	</string>
+	<string name="Jaw">
+		Mandibola
+	</string>
+	<string name="Alt Left Ear">
+		Altro orecchio sinistro
+	</string>
+	<string name="Alt Right Ear">
+		Altro orecchio destro
+	</string>
+	<string name="Alt Left Eye">
+		Altro occhio sinistro
+	</string>
+	<string name="Alt Right Eye">
+		Altro occhio destro
+	</string>
+	<string name="Tongue">
+		Lingua
+	</string>
+	<string name="Groin">
+		Inguine
+	</string>
+	<string name="Left Hind Foot">
+		Piede posteriore sinistro
+	</string>
+	<string name="Right Hind Foot">
+		Piede posteriore destro
+	</string>
+	<string name="Invalid Attachment">
+		Punto di collegamento non valido
+	</string>
+	<string name="ATTACHMENT_MISSING_ITEM">
+		Errore: articolo mancante
+	</string>
+	<string name="ATTACHMENT_MISSING_BASE_ITEM">
+		Errore: articolo di base mancante
+	</string>
+	<string name="ATTACHMENT_NOT_ATTACHED">
+		Errore: l'oggetto è nel vestiario corrente ma non è collegato
+	</string>
+	<string name="YearsMonthsOld">
+		Nato da [AGEYEARS] [AGEMONTHS]
+	</string>
+	<string name="YearsOld">
+		Nato da [AGEYEARS]
+	</string>
+	<string name="MonthsOld">
+		Nato da [AGEMONTHS]
+	</string>
+	<string name="WeeksOld">
+		Nato da [AGEWEEKS]
+	</string>
+	<string name="DaysOld">
+		Nato da [AGEDAYS]
+	</string>
+	<string name="TodayOld">
+		Iscritto oggi
+	</string>
+	<string name="av_render_everyone_now">
+		Ora ti possono vedere tutti.
+	</string>
+	<string name="av_render_not_everyone">
+		Alcune persone vicine a te potrebbero non eseguire il tuo rendering.
+	</string>
+	<string name="av_render_over_half">
+		La maggioranza delle persone vicine a te potrebbe non eseguire il tuo rendering.
+	</string>
+	<string name="av_render_most_of">
+		La gran parte delle persone vicine a te potrebbe non eseguire il tuo rendering.
+	</string>
+	<string name="av_render_anyone">
+		Tutte le persone vicine a te potrebbero non eseguire il tuo rendering.
+	</string>
+	<string name="hud_description_total">
+		Il tuo HUD
+	</string>
+	<string name="hud_name_with_joint">
+		[OBJ_NAME] (indossato su [JNT_NAME])
+	</string>
+	<string name="hud_render_memory_warning">
+		[HUD_DETAILS] fa uso di molta memoria texture
+	</string>
+	<string name="hud_render_cost_warning">
+		[HUD_DETAILS] contiene molti oggetti e texture che occupano una grande quantità di risorse
+	</string>
+	<string name="hud_render_heavy_textures_warning">
+		[HUD_DETAILS] contiene molte texture di grandi dimensioni
+	</string>
+	<string name="hud_render_cramped_warning">
+		[HUD_DETAILS] contiene troppi oggetti
+	</string>
+	<string name="hud_render_textures_warning">
+		[HUD_DETAILS] contiene troppe texture
+	</string>
+	<string name="AgeYearsA">
+		[COUNT] anno
+	</string>
+	<string name="AgeYearsB">
+		[COUNT] anni
+	</string>
+	<string name="AgeYearsC">
+		[COUNT] anni
+	</string>
+	<string name="AgeMonthsA">
+		[COUNT] mese
+	</string>
+	<string name="AgeMonthsB">
+		[COUNT] mesi
+	</string>
+	<string name="AgeMonthsC">
+		[COUNT] mesi
+	</string>
+	<string name="AgeWeeksA">
+		[COUNT] settimana
+	</string>
+	<string name="AgeWeeksB">
+		[COUNT] settimane
+	</string>
+	<string name="AgeWeeksC">
+		[COUNT] settimane
+	</string>
+	<string name="AgeDaysA">
+		[COUNT] giorno
+	</string>
+	<string name="AgeDaysB">
+		[COUNT] giorni
+	</string>
+	<string name="AgeDaysC">
+		[COUNT] giorni
+	</string>
+	<string name="GroupMembersA">
+		[COUNT] iscritto
+	</string>
+	<string name="GroupMembersB">
+		[COUNT] iscritti
+	</string>
+	<string name="GroupMembersC">
+		[COUNT] iscritti
+	</string>
+	<string name="AcctTypeResident">
+		Residente
+	</string>
+	<string name="AcctTypeTrial">
+		In prova
+	</string>
+	<string name="AcctTypeCharterMember">
+		Socio onorario
+	</string>
+	<string name="AcctTypeEmployee">
+		Dipendente Linden Lab
+	</string>
+	<string name="PaymentInfoUsed">
+		Informazioni di pagamento usate
+	</string>
+	<string name="PaymentInfoOnFile">
+		Informazioni di pagamento registrate
+	</string>
+	<string name="NoPaymentInfoOnFile">
+		Nessuna informazione di pagamento disponibile
+	</string>
+	<string name="AgeVerified">
+		Età verificata
+	</string>
+	<string name="NotAgeVerified">
+		Età non verificata
+	</string>
+	<string name="Center 2">
+		Centro 2
+	</string>
+	<string name="Top Right">
+		In alto a destra
+	</string>
+	<string name="Top">
+		in  alto
+	</string>
+	<string name="Top Left">
+		In alto a sinistra
+	</string>
+	<string name="Center">
+		Al centro
+	</string>
+	<string name="Bottom Left">
+		In basso a sinistra
+	</string>
+	<string name="Bottom">
+		In basso
+	</string>
+	<string name="Bottom Right">
+		In basso a destra
+	</string>
+	<string name="CompileQueueDownloadedCompiling">
+		Scaricato, in compilazione
+	</string>
+	<string name="CompileQueueServiceUnavailable">
+		Il servizio di compilazione degli script non è disponibile
+	</string>
+	<string name="CompileQueueScriptNotFound">
+		Script non trovato sul server.
+	</string>
+	<string name="CompileQueueProblemDownloading">
+		Problema nel download
+	</string>
+	<string name="CompileQueueInsufficientPermDownload">
+		Permessi insufficenti per scaricare lo script.
+	</string>
+	<string name="CompileQueueInsufficientPermFor">
+		Permessi insufficenti per
+	</string>
+	<string name="CompileQueueUnknownFailure">
+		Errore di dowload sconosciuto
+	</string>
+	<string name="CompileNoExperiencePerm">
+		Saltato lo script [SCRIPT] con l'esperienza [EXPERIENCE].
+	</string>
+	<string name="CompileQueueTitle">
+		Avanzamento ricompilazione
+	</string>
+	<string name="CompileQueueStart">
+		ricompila
+	</string>
+	<string name="ResetQueueTitle">
+		Azzera avanzamento
+	</string>
+	<string name="ResetQueueStart">
+		azzera
+	</string>
+	<string name="RunQueueTitle">
+		Attiva avanzamento
+	</string>
+	<string name="RunQueueStart">
+		attiva
+	</string>
+	<string name="NotRunQueueTitle">
+		Disattiva avanzamento
+	</string>
+	<string name="NotRunQueueStart">
+		disattiva
+	</string>
+	<string name="CompileSuccessful">
+		Compilazione riuscita!
+	</string>
+	<string name="CompileSuccessfulSaving">
+		Compilazione riuscita, in salvataggio...
+	</string>
+	<string name="SaveComplete">
+		Salvataggio completato.
+	</string>
+	<string name="UploadFailed">
+		Caricamento file non riuscito:
+	</string>
+	<string name="ObjectOutOfRange">
+		Script (oggetto fuori portata)
+	</string>
+	<string name="ScriptWasDeleted">
+		Script (eliminato da inventario)
+	</string>
+	<string name="GodToolsObjectOwnedBy">
+		Oggetto [OBJECT] di proprietà di [OWNER]
+	</string>
+	<string name="GroupsNone">
+		nessuno
+	</string>
 	<string name="Group" value="(gruppo)"/>
-	<string name="Unknown">(Sconosciuto)</string>
+	<string name="Unknown">
+		(Sconosciuto)
+	</string>
 	<string name="SummaryForTheWeek" value="Riassunto della settimana, partendo dal "/>
 	<string name="NextStipendDay" value=". Il prossimo giorno di stipendio è "/>
-	<string name="GroupPlanningDate">[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]</string>
+	<string name="GroupPlanningDate">
+		[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]
+	</string>
 	<string name="GroupIndividualShare" value="Gruppo       Dividendi individuali"/>
 	<string name="GroupColumn" value="Gruppo"/>
-	<string name="Balance">Saldo</string>
-	<string name="Credits">Ringraziamenti</string>
-	<string name="Debits">Debiti</string>
-	<string name="Total">Totale</string>
-	<string name="NoGroupDataFound">Nessun dato trovato per questo gruppo</string>
-	<string name="IMParentEstate">Proprietà principale</string>
-	<string name="IMMainland">continente</string>
-	<string name="IMTeen">teen</string>
-	<string name="Anyone">chiunque</string>
-	<string name="RegionInfoError">errore</string>
-	<string name="RegionInfoAllEstatesOwnedBy">tutte le proprietà immobiliari di [OWNER]</string>
-	<string name="RegionInfoAllEstatesYouOwn">tutte le tue proprietà immobiliari</string>
-	<string name="RegionInfoAllEstatesYouManage">tutte le proprietà immobiliari che gestisci per conto di [OWNER]</string>
-	<string name="RegionInfoAllowedResidents">Sempre consentiti: ([ALLOWEDAGENTS], max [MAXACCESS])</string>
-	<string name="RegionInfoAllowedGroups">Gruppi sempre consentiti: ([ALLOWEDGROUPS], max [MAXACCESS])</string>
-	<string name="RegionInfoBannedResidents">Sempre esclusi: ([BANNEDAGENTS], max [MAXBANNED])</string>
-	<string name="RegionInfoListTypeAllowedAgents">Sempre consentiti:</string>
-	<string name="RegionInfoListTypeBannedAgents">Sempre esclusi:</string>
-	<string name="RegionInfoAllEstates">tutte le proprietà immobiliari</string>
-	<string name="RegionInfoManagedEstates">proprietà immobiliari che gestisci</string>
-	<string name="RegionInfoThisEstate">questa proprietà immobiliare</string>
-	<string name="AndNMore">e [EXTRA_COUNT] ancora</string>
-	<string name="ScriptLimitsParcelScriptMemory">Memoria dello script del lotto</string>
-	<string name="ScriptLimitsParcelsOwned">Lotti in elenco: [PARCELS]</string>
-	<string name="ScriptLimitsMemoryUsed">Memoria utilizzata: [COUNT] kb di [MAX] kb; [AVAILABLE] kb disponibili</string>
-	<string name="ScriptLimitsMemoryUsedSimple">Memoria utilizzata: [COUNT] kb</string>
-	<string name="ScriptLimitsParcelScriptURLs">URL degli script lotti</string>
-	<string name="ScriptLimitsURLsUsed">URL utilizzati: [COUNT] di [MAX]; [AVAILABLE] disponibili</string>
-	<string name="ScriptLimitsURLsUsedSimple">URL utilizzati: [COUNT]</string>
-	<string name="ScriptLimitsRequestError">Errore nella richiesta di informazioni</string>
-	<string name="ScriptLimitsRequestNoParcelSelected">Nessun lotto selezionato</string>
-	<string name="ScriptLimitsRequestWrongRegion">Errore: le informazioni sullo script sono disponibili solo nella tua regione attuale</string>
-	<string name="ScriptLimitsRequestWaiting">Recupero informazioni in corso...</string>
-	<string name="ScriptLimitsRequestDontOwnParcel">Non hai il permesso di visionare questo lotto</string>
-	<string name="SITTING_ON">Seduto su</string>
-	<string name="ATTACH_CHEST">Petto</string>
-	<string name="ATTACH_HEAD">Cranio</string>
-	<string name="ATTACH_LSHOULDER">Spalla sinistra</string>
-	<string name="ATTACH_RSHOULDER">Spalla destra</string>
-	<string name="ATTACH_LHAND">Mano sinistra</string>
-	<string name="ATTACH_RHAND">Mano destra</string>
-	<string name="ATTACH_LFOOT">Piede sinisto</string>
-	<string name="ATTACH_RFOOT">Piede destro</string>
-	<string name="ATTACH_BACK">Spina dorsale</string>
-	<string name="ATTACH_PELVIS">Pelvi</string>
-	<string name="ATTACH_MOUTH">Bocca</string>
-	<string name="ATTACH_CHIN">Mento</string>
-	<string name="ATTACH_LEAR">Orecchio sinistro</string>
-	<string name="ATTACH_REAR">Orecchio destro</string>
-	<string name="ATTACH_LEYE">Occhio sinistro</string>
-	<string name="ATTACH_REYE">Occhio destro</string>
-	<string name="ATTACH_NOSE">Naso</string>
-	<string name="ATTACH_RUARM">Braccio destro</string>
-	<string name="ATTACH_RLARM">Avambraccio destro</string>
-	<string name="ATTACH_LUARM">Braccio sinistro</string>
-	<string name="ATTACH_LLARM">Avambraccio sinistro</string>
-	<string name="ATTACH_RHIP">Anca destra</string>
-	<string name="ATTACH_RULEG">Coscia destra</string>
-	<string name="ATTACH_RLLEG">Coscia destra</string>
-	<string name="ATTACH_LHIP">Anca sinista</string>
-	<string name="ATTACH_LULEG">Coscia sinistra</string>
-	<string name="ATTACH_LLLEG">Polpaccio sinistro</string>
-	<string name="ATTACH_BELLY">Stomaco</string>
-	<string name="ATTACH_LEFT_PEC">Petto sinistro</string>
-	<string name="ATTACH_RIGHT_PEC">Petto destro</string>
-	<string name="ATTACH_HUD_CENTER_2">HUD in centro 2</string>
-	<string name="ATTACH_HUD_TOP_RIGHT">HUD alto a destra</string>
-	<string name="ATTACH_HUD_TOP_CENTER">HUD alto in centro</string>
-	<string name="ATTACH_HUD_TOP_LEFT">HUD alto a sinistra</string>
-	<string name="ATTACH_HUD_CENTER_1">HUD in centro 1</string>
-	<string name="ATTACH_HUD_BOTTOM_LEFT">HUD basso a sinistra</string>
-	<string name="ATTACH_HUD_BOTTOM">HUD basso</string>
-	<string name="ATTACH_HUD_BOTTOM_RIGHT">HUD basso a destra</string>
-	<string name="ATTACH_NECK">Collo</string>
-	<string name="ATTACH_AVATAR_CENTER">Centro avatar</string>
-	<string name="ATTACH_LHAND_RING1">Anulare sinistro</string>
-	<string name="ATTACH_RHAND_RING1">Anulare destro</string>
-	<string name="ATTACH_TAIL_BASE">Base della coda</string>
-	<string name="ATTACH_TAIL_TIP">Punta della coda</string>
-	<string name="ATTACH_LWING">Ala sinistra</string>
-	<string name="ATTACH_RWING">Ala destra</string>
-	<string name="ATTACH_FACE_JAW">Mandibola</string>
-	<string name="ATTACH_FACE_LEAR">Altro orecchio sinistro</string>
-	<string name="ATTACH_FACE_REAR">Altro orecchio destro</string>
-	<string name="ATTACH_FACE_LEYE">Altro occhio sinistro</string>
-	<string name="ATTACH_FACE_REYE">Altro occhio destro</string>
-	<string name="ATTACH_FACE_TONGUE">Lingua</string>
-	<string name="ATTACH_GROIN">Inguine</string>
-	<string name="ATTACH_HIND_LFOOT">Piede posteriore sinistro</string>
-	<string name="ATTACH_HIND_RFOOT">Piede posteriore destro</string>
-	<string name="CursorPos">Riga [LINE], Colonna [COLUMN]</string>
-	<string name="PanelDirCountFound">[COUNT] trovato/i</string>
-	<string name="PanelContentsTooltip">Contenuto dell'oggetto</string>
-	<string name="PanelContentsNewScript">Nuovo script</string>
-	<string name="DoNotDisturbModeResponseDefault">Questo residente ha attivato la modalità 'Non disturbare' e vedrà il tuo messaggio più tardi.</string>
-	<string name="MuteByName">(In base al nome)</string>
-	<string name="MuteAgent">(Residente)</string>
-	<string name="MuteObject">(Oggetto)</string>
-	<string name="MuteGroup">(Gruppo)</string>
-	<string name="MuteExternal">(esterno)</string>
-	<string name="RegionNoCovenant">Non esiste alcun regolamento per questa proprietà.</string>
-	<string name="RegionNoCovenantOtherOwner">Non esiste alcun regolamento per questa proprietà. Il terreno di questa proprietà è messo in vendita dal proprietario, non dalla Linden Lab.  Contatta il proprietario del terreno per i dettagli della vendita.</string>
+	<string name="Balance">
+		Saldo
+	</string>
+	<string name="Credits">
+		Ringraziamenti
+	</string>
+	<string name="Debits">
+		Debiti
+	</string>
+	<string name="Total">
+		Totale
+	</string>
+	<string name="NoGroupDataFound">
+		Nessun dato trovato per questo gruppo
+	</string>
+	<string name="IMParentEstate">
+		Proprietà principale
+	</string>
+	<string name="IMMainland">
+		continente
+	</string>
+	<string name="IMTeen">
+		teen
+	</string>
+	<string name="Anyone">
+		chiunque
+	</string>
+	<string name="RegionInfoError">
+		errore
+	</string>
+	<string name="RegionInfoAllEstatesOwnedBy">
+		tutte le proprietà immobiliari di [OWNER]
+	</string>
+	<string name="RegionInfoAllEstatesYouOwn">
+		tutte le tue proprietà immobiliari
+	</string>
+	<string name="RegionInfoAllEstatesYouManage">
+		tutte le proprietà immobiliari che gestisci per conto di [OWNER]
+	</string>
+	<string name="RegionInfoAllowedResidents">
+		Sempre consentiti: ([ALLOWEDAGENTS], max [MAXACCESS])
+	</string>
+	<string name="RegionInfoAllowedGroups">
+		Gruppi sempre consentiti: ([ALLOWEDGROUPS], max [MAXACCESS])
+	</string>
+	<string name="RegionInfoBannedResidents">
+		Sempre esclusi: ([BANNEDAGENTS], max [MAXBANNED])
+	</string>
+	<string name="RegionInfoListTypeAllowedAgents">
+		Sempre consentiti:
+	</string>
+	<string name="RegionInfoListTypeBannedAgents">
+		Sempre esclusi:
+	</string>
+	<string name="RegionInfoAllEstates">
+		tutte le proprietà immobiliari
+	</string>
+	<string name="RegionInfoManagedEstates">
+		proprietà immobiliari che gestisci
+	</string>
+	<string name="RegionInfoThisEstate">
+		questa proprietà immobiliare
+	</string>
+	<string name="AndNMore">
+		e [EXTRA_COUNT] ancora
+	</string>
+	<string name="ScriptLimitsParcelScriptMemory">
+		Memoria dello script del lotto
+	</string>
+	<string name="ScriptLimitsParcelsOwned">
+		Lotti in elenco: [PARCELS]
+	</string>
+	<string name="ScriptLimitsMemoryUsed">
+		Memoria utilizzata: [COUNT] kb di [MAX] kb; [AVAILABLE] kb disponibili
+	</string>
+	<string name="ScriptLimitsMemoryUsedSimple">
+		Memoria utilizzata: [COUNT] kb
+	</string>
+	<string name="ScriptLimitsParcelScriptURLs">
+		URL degli script lotti
+	</string>
+	<string name="ScriptLimitsURLsUsed">
+		URL utilizzati: [COUNT] di [MAX]; [AVAILABLE] disponibili
+	</string>
+	<string name="ScriptLimitsURLsUsedSimple">
+		URL utilizzati: [COUNT]
+	</string>
+	<string name="ScriptLimitsRequestError">
+		Errore nella richiesta di informazioni
+	</string>
+	<string name="ScriptLimitsRequestNoParcelSelected">
+		Nessun lotto selezionato
+	</string>
+	<string name="ScriptLimitsRequestWrongRegion">
+		Errore: le informazioni sullo script sono disponibili solo nella tua regione attuale
+	</string>
+	<string name="ScriptLimitsRequestWaiting">
+		Recupero informazioni in corso...
+	</string>
+	<string name="ScriptLimitsRequestDontOwnParcel">
+		Non hai il permesso di visionare questo lotto
+	</string>
+	<string name="SITTING_ON">
+		Seduto su
+	</string>
+	<string name="ATTACH_CHEST">
+		Petto
+	</string>
+	<string name="ATTACH_HEAD">
+		Cranio
+	</string>
+	<string name="ATTACH_LSHOULDER">
+		Spalla sinistra
+	</string>
+	<string name="ATTACH_RSHOULDER">
+		Spalla destra
+	</string>
+	<string name="ATTACH_LHAND">
+		Mano sinistra
+	</string>
+	<string name="ATTACH_RHAND">
+		Mano destra
+	</string>
+	<string name="ATTACH_LFOOT">
+		Piede sinisto
+	</string>
+	<string name="ATTACH_RFOOT">
+		Piede destro
+	</string>
+	<string name="ATTACH_BACK">
+		Spina dorsale
+	</string>
+	<string name="ATTACH_PELVIS">
+		Pelvi
+	</string>
+	<string name="ATTACH_MOUTH">
+		Bocca
+	</string>
+	<string name="ATTACH_CHIN">
+		Mento
+	</string>
+	<string name="ATTACH_LEAR">
+		Orecchio sinistro
+	</string>
+	<string name="ATTACH_REAR">
+		Orecchio destro
+	</string>
+	<string name="ATTACH_LEYE">
+		Occhio sinistro
+	</string>
+	<string name="ATTACH_REYE">
+		Occhio destro
+	</string>
+	<string name="ATTACH_NOSE">
+		Naso
+	</string>
+	<string name="ATTACH_RUARM">
+		Braccio destro
+	</string>
+	<string name="ATTACH_RLARM">
+		Avambraccio destro
+	</string>
+	<string name="ATTACH_LUARM">
+		Braccio sinistro
+	</string>
+	<string name="ATTACH_LLARM">
+		Avambraccio sinistro
+	</string>
+	<string name="ATTACH_RHIP">
+		Anca destra
+	</string>
+	<string name="ATTACH_RULEG">
+		Coscia destra
+	</string>
+	<string name="ATTACH_RLLEG">
+		Coscia destra
+	</string>
+	<string name="ATTACH_LHIP">
+		Anca sinista
+	</string>
+	<string name="ATTACH_LULEG">
+		Coscia sinistra
+	</string>
+	<string name="ATTACH_LLLEG">
+		Polpaccio sinistro
+	</string>
+	<string name="ATTACH_BELLY">
+		Stomaco
+	</string>
+	<string name="ATTACH_LEFT_PEC">
+		Petto sinistro
+	</string>
+	<string name="ATTACH_RIGHT_PEC">
+		Petto destro
+	</string>
+	<string name="ATTACH_HUD_CENTER_2">
+		HUD in centro 2
+	</string>
+	<string name="ATTACH_HUD_TOP_RIGHT">
+		HUD alto a destra
+	</string>
+	<string name="ATTACH_HUD_TOP_CENTER">
+		HUD alto in centro
+	</string>
+	<string name="ATTACH_HUD_TOP_LEFT">
+		HUD alto a sinistra
+	</string>
+	<string name="ATTACH_HUD_CENTER_1">
+		HUD in centro 1
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_LEFT">
+		HUD basso a sinistra
+	</string>
+	<string name="ATTACH_HUD_BOTTOM">
+		HUD basso
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_RIGHT">
+		HUD basso a destra
+	</string>
+	<string name="ATTACH_NECK">
+		Collo
+	</string>
+	<string name="ATTACH_AVATAR_CENTER">
+		Centro avatar
+	</string>
+	<string name="ATTACH_LHAND_RING1">
+		Anulare sinistro
+	</string>
+	<string name="ATTACH_RHAND_RING1">
+		Anulare destro
+	</string>
+	<string name="ATTACH_TAIL_BASE">
+		Base della coda
+	</string>
+	<string name="ATTACH_TAIL_TIP">
+		Punta della coda
+	</string>
+	<string name="ATTACH_LWING">
+		Ala sinistra
+	</string>
+	<string name="ATTACH_RWING">
+		Ala destra
+	</string>
+	<string name="ATTACH_FACE_JAW">
+		Mandibola
+	</string>
+	<string name="ATTACH_FACE_LEAR">
+		Altro orecchio sinistro
+	</string>
+	<string name="ATTACH_FACE_REAR">
+		Altro orecchio destro
+	</string>
+	<string name="ATTACH_FACE_LEYE">
+		Altro occhio sinistro
+	</string>
+	<string name="ATTACH_FACE_REYE">
+		Altro occhio destro
+	</string>
+	<string name="ATTACH_FACE_TONGUE">
+		Lingua
+	</string>
+	<string name="ATTACH_GROIN">
+		Inguine
+	</string>
+	<string name="ATTACH_HIND_LFOOT">
+		Piede posteriore sinistro
+	</string>
+	<string name="ATTACH_HIND_RFOOT">
+		Piede posteriore destro
+	</string>
+	<string name="CursorPos">
+		Riga [LINE], Colonna [COLUMN]
+	</string>
+	<string name="PanelDirCountFound">
+		[COUNT] trovato/i
+	</string>
+	<string name="PanelContentsTooltip">
+		Contenuto dell'oggetto
+	</string>
+	<string name="PanelContentsNewScript">
+		Nuovo script
+	</string>
+	<string name="DoNotDisturbModeResponseDefault">
+		Questo residente ha attivato la modalità 'Non disturbare' e vedrà il tuo messaggio più tardi.
+	</string>
+	<string name="MuteByName">
+		(In base al nome)
+	</string>
+	<string name="MuteAgent">
+		(Residente)
+	</string>
+	<string name="MuteObject">
+		(Oggetto)
+	</string>
+	<string name="MuteGroup">
+		(Gruppo)
+	</string>
+	<string name="MuteExternal">
+		(esterno)
+	</string>
+	<string name="RegionNoCovenant">
+		Non esiste alcun regolamento per questa proprietà.
+	</string>
+	<string name="RegionNoCovenantOtherOwner">
+		Non esiste alcun regolamento per questa proprietà. Il terreno di questa proprietà è messo in vendita dal proprietario, non dalla Linden Lab.  Contatta il proprietario del terreno per i dettagli della vendita.
+	</string>
 	<string name="covenant_last_modified" value="Ultima modifica: "/>
 	<string name="none_text" value="(nessuno)"/>
 	<string name="never_text" value="(mai)"/>
-	<string name="GroupOwned">Di proprietà di un gruppo</string>
-	<string name="Public">Pubblica</string>
-	<string name="LocalSettings">Impostazioni locali</string>
-	<string name="RegionSettings">Impostazioni regione</string>
-	<string name="NoEnvironmentSettings">Questa regione non supporta le impostazioni per l’ambiente.</string>
-	<string name="EnvironmentSun">Sole</string>
-	<string name="EnvironmentMoon">Luna</string>
-	<string name="EnvironmentBloom">Fioritura</string>
-	<string name="EnvironmentCloudNoise">Rumore nuvole</string>
-	<string name="EnvironmentNormalMap">Mappa normale</string>
-	<string name="EnvironmentTransparent">Transparent</string>
-	<string name="ClassifiedClicksTxt">Clicca: [TELEPORT] teleport, [MAP] mappa, [PROFILE] profilo</string>
-	<string name="ClassifiedUpdateAfterPublish">(si aggiornerà dopo la pubblicazione)</string>
-	<string name="NoPicksClassifiedsText">Non hai creato luoghi preferiti né inserzioni. Clicca il pulsante + qui sotto per creare un luogo preferito o un'inserzione.</string>
-	<string name="NoPicksText">Non hai creato Luoghi preferiti. Fai clic sul pulsante Nuovo per creare un Luogo preferito.</string>
-	<string name="NoClassifiedsText">Non hai creato Annunci. Fai clic sul pulsante Nuovo per creare un Annuncio.</string>
-	<string name="NoAvatarPicksClassifiedsText">L'utente non ha luoghi preferiti né inserzioni</string>
-	<string name="NoAvatarPicksText">L'utente non ha luoghi preferiti</string>
-	<string name="NoAvatarClassifiedsText">L'utente non ha annunci</string>
-	<string name="PicksClassifiedsLoadingText">Caricamento in corso...</string>
-	<string name="MultiPreviewTitle">Anteprima</string>
-	<string name="MultiPropertiesTitle">Beni immobiliari</string>
-	<string name="InvOfferAnObjectNamed">Un oggetto denominato</string>
-	<string name="InvOfferOwnedByGroup">di proprietà del gruppo</string>
-	<string name="InvOfferOwnedByUnknownGroup">di proprietà di un gruppo sconosciuto</string>
-	<string name="InvOfferOwnedBy">di proprietà di</string>
-	<string name="InvOfferOwnedByUnknownUser">di proprietà di un utente sconosciuto</string>
-	<string name="InvOfferGaveYou">Ti ha offerto</string>
-	<string name="InvOfferDecline">Non hai accettato [DESC] da &lt;nolink&gt;[NAME]&lt;/nolink&gt;.</string>
-	<string name="GroupMoneyTotal">Totale</string>
-	<string name="GroupMoneyBought">comprato</string>
-	<string name="GroupMoneyPaidYou">ti ha pagato</string>
-	<string name="GroupMoneyPaidInto">ha pagato</string>
-	<string name="GroupMoneyBoughtPassTo">ha comprato il pass</string>
-	<string name="GroupMoneyPaidFeeForEvent">pagato la tassa per l'evento</string>
-	<string name="GroupMoneyPaidPrizeForEvent">pagato il premio per l'evento</string>
-	<string name="GroupMoneyBalance">Saldo</string>
-	<string name="GroupMoneyCredits">Ringraziamenti</string>
-	<string name="GroupMoneyDebits">Debiti</string>
-	<string name="GroupMoneyDate">[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]</string>
-	<string name="AcquiredItems">Oggetti acquisiti</string>
-	<string name="Cancel">Annulla</string>
-	<string name="UploadingCosts">Il caricamento di [NAME] costa L$ [AMOUNT]</string>
-	<string name="BuyingCosts">L'acquisto di [NAME] costa L$ [AMOUNT]</string>
-	<string name="UnknownFileExtension">Estensione del file sconosciuta [.%s]
-Tipi conosciuti .wav, .tga, .bmp, .jpg, .jpeg, or .bvh</string>
-	<string name="MuteObject2">Blocca</string>
-	<string name="AddLandmarkNavBarMenu">Aggiungi punto di riferimento...</string>
-	<string name="EditLandmarkNavBarMenu">Modifica punto di riferimento...</string>
-	<string name="accel-mac-control">⌃</string>
-	<string name="accel-mac-command">⌘</string>
-	<string name="accel-mac-option">⌥</string>
-	<string name="accel-mac-shift">⇧</string>
-	<string name="accel-win-control">Ctrl+</string>
-	<string name="accel-win-alt">Alt+</string>
-	<string name="accel-win-shift">Shift+</string>
-	<string name="FileSaved">File salvato</string>
-	<string name="Receiving">In ricezione</string>
-	<string name="AM">antemeridiane</string>
-	<string name="PM">pomeridiane</string>
-	<string name="PST">Ora Pacifico</string>
-	<string name="PDT">Ora legale Pacifico</string>
-	<string name="Direction_Forward">Avanti</string>
-	<string name="Direction_Left">Sinistra</string>
-	<string name="Direction_Right">Destra</string>
-	<string name="Direction_Back">Indietro</string>
-	<string name="Direction_North">Nord</string>
-	<string name="Direction_South">Sud</string>
-	<string name="Direction_West">Ovest</string>
-	<string name="Direction_East">Est</string>
-	<string name="Direction_Up">Su</string>
-	<string name="Direction_Down">Giù</string>
-	<string name="Any Category">Qualsiasi categoria</string>
-	<string name="Shopping">Acquisti</string>
-	<string name="Land Rental">Affitto terreno</string>
-	<string name="Property Rental">Affitto proprietà</string>
-	<string name="Special Attraction">Attrazioni speciali</string>
-	<string name="New Products">Nuovi prodotti</string>
-	<string name="Employment">Lavoro</string>
-	<string name="Wanted">Cercasi</string>
-	<string name="Service">Servizio</string>
-	<string name="Personal">Personale</string>
-	<string name="None">Nessuno</string>
-	<string name="Linden Location">Luogo dei Linden</string>
-	<string name="Adult">Adult</string>
-	<string name="Arts&amp;Culture">Arte &amp; Cultura</string>
-	<string name="Business">Affari</string>
-	<string name="Educational">Educazione</string>
-	<string name="Gaming">Gioco</string>
-	<string name="Hangout">Divertimento</string>
-	<string name="Newcomer Friendly">Accoglienza nuovi residenti</string>
-	<string name="Parks&amp;Nature">Parchi &amp; Natura</string>
-	<string name="Residential">Residenziale</string>
-	<string name="Stage">Fase</string>
-	<string name="Other">Altro</string>
-	<string name="Rental">Affitto</string>
-	<string name="Any">Tutti</string>
-	<string name="You">Tu</string>
-	<string name="Multiple Media">Più supporti</string>
-	<string name="Play Media">Riproduci/Pausa supporto</string>
-	<string name="IntelDriverPage">http://www.intel.com/p/en_US/support/detect/graphics</string>
-	<string name="NvidiaDriverPage">http://www.nvidia.com/Download/index.aspx?lang=en-us</string>
-	<string name="AMDDriverPage">http://support.amd.com/us/Pages/AMDSupportHub.aspx</string>
-	<string name="MBCmdLineError">Un errore è stato riscontrato analizzando la linea di comando.
+	<string name="GroupOwned">
+		Di proprietà di un gruppo
+	</string>
+	<string name="Public">
+		Pubblica
+	</string>
+	<string name="LocalSettings">
+		Impostazioni locali
+	</string>
+	<string name="RegionSettings">
+		Impostazioni regione
+	</string>
+	<string name="NoEnvironmentSettings">
+		Questa regione non supporta le impostazioni per l’ambiente.
+	</string>
+	<string name="EnvironmentSun">
+		Sole
+	</string>
+	<string name="EnvironmentMoon">
+		Luna
+	</string>
+	<string name="EnvironmentBloom">
+		Fioritura
+	</string>
+	<string name="EnvironmentCloudNoise">
+		Rumore nuvole
+	</string>
+	<string name="EnvironmentNormalMap">
+		Mappa normale
+	</string>
+	<string name="EnvironmentTransparent">
+		Transparent
+	</string>
+	<string name="ClassifiedClicksTxt">
+		Clicca: [TELEPORT] teleport, [MAP] mappa, [PROFILE] profilo
+	</string>
+	<string name="ClassifiedUpdateAfterPublish">
+		(si aggiornerà dopo la pubblicazione)
+	</string>
+	<string name="NoPicksClassifiedsText">
+		Non hai creato luoghi preferiti né inserzioni. Clicca il pulsante + qui sotto per creare un luogo preferito o un'inserzione.
+	</string>
+	<string name="NoPicksText">
+		Non hai creato Luoghi preferiti. Fai clic sul pulsante Nuovo per creare un Luogo preferito.
+	</string>
+	<string name="NoClassifiedsText">
+		Non hai creato Annunci. Fai clic sul pulsante Nuovo per creare un Annuncio.
+	</string>
+	<string name="NoAvatarPicksClassifiedsText">
+		L'utente non ha luoghi preferiti né inserzioni
+	</string>
+	<string name="NoAvatarPicksText">
+		L'utente non ha luoghi preferiti
+	</string>
+	<string name="NoAvatarClassifiedsText">
+		L'utente non ha annunci
+	</string>
+	<string name="PicksClassifiedsLoadingText">
+		Caricamento in corso...
+	</string>
+	<string name="MultiPreviewTitle">
+		Anteprima
+	</string>
+	<string name="MultiPropertiesTitle">
+		Beni immobiliari
+	</string>
+	<string name="InvOfferAnObjectNamed">
+		Un oggetto denominato
+	</string>
+	<string name="InvOfferOwnedByGroup">
+		di proprietà del gruppo
+	</string>
+	<string name="InvOfferOwnedByUnknownGroup">
+		di proprietà di un gruppo sconosciuto
+	</string>
+	<string name="InvOfferOwnedBy">
+		di proprietà di
+	</string>
+	<string name="InvOfferOwnedByUnknownUser">
+		di proprietà di un utente sconosciuto
+	</string>
+	<string name="InvOfferGaveYou">
+		Ti ha offerto
+	</string>
+	<string name="InvOfferDecline">
+		Non hai accettato [DESC] da &lt;nolink&gt;[NAME]&lt;/nolink&gt;.
+	</string>
+	<string name="GroupMoneyTotal">
+		Totale
+	</string>
+	<string name="GroupMoneyBought">
+		comprato
+	</string>
+	<string name="GroupMoneyPaidYou">
+		ti ha pagato
+	</string>
+	<string name="GroupMoneyPaidInto">
+		ha pagato
+	</string>
+	<string name="GroupMoneyBoughtPassTo">
+		ha comprato il pass
+	</string>
+	<string name="GroupMoneyPaidFeeForEvent">
+		pagato la tassa per l'evento
+	</string>
+	<string name="GroupMoneyPaidPrizeForEvent">
+		pagato il premio per l'evento
+	</string>
+	<string name="GroupMoneyBalance">
+		Saldo
+	</string>
+	<string name="GroupMoneyCredits">
+		Ringraziamenti
+	</string>
+	<string name="GroupMoneyDebits">
+		Debiti
+	</string>
+	<string name="GroupMoneyDate">
+		[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]
+	</string>
+	<string name="AcquiredItems">
+		Oggetti acquisiti
+	</string>
+	<string name="Cancel">
+		Annulla
+	</string>
+	<string name="UploadingCosts">
+		Il caricamento di [NAME] costa L$ [AMOUNT]
+	</string>
+	<string name="BuyingCosts">
+		L'acquisto di [NAME] costa L$ [AMOUNT]
+	</string>
+	<string name="UnknownFileExtension">
+		Estensione del file sconosciuta [.%s]
+Tipi conosciuti .wav, .tga, .bmp, .jpg, .jpeg, or .bvh
+	</string>
+	<string name="MuteObject2">
+		Blocca
+	</string>
+	<string name="AddLandmarkNavBarMenu">
+		Aggiungi punto di riferimento...
+	</string>
+	<string name="EditLandmarkNavBarMenu">
+		Modifica punto di riferimento...
+	</string>
+	<string name="accel-mac-control">
+		⌃
+	</string>
+	<string name="accel-mac-command">
+		⌘
+	</string>
+	<string name="accel-mac-option">
+		⌥
+	</string>
+	<string name="accel-mac-shift">
+		⇧
+	</string>
+	<string name="accel-win-control">
+		Ctrl+
+	</string>
+	<string name="accel-win-alt">
+		Alt+
+	</string>
+	<string name="accel-win-shift">
+		Shift+
+	</string>
+	<string name="FileSaved">
+		File salvato
+	</string>
+	<string name="Receiving">
+		In ricezione
+	</string>
+	<string name="AM">
+		antemeridiane
+	</string>
+	<string name="PM">
+		pomeridiane
+	</string>
+	<string name="PST">
+		Ora Pacifico
+	</string>
+	<string name="PDT">
+		Ora legale Pacifico
+	</string>
+	<string name="Direction_Forward">
+		Avanti
+	</string>
+	<string name="Direction_Left">
+		Sinistra
+	</string>
+	<string name="Direction_Right">
+		Destra
+	</string>
+	<string name="Direction_Back">
+		Indietro
+	</string>
+	<string name="Direction_North">
+		Nord
+	</string>
+	<string name="Direction_South">
+		Sud
+	</string>
+	<string name="Direction_West">
+		Ovest
+	</string>
+	<string name="Direction_East">
+		Est
+	</string>
+	<string name="Direction_Up">
+		Su
+	</string>
+	<string name="Direction_Down">
+		Giù
+	</string>
+	<string name="Any Category">
+		Qualsiasi categoria
+	</string>
+	<string name="Shopping">
+		Acquisti
+	</string>
+	<string name="Land Rental">
+		Affitto terreno
+	</string>
+	<string name="Property Rental">
+		Affitto proprietà
+	</string>
+	<string name="Special Attraction">
+		Attrazioni speciali
+	</string>
+	<string name="New Products">
+		Nuovi prodotti
+	</string>
+	<string name="Employment">
+		Lavoro
+	</string>
+	<string name="Wanted">
+		Cercasi
+	</string>
+	<string name="Service">
+		Servizio
+	</string>
+	<string name="Personal">
+		Personale
+	</string>
+	<string name="None">
+		Nessuno
+	</string>
+	<string name="Linden Location">
+		Luogo dei Linden
+	</string>
+	<string name="Adult">
+		Adult
+	</string>
+	<string name="Arts&amp;Culture">
+		Arte &amp; Cultura
+	</string>
+	<string name="Business">
+		Affari
+	</string>
+	<string name="Educational">
+		Educazione
+	</string>
+	<string name="Gaming">
+		Gioco
+	</string>
+	<string name="Hangout">
+		Divertimento
+	</string>
+	<string name="Newcomer Friendly">
+		Accoglienza nuovi residenti
+	</string>
+	<string name="Parks&amp;Nature">
+		Parchi &amp; Natura
+	</string>
+	<string name="Residential">
+		Residenziale
+	</string>
+	<string name="Stage">
+		Fase
+	</string>
+	<string name="Other">
+		Altro
+	</string>
+	<string name="Rental">
+		Affitto
+	</string>
+	<string name="Any">
+		Tutti
+	</string>
+	<string name="You">
+		Tu
+	</string>
+	<string name="Multiple Media">
+		Più supporti
+	</string>
+	<string name="Play Media">
+		Riproduci/Pausa supporto
+	</string>
+	<string name="IntelDriverPage">
+		http://www.intel.com/p/en_US/support/detect/graphics
+	</string>
+	<string name="NvidiaDriverPage">
+		http://www.nvidia.com/Download/index.aspx?lang=en-us
+	</string>
+	<string name="AMDDriverPage">
+		http://support.amd.com/us/Pages/AMDSupportHub.aspx
+	</string>
+	<string name="MBCmdLineError">
+		Un errore è stato riscontrato analizzando la linea di comando.
 Per informazioni: http://wiki.secondlife.com/wiki/Client_parameters
-Errore:</string>
-	<string name="MBCmdLineUsg">Uso linea di comando del programma [APP_NAME] :</string>
-	<string name="MBUnableToAccessFile">Il programma [APP_NAME] non è in grado di accedere ad un file necessario.
+Errore:
+	</string>
+	<string name="MBCmdLineUsg">
+		Uso linea di comando del programma [APP_NAME] :
+	</string>
+	<string name="MBUnableToAccessFile">
+		Il programma [APP_NAME] non è in grado di accedere ad un file necessario.
 
 Potrebbe darsi che tu abbia copie multiple attivate o che il tuo sistema reputi erroneamente che il file sia già aperto.
 Se il problema persiste, riavvia il computer e riprova.
-Se il problema continua ancora, dovresti completamente disinstallare l'applicazione [APP_NAME] e reinstallarla.</string>
-	<string name="MBFatalError">Errore critico</string>
-	<string name="MBRequiresAltiVec">Il programma [APP_NAME] richiede un processore con AltiVec (G4 o superiore).</string>
-	<string name="MBAlreadyRunning">Il programma [APP_NAME] è già attivo.
+Se il problema continua ancora, dovresti completamente disinstallare l'applicazione [APP_NAME] e reinstallarla.
+	</string>
+	<string name="MBFatalError">
+		Errore critico
+	</string>
+	<string name="MBRequiresAltiVec">
+		Il programma [APP_NAME] richiede un processore con AltiVec (G4 o superiore).
+	</string>
+	<string name="MBAlreadyRunning">
+		Il programma [APP_NAME] è già attivo.
 Controlla che il programma non sia minimizzato nella tua barra degli strumenti.
-Se il messaggio persiste, riavvia il computer.</string>
-	<string name="MBFrozenCrashed">Sembra che [APP_NAME] si sia bloccata o interrotta nella sessione precedente.
-Vuoi mandare un crash report?</string>
-	<string name="MBAlert">Avviso</string>
-	<string name="MBNoDirectX">Il programmma [APP_NAME] non riesce a trovare una DirectX 9.0b o superiore.
+Se il messaggio persiste, riavvia il computer.
+	</string>
+	<string name="MBFrozenCrashed">
+		Sembra che [APP_NAME] si sia bloccata o interrotta nella sessione precedente.
+Vuoi mandare un crash report?
+	</string>
+	<string name="MBAlert">
+		Avviso
+	</string>
+	<string name="MBNoDirectX">
+		Il programmma [APP_NAME] non riesce a trovare una DirectX 9.0b o superiore.
 [APP_NAME] usa DirectX per rilevare hardware e/o i driver  non aggiornati che possono causare problemi di stabilità, scarsa performance e interruzioni.  Benché tu possa avviare il programma [APP_NAME] senza di esse, consigliamo caldamente l'esecuzione con DirectX 9.0b.
 
-Vuoi continuare?</string>
-	<string name="MBWarning">Attenzione</string>
-	<string name="MBNoAutoUpdate">L'aggiornamento automatico non è stato ancora realizzato per Linux.
-Consigliamo di scaricare l'ultima versione direttamente da www.secondlife.com.</string>
-	<string name="MBRegClassFailed">RegisterClass non riuscito</string>
-	<string name="MBError">Errore</string>
-	<string name="MBFullScreenErr">Impossibile visualizzare a schermo intero con risoluzione [WIDTH] x [HEIGHT].
-Visualizzazione corrente in modalità finestra.</string>
-	<string name="MBDestroyWinFailed">Errore di arresto durante il tentativo di chiusura della finestra (DestroyWindow() non riuscito)</string>
-	<string name="MBShutdownErr">Errore di arresto</string>
-	<string name="MBDevContextErr">Impossibile caricare i driver GL</string>
-	<string name="MBPixelFmtErr">Impossibile trovare un formato pixel adatto</string>
-	<string name="MBPixelFmtDescErr">Impossibile ottenere una descrizione del formato pixel</string>
-	<string name="MBTrueColorWindow">[APP_NAME] richiede True Color (32 bit) per funzionare.
-Vai alle impostazioni dello schermo del tuo computer e imposta il colore in modalità 32 bit.</string>
-	<string name="MBAlpha">[APP_NAME] non funziona poichè è impossibile trovare un canale alpha a 8 bit.  Questo problema normalmente deriva dai driver della scheda video.
+Vuoi continuare?
+	</string>
+	<string name="MBWarning">
+		Attenzione
+	</string>
+	<string name="MBNoAutoUpdate">
+		L'aggiornamento automatico non è stato ancora realizzato per Linux.
+Consigliamo di scaricare l'ultima versione direttamente da www.secondlife.com.
+	</string>
+	<string name="MBRegClassFailed">
+		RegisterClass non riuscito
+	</string>
+	<string name="MBError">
+		Errore
+	</string>
+	<string name="MBFullScreenErr">
+		Impossibile visualizzare a schermo intero con risoluzione [WIDTH] x [HEIGHT].
+Visualizzazione corrente in modalità finestra.
+	</string>
+	<string name="MBDestroyWinFailed">
+		Errore di arresto durante il tentativo di chiusura della finestra (DestroyWindow() non riuscito)
+	</string>
+	<string name="MBShutdownErr">
+		Errore di arresto
+	</string>
+	<string name="MBDevContextErr">
+		Impossibile caricare i driver GL
+	</string>
+	<string name="MBPixelFmtErr">
+		Impossibile trovare un formato pixel adatto
+	</string>
+	<string name="MBPixelFmtDescErr">
+		Impossibile ottenere una descrizione del formato pixel
+	</string>
+	<string name="MBTrueColorWindow">
+		[APP_NAME] richiede True Color (32 bit) per funzionare.
+Vai alle impostazioni dello schermo del tuo computer e imposta il colore in modalità 32 bit.
+	</string>
+	<string name="MBAlpha">
+		[APP_NAME] non funziona poichè è impossibile trovare un canale alpha a 8 bit.  Questo problema normalmente deriva dai driver della scheda video.
 Assicurati di avere installato i driver della scheda video più recenti.
 Assicurati anche che il monitor sia impostato a True Color (32 bit) nel Pannello di controllo &gt; Schermo &gt; Impostazioni.
-Se il messaggio persiste, contatta [SUPPORT_SITE].</string>
-	<string name="MBPixelFmtSetErr">Impossibile impostare il formato pixel</string>
-	<string name="MBGLContextErr">Impossibile creare il GL rendering</string>
-	<string name="MBGLContextActErr">Impossibile attivare il GL rendering</string>
-	<string name="MBVideoDrvErr">[APP_NAME] Non riesce ad avviarsi perchè i driver della tua scheda video non sono stati installati correttamente, non sono aggiornati, o sono per un hardware non supportato. Assicurati di avere i driver della scheda video più recenti e anche se li hai installati, prova a installarli di nuovo.
+Se il messaggio persiste, contatta [SUPPORT_SITE].
+	</string>
+	<string name="MBPixelFmtSetErr">
+		Impossibile impostare il formato pixel
+	</string>
+	<string name="MBGLContextErr">
+		Impossibile creare il GL rendering
+	</string>
+	<string name="MBGLContextActErr">
+		Impossibile attivare il GL rendering
+	</string>
+	<string name="MBVideoDrvErr">
+		[APP_NAME] Non riesce ad avviarsi perchè i driver della tua scheda video non sono stati installati correttamente, non sono aggiornati, o sono per un hardware non supportato. Assicurati di avere i driver della scheda video più recenti e anche se li hai installati, prova a installarli di nuovo.
 
-Se il messaggio persiste, contatta [SUPPORT_SITE].</string>
-	<string name="5 O'Clock Shadow">Barba leggera</string>
-	<string name="All White">Tutti bianchi</string>
-	<string name="Anime Eyes">Occhi grandi</string>
-	<string name="Arced">Arcuato</string>
-	<string name="Arm Length">Lunghezza braccia</string>
-	<string name="Attached">Attaccato</string>
-	<string name="Attached Earlobes">Lobi attaccati</string>
-	<string name="Back Fringe">Frangetta all'indietro</string>
-	<string name="Baggy">Larghi</string>
-	<string name="Bangs">Frange</string>
-	<string name="Beady Eyes">Occhi piccoli</string>
-	<string name="Belly Size">Punto vita</string>
-	<string name="Big">Grande</string>
-	<string name="Big Butt">Sedere grande</string>
-	<string name="Big Hair Back">Capigliatura grande: Indietro</string>
-	<string name="Big Hair Front">Capigliatura grande: anteriore</string>
-	<string name="Big Hair Top">Capigliatura grande: in  alto</string>
-	<string name="Big Head">Grande testa</string>
-	<string name="Big Pectorals">Grandi pettorali</string>
-	<string name="Big Spikes">Capelli con punte</string>
-	<string name="Black">Nero</string>
-	<string name="Blonde">Biondo</string>
-	<string name="Blonde Hair">Capelli biondi</string>
-	<string name="Blush">Fard</string>
-	<string name="Blush Color">Colore fard</string>
-	<string name="Blush Opacity">Opacità fard</string>
-	<string name="Body Definition">Definizione muscolare</string>
-	<string name="Body Fat">Grasso corporeo</string>
-	<string name="Body Freckles">Lentiggini e nei</string>
-	<string name="Body Thick">Corpo più robusto</string>
-	<string name="Body Thickness">Robustezza del corpo</string>
-	<string name="Body Thin">Corpo più magro</string>
-	<string name="Bow Legged">Gambe arcuate</string>
-	<string name="Breast Buoyancy">Altezza del seno</string>
-	<string name="Breast Cleavage">Décolleté</string>
-	<string name="Breast Size">Grandezza del seno</string>
-	<string name="Bridge Width">Larghezza setto</string>
-	<string name="Broad">Largo</string>
-	<string name="Brow Size">Grandezza delle sopracciglia</string>
-	<string name="Bug Eyes">Occhi sporgenti</string>
-	<string name="Bugged Eyes">Occhi sporgenti</string>
-	<string name="Bulbous">Bulboso</string>
-	<string name="Bulbous Nose">Naso bulboso</string>
-	<string name="Breast Physics Mass">Massa seno</string>
-	<string name="Breast Physics Smoothing">Lisciatura seno</string>
-	<string name="Breast Physics Gravity">Gravità seno</string>
-	<string name="Breast Physics Drag">Resistenza seno</string>
-	<string name="Breast Physics InOut Max Effect">Massimo effetto</string>
-	<string name="Breast Physics InOut Spring">Elasticità</string>
-	<string name="Breast Physics InOut Gain">Guadagno</string>
-	<string name="Breast Physics InOut Damping">Attenuazione</string>
-	<string name="Breast Physics UpDown Max Effect">Massimo effetto</string>
-	<string name="Breast Physics UpDown Spring">Elasticità</string>
-	<string name="Breast Physics UpDown Gain">Guadagno</string>
-	<string name="Breast Physics UpDown Damping">Attenuazione</string>
-	<string name="Breast Physics LeftRight Max Effect">Massimo effetto</string>
-	<string name="Breast Physics LeftRight Spring">Elasticità</string>
-	<string name="Breast Physics LeftRight Gain">Guadagno</string>
-	<string name="Breast Physics LeftRight Damping">Attenuazione</string>
-	<string name="Belly Physics Mass">Massa pancia</string>
-	<string name="Belly Physics Smoothing">Lisciatura pancia</string>
-	<string name="Belly Physics Gravity">Gravità pancia</string>
-	<string name="Belly Physics Drag">Resistenza pancia</string>
-	<string name="Belly Physics UpDown Max Effect">Massimo effetto</string>
-	<string name="Belly Physics UpDown Spring">Elasticità</string>
-	<string name="Belly Physics UpDown Gain">Guadagno</string>
-	<string name="Belly Physics UpDown Damping">Attenuazione</string>
-	<string name="Butt Physics Mass">Massa natiche</string>
-	<string name="Butt Physics Smoothing">Lisciatura natiche</string>
-	<string name="Butt Physics Gravity">Gravità natiche</string>
-	<string name="Butt Physics Drag">Resistenza natiche</string>
-	<string name="Butt Physics UpDown Max Effect">Massimo effetto</string>
-	<string name="Butt Physics UpDown Spring">Elasticità</string>
-	<string name="Butt Physics UpDown Gain">Guadagno</string>
-	<string name="Butt Physics UpDown Damping">Attenuazione</string>
-	<string name="Butt Physics LeftRight Max Effect">Massimo effetto</string>
-	<string name="Butt Physics LeftRight Spring">Elasticità</string>
-	<string name="Butt Physics LeftRight Gain">Guadagno</string>
-	<string name="Butt Physics LeftRight Damping">Attenuazione</string>
-	<string name="Bushy Eyebrows">Sopracciglia cespugliose</string>
-	<string name="Bushy Hair">Capelli a cespuglio</string>
-	<string name="Butt Size">Grandezza del sedere</string>
-	<string name="Butt Gravity">Gravità natiche</string>
-	<string name="bustle skirt">Crinolina</string>
-	<string name="no bustle">Nessuna crinolina</string>
-	<string name="more bustle">Più crinolina</string>
-	<string name="Chaplin">Baffetti</string>
-	<string name="Cheek Bones">Zigomi</string>
-	<string name="Chest Size">Ampiezza del torace</string>
-	<string name="Chin Angle">Angolo del mento</string>
-	<string name="Chin Cleft">Fossetta sul mento</string>
-	<string name="Chin Curtains">Barba sottomento</string>
-	<string name="Chin Depth">Profondità mento</string>
-	<string name="Chin Heavy">Mento forte</string>
-	<string name="Chin In">Mento in dentro</string>
-	<string name="Chin Out">Mento sporgente</string>
-	<string name="Chin-Neck">Mento-collo</string>
-	<string name="Clear">Trasparente</string>
-	<string name="Cleft">Fossetta</string>
-	<string name="Close Set Eyes">Occhi ravvicinati</string>
-	<string name="Closed">Chiusa</string>
-	<string name="Closed Back">Chiuso dietro</string>
-	<string name="Closed Front">Chiuso davanti</string>
-	<string name="Closed Left">Chiuso sinistra</string>
-	<string name="Closed Right">Chiuso destra</string>
-	<string name="Coin Purse">Meno pronunciati</string>
-	<string name="Collar Back">Colletto posteriore</string>
-	<string name="Collar Front">Colletto anteriore</string>
-	<string name="Corner Down">Angolo all'ingiù</string>
-	<string name="Corner Up">Angolo all'insù</string>
-	<string name="Creased">Piega</string>
-	<string name="Crooked Nose">Naso storto</string>
-	<string name="Cuff Flare">Svasato con risvolto</string>
-	<string name="Dark">Scuro</string>
-	<string name="Dark Green">Verde scuro</string>
-	<string name="Darker">Più scuro</string>
-	<string name="Deep">Profondo</string>
-	<string name="Default Heels">Tacchi standard</string>
-	<string name="Dense">Folti</string>
-	<string name="Double Chin">Doppio mento</string>
-	<string name="Downturned">All'ingiù</string>
-	<string name="Duffle Bag">Più pronunciati</string>
-	<string name="Ear Angle">Angolo orecchie</string>
-	<string name="Ear Size">Grandezza orecchie</string>
-	<string name="Ear Tips">Estremità orecchie</string>
-	<string name="Egg Head">Ovalizzazione testa</string>
-	<string name="Eye Bags">Occhiaie</string>
-	<string name="Eye Color">Colore degli occhi</string>
-	<string name="Eye Depth">Profondità degli occhi</string>
-	<string name="Eye Lightness">Luminosità degli occhi</string>
-	<string name="Eye Opening">Apertura degli occhi</string>
-	<string name="Eye Pop">Prominenza degli occhi</string>
-	<string name="Eye Size">Grandezza occhi</string>
-	<string name="Eye Spacing">Distanza occhi</string>
-	<string name="Eyebrow Arc">Arco delle sopracciglia</string>
-	<string name="Eyebrow Density">Densità delle sopracciglia</string>
-	<string name="Eyebrow Height">Altezza delle sopracciglia</string>
-	<string name="Eyebrow Points">Sopracciglia appuntite</string>
-	<string name="Eyebrow Size">Grandezza sopracciglia</string>
-	<string name="Eyelash Length">Lunghezza delle ciglia</string>
-	<string name="Eyeliner">Eyeliner</string>
-	<string name="Eyeliner Color">Colore dell'eyeliner</string>
-	<string name="Eyes Bugged">Occhi sporgenti</string>
-	<string name="Face Shear">Taglio del viso</string>
-	<string name="Facial Definition">Definizione del viso</string>
-	<string name="Far Set Eyes">Occhi distanti</string>
-	<string name="Fat Lips">Labbra carnose</string>
-	<string name="Female">Femmina</string>
-	<string name="Fingerless">Senza dita</string>
-	<string name="Fingers">Dita</string>
-	<string name="Flared Cuffs">Risvolti svasati</string>
-	<string name="Flat">Piatto</string>
-	<string name="Flat Butt">Sedere piatto</string>
-	<string name="Flat Head">Testa piatta</string>
-	<string name="Flat Toe">Punta piatta</string>
-	<string name="Foot Size">Misura piede</string>
-	<string name="Forehead Angle">Angolo della fronte</string>
-	<string name="Forehead Heavy">Fronte sporgente</string>
-	<string name="Freckles">Lentiggini</string>
-	<string name="Front Fringe">Frangetta</string>
-	<string name="Full Back">Dietro gonfi</string>
-	<string name="Full Eyeliner">Eyeliner marcato</string>
-	<string name="Full Front">Anteriore gonfio</string>
-	<string name="Full Hair Sides">Lati capelli gonfi</string>
-	<string name="Full Sides">Lati gonfi</string>
-	<string name="Glossy">Lucido</string>
-	<string name="Glove Fingers">Dita con guanti</string>
-	<string name="Glove Length">Lunghezza guanti</string>
-	<string name="Hair">Capigliature</string>
-	<string name="Hair Back">Capelli: Indietro</string>
-	<string name="Hair Front">Capelli: anteriore</string>
-	<string name="Hair Sides">Capelli: lati</string>
-	<string name="Hair Sweep">Direzione capigliatura</string>
-	<string name="Hair Thickess">Foltezza</string>
-	<string name="Hair Thickness">Foltezza</string>
-	<string name="Hair Tilt">Inclinazione</string>
-	<string name="Hair Tilted Left">Verso sinistra</string>
-	<string name="Hair Tilted Right">Verso destra</string>
-	<string name="Hair Volume">Capelli: Volume</string>
-	<string name="Hand Size">Grandezza mani</string>
-	<string name="Handlebars">Baffi a manubrio</string>
-	<string name="Head Length">Lunghezza testa</string>
-	<string name="Head Shape">Forma della testa</string>
-	<string name="Head Size">Grandezza della testa</string>
-	<string name="Head Stretch">Allungamento testa</string>
-	<string name="Heel Height">Altezza tacchi</string>
-	<string name="Heel Shape">Forma tacchi</string>
-	<string name="Height">Altezza</string>
-	<string name="High">Alto</string>
-	<string name="High Heels">Tacchi alti</string>
-	<string name="High Jaw">Mandibola alta</string>
-	<string name="High Platforms">Alta</string>
-	<string name="High and Tight">Alto e stretto</string>
-	<string name="Higher">Più alto</string>
-	<string name="Hip Length">Altezza bacino</string>
-	<string name="Hip Width">Larghezza bacino</string>
-	<string name="Hover">Muovi sopra</string>
-	<string name="In">Dentro</string>
-	<string name="In Shdw Color">Colore ombretto interno</string>
-	<string name="In Shdw Opacity">Opacità ombretto interno</string>
-	<string name="Inner Eye Corner">Angolo interno</string>
-	<string name="Inner Eye Shadow">Ombretto interno</string>
-	<string name="Inner Shadow">Ombretto interno</string>
-	<string name="Jacket Length">Lunghezza giacca</string>
-	<string name="Jacket Wrinkles">Grinze della giacca</string>
-	<string name="Jaw Angle">Angolo mandibola</string>
-	<string name="Jaw Jut">Prognatismo mento</string>
-	<string name="Jaw Shape">Forma del mento</string>
-	<string name="Join">Iscriviti</string>
-	<string name="Jowls">Guance</string>
-	<string name="Knee Angle">Angolo ginocchia</string>
-	<string name="Knock Kneed">Gambe ad X</string>
-	<string name="Large">Grande</string>
-	<string name="Large Hands">Mani grandi</string>
-	<string name="Left Part">Riga a sinistra</string>
-	<string name="Leg Length">Lunghezza gambe</string>
-	<string name="Leg Muscles">Muscoli gambe</string>
-	<string name="Less">Meno</string>
-	<string name="Less Body Fat">Meno grasso corporeo</string>
-	<string name="Less Curtains">Meno</string>
-	<string name="Less Freckles">Meno lentiggini</string>
-	<string name="Less Full">Meno piene</string>
-	<string name="Less Gravity">Più alto</string>
-	<string name="Less Love">Meno maniglie</string>
-	<string name="Less Muscles">Meno muscoli</string>
-	<string name="Less Muscular">Meno muscolari</string>
-	<string name="Less Rosy">Meno rosato</string>
-	<string name="Less Round">Meno rotondo</string>
-	<string name="Less Saddle">Meno a sella</string>
-	<string name="Less Square">Meno quadrato</string>
-	<string name="Less Volume">Meno volume</string>
-	<string name="Less soul">Meno</string>
-	<string name="Lighter">Più leggero</string>
-	<string name="Lip Cleft">Distanza fossetta labbro</string>
-	<string name="Lip Cleft Depth">Prof. fossetta labbro</string>
-	<string name="Lip Fullness">Volume labbra</string>
-	<string name="Lip Pinkness">Tonalità rosa labbra</string>
-	<string name="Lip Ratio">Proporzione labbra</string>
-	<string name="Lip Thickness">Carnosità labbra</string>
-	<string name="Lip Width">Larghezza labbra</string>
-	<string name="Lipgloss">Lipgloss</string>
-	<string name="Lipstick">Rossetto</string>
-	<string name="Lipstick Color">Colore rossetto</string>
-	<string name="Long">Lungo</string>
-	<string name="Long Head">Testa lunga</string>
-	<string name="Long Hips">Bacino alto</string>
-	<string name="Long Legs">Gambe lunghe</string>
-	<string name="Long Neck">Collo lungo</string>
-	<string name="Long Pigtails">Codini lunghi</string>
-	<string name="Long Ponytail">Codino lungo</string>
-	<string name="Long Torso">Torace lungo</string>
-	<string name="Long arms">Braccia lunghe</string>
-	<string name="Loose Pants">Pantaloni ampi</string>
-	<string name="Loose Shirt">Camicia ampia</string>
-	<string name="Loose Sleeves">Maniche non attillate</string>
-	<string name="Love Handles">Maniglie dell'amore</string>
-	<string name="Low">Basso</string>
-	<string name="Low Heels">Tacchi bassi</string>
-	<string name="Low Jaw">Mandibola bassa</string>
-	<string name="Low Platforms">Bassa</string>
-	<string name="Low and Loose">Basso e ampio</string>
-	<string name="Lower">Più basso</string>
-	<string name="Lower Bridge">Parte bassa del setto</string>
-	<string name="Lower Cheeks">Guance inferiori</string>
-	<string name="Male">Maschio</string>
-	<string name="Middle Part">Riga nel mezzo</string>
-	<string name="More">Altro</string>
-	<string name="More Blush">Più fard</string>
-	<string name="More Body Fat">Più grasso corporeo</string>
-	<string name="More Curtains">Più</string>
-	<string name="More Eyeshadow">Più ombretto</string>
-	<string name="More Freckles">Più lentiggini</string>
-	<string name="More Full">Più piene</string>
-	<string name="More Gravity">Più calato</string>
-	<string name="More Lipstick">Più rossetto</string>
-	<string name="More Love">Più maniglie</string>
-	<string name="More Lower Lip">Labbro inf. pronunciato</string>
-	<string name="More Muscles">Più muscoli</string>
-	<string name="More Muscular">Più muscolatura</string>
-	<string name="More Rosy">Più rosato</string>
-	<string name="More Round">Più rotondo</string>
-	<string name="More Saddle">Più a sella</string>
-	<string name="More Sloped">Più orizzontale</string>
-	<string name="More Square">Più quadrato</string>
-	<string name="More Upper Lip">Labbro sup. pronunciato</string>
-	<string name="More Vertical">Più verticale</string>
-	<string name="More Volume">Più volume</string>
-	<string name="More soul">Più</string>
-	<string name="Moustache">Baffi</string>
-	<string name="Mouth Corner">Angolo della bocca</string>
-	<string name="Mouth Position">Posizione della bocca</string>
-	<string name="Mowhawk">Moicana</string>
-	<string name="Muscular">Muscolatura</string>
-	<string name="Mutton Chops">Basette lunghe</string>
-	<string name="Nail Polish">Smalto</string>
-	<string name="Nail Polish Color">Colore smalto</string>
-	<string name="Narrow">Socchiusi</string>
-	<string name="Narrow Back">Laterali post. vicini</string>
-	<string name="Narrow Front">Laterali ant. vicini</string>
-	<string name="Narrow Lips">Labbra strette</string>
-	<string name="Natural">Naturale</string>
-	<string name="Neck Length">Lunghezza del collo</string>
-	<string name="Neck Thickness">Grandezza del collo</string>
-	<string name="No Blush">Senza fard</string>
-	<string name="No Eyeliner">Senza eyeliner</string>
-	<string name="No Eyeshadow">Senza ombretto</string>
-	<string name="No Lipgloss">Senza lipgloss</string>
-	<string name="No Lipstick">Senza rossetto</string>
-	<string name="No Part">Senza riga</string>
-	<string name="No Polish">Senza smalto</string>
-	<string name="No Red">Senza rosso</string>
-	<string name="No Spikes">Senza punte</string>
-	<string name="No White">Senza bianco</string>
-	<string name="No Wrinkles">Senza pieghe</string>
-	<string name="Normal Lower">Inferiore normale</string>
-	<string name="Normal Upper">Superiore normale</string>
-	<string name="Nose Left">Naso a sinistra</string>
-	<string name="Nose Right">Naso a destra</string>
-	<string name="Nose Size">Grandezza naso</string>
-	<string name="Nose Thickness">Spessore naso</string>
-	<string name="Nose Tip Angle">Angolo punta naso</string>
-	<string name="Nose Tip Shape">Forma punta naso</string>
-	<string name="Nose Width">Larghezza naso</string>
-	<string name="Nostril Division">Divisione narici</string>
-	<string name="Nostril Width">Larghezza narici</string>
-	<string name="Opaque">Opaco</string>
-	<string name="Open">Apri</string>
-	<string name="Open Back">Retro aperto</string>
-	<string name="Open Front">Davanti aperto</string>
-	<string name="Open Left">Lato sin. aperto</string>
-	<string name="Open Right">Lato des. aperto</string>
-	<string name="Orange">Arancio</string>
-	<string name="Out">Fuori</string>
-	<string name="Out Shdw Color">Colore ombretto esterno</string>
-	<string name="Out Shdw Opacity">Opacità ombretto esterno</string>
-	<string name="Outer Eye Corner">Angolo esterno occhio</string>
-	<string name="Outer Eye Shadow">Ombretto esterno</string>
-	<string name="Outer Shadow">Ombreggiatura esterna</string>
-	<string name="Overbite">Denti sup. in fuori</string>
-	<string name="Package">Genitali</string>
-	<string name="Painted Nails">Unghie smaltate</string>
-	<string name="Pale">Pallido</string>
-	<string name="Pants Crotch">Cavallo</string>
-	<string name="Pants Fit">Vestibilità pantaloni</string>
-	<string name="Pants Length">Lunghezza pantaloni</string>
-	<string name="Pants Waist">Taglia pantalone</string>
-	<string name="Pants Wrinkles">Pantaloni con le grinze</string>
-	<string name="Part">Con riga</string>
-	<string name="Part Bangs">Frangetta divisa</string>
-	<string name="Pectorals">Pettorali</string>
-	<string name="Pigment">Pigmento</string>
-	<string name="Pigtails">Codini</string>
-	<string name="Pink">Rosa</string>
-	<string name="Pinker">Più rosato</string>
-	<string name="Platform Height">Altezza pianta</string>
-	<string name="Platform Width">Larghezza pianta</string>
-	<string name="Pointy">Appuntito</string>
-	<string name="Pointy Heels">Tacchi a spillo</string>
-	<string name="Ponytail">Codino</string>
-	<string name="Poofy Skirt">Gonna gonfia</string>
-	<string name="Pop Left Eye">Sinistro più aperto</string>
-	<string name="Pop Right Eye">Destro più aperto</string>
-	<string name="Puffy">Paffute</string>
-	<string name="Puffy Eyelids">Palpebre gonfie</string>
-	<string name="Rainbow Color">Tonalità</string>
-	<string name="Red Hair">Presenza di rosso nei capelli</string>
-	<string name="Regular">Normale</string>
-	<string name="Right Part">Riga a destra</string>
-	<string name="Rosy Complexion">Incarnato</string>
-	<string name="Round">Rotondo</string>
-	<string name="Ruddiness">Rossore</string>
-	<string name="Ruddy">Rosse</string>
-	<string name="Rumpled Hair">Capelli mossi</string>
-	<string name="Saddle Bags">Rotondità fianchi</string>
-	<string name="Scrawny Leg">Gambe magre</string>
-	<string name="Separate">Separati</string>
-	<string name="Shallow">Meno pronunciato</string>
-	<string name="Shear Back">Taglio posteriore</string>
-	<string name="Shear Face">Taglio del viso</string>
-	<string name="Shear Front">Taglio anteriore</string>
-	<string name="Shear Left Up">Distorto a sinistra</string>
-	<string name="Shear Right Up">Distorto a destra</string>
-	<string name="Sheared Back">Taglio verso dietro</string>
-	<string name="Sheared Front">Taglio verso davanti</string>
-	<string name="Shift Left">A sinistra</string>
-	<string name="Shift Mouth">Spostamento bocca</string>
-	<string name="Shift Right">A destra</string>
-	<string name="Shirt Bottom">Parte inferiore camicia</string>
-	<string name="Shirt Fit">Vestibilità camicia</string>
-	<string name="Shirt Wrinkles">Camicia con le grinze</string>
-	<string name="Shoe Height">Altezza scarpe</string>
-	<string name="Short">Basso</string>
-	<string name="Short Arms">Braccia corte</string>
-	<string name="Short Legs">Gambe corte</string>
-	<string name="Short Neck">Collo corto</string>
-	<string name="Short Pigtails">Codini corti</string>
-	<string name="Short Ponytail">Codino corto</string>
-	<string name="Short Sideburns">Basette corte</string>
-	<string name="Short Torso">Torace corto</string>
-	<string name="Short hips">Bacino corto</string>
-	<string name="Shoulders">Spalle</string>
-	<string name="Side Fringe">Ciuffi laterali</string>
-	<string name="Sideburns">Basette</string>
-	<string name="Sides Hair">Capigliatura di lato</string>
-	<string name="Sides Hair Down">Capigliatura di lato sciolta</string>
-	<string name="Sides Hair Up">Capigliatura di lato raccolta</string>
-	<string name="Skinny Neck">Collo fino</string>
-	<string name="Skirt Fit">Vestibilità gonna</string>
-	<string name="Skirt Length">Lunghezza gonna</string>
-	<string name="Slanted Forehead">Fronte inclinata</string>
-	<string name="Sleeve Length">Lunghezza maniche</string>
-	<string name="Sleeve Looseness">Morbidezza maniche</string>
-	<string name="Slit Back">Spacco: Indietro</string>
-	<string name="Slit Front">Spacco: anteriore</string>
-	<string name="Slit Left">Spacco: Sinistra</string>
-	<string name="Slit Right">Spacco: Destra</string>
-	<string name="Small">Piccola</string>
-	<string name="Small Hands">Mani piccole</string>
-	<string name="Small Head">Testa piccola</string>
-	<string name="Smooth">Liscio</string>
-	<string name="Smooth Hair">Capelli lisci</string>
-	<string name="Socks Length">Lunghezza calze</string>
-	<string name="Soulpatch">Pizzetto labbro inferiore</string>
-	<string name="Sparse">Piu rade</string>
-	<string name="Spiked Hair">Capelli a punta</string>
-	<string name="Square">Quadrato</string>
-	<string name="Square Toe">Punta quadrata</string>
-	<string name="Squash Head">Testa schiacciata</string>
-	<string name="Stretch Head">Testa allungata</string>
-	<string name="Sunken">Scarne</string>
-	<string name="Sunken Chest">Senza pettorali</string>
-	<string name="Sunken Eyes">Occhi infossati</string>
-	<string name="Sweep Back">Indietro</string>
-	<string name="Sweep Forward">Avanti</string>
-	<string name="Tall">Alto</string>
-	<string name="Taper Back">Ravv. lat. posteriore</string>
-	<string name="Taper Front">Ravv. lat. frontale</string>
-	<string name="Thick Heels">Tacchi spessi</string>
-	<string name="Thick Neck">Collo grosso</string>
-	<string name="Thick Toe">Punta spessa</string>
-	<string name="Thin">Sottili</string>
-	<string name="Thin Eyebrows">Sopracciglia sottili</string>
-	<string name="Thin Lips">Labbra sottili</string>
-	<string name="Thin Nose">Naso sottile</string>
-	<string name="Tight Chin">Mento stretto</string>
-	<string name="Tight Cuffs">Fondo stretto</string>
-	<string name="Tight Pants">Pantaloni attillati</string>
-	<string name="Tight Shirt">Camicia attillata</string>
-	<string name="Tight Skirt">Gonna attillata</string>
-	<string name="Tight Sleeves">Maniche strette</string>
-	<string name="Toe Shape">Forma della punta</string>
-	<string name="Toe Thickness">Spessore della punta</string>
-	<string name="Torso Length">Lunghezza del torace</string>
-	<string name="Torso Muscles">Muscoli del torace</string>
-	<string name="Torso Scrawny">Torso Scrawny</string>
-	<string name="Unattached">Distaccato</string>
-	<string name="Uncreased">Senza piega</string>
-	<string name="Underbite">Denti inf. in fuori</string>
-	<string name="Unnatural">Innaturale</string>
-	<string name="Upper Bridge">Parte alta del setto</string>
-	<string name="Upper Cheeks">Parte alta degli zigomi</string>
-	<string name="Upper Chin Cleft">Fossetta sup. del mento</string>
-	<string name="Upper Eyelid Fold">Piega palpebra sup.</string>
-	<string name="Upturned">All'insù</string>
-	<string name="Very Red">Molto rossi</string>
-	<string name="Waist Height">Vita alta</string>
-	<string name="Well-Fed">Pienotte</string>
-	<string name="White Hair">Capelli bianchi</string>
-	<string name="Wide">Largo</string>
-	<string name="Wide Back">Dietro largo</string>
-	<string name="Wide Front">Davanti largo</string>
-	<string name="Wide Lips">Labbra larghe</string>
-	<string name="Wild">Colorati</string>
-	<string name="Wrinkles">Grinze</string>
-	<string name="LocationCtrlAddLandmarkTooltip">Aggiungi ai miei punti di riferimento</string>
-	<string name="LocationCtrlEditLandmarkTooltip">Modifica i miei punti di riferimento</string>
-	<string name="LocationCtrlInfoBtnTooltip">Maggiori informazioni sulla posizione attuale</string>
-	<string name="LocationCtrlComboBtnTooltip">La cronologia delle mie posizioni</string>
-	<string name="LocationCtrlAdultIconTooltip">Regione con categoria adulti</string>
-	<string name="LocationCtrlModerateIconTooltip">Regione con categoria moderata</string>
-	<string name="LocationCtrlGeneralIconTooltip">Regione generale</string>
-	<string name="LocationCtrlSeeAVsTooltip">Gli avatar in questo lotto non possono essere visti o sentiti da avatar all'esterno del lotto</string>
-	<string name="LocationCtrlPathfindingDirtyTooltip">Gli oggetti che si muovono potrebbero non comportarsi correttamente in questa regione fino a quando non viene eseguito il rebake della regione.</string>
-	<string name="LocationCtrlPathfindingDisabledTooltip">Il pathfinding dinamico non è attivato in questa regione.</string>
-	<string name="UpdaterWindowTitle">Aggiornamento [APP_NAME]</string>
-	<string name="UpdaterNowUpdating">Aggiornamento di [APP_NAME]...</string>
-	<string name="UpdaterNowInstalling">Installazione di [APP_NAME]...</string>
-	<string name="UpdaterUpdatingDescriptive">Il Viewer del programma [APP_NAME] si sta aggiornando all'ultima versione.  Potrebbe volerci del tempo, attendi.</string>
-	<string name="UpdaterProgressBarTextWithEllipses">Download dell'aggiornamento...</string>
-	<string name="UpdaterProgressBarText">Download dell'aggiornamento</string>
-	<string name="UpdaterFailDownloadTitle">Download dell'aggiornamento non riuscito</string>
-	<string name="UpdaterFailUpdateDescriptive">Il programma [APP_NAME] ha riscontrato un'errore durante il tentativo di aggiornamento. Consigliamo di scaricare l'ultima versione direttamente da www.secondlife.com.</string>
-	<string name="UpdaterFailInstallTitle">Installazione dell'aggiornamento non riuscita</string>
-	<string name="UpdaterFailStartTitle">Errore nell'avvio del viewer</string>
-	<string name="ItemsComingInTooFastFrom">[APP_NAME]: Oggetti in arrivo troppo velocemente da [FROM_NAME], anteprima automatica disattivata per [TIME] secondi</string>
-	<string name="ItemsComingInTooFast">[APP_NAME]: Oggetti in arrivo troppo velocemente, anteprima automatica disattivata per [TIME] secondi</string>
-	<string name="IM_logging_string">-- Registrazione messaggi instantanei abilitata --</string>
-	<string name="IM_typing_start_string">[NAME] sta scrivendo...</string>
-	<string name="Unnamed">(anonimo)</string>
-	<string name="IM_moderated_chat_label">(Moderato: Voci disattivate di default)</string>
-	<string name="IM_unavailable_text_label">La chat di testo non è disponibile per questa chiamata.</string>
-	<string name="IM_muted_text_label">La chat di testo è stata disabilitata da un moderatore di gruppo.</string>
-	<string name="IM_default_text_label">Clicca qui per inviare un messaggio instantaneo.</string>
-	<string name="IM_to_label">A</string>
-	<string name="IM_moderator_label">(Moderatore)</string>
-	<string name="Saved_message">(Salvato [LONG_TIMESTAMP])</string>
-	<string name="IM_unblock_only_groups_friends">Per vedere questo messaggio, devi deselezionare 'Solo amici e gruppi possono chiamarmi o mandarmi IM' in Preferenze/Privacy.</string>
-	<string name="OnlineStatus">Online</string>
-	<string name="OfflineStatus">Offline</string>
-	<string name="not_online_msg">Utente non online - il messaggio verrà memorizzato e inviato più tardi.</string>
-	<string name="not_online_inventory">Utente non online - l'inventario è stato salvato</string>
-	<string name="answered_call">Risposto alla chiamata</string>
-	<string name="you_started_call">Hai iniziato una chiamata vocale</string>
-	<string name="you_joined_call">Ti sei collegato alla chiamata in voce</string>
-	<string name="you_auto_rejected_call-im">Hai rifiutato automaticamente la chiamata voce mentre era attivata la modalità 'Non disturbare'.</string>
-	<string name="name_started_call">[NAME] ha iniziato una chiamata vocale</string>
-	<string name="ringing-im">Collegamento alla chiamata vocale...</string>
-	<string name="connected-im">Collegato, clicca Chiudi chiamata per agganciare</string>
-	<string name="hang_up-im">Chiusa la chiamata</string>
-	<string name="conference-title">Chat con più persone</string>
-	<string name="conference-title-incoming">Chiamata in conferenza con [AGENT_NAME]</string>
-	<string name="inventory_item_offered-im">Offerto oggetto di inventario &quot;[ITEM_NAME]&quot;</string>
-	<string name="inventory_folder_offered-im">Offerta cartella di inventario &quot;[ITEM_NAME]&quot;</string>
+Se il messaggio persiste, contatta [SUPPORT_SITE].
+	</string>
+	<string name="5 O'Clock Shadow">
+		Barba leggera
+	</string>
+	<string name="All White">
+		Tutti bianchi
+	</string>
+	<string name="Anime Eyes">
+		Occhi grandi
+	</string>
+	<string name="Arced">
+		Arcuato
+	</string>
+	<string name="Arm Length">
+		Lunghezza braccia
+	</string>
+	<string name="Attached">
+		Attaccato
+	</string>
+	<string name="Attached Earlobes">
+		Lobi attaccati
+	</string>
+	<string name="Back Fringe">
+		Frangetta all'indietro
+	</string>
+	<string name="Baggy">
+		Larghi
+	</string>
+	<string name="Bangs">
+		Frange
+	</string>
+	<string name="Beady Eyes">
+		Occhi piccoli
+	</string>
+	<string name="Belly Size">
+		Punto vita
+	</string>
+	<string name="Big">
+		Grande
+	</string>
+	<string name="Big Butt">
+		Sedere grande
+	</string>
+	<string name="Big Hair Back">
+		Capigliatura grande: Indietro
+	</string>
+	<string name="Big Hair Front">
+		Capigliatura grande: anteriore
+	</string>
+	<string name="Big Hair Top">
+		Capigliatura grande: in  alto
+	</string>
+	<string name="Big Head">
+		Grande testa
+	</string>
+	<string name="Big Pectorals">
+		Grandi pettorali
+	</string>
+	<string name="Big Spikes">
+		Capelli con punte
+	</string>
+	<string name="Black">
+		Nero
+	</string>
+	<string name="Blonde">
+		Biondo
+	</string>
+	<string name="Blonde Hair">
+		Capelli biondi
+	</string>
+	<string name="Blush">
+		Fard
+	</string>
+	<string name="Blush Color">
+		Colore fard
+	</string>
+	<string name="Blush Opacity">
+		Opacità fard
+	</string>
+	<string name="Body Definition">
+		Definizione muscolare
+	</string>
+	<string name="Body Fat">
+		Grasso corporeo
+	</string>
+	<string name="Body Freckles">
+		Lentiggini e nei
+	</string>
+	<string name="Body Thick">
+		Corpo più robusto
+	</string>
+	<string name="Body Thickness">
+		Robustezza del corpo
+	</string>
+	<string name="Body Thin">
+		Corpo più magro
+	</string>
+	<string name="Bow Legged">
+		Gambe arcuate
+	</string>
+	<string name="Breast Buoyancy">
+		Altezza del seno
+	</string>
+	<string name="Breast Cleavage">
+		Décolleté
+	</string>
+	<string name="Breast Size">
+		Grandezza del seno
+	</string>
+	<string name="Bridge Width">
+		Larghezza setto
+	</string>
+	<string name="Broad">
+		Largo
+	</string>
+	<string name="Brow Size">
+		Grandezza delle sopracciglia
+	</string>
+	<string name="Bug Eyes">
+		Occhi sporgenti
+	</string>
+	<string name="Bugged Eyes">
+		Occhi sporgenti
+	</string>
+	<string name="Bulbous">
+		Bulboso
+	</string>
+	<string name="Bulbous Nose">
+		Naso bulboso
+	</string>
+	<string name="Breast Physics Mass">
+		Massa seno
+	</string>
+	<string name="Breast Physics Smoothing">
+		Lisciatura seno
+	</string>
+	<string name="Breast Physics Gravity">
+		Gravità seno
+	</string>
+	<string name="Breast Physics Drag">
+		Resistenza seno
+	</string>
+	<string name="Breast Physics InOut Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Breast Physics InOut Spring">
+		Elasticità
+	</string>
+	<string name="Breast Physics InOut Gain">
+		Guadagno
+	</string>
+	<string name="Breast Physics InOut Damping">
+		Attenuazione
+	</string>
+	<string name="Breast Physics UpDown Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Breast Physics UpDown Spring">
+		Elasticità
+	</string>
+	<string name="Breast Physics UpDown Gain">
+		Guadagno
+	</string>
+	<string name="Breast Physics UpDown Damping">
+		Attenuazione
+	</string>
+	<string name="Breast Physics LeftRight Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Breast Physics LeftRight Spring">
+		Elasticità
+	</string>
+	<string name="Breast Physics LeftRight Gain">
+		Guadagno
+	</string>
+	<string name="Breast Physics LeftRight Damping">
+		Attenuazione
+	</string>
+	<string name="Belly Physics Mass">
+		Massa pancia
+	</string>
+	<string name="Belly Physics Smoothing">
+		Lisciatura pancia
+	</string>
+	<string name="Belly Physics Gravity">
+		Gravità pancia
+	</string>
+	<string name="Belly Physics Drag">
+		Resistenza pancia
+	</string>
+	<string name="Belly Physics UpDown Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Belly Physics UpDown Spring">
+		Elasticità
+	</string>
+	<string name="Belly Physics UpDown Gain">
+		Guadagno
+	</string>
+	<string name="Belly Physics UpDown Damping">
+		Attenuazione
+	</string>
+	<string name="Butt Physics Mass">
+		Massa natiche
+	</string>
+	<string name="Butt Physics Smoothing">
+		Lisciatura natiche
+	</string>
+	<string name="Butt Physics Gravity">
+		Gravità natiche
+	</string>
+	<string name="Butt Physics Drag">
+		Resistenza natiche
+	</string>
+	<string name="Butt Physics UpDown Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Butt Physics UpDown Spring">
+		Elasticità
+	</string>
+	<string name="Butt Physics UpDown Gain">
+		Guadagno
+	</string>
+	<string name="Butt Physics UpDown Damping">
+		Attenuazione
+	</string>
+	<string name="Butt Physics LeftRight Max Effect">
+		Massimo effetto
+	</string>
+	<string name="Butt Physics LeftRight Spring">
+		Elasticità
+	</string>
+	<string name="Butt Physics LeftRight Gain">
+		Guadagno
+	</string>
+	<string name="Butt Physics LeftRight Damping">
+		Attenuazione
+	</string>
+	<string name="Bushy Eyebrows">
+		Sopracciglia cespugliose
+	</string>
+	<string name="Bushy Hair">
+		Capelli a cespuglio
+	</string>
+	<string name="Butt Size">
+		Grandezza del sedere
+	</string>
+	<string name="Butt Gravity">
+		Gravità natiche
+	</string>
+	<string name="bustle skirt">
+		Crinolina
+	</string>
+	<string name="no bustle">
+		Nessuna crinolina
+	</string>
+	<string name="more bustle">
+		Più crinolina
+	</string>
+	<string name="Chaplin">
+		Baffetti
+	</string>
+	<string name="Cheek Bones">
+		Zigomi
+	</string>
+	<string name="Chest Size">
+		Ampiezza del torace
+	</string>
+	<string name="Chin Angle">
+		Angolo del mento
+	</string>
+	<string name="Chin Cleft">
+		Fossetta sul mento
+	</string>
+	<string name="Chin Curtains">
+		Barba sottomento
+	</string>
+	<string name="Chin Depth">
+		Profondità mento
+	</string>
+	<string name="Chin Heavy">
+		Mento forte
+	</string>
+	<string name="Chin In">
+		Mento in dentro
+	</string>
+	<string name="Chin Out">
+		Mento sporgente
+	</string>
+	<string name="Chin-Neck">
+		Mento-collo
+	</string>
+	<string name="Clear">
+		Trasparente
+	</string>
+	<string name="Cleft">
+		Fossetta
+	</string>
+	<string name="Close Set Eyes">
+		Occhi ravvicinati
+	</string>
+	<string name="Closed">
+		Chiusa
+	</string>
+	<string name="Closed Back">
+		Chiuso dietro
+	</string>
+	<string name="Closed Front">
+		Chiuso davanti
+	</string>
+	<string name="Closed Left">
+		Chiuso sinistra
+	</string>
+	<string name="Closed Right">
+		Chiuso destra
+	</string>
+	<string name="Coin Purse">
+		Meno pronunciati
+	</string>
+	<string name="Collar Back">
+		Colletto posteriore
+	</string>
+	<string name="Collar Front">
+		Colletto anteriore
+	</string>
+	<string name="Corner Down">
+		Angolo all'ingiù
+	</string>
+	<string name="Corner Up">
+		Angolo all'insù
+	</string>
+	<string name="Creased">
+		Piega
+	</string>
+	<string name="Crooked Nose">
+		Naso storto
+	</string>
+	<string name="Cuff Flare">
+		Svasato con risvolto
+	</string>
+	<string name="Dark">
+		Scuro
+	</string>
+	<string name="Dark Green">
+		Verde scuro
+	</string>
+	<string name="Darker">
+		Più scuro
+	</string>
+	<string name="Deep">
+		Profondo
+	</string>
+	<string name="Default Heels">
+		Tacchi standard
+	</string>
+	<string name="Dense">
+		Folti
+	</string>
+	<string name="Double Chin">
+		Doppio mento
+	</string>
+	<string name="Downturned">
+		All'ingiù
+	</string>
+	<string name="Duffle Bag">
+		Più pronunciati
+	</string>
+	<string name="Ear Angle">
+		Angolo orecchie
+	</string>
+	<string name="Ear Size">
+		Grandezza orecchie
+	</string>
+	<string name="Ear Tips">
+		Estremità orecchie
+	</string>
+	<string name="Egg Head">
+		Ovalizzazione testa
+	</string>
+	<string name="Eye Bags">
+		Occhiaie
+	</string>
+	<string name="Eye Color">
+		Colore degli occhi
+	</string>
+	<string name="Eye Depth">
+		Profondità degli occhi
+	</string>
+	<string name="Eye Lightness">
+		Luminosità degli occhi
+	</string>
+	<string name="Eye Opening">
+		Apertura degli occhi
+	</string>
+	<string name="Eye Pop">
+		Prominenza degli occhi
+	</string>
+	<string name="Eye Size">
+		Grandezza occhi
+	</string>
+	<string name="Eye Spacing">
+		Distanza occhi
+	</string>
+	<string name="Eyebrow Arc">
+		Arco delle sopracciglia
+	</string>
+	<string name="Eyebrow Density">
+		Densità delle sopracciglia
+	</string>
+	<string name="Eyebrow Height">
+		Altezza delle sopracciglia
+	</string>
+	<string name="Eyebrow Points">
+		Sopracciglia appuntite
+	</string>
+	<string name="Eyebrow Size">
+		Grandezza sopracciglia
+	</string>
+	<string name="Eyelash Length">
+		Lunghezza delle ciglia
+	</string>
+	<string name="Eyeliner">
+		Eyeliner
+	</string>
+	<string name="Eyeliner Color">
+		Colore dell'eyeliner
+	</string>
+	<string name="Eyes Bugged">
+		Occhi sporgenti
+	</string>
+	<string name="Face Shear">
+		Taglio del viso
+	</string>
+	<string name="Facial Definition">
+		Definizione del viso
+	</string>
+	<string name="Far Set Eyes">
+		Occhi distanti
+	</string>
+	<string name="Fat Lips">
+		Labbra carnose
+	</string>
+	<string name="Female">
+		Femmina
+	</string>
+	<string name="Fingerless">
+		Senza dita
+	</string>
+	<string name="Fingers">
+		Dita
+	</string>
+	<string name="Flared Cuffs">
+		Risvolti svasati
+	</string>
+	<string name="Flat">
+		Piatto
+	</string>
+	<string name="Flat Butt">
+		Sedere piatto
+	</string>
+	<string name="Flat Head">
+		Testa piatta
+	</string>
+	<string name="Flat Toe">
+		Punta piatta
+	</string>
+	<string name="Foot Size">
+		Misura piede
+	</string>
+	<string name="Forehead Angle">
+		Angolo della fronte
+	</string>
+	<string name="Forehead Heavy">
+		Fronte sporgente
+	</string>
+	<string name="Freckles">
+		Lentiggini
+	</string>
+	<string name="Front Fringe">
+		Frangetta
+	</string>
+	<string name="Full Back">
+		Dietro gonfi
+	</string>
+	<string name="Full Eyeliner">
+		Eyeliner marcato
+	</string>
+	<string name="Full Front">
+		Anteriore gonfio
+	</string>
+	<string name="Full Hair Sides">
+		Lati capelli gonfi
+	</string>
+	<string name="Full Sides">
+		Lati gonfi
+	</string>
+	<string name="Glossy">
+		Lucido
+	</string>
+	<string name="Glove Fingers">
+		Dita con guanti
+	</string>
+	<string name="Glove Length">
+		Lunghezza guanti
+	</string>
+	<string name="Hair">
+		Capigliature
+	</string>
+	<string name="Hair Back">
+		Capelli: Indietro
+	</string>
+	<string name="Hair Front">
+		Capelli: anteriore
+	</string>
+	<string name="Hair Sides">
+		Capelli: lati
+	</string>
+	<string name="Hair Sweep">
+		Direzione capigliatura
+	</string>
+	<string name="Hair Thickess">
+		Foltezza
+	</string>
+	<string name="Hair Thickness">
+		Foltezza
+	</string>
+	<string name="Hair Tilt">
+		Inclinazione
+	</string>
+	<string name="Hair Tilted Left">
+		Verso sinistra
+	</string>
+	<string name="Hair Tilted Right">
+		Verso destra
+	</string>
+	<string name="Hair Volume">
+		Capelli: Volume
+	</string>
+	<string name="Hand Size">
+		Grandezza mani
+	</string>
+	<string name="Handlebars">
+		Baffi a manubrio
+	</string>
+	<string name="Head Length">
+		Lunghezza testa
+	</string>
+	<string name="Head Shape">
+		Forma della testa
+	</string>
+	<string name="Head Size">
+		Grandezza della testa
+	</string>
+	<string name="Head Stretch">
+		Allungamento testa
+	</string>
+	<string name="Heel Height">
+		Altezza tacchi
+	</string>
+	<string name="Heel Shape">
+		Forma tacchi
+	</string>
+	<string name="Height">
+		Altezza
+	</string>
+	<string name="High">
+		Alto
+	</string>
+	<string name="High Heels">
+		Tacchi alti
+	</string>
+	<string name="High Jaw">
+		Mandibola alta
+	</string>
+	<string name="High Platforms">
+		Alta
+	</string>
+	<string name="High and Tight">
+		Alto e stretto
+	</string>
+	<string name="Higher">
+		Più alto
+	</string>
+	<string name="Hip Length">
+		Altezza bacino
+	</string>
+	<string name="Hip Width">
+		Larghezza bacino
+	</string>
+	<string name="Hover">
+		Muovi sopra
+	</string>
+	<string name="In">
+		Dentro
+	</string>
+	<string name="In Shdw Color">
+		Colore ombretto interno
+	</string>
+	<string name="In Shdw Opacity">
+		Opacità ombretto interno
+	</string>
+	<string name="Inner Eye Corner">
+		Angolo interno
+	</string>
+	<string name="Inner Eye Shadow">
+		Ombretto interno
+	</string>
+	<string name="Inner Shadow">
+		Ombretto interno
+	</string>
+	<string name="Jacket Length">
+		Lunghezza giacca
+	</string>
+	<string name="Jacket Wrinkles">
+		Grinze della giacca
+	</string>
+	<string name="Jaw Angle">
+		Angolo mandibola
+	</string>
+	<string name="Jaw Jut">
+		Prognatismo mento
+	</string>
+	<string name="Jaw Shape">
+		Forma del mento
+	</string>
+	<string name="Join">
+		Iscriviti
+	</string>
+	<string name="Jowls">
+		Guance
+	</string>
+	<string name="Knee Angle">
+		Angolo ginocchia
+	</string>
+	<string name="Knock Kneed">
+		Gambe ad X
+	</string>
+	<string name="Large">
+		Grande
+	</string>
+	<string name="Large Hands">
+		Mani grandi
+	</string>
+	<string name="Left Part">
+		Riga a sinistra
+	</string>
+	<string name="Leg Length">
+		Lunghezza gambe
+	</string>
+	<string name="Leg Muscles">
+		Muscoli gambe
+	</string>
+	<string name="Less">
+		Meno
+	</string>
+	<string name="Less Body Fat">
+		Meno grasso corporeo
+	</string>
+	<string name="Less Curtains">
+		Meno
+	</string>
+	<string name="Less Freckles">
+		Meno lentiggini
+	</string>
+	<string name="Less Full">
+		Meno piene
+	</string>
+	<string name="Less Gravity">
+		Più alto
+	</string>
+	<string name="Less Love">
+		Meno maniglie
+	</string>
+	<string name="Less Muscles">
+		Meno muscoli
+	</string>
+	<string name="Less Muscular">
+		Meno muscolari
+	</string>
+	<string name="Less Rosy">
+		Meno rosato
+	</string>
+	<string name="Less Round">
+		Meno rotondo
+	</string>
+	<string name="Less Saddle">
+		Meno a sella
+	</string>
+	<string name="Less Square">
+		Meno quadrato
+	</string>
+	<string name="Less Volume">
+		Meno volume
+	</string>
+	<string name="Less soul">
+		Meno
+	</string>
+	<string name="Lighter">
+		Più leggero
+	</string>
+	<string name="Lip Cleft">
+		Distanza fossetta labbro
+	</string>
+	<string name="Lip Cleft Depth">
+		Prof. fossetta labbro
+	</string>
+	<string name="Lip Fullness">
+		Volume labbra
+	</string>
+	<string name="Lip Pinkness">
+		Tonalità rosa labbra
+	</string>
+	<string name="Lip Ratio">
+		Proporzione labbra
+	</string>
+	<string name="Lip Thickness">
+		Carnosità labbra
+	</string>
+	<string name="Lip Width">
+		Larghezza labbra
+	</string>
+	<string name="Lipgloss">
+		Lipgloss
+	</string>
+	<string name="Lipstick">
+		Rossetto
+	</string>
+	<string name="Lipstick Color">
+		Colore rossetto
+	</string>
+	<string name="Long">
+		Lungo
+	</string>
+	<string name="Long Head">
+		Testa lunga
+	</string>
+	<string name="Long Hips">
+		Bacino alto
+	</string>
+	<string name="Long Legs">
+		Gambe lunghe
+	</string>
+	<string name="Long Neck">
+		Collo lungo
+	</string>
+	<string name="Long Pigtails">
+		Codini lunghi
+	</string>
+	<string name="Long Ponytail">
+		Codino lungo
+	</string>
+	<string name="Long Torso">
+		Torace lungo
+	</string>
+	<string name="Long arms">
+		Braccia lunghe
+	</string>
+	<string name="Loose Pants">
+		Pantaloni ampi
+	</string>
+	<string name="Loose Shirt">
+		Camicia ampia
+	</string>
+	<string name="Loose Sleeves">
+		Maniche non attillate
+	</string>
+	<string name="Love Handles">
+		Maniglie dell'amore
+	</string>
+	<string name="Low">
+		Basso
+	</string>
+	<string name="Low Heels">
+		Tacchi bassi
+	</string>
+	<string name="Low Jaw">
+		Mandibola bassa
+	</string>
+	<string name="Low Platforms">
+		Bassa
+	</string>
+	<string name="Low and Loose">
+		Basso e ampio
+	</string>
+	<string name="Lower">
+		Più basso
+	</string>
+	<string name="Lower Bridge">
+		Parte bassa del setto
+	</string>
+	<string name="Lower Cheeks">
+		Guance inferiori
+	</string>
+	<string name="Male">
+		Maschio
+	</string>
+	<string name="Middle Part">
+		Riga nel mezzo
+	</string>
+	<string name="More">
+		Altro
+	</string>
+	<string name="More Blush">
+		Più fard
+	</string>
+	<string name="More Body Fat">
+		Più grasso corporeo
+	</string>
+	<string name="More Curtains">
+		Più
+	</string>
+	<string name="More Eyeshadow">
+		Più ombretto
+	</string>
+	<string name="More Freckles">
+		Più lentiggini
+	</string>
+	<string name="More Full">
+		Più piene
+	</string>
+	<string name="More Gravity">
+		Più calato
+	</string>
+	<string name="More Lipstick">
+		Più rossetto
+	</string>
+	<string name="More Love">
+		Più maniglie
+	</string>
+	<string name="More Lower Lip">
+		Labbro inf. pronunciato
+	</string>
+	<string name="More Muscles">
+		Più muscoli
+	</string>
+	<string name="More Muscular">
+		Più muscolatura
+	</string>
+	<string name="More Rosy">
+		Più rosato
+	</string>
+	<string name="More Round">
+		Più rotondo
+	</string>
+	<string name="More Saddle">
+		Più a sella
+	</string>
+	<string name="More Sloped">
+		Più orizzontale
+	</string>
+	<string name="More Square">
+		Più quadrato
+	</string>
+	<string name="More Upper Lip">
+		Labbro sup. pronunciato
+	</string>
+	<string name="More Vertical">
+		Più verticale
+	</string>
+	<string name="More Volume">
+		Più volume
+	</string>
+	<string name="More soul">
+		Più
+	</string>
+	<string name="Moustache">
+		Baffi
+	</string>
+	<string name="Mouth Corner">
+		Angolo della bocca
+	</string>
+	<string name="Mouth Position">
+		Posizione della bocca
+	</string>
+	<string name="Mowhawk">
+		Moicana
+	</string>
+	<string name="Muscular">
+		Muscolatura
+	</string>
+	<string name="Mutton Chops">
+		Basette lunghe
+	</string>
+	<string name="Nail Polish">
+		Smalto
+	</string>
+	<string name="Nail Polish Color">
+		Colore smalto
+	</string>
+	<string name="Narrow">
+		Socchiusi
+	</string>
+	<string name="Narrow Back">
+		Laterali post. vicini
+	</string>
+	<string name="Narrow Front">
+		Laterali ant. vicini
+	</string>
+	<string name="Narrow Lips">
+		Labbra strette
+	</string>
+	<string name="Natural">
+		Naturale
+	</string>
+	<string name="Neck Length">
+		Lunghezza del collo
+	</string>
+	<string name="Neck Thickness">
+		Grandezza del collo
+	</string>
+	<string name="No Blush">
+		Senza fard
+	</string>
+	<string name="No Eyeliner">
+		Senza eyeliner
+	</string>
+	<string name="No Eyeshadow">
+		Senza ombretto
+	</string>
+	<string name="No Lipgloss">
+		Senza lipgloss
+	</string>
+	<string name="No Lipstick">
+		Senza rossetto
+	</string>
+	<string name="No Part">
+		Senza riga
+	</string>
+	<string name="No Polish">
+		Senza smalto
+	</string>
+	<string name="No Red">
+		Senza rosso
+	</string>
+	<string name="No Spikes">
+		Senza punte
+	</string>
+	<string name="No White">
+		Senza bianco
+	</string>
+	<string name="No Wrinkles">
+		Senza pieghe
+	</string>
+	<string name="Normal Lower">
+		Inferiore normale
+	</string>
+	<string name="Normal Upper">
+		Superiore normale
+	</string>
+	<string name="Nose Left">
+		Naso a sinistra
+	</string>
+	<string name="Nose Right">
+		Naso a destra
+	</string>
+	<string name="Nose Size">
+		Grandezza naso
+	</string>
+	<string name="Nose Thickness">
+		Spessore naso
+	</string>
+	<string name="Nose Tip Angle">
+		Angolo punta naso
+	</string>
+	<string name="Nose Tip Shape">
+		Forma punta naso
+	</string>
+	<string name="Nose Width">
+		Larghezza naso
+	</string>
+	<string name="Nostril Division">
+		Divisione narici
+	</string>
+	<string name="Nostril Width">
+		Larghezza narici
+	</string>
+	<string name="Opaque">
+		Opaco
+	</string>
+	<string name="Open">
+		Apri
+	</string>
+	<string name="Open Back">
+		Retro aperto
+	</string>
+	<string name="Open Front">
+		Davanti aperto
+	</string>
+	<string name="Open Left">
+		Lato sin. aperto
+	</string>
+	<string name="Open Right">
+		Lato des. aperto
+	</string>
+	<string name="Orange">
+		Arancio
+	</string>
+	<string name="Out">
+		Fuori
+	</string>
+	<string name="Out Shdw Color">
+		Colore ombretto esterno
+	</string>
+	<string name="Out Shdw Opacity">
+		Opacità ombretto esterno
+	</string>
+	<string name="Outer Eye Corner">
+		Angolo esterno occhio
+	</string>
+	<string name="Outer Eye Shadow">
+		Ombretto esterno
+	</string>
+	<string name="Outer Shadow">
+		Ombreggiatura esterna
+	</string>
+	<string name="Overbite">
+		Denti sup. in fuori
+	</string>
+	<string name="Package">
+		Genitali
+	</string>
+	<string name="Painted Nails">
+		Unghie smaltate
+	</string>
+	<string name="Pale">
+		Pallido
+	</string>
+	<string name="Pants Crotch">
+		Cavallo
+	</string>
+	<string name="Pants Fit">
+		Vestibilità pantaloni
+	</string>
+	<string name="Pants Length">
+		Lunghezza pantaloni
+	</string>
+	<string name="Pants Waist">
+		Taglia pantalone
+	</string>
+	<string name="Pants Wrinkles">
+		Pantaloni con le grinze
+	</string>
+	<string name="Part">
+		Con riga
+	</string>
+	<string name="Part Bangs">
+		Frangetta divisa
+	</string>
+	<string name="Pectorals">
+		Pettorali
+	</string>
+	<string name="Pigment">
+		Pigmento
+	</string>
+	<string name="Pigtails">
+		Codini
+	</string>
+	<string name="Pink">
+		Rosa
+	</string>
+	<string name="Pinker">
+		Più rosato
+	</string>
+	<string name="Platform Height">
+		Altezza pianta
+	</string>
+	<string name="Platform Width">
+		Larghezza pianta
+	</string>
+	<string name="Pointy">
+		Appuntito
+	</string>
+	<string name="Pointy Heels">
+		Tacchi a spillo
+	</string>
+	<string name="Ponytail">
+		Codino
+	</string>
+	<string name="Poofy Skirt">
+		Gonna gonfia
+	</string>
+	<string name="Pop Left Eye">
+		Sinistro più aperto
+	</string>
+	<string name="Pop Right Eye">
+		Destro più aperto
+	</string>
+	<string name="Puffy">
+		Paffute
+	</string>
+	<string name="Puffy Eyelids">
+		Palpebre gonfie
+	</string>
+	<string name="Rainbow Color">
+		Tonalità
+	</string>
+	<string name="Red Hair">
+		Presenza di rosso nei capelli
+	</string>
+	<string name="Regular">
+		Normale
+	</string>
+	<string name="Right Part">
+		Riga a destra
+	</string>
+	<string name="Rosy Complexion">
+		Incarnato
+	</string>
+	<string name="Round">
+		Rotondo
+	</string>
+	<string name="Ruddiness">
+		Rossore
+	</string>
+	<string name="Ruddy">
+		Rosse
+	</string>
+	<string name="Rumpled Hair">
+		Capelli mossi
+	</string>
+	<string name="Saddle Bags">
+		Rotondità fianchi
+	</string>
+	<string name="Scrawny Leg">
+		Gambe magre
+	</string>
+	<string name="Separate">
+		Separati
+	</string>
+	<string name="Shallow">
+		Meno pronunciato
+	</string>
+	<string name="Shear Back">
+		Taglio posteriore
+	</string>
+	<string name="Shear Face">
+		Taglio del viso
+	</string>
+	<string name="Shear Front">
+		Taglio anteriore
+	</string>
+	<string name="Shear Left Up">
+		Distorto a sinistra
+	</string>
+	<string name="Shear Right Up">
+		Distorto a destra
+	</string>
+	<string name="Sheared Back">
+		Taglio verso dietro
+	</string>
+	<string name="Sheared Front">
+		Taglio verso davanti
+	</string>
+	<string name="Shift Left">
+		A sinistra
+	</string>
+	<string name="Shift Mouth">
+		Spostamento bocca
+	</string>
+	<string name="Shift Right">
+		A destra
+	</string>
+	<string name="Shirt Bottom">
+		Parte inferiore camicia
+	</string>
+	<string name="Shirt Fit">
+		Vestibilità camicia
+	</string>
+	<string name="Shirt Wrinkles">
+		Camicia con le grinze
+	</string>
+	<string name="Shoe Height">
+		Altezza scarpe
+	</string>
+	<string name="Short">
+		Basso
+	</string>
+	<string name="Short Arms">
+		Braccia corte
+	</string>
+	<string name="Short Legs">
+		Gambe corte
+	</string>
+	<string name="Short Neck">
+		Collo corto
+	</string>
+	<string name="Short Pigtails">
+		Codini corti
+	</string>
+	<string name="Short Ponytail">
+		Codino corto
+	</string>
+	<string name="Short Sideburns">
+		Basette corte
+	</string>
+	<string name="Short Torso">
+		Torace corto
+	</string>
+	<string name="Short hips">
+		Bacino corto
+	</string>
+	<string name="Shoulders">
+		Spalle
+	</string>
+	<string name="Side Fringe">
+		Ciuffi laterali
+	</string>
+	<string name="Sideburns">
+		Basette
+	</string>
+	<string name="Sides Hair">
+		Capigliatura di lato
+	</string>
+	<string name="Sides Hair Down">
+		Capigliatura di lato sciolta
+	</string>
+	<string name="Sides Hair Up">
+		Capigliatura di lato raccolta
+	</string>
+	<string name="Skinny Neck">
+		Collo fino
+	</string>
+	<string name="Skirt Fit">
+		Vestibilità gonna
+	</string>
+	<string name="Skirt Length">
+		Lunghezza gonna
+	</string>
+	<string name="Slanted Forehead">
+		Fronte inclinata
+	</string>
+	<string name="Sleeve Length">
+		Lunghezza maniche
+	</string>
+	<string name="Sleeve Looseness">
+		Morbidezza maniche
+	</string>
+	<string name="Slit Back">
+		Spacco: Indietro
+	</string>
+	<string name="Slit Front">
+		Spacco: anteriore
+	</string>
+	<string name="Slit Left">
+		Spacco: Sinistra
+	</string>
+	<string name="Slit Right">
+		Spacco: Destra
+	</string>
+	<string name="Small">
+		Piccola
+	</string>
+	<string name="Small Hands">
+		Mani piccole
+	</string>
+	<string name="Small Head">
+		Testa piccola
+	</string>
+	<string name="Smooth">
+		Liscio
+	</string>
+	<string name="Smooth Hair">
+		Capelli lisci
+	</string>
+	<string name="Socks Length">
+		Lunghezza calze
+	</string>
+	<string name="Soulpatch">
+		Pizzetto labbro inferiore
+	</string>
+	<string name="Sparse">
+		Piu rade
+	</string>
+	<string name="Spiked Hair">
+		Capelli a punta
+	</string>
+	<string name="Square">
+		Quadrato
+	</string>
+	<string name="Square Toe">
+		Punta quadrata
+	</string>
+	<string name="Squash Head">
+		Testa schiacciata
+	</string>
+	<string name="Stretch Head">
+		Testa allungata
+	</string>
+	<string name="Sunken">
+		Scarne
+	</string>
+	<string name="Sunken Chest">
+		Senza pettorali
+	</string>
+	<string name="Sunken Eyes">
+		Occhi infossati
+	</string>
+	<string name="Sweep Back">
+		Indietro
+	</string>
+	<string name="Sweep Forward">
+		Avanti
+	</string>
+	<string name="Tall">
+		Alto
+	</string>
+	<string name="Taper Back">
+		Ravv. lat. posteriore
+	</string>
+	<string name="Taper Front">
+		Ravv. lat. frontale
+	</string>
+	<string name="Thick Heels">
+		Tacchi spessi
+	</string>
+	<string name="Thick Neck">
+		Collo grosso
+	</string>
+	<string name="Thick Toe">
+		Punta spessa
+	</string>
+	<string name="Thin">
+		Sottili
+	</string>
+	<string name="Thin Eyebrows">
+		Sopracciglia sottili
+	</string>
+	<string name="Thin Lips">
+		Labbra sottili
+	</string>
+	<string name="Thin Nose">
+		Naso sottile
+	</string>
+	<string name="Tight Chin">
+		Mento stretto
+	</string>
+	<string name="Tight Cuffs">
+		Fondo stretto
+	</string>
+	<string name="Tight Pants">
+		Pantaloni attillati
+	</string>
+	<string name="Tight Shirt">
+		Camicia attillata
+	</string>
+	<string name="Tight Skirt">
+		Gonna attillata
+	</string>
+	<string name="Tight Sleeves">
+		Maniche strette
+	</string>
+	<string name="Toe Shape">
+		Forma della punta
+	</string>
+	<string name="Toe Thickness">
+		Spessore della punta
+	</string>
+	<string name="Torso Length">
+		Lunghezza del torace
+	</string>
+	<string name="Torso Muscles">
+		Muscoli del torace
+	</string>
+	<string name="Torso Scrawny">
+		Torso Scrawny
+	</string>
+	<string name="Unattached">
+		Distaccato
+	</string>
+	<string name="Uncreased">
+		Senza piega
+	</string>
+	<string name="Underbite">
+		Denti inf. in fuori
+	</string>
+	<string name="Unnatural">
+		Innaturale
+	</string>
+	<string name="Upper Bridge">
+		Parte alta del setto
+	</string>
+	<string name="Upper Cheeks">
+		Parte alta degli zigomi
+	</string>
+	<string name="Upper Chin Cleft">
+		Fossetta sup. del mento
+	</string>
+	<string name="Upper Eyelid Fold">
+		Piega palpebra sup.
+	</string>
+	<string name="Upturned">
+		All'insù
+	</string>
+	<string name="Very Red">
+		Molto rossi
+	</string>
+	<string name="Waist Height">
+		Vita alta
+	</string>
+	<string name="Well-Fed">
+		Pienotte
+	</string>
+	<string name="White Hair">
+		Capelli bianchi
+	</string>
+	<string name="Wide">
+		Largo
+	</string>
+	<string name="Wide Back">
+		Dietro largo
+	</string>
+	<string name="Wide Front">
+		Davanti largo
+	</string>
+	<string name="Wide Lips">
+		Labbra larghe
+	</string>
+	<string name="Wild">
+		Colorati
+	</string>
+	<string name="Wrinkles">
+		Grinze
+	</string>
+	<string name="LocationCtrlAddLandmarkTooltip">
+		Aggiungi ai miei punti di riferimento
+	</string>
+	<string name="LocationCtrlEditLandmarkTooltip">
+		Modifica i miei punti di riferimento
+	</string>
+	<string name="LocationCtrlInfoBtnTooltip">
+		Maggiori informazioni sulla posizione attuale
+	</string>
+	<string name="LocationCtrlComboBtnTooltip">
+		La cronologia delle mie posizioni
+	</string>
+	<string name="LocationCtrlAdultIconTooltip">
+		Regione con categoria adulti
+	</string>
+	<string name="LocationCtrlModerateIconTooltip">
+		Regione con categoria moderata
+	</string>
+	<string name="LocationCtrlGeneralIconTooltip">
+		Regione generale
+	</string>
+	<string name="LocationCtrlSeeAVsTooltip">
+		Gli avatar in questo lotto non possono essere visti o sentiti da avatar all'esterno del lotto
+	</string>
+	<string name="LocationCtrlPathfindingDirtyTooltip">
+		Gli oggetti che si muovono potrebbero non comportarsi correttamente in questa regione fino a quando non viene eseguito il rebake della regione.
+	</string>
+	<string name="LocationCtrlPathfindingDisabledTooltip">
+		Il pathfinding dinamico non è attivato in questa regione.
+	</string>
+	<string name="UpdaterWindowTitle">
+		Aggiornamento [APP_NAME]
+	</string>
+	<string name="UpdaterNowUpdating">
+		Aggiornamento di [APP_NAME]...
+	</string>
+	<string name="UpdaterNowInstalling">
+		Installazione di [APP_NAME]...
+	</string>
+	<string name="UpdaterUpdatingDescriptive">
+		Il Viewer del programma [APP_NAME] si sta aggiornando all'ultima versione.  Potrebbe volerci del tempo, attendi.
+	</string>
+	<string name="UpdaterProgressBarTextWithEllipses">
+		Download dell'aggiornamento...
+	</string>
+	<string name="UpdaterProgressBarText">
+		Download dell'aggiornamento
+	</string>
+	<string name="UpdaterFailDownloadTitle">
+		Download dell'aggiornamento non riuscito
+	</string>
+	<string name="UpdaterFailUpdateDescriptive">
+		Il programma [APP_NAME] ha riscontrato un'errore durante il tentativo di aggiornamento. Consigliamo di scaricare l'ultima versione direttamente da www.secondlife.com.
+	</string>
+	<string name="UpdaterFailInstallTitle">
+		Installazione dell'aggiornamento non riuscita
+	</string>
+	<string name="UpdaterFailStartTitle">
+		Errore nell'avvio del viewer
+	</string>
+	<string name="ItemsComingInTooFastFrom">
+		[APP_NAME]: Oggetti in arrivo troppo velocemente da [FROM_NAME], anteprima automatica disattivata per [TIME] secondi
+	</string>
+	<string name="ItemsComingInTooFast">
+		[APP_NAME]: Oggetti in arrivo troppo velocemente, anteprima automatica disattivata per [TIME] secondi
+	</string>
+	<string name="IM_logging_string">
+		-- Registrazione messaggi instantanei abilitata --
+	</string>
+	<string name="IM_typing_start_string">
+		[NAME] sta scrivendo...
+	</string>
+	<string name="Unnamed">
+		(anonimo)
+	</string>
+	<string name="IM_moderated_chat_label">
+		(Moderato: Voci disattivate di default)
+	</string>
+	<string name="IM_unavailable_text_label">
+		La chat di testo non è disponibile per questa chiamata.
+	</string>
+	<string name="IM_muted_text_label">
+		La chat di testo è stata disabilitata da un moderatore di gruppo.
+	</string>
+	<string name="IM_default_text_label">
+		Clicca qui per inviare un messaggio instantaneo.
+	</string>
+	<string name="IM_to_label">
+		A
+	</string>
+	<string name="IM_moderator_label">
+		(Moderatore)
+	</string>
+	<string name="Saved_message">
+		(Salvato [LONG_TIMESTAMP])
+	</string>
+	<string name="IM_unblock_only_groups_friends">
+		Per vedere questo messaggio, devi deselezionare 'Solo amici e gruppi possono chiamarmi o mandarmi IM' in Preferenze/Privacy.
+	</string>
+	<string name="OnlineStatus">
+		Online
+	</string>
+	<string name="OfflineStatus">
+		Offline
+	</string>
+	<string name="not_online_msg">
+		Utente non online - il messaggio verrà memorizzato e inviato più tardi.
+	</string>
+	<string name="not_online_inventory">
+		Utente non online - l'inventario è stato salvato
+	</string>
+	<string name="answered_call">
+		Risposto alla chiamata
+	</string>
+	<string name="you_started_call">
+		Hai iniziato una chiamata vocale
+	</string>
+	<string name="you_joined_call">
+		Ti sei collegato alla chiamata in voce
+	</string>
+	<string name="you_auto_rejected_call-im">
+		Hai rifiutato automaticamente la chiamata voce mentre era attivata la modalità 'Non disturbare'.
+	</string>
+	<string name="name_started_call">
+		[NAME] ha iniziato una chiamata vocale
+	</string>
+	<string name="ringing-im">
+		Collegamento alla chiamata vocale...
+	</string>
+	<string name="connected-im">
+		Collegato, clicca Chiudi chiamata per agganciare
+	</string>
+	<string name="hang_up-im">
+		Chiusa la chiamata
+	</string>
+	<string name="conference-title">
+		Chat con più persone
+	</string>
+	<string name="conference-title-incoming">
+		Chiamata in conferenza con [AGENT_NAME]
+	</string>
+	<string name="inventory_item_offered-im">
+		Offerto oggetto di inventario "[ITEM_NAME]"
+	</string>
+	<string name="inventory_folder_offered-im">
+		Offerta cartella di inventario "[ITEM_NAME]"
+	</string>
 	<string name="bot_warning">
-Stai parlando con un bot, [NAME]. Non condividere informazioni personali.
+		Stai parlando con un bot, [NAME]. Non condividere informazioni personali.
 Scopri di più su https://second.life/scripted-agents.
 	</string>
-	<string name="facebook_post_success">Hai pubblicato su Facebook.</string>
-	<string name="flickr_post_success">Hai pubblicato su Flickr.</string>
-	<string name="twitter_post_success">Hai pubblicato su Twitter.</string>
-	<string name="no_session_message">(La sessione IM non esiste)</string>
-	<string name="only_user_message">Sei l'unico utente di questa sessione.</string>
-	<string name="offline_message">[NAME] è offline</string>
-	<string name="invite_message">Clicca il tasto [BUTTON NAME] per accettare/connetterti a questa voice chat.</string>
-	<string name="muted_message">Hai bloccato questo residente. Quando gli invii un messaggio, verrà automaticamente sbloccato.</string>
-	<string name="generic">Errore nella richiesta, riprova più tardi.</string>
-	<string name="generic_request_error">Errore durante la richiesta, riprova più tardi.</string>
-	<string name="insufficient_perms_error">Non hai sufficienti permessi.</string>
-	<string name="session_does_not_exist_error">Questa sessione non esiste più</string>
-	<string name="no_ability_error">Non hai questa abilitazione.</string>
-	<string name="no_ability">Non hai questa abilitazione.</string>
-	<string name="not_a_mod_error">Non sei un moderatore.</string>
-	<string name="muted">Il moderatore del gruppo ha disattivato la tua chat di testo.</string>
-	<string name="muted_error">Un moderatore di gruppo ti ha disabilitato dalla chat di testo.</string>
-	<string name="add_session_event">Impossibile aggiungere utenti alla chat con [RECIPIENT].</string>
-	<string name="message">Impossibile spedire il tuo messaggio nella sessione chat con [RECIPIENT].</string>
-	<string name="message_session_event">Impossibile inviare il messaggio nella chat con [RECIPIENT].</string>
-	<string name="mute">Errore durante la moderazione.</string>
-	<string name="removed">Sei stato rimosso dal gruppo.</string>
-	<string name="removed_from_group">Sei stato espulso dal gruppo.</string>
-	<string name="close_on_no_ability">Non hai più le abilitazioni per rimanere nella sessione chat.</string>
-	<string name="unread_chat_single">[SOURCES] ha detto qualcosa di nuovo</string>
-	<string name="unread_chat_multiple">[SOURCES] ha detto qualcosa di nuovo</string>
-	<string name="session_initialization_timed_out_error">Sessione di inizializzazione scaduta</string>
-	<string name="Home position set.">Posizione di base impostata.</string>
-	<string name="voice_morphing_url">https://secondlife.com/destination/voice-island</string>
-	<string name="premium_voice_morphing_url">https://secondlife.com/destination/voice-morphing-premium</string>
-	<string name="paid_you_ldollars">[NAME] ti ha inviato un pagamento di L$[AMOUNT] [REASON].</string>
-	<string name="paid_you_ldollars_gift">[NAME] ti ha inviato un pagamento di L$ [AMOUNT]: [REASON]</string>
-	<string name="paid_you_ldollars_no_reason">[NAME] ti ha inviato un pagamento di L$[AMOUNT].</string>
-	<string name="you_paid_ldollars">Hai inviato un pagamento di L$[AMOUNT] a [NAME] [REASON].</string>
-	<string name="you_paid_ldollars_gift">Hai inviato un pagamento di L$ [AMOUNT] a [NAME]: [REASON]</string>
-	<string name="you_paid_ldollars_no_info">Hai pagato L$ [AMOUNT].</string>
-	<string name="you_paid_ldollars_no_reason">Hai inviato un pagamento di L$[AMOUNT] a [NAME].</string>
-	<string name="you_paid_ldollars_no_name">Hai pagato L$ [AMOUNT] [REASON].</string>
-	<string name="you_paid_failure_ldollars">Non hai pagato [NAME] L$[AMOUNT] [REASON].</string>
-	<string name="you_paid_failure_ldollars_gift">Non hai inviato un pagamento di L$ [AMOUNT] a [NAME]: [REASON]</string>
-	<string name="you_paid_failure_ldollars_no_info">Non hai pagato L$ [AMOUNT].</string>
-	<string name="you_paid_failure_ldollars_no_reason">Non hai pagato [NAME] L$[AMOUNT].</string>
-	<string name="you_paid_failure_ldollars_no_name">Non hai pagato L$ [AMOUNT] [REASON].</string>
-	<string name="for item">per [ITEM]</string>
-	<string name="for a parcel of land">per un lotto di terreno</string>
-	<string name="for a land access pass">per un permesso di accesso al terreno</string>
-	<string name="for deeding land">per la cessione di terreno</string>
-	<string name="to create a group">per creare un gruppo</string>
-	<string name="to join a group">per aderire a un gruppo</string>
-	<string name="to upload">per caricare</string>
-	<string name="to publish a classified ad">per pubblicare un annuncio</string>
-	<string name="giving">Contributo di L$ [AMOUNT]</string>
-	<string name="uploading_costs">Il costo per il caricamento è di L$ [AMOUNT]</string>
-	<string name="this_costs">Il costo è L$ [AMOUNT]</string>
-	<string name="buying_selected_land">L'acquisto del terreno prescelto costa L$ [AMOUNT]</string>
-	<string name="this_object_costs">Il costo dell'oggetto è L$ [AMOUNT]</string>
-	<string name="group_role_everyone">Tutti</string>
-	<string name="group_role_officers">Funzionari</string>
-	<string name="group_role_owners">Proprietari</string>
-	<string name="group_member_status_online">Online</string>
-	<string name="uploading_abuse_report">Caricamento in corso...
+	<string name="facebook_post_success">
+		Hai pubblicato su Facebook.
+	</string>
+	<string name="flickr_post_success">
+		Hai pubblicato su Flickr.
+	</string>
+	<string name="twitter_post_success">
+		Hai pubblicato su Twitter.
+	</string>
+	<string name="no_session_message">
+		(La sessione IM non esiste)
+	</string>
+	<string name="only_user_message">
+		Sei l'unico utente di questa sessione.
+	</string>
+	<string name="offline_message">
+		[NAME] è offline
+	</string>
+	<string name="invite_message">
+		Clicca il tasto [BUTTON NAME] per accettare/connetterti a questa voice chat.
+	</string>
+	<string name="muted_message">
+		Hai bloccato questo residente. Quando gli invii un messaggio, verrà automaticamente sbloccato.
+	</string>
+	<string name="generic">
+		Errore nella richiesta, riprova più tardi.
+	</string>
+	<string name="generic_request_error">
+		Errore durante la richiesta, riprova più tardi.
+	</string>
+	<string name="insufficient_perms_error">
+		Non hai sufficienti permessi.
+	</string>
+	<string name="session_does_not_exist_error">
+		Questa sessione non esiste più
+	</string>
+	<string name="no_ability_error">
+		Non hai questa abilitazione.
+	</string>
+	<string name="no_ability">
+		Non hai questa abilitazione.
+	</string>
+	<string name="not_a_mod_error">
+		Non sei un moderatore.
+	</string>
+	<string name="muted">
+		Il moderatore del gruppo ha disattivato la tua chat di testo.
+	</string>
+	<string name="muted_error">
+		Un moderatore di gruppo ti ha disabilitato dalla chat di testo.
+	</string>
+	<string name="add_session_event">
+		Impossibile aggiungere utenti alla chat con [RECIPIENT].
+	</string>
+	<string name="message">
+		Impossibile spedire il tuo messaggio nella sessione chat con [RECIPIENT].
+	</string>
+	<string name="message_session_event">
+		Impossibile inviare il messaggio nella chat con [RECIPIENT].
+	</string>
+	<string name="mute">
+		Errore durante la moderazione.
+	</string>
+	<string name="removed">
+		Sei stato rimosso dal gruppo.
+	</string>
+	<string name="removed_from_group">
+		Sei stato espulso dal gruppo.
+	</string>
+	<string name="close_on_no_ability">
+		Non hai più le abilitazioni per rimanere nella sessione chat.
+	</string>
+	<string name="unread_chat_single">
+		[SOURCES] ha detto qualcosa di nuovo
+	</string>
+	<string name="unread_chat_multiple">
+		[SOURCES] ha detto qualcosa di nuovo
+	</string>
+	<string name="session_initialization_timed_out_error">
+		Sessione di inizializzazione scaduta
+	</string>
+	<string name="Home position set.">
+		Posizione di base impostata.
+	</string>
+	<string name="voice_morphing_url">
+		https://secondlife.com/destination/voice-island
+	</string>
+	<string name="premium_voice_morphing_url">
+		https://secondlife.com/destination/voice-morphing-premium
+	</string>
+	<string name="paid_you_ldollars">
+		[NAME] ti ha inviato un pagamento di L$[AMOUNT] [REASON].
+	</string>
+	<string name="paid_you_ldollars_gift">
+		[NAME] ti ha inviato un pagamento di L$ [AMOUNT]: [REASON]
+	</string>
+	<string name="paid_you_ldollars_no_reason">
+		[NAME] ti ha inviato un pagamento di L$[AMOUNT].
+	</string>
+	<string name="you_paid_ldollars">
+		Hai inviato un pagamento di L$[AMOUNT] a [NAME] [REASON].
+	</string>
+	<string name="you_paid_ldollars_gift">
+		Hai inviato un pagamento di L$ [AMOUNT] a [NAME]: [REASON]
+	</string>
+	<string name="you_paid_ldollars_no_info">
+		Hai pagato L$ [AMOUNT].
+	</string>
+	<string name="you_paid_ldollars_no_reason">
+		Hai inviato un pagamento di L$[AMOUNT] a [NAME].
+	</string>
+	<string name="you_paid_ldollars_no_name">
+		Hai pagato L$ [AMOUNT] [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars">
+		Non hai pagato [NAME] L$[AMOUNT] [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars_gift">
+		Non hai inviato un pagamento di L$ [AMOUNT] a [NAME]: [REASON]
+	</string>
+	<string name="you_paid_failure_ldollars_no_info">
+		Non hai pagato L$ [AMOUNT].
+	</string>
+	<string name="you_paid_failure_ldollars_no_reason">
+		Non hai pagato [NAME] L$[AMOUNT].
+	</string>
+	<string name="you_paid_failure_ldollars_no_name">
+		Non hai pagato L$ [AMOUNT] [REASON].
+	</string>
+	<string name="for item">
+		per [ITEM]
+	</string>
+	<string name="for a parcel of land">
+		per un lotto di terreno
+	</string>
+	<string name="for a land access pass">
+		per un permesso di accesso al terreno
+	</string>
+	<string name="for deeding land">
+		per la cessione di terreno
+	</string>
+	<string name="to create a group">
+		per creare un gruppo
+	</string>
+	<string name="to join a group">
+		per aderire a un gruppo
+	</string>
+	<string name="to upload">
+		per caricare
+	</string>
+	<string name="to publish a classified ad">
+		per pubblicare un annuncio
+	</string>
+	<string name="giving">
+		Contributo di L$ [AMOUNT]
+	</string>
+	<string name="uploading_costs">
+		Il costo per il caricamento è di L$ [AMOUNT]
+	</string>
+	<string name="this_costs">
+		Il costo è L$ [AMOUNT]
+	</string>
+	<string name="buying_selected_land">
+		L'acquisto del terreno prescelto costa L$ [AMOUNT]
+	</string>
+	<string name="this_object_costs">
+		Il costo dell'oggetto è L$ [AMOUNT]
+	</string>
+	<string name="group_role_everyone">
+		Tutti
+	</string>
+	<string name="group_role_officers">
+		Funzionari
+	</string>
+	<string name="group_role_owners">
+		Proprietari
+	</string>
+	<string name="group_member_status_online">
+		Online
+	</string>
+	<string name="uploading_abuse_report">
+		Caricamento in corso...
 
-Segnala abuso</string>
-	<string name="New Shape">Nuova figura corporea</string>
-	<string name="New Skin">Nuova pelle</string>
-	<string name="New Hair">Nuovi capelli</string>
-	<string name="New Eyes">Nuovi occhi</string>
-	<string name="New Shirt">Nuova camicia</string>
-	<string name="New Pants">Nuovi pantaloni</string>
-	<string name="New Shoes">Nuove scarpe</string>
-	<string name="New Socks">Nuove calze</string>
-	<string name="New Jacket">Nuova giacca</string>
-	<string name="New Gloves">Nuovi guanti</string>
-	<string name="New Undershirt">Nuova maglietta intima</string>
-	<string name="New Underpants">Nuovi slip</string>
-	<string name="New Skirt">Nuova gonna</string>
-	<string name="New Alpha">Nuovo Alpha (trasparenza)</string>
-	<string name="New Tattoo">Nuovo tatuaggio</string>
-	<string name="New Universal">Nuovo Universale</string>
-	<string name="New Physics">Nuova fisica</string>
-	<string name="Invalid Wearable">Capo da indossare non valido</string>
-	<string name="New Gesture">Nuova gesture</string>
-	<string name="New Script">Nuovo script</string>
-	<string name="New Note">Nuovo appunto</string>
-	<string name="New Folder">Nuova cartella</string>
-	<string name="Contents">Contenuto</string>
-	<string name="Gesture">Gesture</string>
-	<string name="Male Gestures">Gesture maschili</string>
-	<string name="Female Gestures">Gesture femminili</string>
-	<string name="Other Gestures">Altre gesture</string>
-	<string name="Speech Gestures">Gesture del parlato</string>
-	<string name="Common Gestures">Gesture comuni</string>
-	<string name="Male - Excuse me">Maschio - Chiedere scusa</string>
-	<string name="Male - Get lost">Maschio - Levati dai piedi!</string>
-	<string name="Male - Blow kiss">Maschio - Butta un bacio</string>
-	<string name="Male - Boo">Maschio - Bu</string>
-	<string name="Male - Bored">Maschio - Annoiato</string>
-	<string name="Male - Hey">Maschio - Ehi</string>
-	<string name="Male - Laugh">Maschio - Ridere</string>
-	<string name="Male - Repulsed">Maschio - Disgustato</string>
-	<string name="Male - Shrug">Maschio - Spallucce</string>
-	<string name="Male - Stick tougue out">Maschio - Tira fuori la lingua</string>
-	<string name="Male - Wow">Maschio - Accipicchia</string>
-	<string name="Female - Chuckle">Femmina - Risatina</string>
-	<string name="Female - Cry">Femmina - Pianto</string>
-	<string name="Female - Embarrassed">Femmina - Imbarazzata</string>
-	<string name="Female - Excuse me">Femmina - Chiedere scusa</string>
-	<string name="Female - Get lost">Femmina - Levati dai piedi!</string>
-	<string name="Female - Blow kiss">Femmina - Butta un bacio</string>
-	<string name="Female - Boo">Femmina - Bu</string>
-	<string name="Female - Bored">Femmina - Annoiata</string>
-	<string name="Female - Hey">Femmina - Ehi</string>
-	<string name="Female - Hey baby">Femmina - Ehi tu</string>
-	<string name="Female - Laugh">Femmina - Ridere</string>
-	<string name="Female - Looking good">Femmina - Sei in forma</string>
-	<string name="Female - Over here">Femmina - Per di qua</string>
-	<string name="Female - Please">Femmina - Per cortesia</string>
-	<string name="Female - Repulsed">Femmina - Disgustata</string>
-	<string name="Female - Shrug">Femmina - Spallucce</string>
-	<string name="Female - Stick tougue out">Femmina - Tira fuori la lingua</string>
-	<string name="Female - Wow">Femmina - Accipicchia</string>
-	<string name="New Daycycle">Nuovo ciclo giornata</string>
-	<string name="New Water">Nuova acqua</string>
-	<string name="New Sky">Nuovo cielo</string>
-	<string name="/bow">/inchino</string>
-	<string name="/clap">/applausi</string>
-	<string name="/count">/numero</string>
-	<string name="/extinguish">/estingui</string>
-	<string name="/kmb">/chissene</string>
-	<string name="/muscle">/muscolo</string>
-	<string name="/no">/no</string>
-	<string name="/no!">/no!</string>
-	<string name="/paper">/carta</string>
-	<string name="/pointme">/indicome</string>
-	<string name="/pointyou">/indicotu</string>
-	<string name="/rock">/sasso</string>
-	<string name="/scissor">/forbici</string>
-	<string name="/smoke">/fumo</string>
-	<string name="/stretch">/stiracchiata</string>
-	<string name="/whistle">/fischietto</string>
-	<string name="/yes">/si</string>
-	<string name="/yes!">/si!</string>
-	<string name="afk">non alla tastiera</string>
-	<string name="dance1">danza1</string>
-	<string name="dance2">danza2</string>
-	<string name="dance3">danza3</string>
-	<string name="dance4">danza4</string>
-	<string name="dance5">danza5</string>
-	<string name="dance6">danza6</string>
-	<string name="dance7">danza7</string>
-	<string name="dance8">danza8</string>
-	<string name="AvatarBirthDateFormat">[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]</string>
-	<string name="DefaultMimeType">nessuna/nessuna</string>
-	<string name="texture_load_dimensions_error">Impossibile caricare immagini di dimensioni superiori a [WIDTH]*[HEIGHT]</string>
-	<string name="outfit_photo_load_dimensions_error">Le dimensioni massime delle foto di vestiario sono [WIDTH]*[HEIGHT]. Ridimensiona l'immagine o usane un'altra</string>
-	<string name="outfit_photo_select_dimensions_error">Le dimensioni massime delle foto di vestiario sono [WIDTH]*[HEIGHT]. Seleziona un'altra texture</string>
-	<string name="outfit_photo_verify_dimensions_error">Impossibile verificare le dimensioni della foto. Attendi che le dimensioni siano visualizzate nel selettore.</string>
+Segnala abuso
+	</string>
+	<string name="New Shape">
+		Nuova figura corporea
+	</string>
+	<string name="New Skin">
+		Nuova pelle
+	</string>
+	<string name="New Hair">
+		Nuovi capelli
+	</string>
+	<string name="New Eyes">
+		Nuovi occhi
+	</string>
+	<string name="New Shirt">
+		Nuova camicia
+	</string>
+	<string name="New Pants">
+		Nuovi pantaloni
+	</string>
+	<string name="New Shoes">
+		Nuove scarpe
+	</string>
+	<string name="New Socks">
+		Nuove calze
+	</string>
+	<string name="New Jacket">
+		Nuova giacca
+	</string>
+	<string name="New Gloves">
+		Nuovi guanti
+	</string>
+	<string name="New Undershirt">
+		Nuova maglietta intima
+	</string>
+	<string name="New Underpants">
+		Nuovi slip
+	</string>
+	<string name="New Skirt">
+		Nuova gonna
+	</string>
+	<string name="New Alpha">
+		Nuovo Alpha (trasparenza)
+	</string>
+	<string name="New Tattoo">
+		Nuovo tatuaggio
+	</string>
+	<string name="New Universal">
+		Nuovo Universale
+	</string>
+	<string name="New Physics">
+		Nuova fisica
+	</string>
+	<string name="Invalid Wearable">
+		Capo da indossare non valido
+	</string>
+	<string name="New Gesture">
+		Nuova gesture
+	</string>
+	<string name="New Script">
+		Nuovo script
+	</string>
+	<string name="New Note">
+		Nuovo appunto
+	</string>
+	<string name="New Folder">
+		Nuova cartella
+	</string>
+	<string name="Contents">
+		Contenuto
+	</string>
+	<string name="Gesture">
+		Gesture
+	</string>
+	<string name="Male Gestures">
+		Gesture maschili
+	</string>
+	<string name="Female Gestures">
+		Gesture femminili
+	</string>
+	<string name="Other Gestures">
+		Altre gesture
+	</string>
+	<string name="Speech Gestures">
+		Gesture del parlato
+	</string>
+	<string name="Common Gestures">
+		Gesture comuni
+	</string>
+	<string name="Male - Excuse me">
+		Maschio - Chiedere scusa
+	</string>
+	<string name="Male - Get lost">
+		Maschio - Levati dai piedi!
+	</string>
+	<string name="Male - Blow kiss">
+		Maschio - Butta un bacio
+	</string>
+	<string name="Male - Boo">
+		Maschio - Bu
+	</string>
+	<string name="Male - Bored">
+		Maschio - Annoiato
+	</string>
+	<string name="Male - Hey">
+		Maschio - Ehi
+	</string>
+	<string name="Male - Laugh">
+		Maschio - Ridere
+	</string>
+	<string name="Male - Repulsed">
+		Maschio - Disgustato
+	</string>
+	<string name="Male - Shrug">
+		Maschio - Spallucce
+	</string>
+	<string name="Male - Stick tougue out">
+		Maschio - Tira fuori la lingua
+	</string>
+	<string name="Male - Wow">
+		Maschio - Accipicchia
+	</string>
+	<string name="Female - Chuckle">
+		Femmina - Risatina
+	</string>
+	<string name="Female - Cry">
+		Femmina - Pianto
+	</string>
+	<string name="Female - Embarrassed">
+		Femmina - Imbarazzata
+	</string>
+	<string name="Female - Excuse me">
+		Femmina - Chiedere scusa
+	</string>
+	<string name="Female - Get lost">
+		Femmina - Levati dai piedi!
+	</string>
+	<string name="Female - Blow kiss">
+		Femmina - Butta un bacio
+	</string>
+	<string name="Female - Boo">
+		Femmina - Bu
+	</string>
+	<string name="Female - Bored">
+		Femmina - Annoiata
+	</string>
+	<string name="Female - Hey">
+		Femmina - Ehi
+	</string>
+	<string name="Female - Hey baby">
+		Femmina - Ehi tu
+	</string>
+	<string name="Female - Laugh">
+		Femmina - Ridere
+	</string>
+	<string name="Female - Looking good">
+		Femmina - Sei in forma
+	</string>
+	<string name="Female - Over here">
+		Femmina - Per di qua
+	</string>
+	<string name="Female - Please">
+		Femmina - Per cortesia
+	</string>
+	<string name="Female - Repulsed">
+		Femmina - Disgustata
+	</string>
+	<string name="Female - Shrug">
+		Femmina - Spallucce
+	</string>
+	<string name="Female - Stick tougue out">
+		Femmina - Tira fuori la lingua
+	</string>
+	<string name="Female - Wow">
+		Femmina - Accipicchia
+	</string>
+	<string name="New Daycycle">
+		Nuovo ciclo giornata
+	</string>
+	<string name="New Water">
+		Nuova acqua
+	</string>
+	<string name="New Sky">
+		Nuovo cielo
+	</string>
+	<string name="/bow">
+		/inchino
+	</string>
+	<string name="/clap">
+		/applausi
+	</string>
+	<string name="/count">
+		/numero
+	</string>
+	<string name="/extinguish">
+		/estingui
+	</string>
+	<string name="/kmb">
+		/chissene
+	</string>
+	<string name="/muscle">
+		/muscolo
+	</string>
+	<string name="/no">
+		/no
+	</string>
+	<string name="/no!">
+		/no!
+	</string>
+	<string name="/paper">
+		/carta
+	</string>
+	<string name="/pointme">
+		/indicome
+	</string>
+	<string name="/pointyou">
+		/indicotu
+	</string>
+	<string name="/rock">
+		/sasso
+	</string>
+	<string name="/scissor">
+		/forbici
+	</string>
+	<string name="/smoke">
+		/fumo
+	</string>
+	<string name="/stretch">
+		/stiracchiata
+	</string>
+	<string name="/whistle">
+		/fischietto
+	</string>
+	<string name="/yes">
+		/si
+	</string>
+	<string name="/yes!">
+		/si!
+	</string>
+	<string name="afk">
+		non alla tastiera
+	</string>
+	<string name="dance1">
+		danza1
+	</string>
+	<string name="dance2">
+		danza2
+	</string>
+	<string name="dance3">
+		danza3
+	</string>
+	<string name="dance4">
+		danza4
+	</string>
+	<string name="dance5">
+		danza5
+	</string>
+	<string name="dance6">
+		danza6
+	</string>
+	<string name="dance7">
+		danza7
+	</string>
+	<string name="dance8">
+		danza8
+	</string>
+	<string name="AvatarBirthDateFormat">
+		[day,datetime,slt]/[mthnum,datetime,slt]/[year,datetime,slt]
+	</string>
+	<string name="DefaultMimeType">
+		nessuna/nessuna
+	</string>
+	<string name="texture_load_dimensions_error">
+		Impossibile caricare immagini di dimensioni superiori a [WIDTH]*[HEIGHT]
+	</string>
+	<string name="outfit_photo_load_dimensions_error">
+		Le dimensioni massime delle foto di vestiario sono [WIDTH]*[HEIGHT]. Ridimensiona l'immagine o usane un'altra
+	</string>
+	<string name="outfit_photo_select_dimensions_error">
+		Le dimensioni massime delle foto di vestiario sono [WIDTH]*[HEIGHT]. Seleziona un'altra texture
+	</string>
+	<string name="outfit_photo_verify_dimensions_error">
+		Impossibile verificare le dimensioni della foto. Attendi che le dimensioni siano visualizzate nel selettore.
+	</string>
 	<string name="words_separator" value=","/>
-	<string name="server_is_down">Nonostante i nostri tentativi, si è verificato un errore imprevisto.
+	<string name="server_is_down">
+		Nonostante i nostri tentativi, si è verificato un errore imprevisto.
 
 Consulta la pagina http://status.secondlifegrid.net per determinare se il problema del servizio è già stato riscontrato.
-        Se il problema continua, ti consigliamo di controllare le tue impostazioni di rete e del firewall.</string>
-	<string name="dateTimeWeekdaysNames">lunedì:martedì:mercoledì:giovedì:venerdì:sabato:domenica</string>
-	<string name="dateTimeWeekdaysShortNames">lun:mar:mer:gio:ven:sab:dom</string>
-	<string name="dateTimeMonthNames">gennaio:febbraio:marzo:aprile:maggio:giugno:luglio:agosto:settembre:ottobre:novembre:dicembre</string>
-	<string name="dateTimeMonthShortNames">gen:feb:mar:apr:mag:giu:lug:ago:sett:ott:nov:dic</string>
-	<string name="dateTimeDayFormat">[MDAY]</string>
-	<string name="dateTimeAM">antemeridiane</string>
-	<string name="dateTimePM">pomeridiane</string>
-	<string name="LocalEstimateUSD">US$ [AMOUNT]</string>
-	<string name="Group Ban">Espulsione di gruppo</string>
-	<string name="Membership">Abbonamento</string>
-	<string name="Roles">Ruoli</string>
-	<string name="Group Identity">Identità gruppo</string>
-	<string name="Parcel Management">Gestione lotto</string>
-	<string name="Parcel Identity">Identità lotto</string>
-	<string name="Parcel Settings">Impostazioni lotto</string>
-	<string name="Parcel Powers">Poteri lotto</string>
-	<string name="Parcel Access">Accesso al lotto</string>
-	<string name="Parcel Content">Contenuto lotto</string>
-	<string name="Object Management">Gestione oggetti</string>
-	<string name="Accounting">Contabilità</string>
-	<string name="Notices">Avvisi</string>
-	<string name="Chat" value="Chat :">Chat</string>
-	<string name="BaseMembership">Base</string>
-	<string name="PremiumMembership">Premium</string>
-	<string name="Premium_PlusMembership">Premium Plus</string>
-	<string name="DeleteItems">Cancellare gli elementi selezionati?</string>
-	<string name="DeleteItem">Cancellare l’elemento selezionato?</string>
-	<string name="EmptyOutfitText">Questo vestiario non contiene alcun elemento</string>
-	<string name="ExternalEditorNotSet">Seleziona un editor usando le impostazioni ExternalEditor.</string>
-	<string name="ExternalEditorNotFound">L'editor esterno specificato non è stato trovato.
+        Se il problema continua, ti consigliamo di controllare le tue impostazioni di rete e del firewall.
+	</string>
+	<string name="dateTimeWeekdaysNames">
+		lunedì:martedì:mercoledì:giovedì:venerdì:sabato:domenica
+	</string>
+	<string name="dateTimeWeekdaysShortNames">
+		lun:mar:mer:gio:ven:sab:dom
+	</string>
+	<string name="dateTimeMonthNames">
+		gennaio:febbraio:marzo:aprile:maggio:giugno:luglio:agosto:settembre:ottobre:novembre:dicembre
+	</string>
+	<string name="dateTimeMonthShortNames">
+		gen:feb:mar:apr:mag:giu:lug:ago:sett:ott:nov:dic
+	</string>
+	<string name="dateTimeDayFormat">
+		[MDAY]
+	</string>
+	<string name="dateTimeAM">
+		antemeridiane
+	</string>
+	<string name="dateTimePM">
+		pomeridiane
+	</string>
+	<string name="LocalEstimateUSD">
+		US$ [AMOUNT]
+	</string>
+	<string name="Group Ban">
+		Espulsione di gruppo
+	</string>
+	<string name="Membership">
+		Abbonamento
+	</string>
+	<string name="Roles">
+		Ruoli
+	</string>
+	<string name="Group Identity">
+		Identità gruppo
+	</string>
+	<string name="Parcel Management">
+		Gestione lotto
+	</string>
+	<string name="Parcel Identity">
+		Identità lotto
+	</string>
+	<string name="Parcel Settings">
+		Impostazioni lotto
+	</string>
+	<string name="Parcel Powers">
+		Poteri lotto
+	</string>
+	<string name="Parcel Access">
+		Accesso al lotto
+	</string>
+	<string name="Parcel Content">
+		Contenuto lotto
+	</string>
+	<string name="Object Management">
+		Gestione oggetti
+	</string>
+	<string name="Accounting">
+		Contabilità
+	</string>
+	<string name="Notices">
+		Avvisi
+	</string>
+	<string name="Chat" value="Chat :">
+		Chat
+	</string>
+	<string name="BaseMembership">
+		Base
+	</string>
+	<string name="PremiumMembership">
+		Premium
+	</string>
+	<string name="Premium_PlusMembership">
+		Premium Plus
+	</string>
+	<string name="DeleteItems">
+		Cancellare gli elementi selezionati?
+	</string>
+	<string name="DeleteItem">
+		Cancellare l’elemento selezionato?
+	</string>
+	<string name="EmptyOutfitText">
+		Questo vestiario non contiene alcun elemento
+	</string>
+	<string name="ExternalEditorNotSet">
+		Seleziona un editor usando le impostazioni ExternalEditor.
+	</string>
+	<string name="ExternalEditorNotFound">
+		L'editor esterno specificato non è stato trovato.
 Prova a racchiudere il percorso dell'editor in doppie virgolette.
-(per es. &quot;/percorso per il mio/editor&quot; &quot;%s&quot;)</string>
-	<string name="ExternalEditorCommandParseError">Errore nell'elaborazione del comando dell'editor esterno.</string>
-	<string name="ExternalEditorFailedToRun">L'editor esterno non è stato avviato.</string>
-	<string name="TranslationFailed">Traduzione non riuscita: [REASON]</string>
-	<string name="TranslationResponseParseError">Errore di elaborazione della risposta della traduzione.</string>
-	<string name="Esc">Esc</string>
-	<string name="Space">Space</string>
-	<string name="Enter">Enter</string>
-	<string name="Tab">Tab</string>
-	<string name="Ins">Ins</string>
-	<string name="Del">Del</string>
-	<string name="Backsp">Backsp</string>
-	<string name="Shift">Shift</string>
-	<string name="Ctrl">Ctrl</string>
-	<string name="Alt">Alt</string>
-	<string name="CapsLock">CapsLock</string>
-	<string name="Home">Home</string>
-	<string name="End">End</string>
-	<string name="PgUp">PgUp</string>
-	<string name="PgDn">PgDn</string>
-	<string name="F1">F1</string>
-	<string name="F2">F2</string>
-	<string name="F3">F3</string>
-	<string name="F4">F4</string>
-	<string name="F5">F5</string>
-	<string name="F6">F6</string>
-	<string name="F7">F7</string>
-	<string name="F8">F8</string>
-	<string name="F9">F9</string>
-	<string name="F10">F10</string>
-	<string name="F11">F11</string>
-	<string name="F12">F12</string>
-	<string name="Add">Aggiungi</string>
-	<string name="Subtract">Sottrai</string>
-	<string name="Multiply">Moltiplica</string>
-	<string name="Divide">Dividi</string>
-	<string name="PAD_DIVIDE">PAD_DIVIDE</string>
-	<string name="PAD_LEFT">PAD_LEFT</string>
-	<string name="PAD_RIGHT">PAD_RIGHT</string>
-	<string name="PAD_DOWN">PAD_DOWN</string>
-	<string name="PAD_UP">PAD_UP</string>
-	<string name="PAD_HOME">PAD_HOME</string>
-	<string name="PAD_END">PAD_END</string>
-	<string name="PAD_PGUP">PAD_PGUP</string>
-	<string name="PAD_PGDN">PAD_PGDN</string>
-	<string name="PAD_CENTER">PAD_CENTER</string>
-	<string name="PAD_INS">PAD_INS</string>
-	<string name="PAD_DEL">PAD_DEL</string>
-	<string name="PAD_Enter">PAD_Enter</string>
-	<string name="PAD_BUTTON0">PAD_BUTTON0</string>
-	<string name="PAD_BUTTON1">PAD_BUTTON1</string>
-	<string name="PAD_BUTTON2">PAD_BUTTON2</string>
-	<string name="PAD_BUTTON3">PAD_BUTTON3</string>
-	<string name="PAD_BUTTON4">PAD_BUTTON4</string>
-	<string name="PAD_BUTTON5">PAD_BUTTON5</string>
-	<string name="PAD_BUTTON6">PAD_BUTTON6</string>
-	<string name="PAD_BUTTON7">PAD_BUTTON7</string>
-	<string name="PAD_BUTTON8">PAD_BUTTON8</string>
-	<string name="PAD_BUTTON9">PAD_BUTTON9</string>
-	<string name="PAD_BUTTON10">PAD_BUTTON10</string>
-	<string name="PAD_BUTTON11">PAD_BUTTON11</string>
-	<string name="PAD_BUTTON12">PAD_BUTTON12</string>
-	<string name="PAD_BUTTON13">PAD_BUTTON13</string>
-	<string name="PAD_BUTTON14">PAD_BUTTON14</string>
-	<string name="PAD_BUTTON15">PAD_BUTTON15</string>
-	<string name="-">-</string>
-	<string name="=">=</string>
-	<string name="`">`</string>
-	<string name=";">;</string>
-	<string name="[">[</string>
-	<string name="]">]</string>
-	<string name="\">\</string>
-	<string name="0">0</string>
-	<string name="1">1</string>
-	<string name="2">2</string>
-	<string name="3">3</string>
-	<string name="4">4</string>
-	<string name="5">5</string>
-	<string name="6">6</string>
-	<string name="7">7</string>
-	<string name="8">8</string>
-	<string name="9">9</string>
-	<string name="A">A</string>
-	<string name="B">B</string>
-	<string name="C">C</string>
-	<string name="D">D</string>
-	<string name="E">E</string>
-	<string name="F">F</string>
-	<string name="G">G</string>
-	<string name="H">H</string>
-	<string name="I">I</string>
-	<string name="J">J</string>
-	<string name="K">K</string>
-	<string name="L">L</string>
-	<string name="M">M</string>
-	<string name="N">N</string>
-	<string name="O">O</string>
-	<string name="P">P</string>
-	<string name="Q">Q</string>
-	<string name="R">R</string>
-	<string name="S">S</string>
-	<string name="T">T</string>
-	<string name="U">U</string>
-	<string name="V">V</string>
-	<string name="W">W</string>
-	<string name="X">X</string>
-	<string name="Y">Y</string>
-	<string name="Z">Z</string>
-	<string name="BeaconParticle">Visualizzazione marcatori particelle (blu)</string>
-	<string name="BeaconPhysical">Visualizzazione marcatori oggetti fisici (verde)</string>
-	<string name="BeaconScripted">Visualizzazione marcatori oggetti scriptati (rosso)</string>
-	<string name="BeaconScriptedTouch">Visualizzazione marcatori oggetti scriptati con funzione tocco (rosso)</string>
-	<string name="BeaconSound">Visualizzazione marcatori suoni (giallo)</string>
-	<string name="BeaconMedia">Visualizzazione marcatori multimedia (bianco)</string>
-	<string name="BeaconSun">Marcatore visualizza direzione sole (arancione)</string>
-	<string name="BeaconMoon">Marcatore visualizza direzione luna (viola)</string>
-	<string name="ParticleHiding">Particelle nascoste</string>
-	<string name="Command_AboutLand_Label">Informazioni sul terreno</string>
-	<string name="Command_Appearance_Label">Aspetto fisico</string>
-	<string name="Command_Avatar_Label">Avatar</string>
-	<string name="Command_Build_Label">Costruisci</string>
-	<string name="Command_Chat_Label">Chat</string>
-	<string name="Command_Conversations_Label">Conversazioni</string>
-	<string name="Command_Compass_Label">Bussola</string>
-	<string name="Command_Destinations_Label">Destinazioni</string>
-	<string name="Command_Environments_Label">I miei ambienti</string>
-	<string name="Command_Facebook_Label">Facebook</string>
-	<string name="Command_Flickr_Label">Flickr</string>
-	<string name="Command_Gestures_Label">Gesture</string>
-	<string name="Command_Grid_Status_Label">Stato della griglia</string>
-	<string name="Command_HowTo_Label">Istruzioni</string>
-	<string name="Command_Inventory_Label">Inventario</string>
-	<string name="Command_Map_Label">Mappa</string>
-	<string name="Command_Marketplace_Label">Mercato</string>
-	<string name="Command_MarketplaceListings_Label">Marketplace</string>
-	<string name="Command_MiniMap_Label">Mini mappa</string>
-	<string name="Command_Move_Label">Cammina / corri / vola</string>
-	<string name="Command_Outbox_Label">Casella in uscita del rivenditore</string>
-	<string name="Command_People_Label">Persone</string>
-	<string name="Command_Picks_Label">Preferiti</string>
-	<string name="Command_Places_Label">Luoghi</string>
-	<string name="Command_Preferences_Label">Preferenze</string>
-	<string name="Command_Profile_Label">Profilo</string>
-	<string name="Command_Report_Abuse_Label">Segnala abuso</string>
-	<string name="Command_Search_Label">Ricerca</string>
-	<string name="Command_Snapshot_Label">Istantanea</string>
-	<string name="Command_Speak_Label">Parla</string>
-	<string name="Command_Twitter_Label">Twitter</string>
-	<string name="Command_View_Label">Controlli fotocamera</string>
-	<string name="Command_Voice_Label">Impostazioni voce</string>
-	<string name="Command_AboutLand_Tooltip">Informazioni sul terreno che visiti</string>
-	<string name="Command_Appearance_Tooltip">Cambia l'avatar</string>
-	<string name="Command_Avatar_Tooltip">Seleziona un avatar completo</string>
-	<string name="Command_Build_Tooltip">Costruzione oggetti e modifica terreno</string>
-	<string name="Command_Chat_Tooltip">Chatta con persone vicine usando il testo</string>
-	<string name="Command_Conversations_Tooltip">Conversa con chiunque</string>
-	<string name="Command_Compass_Tooltip">Bussola</string>
-	<string name="Command_Destinations_Tooltip">Destinazioni interessanti</string>
-	<string name="Command_Environments_Tooltip">I miei ambienti</string>
-	<string name="Command_Facebook_Tooltip">Pubblica su Facebook</string>
-	<string name="Command_Flickr_Tooltip">Carica su Flickr</string>
-	<string name="Command_Gestures_Tooltip">Gesti per il tuo avatar</string>
-	<string name="Command_Grid_Status_Tooltip">Mostra stato griglia corrente</string>
-	<string name="Command_HowTo_Tooltip">Come eseguire le attività più comuni</string>
-	<string name="Command_Inventory_Tooltip">Visualizza e usa le tue cose</string>
-	<string name="Command_Map_Tooltip">Mappa del mondo</string>
-	<string name="Command_Marketplace_Tooltip">Vai allo shopping</string>
-	<string name="Command_MarketplaceListings_Tooltip">Vendi le tue creazioni</string>
-	<string name="Command_MiniMap_Tooltip">Mostra le persone vicine</string>
-	<string name="Command_Move_Tooltip">Movimento avatar</string>
-	<string name="Command_Outbox_Tooltip">Trasferisci elementi al tuo mercato per la vendita</string>
-	<string name="Command_People_Tooltip">Amici, gruppi e persone vicine</string>
-	<string name="Command_Picks_Tooltip">Luoghi da mostrare come preferiti nel profilo</string>
-	<string name="Command_Places_Tooltip">Luoghi salvati</string>
-	<string name="Command_Preferences_Tooltip">Preferenze</string>
-	<string name="Command_Profile_Tooltip">Modifica o visualizza il tuo profilo</string>
-	<string name="Command_Report_Abuse_Tooltip">Segnala abuso</string>
-	<string name="Command_Search_Tooltip">Trova luoghi, eventi, persone</string>
-	<string name="Command_Snapshot_Tooltip">Scatta una foto</string>
-	<string name="Command_Speak_Tooltip">Parla con persone vicine usando il microfono</string>
-	<string name="Command_Twitter_Tooltip">Twitter</string>
-	<string name="Command_View_Tooltip">Modifica angolo fotocamera</string>
-	<string name="Command_Voice_Tooltip">I controlli per il volume per le chiamate e per le persone nelle vicinanze nel mondo virtuale</string>
-	<string name="Toolbar_Bottom_Tooltip">attualmente nella barra degli strumenti in basso</string>
-	<string name="Toolbar_Left_Tooltip">attualmente nella barra degli strumenti a sinistra</string>
-	<string name="Toolbar_Right_Tooltip">attualmente nella barra degli strumenti a destra</string>
-	<string name="Retain%">Mantieni%</string>
-	<string name="Detail">Dettagli</string>
-	<string name="Better Detail">Migliori dettagli</string>
-	<string name="Surface">Superficie</string>
-	<string name="Solid">Solido</string>
-	<string name="Wrap">Involucro</string>
-	<string name="Preview">Anteprima</string>
-	<string name="Normal">Normale</string>
-	<string name="Pathfinding_Wiki_URL">http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer</string>
-	<string name="Pathfinding_Object_Attr_None">Nessuno</string>
-	<string name="Pathfinding_Object_Attr_Permanent">Influenza il navmesh</string>
-	<string name="Pathfinding_Object_Attr_Character">Personaggio</string>
-	<string name="Pathfinding_Object_Attr_MultiSelect">(Multiple)</string>
-	<string name="snapshot_quality_very_low">Molto basso</string>
-	<string name="snapshot_quality_low">Basso</string>
-	<string name="snapshot_quality_medium">Medio</string>
-	<string name="snapshot_quality_high">Alto</string>
-	<string name="snapshot_quality_very_high">Molto alto</string>
-	<string name="TeleportMaturityExceeded">Il Residente non può visitare questa regione.</string>
-	<string name="UserDictionary">[User]</string>
-	<string name="experience_tools_experience">Esperienza</string>
-	<string name="ExperienceNameNull">(nessuna esperienza)</string>
-	<string name="ExperienceNameUntitled">(esperienza senza titolo)</string>
-	<string name="Land-Scope">A livello di terreno</string>
-	<string name="Grid-Scope">A livello di griglia</string>
-	<string name="Allowed_Experiences_Tab">CONSENTITO</string>
-	<string name="Blocked_Experiences_Tab">BLOCCATO</string>
-	<string name="Contrib_Experiences_Tab">FORNITORE</string>
-	<string name="Admin_Experiences_Tab">AMMINISTRATORE</string>
-	<string name="Recent_Experiences_Tab">RECENTE</string>
-	<string name="Owned_Experiences_Tab">DI PROPRIETÀ</string>
-	<string name="ExperiencesCounter">([EXPERIENCES], massimo [MAXEXPERIENCES])</string>
-	<string name="ExperiencePermission1">gestione dei tuoi comandi</string>
-	<string name="ExperiencePermission3">attivazione di animazioni per il tuo avatar</string>
-	<string name="ExperiencePermission4">collegamento al tuo avatar</string>
-	<string name="ExperiencePermission9">monitoraggio della tua videocamera</string>
-	<string name="ExperiencePermission10">controllo della tua videocamera</string>
-	<string name="ExperiencePermission11">ti teletrasporta</string>
-	<string name="ExperiencePermission12">accettazione automatica delle autorizzazioni per le esperienze</string>
-	<string name="ExperiencePermission16">obbliga l'avatar a sedersi</string>
-	<string name="ExperiencePermission17">cambia le impostazioni dell’ambiente</string>
-	<string name="ExperiencePermissionShortUnknown">ha eseguito un'operazione sconosciuta: [Permission]</string>
-	<string name="ExperiencePermissionShort1">Gestione dei comandi</string>
-	<string name="ExperiencePermissionShort3">Attivazione di animazioni</string>
-	<string name="ExperiencePermissionShort4">Collegamento</string>
-	<string name="ExperiencePermissionShort9">Monitoraggio videocamera</string>
-	<string name="ExperiencePermissionShort10">Controllo videocamera</string>
-	<string name="ExperiencePermissionShort11">Teleport</string>
-	<string name="ExperiencePermissionShort12">Autorizzazione</string>
-	<string name="ExperiencePermissionShort16">Siediti</string>
-	<string name="ExperiencePermissionShort17">Ambiente</string>
-	<string name="logging_calls_disabled_log_empty">Le conversazioni non vengono registrate. Per iniziare a registrare, seleziona &quot;Salva: Solo registro&quot; oppure &quot;Salva: Registri e trascrizioni&quot; in Preferenze &gt; Chat.</string>
-	<string name="logging_calls_disabled_log_not_empty">Non verranno registrate più le conversazioni. Per riprendere a registrare, seleziona &quot;Salva: Solo registro&quot; oppure &quot;Salva: Registri e trascrizioni&quot; in Preferenze &gt; Chat.</string>
-	<string name="logging_calls_enabled_log_empty">Nessuna conversazione in registro. Dopo che hai contattato qualcuno o se qualcuno ti contatta, una voce del registro verrà mostrata qui.</string>
-	<string name="loading_chat_logs">Caricamento in corso...</string>
-	<string name="na">n/d</string>
-	<string name="preset_combo_label">-Lista vuota-</string>
-	<string name="Default">Predefinita</string>
-	<string name="none_paren_cap">(Nulla)</string>
-	<string name="no_limit">Senza limite</string>
-	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">La forma della fisica contiene triangoli troppo piccoli. Prova a semplificare il modello della fisica.</string>
-	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">La forma della fisica contiene dati di conferma errati. Prova a correggere il modello della fisica.</string>
-	<string name="Mav_Details_MAV_UNKNOWN_VERSION">La versione della forma fisica non è corretta. Imposta la versione corretta per il modello della fisica.</string>
-	<string name="couldnt_resolve_host">Il DNS non ha potuto risolvere il nome dell’host([HOSTNAME]). 
+(per es. "/percorso per il mio/editor" "%s")
+	</string>
+	<string name="ExternalEditorCommandParseError">
+		Errore nell'elaborazione del comando dell'editor esterno.
+	</string>
+	<string name="ExternalEditorFailedToRun">
+		L'editor esterno non è stato avviato.
+	</string>
+	<string name="TranslationFailed">
+		Traduzione non riuscita: [REASON]
+	</string>
+	<string name="TranslationResponseParseError">
+		Errore di elaborazione della risposta della traduzione.
+	</string>
+	<string name="Esc">
+		Esc
+	</string>
+	<string name="Space">
+		Space
+	</string>
+	<string name="Enter">
+		Enter
+	</string>
+	<string name="Tab">
+		Tab
+	</string>
+	<string name="Ins">
+		Ins
+	</string>
+	<string name="Del">
+		Del
+	</string>
+	<string name="Backsp">
+		Backsp
+	</string>
+	<string name="Shift">
+		Shift
+	</string>
+	<string name="Ctrl">
+		Ctrl
+	</string>
+	<string name="Alt">
+		Alt
+	</string>
+	<string name="CapsLock">
+		CapsLock
+	</string>
+	<string name="Home">
+		Home
+	</string>
+	<string name="End">
+		End
+	</string>
+	<string name="PgUp">
+		PgUp
+	</string>
+	<string name="PgDn">
+		PgDn
+	</string>
+	<string name="F1">
+		F1
+	</string>
+	<string name="F2">
+		F2
+	</string>
+	<string name="F3">
+		F3
+	</string>
+	<string name="F4">
+		F4
+	</string>
+	<string name="F5">
+		F5
+	</string>
+	<string name="F6">
+		F6
+	</string>
+	<string name="F7">
+		F7
+	</string>
+	<string name="F8">
+		F8
+	</string>
+	<string name="F9">
+		F9
+	</string>
+	<string name="F10">
+		F10
+	</string>
+	<string name="F11">
+		F11
+	</string>
+	<string name="F12">
+		F12
+	</string>
+	<string name="Add">
+		Aggiungi
+	</string>
+	<string name="Subtract">
+		Sottrai
+	</string>
+	<string name="Multiply">
+		Moltiplica
+	</string>
+	<string name="Divide">
+		Dividi
+	</string>
+	<string name="PAD_DIVIDE">
+		PAD_DIVIDE
+	</string>
+	<string name="PAD_LEFT">
+		PAD_LEFT
+	</string>
+	<string name="PAD_RIGHT">
+		PAD_RIGHT
+	</string>
+	<string name="PAD_DOWN">
+		PAD_DOWN
+	</string>
+	<string name="PAD_UP">
+		PAD_UP
+	</string>
+	<string name="PAD_HOME">
+		PAD_HOME
+	</string>
+	<string name="PAD_END">
+		PAD_END
+	</string>
+	<string name="PAD_PGUP">
+		PAD_PGUP
+	</string>
+	<string name="PAD_PGDN">
+		PAD_PGDN
+	</string>
+	<string name="PAD_CENTER">
+		PAD_CENTER
+	</string>
+	<string name="PAD_INS">
+		PAD_INS
+	</string>
+	<string name="PAD_DEL">
+		PAD_DEL
+	</string>
+	<string name="PAD_Enter">
+		PAD_Enter
+	</string>
+	<string name="PAD_BUTTON0">
+		PAD_BUTTON0
+	</string>
+	<string name="PAD_BUTTON1">
+		PAD_BUTTON1
+	</string>
+	<string name="PAD_BUTTON2">
+		PAD_BUTTON2
+	</string>
+	<string name="PAD_BUTTON3">
+		PAD_BUTTON3
+	</string>
+	<string name="PAD_BUTTON4">
+		PAD_BUTTON4
+	</string>
+	<string name="PAD_BUTTON5">
+		PAD_BUTTON5
+	</string>
+	<string name="PAD_BUTTON6">
+		PAD_BUTTON6
+	</string>
+	<string name="PAD_BUTTON7">
+		PAD_BUTTON7
+	</string>
+	<string name="PAD_BUTTON8">
+		PAD_BUTTON8
+	</string>
+	<string name="PAD_BUTTON9">
+		PAD_BUTTON9
+	</string>
+	<string name="PAD_BUTTON10">
+		PAD_BUTTON10
+	</string>
+	<string name="PAD_BUTTON11">
+		PAD_BUTTON11
+	</string>
+	<string name="PAD_BUTTON12">
+		PAD_BUTTON12
+	</string>
+	<string name="PAD_BUTTON13">
+		PAD_BUTTON13
+	</string>
+	<string name="PAD_BUTTON14">
+		PAD_BUTTON14
+	</string>
+	<string name="PAD_BUTTON15">
+		PAD_BUTTON15
+	</string>
+	<string name="-">
+		-
+	</string>
+	<string name="=">
+		=
+	</string>
+	<string name="`">
+		`
+	</string>
+	<string name=";">
+		;
+	</string>
+	<string name="[">
+		[
+	</string>
+	<string name="]">
+		]
+	</string>
+	<string name="\">
+		\
+	</string>
+	<string name="0">
+		0
+	</string>
+	<string name="1">
+		1
+	</string>
+	<string name="2">
+		2
+	</string>
+	<string name="3">
+		3
+	</string>
+	<string name="4">
+		4
+	</string>
+	<string name="5">
+		5
+	</string>
+	<string name="6">
+		6
+	</string>
+	<string name="7">
+		7
+	</string>
+	<string name="8">
+		8
+	</string>
+	<string name="9">
+		9
+	</string>
+	<string name="A">
+		A
+	</string>
+	<string name="B">
+		B
+	</string>
+	<string name="C">
+		C
+	</string>
+	<string name="D">
+		D
+	</string>
+	<string name="E">
+		E
+	</string>
+	<string name="F">
+		F
+	</string>
+	<string name="G">
+		G
+	</string>
+	<string name="H">
+		H
+	</string>
+	<string name="I">
+		I
+	</string>
+	<string name="J">
+		J
+	</string>
+	<string name="K">
+		K
+	</string>
+	<string name="L">
+		L
+	</string>
+	<string name="M">
+		M
+	</string>
+	<string name="N">
+		N
+	</string>
+	<string name="O">
+		O
+	</string>
+	<string name="P">
+		P
+	</string>
+	<string name="Q">
+		Q
+	</string>
+	<string name="R">
+		R
+	</string>
+	<string name="S">
+		S
+	</string>
+	<string name="T">
+		T
+	</string>
+	<string name="U">
+		U
+	</string>
+	<string name="V">
+		V
+	</string>
+	<string name="W">
+		W
+	</string>
+	<string name="X">
+		X
+	</string>
+	<string name="Y">
+		Y
+	</string>
+	<string name="Z">
+		Z
+	</string>
+	<string name="BeaconParticle">
+		Visualizzazione marcatori particelle (blu)
+	</string>
+	<string name="BeaconPhysical">
+		Visualizzazione marcatori oggetti fisici (verde)
+	</string>
+	<string name="BeaconScripted">
+		Visualizzazione marcatori oggetti scriptati (rosso)
+	</string>
+	<string name="BeaconScriptedTouch">
+		Visualizzazione marcatori oggetti scriptati con funzione tocco (rosso)
+	</string>
+	<string name="BeaconSound">
+		Visualizzazione marcatori suoni (giallo)
+	</string>
+	<string name="BeaconMedia">
+		Visualizzazione marcatori multimedia (bianco)
+	</string>
+	<string name="BeaconSun">
+		Marcatore visualizza direzione sole (arancione)
+	</string>
+	<string name="BeaconMoon">
+		Marcatore visualizza direzione luna (viola)
+	</string>
+	<string name="ParticleHiding">
+		Particelle nascoste
+	</string>
+	<string name="Command_AboutLand_Label">
+		Informazioni sul terreno
+	</string>
+	<string name="Command_Appearance_Label">
+		Aspetto fisico
+	</string>
+	<string name="Command_Avatar_Label">
+		Avatar
+	</string>
+	<string name="Command_Build_Label">
+		Costruisci
+	</string>
+	<string name="Command_Chat_Label">
+		Chat
+	</string>
+	<string name="Command_Conversations_Label">
+		Conversazioni
+	</string>
+	<string name="Command_Compass_Label">
+		Bussola
+	</string>
+	<string name="Command_Destinations_Label">
+		Destinazioni
+	</string>
+	<string name="Command_Environments_Label">
+		I miei ambienti
+	</string>
+	<string name="Command_Facebook_Label">
+		Facebook
+	</string>
+	<string name="Command_Flickr_Label">
+		Flickr
+	</string>
+	<string name="Command_Gestures_Label">
+		Gesture
+	</string>
+	<string name="Command_Grid_Status_Label">
+		Stato della griglia
+	</string>
+	<string name="Command_HowTo_Label">
+		Istruzioni
+	</string>
+	<string name="Command_Inventory_Label">
+		Inventario
+	</string>
+	<string name="Command_Map_Label">
+		Mappa
+	</string>
+	<string name="Command_Marketplace_Label">
+		Mercato
+	</string>
+	<string name="Command_MarketplaceListings_Label">
+		Marketplace
+	</string>
+	<string name="Command_MiniMap_Label">
+		Mini mappa
+	</string>
+	<string name="Command_Move_Label">
+		Cammina / corri / vola
+	</string>
+	<string name="Command_Outbox_Label">
+		Casella in uscita del rivenditore
+	</string>
+	<string name="Command_People_Label">
+		Persone
+	</string>
+	<string name="Command_Picks_Label">
+		Preferiti
+	</string>
+	<string name="Command_Places_Label">
+		Luoghi
+	</string>
+	<string name="Command_Preferences_Label">
+		Preferenze
+	</string>
+	<string name="Command_Profile_Label">
+		Profilo
+	</string>
+	<string name="Command_Report_Abuse_Label">
+		Segnala abuso
+	</string>
+	<string name="Command_Search_Label">
+		Ricerca
+	</string>
+	<string name="Command_Snapshot_Label">
+		Istantanea
+	</string>
+	<string name="Command_Speak_Label">
+		Parla
+	</string>
+	<string name="Command_Twitter_Label">
+		Twitter
+	</string>
+	<string name="Command_View_Label">
+		Controlli fotocamera
+	</string>
+	<string name="Command_Voice_Label">
+		Impostazioni voce
+	</string>
+	<string name="Command_AboutLand_Tooltip">
+		Informazioni sul terreno che visiti
+	</string>
+	<string name="Command_Appearance_Tooltip">
+		Cambia l'avatar
+	</string>
+	<string name="Command_Avatar_Tooltip">
+		Seleziona un avatar completo
+	</string>
+	<string name="Command_Build_Tooltip">
+		Costruzione oggetti e modifica terreno
+	</string>
+	<string name="Command_Chat_Tooltip">
+		Chatta con persone vicine usando il testo
+	</string>
+	<string name="Command_Conversations_Tooltip">
+		Conversa con chiunque
+	</string>
+	<string name="Command_Compass_Tooltip">
+		Bussola
+	</string>
+	<string name="Command_Destinations_Tooltip">
+		Destinazioni interessanti
+	</string>
+	<string name="Command_Environments_Tooltip">
+		I miei ambienti
+	</string>
+	<string name="Command_Facebook_Tooltip">
+		Pubblica su Facebook
+	</string>
+	<string name="Command_Flickr_Tooltip">
+		Carica su Flickr
+	</string>
+	<string name="Command_Gestures_Tooltip">
+		Gesti per il tuo avatar
+	</string>
+	<string name="Command_Grid_Status_Tooltip">
+		Mostra stato griglia corrente
+	</string>
+	<string name="Command_HowTo_Tooltip">
+		Come eseguire le attività più comuni
+	</string>
+	<string name="Command_Inventory_Tooltip">
+		Visualizza e usa le tue cose
+	</string>
+	<string name="Command_Map_Tooltip">
+		Mappa del mondo
+	</string>
+	<string name="Command_Marketplace_Tooltip">
+		Vai allo shopping
+	</string>
+	<string name="Command_MarketplaceListings_Tooltip">
+		Vendi le tue creazioni
+	</string>
+	<string name="Command_MiniMap_Tooltip">
+		Mostra le persone vicine
+	</string>
+	<string name="Command_Move_Tooltip">
+		Movimento avatar
+	</string>
+	<string name="Command_Outbox_Tooltip">
+		Trasferisci elementi al tuo mercato per la vendita
+	</string>
+	<string name="Command_People_Tooltip">
+		Amici, gruppi e persone vicine
+	</string>
+	<string name="Command_Picks_Tooltip">
+		Luoghi da mostrare come preferiti nel profilo
+	</string>
+	<string name="Command_Places_Tooltip">
+		Luoghi salvati
+	</string>
+	<string name="Command_Preferences_Tooltip">
+		Preferenze
+	</string>
+	<string name="Command_Profile_Tooltip">
+		Modifica o visualizza il tuo profilo
+	</string>
+	<string name="Command_Report_Abuse_Tooltip">
+		Segnala abuso
+	</string>
+	<string name="Command_Search_Tooltip">
+		Trova luoghi, eventi, persone
+	</string>
+	<string name="Command_Snapshot_Tooltip">
+		Scatta una foto
+	</string>
+	<string name="Command_Speak_Tooltip">
+		Parla con persone vicine usando il microfono
+	</string>
+	<string name="Command_Twitter_Tooltip">
+		Twitter
+	</string>
+	<string name="Command_View_Tooltip">
+		Modifica angolo fotocamera
+	</string>
+	<string name="Command_Voice_Tooltip">
+		I controlli per il volume per le chiamate e per le persone nelle vicinanze nel mondo virtuale
+	</string>
+	<string name="Toolbar_Bottom_Tooltip">
+		attualmente nella barra degli strumenti in basso
+	</string>
+	<string name="Toolbar_Left_Tooltip">
+		attualmente nella barra degli strumenti a sinistra
+	</string>
+	<string name="Toolbar_Right_Tooltip">
+		attualmente nella barra degli strumenti a destra
+	</string>
+	<string name="Retain%">
+		Mantieni%
+	</string>
+	<string name="Detail">
+		Dettagli
+	</string>
+	<string name="Better Detail">
+		Migliori dettagli
+	</string>
+	<string name="Surface">
+		Superficie
+	</string>
+	<string name="Solid">
+		Solido
+	</string>
+	<string name="Wrap">
+		Involucro
+	</string>
+	<string name="Preview">
+		Anteprima
+	</string>
+	<string name="Normal">
+		Normale
+	</string>
+	<string name="Pathfinding_Wiki_URL">
+		http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer
+	</string>
+	<string name="Pathfinding_Object_Attr_None">
+		Nessuno
+	</string>
+	<string name="Pathfinding_Object_Attr_Permanent">
+		Influenza il navmesh
+	</string>
+	<string name="Pathfinding_Object_Attr_Character">
+		Personaggio
+	</string>
+	<string name="Pathfinding_Object_Attr_MultiSelect">
+		(Multiple)
+	</string>
+	<string name="snapshot_quality_very_low">
+		Molto basso
+	</string>
+	<string name="snapshot_quality_low">
+		Basso
+	</string>
+	<string name="snapshot_quality_medium">
+		Medio
+	</string>
+	<string name="snapshot_quality_high">
+		Alto
+	</string>
+	<string name="snapshot_quality_very_high">
+		Molto alto
+	</string>
+	<string name="TeleportMaturityExceeded">
+		Il Residente non può visitare questa regione.
+	</string>
+	<string name="UserDictionary">
+		[User]
+	</string>
+	<string name="experience_tools_experience">
+		Esperienza
+	</string>
+	<string name="ExperienceNameNull">
+		(nessuna esperienza)
+	</string>
+	<string name="ExperienceNameUntitled">
+		(esperienza senza titolo)
+	</string>
+	<string name="Land-Scope">
+		A livello di terreno
+	</string>
+	<string name="Grid-Scope">
+		A livello di griglia
+	</string>
+	<string name="Allowed_Experiences_Tab">
+		CONSENTITO
+	</string>
+	<string name="Blocked_Experiences_Tab">
+		BLOCCATO
+	</string>
+	<string name="Contrib_Experiences_Tab">
+		FORNITORE
+	</string>
+	<string name="Admin_Experiences_Tab">
+		AMMINISTRATORE
+	</string>
+	<string name="Recent_Experiences_Tab">
+		RECENTE
+	</string>
+	<string name="Owned_Experiences_Tab">
+		DI PROPRIETÀ
+	</string>
+	<string name="ExperiencesCounter">
+		([EXPERIENCES], massimo [MAXEXPERIENCES])
+	</string>
+	<string name="ExperiencePermission1">
+		gestione dei tuoi comandi
+	</string>
+	<string name="ExperiencePermission3">
+		attivazione di animazioni per il tuo avatar
+	</string>
+	<string name="ExperiencePermission4">
+		collegamento al tuo avatar
+	</string>
+	<string name="ExperiencePermission9">
+		monitoraggio della tua videocamera
+	</string>
+	<string name="ExperiencePermission10">
+		controllo della tua videocamera
+	</string>
+	<string name="ExperiencePermission11">
+		ti teletrasporta
+	</string>
+	<string name="ExperiencePermission12">
+		accettazione automatica delle autorizzazioni per le esperienze
+	</string>
+	<string name="ExperiencePermission16">
+		obbliga l'avatar a sedersi
+	</string>
+	<string name="ExperiencePermission17">
+		cambia le impostazioni dell’ambiente
+	</string>
+	<string name="ExperiencePermissionShortUnknown">
+		ha eseguito un'operazione sconosciuta: [Permission]
+	</string>
+	<string name="ExperiencePermissionShort1">
+		Gestione dei comandi
+	</string>
+	<string name="ExperiencePermissionShort3">
+		Attivazione di animazioni
+	</string>
+	<string name="ExperiencePermissionShort4">
+		Collegamento
+	</string>
+	<string name="ExperiencePermissionShort9">
+		Monitoraggio videocamera
+	</string>
+	<string name="ExperiencePermissionShort10">
+		Controllo videocamera
+	</string>
+	<string name="ExperiencePermissionShort11">
+		Teleport
+	</string>
+	<string name="ExperiencePermissionShort12">
+		Autorizzazione
+	</string>
+	<string name="ExperiencePermissionShort16">
+		Siediti
+	</string>
+	<string name="ExperiencePermissionShort17">
+		Ambiente
+	</string>
+	<string name="logging_calls_disabled_log_empty">
+		Le conversazioni non vengono registrate. Per iniziare a registrare, seleziona "Salva: Solo registro" oppure "Salva: Registri e trascrizioni" in Preferenze &gt; Chat.
+	</string>
+	<string name="logging_calls_disabled_log_not_empty">
+		Non verranno registrate più le conversazioni. Per riprendere a registrare, seleziona "Salva: Solo registro" oppure "Salva: Registri e trascrizioni" in Preferenze &gt; Chat.
+	</string>
+	<string name="logging_calls_enabled_log_empty">
+		Nessuna conversazione in registro. Dopo che hai contattato qualcuno o se qualcuno ti contatta, una voce del registro verrà mostrata qui.
+	</string>
+	<string name="loading_chat_logs">
+		Caricamento in corso...
+	</string>
+	<string name="na">
+		n/d
+	</string>
+	<string name="preset_combo_label">
+		-Lista vuota-
+	</string>
+	<string name="Default">
+		Predefinita
+	</string>
+	<string name="none_paren_cap">
+		(Nulla)
+	</string>
+	<string name="no_limit">
+		Senza limite
+	</string>
+	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">
+		La forma della fisica contiene triangoli troppo piccoli. Prova a semplificare il modello della fisica.
+	</string>
+	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">
+		La forma della fisica contiene dati di conferma errati. Prova a correggere il modello della fisica.
+	</string>
+	<string name="Mav_Details_MAV_UNKNOWN_VERSION">
+		La versione della forma fisica non è corretta. Imposta la versione corretta per il modello della fisica.
+	</string>
+	<string name="couldnt_resolve_host">
+		Il DNS non ha potuto risolvere il nome dell’host([HOSTNAME]). 
 Verifica di riuscire a connetterti al sito web www.secondlife.com. 
 Se riesci ma continui a ricevere questo errore, visita la sezione 
-Assistenza e segnala il problema.</string>
-	<string name="ssl_peer_certificate">Il server per il login non ha potuto effettuare la verifica tramite SSL. 
+Assistenza e segnala il problema.
+	</string>
+	<string name="ssl_peer_certificate">
+		Il server per il login non ha potuto effettuare la verifica tramite SSL. 
 Se continui a ricevere questo errore, visita 
 la sezione Assistenza nel sito SecondLife.com 
-e segnala il problema.</string>
-	<string name="ssl_connect_error">Spesso l’errore è dovuto all’orologio del computer, impostato incorrettamente. 
+e segnala il problema.
+	</string>
+	<string name="ssl_connect_error">
+		Spesso l’errore è dovuto all’orologio del computer, impostato incorrettamente. 
 Vai al Pannello di Controllo e assicurati che data e ora siano 
 esatte. Controlla anche che il network e il firewall siano impostati 
 correttamente. Se continui a ricevere questo errore, visita la sezione 
 Assistenza nel sito SecondLife.com e segnala il problema. 
 
-[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base conoscenze]</string>
+[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base conoscenze]
+	</string>
 </strings>

--- a/indra/newview/skins/default/xui/it/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/it/teleport_strings.xml
@@ -1,38 +1,94 @@
 <?xml version="1.0" ?>
 <teleport_messages>
 	<message_set name="errors">
-		<message name="invalid_tport">C'è stato un problema nell'elaborare la tua richiesta di teleport. Potresti dover effettuare nuovamente l'accesso prima di poter usare il teleport.
-Se si continua a visualizzare questo messaggio, consulta la pagina [SUPPORT_SITE].</message>
-		<message name="invalid_region_handoff">Si è verificato un problema nel tentativo di attraversare regioni. È possibile che per potere attraversare le regioni, tu debba effettuare nuovamente l'accesso.
-Se si continua a visualizzare questo messaggio, consulta la pagina [SUPPORT_SITE].</message>
-		<message name="blocked_tport">Spiacenti, il teletrasporto è bloccato al momento. Prova di nuovo tra pochi istanti. Se ancora non potrai teletrasportarti, per favore scollegati e ricollegati per risolvere il problema.</message>
-		<message name="nolandmark_tport">Spiacenti, ma il sistema non riesce a localizzare la destinazione del landmark</message>
-		<message name="timeout_tport">Spiacenti, il sistema non riesce a completare il teletrasporto. Riprova tra un attimo.</message>
-		<message name="NoHelpIslandTP">Non puoi teleportarti nuovamente a Welcome Island.
-Per ripetere l'esercitazione, visita 'Welcome Island Public'.</message>
-		<message name="noaccess_tport">Spiacenti, ma non hai accesso nel luogo di destinazione richiesto.</message>
-		<message name="missing_attach_tport">Gli oggetti da te indossati non sono ancoa arrivati. Attendi ancora qualche secondo o scollegati e ricollegati prima di provare a teleportarti.</message>
-		<message name="too_many_uploads_tport">Il server della regione è al momento occupato e la tua richiesta di teletrasporto non può essere soddisfatta entro breve tempo. Per favore prova di nuovo tra qualche minuto o spostati in un'area meno affollata.</message>
-		<message name="expired_tport">Spiacenti, il sistema non riesce a soddisfare la tua richiesta di teletrasporto entro un tempo ragionevole. Riprova tra qualche minuto.</message>
-		<message name="expired_region_handoff">Spiacenti, il sistema non riesce a completare il cambio di regione entro un tempo ragionevole. Riprova tra qualche minuto.</message>
-		<message name="no_host">Impossibile trovare la destinazione del teletrasporto; potrebbe essere temporaneamente non accessibile o non esistere più. Riprovaci tra qualche minuto.</message>
-		<message name="no_inventory_host">L'inventario è temporaneamente inaccessibile.</message>
-		<message name="MustGetAgeRegion">Per poter entrare in questa regione devi avere almeno 18 anni.</message>
-		<message name="RegionTPSpecialUsageBlocked">Impossibile entrare nella regione. '[REGION_NAME]' è una regione per giochi di abilità e per entrare è necessario soddisfare alcuni requisiti. Per dettagli, leggi le [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life domande frequenti sui giochi di abilità].</message>
-		<message name="preexisting_tport">Mi dispiace, ma il sistema non è stato in grado di avviare il teletrasporto. Ti preghiamo di riprovare tra qualche minuto.</message>
+		<message name="invalid_tport">
+			C'è stato un problema nell'elaborare la tua richiesta di teleport. Potresti dover effettuare nuovamente l'accesso prima di poter usare il teleport.
+Se si continua a visualizzare questo messaggio, consulta la pagina [SUPPORT_SITE].
+		</message>
+		<message name="invalid_region_handoff">
+			Si è verificato un problema nel tentativo di attraversare regioni. È possibile che per potere attraversare le regioni, tu debba effettuare nuovamente l'accesso.
+Se si continua a visualizzare questo messaggio, consulta la pagina [SUPPORT_SITE].
+		</message>
+		<message name="blocked_tport">
+			Spiacenti, il teletrasporto è bloccato al momento. Prova di nuovo tra pochi istanti. Se ancora non potrai teletrasportarti, per favore scollegati e ricollegati per risolvere il problema.
+		</message>
+		<message name="nolandmark_tport">
+			Spiacenti, ma il sistema non riesce a localizzare la destinazione del landmark
+		</message>
+		<message name="timeout_tport">
+			Spiacenti, il sistema non riesce a completare il teletrasporto. Riprova tra un attimo.
+		</message>
+		<message name="NoHelpIslandTP">
+			Non puoi teleportarti nuovamente a Welcome Island.
+Per ripetere l'esercitazione, visita 'Welcome Island Public'.
+		</message>
+		<message name="noaccess_tport">
+			Spiacenti, ma non hai accesso nel luogo di destinazione richiesto.
+		</message>
+		<message name="missing_attach_tport">
+			Gli oggetti da te indossati non sono ancoa arrivati. Attendi ancora qualche secondo o scollegati e ricollegati prima di provare a teleportarti.
+		</message>
+		<message name="too_many_uploads_tport">
+			Il server della regione è al momento occupato e la tua richiesta di teletrasporto non può essere soddisfatta entro breve tempo. Per favore prova di nuovo tra qualche minuto o spostati in un'area meno affollata.
+		</message>
+		<message name="expired_tport">
+			Spiacenti, il sistema non riesce a soddisfare la tua richiesta di teletrasporto entro un tempo ragionevole. Riprova tra qualche minuto.
+		</message>
+		<message name="expired_region_handoff">
+			Spiacenti, il sistema non riesce a completare il cambio di regione entro un tempo ragionevole. Riprova tra qualche minuto.
+		</message>
+		<message name="no_host">
+			Impossibile trovare la destinazione del teletrasporto; potrebbe essere temporaneamente non accessibile o non esistere più. Riprovaci tra qualche minuto.
+		</message>
+		<message name="no_inventory_host">
+			L'inventario è temporaneamente inaccessibile.
+		</message>
+		<message name="MustGetAgeRegion">
+			Per poter entrare in questa regione devi avere almeno 18 anni.
+		</message>
+		<message name="RegionTPSpecialUsageBlocked">
+			Impossibile entrare nella regione. '[REGION_NAME]' è una regione per giochi di abilità e per entrare è necessario soddisfare alcuni requisiti. Per dettagli, leggi le [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life domande frequenti sui giochi di abilità].
+		</message>
+		<message name="preexisting_tport">
+			Mi dispiace, ma il sistema non è stato in grado di avviare il teletrasporto. Ti preghiamo di riprovare tra qualche minuto.
+		</message>
 	</message_set>
 	<message_set name="progress">
-		<message name="sending_dest">In invio a destinazione.</message>
-		<message name="redirecting">In reindirizzamento ad una nuova destinazione.</message>
-		<message name="relaying">In reinvio a destinazione.</message>
-		<message name="sending_home">In invio verso la destinazione casa.</message>
-		<message name="sending_landmark">In invio verso la destinazione del landmark.</message>
-		<message name="completing">Teletrasporto completato</message>
-		<message name="completed_from">Teleport completato da [T_SLURL]</message>
-		<message name="resolving">Elaborazione della destinazione in corso...</message>
-		<message name="contacting">Contatto in corso con la nuova regione.</message>
-		<message name="arriving">In arrivo a destinazione...</message>
-		<message name="requesting">Avvio teletrasporto....</message>
-		<message name="pending">Teleport in sospeso...</message>
+		<message name="sending_dest">
+			In invio a destinazione.
+		</message>
+		<message name="redirecting">
+			In reindirizzamento ad una nuova destinazione.
+		</message>
+		<message name="relaying">
+			In reinvio a destinazione.
+		</message>
+		<message name="sending_home">
+			In invio verso la destinazione casa.
+		</message>
+		<message name="sending_landmark">
+			In invio verso la destinazione del landmark.
+		</message>
+		<message name="completing">
+			Teletrasporto completato
+		</message>
+		<message name="completed_from">
+			Teleport completato da [T_SLURL]
+		</message>
+		<message name="resolving">
+			Elaborazione della destinazione in corso...
+		</message>
+		<message name="contacting">
+			Contatto in corso con la nuova regione.
+		</message>
+		<message name="arriving">
+			In arrivo a destinazione...
+		</message>
+		<message name="requesting">
+			Avvio teletrasporto....
+		</message>
+		<message name="pending">
+			Teleport in sospeso...
+		</message>
 	</message_set>
 </teleport_messages>

--- a/indra/newview/skins/default/xui/ja/strings.xml
+++ b/indra/newview/skins/default/xui/ja/strings.xml
@@ -6150,7 +6150,7 @@ www.secondlife.com から最新バージョンをダウンロードしてくだ�
 		フォルダ「[ITEM_NAME]」がインベントリに送られてきました。
 	</string>
 	<string name="bot_warning">
-[NAME]とチャットしています。個人情報を共有しないでください。
+		[NAME]とチャットしています。個人情報を共有しないでください。
 詳細は https://second.life/scripted-agents をご覧ください。
 	</string>
 	<string name="share_alert">

--- a/indra/newview/skins/default/xui/pl/strings.xml
+++ b/indra/newview/skins/default/xui/pl/strings.xml
@@ -22,14 +22,14 @@
 		Konfiguracja budowania: [BUILD_CONFIG]
 	</string>
 	<string name="AboutPosition">
-Położenie [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] w [REGION] zlokalizowanym w &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+		Położenie [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] w [REGION] zlokalizowanym w &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (koordynaty globalne [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
 [SERVER_RELEASE_NOTES_URL]
 	</string>
 	<string name="AboutSystem">
-Procesor (CPU): [CPU]
+		Procesor (CPU): [CPU]
 Pamięć (Memory): [MEMORY_MB] MB
 System operacyjny (OS Version): [OS_VERSION]
 Dostawca karty graficznej (Graphics Card Vendor): [GRAPHICS_CARD_VENDOR]
@@ -42,7 +42,7 @@ Karta graficzna (Graphics Card): [GRAPHICS_CARD]
 		Wersja OpenGL: [OPENGL_VERSION]
 	</string>
 	<string name="AboutSettings">
-Rozmiar okna (Window size): [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+		Rozmiar okna (Window size): [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Dostrojenie rozmiaru czcionki: [FONT_SIZE_ADJUSTMENT]pt
 Skalowanie interfejsu (UI Scaling): [UI_SCALE]
 Pole widzenia (Draw Distance): [DRAW_DISTANCE]m
@@ -56,7 +56,7 @@ Pamięć podręczna dysku (Disk cache): [DISK_CACHE_INFO]
 		Tryb obrazu HiDPI: [HIDPI]
 	</string>
 	<string name="AboutLibs">
-Wersja dekodera J2C: [J2C_VERSION]
+		Wersja dekodera J2C: [J2C_VERSION]
 Wersja sterownika dźwięku (Audio Driver): [AUDIO_DRIVER_VERSION]
 [LIBCEF_VERSION]
 Wersja LibVLC: [LIBVLC_VERSION]
@@ -572,7 +572,7 @@ Jeśli myślisz, że to błąd skontaktuj się z support@secondlife.com
 		Usunięcie znajomego
 	</string>
 	<string name="BUTTON_CLOSE_DARWIN">
-		Zamknij (&#8984;W)
+		Zamknij (⌘W)
 	</string>
 	<string name="BUTTON_CLOSE_WIN">
 		Zamknij (Ctrl+W)
@@ -596,11 +596,11 @@ Jeśli myślisz, że to błąd skontaktuj się z support@secondlife.com
 		Pokaż Pomoc
 	</string>
 	<string name="TooltipNotecardNotAllowedTypeDrop">
-Przedmioty tego typu nie mogą być dołączane
+		Przedmioty tego typu nie mogą być dołączane
 do notek z tego regionu.
 	</string>
 	<string name="TooltipNotecardOwnerRestrictedDrop">
-Tylko przedmioty z nieograniczonymi
+		Tylko przedmioty z nieograniczonymi
 uprawnieniami 'następnego właściciela'
 mogą być dołączane do notek.
 	</string>
@@ -1622,7 +1622,7 @@ Jeśli ciągle otrzymujesz tą wiadomość, to skontaktuj się z pomocą technic
 	<string name="Scripts" value=" Skrypty,"/>
 	<string name="Sounds" value=" Dźwięki,"/>
 	<string name="Textures" value=" Tekstury,"/>
-	<string name="Settings" value=" Otoczenia," />
+	<string name="Settings" value=" Otoczenia,"/>
 	<string name="Snapshots" value=" Zdjęcia,"/>
 	<string name="No Filters" value="Nie "/>
 	<string name="Since Logoff" value=" - od wylogowania"/>
@@ -4359,7 +4359,7 @@ Jeżeli nadal otrzymujesz ten komunikat, skontaktuj się z [SUPPORT_SITE].
 		(Zapisano [LONG_TIMESTAMP])
 	</string>
 	<string name="IM_unblock_only_groups_friends">
-		Aby zobaczyć tą wiadomość musisz odznaczyć &apos;Tylko znajomi i grupy mogą wysyłać mi wiad. prywatne (IM) oraz rozmowy głosowe&apos; w Ustawieniach/Prywatności.
+		Aby zobaczyć tą wiadomość musisz odznaczyć 'Tylko znajomi i grupy mogą wysyłać mi wiad. prywatne (IM) oraz rozmowy głosowe' w Ustawieniach/Prywatności.
 	</string>
 	<string name="OnlineStatus">
 		dostępny/a
@@ -4413,7 +4413,7 @@ Jeżeli nadal otrzymujesz ten komunikat, skontaktuj się z [SUPPORT_SITE].
 		Zaoferowano folder: '[ITEM_NAME]'
 	</string>
 	<string name="bot_warning">
-Rozmawiasz z botem [NAME]. Nie udostępniaj żadnych danych osobowych.
+		Rozmawiasz z botem [NAME]. Nie udostępniaj żadnych danych osobowych.
 Dowiedz się więcej na https://second.life/scripted-agents.
 	</string>
 	<string name="share_alert">
@@ -5290,10 +5290,10 @@ Spróbuj załączyć ścieżkę do edytora w cytowaniu.
 		Otoczenie
 	</string>
 	<string name="logging_calls_disabled_log_empty">
-		Rozmowy nie są zapisywane do dziennika. Jeśli chcesz zacząć je logować wybierz "Zapisywanie: tylko dziennik" lub "Zapisywanie: dziennik i logi rozmów" w Preferencje > Czat.
+		Rozmowy nie są zapisywane do dziennika. Jeśli chcesz zacząć je logować wybierz "Zapisywanie: tylko dziennik" lub "Zapisywanie: dziennik i logi rozmów" w Preferencje &gt; Czat.
 	</string>
 	<string name="logging_calls_disabled_log_not_empty">
-		Rozmowy nie będą więcej zapisywane. Jeśli chcesz kontynuować ich logowanie wybierz "Zapisywanie: tylko dziennik" lub "Zapisywanie: dziennik i logi rozmów" w Preferencje > Czat.
+		Rozmowy nie będą więcej zapisywane. Jeśli chcesz kontynuować ich logowanie wybierz "Zapisywanie: tylko dziennik" lub "Zapisywanie: dziennik i logi rozmów" w Preferencje &gt; Czat.
 	</string>
 	<string name="logging_calls_enabled_log_empty">
 		Nie ma zapisanych rozmów. Jeśli skontaktujesz się z kimś, lub ktoś z Tobą, to wpis dziennika pojawi się tutaj.

--- a/indra/newview/skins/default/xui/pl/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/pl/teleport_strings.xml
@@ -22,7 +22,7 @@ Spróbuj jeszcze raz.
 		</message>
 		<message name="NoHelpIslandTP">
 			Brak możliwości ponownej teleportacji do Welcome Island.
-Odwiedź &apos;Welcome Island Public&apos; by powtórzyć szkolenie.
+Odwiedź 'Welcome Island Public' by powtórzyć szkolenie.
 		</message>
 		<message name="noaccess_tport">
 			Przepraszamy, ale nie masz dostępu do miejsca docelowego.

--- a/indra/newview/skins/default/xui/pt/strings.xml
+++ b/indra/newview/skins/default/xui/pt/strings.xml
@@ -1,574 +1,1628 @@
 <?xml version="1.0" ?>
 <strings>
-	<string name="CAPITALIZED_APP_NAME">SECOND LIFE</string>
-	<string name="SUPPORT_SITE">Portal de Supporte Second Life</string>
-	<string name="StartupDetectingHardware">Detectando hardware...</string>
-	<string name="StartupLoading">Carregando [APP_NAME]...</string>
-	<string name="StartupClearingCache">Limpando o cache...</string>
-	<string name="StartupInitializingTextureCache">Iniciando cache de texturas...</string>
-	<string name="StartupRequireDriverUpdate">Falha na inicialização dos gráficos. Atualize seu driver gráfico!</string>
-	<string name="AboutHeader">[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
-[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]</string>
-	<string name="BuildConfig">Configuração do corpo [BUILD_CONFIG]</string>
-	<string name="AboutPosition">Você está em [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] em [REGION] localizado em &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
+	<string name="CAPITALIZED_APP_NAME">
+		SECOND LIFE
+	</string>
+	<string name="SUPPORT_SITE">
+		Portal de Supporte Second Life
+	</string>
+	<string name="StartupDetectingHardware">
+		Detectando hardware...
+	</string>
+	<string name="StartupLoading">
+		Carregando [APP_NAME]...
+	</string>
+	<string name="StartupClearingCache">
+		Limpando o cache...
+	</string>
+	<string name="StartupInitializingTextureCache">
+		Iniciando cache de texturas...
+	</string>
+	<string name="StartupRequireDriverUpdate">
+		Falha na inicialização dos gráficos. Atualize seu driver gráfico!
+	</string>
+	<string name="AboutHeader">
+		[CHANNEL] [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2].[VIEWER_VERSION_3] ([ADDRESS_SIZE]bit) 
+[[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
+	</string>
+	<string name="BuildConfig">
+		Configuração do corpo [BUILD_CONFIG]
+	</string>
+	<string name="AboutPosition">
+		Você está em [POSITION_LOCAL_0,number,1], [POSITION_LOCAL_1,number,1], [POSITION_LOCAL_2,number,1] em [REGION] localizado em &lt;nolink&gt;[HOSTNAME]&lt;/nolink&gt;
 SLURL: &lt;nolink&gt;[SLURL]&lt;/nolink&gt;
 (coordenadas globais [POSITION_0,number,1], [POSITION_1,number,1], [POSITION_2,number,1])
 [SERVER_VERSION]
-[SERVER_RELEASE_NOTES_URL]</string>
-	<string name="AboutSystem">CPU: [CPU]
+[SERVER_RELEASE_NOTES_URL]
+	</string>
+	<string name="AboutSystem">
+		CPU: [CPU]
 Memória: [MEMORY_MB] MBs
 Versão OS: [OS_VERSION]
 Placa de vídeo: [GRAPHICS_CARD_VENDOR]
-Placa gráfica: [GRAPHICS_CARD]</string>
-	<string name="AboutDriver">Versão do driver de vídeo Windows: [GRAPHICS_DRIVER_VERSION]</string>
-	<string name="AboutOGL">Versão do OpenGL: [OPENGL_VERSION]</string>
-	<string name="AboutSettings">Tamanho da janela: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
+Placa gráfica: [GRAPHICS_CARD]
+	</string>
+	<string name="AboutDriver">
+		Versão do driver de vídeo Windows: [GRAPHICS_DRIVER_VERSION]
+	</string>
+	<string name="AboutOGL">
+		Versão do OpenGL: [OPENGL_VERSION]
+	</string>
+	<string name="AboutSettings">
+		Tamanho da janela: [WINDOW_WIDTH]x[WINDOW_HEIGHT]
 Ajuste do tamanho da fonte: [FONT_SIZE_ADJUSTMENT]pt
 UI Escala: [UI_SCALE]
 Estabelecer a distância: [DRAW_DISTANCE]m
 Largura da banda: [NET_BANDWITH]kbit/s
 LOD fator: [LOD_FACTOR]
 Qualidade de renderização: [RENDER_QUALITY]
-Memória de textura: [TEXTURE_MEMORY]MB</string>
-	<string name="AboutOSXHiDPI">HiDPI modo de exibição: [HIDPI]</string>
-	<string name="AboutLibs">Versão do J2C Decoder: [J2C_VERSION] 
+Memória de textura: [TEXTURE_MEMORY]MB
+	</string>
+	<string name="AboutOSXHiDPI">
+		HiDPI modo de exibição: [HIDPI]
+	</string>
+	<string name="AboutLibs">
+		Versão do J2C Decoder: [J2C_VERSION] 
 Versão do driver de áudio: [AUDIO_DRIVER_VERSION]
 [LIBCEF_VERSION] 
 Versão do LibVLC: [LIBVLC_VERSION] 
-Versão do servidor de voz: [VOICE_VERSION]</string>
-	<string name="AboutTraffic">Packets Lost: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)</string>
-	<string name="AboutTime">[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]</string>
-	<string name="ErrorFetchingServerReleaseNotesURL">Erro ao obter URL de notas de versão do servidor.</string>
-	<string name="BuildConfiguration">Configuração do corpo</string>
-	<string name="ProgressRestoring">Restaurando...</string>
-	<string name="ProgressChangingResolution">Alterando a resolução...</string>
-	<string name="Fullbright">Fullbright (antigo)</string>
-	<string name="LoginInProgress">Fazendo login. [APP_NAME] pode parecer congelado. Por favor, aguarde.</string>
-	<string name="LoginInProgressNoFrozen">Logando...</string>
-	<string name="LoginAuthenticating">Autenticando</string>
-	<string name="LoginMaintenance">Executando manutenção da conta...</string>
-	<string name="LoginAttempt">Falha na tentativa anterior de login. Login, tentativa [NUMBER]</string>
-	<string name="LoginPrecaching">Carregando mundo...</string>
-	<string name="LoginInitializingBrowser">Inicializando navegador embutido...</string>
-	<string name="LoginInitializingMultimedia">Inicializando multimídia...</string>
-	<string name="LoginInitializingFonts">Carregando fontes...</string>
-	<string name="LoginVerifyingCache">Verificando arquivos cache (pode levar de 60-90 segundos)...</string>
-	<string name="LoginProcessingResponse">Processando resposta...</string>
-	<string name="LoginInitializingWorld">Inicializando mundo...</string>
-	<string name="LoginDecodingImages">Decodificando imagens...</string>
-	<string name="LoginInitializingQuicktime">Inicializando o QuickTime...</string>
-	<string name="LoginQuicktimeNotFound">O QuickTime não foi encontrado - falha ao iniciar.</string>
-	<string name="LoginQuicktimeOK">O QuickTime foi inicializado com sucesso.</string>
-	<string name="LoginRequestSeedCapGrant">Solicitando recursos da região...</string>
-	<string name="LoginRetrySeedCapGrant">Solicitando recursos da região, tentativa [NUMBER]...</string>
-	<string name="LoginWaitingForRegionHandshake">Aguardando handshake com a região...</string>
-	<string name="LoginConnectingToRegion">Conectando à região...</string>
-	<string name="LoginDownloadingClothing">Baixando roupas...</string>
-	<string name="InvalidCertificate">O servidor respondeu com um certificado inválido ou corrompido. Por favor contate o administrador do Grid.</string>
-	<string name="CertInvalidHostname">Um hostname inválido foi usado para acessar o servidor. Verifique o SLURL ou hostname do Grid.</string>
-	<string name="CertExpired">O certificado dado pelo Grid parece estar vencido.  Verifique o relógio do sistema ou contate o administrador do Grid.</string>
-	<string name="CertKeyUsage">O certificado dado pelo servidor não pôde ser usado para SSL.  Por favor contate o administrador do Grid.</string>
-	<string name="CertBasicConstraints">A cadeia de certificados do servidor tinha certificados demais.  Por favor contate o administrador do Grid.</string>
-	<string name="CertInvalidSignature">A assinatura do certificado dado pelo servidor do Grid não pôde ser verificada.  Contate o administrador do seu Grid.</string>
-	<string name="LoginFailedNoNetwork">Erro de rede: Falha de conexão: verifique sua conexão à internet.</string>
-	<string name="LoginFailedHeader">Falha do login.</string>
-	<string name="Quit">Sair</string>
-	<string name="create_account_url">http://join.secondlife.com/?sourceid=[sourceid]</string>
-	<string name="AgniGridLabel">Grade principal do Second Life (Agni)</string>
-	<string name="AditiGridLabel">Grade de teste beta do Second Life (Aditi)</string>
-	<string name="ViewerDownloadURL">http://secondlife.com/download</string>
-	<string name="LoginFailedViewerNotPermitted">O visualizador utilizado já não é compatível com o Second Life.  Visite a página abaixo para baixar uma versão atual: http://secondlife.com/download
+Versão do servidor de voz: [VOICE_VERSION]
+	</string>
+	<string name="AboutTraffic">
+		Packets Lost: [PACKETS_LOST,number,0]/[PACKETS_IN,number,0] ([PACKETS_PCT,number,1]%)
+	</string>
+	<string name="AboutTime">
+		[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
+	</string>
+	<string name="ErrorFetchingServerReleaseNotesURL">
+		Erro ao obter URL de notas de versão do servidor.
+	</string>
+	<string name="BuildConfiguration">
+		Configuração do corpo
+	</string>
+	<string name="ProgressRestoring">
+		Restaurando...
+	</string>
+	<string name="ProgressChangingResolution">
+		Alterando a resolução...
+	</string>
+	<string name="Fullbright">
+		Fullbright (antigo)
+	</string>
+	<string name="LoginInProgress">
+		Fazendo login. [APP_NAME] pode parecer congelado. Por favor, aguarde.
+	</string>
+	<string name="LoginInProgressNoFrozen">
+		Logando...
+	</string>
+	<string name="LoginAuthenticating">
+		Autenticando
+	</string>
+	<string name="LoginMaintenance">
+		Executando manutenção da conta...
+	</string>
+	<string name="LoginAttempt">
+		Falha na tentativa anterior de login. Login, tentativa [NUMBER]
+	</string>
+	<string name="LoginPrecaching">
+		Carregando mundo...
+	</string>
+	<string name="LoginInitializingBrowser">
+		Inicializando navegador embutido...
+	</string>
+	<string name="LoginInitializingMultimedia">
+		Inicializando multimídia...
+	</string>
+	<string name="LoginInitializingFonts">
+		Carregando fontes...
+	</string>
+	<string name="LoginVerifyingCache">
+		Verificando arquivos cache (pode levar de 60-90 segundos)...
+	</string>
+	<string name="LoginProcessingResponse">
+		Processando resposta...
+	</string>
+	<string name="LoginInitializingWorld">
+		Inicializando mundo...
+	</string>
+	<string name="LoginDecodingImages">
+		Decodificando imagens...
+	</string>
+	<string name="LoginInitializingQuicktime">
+		Inicializando o QuickTime...
+	</string>
+	<string name="LoginQuicktimeNotFound">
+		O QuickTime não foi encontrado - falha ao iniciar.
+	</string>
+	<string name="LoginQuicktimeOK">
+		O QuickTime foi inicializado com sucesso.
+	</string>
+	<string name="LoginRequestSeedCapGrant">
+		Solicitando recursos da região...
+	</string>
+	<string name="LoginRetrySeedCapGrant">
+		Solicitando recursos da região, tentativa [NUMBER]...
+	</string>
+	<string name="LoginWaitingForRegionHandshake">
+		Aguardando handshake com a região...
+	</string>
+	<string name="LoginConnectingToRegion">
+		Conectando à região...
+	</string>
+	<string name="LoginDownloadingClothing">
+		Baixando roupas...
+	</string>
+	<string name="InvalidCertificate">
+		O servidor respondeu com um certificado inválido ou corrompido. Por favor contate o administrador do Grid.
+	</string>
+	<string name="CertInvalidHostname">
+		Um hostname inválido foi usado para acessar o servidor. Verifique o SLURL ou hostname do Grid.
+	</string>
+	<string name="CertExpired">
+		O certificado dado pelo Grid parece estar vencido.  Verifique o relógio do sistema ou contate o administrador do Grid.
+	</string>
+	<string name="CertKeyUsage">
+		O certificado dado pelo servidor não pôde ser usado para SSL.  Por favor contate o administrador do Grid.
+	</string>
+	<string name="CertBasicConstraints">
+		A cadeia de certificados do servidor tinha certificados demais.  Por favor contate o administrador do Grid.
+	</string>
+	<string name="CertInvalidSignature">
+		A assinatura do certificado dado pelo servidor do Grid não pôde ser verificada.  Contate o administrador do seu Grid.
+	</string>
+	<string name="LoginFailedNoNetwork">
+		Erro de rede: Falha de conexão: verifique sua conexão à internet.
+	</string>
+	<string name="LoginFailedHeader">
+		Falha do login.
+	</string>
+	<string name="Quit">
+		Sair
+	</string>
+	<string name="create_account_url">
+		http://join.secondlife.com/?sourceid=[sourceid]
+	</string>
+	<string name="AgniGridLabel">
+		Grade principal do Second Life (Agni)
+	</string>
+	<string name="AditiGridLabel">
+		Grade de teste beta do Second Life (Aditi)
+	</string>
+	<string name="ViewerDownloadURL">
+		http://secondlife.com/download
+	</string>
+	<string name="LoginFailedViewerNotPermitted">
+		O visualizador utilizado já não é compatível com o Second Life.  Visite a página abaixo para baixar uma versão atual: http://secondlife.com/download
 
-Para saber mais, visite as perguntas frequentes abaixo: http://secondlife.com/viewer-access-faq</string>
-	<string name="LoginIntermediateOptionalUpdateAvailable">Existe uma versão atualizada do seu visualizador: [VERSION]</string>
-	<string name="LoginFailedRequiredUpdate">Atualização de visualizador obrigatória: [VERSION]</string>
-	<string name="LoginFailedAlreadyLoggedIn">Este agente já fez login.</string>
-	<string name="LoginFailedAuthenticationFailed">Desculpe! Não foi possível fazer seu login. Verifique se digitou o nome de usuário correto* (como kiki45 ou astro.física) * e senha. Verifique também que a tecla Maiúscula está desativada.</string>
-	<string name="LoginFailedPasswordChanged">Como medida de precaução, sua senha foi alterada.  Visite sua conta em http://secondlife.com/password e responda a pergunta de segurança para mudar sua senha. Lamentamos qualquer inconveniente.</string>
-	<string name="LoginFailedPasswordReset">Fizemos algumas alterações a seu sistema. Você precisa selecionar outra senha.  Visite sua conta em http://secondlife.com/password e responda a pergunta de segurança para mudar sua senha. Lamentamos qualquer inconveniente.</string>
-	<string name="LoginFailedEmployeesOnly">O Second Life está fechado para manutenção no momento.  Somente funcionários podem acessá-lo.  Consulte www.secondlife.com/status para as últimas atualizações.</string>
-	<string name="LoginFailedPremiumOnly">Logons do Second Life estão temporariamente restritos para garantir a melhor experiência possível para os usuários no mundo virtual.
+Para saber mais, visite as perguntas frequentes abaixo: http://secondlife.com/viewer-access-faq
+	</string>
+	<string name="LoginIntermediateOptionalUpdateAvailable">
+		Existe uma versão atualizada do seu visualizador: [VERSION]
+	</string>
+	<string name="LoginFailedRequiredUpdate">
+		Atualização de visualizador obrigatória: [VERSION]
+	</string>
+	<string name="LoginFailedAlreadyLoggedIn">
+		Este agente já fez login.
+	</string>
+	<string name="LoginFailedAuthenticationFailed">
+		Desculpe! Não foi possível fazer seu login. Verifique se digitou o nome de usuário correto* (como kiki45 ou astro.física) * e senha. Verifique também que a tecla Maiúscula está desativada.
+	</string>
+	<string name="LoginFailedPasswordChanged">
+		Como medida de precaução, sua senha foi alterada.  Visite sua conta em http://secondlife.com/password e responda a pergunta de segurança para mudar sua senha. Lamentamos qualquer inconveniente.
+	</string>
+	<string name="LoginFailedPasswordReset">
+		Fizemos algumas alterações a seu sistema. Você precisa selecionar outra senha.  Visite sua conta em http://secondlife.com/password e responda a pergunta de segurança para mudar sua senha. Lamentamos qualquer inconveniente.
+	</string>
+	<string name="LoginFailedEmployeesOnly">
+		O Second Life está fechado para manutenção no momento.  Somente funcionários podem acessá-lo.  Consulte www.secondlife.com/status para as últimas atualizações.
+	</string>
+	<string name="LoginFailedPremiumOnly">
+		Logons do Second Life estão temporariamente restritos para garantir a melhor experiência possível para os usuários no mundo virtual.
 
-Pessoas com contas gratuitas não poderão acessar o Second Life no momento para dar espaço para aquelas que pagaram pelo Second Life.</string>
-	<string name="LoginFailedComputerProhibited">O Second Life não pode ser acessado deste computador.  Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LoginFailedAcountSuspended">Sua conta não está disponível para acesso até [TIME], horário do Pacífico nos EUA (GMT-08).</string>
-	<string name="LoginFailedAccountDisabled">Não é possível concluir a solicitação neste momento. 
-Entre em contato com o suporte do Second Life para obter ajuda em http://support.secondlife.com.</string>
-	<string name="LoginFailedTransformError">Dados discrepantes detectados durante o login.  Contate support@secondlife.com.</string>
-	<string name="LoginFailedAccountMaintenance">Sua conta está passando por um breve período de manutenção.  Sua conta não está disponível para acesso até [TIME], horário do Pacífico nos EUA (GMT-08).  Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LoginFailedPendingLogoutFault">Reação à solicitação de saída foi uma falha do simulador.</string>
-	<string name="LoginFailedPendingLogout">O sistema o está desconectando no momento. 
-Aguarde um minuto antes que tentar logar-se novamente.</string>
-	<string name="LoginFailedUnableToCreateSession">Impossível criar sessão válida.</string>
-	<string name="LoginFailedUnableToConnectToSimulator">Não foi possível conectar o simulador.</string>
-	<string name="LoginFailedRestrictedHours">Sua conta possui acesso ao Second Life das [START] às [END], horário da costa leste dos EUA. Volte novamente durante seu horário de acesso.  Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LoginFailedIncorrectParameters">Parâmetros incorretos. Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LoginFailedFirstNameNotAlphanumeric">O parâmetro de primeiro nome deve ser alfanumérico.  Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LoginFailedLastNameNotAlphanumeric">O parâmetro de sobrenome deve ser alfanumérico.  Se você acredita que houve algum equívoco, contate support@secondlife.com.</string>
-	<string name="LogoutFailedRegionGoingOffline">Região passando para modo offline.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutFailedAgentNotInRegion">Não há agente na região.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutFailedPendingLogin">A região estava acessada por outra sessão.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutFailedLoggingOut">A região estava passando para o modo offline na sessão anterior.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutFailedStillLoggingOut">A região estava passando para o modo offline na sessão anterior.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutSucceeded">A região passou para o modo offline na última sessão.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LogoutFailedLogoutBegun">A região inicou o modo offline.  Tente novamente dentro de alguns instantes.</string>
-	<string name="LoginFailedLoggingOutSession">O sistema iniciou o modo offline em sua sessão anterior.  Tente novamente dentro de alguns instantes.</string>
-	<string name="AgentLostConnection">Esta região pode estar passando por problemas. Por favor, verifique sua conexão com a internet.</string>
-	<string name="SavingSettings">Salvando configurações...</string>
-	<string name="LoggingOut">Saindo...</string>
-	<string name="ShuttingDown">Fechando...</string>
-	<string name="YouHaveBeenDisconnected">Você foi desconectado da região onde estava.</string>
-	<string name="SentToInvalidRegion">Você foi enviado para uma região inválida.</string>
-	<string name="TestingDisconnect">Teste de desconexão</string>
-	<string name="SocialFacebookConnecting">Conectando ao Facebook...</string>
-	<string name="SocialFacebookPosting">Publicando...</string>
-	<string name="SocialFacebookDisconnecting">Desconectando do Facebook...</string>
-	<string name="SocialFacebookErrorConnecting">Problema ao conectar ao Facebook</string>
-	<string name="SocialFacebookErrorPosting">Problema ao publicar no Facebook</string>
-	<string name="SocialFacebookErrorDisconnecting">Problema ao desconectar do Facebook</string>
-	<string name="SocialFlickrConnecting">Conectando ao Flickr...</string>
-	<string name="SocialFlickrPosting">Publicando...</string>
-	<string name="SocialFlickrDisconnecting">Desconectando do Flickr...</string>
-	<string name="SocialFlickrErrorConnecting">Problema ao conectar ao Flickr</string>
-	<string name="SocialFlickrErrorPosting">Problema ao publicar no Flickr</string>
-	<string name="SocialFlickrErrorDisconnecting">Problema ao desconectar do Flickr</string>
-	<string name="SocialTwitterConnecting">Conectando ao Twitter...</string>
-	<string name="SocialTwitterPosting">Publicando...</string>
-	<string name="SocialTwitterDisconnecting">Desconectando do Twitter...</string>
-	<string name="SocialTwitterErrorConnecting">Problema ao conectar ao Twitter</string>
-	<string name="SocialTwitterErrorPosting">Problema ao publicar no Twitter</string>
-	<string name="SocialTwitterErrorDisconnecting">Problema ao desconectar do Twitter</string>
-	<string name="BlackAndWhite">Preto e branco</string>
-	<string name="Colors1970">Cores dos anos 1970</string>
-	<string name="Intense">Intenso</string>
-	<string name="Newspaper">Retícula</string>
-	<string name="Sepia">Sépia</string>
-	<string name="Spotlight">Destaque</string>
-	<string name="Video">Vídeo</string>
-	<string name="Autocontrast">Autocontraste</string>
-	<string name="LensFlare">Reflexo de flash</string>
-	<string name="Miniature">Miniatura</string>
-	<string name="Toycamera">Câmera de brinquedo</string>
-	<string name="TooltipPerson">Pessoa</string>
-	<string name="TooltipNoName">(sem nome)</string>
-	<string name="TooltipOwner">Proprietário:</string>
-	<string name="TooltipPublic">Público</string>
-	<string name="TooltipIsGroup">(Grupo)</string>
-	<string name="TooltipForSaleL$">À venda: L$[AMOUNT]</string>
-	<string name="TooltipFlagGroupBuild">Construído por Grupo</string>
-	<string name="TooltipFlagNoBuild">Não é permitido construir</string>
-	<string name="TooltipFlagNoEdit">Construído por Grupo</string>
-	<string name="TooltipFlagNotSafe">Não é seguro</string>
-	<string name="TooltipFlagNoFly">Não é permitido voar</string>
-	<string name="TooltipFlagGroupScripts">Scripts de Grupo</string>
-	<string name="TooltipFlagNoScripts">Não são permitidos scripts</string>
-	<string name="TooltipLand">Terreno:</string>
-	<string name="TooltipMustSingleDrop">Apenas um item único pode ser arrastado para este local</string>
-	<string name="TooltipTooManyWearables">Você não pode usar uma pasta que contenha mais de [AMOUNT] itens.  Você pode mudar esse limite em Avançado &gt; Mostrar configurações de depuração &gt; WearFolderLimit.</string>
+Pessoas com contas gratuitas não poderão acessar o Second Life no momento para dar espaço para aquelas que pagaram pelo Second Life.
+	</string>
+	<string name="LoginFailedComputerProhibited">
+		O Second Life não pode ser acessado deste computador.  Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedAcountSuspended">
+		Sua conta não está disponível para acesso até [TIME], horário do Pacífico nos EUA (GMT-08).
+	</string>
+	<string name="LoginFailedAccountDisabled">
+		Não é possível concluir a solicitação neste momento. 
+Entre em contato com o suporte do Second Life para obter ajuda em http://support.secondlife.com.
+	</string>
+	<string name="LoginFailedTransformError">
+		Dados discrepantes detectados durante o login.  Contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedAccountMaintenance">
+		Sua conta está passando por um breve período de manutenção.  Sua conta não está disponível para acesso até [TIME], horário do Pacífico nos EUA (GMT-08).  Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedPendingLogoutFault">
+		Reação à solicitação de saída foi uma falha do simulador.
+	</string>
+	<string name="LoginFailedPendingLogout">
+		O sistema o está desconectando no momento. 
+Aguarde um minuto antes que tentar logar-se novamente.
+	</string>
+	<string name="LoginFailedUnableToCreateSession">
+		Impossível criar sessão válida.
+	</string>
+	<string name="LoginFailedUnableToConnectToSimulator">
+		Não foi possível conectar o simulador.
+	</string>
+	<string name="LoginFailedRestrictedHours">
+		Sua conta possui acesso ao Second Life das [START] às [END], horário da costa leste dos EUA. Volte novamente durante seu horário de acesso.  Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedIncorrectParameters">
+		Parâmetros incorretos. Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedFirstNameNotAlphanumeric">
+		O parâmetro de primeiro nome deve ser alfanumérico.  Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LoginFailedLastNameNotAlphanumeric">
+		O parâmetro de sobrenome deve ser alfanumérico.  Se você acredita que houve algum equívoco, contate support@secondlife.com.
+	</string>
+	<string name="LogoutFailedRegionGoingOffline">
+		Região passando para modo offline.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutFailedAgentNotInRegion">
+		Não há agente na região.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutFailedPendingLogin">
+		A região estava acessada por outra sessão.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutFailedLoggingOut">
+		A região estava passando para o modo offline na sessão anterior.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutFailedStillLoggingOut">
+		A região estava passando para o modo offline na sessão anterior.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutSucceeded">
+		A região passou para o modo offline na última sessão.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LogoutFailedLogoutBegun">
+		A região inicou o modo offline.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="LoginFailedLoggingOutSession">
+		O sistema iniciou o modo offline em sua sessão anterior.  Tente novamente dentro de alguns instantes.
+	</string>
+	<string name="AgentLostConnection">
+		Esta região pode estar passando por problemas. Por favor, verifique sua conexão com a internet.
+	</string>
+	<string name="SavingSettings">
+		Salvando configurações...
+	</string>
+	<string name="LoggingOut">
+		Saindo...
+	</string>
+	<string name="ShuttingDown">
+		Fechando...
+	</string>
+	<string name="YouHaveBeenDisconnected">
+		Você foi desconectado da região onde estava.
+	</string>
+	<string name="SentToInvalidRegion">
+		Você foi enviado para uma região inválida.
+	</string>
+	<string name="TestingDisconnect">
+		Teste de desconexão
+	</string>
+	<string name="SocialFacebookConnecting">
+		Conectando ao Facebook...
+	</string>
+	<string name="SocialFacebookPosting">
+		Publicando...
+	</string>
+	<string name="SocialFacebookDisconnecting">
+		Desconectando do Facebook...
+	</string>
+	<string name="SocialFacebookErrorConnecting">
+		Problema ao conectar ao Facebook
+	</string>
+	<string name="SocialFacebookErrorPosting">
+		Problema ao publicar no Facebook
+	</string>
+	<string name="SocialFacebookErrorDisconnecting">
+		Problema ao desconectar do Facebook
+	</string>
+	<string name="SocialFlickrConnecting">
+		Conectando ao Flickr...
+	</string>
+	<string name="SocialFlickrPosting">
+		Publicando...
+	</string>
+	<string name="SocialFlickrDisconnecting">
+		Desconectando do Flickr...
+	</string>
+	<string name="SocialFlickrErrorConnecting">
+		Problema ao conectar ao Flickr
+	</string>
+	<string name="SocialFlickrErrorPosting">
+		Problema ao publicar no Flickr
+	</string>
+	<string name="SocialFlickrErrorDisconnecting">
+		Problema ao desconectar do Flickr
+	</string>
+	<string name="SocialTwitterConnecting">
+		Conectando ao Twitter...
+	</string>
+	<string name="SocialTwitterPosting">
+		Publicando...
+	</string>
+	<string name="SocialTwitterDisconnecting">
+		Desconectando do Twitter...
+	</string>
+	<string name="SocialTwitterErrorConnecting">
+		Problema ao conectar ao Twitter
+	</string>
+	<string name="SocialTwitterErrorPosting">
+		Problema ao publicar no Twitter
+	</string>
+	<string name="SocialTwitterErrorDisconnecting">
+		Problema ao desconectar do Twitter
+	</string>
+	<string name="BlackAndWhite">
+		Preto e branco
+	</string>
+	<string name="Colors1970">
+		Cores dos anos 1970
+	</string>
+	<string name="Intense">
+		Intenso
+	</string>
+	<string name="Newspaper">
+		Retícula
+	</string>
+	<string name="Sepia">
+		Sépia
+	</string>
+	<string name="Spotlight">
+		Destaque
+	</string>
+	<string name="Video">
+		Vídeo
+	</string>
+	<string name="Autocontrast">
+		Autocontraste
+	</string>
+	<string name="LensFlare">
+		Reflexo de flash
+	</string>
+	<string name="Miniature">
+		Miniatura
+	</string>
+	<string name="Toycamera">
+		Câmera de brinquedo
+	</string>
+	<string name="TooltipPerson">
+		Pessoa
+	</string>
+	<string name="TooltipNoName">
+		(sem nome)
+	</string>
+	<string name="TooltipOwner">
+		Proprietário:
+	</string>
+	<string name="TooltipPublic">
+		Público
+	</string>
+	<string name="TooltipIsGroup">
+		(Grupo)
+	</string>
+	<string name="TooltipForSaleL$">
+		À venda: L$[AMOUNT]
+	</string>
+	<string name="TooltipFlagGroupBuild">
+		Construído por Grupo
+	</string>
+	<string name="TooltipFlagNoBuild">
+		Não é permitido construir
+	</string>
+	<string name="TooltipFlagNoEdit">
+		Construído por Grupo
+	</string>
+	<string name="TooltipFlagNotSafe">
+		Não é seguro
+	</string>
+	<string name="TooltipFlagNoFly">
+		Não é permitido voar
+	</string>
+	<string name="TooltipFlagGroupScripts">
+		Scripts de Grupo
+	</string>
+	<string name="TooltipFlagNoScripts">
+		Não são permitidos scripts
+	</string>
+	<string name="TooltipLand">
+		Terreno:
+	</string>
+	<string name="TooltipMustSingleDrop">
+		Apenas um item único pode ser arrastado para este local
+	</string>
+	<string name="TooltipTooManyWearables">
+		Você não pode usar uma pasta que contenha mais de [AMOUNT] itens.  Você pode mudar esse limite em Avançado &gt; Mostrar configurações de depuração &gt; WearFolderLimit.
+	</string>
 	<string name="TooltipPrice" value="L$[AMOUNT]"/>
-	<string name="TooltipSLIcon">Isso contém um link para uma página no domínio oficial do SecondLife.com ou LindenLab.com.</string>
-	<string name="TooltipOutboxDragToWorld">Não é possível fazer rez de itens da pasta Listagens do Marketplace</string>
-	<string name="TooltipOutboxWorn">Não é possível colocar itens que você estiver usando na pasta Listagens do Marketplace</string>
-	<string name="TooltipOutboxFolderLevels">A profundidade das pastas aninhadas excede [AMOUNT]. Diminua a profundidade das pastas dentro de pastas. Agrupe os itens se necessário.</string>
-	<string name="TooltipOutboxTooManyFolders">O número de subpastas excede [AMOUNT]. Diminua a o número de pastas em sua listagem. Agrupe os itens se necessário.</string>
-	<string name="TooltipOutboxTooManyObjects">O número de itens excede [AMOUNT]. Para vender mais que [AMOUNT] itens em uma listagem, você deve agrupar alguns deles.</string>
-	<string name="TooltipOutboxTooManyStockItems">O número de itens de estoque excede [AMOUNT].</string>
-	<string name="TooltipOutboxCannotDropOnRoot">Você pode soltar somente itens ou pastas na aba TUDO ou NÃO ASSOCIADOS. Selecione uma dessas abas e mova seus itens ou pastas novamente.</string>
-	<string name="TooltipOutboxNoTransfer">Um ou mais objetos não podem ser vendidos ou transferidos</string>
-	<string name="TooltipOutboxNotInInventory">É possível colocar somente itens do seu inventário no Marketplace</string>
-	<string name="TooltipOutboxLinked">Não é possível colocar itens ou pastas vinculadas no Marketplace</string>
-	<string name="TooltipOutboxCallingCard">Não é possível colocar cartões de visitas no Marketplace</string>
-	<string name="TooltipOutboxDragActive">Não é possível mover uma listagem publicada</string>
-	<string name="TooltipOutboxCannotMoveRoot">Não é possível mover a pasta raiz das listagens do Marketplace</string>
-	<string name="TooltipOutboxMixedStock">Todos os itens em uma pasta de estoque têm o mesmo tipo e permissão</string>
-	<string name="TooltipDragOntoOwnChild">Não é possível mover uma pasta para seu filho</string>
-	<string name="TooltipDragOntoSelf">Não é possível mover uma pasta para dentro dela mesma</string>
-	<string name="TooltipHttpUrl">Clique para ver a página web</string>
-	<string name="TooltipSLURL">Clique para ver os dados desta localização</string>
-	<string name="TooltipAgentUrl">Clique para ver o perfil deste residente</string>
-	<string name="TooltipAgentInspect">Saiba mais sobre este residente</string>
-	<string name="TooltipAgentMute">Clique para silenciar este residente</string>
-	<string name="TooltipAgentUnmute">Clique para desfazer silenciar neste residente</string>
-	<string name="TooltipAgentIM">Clique para enviar uma MI para este residente</string>
-	<string name="TooltipAgentPay">Clique para pagar este residente</string>
-	<string name="TooltipAgentOfferTeleport">Clique para enviar um pedido de amizade a este residente</string>
-	<string name="TooltipAgentRequestFriend">Clique para enviar um pedido de amizade a este residente</string>
-	<string name="TooltipGroupUrl">Clique para ver a descrição deste Grupo</string>
-	<string name="TooltipEventUrl">Clique para ver a descrição deste evento</string>
-	<string name="TooltipClassifiedUrl">Clique para ver este anúncio</string>
-	<string name="TooltipParcelUrl">Clique para ver a descrição desta parcela</string>
-	<string name="TooltipTeleportUrl">Clique para teletransportar para esta localização</string>
-	<string name="TooltipObjectIMUrl">Clique para ver a descrição deste objeto</string>
-	<string name="TooltipMapUrl">Clique para ver esta localização no mapa</string>
-	<string name="TooltipSLAPP">Clique para ativar no secondlife:// comando</string>
+	<string name="TooltipSLIcon">
+		Isso contém um link para uma página no domínio oficial do SecondLife.com ou LindenLab.com.
+	</string>
+	<string name="TooltipOutboxDragToWorld">
+		Não é possível fazer rez de itens da pasta Listagens do Marketplace
+	</string>
+	<string name="TooltipOutboxWorn">
+		Não é possível colocar itens que você estiver usando na pasta Listagens do Marketplace
+	</string>
+	<string name="TooltipOutboxFolderLevels">
+		A profundidade das pastas aninhadas excede [AMOUNT]. Diminua a profundidade das pastas dentro de pastas. Agrupe os itens se necessário.
+	</string>
+	<string name="TooltipOutboxTooManyFolders">
+		O número de subpastas excede [AMOUNT]. Diminua a o número de pastas em sua listagem. Agrupe os itens se necessário.
+	</string>
+	<string name="TooltipOutboxTooManyObjects">
+		O número de itens excede [AMOUNT]. Para vender mais que [AMOUNT] itens em uma listagem, você deve agrupar alguns deles.
+	</string>
+	<string name="TooltipOutboxTooManyStockItems">
+		O número de itens de estoque excede [AMOUNT].
+	</string>
+	<string name="TooltipOutboxCannotDropOnRoot">
+		Você pode soltar somente itens ou pastas na aba TUDO ou NÃO ASSOCIADOS. Selecione uma dessas abas e mova seus itens ou pastas novamente.
+	</string>
+	<string name="TooltipOutboxNoTransfer">
+		Um ou mais objetos não podem ser vendidos ou transferidos
+	</string>
+	<string name="TooltipOutboxNotInInventory">
+		É possível colocar somente itens do seu inventário no Marketplace
+	</string>
+	<string name="TooltipOutboxLinked">
+		Não é possível colocar itens ou pastas vinculadas no Marketplace
+	</string>
+	<string name="TooltipOutboxCallingCard">
+		Não é possível colocar cartões de visitas no Marketplace
+	</string>
+	<string name="TooltipOutboxDragActive">
+		Não é possível mover uma listagem publicada
+	</string>
+	<string name="TooltipOutboxCannotMoveRoot">
+		Não é possível mover a pasta raiz das listagens do Marketplace
+	</string>
+	<string name="TooltipOutboxMixedStock">
+		Todos os itens em uma pasta de estoque têm o mesmo tipo e permissão
+	</string>
+	<string name="TooltipDragOntoOwnChild">
+		Não é possível mover uma pasta para seu filho
+	</string>
+	<string name="TooltipDragOntoSelf">
+		Não é possível mover uma pasta para dentro dela mesma
+	</string>
+	<string name="TooltipHttpUrl">
+		Clique para ver a página web
+	</string>
+	<string name="TooltipSLURL">
+		Clique para ver os dados desta localização
+	</string>
+	<string name="TooltipAgentUrl">
+		Clique para ver o perfil deste residente
+	</string>
+	<string name="TooltipAgentInspect">
+		Saiba mais sobre este residente
+	</string>
+	<string name="TooltipAgentMute">
+		Clique para silenciar este residente
+	</string>
+	<string name="TooltipAgentUnmute">
+		Clique para desfazer silenciar neste residente
+	</string>
+	<string name="TooltipAgentIM">
+		Clique para enviar uma MI para este residente
+	</string>
+	<string name="TooltipAgentPay">
+		Clique para pagar este residente
+	</string>
+	<string name="TooltipAgentOfferTeleport">
+		Clique para enviar um pedido de amizade a este residente
+	</string>
+	<string name="TooltipAgentRequestFriend">
+		Clique para enviar um pedido de amizade a este residente
+	</string>
+	<string name="TooltipGroupUrl">
+		Clique para ver a descrição deste Grupo
+	</string>
+	<string name="TooltipEventUrl">
+		Clique para ver a descrição deste evento
+	</string>
+	<string name="TooltipClassifiedUrl">
+		Clique para ver este anúncio
+	</string>
+	<string name="TooltipParcelUrl">
+		Clique para ver a descrição desta parcela
+	</string>
+	<string name="TooltipTeleportUrl">
+		Clique para teletransportar para esta localização
+	</string>
+	<string name="TooltipObjectIMUrl">
+		Clique para ver a descrição deste objeto
+	</string>
+	<string name="TooltipMapUrl">
+		Clique para ver esta localização no mapa
+	</string>
+	<string name="TooltipSLAPP">
+		Clique para ativar no secondlife:// comando
+	</string>
 	<string name="CurrentURL" value="URL atual: [CurrentURL]"/>
-	<string name="TooltipEmail">Clique para escrever um email</string>
-	<string name="SLurlLabelTeleport">Teletransportar para</string>
-	<string name="SLurlLabelShowOnMap">Mostrar no mapa para</string>
-	<string name="SLappAgentMute">Silenciar</string>
-	<string name="SLappAgentUnmute">Desfazer silenciar</string>
-	<string name="SLappAgentIM">MI</string>
-	<string name="SLappAgentPay">Pagar</string>
-	<string name="SLappAgentOfferTeleport">Oferecer teletransporte para</string>
-	<string name="SLappAgentRequestFriend">Pedido de amizade</string>
-	<string name="SLappAgentRemoveFriend">Remoção de amigo</string>
-	<string name="BUTTON_CLOSE_DARWIN">Fechar (⌘W)</string>
-	<string name="BUTTON_CLOSE_WIN">Fechar (Ctrl+W)</string>
-	<string name="BUTTON_CLOSE_CHROME">Fechar</string>
-	<string name="BUTTON_RESTORE">Restaurar</string>
-	<string name="BUTTON_MINIMIZE">Minimizar</string>
-	<string name="BUTTON_TEAR_OFF">Separar-se da janela</string>
-	<string name="BUTTON_DOCK">conectar-se à barra</string>
-	<string name="BUTTON_HELP">Mostrar ajuda</string>
-	<string name="TooltipNotecardNotAllowedTypeDrop">Os itens deste tipo não podem ser anexados 
-às anotações desta região.</string>
-	<string name="TooltipNotecardOwnerRestrictedDrop">Somente itens com permissões irrestritas 
+	<string name="TooltipEmail">
+		Clique para escrever um email
+	</string>
+	<string name="SLurlLabelTeleport">
+		Teletransportar para
+	</string>
+	<string name="SLurlLabelShowOnMap">
+		Mostrar no mapa para
+	</string>
+	<string name="SLappAgentMute">
+		Silenciar
+	</string>
+	<string name="SLappAgentUnmute">
+		Desfazer silenciar
+	</string>
+	<string name="SLappAgentIM">
+		MI
+	</string>
+	<string name="SLappAgentPay">
+		Pagar
+	</string>
+	<string name="SLappAgentOfferTeleport">
+		Oferecer teletransporte para
+	</string>
+	<string name="SLappAgentRequestFriend">
+		Pedido de amizade
+	</string>
+	<string name="SLappAgentRemoveFriend">
+		Remoção de amigo
+	</string>
+	<string name="BUTTON_CLOSE_DARWIN">
+		Fechar (⌘W)
+	</string>
+	<string name="BUTTON_CLOSE_WIN">
+		Fechar (Ctrl+W)
+	</string>
+	<string name="BUTTON_CLOSE_CHROME">
+		Fechar
+	</string>
+	<string name="BUTTON_RESTORE">
+		Restaurar
+	</string>
+	<string name="BUTTON_MINIMIZE">
+		Minimizar
+	</string>
+	<string name="BUTTON_TEAR_OFF">
+		Separar-se da janela
+	</string>
+	<string name="BUTTON_DOCK">
+		conectar-se à barra
+	</string>
+	<string name="BUTTON_HELP">
+		Mostrar ajuda
+	</string>
+	<string name="TooltipNotecardNotAllowedTypeDrop">
+		Os itens deste tipo não podem ser anexados 
+às anotações desta região.
+	</string>
+	<string name="TooltipNotecardOwnerRestrictedDrop">
+		Somente itens com permissões irrestritas 
 do 'próximo proprietário’ pode 
-ser anexado às anotações.</string>
-	<string name="Searching">Buscando...</string>
-	<string name="NoneFound">Não encontrado.</string>
-	<string name="RetrievingData">Buscando...</string>
-	<string name="ReleaseNotes">Notas de versão</string>
-	<string name="RELEASE_NOTES_BASE_URL">https://releasenotes.secondlife.com/viewer/</string>
-	<string name="LoadingData">Carregando...</string>
-	<string name="AvatarNameNobody">(ninguém)</string>
-	<string name="AvatarNameWaiting">(aguardando)</string>
-	<string name="GroupNameNone">(nenhum)</string>
-	<string name="AssetErrorNone">Nenhum erro</string>
-	<string name="AssetErrorRequestFailed">Item pedido falhou</string>
-	<string name="AssetErrorNonexistentFile">Item pedido: arquivo inexistente</string>
-	<string name="AssetErrorNotInDatabase">Item pedido: item não encontrado na base de dados.</string>
-	<string name="AssetErrorEOF">Fim do arquivo</string>
-	<string name="AssetErrorCannotOpenFile">Não é possível abrir arquivo</string>
-	<string name="AssetErrorFileNotFound">Arquivo não encontrado</string>
-	<string name="AssetErrorTCPTimeout">Tempo de transferência de arquivo expirado</string>
-	<string name="AssetErrorCircuitGone">Circuito caiu</string>
-	<string name="AssetErrorPriceMismatch">Visualizador e servidor não concordam no preço</string>
-	<string name="AssetErrorUnknownStatus">Status desconhecido</string>
-	<string name="AssetUploadServerUnreacheble">Serviço não disponível.</string>
-	<string name="AssetUploadServerDifficulties">O servidor está enfrentando dificuldades inesperadas.</string>
-	<string name="AssetUploadServerUnavaliable">Serviço não disponível ou o tempo final para upload foi atingido.</string>
-	<string name="AssetUploadRequestInvalid">Erro na solicitação de upload. Acesso 
-http://secondlife.com/support para ajuda ao resolver este problema.</string>
-	<string name="SettingValidationError">Falha na validação para importação das configurações [NAME]</string>
-	<string name="SettingImportFileError">Não foi possível abrir o arquivo [FILE]</string>
-	<string name="SettingParseFileError">Não foi possível abrir o arquivo [FILE]</string>
-	<string name="SettingTranslateError">Não foi possível traduzir o vento antigo [NAME]</string>
-	<string name="texture">textura</string>
-	<string name="sound">som</string>
-	<string name="calling card">cartão de visitas</string>
-	<string name="landmark">landmark</string>
-	<string name="legacy script">script obsoleto</string>
-	<string name="clothing">roupas</string>
-	<string name="object">objeto</string>
-	<string name="note card">anotação</string>
-	<string name="folder">pasta</string>
-	<string name="root">raiz</string>
-	<string name="lsl2 script">script LSL2</string>
-	<string name="lsl bytecode">bytecode LSL</string>
-	<string name="tga texture">textura tga</string>
-	<string name="body part">parte do corpo</string>
-	<string name="snapshot">fotografia</string>
-	<string name="lost and found">Achados e Perdidos</string>
-	<string name="targa image">imagem targa</string>
-	<string name="trash">Lixo</string>
-	<string name="jpeg image">imagem jpeg</string>
-	<string name="animation">animação</string>
-	<string name="gesture">gesto</string>
-	<string name="simstate">simstate</string>
-	<string name="favorite">favorito</string>
-	<string name="symbolic link">link</string>
-	<string name="symbolic folder link">link da pasta</string>
-	<string name="settings blob">configurações</string>
-	<string name="mesh">mesh</string>
-	<string name="AvatarEditingAppearance">(Edição Aparência)</string>
-	<string name="AvatarAway">Distante</string>
-	<string name="AvatarDoNotDisturb">Não perturbe</string>
-	<string name="AvatarMuted">Mudo</string>
-	<string name="anim_express_afraid">Temeroso</string>
-	<string name="anim_express_anger">Bravo</string>
-	<string name="anim_away">Distante</string>
-	<string name="anim_backflip">Virar para trás</string>
-	<string name="anim_express_laugh">Rir segurando a barriga</string>
-	<string name="anim_express_toothsmile">Sorriso largo</string>
-	<string name="anim_blowkiss">Mandar beijo</string>
-	<string name="anim_express_bored">Entediado</string>
-	<string name="anim_bow">Reverência</string>
-	<string name="anim_clap">Aplaudir</string>
-	<string name="anim_courtbow">Saudação formal</string>
-	<string name="anim_express_cry">Chorar</string>
-	<string name="anim_dance1">Dança 1</string>
-	<string name="anim_dance2">Dança 2</string>
-	<string name="anim_dance3">Dança 3</string>
-	<string name="anim_dance4">Dança 4</string>
-	<string name="anim_dance5">Dança 5</string>
-	<string name="anim_dance6">Dança 6</string>
-	<string name="anim_dance7">Dança 7</string>
-	<string name="anim_dance8">Dança 8</string>
-	<string name="anim_express_disdain">Desdém</string>
-	<string name="anim_drink">Beber</string>
-	<string name="anim_express_embarrased">Envergonhado</string>
-	<string name="anim_angry_fingerwag">Negar com o dedo.</string>
-	<string name="anim_fist_pump">Vibrar provocando</string>
-	<string name="anim_yoga_float">Levitar Yoga</string>
-	<string name="anim_express_frown">Careta</string>
-	<string name="anim_impatient">Impaciente</string>
-	<string name="anim_jumpforjoy">Pular de alegria</string>
-	<string name="anim_kissmybutt">Beije meu bumbum</string>
-	<string name="anim_express_kiss">Beijar</string>
-	<string name="anim_laugh_short">Rir</string>
-	<string name="anim_musclebeach">Exibir músculos</string>
-	<string name="anim_no_unhappy">Não (descontente)</string>
-	<string name="anim_no_head">Não</string>
-	<string name="anim_nyanya">Nya-nya-nya</string>
-	<string name="anim_punch_onetwo">Soco um-dois</string>
-	<string name="anim_express_open_mouth">Abrir a boca</string>
-	<string name="anim_peace">Paz</string>
-	<string name="anim_point_you">Apontar para o outro</string>
-	<string name="anim_point_me">Apontar para si</string>
-	<string name="anim_punch_l">Soco esquerdo</string>
-	<string name="anim_punch_r">Soco direito</string>
-	<string name="anim_rps_countdown">RPS contar</string>
-	<string name="anim_rps_paper">RPS papel</string>
-	<string name="anim_rps_rock">RPS pedra</string>
-	<string name="anim_rps_scissors">RPS tesoura</string>
-	<string name="anim_express_repulsed">Repulsa</string>
-	<string name="anim_kick_roundhouse_r">Chute giratório</string>
-	<string name="anim_express_sad">Triste</string>
-	<string name="anim_salute">Saúde</string>
-	<string name="anim_shout">Gritar</string>
-	<string name="anim_express_shrug">Encolher ombros</string>
-	<string name="anim_express_smile">Sorrir</string>
-	<string name="anim_smoke_idle">Fumar à toa</string>
-	<string name="anim_smoke_inhale">Inalar fumaça</string>
-	<string name="anim_smoke_throw_down">Expelir fumaça</string>
-	<string name="anim_express_surprise">Surpresa</string>
-	<string name="anim_sword_strike_r">Golpe de espada</string>
-	<string name="anim_angry_tantrum">Enraivecer</string>
-	<string name="anim_express_tongue_out">Mostrar a língua</string>
-	<string name="anim_hello">Onda</string>
-	<string name="anim_whisper">Sussurrar</string>
-	<string name="anim_whistle">Assobiar</string>
-	<string name="anim_express_wink">Piscar</string>
-	<string name="anim_wink_hollywood">Piscar (Hollywood)</string>
-	<string name="anim_express_worry">Preocupar-se</string>
-	<string name="anim_yes_happy">Sim (Feliz)</string>
-	<string name="anim_yes_head">Sim</string>
-	<string name="multiple_textures">Múltiplo</string>
-	<string name="use_texture">Usar textura</string>
-	<string name="manip_hint1">Mova o cursor do mouse sobre a regra</string>
-	<string name="manip_hint2">para ajustar à grade</string>
-	<string name="texture_loading">Carregando...</string>
-	<string name="worldmap_offline">Offline</string>
-	<string name="worldmap_item_tooltip_format">L$[PRICE] por [AREA] m²</string>
-	<string name="worldmap_results_none_found">Nenhum encontrado.</string>
-	<string name="Ok">OK</string>
-	<string name="Premature end of file">término prematuro do arquivo</string>
-	<string name="ST_NO_JOINT">Não é possível encontrar a raiz (ROOT) ou junção (JOINT).</string>
-	<string name="NearbyChatTitle">Bate-papo local</string>
-	<string name="NearbyChatLabel">(Bate-papo local)</string>
-	<string name="whisper">sussurra:</string>
-	<string name="shout">grita:</string>
-	<string name="ringing">Conectando à conversa de voz no mundo</string>
-	<string name="connected">Conectado</string>
-	<string name="unavailable">Voz não disponível na sua localização atual</string>
-	<string name="hang_up">Desconectado da conversa de Voz no mundo</string>
-	<string name="reconnect_nearby">Agora você será reconectado ao bate-papo local.</string>
-	<string name="ScriptQuestionCautionChatGranted">'[OBJECTNAME]', um objeto de  '[OWNERNAME]', localizado em [REGIONNAME] a [REGIONPOS], obteve permissão para: [PERMISSIONS].</string>
-	<string name="ScriptQuestionCautionChatDenied">'[OBJECTNAME]', um objeto de  '[OWNERNAME]', localizado em [REGIONNAME] a [REGIONPOS], teve permissão negada para: [PERMISSIONS].</string>
-	<string name="AdditionalPermissionsRequestHeader">Se você permitir acesso à sua conta, o objeto também poderá:</string>
-	<string name="ScriptTakeMoney">Tomar linden dólares (L$) de você</string>
-	<string name="ActOnControlInputs">Atue nas suas entradas de controle</string>
-	<string name="RemapControlInputs">Remapeie suas entradas de controle</string>
-	<string name="AnimateYourAvatar">Faça uma animação para o seu avatar</string>
-	<string name="AttachToYourAvatar">Anexe ao seu avatar</string>
-	<string name="ReleaseOwnership">Libere a propriedade e torne-a pública</string>
-	<string name="LinkAndDelink">Una e desuna de outros objetos</string>
-	<string name="AddAndRemoveJoints">Adicione e remova junções com outros objetos</string>
-	<string name="ChangePermissions">Modifique as permissões</string>
-	<string name="TrackYourCamera">Acompanhe sua câmera</string>
-	<string name="ControlYourCamera">Controle sua camera</string>
-	<string name="TeleportYourAgent">Teletransportá-lo</string>
-	<string name="ForceSitAvatar">Forçar o avatar a sentar</string>
-	<string name="ChangeEnvSettings">Alterar sua configurações de ambiente</string>
-	<string name="AgentNameSubst">(Você)</string>
+ser anexado às anotações.
+	</string>
+	<string name="Searching">
+		Buscando...
+	</string>
+	<string name="NoneFound">
+		Não encontrado.
+	</string>
+	<string name="RetrievingData">
+		Buscando...
+	</string>
+	<string name="ReleaseNotes">
+		Notas de versão
+	</string>
+	<string name="RELEASE_NOTES_BASE_URL">
+		https://releasenotes.secondlife.com/viewer/
+	</string>
+	<string name="LoadingData">
+		Carregando...
+	</string>
+	<string name="AvatarNameNobody">
+		(ninguém)
+	</string>
+	<string name="AvatarNameWaiting">
+		(aguardando)
+	</string>
+	<string name="GroupNameNone">
+		(nenhum)
+	</string>
+	<string name="AssetErrorNone">
+		Nenhum erro
+	</string>
+	<string name="AssetErrorRequestFailed">
+		Item pedido falhou
+	</string>
+	<string name="AssetErrorNonexistentFile">
+		Item pedido: arquivo inexistente
+	</string>
+	<string name="AssetErrorNotInDatabase">
+		Item pedido: item não encontrado na base de dados.
+	</string>
+	<string name="AssetErrorEOF">
+		Fim do arquivo
+	</string>
+	<string name="AssetErrorCannotOpenFile">
+		Não é possível abrir arquivo
+	</string>
+	<string name="AssetErrorFileNotFound">
+		Arquivo não encontrado
+	</string>
+	<string name="AssetErrorTCPTimeout">
+		Tempo de transferência de arquivo expirado
+	</string>
+	<string name="AssetErrorCircuitGone">
+		Circuito caiu
+	</string>
+	<string name="AssetErrorPriceMismatch">
+		Visualizador e servidor não concordam no preço
+	</string>
+	<string name="AssetErrorUnknownStatus">
+		Status desconhecido
+	</string>
+	<string name="AssetUploadServerUnreacheble">
+		Serviço não disponível.
+	</string>
+	<string name="AssetUploadServerDifficulties">
+		O servidor está enfrentando dificuldades inesperadas.
+	</string>
+	<string name="AssetUploadServerUnavaliable">
+		Serviço não disponível ou o tempo final para upload foi atingido.
+	</string>
+	<string name="AssetUploadRequestInvalid">
+		Erro na solicitação de upload. Acesso 
+http://secondlife.com/support para ajuda ao resolver este problema.
+	</string>
+	<string name="SettingValidationError">
+		Falha na validação para importação das configurações [NAME]
+	</string>
+	<string name="SettingImportFileError">
+		Não foi possível abrir o arquivo [FILE]
+	</string>
+	<string name="SettingParseFileError">
+		Não foi possível abrir o arquivo [FILE]
+	</string>
+	<string name="SettingTranslateError">
+		Não foi possível traduzir o vento antigo [NAME]
+	</string>
+	<string name="texture">
+		textura
+	</string>
+	<string name="sound">
+		som
+	</string>
+	<string name="calling card">
+		cartão de visitas
+	</string>
+	<string name="landmark">
+		landmark
+	</string>
+	<string name="legacy script">
+		script obsoleto
+	</string>
+	<string name="clothing">
+		roupas
+	</string>
+	<string name="object">
+		objeto
+	</string>
+	<string name="note card">
+		anotação
+	</string>
+	<string name="folder">
+		pasta
+	</string>
+	<string name="root">
+		raiz
+	</string>
+	<string name="lsl2 script">
+		script LSL2
+	</string>
+	<string name="lsl bytecode">
+		bytecode LSL
+	</string>
+	<string name="tga texture">
+		textura tga
+	</string>
+	<string name="body part">
+		parte do corpo
+	</string>
+	<string name="snapshot">
+		fotografia
+	</string>
+	<string name="lost and found">
+		Achados e Perdidos
+	</string>
+	<string name="targa image">
+		imagem targa
+	</string>
+	<string name="trash">
+		Lixo
+	</string>
+	<string name="jpeg image">
+		imagem jpeg
+	</string>
+	<string name="animation">
+		animação
+	</string>
+	<string name="gesture">
+		gesto
+	</string>
+	<string name="simstate">
+		simstate
+	</string>
+	<string name="favorite">
+		favorito
+	</string>
+	<string name="symbolic link">
+		link
+	</string>
+	<string name="symbolic folder link">
+		link da pasta
+	</string>
+	<string name="settings blob">
+		configurações
+	</string>
+	<string name="mesh">
+		mesh
+	</string>
+	<string name="AvatarEditingAppearance">
+		(Edição Aparência)
+	</string>
+	<string name="AvatarAway">
+		Distante
+	</string>
+	<string name="AvatarDoNotDisturb">
+		Não perturbe
+	</string>
+	<string name="AvatarMuted">
+		Mudo
+	</string>
+	<string name="anim_express_afraid">
+		Temeroso
+	</string>
+	<string name="anim_express_anger">
+		Bravo
+	</string>
+	<string name="anim_away">
+		Distante
+	</string>
+	<string name="anim_backflip">
+		Virar para trás
+	</string>
+	<string name="anim_express_laugh">
+		Rir segurando a barriga
+	</string>
+	<string name="anim_express_toothsmile">
+		Sorriso largo
+	</string>
+	<string name="anim_blowkiss">
+		Mandar beijo
+	</string>
+	<string name="anim_express_bored">
+		Entediado
+	</string>
+	<string name="anim_bow">
+		Reverência
+	</string>
+	<string name="anim_clap">
+		Aplaudir
+	</string>
+	<string name="anim_courtbow">
+		Saudação formal
+	</string>
+	<string name="anim_express_cry">
+		Chorar
+	</string>
+	<string name="anim_dance1">
+		Dança 1
+	</string>
+	<string name="anim_dance2">
+		Dança 2
+	</string>
+	<string name="anim_dance3">
+		Dança 3
+	</string>
+	<string name="anim_dance4">
+		Dança 4
+	</string>
+	<string name="anim_dance5">
+		Dança 5
+	</string>
+	<string name="anim_dance6">
+		Dança 6
+	</string>
+	<string name="anim_dance7">
+		Dança 7
+	</string>
+	<string name="anim_dance8">
+		Dança 8
+	</string>
+	<string name="anim_express_disdain">
+		Desdém
+	</string>
+	<string name="anim_drink">
+		Beber
+	</string>
+	<string name="anim_express_embarrased">
+		Envergonhado
+	</string>
+	<string name="anim_angry_fingerwag">
+		Negar com o dedo.
+	</string>
+	<string name="anim_fist_pump">
+		Vibrar provocando
+	</string>
+	<string name="anim_yoga_float">
+		Levitar Yoga
+	</string>
+	<string name="anim_express_frown">
+		Careta
+	</string>
+	<string name="anim_impatient">
+		Impaciente
+	</string>
+	<string name="anim_jumpforjoy">
+		Pular de alegria
+	</string>
+	<string name="anim_kissmybutt">
+		Beije meu bumbum
+	</string>
+	<string name="anim_express_kiss">
+		Beijar
+	</string>
+	<string name="anim_laugh_short">
+		Rir
+	</string>
+	<string name="anim_musclebeach">
+		Exibir músculos
+	</string>
+	<string name="anim_no_unhappy">
+		Não (descontente)
+	</string>
+	<string name="anim_no_head">
+		Não
+	</string>
+	<string name="anim_nyanya">
+		Nya-nya-nya
+	</string>
+	<string name="anim_punch_onetwo">
+		Soco um-dois
+	</string>
+	<string name="anim_express_open_mouth">
+		Abrir a boca
+	</string>
+	<string name="anim_peace">
+		Paz
+	</string>
+	<string name="anim_point_you">
+		Apontar para o outro
+	</string>
+	<string name="anim_point_me">
+		Apontar para si
+	</string>
+	<string name="anim_punch_l">
+		Soco esquerdo
+	</string>
+	<string name="anim_punch_r">
+		Soco direito
+	</string>
+	<string name="anim_rps_countdown">
+		RPS contar
+	</string>
+	<string name="anim_rps_paper">
+		RPS papel
+	</string>
+	<string name="anim_rps_rock">
+		RPS pedra
+	</string>
+	<string name="anim_rps_scissors">
+		RPS tesoura
+	</string>
+	<string name="anim_express_repulsed">
+		Repulsa
+	</string>
+	<string name="anim_kick_roundhouse_r">
+		Chute giratório
+	</string>
+	<string name="anim_express_sad">
+		Triste
+	</string>
+	<string name="anim_salute">
+		Saúde
+	</string>
+	<string name="anim_shout">
+		Gritar
+	</string>
+	<string name="anim_express_shrug">
+		Encolher ombros
+	</string>
+	<string name="anim_express_smile">
+		Sorrir
+	</string>
+	<string name="anim_smoke_idle">
+		Fumar à toa
+	</string>
+	<string name="anim_smoke_inhale">
+		Inalar fumaça
+	</string>
+	<string name="anim_smoke_throw_down">
+		Expelir fumaça
+	</string>
+	<string name="anim_express_surprise">
+		Surpresa
+	</string>
+	<string name="anim_sword_strike_r">
+		Golpe de espada
+	</string>
+	<string name="anim_angry_tantrum">
+		Enraivecer
+	</string>
+	<string name="anim_express_tongue_out">
+		Mostrar a língua
+	</string>
+	<string name="anim_hello">
+		Onda
+	</string>
+	<string name="anim_whisper">
+		Sussurrar
+	</string>
+	<string name="anim_whistle">
+		Assobiar
+	</string>
+	<string name="anim_express_wink">
+		Piscar
+	</string>
+	<string name="anim_wink_hollywood">
+		Piscar (Hollywood)
+	</string>
+	<string name="anim_express_worry">
+		Preocupar-se
+	</string>
+	<string name="anim_yes_happy">
+		Sim (Feliz)
+	</string>
+	<string name="anim_yes_head">
+		Sim
+	</string>
+	<string name="multiple_textures">
+		Múltiplo
+	</string>
+	<string name="use_texture">
+		Usar textura
+	</string>
+	<string name="manip_hint1">
+		Mova o cursor do mouse sobre a regra
+	</string>
+	<string name="manip_hint2">
+		para ajustar à grade
+	</string>
+	<string name="texture_loading">
+		Carregando...
+	</string>
+	<string name="worldmap_offline">
+		Offline
+	</string>
+	<string name="worldmap_item_tooltip_format">
+		L$[PRICE] por [AREA] m²
+	</string>
+	<string name="worldmap_results_none_found">
+		Nenhum encontrado.
+	</string>
+	<string name="Ok">
+		OK
+	</string>
+	<string name="Premature end of file">
+		término prematuro do arquivo
+	</string>
+	<string name="ST_NO_JOINT">
+		Não é possível encontrar a raiz (ROOT) ou junção (JOINT).
+	</string>
+	<string name="NearbyChatTitle">
+		Bate-papo local
+	</string>
+	<string name="NearbyChatLabel">
+		(Bate-papo local)
+	</string>
+	<string name="whisper">
+		sussurra:
+	</string>
+	<string name="shout">
+		grita:
+	</string>
+	<string name="ringing">
+		Conectando à conversa de voz no mundo
+	</string>
+	<string name="connected">
+		Conectado
+	</string>
+	<string name="unavailable">
+		Voz não disponível na sua localização atual
+	</string>
+	<string name="hang_up">
+		Desconectado da conversa de Voz no mundo
+	</string>
+	<string name="reconnect_nearby">
+		Agora você será reconectado ao bate-papo local.
+	</string>
+	<string name="ScriptQuestionCautionChatGranted">
+		'[OBJECTNAME]', um objeto de  '[OWNERNAME]', localizado em [REGIONNAME] a [REGIONPOS], obteve permissão para: [PERMISSIONS].
+	</string>
+	<string name="ScriptQuestionCautionChatDenied">
+		'[OBJECTNAME]', um objeto de  '[OWNERNAME]', localizado em [REGIONNAME] a [REGIONPOS], teve permissão negada para: [PERMISSIONS].
+	</string>
+	<string name="AdditionalPermissionsRequestHeader">
+		Se você permitir acesso à sua conta, o objeto também poderá:
+	</string>
+	<string name="ScriptTakeMoney">
+		Tomar linden dólares (L$) de você
+	</string>
+	<string name="ActOnControlInputs">
+		Atue nas suas entradas de controle
+	</string>
+	<string name="RemapControlInputs">
+		Remapeie suas entradas de controle
+	</string>
+	<string name="AnimateYourAvatar">
+		Faça uma animação para o seu avatar
+	</string>
+	<string name="AttachToYourAvatar">
+		Anexe ao seu avatar
+	</string>
+	<string name="ReleaseOwnership">
+		Libere a propriedade e torne-a pública
+	</string>
+	<string name="LinkAndDelink">
+		Una e desuna de outros objetos
+	</string>
+	<string name="AddAndRemoveJoints">
+		Adicione e remova junções com outros objetos
+	</string>
+	<string name="ChangePermissions">
+		Modifique as permissões
+	</string>
+	<string name="TrackYourCamera">
+		Acompanhe sua câmera
+	</string>
+	<string name="ControlYourCamera">
+		Controle sua camera
+	</string>
+	<string name="TeleportYourAgent">
+		Teletransportá-lo
+	</string>
+	<string name="ForceSitAvatar">
+		Forçar o avatar a sentar
+	</string>
+	<string name="ChangeEnvSettings">
+		Alterar sua configurações de ambiente
+	</string>
+	<string name="AgentNameSubst">
+		(Você)
+	</string>
 	<string name="JoinAnExperience"/>
-	<string name="SilentlyManageEstateAccess">Suprimir alertas ao gerenciar listas de acesso ao terreno</string>
-	<string name="OverrideYourAnimations">Substituir suas animações padrão</string>
-	<string name="ScriptReturnObjects">Retornar objetos em seu nome</string>
-	<string name="UnknownScriptPermission">(desconhecido)!</string>
-	<string name="SIM_ACCESS_PG">Público geral</string>
-	<string name="SIM_ACCESS_MATURE">Moderado</string>
-	<string name="SIM_ACCESS_ADULT">Adulto</string>
-	<string name="SIM_ACCESS_DOWN">Desconectado</string>
-	<string name="SIM_ACCESS_MIN">Desconhecido</string>
-	<string name="land_type_unknown">(desconhecido)</string>
-	<string name="Estate / Full Region">Propriedadade / Região inteira:</string>
-	<string name="Estate / Homestead">Imóvel / Homestead</string>
-	<string name="Mainland / Homestead">Continente / Homestead</string>
-	<string name="Mainland / Full Region">Continente / Região inteira:</string>
-	<string name="all_files">Todos os arquivos</string>
-	<string name="sound_files">Sons</string>
-	<string name="animation_files">Animações</string>
-	<string name="image_files">Imagens</string>
-	<string name="save_file_verb">Salvar</string>
-	<string name="load_file_verb">Carregar</string>
-	<string name="targa_image_files">Imagens Targa</string>
-	<string name="bitmap_image_files">Imagens Bitmap</string>
-	<string name="png_image_files">Imagens PNG</string>
-	<string name="save_texture_image_files">Imagens targa ou PNG</string>
-	<string name="avi_movie_file">Arquivo de vídeo AVI</string>
-	<string name="xaf_animation_file">Arquivo de animação XAF</string>
-	<string name="xml_file">Arquivo XML</string>
-	<string name="raw_file">Arquivo RAW</string>
-	<string name="compressed_image_files">Imagens compactadas</string>
-	<string name="load_files">Carregar arquivos</string>
-	<string name="choose_the_directory">Selecionar pasta</string>
-	<string name="script_files">Scripts</string>
-	<string name="dictionary_files">Dicionários</string>
-	<string name="shape">Silhueta</string>
-	<string name="skin">Pele</string>
-	<string name="hair">Cabelo</string>
-	<string name="eyes">Olhos</string>
-	<string name="shirt">Camisa</string>
-	<string name="pants">Calças</string>
-	<string name="shoes">Sapatos</string>
-	<string name="socks">Meias</string>
-	<string name="jacket">Blusa</string>
-	<string name="gloves">Luvas</string>
-	<string name="undershirt">Camiseta</string>
-	<string name="underpants">Roupa de baixo</string>
-	<string name="skirt">Saia</string>
-	<string name="alpha">Alpha</string>
-	<string name="tattoo">Tatuagem</string>
-	<string name="universal">Universal</string>
-	<string name="physics">Físico</string>
-	<string name="invalid">Inválido</string>
-	<string name="none">nenhum</string>
-	<string name="shirt_not_worn">Camisa não vestida</string>
-	<string name="pants_not_worn">Calças não vestidas</string>
-	<string name="shoes_not_worn">Sapatos não calçados</string>
-	<string name="socks_not_worn">Meias não calçadas</string>
-	<string name="jacket_not_worn">Jaqueta não vestida</string>
-	<string name="gloves_not_worn">Luvas não calçadas</string>
-	<string name="undershirt_not_worn">Camiseta não vestida</string>
-	<string name="underpants_not_worn">Roupa de baixo não vestida</string>
-	<string name="skirt_not_worn">Saia não vestida</string>
-	<string name="alpha_not_worn">Alpha não vestido</string>
-	<string name="tattoo_not_worn">Tatuagem não usada</string>
-	<string name="universal_not_worn">Universal não usado</string>
-	<string name="physics_not_worn">Físico não usado</string>
-	<string name="invalid_not_worn">inválido</string>
-	<string name="create_new_shape">Criar novo físico</string>
-	<string name="create_new_skin">Criar pele nova</string>
-	<string name="create_new_hair">Criar cabelo novo</string>
-	<string name="create_new_eyes">Criar olhos novos</string>
-	<string name="create_new_shirt">Criar camisa nova</string>
-	<string name="create_new_pants">Criar calças novas</string>
-	<string name="create_new_shoes">Criar sapatos novos</string>
-	<string name="create_new_socks">Criar meias novas</string>
-	<string name="create_new_jacket">Criar jaqueta nova</string>
-	<string name="create_new_gloves">Criar luvas novas</string>
-	<string name="create_new_undershirt">Criar camiseta nova</string>
-	<string name="create_new_underpants">Criar roupa de baixo nova</string>
-	<string name="create_new_skirt">Criar saia nova</string>
-	<string name="create_new_alpha">Criar Alpha novo</string>
-	<string name="create_new_tattoo">Criar nova tatuagem</string>
-	<string name="create_new_universal">Criar um novo universal</string>
-	<string name="create_new_physics">Criar novo físico</string>
-	<string name="create_new_invalid">inválido</string>
-	<string name="NewWearable">Novo [WEARABLE_ITEM]</string>
-	<string name="next">Próximo</string>
-	<string name="ok">OK</string>
-	<string name="GroupNotifyGroupNotice">Anúncio de grupo</string>
-	<string name="GroupNotifyGroupNotices">Anúncios do grupo</string>
-	<string name="GroupNotifySentBy">Enviado por</string>
-	<string name="GroupNotifyAttached">Anexo:</string>
-	<string name="GroupNotifyViewPastNotices">Ver últimos anúncios ou optar por não receber essas mensagens aqui.</string>
-	<string name="GroupNotifyOpenAttachment">Abrir anexo</string>
-	<string name="GroupNotifySaveAttachment">Salvar anexo</string>
-	<string name="TeleportOffer">Oferta de teletransporte</string>
-	<string name="StartUpNotifications">Novas notificações chegaram enquanto você estava fora...</string>
-	<string name="OverflowInfoChannelString">Você tem mais [%d] notificações</string>
-	<string name="BodyPartsRightArm">Braço direito</string>
-	<string name="BodyPartsHead">Cabeça</string>
-	<string name="BodyPartsLeftArm">Braço esquerdo</string>
-	<string name="BodyPartsLeftLeg">Perna esquerda</string>
-	<string name="BodyPartsTorso">Tronco</string>
-	<string name="BodyPartsRightLeg">Perna direita</string>
-	<string name="BodyPartsEnhancedSkeleton">Esqueleto aprimorado</string>
-	<string name="GraphicsQualityLow">Baixo</string>
-	<string name="GraphicsQualityMid">Meio</string>
-	<string name="GraphicsQualityHigh">Alto</string>
-	<string name="LeaveMouselook">Pressione ESC para retornar para visão do mundo</string>
-	<string name="InventoryNoMatchingItems">Não encontrou o que procura? Tente buscar no [secondlife:///app/search/people/[SEARCH_TERM] Search].</string>
-	<string name="InventoryNoMatchingRecentItems">Não encontrou o que procura? Tente [secondlife:///app/inventory/filters Show filters].</string>
-	<string name="PlacesNoMatchingItems">Não encontrou o que procura? Tente buscar no [secondlife:///app/search/groups/[SEARCH_TERM] Search].</string>
-	<string name="FavoritesNoMatchingItems">Arraste um marco para adicioná-lo aos seus favoritos.</string>
-	<string name="MarketplaceNoMatchingItems">Nenhum item correspondente encontrado. Verifique a ortografia de sua cadeia de pesquisa e tente novamente.</string>
-	<string name="InventoryNoTexture">Você não possui uma cópia desta textura no seu inventário</string>
-	<string name="InventoryInboxNoItems">Suas compras do Marketplace aparecerão aqui. Depois, você poderá arrastá-las para seu inventário para usá-las.</string>
-	<string name="MarketplaceURL">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/</string>
-	<string name="MarketplaceURL_CreateStore">http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3</string>
-	<string name="MarketplaceURL_Dashboard">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard</string>
-	<string name="MarketplaceURL_Imports">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports</string>
-	<string name="MarketplaceURL_LearnMore">https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more</string>
-	<string name="InventoryPlayAnimationTooltip">Abrir a janela com as opções do Jogo.</string>
-	<string name="InventoryPlayGestureTooltip">Executar o gesto selecionado no mundo.</string>
-	<string name="InventoryPlaySoundTooltip">Abrir a janela com as opções do Jogo.</string>
-	<string name="InventoryOutboxNotMerchantTitle">Qualquer um pode vender itens no Mercado.</string>
+	<string name="SilentlyManageEstateAccess">
+		Suprimir alertas ao gerenciar listas de acesso ao terreno
+	</string>
+	<string name="OverrideYourAnimations">
+		Substituir suas animações padrão
+	</string>
+	<string name="ScriptReturnObjects">
+		Retornar objetos em seu nome
+	</string>
+	<string name="UnknownScriptPermission">
+		(desconhecido)!
+	</string>
+	<string name="SIM_ACCESS_PG">
+		Público geral
+	</string>
+	<string name="SIM_ACCESS_MATURE">
+		Moderado
+	</string>
+	<string name="SIM_ACCESS_ADULT">
+		Adulto
+	</string>
+	<string name="SIM_ACCESS_DOWN">
+		Desconectado
+	</string>
+	<string name="SIM_ACCESS_MIN">
+		Desconhecido
+	</string>
+	<string name="land_type_unknown">
+		(desconhecido)
+	</string>
+	<string name="Estate / Full Region">
+		Propriedadade / Região inteira:
+	</string>
+	<string name="Estate / Homestead">
+		Imóvel / Homestead
+	</string>
+	<string name="Mainland / Homestead">
+		Continente / Homestead
+	</string>
+	<string name="Mainland / Full Region">
+		Continente / Região inteira:
+	</string>
+	<string name="all_files">
+		Todos os arquivos
+	</string>
+	<string name="sound_files">
+		Sons
+	</string>
+	<string name="animation_files">
+		Animações
+	</string>
+	<string name="image_files">
+		Imagens
+	</string>
+	<string name="save_file_verb">
+		Salvar
+	</string>
+	<string name="load_file_verb">
+		Carregar
+	</string>
+	<string name="targa_image_files">
+		Imagens Targa
+	</string>
+	<string name="bitmap_image_files">
+		Imagens Bitmap
+	</string>
+	<string name="png_image_files">
+		Imagens PNG
+	</string>
+	<string name="save_texture_image_files">
+		Imagens targa ou PNG
+	</string>
+	<string name="avi_movie_file">
+		Arquivo de vídeo AVI
+	</string>
+	<string name="xaf_animation_file">
+		Arquivo de animação XAF
+	</string>
+	<string name="xml_file">
+		Arquivo XML
+	</string>
+	<string name="raw_file">
+		Arquivo RAW
+	</string>
+	<string name="compressed_image_files">
+		Imagens compactadas
+	</string>
+	<string name="load_files">
+		Carregar arquivos
+	</string>
+	<string name="choose_the_directory">
+		Selecionar pasta
+	</string>
+	<string name="script_files">
+		Scripts
+	</string>
+	<string name="dictionary_files">
+		Dicionários
+	</string>
+	<string name="shape">
+		Silhueta
+	</string>
+	<string name="skin">
+		Pele
+	</string>
+	<string name="hair">
+		Cabelo
+	</string>
+	<string name="eyes">
+		Olhos
+	</string>
+	<string name="shirt">
+		Camisa
+	</string>
+	<string name="pants">
+		Calças
+	</string>
+	<string name="shoes">
+		Sapatos
+	</string>
+	<string name="socks">
+		Meias
+	</string>
+	<string name="jacket">
+		Blusa
+	</string>
+	<string name="gloves">
+		Luvas
+	</string>
+	<string name="undershirt">
+		Camiseta
+	</string>
+	<string name="underpants">
+		Roupa de baixo
+	</string>
+	<string name="skirt">
+		Saia
+	</string>
+	<string name="alpha">
+		Alpha
+	</string>
+	<string name="tattoo">
+		Tatuagem
+	</string>
+	<string name="universal">
+		Universal
+	</string>
+	<string name="physics">
+		Físico
+	</string>
+	<string name="invalid">
+		Inválido
+	</string>
+	<string name="none">
+		nenhum
+	</string>
+	<string name="shirt_not_worn">
+		Camisa não vestida
+	</string>
+	<string name="pants_not_worn">
+		Calças não vestidas
+	</string>
+	<string name="shoes_not_worn">
+		Sapatos não calçados
+	</string>
+	<string name="socks_not_worn">
+		Meias não calçadas
+	</string>
+	<string name="jacket_not_worn">
+		Jaqueta não vestida
+	</string>
+	<string name="gloves_not_worn">
+		Luvas não calçadas
+	</string>
+	<string name="undershirt_not_worn">
+		Camiseta não vestida
+	</string>
+	<string name="underpants_not_worn">
+		Roupa de baixo não vestida
+	</string>
+	<string name="skirt_not_worn">
+		Saia não vestida
+	</string>
+	<string name="alpha_not_worn">
+		Alpha não vestido
+	</string>
+	<string name="tattoo_not_worn">
+		Tatuagem não usada
+	</string>
+	<string name="universal_not_worn">
+		Universal não usado
+	</string>
+	<string name="physics_not_worn">
+		Físico não usado
+	</string>
+	<string name="invalid_not_worn">
+		inválido
+	</string>
+	<string name="create_new_shape">
+		Criar novo físico
+	</string>
+	<string name="create_new_skin">
+		Criar pele nova
+	</string>
+	<string name="create_new_hair">
+		Criar cabelo novo
+	</string>
+	<string name="create_new_eyes">
+		Criar olhos novos
+	</string>
+	<string name="create_new_shirt">
+		Criar camisa nova
+	</string>
+	<string name="create_new_pants">
+		Criar calças novas
+	</string>
+	<string name="create_new_shoes">
+		Criar sapatos novos
+	</string>
+	<string name="create_new_socks">
+		Criar meias novas
+	</string>
+	<string name="create_new_jacket">
+		Criar jaqueta nova
+	</string>
+	<string name="create_new_gloves">
+		Criar luvas novas
+	</string>
+	<string name="create_new_undershirt">
+		Criar camiseta nova
+	</string>
+	<string name="create_new_underpants">
+		Criar roupa de baixo nova
+	</string>
+	<string name="create_new_skirt">
+		Criar saia nova
+	</string>
+	<string name="create_new_alpha">
+		Criar Alpha novo
+	</string>
+	<string name="create_new_tattoo">
+		Criar nova tatuagem
+	</string>
+	<string name="create_new_universal">
+		Criar um novo universal
+	</string>
+	<string name="create_new_physics">
+		Criar novo físico
+	</string>
+	<string name="create_new_invalid">
+		inválido
+	</string>
+	<string name="NewWearable">
+		Novo [WEARABLE_ITEM]
+	</string>
+	<string name="next">
+		Próximo
+	</string>
+	<string name="ok">
+		OK
+	</string>
+	<string name="GroupNotifyGroupNotice">
+		Anúncio de grupo
+	</string>
+	<string name="GroupNotifyGroupNotices">
+		Anúncios do grupo
+	</string>
+	<string name="GroupNotifySentBy">
+		Enviado por
+	</string>
+	<string name="GroupNotifyAttached">
+		Anexo:
+	</string>
+	<string name="GroupNotifyViewPastNotices">
+		Ver últimos anúncios ou optar por não receber essas mensagens aqui.
+	</string>
+	<string name="GroupNotifyOpenAttachment">
+		Abrir anexo
+	</string>
+	<string name="GroupNotifySaveAttachment">
+		Salvar anexo
+	</string>
+	<string name="TeleportOffer">
+		Oferta de teletransporte
+	</string>
+	<string name="StartUpNotifications">
+		Novas notificações chegaram enquanto você estava fora...
+	</string>
+	<string name="OverflowInfoChannelString">
+		Você tem mais [%d] notificações
+	</string>
+	<string name="BodyPartsRightArm">
+		Braço direito
+	</string>
+	<string name="BodyPartsHead">
+		Cabeça
+	</string>
+	<string name="BodyPartsLeftArm">
+		Braço esquerdo
+	</string>
+	<string name="BodyPartsLeftLeg">
+		Perna esquerda
+	</string>
+	<string name="BodyPartsTorso">
+		Tronco
+	</string>
+	<string name="BodyPartsRightLeg">
+		Perna direita
+	</string>
+	<string name="BodyPartsEnhancedSkeleton">
+		Esqueleto aprimorado
+	</string>
+	<string name="GraphicsQualityLow">
+		Baixo
+	</string>
+	<string name="GraphicsQualityMid">
+		Meio
+	</string>
+	<string name="GraphicsQualityHigh">
+		Alto
+	</string>
+	<string name="LeaveMouselook">
+		Pressione ESC para retornar para visão do mundo
+	</string>
+	<string name="InventoryNoMatchingItems">
+		Não encontrou o que procura? Tente buscar no [secondlife:///app/search/people/[SEARCH_TERM] Search].
+	</string>
+	<string name="InventoryNoMatchingRecentItems">
+		Não encontrou o que procura? Tente [secondlife:///app/inventory/filters Show filters].
+	</string>
+	<string name="PlacesNoMatchingItems">
+		Não encontrou o que procura? Tente buscar no [secondlife:///app/search/groups/[SEARCH_TERM] Search].
+	</string>
+	<string name="FavoritesNoMatchingItems">
+		Arraste um marco para adicioná-lo aos seus favoritos.
+	</string>
+	<string name="MarketplaceNoMatchingItems">
+		Nenhum item correspondente encontrado. Verifique a ortografia de sua cadeia de pesquisa e tente novamente.
+	</string>
+	<string name="InventoryNoTexture">
+		Você não possui uma cópia desta textura no seu inventário
+	</string>
+	<string name="InventoryInboxNoItems">
+		Suas compras do Marketplace aparecerão aqui. Depois, você poderá arrastá-las para seu inventário para usá-las.
+	</string>
+	<string name="MarketplaceURL">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/
+	</string>
+	<string name="MarketplaceURL_CreateStore">
+		http://community.secondlife.com/t5/English-Knowledge-Base/Selling-in-the-Marketplace/ta-p/700193#Section_.3
+	</string>
+	<string name="MarketplaceURL_Dashboard">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/dashboard
+	</string>
+	<string name="MarketplaceURL_Imports">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/merchants/store/imports
+	</string>
+	<string name="MarketplaceURL_LearnMore">
+		https://marketplace.[MARKETPLACE_DOMAIN_NAME]/learn_more
+	</string>
+	<string name="InventoryPlayAnimationTooltip">
+		Abrir a janela com as opções do Jogo.
+	</string>
+	<string name="InventoryPlayGestureTooltip">
+		Executar o gesto selecionado no mundo.
+	</string>
+	<string name="InventoryPlaySoundTooltip">
+		Abrir a janela com as opções do Jogo.
+	</string>
+	<string name="InventoryOutboxNotMerchantTitle">
+		Qualquer um pode vender itens no Mercado.
+	</string>
 	<string name="InventoryOutboxNotMerchantTooltip"/>
-	<string name="InventoryOutboxNotMerchant">Se você deseja se tornar um lojista, precisará [[MARKETPLACE_CREATE_STORE_URL] criar uma loja no Mercado].</string>
-	<string name="InventoryOutboxNoItemsTitle">Sua caixa de saída está vazia</string>
+	<string name="InventoryOutboxNotMerchant">
+		Se você deseja se tornar um lojista, precisará [[MARKETPLACE_CREATE_STORE_URL] criar uma loja no Mercado].
+	</string>
+	<string name="InventoryOutboxNoItemsTitle">
+		Sua caixa de saída está vazia
+	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
-	<string name="InventoryOutboxNoItems">Arraste as pastas para estas áreas e então clique em &quot;Enviar para Mercado&quot; para listar os itens para venda no [[MARKETPLACE_DASHBOARD_URL] Mercado].</string>
-	<string name="InventoryOutboxInitializingTitle">Inicializando o Marketplace.</string>
-	<string name="InventoryOutboxInitializing">Estamos acessando sua conta na [loja [MARKETPLACE_CREATE_STORE_URL] do Marketplace].</string>
-	<string name="InventoryOutboxErrorTitle">Erros do Marketplace.</string>
-	<string name="InventoryOutboxError">A loja [[MARKETPLACE_CREATE_STORE_URL] no Marketplace] está retornando erros.</string>
-	<string name="InventoryMarketplaceError">Erro ao abrir as listagens do Marketplace.
-Se você continuar a receber essa mensagem, entre em contato com o suporte do Second Life para obter ajuda em http://support.secondlife.com</string>
-	<string name="InventoryMarketplaceListingsNoItemsTitle">Sua pasta Listagens do Marketplace está vazia.</string>
-	<string name="InventoryMarketplaceListingsNoItems">Arraste pastas para esta área para listá-las para venda no [Marketplace [MARKETPLACE_DASHBOARD_URL]].</string>
-	<string name="InventoryItemsCount">( [ITEMS_COUNT] Items )</string>
-	<string name="Marketplace Validation Warning Stock">a pasta de estoque deve estar em uma pasta de versões</string>
-	<string name="Marketplace Validation Error Mixed Stock">: Erro: todos os itens em uma pasta de estoque devem ser de cópia proibida e todos do mesmo tipo</string>
-	<string name="Marketplace Validation Error Subfolder In Stock">: Erro: a pasta de estoque não pode ter subpastas</string>
-	<string name="Marketplace Validation Warning Empty">: Aviso: a pasta não contém itens</string>
-	<string name="Marketplace Validation Warning Create Stock">: Aviso: criando pasta de estoque</string>
-	<string name="Marketplace Validation Warning Create Version">: Aviso: criando pasta de versões</string>
-	<string name="Marketplace Validation Warning Move">: Aviso: movendo itens</string>
-	<string name="Marketplace Validation Warning Delete">: Aviso: conteúdo da pasta transferido para pasta de estoque, removendo pasta vazia</string>
-	<string name="Marketplace Validation Error Stock Item">: Erro: itens de cópia proibida devem estar em uma pasta de estoque</string>
-	<string name="Marketplace Validation Warning Unwrapped Item">: Aviso: os itens devem estar em uma pasta de versões</string>
-	<string name="Marketplace Validation Error">: Erro:</string>
-	<string name="Marketplace Validation Warning">: Aviso:</string>
-	<string name="Marketplace Validation Error Empty Version">: Aviso: a pasta de versões deve conter pelo menos 1 item</string>
-	<string name="Marketplace Validation Error Empty Stock">: Aviso: a pasta de estoque deve conter pelo menos 1 item</string>
-	<string name="Marketplace Validation No Error">Não há erros ou avisos</string>
-	<string name="Marketplace Error None">Sem erros</string>
-	<string name="Marketplace Error Prefix">Erro:</string>
-	<string name="Marketplace Error Not Merchant">antes de enviar os itens para o Marketplace, é necessário que você se defina como um lojista (sem custos).</string>
-	<string name="Marketplace Error Not Accepted">Não é possível mover o item nessa pasta.</string>
-	<string name="Marketplace Error Unsellable Item">Este item não pode ser vendido no Marketplace.</string>
-	<string name="MarketplaceNoID">no Mkt ID</string>
-	<string name="MarketplaceLive">publicada</string>
-	<string name="MarketplaceActive">ativo</string>
-	<string name="MarketplaceMax">máx</string>
-	<string name="MarketplaceStock">estoque</string>
-	<string name="MarketplaceNoStock">esgotado</string>
-	<string name="MarketplaceUpdating">atualizando...</string>
-	<string name="UploadFeeInfo">A taxa é baseada em seu nível de inscrição. Níveis mais altos possuem taxas mais baixas. [https://secondlife.com/my/account/membership.php? Saiba mais]</string>
-	<string name="Open landmarks">Marcos em aberto</string>
-	<string name="Unconstrained">Ilimitado</string>
+	<string name="InventoryOutboxNoItems">
+		Arraste as pastas para estas áreas e então clique em "Enviar para Mercado" para listar os itens para venda no [[MARKETPLACE_DASHBOARD_URL] Mercado].
+	</string>
+	<string name="InventoryOutboxInitializingTitle">
+		Inicializando o Marketplace.
+	</string>
+	<string name="InventoryOutboxInitializing">
+		Estamos acessando sua conta na [loja [MARKETPLACE_CREATE_STORE_URL] do Marketplace].
+	</string>
+	<string name="InventoryOutboxErrorTitle">
+		Erros do Marketplace.
+	</string>
+	<string name="InventoryOutboxError">
+		A loja [[MARKETPLACE_CREATE_STORE_URL] no Marketplace] está retornando erros.
+	</string>
+	<string name="InventoryMarketplaceError">
+		Erro ao abrir as listagens do Marketplace.
+Se você continuar a receber essa mensagem, entre em contato com o suporte do Second Life para obter ajuda em http://support.secondlife.com
+	</string>
+	<string name="InventoryMarketplaceListingsNoItemsTitle">
+		Sua pasta Listagens do Marketplace está vazia.
+	</string>
+	<string name="InventoryMarketplaceListingsNoItems">
+		Arraste pastas para esta área para listá-las para venda no [Marketplace [MARKETPLACE_DASHBOARD_URL]].
+	</string>
+	<string name="InventoryItemsCount">
+		( [ITEMS_COUNT] Items )
+	</string>
+	<string name="Marketplace Validation Warning Stock">
+		a pasta de estoque deve estar em uma pasta de versões
+	</string>
+	<string name="Marketplace Validation Error Mixed Stock">
+		: Erro: todos os itens em uma pasta de estoque devem ser de cópia proibida e todos do mesmo tipo
+	</string>
+	<string name="Marketplace Validation Error Subfolder In Stock">
+		: Erro: a pasta de estoque não pode ter subpastas
+	</string>
+	<string name="Marketplace Validation Warning Empty">
+		: Aviso: a pasta não contém itens
+	</string>
+	<string name="Marketplace Validation Warning Create Stock">
+		: Aviso: criando pasta de estoque
+	</string>
+	<string name="Marketplace Validation Warning Create Version">
+		: Aviso: criando pasta de versões
+	</string>
+	<string name="Marketplace Validation Warning Move">
+		: Aviso: movendo itens
+	</string>
+	<string name="Marketplace Validation Warning Delete">
+		: Aviso: conteúdo da pasta transferido para pasta de estoque, removendo pasta vazia
+	</string>
+	<string name="Marketplace Validation Error Stock Item">
+		: Erro: itens de cópia proibida devem estar em uma pasta de estoque
+	</string>
+	<string name="Marketplace Validation Warning Unwrapped Item">
+		: Aviso: os itens devem estar em uma pasta de versões
+	</string>
+	<string name="Marketplace Validation Error">
+		: Erro:
+	</string>
+	<string name="Marketplace Validation Warning">
+		: Aviso:
+	</string>
+	<string name="Marketplace Validation Error Empty Version">
+		: Aviso: a pasta de versões deve conter pelo menos 1 item
+	</string>
+	<string name="Marketplace Validation Error Empty Stock">
+		: Aviso: a pasta de estoque deve conter pelo menos 1 item
+	</string>
+	<string name="Marketplace Validation No Error">
+		Não há erros ou avisos
+	</string>
+	<string name="Marketplace Error None">
+		Sem erros
+	</string>
+	<string name="Marketplace Error Prefix">
+		Erro:
+	</string>
+	<string name="Marketplace Error Not Merchant">
+		antes de enviar os itens para o Marketplace, é necessário que você se defina como um lojista (sem custos).
+	</string>
+	<string name="Marketplace Error Not Accepted">
+		Não é possível mover o item nessa pasta.
+	</string>
+	<string name="Marketplace Error Unsellable Item">
+		Este item não pode ser vendido no Marketplace.
+	</string>
+	<string name="MarketplaceNoID">
+		no Mkt ID
+	</string>
+	<string name="MarketplaceLive">
+		publicada
+	</string>
+	<string name="MarketplaceActive">
+		ativo
+	</string>
+	<string name="MarketplaceMax">
+		máx
+	</string>
+	<string name="MarketplaceStock">
+		estoque
+	</string>
+	<string name="MarketplaceNoStock">
+		esgotado
+	</string>
+	<string name="MarketplaceUpdating">
+		atualizando...
+	</string>
+	<string name="UploadFeeInfo">
+		A taxa é baseada em seu nível de inscrição. Níveis mais altos possuem taxas mais baixas. [https://secondlife.com/my/account/membership.php? Saiba mais]
+	</string>
+	<string name="Open landmarks">
+		Marcos em aberto
+	</string>
+	<string name="Unconstrained">
+		Ilimitado
+	</string>
 	<string name="no_transfer" value="(não transferível)"/>
 	<string name="no_modify" value="(não modificável)"/>
 	<string name="no_copy" value="(não copiável)"/>
 	<string name="worn" value="(vestido)"/>
 	<string name="link" value="(link)"/>
 	<string name="broken_link" value="(link_quebrado)&quot;"/>
-	<string name="LoadingContents">Carregando conteúdo...</string>
-	<string name="NoContents">Nenhum conteúdo</string>
+	<string name="LoadingContents">
+		Carregando conteúdo...
+	</string>
+	<string name="NoContents">
+		Nenhum conteúdo
+	</string>
 	<string name="WornOnAttachmentPoint" value="(vestido em [ATTACHMENT_POINT])"/>
 	<string name="AttachmentErrorMessage" value="([ATTACHMENT_ERROR])"/>
 	<string name="ActiveGesture" value="[GESLABEL] (ativado)"/>
@@ -595,1417 +1649,4139 @@ Se você continuar a receber essa mensagem, entre em contato com o suporte do Se
 	<string name="Snapshots" value="Fotografias"/>
 	<string name="No Filters" value="Não"/>
 	<string name="Since Logoff" value="- Desde desligado"/>
-	<string name="InvFolder My Inventory">Meu inventário</string>
-	<string name="InvFolder Library">Biblioteca</string>
-	<string name="InvFolder Textures">Texturas</string>
-	<string name="InvFolder Sounds">Sons</string>
-	<string name="InvFolder Calling Cards">Cartões de visitas</string>
-	<string name="InvFolder Landmarks">Marcos</string>
-	<string name="InvFolder Scripts">Scripts</string>
-	<string name="InvFolder Clothing">Vestuário</string>
-	<string name="InvFolder Objects">Objetos</string>
-	<string name="InvFolder Notecards">Anotações</string>
-	<string name="InvFolder New Folder">Nova pasta</string>
-	<string name="InvFolder Inventory">Inventário</string>
-	<string name="InvFolder Uncompressed Images">Imagens descompactadas</string>
-	<string name="InvFolder Body Parts">Corpo</string>
-	<string name="InvFolder Trash">Lixo</string>
-	<string name="InvFolder Photo Album">Álbum de fotografias</string>
-	<string name="InvFolder Lost And Found">Achados e Perdidos</string>
-	<string name="InvFolder Uncompressed Sounds">Sons descompactados</string>
-	<string name="InvFolder Animations">Animações</string>
-	<string name="InvFolder Gestures">Gestos</string>
-	<string name="InvFolder Favorite">Meus favoritos</string>
-	<string name="InvFolder favorite">Meus favoritos</string>
-	<string name="InvFolder Favorites">Meus favoritos</string>
-	<string name="InvFolder favorites">Meus favoritos</string>
-	<string name="InvFolder Current Outfit">Look atual</string>
-	<string name="InvFolder Initial Outfits">Looks iniciais</string>
-	<string name="InvFolder My Outfits">Meus looks</string>
-	<string name="InvFolder Accessories">Acessórios</string>
-	<string name="InvFolder Meshes">Meshes:</string>
-	<string name="InvFolder Received Items">Itens recebidos</string>
-	<string name="InvFolder Merchant Outbox">Caixa de saída do lojista</string>
-	<string name="InvFolder Friends">Amigos</string>
-	<string name="InvFolder All">Tudo</string>
-	<string name="no_attachments">Nenhum anexo vestido</string>
-	<string name="Attachments remain">Anexos ([COUNT] slots permanecem)</string>
-	<string name="Buy">Comprar</string>
-	<string name="BuyforL$">Comprar por L$</string>
-	<string name="Stone">Pedra</string>
-	<string name="Metal">Metal</string>
-	<string name="Glass">Vidro</string>
-	<string name="Wood">Madeira</string>
-	<string name="Flesh">Carne</string>
-	<string name="Plastic">Plástico</string>
-	<string name="Rubber">Borrracha</string>
-	<string name="Light">Luz</string>
-	<string name="KBShift">Shift</string>
-	<string name="KBCtrl">Ctrl</string>
-	<string name="Chest">Peito</string>
-	<string name="Skull">Crânio</string>
-	<string name="Left Shoulder">Ombro esquerdo</string>
-	<string name="Right Shoulder">Ombro direito</string>
-	<string name="Left Hand">Mão esquerda</string>
-	<string name="Right Hand">Mão direita</string>
-	<string name="Left Foot">Pé esquerdo</string>
-	<string name="Right Foot">Pé direito</string>
-	<string name="Spine">Espinha</string>
-	<string name="Pelvis">Pélvis</string>
-	<string name="Mouth">Boca</string>
-	<string name="Chin">Queixo</string>
-	<string name="Left Ear">Orelha esquerda</string>
-	<string name="Right Ear">Orelha direita</string>
-	<string name="Left Eyeball">Globo ocular esquerdo</string>
-	<string name="Right Eyeball">Globo ocular direito</string>
-	<string name="Nose">Nariz</string>
-	<string name="R Upper Arm">Braço superior D</string>
-	<string name="R Forearm">Antebraço D</string>
-	<string name="L Upper Arm">Braço superior E</string>
-	<string name="L Forearm">Antebraço E</string>
-	<string name="Right Hip">Quadril direito</string>
-	<string name="R Upper Leg">Coxa D</string>
-	<string name="R Lower Leg">Perna inferior D</string>
-	<string name="Left Hip">Quadril esquerdo</string>
-	<string name="L Upper Leg">Coxa E</string>
-	<string name="L Lower Leg">Perna inferior E</string>
-	<string name="Stomach">Estômago</string>
-	<string name="Left Pec">Peitoral E</string>
-	<string name="Right Pec">Peitoral D</string>
-	<string name="Neck">Pescoço</string>
-	<string name="Avatar Center">Centro do avatar</string>
-	<string name="Left Ring Finger">Anelar esquerdo</string>
-	<string name="Right Ring Finger">Anelar direito</string>
-	<string name="Tail Base">Base do rabo</string>
-	<string name="Tail Tip">Ponta do rabo</string>
-	<string name="Left Wing">Asa esquerda</string>
-	<string name="Right Wing">Asa direita</string>
-	<string name="Jaw">Maxilar</string>
-	<string name="Alt Left Ear">Orelha esquerda alt.</string>
-	<string name="Alt Right Ear">Orelha direita alt.</string>
-	<string name="Alt Left Eye">Olho esquerdo alt.</string>
-	<string name="Alt Right Eye">Olho direito alt.</string>
-	<string name="Tongue">Língua</string>
-	<string name="Groin">Virilha</string>
-	<string name="Left Hind Foot">Pata esq. traseira</string>
-	<string name="Right Hind Foot">Pata dir. traseira</string>
-	<string name="Invalid Attachment">Ponto de encaixe inválido</string>
-	<string name="ATTACHMENT_MISSING_ITEM">Erro: item ausente</string>
-	<string name="ATTACHMENT_MISSING_BASE_ITEM">Erro: item base ausente</string>
-	<string name="ATTACHMENT_NOT_ATTACHED">Erro: o objeto está no look atual, mas não foi anexado</string>
-	<string name="YearsMonthsOld">[AGEYEARS] [AGEMONTHS] de idade</string>
-	<string name="YearsOld">[AGEYEARS] de idade</string>
-	<string name="MonthsOld">[AGEMONTHS] de idade</string>
-	<string name="WeeksOld">[AGEWEEKS] de idade</string>
-	<string name="DaysOld">[AGEDAYS] de idade</string>
-	<string name="TodayOld">Cadastrado hoje</string>
-	<string name="av_render_everyone_now">Agora, todos podem te ver.</string>
-	<string name="av_render_not_everyone">Sua renderização pode não acontecer para todos ao seu redor.</string>
-	<string name="av_render_over_half">Sua renderização pode não acontecer para metade das pessoas ao seu redor.</string>
-	<string name="av_render_most_of">Sua renderização pode não acontecer para a maioria das pessoas ao seu redor.</string>
-	<string name="av_render_anyone">Sua renderização pode não acontecer para ninguém ao seu redor.</string>
-	<string name="hud_description_total">Seu HUD</string>
-	<string name="hud_name_with_joint">[OBJ_NAME] (vestido em [JNT_NAME])</string>
-	<string name="hud_render_memory_warning">[HUD_DETAILS] usa muita memória de textura</string>
-	<string name="hud_render_cost_warning">[HUD_DETAILS] contém muitos objetos e texturas que utilizam o máximo de recursos</string>
-	<string name="hud_render_heavy_textures_warning">[HUD_DETAILS] contém muitas texturas grandes</string>
-	<string name="hud_render_cramped_warning">[HUD_DETAILS] contém muitos objetos</string>
-	<string name="hud_render_textures_warning">[HUD_DETAILS] contém muitas texturas</string>
-	<string name="AgeYearsA">[COUNT] ano</string>
-	<string name="AgeYearsB">[COUNT] anos</string>
-	<string name="AgeYearsC">[COUNT] anos</string>
-	<string name="AgeMonthsA">[COUNT] mês</string>
-	<string name="AgeMonthsB">[COUNT] meses</string>
-	<string name="AgeMonthsC">[COUNT] meses</string>
-	<string name="AgeWeeksA">[COUNT] semana</string>
-	<string name="AgeWeeksB">[COUNT] semanas</string>
-	<string name="AgeWeeksC">[COUNT] semanas</string>
-	<string name="AgeDaysA">[COUNT] dia</string>
-	<string name="AgeDaysB">[COUNT] dias</string>
-	<string name="AgeDaysC">[COUNT] dias</string>
-	<string name="GroupMembersA">[COUNT] membro</string>
-	<string name="GroupMembersB">[COUNT] membros</string>
-	<string name="GroupMembersC">[COUNT] membros</string>
-	<string name="AcctTypeResident">Residente</string>
-	<string name="AcctTypeTrial">Prova</string>
-	<string name="AcctTypeCharterMember">Lista de membros</string>
-	<string name="AcctTypeEmployee">Empregado da Linden Lab</string>
-	<string name="PaymentInfoUsed">Dados de pagamento usados</string>
-	<string name="PaymentInfoOnFile">Dados de pagamento fornecidos</string>
-	<string name="NoPaymentInfoOnFile">Nenhum dado de pagamento</string>
-	<string name="AgeVerified">Idade comprovada</string>
-	<string name="NotAgeVerified">Idade não comprovada</string>
-	<string name="Center 2">Centro 2</string>
-	<string name="Top Right">Topo direita</string>
-	<string name="Top">Topo</string>
-	<string name="Top Left">Topo esquerda</string>
-	<string name="Center">Centro</string>
-	<string name="Bottom Left">Inferior esquerdo</string>
-	<string name="Bottom">Inferior</string>
-	<string name="Bottom Right">Inferior direito</string>
-	<string name="CompileQueueDownloadedCompiling">Baixado, agora compilando</string>
-	<string name="CompileQueueServiceUnavailable">Serviço de compilação de scripts não disponível</string>
-	<string name="CompileQueueScriptNotFound">Script não encontrado no servidor.</string>
-	<string name="CompileQueueProblemDownloading">Problema no  download</string>
-	<string name="CompileQueueInsufficientPermDownload">Permissões insuficientes para  fazer o download do script.</string>
-	<string name="CompileQueueInsufficientPermFor">Permissões insuficientes para</string>
-	<string name="CompileQueueUnknownFailure">Falha desconhecida para download</string>
-	<string name="CompileNoExperiencePerm">Pulando script [SCRIPT] com experiência [EXPERIENCE]</string>
-	<string name="CompileQueueTitle">Progresso do recompilamento</string>
-	<string name="CompileQueueStart">recompilar</string>
-	<string name="ResetQueueTitle">Reset Progresso</string>
-	<string name="ResetQueueStart">Zerar</string>
-	<string name="RunQueueTitle">Definir funcionamento do progresso</string>
-	<string name="RunQueueStart">deixar funcionando</string>
-	<string name="NotRunQueueTitle">Definir progresso não funcionando</string>
-	<string name="NotRunQueueStart">não deixar funcionando</string>
-	<string name="CompileSuccessful">Compilação bem sucedida</string>
-	<string name="CompileSuccessfulSaving">Compilação bem sucedida, salvando...</string>
-	<string name="SaveComplete">Salvo.</string>
-	<string name="UploadFailed">Falha ao carregar arquivo:</string>
-	<string name="ObjectOutOfRange">Script (objeto fora de alcance)</string>
-	<string name="ScriptWasDeleted">Script (excluído do inventário)</string>
-	<string name="GodToolsObjectOwnedBy">Objeto [OBJECT] de propriedade de [OWNER]</string>
-	<string name="GroupsNone">nenhum</string>
+	<string name="InvFolder My Inventory">
+		Meu inventário
+	</string>
+	<string name="InvFolder Library">
+		Biblioteca
+	</string>
+	<string name="InvFolder Textures">
+		Texturas
+	</string>
+	<string name="InvFolder Sounds">
+		Sons
+	</string>
+	<string name="InvFolder Calling Cards">
+		Cartões de visitas
+	</string>
+	<string name="InvFolder Landmarks">
+		Marcos
+	</string>
+	<string name="InvFolder Scripts">
+		Scripts
+	</string>
+	<string name="InvFolder Clothing">
+		Vestuário
+	</string>
+	<string name="InvFolder Objects">
+		Objetos
+	</string>
+	<string name="InvFolder Notecards">
+		Anotações
+	</string>
+	<string name="InvFolder New Folder">
+		Nova pasta
+	</string>
+	<string name="InvFolder Inventory">
+		Inventário
+	</string>
+	<string name="InvFolder Uncompressed Images">
+		Imagens descompactadas
+	</string>
+	<string name="InvFolder Body Parts">
+		Corpo
+	</string>
+	<string name="InvFolder Trash">
+		Lixo
+	</string>
+	<string name="InvFolder Photo Album">
+		Álbum de fotografias
+	</string>
+	<string name="InvFolder Lost And Found">
+		Achados e Perdidos
+	</string>
+	<string name="InvFolder Uncompressed Sounds">
+		Sons descompactados
+	</string>
+	<string name="InvFolder Animations">
+		Animações
+	</string>
+	<string name="InvFolder Gestures">
+		Gestos
+	</string>
+	<string name="InvFolder Favorite">
+		Meus favoritos
+	</string>
+	<string name="InvFolder favorite">
+		Meus favoritos
+	</string>
+	<string name="InvFolder Favorites">
+		Meus favoritos
+	</string>
+	<string name="InvFolder favorites">
+		Meus favoritos
+	</string>
+	<string name="InvFolder Current Outfit">
+		Look atual
+	</string>
+	<string name="InvFolder Initial Outfits">
+		Looks iniciais
+	</string>
+	<string name="InvFolder My Outfits">
+		Meus looks
+	</string>
+	<string name="InvFolder Accessories">
+		Acessórios
+	</string>
+	<string name="InvFolder Meshes">
+		Meshes:
+	</string>
+	<string name="InvFolder Received Items">
+		Itens recebidos
+	</string>
+	<string name="InvFolder Merchant Outbox">
+		Caixa de saída do lojista
+	</string>
+	<string name="InvFolder Friends">
+		Amigos
+	</string>
+	<string name="InvFolder All">
+		Tudo
+	</string>
+	<string name="no_attachments">
+		Nenhum anexo vestido
+	</string>
+	<string name="Attachments remain">
+		Anexos ([COUNT] slots permanecem)
+	</string>
+	<string name="Buy">
+		Comprar
+	</string>
+	<string name="BuyforL$">
+		Comprar por L$
+	</string>
+	<string name="Stone">
+		Pedra
+	</string>
+	<string name="Metal">
+		Metal
+	</string>
+	<string name="Glass">
+		Vidro
+	</string>
+	<string name="Wood">
+		Madeira
+	</string>
+	<string name="Flesh">
+		Carne
+	</string>
+	<string name="Plastic">
+		Plástico
+	</string>
+	<string name="Rubber">
+		Borrracha
+	</string>
+	<string name="Light">
+		Luz
+	</string>
+	<string name="KBShift">
+		Shift
+	</string>
+	<string name="KBCtrl">
+		Ctrl
+	</string>
+	<string name="Chest">
+		Peito
+	</string>
+	<string name="Skull">
+		Crânio
+	</string>
+	<string name="Left Shoulder">
+		Ombro esquerdo
+	</string>
+	<string name="Right Shoulder">
+		Ombro direito
+	</string>
+	<string name="Left Hand">
+		Mão esquerda
+	</string>
+	<string name="Right Hand">
+		Mão direita
+	</string>
+	<string name="Left Foot">
+		Pé esquerdo
+	</string>
+	<string name="Right Foot">
+		Pé direito
+	</string>
+	<string name="Spine">
+		Espinha
+	</string>
+	<string name="Pelvis">
+		Pélvis
+	</string>
+	<string name="Mouth">
+		Boca
+	</string>
+	<string name="Chin">
+		Queixo
+	</string>
+	<string name="Left Ear">
+		Orelha esquerda
+	</string>
+	<string name="Right Ear">
+		Orelha direita
+	</string>
+	<string name="Left Eyeball">
+		Globo ocular esquerdo
+	</string>
+	<string name="Right Eyeball">
+		Globo ocular direito
+	</string>
+	<string name="Nose">
+		Nariz
+	</string>
+	<string name="R Upper Arm">
+		Braço superior D
+	</string>
+	<string name="R Forearm">
+		Antebraço D
+	</string>
+	<string name="L Upper Arm">
+		Braço superior E
+	</string>
+	<string name="L Forearm">
+		Antebraço E
+	</string>
+	<string name="Right Hip">
+		Quadril direito
+	</string>
+	<string name="R Upper Leg">
+		Coxa D
+	</string>
+	<string name="R Lower Leg">
+		Perna inferior D
+	</string>
+	<string name="Left Hip">
+		Quadril esquerdo
+	</string>
+	<string name="L Upper Leg">
+		Coxa E
+	</string>
+	<string name="L Lower Leg">
+		Perna inferior E
+	</string>
+	<string name="Stomach">
+		Estômago
+	</string>
+	<string name="Left Pec">
+		Peitoral E
+	</string>
+	<string name="Right Pec">
+		Peitoral D
+	</string>
+	<string name="Neck">
+		Pescoço
+	</string>
+	<string name="Avatar Center">
+		Centro do avatar
+	</string>
+	<string name="Left Ring Finger">
+		Anelar esquerdo
+	</string>
+	<string name="Right Ring Finger">
+		Anelar direito
+	</string>
+	<string name="Tail Base">
+		Base do rabo
+	</string>
+	<string name="Tail Tip">
+		Ponta do rabo
+	</string>
+	<string name="Left Wing">
+		Asa esquerda
+	</string>
+	<string name="Right Wing">
+		Asa direita
+	</string>
+	<string name="Jaw">
+		Maxilar
+	</string>
+	<string name="Alt Left Ear">
+		Orelha esquerda alt.
+	</string>
+	<string name="Alt Right Ear">
+		Orelha direita alt.
+	</string>
+	<string name="Alt Left Eye">
+		Olho esquerdo alt.
+	</string>
+	<string name="Alt Right Eye">
+		Olho direito alt.
+	</string>
+	<string name="Tongue">
+		Língua
+	</string>
+	<string name="Groin">
+		Virilha
+	</string>
+	<string name="Left Hind Foot">
+		Pata esq. traseira
+	</string>
+	<string name="Right Hind Foot">
+		Pata dir. traseira
+	</string>
+	<string name="Invalid Attachment">
+		Ponto de encaixe inválido
+	</string>
+	<string name="ATTACHMENT_MISSING_ITEM">
+		Erro: item ausente
+	</string>
+	<string name="ATTACHMENT_MISSING_BASE_ITEM">
+		Erro: item base ausente
+	</string>
+	<string name="ATTACHMENT_NOT_ATTACHED">
+		Erro: o objeto está no look atual, mas não foi anexado
+	</string>
+	<string name="YearsMonthsOld">
+		[AGEYEARS] [AGEMONTHS] de idade
+	</string>
+	<string name="YearsOld">
+		[AGEYEARS] de idade
+	</string>
+	<string name="MonthsOld">
+		[AGEMONTHS] de idade
+	</string>
+	<string name="WeeksOld">
+		[AGEWEEKS] de idade
+	</string>
+	<string name="DaysOld">
+		[AGEDAYS] de idade
+	</string>
+	<string name="TodayOld">
+		Cadastrado hoje
+	</string>
+	<string name="av_render_everyone_now">
+		Agora, todos podem te ver.
+	</string>
+	<string name="av_render_not_everyone">
+		Sua renderização pode não acontecer para todos ao seu redor.
+	</string>
+	<string name="av_render_over_half">
+		Sua renderização pode não acontecer para metade das pessoas ao seu redor.
+	</string>
+	<string name="av_render_most_of">
+		Sua renderização pode não acontecer para a maioria das pessoas ao seu redor.
+	</string>
+	<string name="av_render_anyone">
+		Sua renderização pode não acontecer para ninguém ao seu redor.
+	</string>
+	<string name="hud_description_total">
+		Seu HUD
+	</string>
+	<string name="hud_name_with_joint">
+		[OBJ_NAME] (vestido em [JNT_NAME])
+	</string>
+	<string name="hud_render_memory_warning">
+		[HUD_DETAILS] usa muita memória de textura
+	</string>
+	<string name="hud_render_cost_warning">
+		[HUD_DETAILS] contém muitos objetos e texturas que utilizam o máximo de recursos
+	</string>
+	<string name="hud_render_heavy_textures_warning">
+		[HUD_DETAILS] contém muitas texturas grandes
+	</string>
+	<string name="hud_render_cramped_warning">
+		[HUD_DETAILS] contém muitos objetos
+	</string>
+	<string name="hud_render_textures_warning">
+		[HUD_DETAILS] contém muitas texturas
+	</string>
+	<string name="AgeYearsA">
+		[COUNT] ano
+	</string>
+	<string name="AgeYearsB">
+		[COUNT] anos
+	</string>
+	<string name="AgeYearsC">
+		[COUNT] anos
+	</string>
+	<string name="AgeMonthsA">
+		[COUNT] mês
+	</string>
+	<string name="AgeMonthsB">
+		[COUNT] meses
+	</string>
+	<string name="AgeMonthsC">
+		[COUNT] meses
+	</string>
+	<string name="AgeWeeksA">
+		[COUNT] semana
+	</string>
+	<string name="AgeWeeksB">
+		[COUNT] semanas
+	</string>
+	<string name="AgeWeeksC">
+		[COUNT] semanas
+	</string>
+	<string name="AgeDaysA">
+		[COUNT] dia
+	</string>
+	<string name="AgeDaysB">
+		[COUNT] dias
+	</string>
+	<string name="AgeDaysC">
+		[COUNT] dias
+	</string>
+	<string name="GroupMembersA">
+		[COUNT] membro
+	</string>
+	<string name="GroupMembersB">
+		[COUNT] membros
+	</string>
+	<string name="GroupMembersC">
+		[COUNT] membros
+	</string>
+	<string name="AcctTypeResident">
+		Residente
+	</string>
+	<string name="AcctTypeTrial">
+		Prova
+	</string>
+	<string name="AcctTypeCharterMember">
+		Lista de membros
+	</string>
+	<string name="AcctTypeEmployee">
+		Empregado da Linden Lab
+	</string>
+	<string name="PaymentInfoUsed">
+		Dados de pagamento usados
+	</string>
+	<string name="PaymentInfoOnFile">
+		Dados de pagamento fornecidos
+	</string>
+	<string name="NoPaymentInfoOnFile">
+		Nenhum dado de pagamento
+	</string>
+	<string name="AgeVerified">
+		Idade comprovada
+	</string>
+	<string name="NotAgeVerified">
+		Idade não comprovada
+	</string>
+	<string name="Center 2">
+		Centro 2
+	</string>
+	<string name="Top Right">
+		Topo direita
+	</string>
+	<string name="Top">
+		Topo
+	</string>
+	<string name="Top Left">
+		Topo esquerda
+	</string>
+	<string name="Center">
+		Centro
+	</string>
+	<string name="Bottom Left">
+		Inferior esquerdo
+	</string>
+	<string name="Bottom">
+		Inferior
+	</string>
+	<string name="Bottom Right">
+		Inferior direito
+	</string>
+	<string name="CompileQueueDownloadedCompiling">
+		Baixado, agora compilando
+	</string>
+	<string name="CompileQueueServiceUnavailable">
+		Serviço de compilação de scripts não disponível
+	</string>
+	<string name="CompileQueueScriptNotFound">
+		Script não encontrado no servidor.
+	</string>
+	<string name="CompileQueueProblemDownloading">
+		Problema no  download
+	</string>
+	<string name="CompileQueueInsufficientPermDownload">
+		Permissões insuficientes para  fazer o download do script.
+	</string>
+	<string name="CompileQueueInsufficientPermFor">
+		Permissões insuficientes para
+	</string>
+	<string name="CompileQueueUnknownFailure">
+		Falha desconhecida para download
+	</string>
+	<string name="CompileNoExperiencePerm">
+		Pulando script [SCRIPT] com experiência [EXPERIENCE]
+	</string>
+	<string name="CompileQueueTitle">
+		Progresso do recompilamento
+	</string>
+	<string name="CompileQueueStart">
+		recompilar
+	</string>
+	<string name="ResetQueueTitle">
+		Reset Progresso
+	</string>
+	<string name="ResetQueueStart">
+		Zerar
+	</string>
+	<string name="RunQueueTitle">
+		Definir funcionamento do progresso
+	</string>
+	<string name="RunQueueStart">
+		deixar funcionando
+	</string>
+	<string name="NotRunQueueTitle">
+		Definir progresso não funcionando
+	</string>
+	<string name="NotRunQueueStart">
+		não deixar funcionando
+	</string>
+	<string name="CompileSuccessful">
+		Compilação bem sucedida
+	</string>
+	<string name="CompileSuccessfulSaving">
+		Compilação bem sucedida, salvando...
+	</string>
+	<string name="SaveComplete">
+		Salvo.
+	</string>
+	<string name="UploadFailed">
+		Falha ao carregar arquivo:
+	</string>
+	<string name="ObjectOutOfRange">
+		Script (objeto fora de alcance)
+	</string>
+	<string name="ScriptWasDeleted">
+		Script (excluído do inventário)
+	</string>
+	<string name="GodToolsObjectOwnedBy">
+		Objeto [OBJECT] de propriedade de [OWNER]
+	</string>
+	<string name="GroupsNone">
+		nenhum
+	</string>
 	<string name="Group" value="(grupo)"/>
-	<string name="Unknown">(Desconhecido)</string>
+	<string name="Unknown">
+		(Desconhecido)
+	</string>
 	<string name="SummaryForTheWeek" value="Resumo para esta semana, com início em "/>
 	<string name="NextStipendDay" value=". Próximo dia de salário é "/>
-	<string name="GroupPlanningDate">[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]</string>
+	<string name="GroupPlanningDate">
+		[mthnum,datetime,utc]/[day,datetime,utc]/[year,datetime,utc]
+	</string>
 	<string name="GroupIndividualShare" value="Grupo       Divisão individualI"/>
 	<string name="GroupColumn" value="Grupo"/>
-	<string name="Balance">Balanço</string>
-	<string name="Credits">Créditos</string>
-	<string name="Debits">Débitos</string>
-	<string name="Total">Total</string>
-	<string name="NoGroupDataFound">Não há dados de grupo</string>
-	<string name="IMParentEstate">Propriedade-pai</string>
-	<string name="IMMainland">continente</string>
-	<string name="IMTeen">adolescente</string>
-	<string name="Anyone">qualquer um</string>
-	<string name="RegionInfoError">erro</string>
-	<string name="RegionInfoAllEstatesOwnedBy">todas as propriedades pertencem a [OWNER]</string>
-	<string name="RegionInfoAllEstatesYouOwn">todas as propriedades que você possui</string>
-	<string name="RegionInfoAllEstatesYouManage">todas as propriedades que você gerencia para [OWNER]</string>
-	<string name="RegionInfoAllowedResidents">Sempre permitido: ([ALLOWEDAGENTS], máx [MAXACCESS])</string>
-	<string name="RegionInfoAllowedGroups">Grupos sempre permitidos: ([ALLOWEDGROUPS], máx [MAXACCESS])</string>
-	<string name="RegionInfoBannedResidents">Grupos banidos: ([BANNEDAGENTS], máx [MAXBANNED])</string>
-	<string name="RegionInfoListTypeAllowedAgents">Sempre permitido</string>
-	<string name="RegionInfoListTypeBannedAgents">Sempre banido</string>
-	<string name="RegionInfoAllEstates">todos os terrenos</string>
-	<string name="RegionInfoManagedEstates">administre terrenos</string>
-	<string name="RegionInfoThisEstate">este terreno</string>
-	<string name="AndNMore">e [EXTRA_COUNT] mais</string>
-	<string name="ScriptLimitsParcelScriptMemory">Memória de scripts no lote</string>
-	<string name="ScriptLimitsParcelsOwned">Lotes listados: [PARCELS]</string>
-	<string name="ScriptLimitsMemoryUsed">Memória usada: [COUNT] kb de [MAX] kb; [AVAILABLE] kb disponíveis</string>
-	<string name="ScriptLimitsMemoryUsedSimple">Memória usada: [COUNT] kb</string>
-	<string name="ScriptLimitsParcelScriptURLs">URL dos scripts do lote</string>
-	<string name="ScriptLimitsURLsUsed">URLs usados: [COUNT] de [MAX]; [AVAILABLE] disponíveis</string>
-	<string name="ScriptLimitsURLsUsedSimple">URLs usados: [COUNT]</string>
-	<string name="ScriptLimitsRequestError">Erro ao solicitar dados</string>
-	<string name="ScriptLimitsRequestNoParcelSelected">Nenhum lote foi selecionado</string>
-	<string name="ScriptLimitsRequestWrongRegion">Erro: dados de script só disponíveis na região da posição atual</string>
-	<string name="ScriptLimitsRequestWaiting">Obtendo dados...</string>
-	<string name="ScriptLimitsRequestDontOwnParcel">Você não está autorizado a examinar este lote.</string>
-	<string name="SITTING_ON">Sentado em</string>
-	<string name="ATTACH_CHEST">Peito</string>
-	<string name="ATTACH_HEAD">Crânio</string>
-	<string name="ATTACH_LSHOULDER">Ombro esquerdo</string>
-	<string name="ATTACH_RSHOULDER">Ombro direito</string>
-	<string name="ATTACH_LHAND">Mão esquerda</string>
-	<string name="ATTACH_RHAND">Mão direita</string>
-	<string name="ATTACH_LFOOT">Pé esquerdo</string>
-	<string name="ATTACH_RFOOT">Pé direito</string>
-	<string name="ATTACH_BACK">Coluna</string>
-	<string name="ATTACH_PELVIS">Pélvis</string>
-	<string name="ATTACH_MOUTH">Boca</string>
-	<string name="ATTACH_CHIN">Queixo</string>
-	<string name="ATTACH_LEAR">Orelha esquerda</string>
-	<string name="ATTACH_REAR">Orelha direita</string>
-	<string name="ATTACH_LEYE">Olho esquerdo</string>
-	<string name="ATTACH_REYE">Olho direito</string>
-	<string name="ATTACH_NOSE">Nariz</string>
-	<string name="ATTACH_RUARM">Braço direito</string>
-	<string name="ATTACH_RLARM">Antebraço direito</string>
-	<string name="ATTACH_LUARM">Braço esquerdo</string>
-	<string name="ATTACH_LLARM">Antebraço esquerdo</string>
-	<string name="ATTACH_RHIP">Quadril direito</string>
-	<string name="ATTACH_RULEG">Coxa direita</string>
-	<string name="ATTACH_RLLEG">Perna direita</string>
-	<string name="ATTACH_LHIP">Quadril esquerdo</string>
-	<string name="ATTACH_LULEG">Coxa esquerda</string>
-	<string name="ATTACH_LLLEG">Perna esquerda</string>
-	<string name="ATTACH_BELLY">Estômago</string>
-	<string name="ATTACH_LEFT_PEC">Peitorais E</string>
-	<string name="ATTACH_RIGHT_PEC">Peitorais D</string>
-	<string name="ATTACH_HUD_CENTER_2">HUD Central 2</string>
-	<string name="ATTACH_HUD_TOP_RIGHT">HUD	superior direito</string>
-	<string name="ATTACH_HUD_TOP_CENTER">HUD centro superior</string>
-	<string name="ATTACH_HUD_TOP_LEFT">HUD superior esquerdo</string>
-	<string name="ATTACH_HUD_CENTER_1">HUD Central 1</string>
-	<string name="ATTACH_HUD_BOTTOM_LEFT">HUD esquerda inferior</string>
-	<string name="ATTACH_HUD_BOTTOM">HUD inferior</string>
-	<string name="ATTACH_HUD_BOTTOM_RIGHT">HUD direito inferior</string>
-	<string name="ATTACH_NECK">Pescoço</string>
-	<string name="ATTACH_AVATAR_CENTER">Centro do avatar</string>
-	<string name="ATTACH_LHAND_RING1">Anelar esquerdo</string>
-	<string name="ATTACH_RHAND_RING1">Anelar direito</string>
-	<string name="ATTACH_TAIL_BASE">Base do rabo</string>
-	<string name="ATTACH_TAIL_TIP">Ponta do rabo</string>
-	<string name="ATTACH_LWING">Asa esquerda</string>
-	<string name="ATTACH_RWING">Asa direita</string>
-	<string name="ATTACH_FACE_JAW">Maxilar</string>
-	<string name="ATTACH_FACE_LEAR">Orelha esquerda alt.</string>
-	<string name="ATTACH_FACE_REAR">Orelha direita alt.</string>
-	<string name="ATTACH_FACE_LEYE">Olho esquerdo alt.</string>
-	<string name="ATTACH_FACE_REYE">Olho direito alt.</string>
-	<string name="ATTACH_FACE_TONGUE">Língua</string>
-	<string name="ATTACH_GROIN">Virilha</string>
-	<string name="ATTACH_HIND_LFOOT">Pata esq. traseira</string>
-	<string name="ATTACH_HIND_RFOOT">Pata dir. traseira</string>
-	<string name="CursorPos">Linha [LINE], Coluna [COLUMN]</string>
-	<string name="PanelDirCountFound">[COUNT] encontrado</string>
-	<string name="PanelContentsTooltip">Conteúdo do objeto</string>
-	<string name="PanelContentsNewScript">Novo Script</string>
-	<string name="DoNotDisturbModeResponseDefault">Este residente ativou o &quot;Não perturbe&quot; e verá sua mensagem mais tarde.</string>
-	<string name="MuteByName">(por nome)</string>
-	<string name="MuteAgent">(residente)</string>
-	<string name="MuteObject">(objeto)</string>
-	<string name="MuteGroup">(grupo)</string>
-	<string name="MuteExternal">(Externo)</string>
-	<string name="RegionNoCovenant">Não foi definido um contrato para essa região.</string>
-	<string name="RegionNoCovenantOtherOwner">Não foi definido um contrato para essa Região. O terreno nesta região está sendo vendido pelo Proprietário, não pela Linden Lab. Favor contatar o Proprietário da região para detalhes de venda.</string>
+	<string name="Balance">
+		Balanço
+	</string>
+	<string name="Credits">
+		Créditos
+	</string>
+	<string name="Debits">
+		Débitos
+	</string>
+	<string name="Total">
+		Total
+	</string>
+	<string name="NoGroupDataFound">
+		Não há dados de grupo
+	</string>
+	<string name="IMParentEstate">
+		Propriedade-pai
+	</string>
+	<string name="IMMainland">
+		continente
+	</string>
+	<string name="IMTeen">
+		adolescente
+	</string>
+	<string name="Anyone">
+		qualquer um
+	</string>
+	<string name="RegionInfoError">
+		erro
+	</string>
+	<string name="RegionInfoAllEstatesOwnedBy">
+		todas as propriedades pertencem a [OWNER]
+	</string>
+	<string name="RegionInfoAllEstatesYouOwn">
+		todas as propriedades que você possui
+	</string>
+	<string name="RegionInfoAllEstatesYouManage">
+		todas as propriedades que você gerencia para [OWNER]
+	</string>
+	<string name="RegionInfoAllowedResidents">
+		Sempre permitido: ([ALLOWEDAGENTS], máx [MAXACCESS])
+	</string>
+	<string name="RegionInfoAllowedGroups">
+		Grupos sempre permitidos: ([ALLOWEDGROUPS], máx [MAXACCESS])
+	</string>
+	<string name="RegionInfoBannedResidents">
+		Grupos banidos: ([BANNEDAGENTS], máx [MAXBANNED])
+	</string>
+	<string name="RegionInfoListTypeAllowedAgents">
+		Sempre permitido
+	</string>
+	<string name="RegionInfoListTypeBannedAgents">
+		Sempre banido
+	</string>
+	<string name="RegionInfoAllEstates">
+		todos os terrenos
+	</string>
+	<string name="RegionInfoManagedEstates">
+		administre terrenos
+	</string>
+	<string name="RegionInfoThisEstate">
+		este terreno
+	</string>
+	<string name="AndNMore">
+		e [EXTRA_COUNT] mais
+	</string>
+	<string name="ScriptLimitsParcelScriptMemory">
+		Memória de scripts no lote
+	</string>
+	<string name="ScriptLimitsParcelsOwned">
+		Lotes listados: [PARCELS]
+	</string>
+	<string name="ScriptLimitsMemoryUsed">
+		Memória usada: [COUNT] kb de [MAX] kb; [AVAILABLE] kb disponíveis
+	</string>
+	<string name="ScriptLimitsMemoryUsedSimple">
+		Memória usada: [COUNT] kb
+	</string>
+	<string name="ScriptLimitsParcelScriptURLs">
+		URL dos scripts do lote
+	</string>
+	<string name="ScriptLimitsURLsUsed">
+		URLs usados: [COUNT] de [MAX]; [AVAILABLE] disponíveis
+	</string>
+	<string name="ScriptLimitsURLsUsedSimple">
+		URLs usados: [COUNT]
+	</string>
+	<string name="ScriptLimitsRequestError">
+		Erro ao solicitar dados
+	</string>
+	<string name="ScriptLimitsRequestNoParcelSelected">
+		Nenhum lote foi selecionado
+	</string>
+	<string name="ScriptLimitsRequestWrongRegion">
+		Erro: dados de script só disponíveis na região da posição atual
+	</string>
+	<string name="ScriptLimitsRequestWaiting">
+		Obtendo dados...
+	</string>
+	<string name="ScriptLimitsRequestDontOwnParcel">
+		Você não está autorizado a examinar este lote.
+	</string>
+	<string name="SITTING_ON">
+		Sentado em
+	</string>
+	<string name="ATTACH_CHEST">
+		Peito
+	</string>
+	<string name="ATTACH_HEAD">
+		Crânio
+	</string>
+	<string name="ATTACH_LSHOULDER">
+		Ombro esquerdo
+	</string>
+	<string name="ATTACH_RSHOULDER">
+		Ombro direito
+	</string>
+	<string name="ATTACH_LHAND">
+		Mão esquerda
+	</string>
+	<string name="ATTACH_RHAND">
+		Mão direita
+	</string>
+	<string name="ATTACH_LFOOT">
+		Pé esquerdo
+	</string>
+	<string name="ATTACH_RFOOT">
+		Pé direito
+	</string>
+	<string name="ATTACH_BACK">
+		Coluna
+	</string>
+	<string name="ATTACH_PELVIS">
+		Pélvis
+	</string>
+	<string name="ATTACH_MOUTH">
+		Boca
+	</string>
+	<string name="ATTACH_CHIN">
+		Queixo
+	</string>
+	<string name="ATTACH_LEAR">
+		Orelha esquerda
+	</string>
+	<string name="ATTACH_REAR">
+		Orelha direita
+	</string>
+	<string name="ATTACH_LEYE">
+		Olho esquerdo
+	</string>
+	<string name="ATTACH_REYE">
+		Olho direito
+	</string>
+	<string name="ATTACH_NOSE">
+		Nariz
+	</string>
+	<string name="ATTACH_RUARM">
+		Braço direito
+	</string>
+	<string name="ATTACH_RLARM">
+		Antebraço direito
+	</string>
+	<string name="ATTACH_LUARM">
+		Braço esquerdo
+	</string>
+	<string name="ATTACH_LLARM">
+		Antebraço esquerdo
+	</string>
+	<string name="ATTACH_RHIP">
+		Quadril direito
+	</string>
+	<string name="ATTACH_RULEG">
+		Coxa direita
+	</string>
+	<string name="ATTACH_RLLEG">
+		Perna direita
+	</string>
+	<string name="ATTACH_LHIP">
+		Quadril esquerdo
+	</string>
+	<string name="ATTACH_LULEG">
+		Coxa esquerda
+	</string>
+	<string name="ATTACH_LLLEG">
+		Perna esquerda
+	</string>
+	<string name="ATTACH_BELLY">
+		Estômago
+	</string>
+	<string name="ATTACH_LEFT_PEC">
+		Peitorais E
+	</string>
+	<string name="ATTACH_RIGHT_PEC">
+		Peitorais D
+	</string>
+	<string name="ATTACH_HUD_CENTER_2">
+		HUD Central 2
+	</string>
+	<string name="ATTACH_HUD_TOP_RIGHT">
+		HUD	superior direito
+	</string>
+	<string name="ATTACH_HUD_TOP_CENTER">
+		HUD centro superior
+	</string>
+	<string name="ATTACH_HUD_TOP_LEFT">
+		HUD superior esquerdo
+	</string>
+	<string name="ATTACH_HUD_CENTER_1">
+		HUD Central 1
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_LEFT">
+		HUD esquerda inferior
+	</string>
+	<string name="ATTACH_HUD_BOTTOM">
+		HUD inferior
+	</string>
+	<string name="ATTACH_HUD_BOTTOM_RIGHT">
+		HUD direito inferior
+	</string>
+	<string name="ATTACH_NECK">
+		Pescoço
+	</string>
+	<string name="ATTACH_AVATAR_CENTER">
+		Centro do avatar
+	</string>
+	<string name="ATTACH_LHAND_RING1">
+		Anelar esquerdo
+	</string>
+	<string name="ATTACH_RHAND_RING1">
+		Anelar direito
+	</string>
+	<string name="ATTACH_TAIL_BASE">
+		Base do rabo
+	</string>
+	<string name="ATTACH_TAIL_TIP">
+		Ponta do rabo
+	</string>
+	<string name="ATTACH_LWING">
+		Asa esquerda
+	</string>
+	<string name="ATTACH_RWING">
+		Asa direita
+	</string>
+	<string name="ATTACH_FACE_JAW">
+		Maxilar
+	</string>
+	<string name="ATTACH_FACE_LEAR">
+		Orelha esquerda alt.
+	</string>
+	<string name="ATTACH_FACE_REAR">
+		Orelha direita alt.
+	</string>
+	<string name="ATTACH_FACE_LEYE">
+		Olho esquerdo alt.
+	</string>
+	<string name="ATTACH_FACE_REYE">
+		Olho direito alt.
+	</string>
+	<string name="ATTACH_FACE_TONGUE">
+		Língua
+	</string>
+	<string name="ATTACH_GROIN">
+		Virilha
+	</string>
+	<string name="ATTACH_HIND_LFOOT">
+		Pata esq. traseira
+	</string>
+	<string name="ATTACH_HIND_RFOOT">
+		Pata dir. traseira
+	</string>
+	<string name="CursorPos">
+		Linha [LINE], Coluna [COLUMN]
+	</string>
+	<string name="PanelDirCountFound">
+		[COUNT] encontrado
+	</string>
+	<string name="PanelContentsTooltip">
+		Conteúdo do objeto
+	</string>
+	<string name="PanelContentsNewScript">
+		Novo Script
+	</string>
+	<string name="DoNotDisturbModeResponseDefault">
+		Este residente ativou o "Não perturbe" e verá sua mensagem mais tarde.
+	</string>
+	<string name="MuteByName">
+		(por nome)
+	</string>
+	<string name="MuteAgent">
+		(residente)
+	</string>
+	<string name="MuteObject">
+		(objeto)
+	</string>
+	<string name="MuteGroup">
+		(grupo)
+	</string>
+	<string name="MuteExternal">
+		(Externo)
+	</string>
+	<string name="RegionNoCovenant">
+		Não foi definido um contrato para essa região.
+	</string>
+	<string name="RegionNoCovenantOtherOwner">
+		Não foi definido um contrato para essa Região. O terreno nesta região está sendo vendido pelo Proprietário, não pela Linden Lab. Favor contatar o Proprietário da região para detalhes de venda.
+	</string>
 	<string name="covenant_last_modified" value="Última modificação: "/>
 	<string name="none_text" value="(nenhum)"/>
 	<string name="never_text" value="(nunca)"/>
-	<string name="GroupOwned">Propriedade do Grupo</string>
-	<string name="Public">Público</string>
-	<string name="LocalSettings">Configurações locais</string>
-	<string name="RegionSettings">Configurações da região</string>
-	<string name="NoEnvironmentSettings">Esta Região não suporta as configurações do ambiente.</string>
-	<string name="EnvironmentSun">Dom</string>
-	<string name="EnvironmentMoon">Lua</string>
-	<string name="EnvironmentBloom">Florescer</string>
-	<string name="EnvironmentCloudNoise">Ruído na nuvem</string>
-	<string name="EnvironmentNormalMap">Mapa normal</string>
-	<string name="EnvironmentTransparent">Transparente</string>
-	<string name="ClassifiedClicksTxt">Cliques: [TELEPORT] teletransporte, [MAP] mapa, [PROFILE] perfil</string>
-	<string name="ClassifiedUpdateAfterPublish">(vai atualizar depois de publicado)</string>
-	<string name="NoPicksClassifiedsText">Você não criou nenhum Destaque ou Anúncio.  Clique no botão &quot;+&quot; para criar um Destaque ou Anúncio.</string>
-	<string name="NoPicksText">Você não criou nenhuma Escolha. Clique em Novo Botão para criar um Escolher</string>
-	<string name="NoClassifiedsText">Você criou nenhum Anúncio. Clique em Novo Botão para criar um Classificado</string>
-	<string name="NoAvatarPicksClassifiedsText">O usuário não tem nenhum destaque ou anúncio</string>
-	<string name="NoAvatarPicksText">Usuário não tem escolha</string>
-	<string name="NoAvatarClassifiedsText">Usuário não tem anúncio</string>
-	<string name="PicksClassifiedsLoadingText">Carregando...</string>
-	<string name="MultiPreviewTitle">Preview</string>
-	<string name="MultiPropertiesTitle">Propriedades</string>
-	<string name="InvOfferAnObjectNamed">um objeto chamado</string>
-	<string name="InvOfferOwnedByGroup">possuído pelo grupo</string>
-	<string name="InvOfferOwnedByUnknownGroup">de um grupo desconhecido</string>
-	<string name="InvOfferOwnedBy">de</string>
-	<string name="InvOfferOwnedByUnknownUser">de usuário desconhecido</string>
-	<string name="InvOfferGaveYou">deu a você</string>
-	<string name="InvOfferDecline">Você recusou um(a) [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.</string>
-	<string name="GroupMoneyTotal">Total</string>
-	<string name="GroupMoneyBought">comprou</string>
-	<string name="GroupMoneyPaidYou">pagou a você</string>
-	<string name="GroupMoneyPaidInto">depositado</string>
-	<string name="GroupMoneyBoughtPassTo">comprou passe para</string>
-	<string name="GroupMoneyPaidFeeForEvent">pagou taxa para o evento</string>
-	<string name="GroupMoneyPaidPrizeForEvent">pagou prêmio para o evento</string>
-	<string name="GroupMoneyBalance">Saldo</string>
-	<string name="GroupMoneyCredits">Créditos</string>
-	<string name="GroupMoneyDebits">Débitos</string>
-	<string name="GroupMoneyDate">[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]</string>
-	<string name="AcquiredItems">Itens adquiridos</string>
-	<string name="Cancel">Cancelar</string>
-	<string name="UploadingCosts">Carregar [NAME] custa L$ [AMOUNT]</string>
-	<string name="BuyingCosts">Isso custa L$ [AMOUNT]</string>
-	<string name="UnknownFileExtension">Extensão de arquivo desconhecida [.%s]
-Expected .wav, .tga, .bmp, .jpg, .jpeg, or .bvh</string>
-	<string name="MuteObject2">Bloquear</string>
-	<string name="AddLandmarkNavBarMenu">Adicionar marco...</string>
-	<string name="EditLandmarkNavBarMenu">Editar marco...</string>
-	<string name="accel-mac-control">⌃</string>
-	<string name="accel-mac-command">⌘</string>
-	<string name="accel-mac-option">⌥</string>
-	<string name="accel-mac-shift">⇧</string>
-	<string name="accel-win-control">Ctrl+</string>
-	<string name="accel-win-alt">Alt+</string>
-	<string name="accel-win-shift">Shift+</string>
-	<string name="FileSaved">Arquivo salvo</string>
-	<string name="Receiving">Recebendo</string>
-	<string name="AM">AM</string>
-	<string name="PM">PM</string>
-	<string name="PST">PST</string>
-	<string name="PDT">PDT</string>
-	<string name="Direction_Forward">Frente</string>
-	<string name="Direction_Left">Esquerda</string>
-	<string name="Direction_Right">Direita</string>
-	<string name="Direction_Back">Atrás</string>
-	<string name="Direction_North">Norte</string>
-	<string name="Direction_South">Sul</string>
-	<string name="Direction_West">Oeste</string>
-	<string name="Direction_East">Leste</string>
-	<string name="Direction_Up">P/ cima</string>
-	<string name="Direction_Down">P/ baixo</string>
-	<string name="Any Category">Qualquer categoria</string>
-	<string name="Shopping">Compras</string>
-	<string name="Land Rental">Aluguel de terrenos</string>
-	<string name="Property Rental">Aluguel de propriedade</string>
-	<string name="Special Attraction">Atração especial</string>
-	<string name="New Products">Novos Produtos</string>
-	<string name="Employment">Emprego</string>
-	<string name="Wanted">Desejado</string>
-	<string name="Service">Serviço</string>
-	<string name="Personal">Pessoal</string>
-	<string name="None">Nenhum</string>
-	<string name="Linden Location">Locação Linden</string>
-	<string name="Adult">Adulto</string>
-	<string name="Arts&amp;Culture">Artes e Cultura</string>
-	<string name="Business">Negócios</string>
-	<string name="Educational">Educacional</string>
-	<string name="Gaming">Games</string>
-	<string name="Hangout">Moradia</string>
-	<string name="Newcomer Friendly">Para recém-chegados</string>
-	<string name="Parks&amp;Nature">Parques &amp; Natureza</string>
-	<string name="Residential">Residencial</string>
-	<string name="Stage">Estágio</string>
-	<string name="Other">Outros</string>
-	<string name="Rental">Aluguel</string>
-	<string name="Any">Qualquer</string>
-	<string name="You">Você</string>
-	<string name="Multiple Media">Mídia múltipla</string>
-	<string name="Play Media">Tocar/Pausar mídia</string>
-	<string name="IntelDriverPage">http://www.intel.com/p/en_US/support/detect/graphics</string>
-	<string name="NvidiaDriverPage">http://www.nvidia.com.br/Download/index.aspx?lang=br</string>
-	<string name="AMDDriverPage">http://support.amd.com/us/Pages/AMDSupportHub.aspx</string>
-	<string name="MBCmdLineError">Um erro foi encontrado analisando a linha de comando.
+	<string name="GroupOwned">
+		Propriedade do Grupo
+	</string>
+	<string name="Public">
+		Público
+	</string>
+	<string name="LocalSettings">
+		Configurações locais
+	</string>
+	<string name="RegionSettings">
+		Configurações da região
+	</string>
+	<string name="NoEnvironmentSettings">
+		Esta Região não suporta as configurações do ambiente.
+	</string>
+	<string name="EnvironmentSun">
+		Dom
+	</string>
+	<string name="EnvironmentMoon">
+		Lua
+	</string>
+	<string name="EnvironmentBloom">
+		Florescer
+	</string>
+	<string name="EnvironmentCloudNoise">
+		Ruído na nuvem
+	</string>
+	<string name="EnvironmentNormalMap">
+		Mapa normal
+	</string>
+	<string name="EnvironmentTransparent">
+		Transparente
+	</string>
+	<string name="ClassifiedClicksTxt">
+		Cliques: [TELEPORT] teletransporte, [MAP] mapa, [PROFILE] perfil
+	</string>
+	<string name="ClassifiedUpdateAfterPublish">
+		(vai atualizar depois de publicado)
+	</string>
+	<string name="NoPicksClassifiedsText">
+		Você não criou nenhum Destaque ou Anúncio.  Clique no botão "+" para criar um Destaque ou Anúncio.
+	</string>
+	<string name="NoPicksText">
+		Você não criou nenhuma Escolha. Clique em Novo Botão para criar um Escolher
+	</string>
+	<string name="NoClassifiedsText">
+		Você criou nenhum Anúncio. Clique em Novo Botão para criar um Classificado
+	</string>
+	<string name="NoAvatarPicksClassifiedsText">
+		O usuário não tem nenhum destaque ou anúncio
+	</string>
+	<string name="NoAvatarPicksText">
+		Usuário não tem escolha
+	</string>
+	<string name="NoAvatarClassifiedsText">
+		Usuário não tem anúncio
+	</string>
+	<string name="PicksClassifiedsLoadingText">
+		Carregando...
+	</string>
+	<string name="MultiPreviewTitle">
+		Preview
+	</string>
+	<string name="MultiPropertiesTitle">
+		Propriedades
+	</string>
+	<string name="InvOfferAnObjectNamed">
+		um objeto chamado
+	</string>
+	<string name="InvOfferOwnedByGroup">
+		possuído pelo grupo
+	</string>
+	<string name="InvOfferOwnedByUnknownGroup">
+		de um grupo desconhecido
+	</string>
+	<string name="InvOfferOwnedBy">
+		de
+	</string>
+	<string name="InvOfferOwnedByUnknownUser">
+		de usuário desconhecido
+	</string>
+	<string name="InvOfferGaveYou">
+		deu a você
+	</string>
+	<string name="InvOfferDecline">
+		Você recusou um(a) [DESC] de &lt;nolink&gt;[NAME]&lt;/nolink&gt;.
+	</string>
+	<string name="GroupMoneyTotal">
+		Total
+	</string>
+	<string name="GroupMoneyBought">
+		comprou
+	</string>
+	<string name="GroupMoneyPaidYou">
+		pagou a você
+	</string>
+	<string name="GroupMoneyPaidInto">
+		depositado
+	</string>
+	<string name="GroupMoneyBoughtPassTo">
+		comprou passe para
+	</string>
+	<string name="GroupMoneyPaidFeeForEvent">
+		pagou taxa para o evento
+	</string>
+	<string name="GroupMoneyPaidPrizeForEvent">
+		pagou prêmio para o evento
+	</string>
+	<string name="GroupMoneyBalance">
+		Saldo
+	</string>
+	<string name="GroupMoneyCredits">
+		Créditos
+	</string>
+	<string name="GroupMoneyDebits">
+		Débitos
+	</string>
+	<string name="GroupMoneyDate">
+		[weekday,datetime,utc] [mth,datetime,utc] [day,datetime,utc], [year,datetime,utc]
+	</string>
+	<string name="AcquiredItems">
+		Itens adquiridos
+	</string>
+	<string name="Cancel">
+		Cancelar
+	</string>
+	<string name="UploadingCosts">
+		Carregar [NAME] custa L$ [AMOUNT]
+	</string>
+	<string name="BuyingCosts">
+		Isso custa L$ [AMOUNT]
+	</string>
+	<string name="UnknownFileExtension">
+		Extensão de arquivo desconhecida [.%s]
+Expected .wav, .tga, .bmp, .jpg, .jpeg, or .bvh
+	</string>
+	<string name="MuteObject2">
+		Bloquear
+	</string>
+	<string name="AddLandmarkNavBarMenu">
+		Adicionar marco...
+	</string>
+	<string name="EditLandmarkNavBarMenu">
+		Editar marco...
+	</string>
+	<string name="accel-mac-control">
+		⌃
+	</string>
+	<string name="accel-mac-command">
+		⌘
+	</string>
+	<string name="accel-mac-option">
+		⌥
+	</string>
+	<string name="accel-mac-shift">
+		⇧
+	</string>
+	<string name="accel-win-control">
+		Ctrl+
+	</string>
+	<string name="accel-win-alt">
+		Alt+
+	</string>
+	<string name="accel-win-shift">
+		Shift+
+	</string>
+	<string name="FileSaved">
+		Arquivo salvo
+	</string>
+	<string name="Receiving">
+		Recebendo
+	</string>
+	<string name="AM">
+		AM
+	</string>
+	<string name="PM">
+		PM
+	</string>
+	<string name="PST">
+		PST
+	</string>
+	<string name="PDT">
+		PDT
+	</string>
+	<string name="Direction_Forward">
+		Frente
+	</string>
+	<string name="Direction_Left">
+		Esquerda
+	</string>
+	<string name="Direction_Right">
+		Direita
+	</string>
+	<string name="Direction_Back">
+		Atrás
+	</string>
+	<string name="Direction_North">
+		Norte
+	</string>
+	<string name="Direction_South">
+		Sul
+	</string>
+	<string name="Direction_West">
+		Oeste
+	</string>
+	<string name="Direction_East">
+		Leste
+	</string>
+	<string name="Direction_Up">
+		P/ cima
+	</string>
+	<string name="Direction_Down">
+		P/ baixo
+	</string>
+	<string name="Any Category">
+		Qualquer categoria
+	</string>
+	<string name="Shopping">
+		Compras
+	</string>
+	<string name="Land Rental">
+		Aluguel de terrenos
+	</string>
+	<string name="Property Rental">
+		Aluguel de propriedade
+	</string>
+	<string name="Special Attraction">
+		Atração especial
+	</string>
+	<string name="New Products">
+		Novos Produtos
+	</string>
+	<string name="Employment">
+		Emprego
+	</string>
+	<string name="Wanted">
+		Desejado
+	</string>
+	<string name="Service">
+		Serviço
+	</string>
+	<string name="Personal">
+		Pessoal
+	</string>
+	<string name="None">
+		Nenhum
+	</string>
+	<string name="Linden Location">
+		Locação Linden
+	</string>
+	<string name="Adult">
+		Adulto
+	</string>
+	<string name="Arts&amp;Culture">
+		Artes e Cultura
+	</string>
+	<string name="Business">
+		Negócios
+	</string>
+	<string name="Educational">
+		Educacional
+	</string>
+	<string name="Gaming">
+		Games
+	</string>
+	<string name="Hangout">
+		Moradia
+	</string>
+	<string name="Newcomer Friendly">
+		Para recém-chegados
+	</string>
+	<string name="Parks&amp;Nature">
+		Parques &amp; Natureza
+	</string>
+	<string name="Residential">
+		Residencial
+	</string>
+	<string name="Stage">
+		Estágio
+	</string>
+	<string name="Other">
+		Outros
+	</string>
+	<string name="Rental">
+		Aluguel
+	</string>
+	<string name="Any">
+		Qualquer
+	</string>
+	<string name="You">
+		Você
+	</string>
+	<string name="Multiple Media">
+		Mídia múltipla
+	</string>
+	<string name="Play Media">
+		Tocar/Pausar mídia
+	</string>
+	<string name="IntelDriverPage">
+		http://www.intel.com/p/en_US/support/detect/graphics
+	</string>
+	<string name="NvidiaDriverPage">
+		http://www.nvidia.com.br/Download/index.aspx?lang=br
+	</string>
+	<string name="AMDDriverPage">
+		http://support.amd.com/us/Pages/AMDSupportHub.aspx
+	</string>
+	<string name="MBCmdLineError">
+		Um erro foi encontrado analisando a linha de comando.
 Consulte: http://wiki.secondlife.com/wiki/Client_parameters
-Erro:</string>
-	<string name="MBCmdLineUsg">[APP_NAME] Uso de linha de comando:</string>
-	<string name="MBUnableToAccessFile">[APP_NAME] não é capaz de acessar um arquivo que ele precisa.
+Erro:
+	</string>
+	<string name="MBCmdLineUsg">
+		[APP_NAME] Uso de linha de comando:
+	</string>
+	<string name="MBUnableToAccessFile">
+		[APP_NAME] não é capaz de acessar um arquivo que ele precisa.
 
 Isto pode ocorrer porque você de alguma maneira tem várias cópias em execução, ou o seu sistema acredita de maneira incorreta que um arquivo está aberto.
 Se a mensagem persistir, reinicie o computador e tente novamente.
-Se o error persistir, pode ser necessário desinstalar completamente [APP_NAME] e reinstalá-lo.</string>
-	<string name="MBFatalError">Erro fatal</string>
-	<string name="MBRequiresAltiVec">[APP_NAME] exige processador com AltiVec (G4 ou superior).</string>
-	<string name="MBAlreadyRunning">[APP_NAME] já está em execução.
+Se o error persistir, pode ser necessário desinstalar completamente [APP_NAME] e reinstalá-lo.
+	</string>
+	<string name="MBFatalError">
+		Erro fatal
+	</string>
+	<string name="MBRequiresAltiVec">
+		[APP_NAME] exige processador com AltiVec (G4 ou superior).
+	</string>
+	<string name="MBAlreadyRunning">
+		[APP_NAME] já está em execução.
 Verifique a sua barra de tarefas para obter uma cópia do programa minimizado.
-Se a mensagem persistir, reinicie o computador.</string>
-	<string name="MBFrozenCrashed">[APP_NAME] parece ter congelado ou falhado na execução anterior. Enviar relatório de falha?</string>
-	<string name="MBAlert">Alerta</string>
-	<string name="MBNoDirectX">[APP_NAME] é incapaz de detectar o DirectX 9.0b ou superior.
+Se a mensagem persistir, reinicie o computador.
+	</string>
+	<string name="MBFrozenCrashed">
+		[APP_NAME] parece ter congelado ou falhado na execução anterior. Enviar relatório de falha?
+	</string>
+	<string name="MBAlert">
+		Alerta
+	</string>
+	<string name="MBNoDirectX">
+		[APP_NAME] é incapaz de detectar o DirectX 9.0b ou superior.
 [APP_NAME] usa o DirectX para a detecção de hardware e / ou controladores desatualizados que podem causar problemas de estabilidade, desempenho ruim e falhas. Embora você possa executar [APP_NAME] sem ele, nós recomendamos fortemente que utilize o DirectX 9.0b.
 
-Deseja continuar?</string>
-	<string name="MBWarning">Aviso</string>
-	<string name="MBNoAutoUpdate">Atualização automática ainda não está implementada para o Linux.
-Faça o download da versão mais recente do www.secondlife.com.</string>
-	<string name="MBRegClassFailed">RegisterClass falhou</string>
-	<string name="MBError">Erro</string>
-	<string name="MBFullScreenErr">Incapaz de funcionar com tela cheia de [WIDTH] x [HEIGHT].
-Executando em janela.</string>
-	<string name="MBDestroyWinFailed">Erro de desligamento ao destruir janela (DestroyWindow() failed)</string>
-	<string name="MBShutdownErr">Erro de desligamento</string>
-	<string name="MBDevContextErr">Não é possível fazer contexto do dispositivo GL</string>
-	<string name="MBPixelFmtErr">Não é possível encontrar um formato de pixel adequado</string>
-	<string name="MBPixelFmtDescErr">Não é possível encontrar descrição de formato de pixel</string>
-	<string name="MBTrueColorWindow">[APP_NAME] requer True Color (32-bit) para ser executado.
-Por favor, vá para as configurações de vídeo do computador e defina o modo de cores para 32-bit.</string>
-	<string name="MBAlpha">[APP_NAME] é incapaz de executar porque ele não consegue obter um canal alpha de 8 bits. Geralmente isso ocorre devido a problemas de drivers da placa de vídeo.
+Deseja continuar?
+	</string>
+	<string name="MBWarning">
+		Aviso
+	</string>
+	<string name="MBNoAutoUpdate">
+		Atualização automática ainda não está implementada para o Linux.
+Faça o download da versão mais recente do www.secondlife.com.
+	</string>
+	<string name="MBRegClassFailed">
+		RegisterClass falhou
+	</string>
+	<string name="MBError">
+		Erro
+	</string>
+	<string name="MBFullScreenErr">
+		Incapaz de funcionar com tela cheia de [WIDTH] x [HEIGHT].
+Executando em janela.
+	</string>
+	<string name="MBDestroyWinFailed">
+		Erro de desligamento ao destruir janela (DestroyWindow() failed)
+	</string>
+	<string name="MBShutdownErr">
+		Erro de desligamento
+	</string>
+	<string name="MBDevContextErr">
+		Não é possível fazer contexto do dispositivo GL
+	</string>
+	<string name="MBPixelFmtErr">
+		Não é possível encontrar um formato de pixel adequado
+	</string>
+	<string name="MBPixelFmtDescErr">
+		Não é possível encontrar descrição de formato de pixel
+	</string>
+	<string name="MBTrueColorWindow">
+		[APP_NAME] requer True Color (32-bit) para ser executado.
+Por favor, vá para as configurações de vídeo do computador e defina o modo de cores para 32-bit.
+	</string>
+	<string name="MBAlpha">
+		[APP_NAME] é incapaz de executar porque ele não consegue obter um canal alpha de 8 bits. Geralmente isso ocorre devido a problemas de drivers da placa de vídeo.
 Por favor, certifique-se que os últimos drivers da placa de vídeo estão instalados.
 Também não se esqueça de definir seu monitor para True Color (32-bit), em painéis de controle Configurações&gt; Display&gt;.
-Se você continuar a receber esta mensagem, contate o [SUPPORT_SITE].</string>
-	<string name="MBPixelFmtSetErr">Não é possível definir o formato de pixel</string>
-	<string name="MBGLContextErr">Não é possível criar o contexto de renderização GL</string>
-	<string name="MBGLContextActErr">Não é possível ativar o contexto de renderização GL</string>
-	<string name="MBVideoDrvErr">[APP_NAME] é incapaz de funcionar por causa do seu driver de video não ter sido instalado corretamente, estão desatualizados, ou não são suportados pelo hardware. Por favor certifique-se que você possui os drivers de placa de vídeo mais recente e mesmo assim, tente reinstalá-los.
+Se você continuar a receber esta mensagem, contate o [SUPPORT_SITE].
+	</string>
+	<string name="MBPixelFmtSetErr">
+		Não é possível definir o formato de pixel
+	</string>
+	<string name="MBGLContextErr">
+		Não é possível criar o contexto de renderização GL
+	</string>
+	<string name="MBGLContextActErr">
+		Não é possível ativar o contexto de renderização GL
+	</string>
+	<string name="MBVideoDrvErr">
+		[APP_NAME] é incapaz de funcionar por causa do seu driver de video não ter sido instalado corretamente, estão desatualizados, ou não são suportados pelo hardware. Por favor certifique-se que você possui os drivers de placa de vídeo mais recente e mesmo assim, tente reinstalá-los.
 
-If you continue to receive this message, contact the [SUPPORT_SITE].</string>
-	<string name="5 O'Clock Shadow">Barba por fazer</string>
-	<string name="All White">Todo branco</string>
-	<string name="Anime Eyes">Olhos de Anime</string>
-	<string name="Arced">Arqueados</string>
-	<string name="Arm Length">Comprimento do braço</string>
-	<string name="Attached">Anexado</string>
-	<string name="Attached Earlobes">Lóbulos da orelha anexados</string>
-	<string name="Back Fringe">corte traseiro</string>
-	<string name="Baggy">folgado</string>
-	<string name="Bangs">Franja</string>
-	<string name="Beady Eyes">Olhos pequenos</string>
-	<string name="Belly Size">Tamanho da barriga</string>
-	<string name="Big">Grande</string>
-	<string name="Big Butt">Bunda grande</string>
-	<string name="Big Hair Back">Cabelo volumoso: Trás</string>
-	<string name="Big Hair Front">Cabelo volumoso: Frente</string>
-	<string name="Big Hair Top">Cabelo volumoso: Topo</string>
-	<string name="Big Head">cabeça grande</string>
-	<string name="Big Pectorals">Peitorais grandes</string>
-	<string name="Big Spikes">Pontas grandes</string>
-	<string name="Black">Negro</string>
-	<string name="Blonde">Loiro</string>
-	<string name="Blonde Hair">Cabelo loiro</string>
-	<string name="Blush">Blush</string>
-	<string name="Blush Color">Cor do blush</string>
-	<string name="Blush Opacity">Opacidade do blush</string>
-	<string name="Body Definition">Definição do corpo</string>
-	<string name="Body Fat">Gordura</string>
-	<string name="Body Freckles">Sardas</string>
-	<string name="Body Thick">Corpo cheio</string>
-	<string name="Body Thickness">Ossatura</string>
-	<string name="Body Thin">Corpo magro</string>
-	<string name="Bow Legged">Pernas arqueadas</string>
-	<string name="Breast Buoyancy">Caimento dos seios</string>
-	<string name="Breast Cleavage">Separação dos seios</string>
-	<string name="Breast Size">Tamanho dos seios</string>
-	<string name="Bridge Width">Largura do nariz</string>
-	<string name="Broad">Largo</string>
-	<string name="Brow Size">Tamanho da sobrancelha</string>
-	<string name="Bug Eyes">Olhos saltados</string>
-	<string name="Bugged Eyes">Olhos esbugalhados</string>
-	<string name="Bulbous">Bulbos</string>
-	<string name="Bulbous Nose">Nariz em bulbo</string>
-	<string name="Breast Physics Mass">Seios - massa</string>
-	<string name="Breast Physics Smoothing">Seios - suavização</string>
-	<string name="Breast Physics Gravity">Seios - gravidade</string>
-	<string name="Breast Physics Drag">Seios - resistência do ar</string>
-	<string name="Breast Physics InOut Max Effect">Efeito máximo</string>
-	<string name="Breast Physics InOut Spring">Vibração</string>
-	<string name="Breast Physics InOut Gain">Ganho</string>
-	<string name="Breast Physics InOut Damping">Duração</string>
-	<string name="Breast Physics UpDown Max Effect">Efeito máximo</string>
-	<string name="Breast Physics UpDown Spring">Vibração</string>
-	<string name="Breast Physics UpDown Gain">Ganho</string>
-	<string name="Breast Physics UpDown Damping">Duração</string>
-	<string name="Breast Physics LeftRight Max Effect">Efeito máximo</string>
-	<string name="Breast Physics LeftRight Spring">Vibração</string>
-	<string name="Breast Physics LeftRight Gain">Ganho</string>
-	<string name="Breast Physics LeftRight Damping">Duração</string>
-	<string name="Belly Physics Mass">Barriga - massa</string>
-	<string name="Belly Physics Smoothing">Barriga - suavização</string>
-	<string name="Belly Physics Gravity">Barriga - gravidade</string>
-	<string name="Belly Physics Drag">Barriga - resistência do ar</string>
-	<string name="Belly Physics UpDown Max Effect">Efeito máximo</string>
-	<string name="Belly Physics UpDown Spring">Vibração</string>
-	<string name="Belly Physics UpDown Gain">Ganho</string>
-	<string name="Belly Physics UpDown Damping">Duração</string>
-	<string name="Butt Physics Mass">Nádegas - massa</string>
-	<string name="Butt Physics Smoothing">Nádegas - suavização</string>
-	<string name="Butt Physics Gravity">Nádegas - gravidade</string>
-	<string name="Butt Physics Drag">Nádegas - resistência do ar</string>
-	<string name="Butt Physics UpDown Max Effect">Efeito máximo</string>
-	<string name="Butt Physics UpDown Spring">Vibração</string>
-	<string name="Butt Physics UpDown Gain">Ganho</string>
-	<string name="Butt Physics UpDown Damping">Duração</string>
-	<string name="Butt Physics LeftRight Max Effect">Efeito máximo</string>
-	<string name="Butt Physics LeftRight Spring">Vibração</string>
-	<string name="Butt Physics LeftRight Gain">Ganho</string>
-	<string name="Butt Physics LeftRight Damping">Duração</string>
-	<string name="Bushy Eyebrows">Sobrancelhas grossas</string>
-	<string name="Bushy Hair">Cabelo grosso</string>
-	<string name="Butt Size">Tamanho do traseiro</string>
-	<string name="Butt Gravity">Nádegas - gravidade</string>
-	<string name="bustle skirt">Saia armada</string>
-	<string name="no bustle">Saia reta</string>
-	<string name="more bustle">Mais</string>
-	<string name="Chaplin">Chaplin</string>
-	<string name="Cheek Bones">Maçãs do rosto</string>
-	<string name="Chest Size">Tamanho do peito</string>
-	<string name="Chin Angle">Ângulo do queixo</string>
-	<string name="Chin Cleft">Fissura do queixo</string>
-	<string name="Chin Curtains">Barba de contorno</string>
-	<string name="Chin Depth">Profundidade do queixo</string>
-	<string name="Chin Heavy">Queixo pronunciado</string>
-	<string name="Chin In">Queixo para dentro</string>
-	<string name="Chin Out">Queixo para fora</string>
-	<string name="Chin-Neck">Queixo-pescoço</string>
-	<string name="Clear">Limpar</string>
-	<string name="Cleft">Fenda</string>
-	<string name="Close Set Eyes">Fechar conjunto de olhos</string>
-	<string name="Closed">Fechado</string>
-	<string name="Closed Back">Trás fechada</string>
-	<string name="Closed Front">Frente fechada</string>
-	<string name="Closed Left">Esquerda fechada</string>
-	<string name="Closed Right">Direita fechada</string>
-	<string name="Coin Purse">Pouco volume</string>
-	<string name="Collar Back">Colarinho posterior</string>
-	<string name="Collar Front">Colarinho anterior</string>
-	<string name="Corner Down">Canto para baixo</string>
-	<string name="Corner Up">Canto para cima</string>
-	<string name="Creased">Vincado</string>
-	<string name="Crooked Nose">Nariz torto</string>
-	<string name="Cuff Flare">Bainha larga</string>
-	<string name="Dark">Escuro</string>
-	<string name="Dark Green">Verde escuro</string>
-	<string name="Darker">Mais escuro</string>
-	<string name="Deep">Profundidade</string>
-	<string name="Default Heels">Salto padrão</string>
-	<string name="Dense">Densidade</string>
-	<string name="Double Chin">Queixo duplo</string>
-	<string name="Downturned">Curvado para baixo</string>
-	<string name="Duffle Bag">Mais volume</string>
-	<string name="Ear Angle">Ângulo da orelha</string>
-	<string name="Ear Size">Tamanho da orelha</string>
-	<string name="Ear Tips">Pontas das orelhas</string>
-	<string name="Egg Head">Cabeça oval</string>
-	<string name="Eye Bags">Olheiras</string>
-	<string name="Eye Color">Cor dos olhos</string>
-	<string name="Eye Depth">Profundidade dos olhos</string>
-	<string name="Eye Lightness">Luminosidade dos olhos</string>
-	<string name="Eye Opening">Abertura dos olhos</string>
-	<string name="Eye Pop">Olho saltado</string>
-	<string name="Eye Size">Tamanho dos olhos</string>
-	<string name="Eye Spacing">Espaçamento dos olhos</string>
-	<string name="Eyebrow Arc">Arco da sobrancelha</string>
-	<string name="Eyebrow Density">Densidade da sobrancelha</string>
-	<string name="Eyebrow Height">Altura da sobrancelha</string>
-	<string name="Eyebrow Points">Pontas da sobrancelha</string>
-	<string name="Eyebrow Size">Tamanho da sobrancelha</string>
-	<string name="Eyelash Length">Comprimento das pestanas</string>
-	<string name="Eyeliner">Delineador</string>
-	<string name="Eyeliner Color">Cor do delineador</string>
-	<string name="Eyes Bugged">Olhos esbugalhados</string>
-	<string name="Face Shear">Face raspada</string>
-	<string name="Facial Definition">Definição facial</string>
-	<string name="Far Set Eyes">Distância entre os olhos</string>
-	<string name="Fat Lips">Lábios carnudos</string>
-	<string name="Female">Feminino</string>
-	<string name="Fingerless">Dedos</string>
-	<string name="Fingers">Dedos</string>
-	<string name="Flared Cuffs">Punhos largos</string>
-	<string name="Flat">Chato</string>
-	<string name="Flat Butt">Traseiro chato</string>
-	<string name="Flat Head">Cabeça chata</string>
-	<string name="Flat Toe">Dedos dos pés chatos</string>
-	<string name="Foot Size">Tamanho dos pés</string>
-	<string name="Forehead Angle">Ângulo da testa</string>
-	<string name="Forehead Heavy">Testa pronunciada</string>
-	<string name="Freckles">Sardas</string>
-	<string name="Front Fringe">Franja</string>
-	<string name="Full Back">Trás cheia</string>
-	<string name="Full Eyeliner">Delienador cheio</string>
-	<string name="Full Front">Frente cheia</string>
-	<string name="Full Hair Sides">Cabelos laterais cheios</string>
-	<string name="Full Sides">Lados cheios</string>
-	<string name="Glossy">Brilhante</string>
-	<string name="Glove Fingers">Dedos da luva</string>
-	<string name="Glove Length">Comprimento das luvas</string>
-	<string name="Hair">Cabelo</string>
-	<string name="Hair Back">Cabelo: Trás</string>
-	<string name="Hair Front">Cabelo: Frente</string>
-	<string name="Hair Sides">Cabelos: Lateral</string>
-	<string name="Hair Sweep">Cabelo penteado</string>
-	<string name="Hair Thickess">Espessura do cabelo</string>
-	<string name="Hair Thickness">Espessura do cabelo</string>
-	<string name="Hair Tilt">Divisão do cabelo</string>
-	<string name="Hair Tilted Left">Divistão do cabelo esquerda</string>
-	<string name="Hair Tilted Right">Divisão do cabelo direita</string>
-	<string name="Hair Volume">Cabelo: Volume</string>
-	<string name="Hand Size">Tamanho das mãos</string>
-	<string name="Handlebars">Bigode</string>
-	<string name="Head Length">Comprimento da cabeça</string>
-	<string name="Head Shape">Formato da cabeça</string>
-	<string name="Head Size">Tamanho da cabeça</string>
-	<string name="Head Stretch">Extensão da cabeça</string>
-	<string name="Heel Height">Altura do salto</string>
-	<string name="Heel Shape">Formato do salto</string>
-	<string name="Height">Altura</string>
-	<string name="High">Alto</string>
-	<string name="High Heels">Salto alto</string>
-	<string name="High Jaw">Maxilar alto</string>
-	<string name="High Platforms">Plataformas altas</string>
-	<string name="High and Tight">Alto e justo</string>
-	<string name="Higher">Mais alto</string>
-	<string name="Hip Length">Comprimento do quadril</string>
-	<string name="Hip Width">Largura do quadril</string>
-	<string name="Hover">Pairar</string>
-	<string name="In">Dentro</string>
-	<string name="In Shdw Color">Cor da sombra interna</string>
-	<string name="In Shdw Opacity">Opacidade da sombra interna</string>
-	<string name="Inner Eye Corner">Canto interno dos olhos</string>
-	<string name="Inner Eye Shadow">Sombra interna dos olhos</string>
-	<string name="Inner Shadow">Sombra interna</string>
-	<string name="Jacket Length">Comprimento da blusa</string>
-	<string name="Jacket Wrinkles">Dobras da jaqueta</string>
-	<string name="Jaw Angle">Ângulo da mandíbula</string>
-	<string name="Jaw Jut">Posição do maxilar</string>
-	<string name="Jaw Shape">Formato do maxilar</string>
-	<string name="Join">Juntar</string>
-	<string name="Jowls">Papo</string>
-	<string name="Knee Angle">Ângulo do joelho</string>
-	<string name="Knock Kneed">Joelhos para dentro</string>
-	<string name="Large">Grande</string>
-	<string name="Large Hands">Mãos grandes</string>
-	<string name="Left Part">Parte esquerda</string>
-	<string name="Leg Length">Comprimento da perna</string>
-	<string name="Leg Muscles">Musculatura da perna</string>
-	<string name="Less">Menos</string>
-	<string name="Less Body Fat">Menos gordura</string>
-	<string name="Less Curtains">Menos barba</string>
-	<string name="Less Freckles">Menos sardas</string>
-	<string name="Less Full">Menos</string>
-	<string name="Less Gravity">Menos gravidade</string>
-	<string name="Less Love">Menos excesso</string>
-	<string name="Less Muscles">Menos músculos</string>
-	<string name="Less Muscular">Menos musculoso</string>
-	<string name="Less Rosy">Menos rosado</string>
-	<string name="Less Round">Menos arredondado</string>
-	<string name="Less Saddle">Menos ancas</string>
-	<string name="Less Square">Menos quadrado</string>
-	<string name="Less Volume">Menos volume</string>
-	<string name="Less soul">Menos alma</string>
-	<string name="Lighter">Lighter</string>
-	<string name="Lip Cleft">Fenda dos lábios</string>
-	<string name="Lip Cleft Depth">Profundidade da fenda dos lábios</string>
-	<string name="Lip Fullness">Volume dos lábios</string>
-	<string name="Lip Pinkness">Rosado dos lábios</string>
-	<string name="Lip Ratio">Proporção dos lábios</string>
-	<string name="Lip Thickness">Espessura dos lábios</string>
-	<string name="Lip Width">Largura dos lábios</string>
-	<string name="Lipgloss">Brilho dos lábios</string>
-	<string name="Lipstick">Batom</string>
-	<string name="Lipstick Color">Cor do batom</string>
-	<string name="Long">Longo</string>
-	<string name="Long Head">Cabeça alongada</string>
-	<string name="Long Hips">Lábios longos</string>
-	<string name="Long Legs">Pernas longas</string>
-	<string name="Long Neck">Pescoço longo</string>
-	<string name="Long Pigtails">Chiquinhas longas</string>
-	<string name="Long Ponytail">Rabo de cavalo longo</string>
-	<string name="Long Torso">Torso longo</string>
-	<string name="Long arms">Braços longos</string>
-	<string name="Loose Pants">Pantalonas</string>
-	<string name="Loose Shirt">Camisa folgada</string>
-	<string name="Loose Sleeves">Mangas folgadas</string>
-	<string name="Love Handles">Pneu</string>
-	<string name="Low">Baixo</string>
-	<string name="Low Heels">Salto baixo</string>
-	<string name="Low Jaw">Maxilar baixo</string>
-	<string name="Low Platforms">Plataformas baixas</string>
-	<string name="Low and Loose">Baixo e solto</string>
-	<string name="Lower">Mais baixo</string>
-	<string name="Lower Bridge">Mais baixa</string>
-	<string name="Lower Cheeks">Bochechas abaixadas</string>
-	<string name="Male">Masculino</string>
-	<string name="Middle Part">Parte do meio</string>
-	<string name="More">Mais</string>
-	<string name="More Blush">Mais blush</string>
-	<string name="More Body Fat">Mais gordura</string>
-	<string name="More Curtains">Mais barba</string>
-	<string name="More Eyeshadow">Mais sombra dos olhos</string>
-	<string name="More Freckles">Mais sardas</string>
-	<string name="More Full">Mais volume</string>
-	<string name="More Gravity">Mais gravidade</string>
-	<string name="More Lipstick">Mais batom</string>
-	<string name="More Love">Mais cintura</string>
-	<string name="More Lower Lip">Mais lábio inferior</string>
-	<string name="More Muscles">Mais músculos</string>
-	<string name="More Muscular">Mais musculoso</string>
-	<string name="More Rosy">Mais rosado</string>
-	<string name="More Round">Mais arredondado</string>
-	<string name="More Saddle">Mais ancas</string>
-	<string name="More Sloped">Mais inclinado</string>
-	<string name="More Square">Mais quadrado</string>
-	<string name="More Upper Lip">Mais lábios superiores</string>
-	<string name="More Vertical">Mais vertical</string>
-	<string name="More Volume">Mais volume</string>
-	<string name="More soul">Mais alma</string>
-	<string name="Moustache">Bigode</string>
-	<string name="Mouth Corner">Canto da boca</string>
-	<string name="Mouth Position">Posição da boca</string>
-	<string name="Mowhawk">Moicano</string>
-	<string name="Muscular">Muscular</string>
-	<string name="Mutton Chops">Costeletas</string>
-	<string name="Nail Polish">Esmate das unhas</string>
-	<string name="Nail Polish Color">Cor do esmalte das unhas</string>
-	<string name="Narrow">Estreito</string>
-	<string name="Narrow Back">Costas estreitas</string>
-	<string name="Narrow Front">Frente estreita</string>
-	<string name="Narrow Lips">Lábios estreitos</string>
-	<string name="Natural">Natural</string>
-	<string name="Neck Length">Comprimento do pescoço</string>
-	<string name="Neck Thickness">Espessura do pescoço</string>
-	<string name="No Blush">Sem blush</string>
-	<string name="No Eyeliner">Sem delineador</string>
-	<string name="No Eyeshadow">Sem sombra</string>
-	<string name="No Lipgloss">Sem brilho</string>
-	<string name="No Lipstick">Sem batom</string>
-	<string name="No Part">Sem parte</string>
-	<string name="No Polish">Sem esmalte</string>
-	<string name="No Red">Sem vermelho</string>
-	<string name="No Spikes">Sem pontas</string>
-	<string name="No White">Sem branco</string>
-	<string name="No Wrinkles">Sem dobras</string>
-	<string name="Normal Lower">Normal inferior</string>
-	<string name="Normal Upper">Normal superior</string>
-	<string name="Nose Left">Nariz para esquerda</string>
-	<string name="Nose Right">Nariz para direita</string>
-	<string name="Nose Size">Tamanho do nariz</string>
-	<string name="Nose Thickness">Espessura do nariz</string>
-	<string name="Nose Tip Angle">Ângulo da ponta do nariz</string>
-	<string name="Nose Tip Shape">Formato da ponta do nariz</string>
-	<string name="Nose Width">Largura do nariz</string>
-	<string name="Nostril Division">Divisão das narinas</string>
-	<string name="Nostril Width">Largura das narinas</string>
-	<string name="Opaque">Opaco</string>
-	<string name="Open">Abrir</string>
-	<string name="Open Back">Aberto atrás</string>
-	<string name="Open Front">Aberto na frente</string>
-	<string name="Open Left">Aberto esquerdo</string>
-	<string name="Open Right">Aberto direito</string>
-	<string name="Orange">Laranja</string>
-	<string name="Out">Fora</string>
-	<string name="Out Shdw Color">Cor da sombra externa</string>
-	<string name="Out Shdw Opacity">Opacidade da sombra externa</string>
-	<string name="Outer Eye Corner">Canto externo do olho</string>
-	<string name="Outer Eye Shadow">Sombra externa do olho</string>
-	<string name="Outer Shadow">Sombra externa</string>
-	<string name="Overbite">Má oclusão</string>
-	<string name="Package">Púbis</string>
-	<string name="Painted Nails">Unhas pintadas</string>
-	<string name="Pale">Pálido</string>
-	<string name="Pants Crotch">Cavalo da calça</string>
-	<string name="Pants Fit">Caimento das calças</string>
-	<string name="Pants Length">Comprimento das calças</string>
-	<string name="Pants Waist">Cintura da calça</string>
-	<string name="Pants Wrinkles">Dobras das calças</string>
-	<string name="Part">Parte</string>
-	<string name="Part Bangs">Divisão da franja</string>
-	<string name="Pectorals">Peitorais</string>
-	<string name="Pigment">Pigmento</string>
-	<string name="Pigtails">Chiquinhas</string>
-	<string name="Pink">Rosa</string>
-	<string name="Pinker">Mais rosado</string>
-	<string name="Platform Height">Altura da plataforma</string>
-	<string name="Platform Width">Largura da plataforma</string>
-	<string name="Pointy">Pontudo</string>
-	<string name="Pointy Heels">Salto agulha</string>
-	<string name="Ponytail">Rabo de cavalo</string>
-	<string name="Poofy Skirt">Saia bufante</string>
-	<string name="Pop Left Eye">Olho saltado esquerdo</string>
-	<string name="Pop Right Eye">Olho saltado direito</string>
-	<string name="Puffy">Inchado</string>
-	<string name="Puffy Eyelids">Pálpebras inchadas</string>
-	<string name="Rainbow Color">Cor do arco íris</string>
-	<string name="Red Hair">Cabelo ruivo</string>
-	<string name="Regular">Normal</string>
-	<string name="Right Part">Parte direita</string>
-	<string name="Rosy Complexion">Rosado da face</string>
-	<string name="Round">Arredondado</string>
-	<string name="Ruddiness">Rubor</string>
-	<string name="Ruddy">Corado</string>
-	<string name="Rumpled Hair">Cabelo desalinhado</string>
-	<string name="Saddle Bags">Culote</string>
-	<string name="Scrawny Leg">Pernas magricelas</string>
-	<string name="Separate">Separar</string>
-	<string name="Shallow">Raso</string>
-	<string name="Shear Back">Trás rente</string>
-	<string name="Shear Face">Face raspada</string>
-	<string name="Shear Front">Frente rente</string>
-	<string name="Shear Left Up">Esquerda rente para cima</string>
-	<string name="Shear Right Up">Trás rente para cima</string>
-	<string name="Sheared Back">Rente atrás</string>
-	<string name="Sheared Front">Rente frente</string>
-	<string name="Shift Left">Deslocar p/ esquerda</string>
-	<string name="Shift Mouth">Deslocar boca</string>
-	<string name="Shift Right">Deslocar p/ direita</string>
-	<string name="Shirt Bottom">Barra da camisa</string>
-	<string name="Shirt Fit">Ajuste da camisa</string>
-	<string name="Shirt Wrinkles">+/- amassada</string>
-	<string name="Shoe Height">Altura do sapato</string>
-	<string name="Short">Curto</string>
-	<string name="Short Arms">Braços curtos</string>
-	<string name="Short Legs">Pernas curtas</string>
-	<string name="Short Neck">Pescoço curto</string>
-	<string name="Short Pigtails">Chiquinhas curtas</string>
-	<string name="Short Ponytail">Rabo de cavalo curto</string>
-	<string name="Short Sideburns">Costeletas curtas</string>
-	<string name="Short Torso">Tronco curto</string>
-	<string name="Short hips">Quadril curto</string>
-	<string name="Shoulders">Ombros</string>
-	<string name="Side Fringe">pontas laterais</string>
-	<string name="Sideburns">Costeletas</string>
-	<string name="Sides Hair">Cabelo lateral</string>
-	<string name="Sides Hair Down">Cabelo lateral long</string>
-	<string name="Sides Hair Up">Cabelo lateral superior</string>
-	<string name="Skinny Neck">Pescoço fino</string>
-	<string name="Skirt Fit">Ajuste de saia</string>
-	<string name="Skirt Length">Comprimento da saia</string>
-	<string name="Slanted Forehead">Testa inclinada</string>
-	<string name="Sleeve Length">Comprimento da manga</string>
-	<string name="Sleeve Looseness">Folga da manga</string>
-	<string name="Slit Back">Abertura : Atrás</string>
-	<string name="Slit Front">Abertura: Frente</string>
-	<string name="Slit Left">Abertura: Esquerda</string>
-	<string name="Slit Right">Abertura: Direita</string>
-	<string name="Small">Pequeno</string>
-	<string name="Small Hands">Mãos pequenas</string>
-	<string name="Small Head">Cabeça pequena</string>
-	<string name="Smooth">Suavizar</string>
-	<string name="Smooth Hair">Suavizar cabelo</string>
-	<string name="Socks Length">Comprimento das meias</string>
-	<string name="Soulpatch">Cavanhaque</string>
-	<string name="Sparse">Disperso</string>
-	<string name="Spiked Hair">Cabelo espetado</string>
-	<string name="Square">Quadrado</string>
-	<string name="Square Toe">Dedo quadrado</string>
-	<string name="Squash Head">Cabeça de Pera</string>
-	<string name="Stretch Head">Cabeça  esticada</string>
-	<string name="Sunken">Afundar</string>
-	<string name="Sunken Chest">Peito afundado</string>
-	<string name="Sunken Eyes">Olhos afundados</string>
-	<string name="Sweep Back">Pentear para trás</string>
-	<string name="Sweep Forward">Pentear para frente</string>
-	<string name="Tall">Alto</string>
-	<string name="Taper Back">Afinar atrás</string>
-	<string name="Taper Front">Afinar a frente</string>
-	<string name="Thick Heels">Salto grosso</string>
-	<string name="Thick Neck">Pescoço grosso</string>
-	<string name="Thick Toe">Dedo grosso</string>
-	<string name="Thin">Fino</string>
-	<string name="Thin Eyebrows">Sobrancelhas finas</string>
-	<string name="Thin Lips">Lábios finos</string>
-	<string name="Thin Nose">Nariz fino</string>
-	<string name="Tight Chin">Queixo apertado</string>
-	<string name="Tight Cuffs">Punho justo</string>
-	<string name="Tight Pants">Calça justa</string>
-	<string name="Tight Shirt">Camisa justa</string>
-	<string name="Tight Skirt">Saia justa</string>
-	<string name="Tight Sleeves">Tight Sleeves</string>
-	<string name="Toe Shape">Formato dos dedos</string>
-	<string name="Toe Thickness">Espessura dos dos dedos</string>
-	<string name="Torso Length">Comprimento do tronco</string>
-	<string name="Torso Muscles">Músculos do tronco</string>
-	<string name="Torso Scrawny">Tronco magricela</string>
-	<string name="Unattached">Desanexado</string>
-	<string name="Uncreased">Uncreased</string>
-	<string name="Underbite">Underbite</string>
-	<string name="Unnatural">Não natural</string>
-	<string name="Upper Bridge">Parte alta do nariz</string>
-	<string name="Upper Cheeks">Bochechas altas</string>
-	<string name="Upper Chin Cleft">fenda do queixo alta</string>
-	<string name="Upper Eyelid Fold">Curvatura dos cílios supériores</string>
-	<string name="Upturned">Voltado para cima</string>
-	<string name="Very Red">Bem vermelho</string>
-	<string name="Waist Height">Altura da cintura</string>
-	<string name="Well-Fed">Corpulento</string>
-	<string name="White Hair">Grisalho</string>
-	<string name="Wide">Amplo</string>
-	<string name="Wide Back">Costas largas</string>
-	<string name="Wide Front">Testa larga</string>
-	<string name="Wide Lips">Lábios amplos</string>
-	<string name="Wild">Selvagem</string>
-	<string name="Wrinkles">Rugas</string>
-	<string name="LocationCtrlAddLandmarkTooltip">Adicionar às minhas Landmarks</string>
-	<string name="LocationCtrlEditLandmarkTooltip">Editar minhas Landmarks</string>
-	<string name="LocationCtrlInfoBtnTooltip">Ver mais informações sobre a localização atual</string>
-	<string name="LocationCtrlComboBtnTooltip">Histórico de localizações</string>
-	<string name="LocationCtrlAdultIconTooltip">Região Adulta</string>
-	<string name="LocationCtrlModerateIconTooltip">Região Moderada</string>
-	<string name="LocationCtrlGeneralIconTooltip">Região em geral</string>
-	<string name="LocationCtrlSeeAVsTooltip">Os avatares neste lote não podem ser vistos ou ouvidos por avatares fora dele</string>
-	<string name="LocationCtrlPathfindingDirtyTooltip">Os objetos que se movem podem não se comportar corretamente nesta região até que ela seja recarregada.</string>
-	<string name="LocationCtrlPathfindingDisabledTooltip">O pathfinding dinâmico não está habilitado nesta região.</string>
-	<string name="UpdaterWindowTitle">[APP_NAME] Atualização</string>
-	<string name="UpdaterNowUpdating">Atualizando agora o [APP_NAME]...</string>
-	<string name="UpdaterNowInstalling">Instalando [APP_NAME]...</string>
-	<string name="UpdaterUpdatingDescriptive">Seu visualizador [APP_NAME] está sendo atualizado para a versão mais recente. Isso pode levar algum tempo, então por favor seja paciente.</string>
-	<string name="UpdaterProgressBarTextWithEllipses">Fazendo o download da atualização...</string>
-	<string name="UpdaterProgressBarText">Fazendo o download da atualização</string>
-	<string name="UpdaterFailDownloadTitle">Falha no download da atualização</string>
-	<string name="UpdaterFailUpdateDescriptive">Um erro ocorreu ao atualizar [APP_NAME]. Por favor, faça o download da versão mais recente em www.secondlife.com.</string>
-	<string name="UpdaterFailInstallTitle">Falha ao instalar a atualização</string>
-	<string name="UpdaterFailStartTitle">Falha ao iniciar o visualizador</string>
-	<string name="ItemsComingInTooFastFrom">[APP_NAME]: Entrada de itens rápida demais de [FROM_NAME], visualização automática suspensa por [TIME] segundos</string>
-	<string name="ItemsComingInTooFast">[APP_NAME]: Entrada de itens rápida demais, visualização automática suspensa por [TIME] segundos</string>
-	<string name="IM_logging_string">-- Log de mensagem instantânea habilitado --</string>
-	<string name="IM_typing_start_string">[NAME] está digitando...</string>
-	<string name="Unnamed">(Anônimo)</string>
-	<string name="IM_moderated_chat_label">(Moderado: Voz desativado por padrão)</string>
-	<string name="IM_unavailable_text_label">Bate-papo de texto não está disponível para esta chamada.</string>
-	<string name="IM_muted_text_label">Seu bate- papo de texto foi desabilitado por um Moderador do Grupo.</string>
-	<string name="IM_default_text_label">Clique aqui para menagem instantânea.</string>
-	<string name="IM_to_label">Para</string>
-	<string name="IM_moderator_label">(Moderador)</string>
-	<string name="Saved_message">(Salvo em [LONG_TIMESTAMP])</string>
-	<string name="IM_unblock_only_groups_friends">Para visualizar esta mensagem, você deve desmarcar &quot;Apenas amigos e grupos podem me ligar ou enviar MIs&quot; em Preferências/Privacidade.</string>
-	<string name="OnlineStatus">Conectado</string>
-	<string name="OfflineStatus">Desconectado</string>
-	<string name="not_online_msg">O usuário não está online. As mensagens serão armazenadas e enviadas mais tarde.</string>
-	<string name="not_online_inventory">O usuário não está online. O inventário foi salvo.</string>
-	<string name="answered_call">Ligação atendida</string>
-	<string name="you_started_call">Você iniciou uma ligação de voz</string>
-	<string name="you_joined_call">Você entrou na ligação</string>
-	<string name="you_auto_rejected_call-im">Você recusou automaticamente a chamada de voz enquanto &quot;Não perturbe&quot; estava ativado.</string>
-	<string name="name_started_call">[NAME] iniciou uma ligação de voz</string>
-	<string name="ringing-im">Entrando em ligação de voz...</string>
-	<string name="connected-im">Conectado. Para sair, clique em Desligar</string>
-	<string name="hang_up-im">Saiu da ligação de voz</string>
-	<string name="conference-title">Bate-papo com várias pessoas</string>
-	<string name="conference-title-incoming">Conversa com [AGENT_NAME]</string>
-	<string name="inventory_item_offered-im">Item do inventário '[ITEM_NAME]' oferecido</string>
-	<string name="inventory_folder_offered-im">Pasta do inventário '[ITEM_NAME]' oferecida</string>
+If you continue to receive this message, contact the [SUPPORT_SITE].
+	</string>
+	<string name="5 O'Clock Shadow">
+		Barba por fazer
+	</string>
+	<string name="All White">
+		Todo branco
+	</string>
+	<string name="Anime Eyes">
+		Olhos de Anime
+	</string>
+	<string name="Arced">
+		Arqueados
+	</string>
+	<string name="Arm Length">
+		Comprimento do braço
+	</string>
+	<string name="Attached">
+		Anexado
+	</string>
+	<string name="Attached Earlobes">
+		Lóbulos da orelha anexados
+	</string>
+	<string name="Back Fringe">
+		corte traseiro
+	</string>
+	<string name="Baggy">
+		folgado
+	</string>
+	<string name="Bangs">
+		Franja
+	</string>
+	<string name="Beady Eyes">
+		Olhos pequenos
+	</string>
+	<string name="Belly Size">
+		Tamanho da barriga
+	</string>
+	<string name="Big">
+		Grande
+	</string>
+	<string name="Big Butt">
+		Bunda grande
+	</string>
+	<string name="Big Hair Back">
+		Cabelo volumoso: Trás
+	</string>
+	<string name="Big Hair Front">
+		Cabelo volumoso: Frente
+	</string>
+	<string name="Big Hair Top">
+		Cabelo volumoso: Topo
+	</string>
+	<string name="Big Head">
+		cabeça grande
+	</string>
+	<string name="Big Pectorals">
+		Peitorais grandes
+	</string>
+	<string name="Big Spikes">
+		Pontas grandes
+	</string>
+	<string name="Black">
+		Negro
+	</string>
+	<string name="Blonde">
+		Loiro
+	</string>
+	<string name="Blonde Hair">
+		Cabelo loiro
+	</string>
+	<string name="Blush">
+		Blush
+	</string>
+	<string name="Blush Color">
+		Cor do blush
+	</string>
+	<string name="Blush Opacity">
+		Opacidade do blush
+	</string>
+	<string name="Body Definition">
+		Definição do corpo
+	</string>
+	<string name="Body Fat">
+		Gordura
+	</string>
+	<string name="Body Freckles">
+		Sardas
+	</string>
+	<string name="Body Thick">
+		Corpo cheio
+	</string>
+	<string name="Body Thickness">
+		Ossatura
+	</string>
+	<string name="Body Thin">
+		Corpo magro
+	</string>
+	<string name="Bow Legged">
+		Pernas arqueadas
+	</string>
+	<string name="Breast Buoyancy">
+		Caimento dos seios
+	</string>
+	<string name="Breast Cleavage">
+		Separação dos seios
+	</string>
+	<string name="Breast Size">
+		Tamanho dos seios
+	</string>
+	<string name="Bridge Width">
+		Largura do nariz
+	</string>
+	<string name="Broad">
+		Largo
+	</string>
+	<string name="Brow Size">
+		Tamanho da sobrancelha
+	</string>
+	<string name="Bug Eyes">
+		Olhos saltados
+	</string>
+	<string name="Bugged Eyes">
+		Olhos esbugalhados
+	</string>
+	<string name="Bulbous">
+		Bulbos
+	</string>
+	<string name="Bulbous Nose">
+		Nariz em bulbo
+	</string>
+	<string name="Breast Physics Mass">
+		Seios - massa
+	</string>
+	<string name="Breast Physics Smoothing">
+		Seios - suavização
+	</string>
+	<string name="Breast Physics Gravity">
+		Seios - gravidade
+	</string>
+	<string name="Breast Physics Drag">
+		Seios - resistência do ar
+	</string>
+	<string name="Breast Physics InOut Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Breast Physics InOut Spring">
+		Vibração
+	</string>
+	<string name="Breast Physics InOut Gain">
+		Ganho
+	</string>
+	<string name="Breast Physics InOut Damping">
+		Duração
+	</string>
+	<string name="Breast Physics UpDown Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Breast Physics UpDown Spring">
+		Vibração
+	</string>
+	<string name="Breast Physics UpDown Gain">
+		Ganho
+	</string>
+	<string name="Breast Physics UpDown Damping">
+		Duração
+	</string>
+	<string name="Breast Physics LeftRight Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Breast Physics LeftRight Spring">
+		Vibração
+	</string>
+	<string name="Breast Physics LeftRight Gain">
+		Ganho
+	</string>
+	<string name="Breast Physics LeftRight Damping">
+		Duração
+	</string>
+	<string name="Belly Physics Mass">
+		Barriga - massa
+	</string>
+	<string name="Belly Physics Smoothing">
+		Barriga - suavização
+	</string>
+	<string name="Belly Physics Gravity">
+		Barriga - gravidade
+	</string>
+	<string name="Belly Physics Drag">
+		Barriga - resistência do ar
+	</string>
+	<string name="Belly Physics UpDown Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Belly Physics UpDown Spring">
+		Vibração
+	</string>
+	<string name="Belly Physics UpDown Gain">
+		Ganho
+	</string>
+	<string name="Belly Physics UpDown Damping">
+		Duração
+	</string>
+	<string name="Butt Physics Mass">
+		Nádegas - massa
+	</string>
+	<string name="Butt Physics Smoothing">
+		Nádegas - suavização
+	</string>
+	<string name="Butt Physics Gravity">
+		Nádegas - gravidade
+	</string>
+	<string name="Butt Physics Drag">
+		Nádegas - resistência do ar
+	</string>
+	<string name="Butt Physics UpDown Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Butt Physics UpDown Spring">
+		Vibração
+	</string>
+	<string name="Butt Physics UpDown Gain">
+		Ganho
+	</string>
+	<string name="Butt Physics UpDown Damping">
+		Duração
+	</string>
+	<string name="Butt Physics LeftRight Max Effect">
+		Efeito máximo
+	</string>
+	<string name="Butt Physics LeftRight Spring">
+		Vibração
+	</string>
+	<string name="Butt Physics LeftRight Gain">
+		Ganho
+	</string>
+	<string name="Butt Physics LeftRight Damping">
+		Duração
+	</string>
+	<string name="Bushy Eyebrows">
+		Sobrancelhas grossas
+	</string>
+	<string name="Bushy Hair">
+		Cabelo grosso
+	</string>
+	<string name="Butt Size">
+		Tamanho do traseiro
+	</string>
+	<string name="Butt Gravity">
+		Nádegas - gravidade
+	</string>
+	<string name="bustle skirt">
+		Saia armada
+	</string>
+	<string name="no bustle">
+		Saia reta
+	</string>
+	<string name="more bustle">
+		Mais
+	</string>
+	<string name="Chaplin">
+		Chaplin
+	</string>
+	<string name="Cheek Bones">
+		Maçãs do rosto
+	</string>
+	<string name="Chest Size">
+		Tamanho do peito
+	</string>
+	<string name="Chin Angle">
+		Ângulo do queixo
+	</string>
+	<string name="Chin Cleft">
+		Fissura do queixo
+	</string>
+	<string name="Chin Curtains">
+		Barba de contorno
+	</string>
+	<string name="Chin Depth">
+		Profundidade do queixo
+	</string>
+	<string name="Chin Heavy">
+		Queixo pronunciado
+	</string>
+	<string name="Chin In">
+		Queixo para dentro
+	</string>
+	<string name="Chin Out">
+		Queixo para fora
+	</string>
+	<string name="Chin-Neck">
+		Queixo-pescoço
+	</string>
+	<string name="Clear">
+		Limpar
+	</string>
+	<string name="Cleft">
+		Fenda
+	</string>
+	<string name="Close Set Eyes">
+		Fechar conjunto de olhos
+	</string>
+	<string name="Closed">
+		Fechado
+	</string>
+	<string name="Closed Back">
+		Trás fechada
+	</string>
+	<string name="Closed Front">
+		Frente fechada
+	</string>
+	<string name="Closed Left">
+		Esquerda fechada
+	</string>
+	<string name="Closed Right">
+		Direita fechada
+	</string>
+	<string name="Coin Purse">
+		Pouco volume
+	</string>
+	<string name="Collar Back">
+		Colarinho posterior
+	</string>
+	<string name="Collar Front">
+		Colarinho anterior
+	</string>
+	<string name="Corner Down">
+		Canto para baixo
+	</string>
+	<string name="Corner Up">
+		Canto para cima
+	</string>
+	<string name="Creased">
+		Vincado
+	</string>
+	<string name="Crooked Nose">
+		Nariz torto
+	</string>
+	<string name="Cuff Flare">
+		Bainha larga
+	</string>
+	<string name="Dark">
+		Escuro
+	</string>
+	<string name="Dark Green">
+		Verde escuro
+	</string>
+	<string name="Darker">
+		Mais escuro
+	</string>
+	<string name="Deep">
+		Profundidade
+	</string>
+	<string name="Default Heels">
+		Salto padrão
+	</string>
+	<string name="Dense">
+		Densidade
+	</string>
+	<string name="Double Chin">
+		Queixo duplo
+	</string>
+	<string name="Downturned">
+		Curvado para baixo
+	</string>
+	<string name="Duffle Bag">
+		Mais volume
+	</string>
+	<string name="Ear Angle">
+		Ângulo da orelha
+	</string>
+	<string name="Ear Size">
+		Tamanho da orelha
+	</string>
+	<string name="Ear Tips">
+		Pontas das orelhas
+	</string>
+	<string name="Egg Head">
+		Cabeça oval
+	</string>
+	<string name="Eye Bags">
+		Olheiras
+	</string>
+	<string name="Eye Color">
+		Cor dos olhos
+	</string>
+	<string name="Eye Depth">
+		Profundidade dos olhos
+	</string>
+	<string name="Eye Lightness">
+		Luminosidade dos olhos
+	</string>
+	<string name="Eye Opening">
+		Abertura dos olhos
+	</string>
+	<string name="Eye Pop">
+		Olho saltado
+	</string>
+	<string name="Eye Size">
+		Tamanho dos olhos
+	</string>
+	<string name="Eye Spacing">
+		Espaçamento dos olhos
+	</string>
+	<string name="Eyebrow Arc">
+		Arco da sobrancelha
+	</string>
+	<string name="Eyebrow Density">
+		Densidade da sobrancelha
+	</string>
+	<string name="Eyebrow Height">
+		Altura da sobrancelha
+	</string>
+	<string name="Eyebrow Points">
+		Pontas da sobrancelha
+	</string>
+	<string name="Eyebrow Size">
+		Tamanho da sobrancelha
+	</string>
+	<string name="Eyelash Length">
+		Comprimento das pestanas
+	</string>
+	<string name="Eyeliner">
+		Delineador
+	</string>
+	<string name="Eyeliner Color">
+		Cor do delineador
+	</string>
+	<string name="Eyes Bugged">
+		Olhos esbugalhados
+	</string>
+	<string name="Face Shear">
+		Face raspada
+	</string>
+	<string name="Facial Definition">
+		Definição facial
+	</string>
+	<string name="Far Set Eyes">
+		Distância entre os olhos
+	</string>
+	<string name="Fat Lips">
+		Lábios carnudos
+	</string>
+	<string name="Female">
+		Feminino
+	</string>
+	<string name="Fingerless">
+		Dedos
+	</string>
+	<string name="Fingers">
+		Dedos
+	</string>
+	<string name="Flared Cuffs">
+		Punhos largos
+	</string>
+	<string name="Flat">
+		Chato
+	</string>
+	<string name="Flat Butt">
+		Traseiro chato
+	</string>
+	<string name="Flat Head">
+		Cabeça chata
+	</string>
+	<string name="Flat Toe">
+		Dedos dos pés chatos
+	</string>
+	<string name="Foot Size">
+		Tamanho dos pés
+	</string>
+	<string name="Forehead Angle">
+		Ângulo da testa
+	</string>
+	<string name="Forehead Heavy">
+		Testa pronunciada
+	</string>
+	<string name="Freckles">
+		Sardas
+	</string>
+	<string name="Front Fringe">
+		Franja
+	</string>
+	<string name="Full Back">
+		Trás cheia
+	</string>
+	<string name="Full Eyeliner">
+		Delienador cheio
+	</string>
+	<string name="Full Front">
+		Frente cheia
+	</string>
+	<string name="Full Hair Sides">
+		Cabelos laterais cheios
+	</string>
+	<string name="Full Sides">
+		Lados cheios
+	</string>
+	<string name="Glossy">
+		Brilhante
+	</string>
+	<string name="Glove Fingers">
+		Dedos da luva
+	</string>
+	<string name="Glove Length">
+		Comprimento das luvas
+	</string>
+	<string name="Hair">
+		Cabelo
+	</string>
+	<string name="Hair Back">
+		Cabelo: Trás
+	</string>
+	<string name="Hair Front">
+		Cabelo: Frente
+	</string>
+	<string name="Hair Sides">
+		Cabelos: Lateral
+	</string>
+	<string name="Hair Sweep">
+		Cabelo penteado
+	</string>
+	<string name="Hair Thickess">
+		Espessura do cabelo
+	</string>
+	<string name="Hair Thickness">
+		Espessura do cabelo
+	</string>
+	<string name="Hair Tilt">
+		Divisão do cabelo
+	</string>
+	<string name="Hair Tilted Left">
+		Divistão do cabelo esquerda
+	</string>
+	<string name="Hair Tilted Right">
+		Divisão do cabelo direita
+	</string>
+	<string name="Hair Volume">
+		Cabelo: Volume
+	</string>
+	<string name="Hand Size">
+		Tamanho das mãos
+	</string>
+	<string name="Handlebars">
+		Bigode
+	</string>
+	<string name="Head Length">
+		Comprimento da cabeça
+	</string>
+	<string name="Head Shape">
+		Formato da cabeça
+	</string>
+	<string name="Head Size">
+		Tamanho da cabeça
+	</string>
+	<string name="Head Stretch">
+		Extensão da cabeça
+	</string>
+	<string name="Heel Height">
+		Altura do salto
+	</string>
+	<string name="Heel Shape">
+		Formato do salto
+	</string>
+	<string name="Height">
+		Altura
+	</string>
+	<string name="High">
+		Alto
+	</string>
+	<string name="High Heels">
+		Salto alto
+	</string>
+	<string name="High Jaw">
+		Maxilar alto
+	</string>
+	<string name="High Platforms">
+		Plataformas altas
+	</string>
+	<string name="High and Tight">
+		Alto e justo
+	</string>
+	<string name="Higher">
+		Mais alto
+	</string>
+	<string name="Hip Length">
+		Comprimento do quadril
+	</string>
+	<string name="Hip Width">
+		Largura do quadril
+	</string>
+	<string name="Hover">
+		Pairar
+	</string>
+	<string name="In">
+		Dentro
+	</string>
+	<string name="In Shdw Color">
+		Cor da sombra interna
+	</string>
+	<string name="In Shdw Opacity">
+		Opacidade da sombra interna
+	</string>
+	<string name="Inner Eye Corner">
+		Canto interno dos olhos
+	</string>
+	<string name="Inner Eye Shadow">
+		Sombra interna dos olhos
+	</string>
+	<string name="Inner Shadow">
+		Sombra interna
+	</string>
+	<string name="Jacket Length">
+		Comprimento da blusa
+	</string>
+	<string name="Jacket Wrinkles">
+		Dobras da jaqueta
+	</string>
+	<string name="Jaw Angle">
+		Ângulo da mandíbula
+	</string>
+	<string name="Jaw Jut">
+		Posição do maxilar
+	</string>
+	<string name="Jaw Shape">
+		Formato do maxilar
+	</string>
+	<string name="Join">
+		Juntar
+	</string>
+	<string name="Jowls">
+		Papo
+	</string>
+	<string name="Knee Angle">
+		Ângulo do joelho
+	</string>
+	<string name="Knock Kneed">
+		Joelhos para dentro
+	</string>
+	<string name="Large">
+		Grande
+	</string>
+	<string name="Large Hands">
+		Mãos grandes
+	</string>
+	<string name="Left Part">
+		Parte esquerda
+	</string>
+	<string name="Leg Length">
+		Comprimento da perna
+	</string>
+	<string name="Leg Muscles">
+		Musculatura da perna
+	</string>
+	<string name="Less">
+		Menos
+	</string>
+	<string name="Less Body Fat">
+		Menos gordura
+	</string>
+	<string name="Less Curtains">
+		Menos barba
+	</string>
+	<string name="Less Freckles">
+		Menos sardas
+	</string>
+	<string name="Less Full">
+		Menos
+	</string>
+	<string name="Less Gravity">
+		Menos gravidade
+	</string>
+	<string name="Less Love">
+		Menos excesso
+	</string>
+	<string name="Less Muscles">
+		Menos músculos
+	</string>
+	<string name="Less Muscular">
+		Menos musculoso
+	</string>
+	<string name="Less Rosy">
+		Menos rosado
+	</string>
+	<string name="Less Round">
+		Menos arredondado
+	</string>
+	<string name="Less Saddle">
+		Menos ancas
+	</string>
+	<string name="Less Square">
+		Menos quadrado
+	</string>
+	<string name="Less Volume">
+		Menos volume
+	</string>
+	<string name="Less soul">
+		Menos alma
+	</string>
+	<string name="Lighter">
+		Lighter
+	</string>
+	<string name="Lip Cleft">
+		Fenda dos lábios
+	</string>
+	<string name="Lip Cleft Depth">
+		Profundidade da fenda dos lábios
+	</string>
+	<string name="Lip Fullness">
+		Volume dos lábios
+	</string>
+	<string name="Lip Pinkness">
+		Rosado dos lábios
+	</string>
+	<string name="Lip Ratio">
+		Proporção dos lábios
+	</string>
+	<string name="Lip Thickness">
+		Espessura dos lábios
+	</string>
+	<string name="Lip Width">
+		Largura dos lábios
+	</string>
+	<string name="Lipgloss">
+		Brilho dos lábios
+	</string>
+	<string name="Lipstick">
+		Batom
+	</string>
+	<string name="Lipstick Color">
+		Cor do batom
+	</string>
+	<string name="Long">
+		Longo
+	</string>
+	<string name="Long Head">
+		Cabeça alongada
+	</string>
+	<string name="Long Hips">
+		Lábios longos
+	</string>
+	<string name="Long Legs">
+		Pernas longas
+	</string>
+	<string name="Long Neck">
+		Pescoço longo
+	</string>
+	<string name="Long Pigtails">
+		Chiquinhas longas
+	</string>
+	<string name="Long Ponytail">
+		Rabo de cavalo longo
+	</string>
+	<string name="Long Torso">
+		Torso longo
+	</string>
+	<string name="Long arms">
+		Braços longos
+	</string>
+	<string name="Loose Pants">
+		Pantalonas
+	</string>
+	<string name="Loose Shirt">
+		Camisa folgada
+	</string>
+	<string name="Loose Sleeves">
+		Mangas folgadas
+	</string>
+	<string name="Love Handles">
+		Pneu
+	</string>
+	<string name="Low">
+		Baixo
+	</string>
+	<string name="Low Heels">
+		Salto baixo
+	</string>
+	<string name="Low Jaw">
+		Maxilar baixo
+	</string>
+	<string name="Low Platforms">
+		Plataformas baixas
+	</string>
+	<string name="Low and Loose">
+		Baixo e solto
+	</string>
+	<string name="Lower">
+		Mais baixo
+	</string>
+	<string name="Lower Bridge">
+		Mais baixa
+	</string>
+	<string name="Lower Cheeks">
+		Bochechas abaixadas
+	</string>
+	<string name="Male">
+		Masculino
+	</string>
+	<string name="Middle Part">
+		Parte do meio
+	</string>
+	<string name="More">
+		Mais
+	</string>
+	<string name="More Blush">
+		Mais blush
+	</string>
+	<string name="More Body Fat">
+		Mais gordura
+	</string>
+	<string name="More Curtains">
+		Mais barba
+	</string>
+	<string name="More Eyeshadow">
+		Mais sombra dos olhos
+	</string>
+	<string name="More Freckles">
+		Mais sardas
+	</string>
+	<string name="More Full">
+		Mais volume
+	</string>
+	<string name="More Gravity">
+		Mais gravidade
+	</string>
+	<string name="More Lipstick">
+		Mais batom
+	</string>
+	<string name="More Love">
+		Mais cintura
+	</string>
+	<string name="More Lower Lip">
+		Mais lábio inferior
+	</string>
+	<string name="More Muscles">
+		Mais músculos
+	</string>
+	<string name="More Muscular">
+		Mais musculoso
+	</string>
+	<string name="More Rosy">
+		Mais rosado
+	</string>
+	<string name="More Round">
+		Mais arredondado
+	</string>
+	<string name="More Saddle">
+		Mais ancas
+	</string>
+	<string name="More Sloped">
+		Mais inclinado
+	</string>
+	<string name="More Square">
+		Mais quadrado
+	</string>
+	<string name="More Upper Lip">
+		Mais lábios superiores
+	</string>
+	<string name="More Vertical">
+		Mais vertical
+	</string>
+	<string name="More Volume">
+		Mais volume
+	</string>
+	<string name="More soul">
+		Mais alma
+	</string>
+	<string name="Moustache">
+		Bigode
+	</string>
+	<string name="Mouth Corner">
+		Canto da boca
+	</string>
+	<string name="Mouth Position">
+		Posição da boca
+	</string>
+	<string name="Mowhawk">
+		Moicano
+	</string>
+	<string name="Muscular">
+		Muscular
+	</string>
+	<string name="Mutton Chops">
+		Costeletas
+	</string>
+	<string name="Nail Polish">
+		Esmate das unhas
+	</string>
+	<string name="Nail Polish Color">
+		Cor do esmalte das unhas
+	</string>
+	<string name="Narrow">
+		Estreito
+	</string>
+	<string name="Narrow Back">
+		Costas estreitas
+	</string>
+	<string name="Narrow Front">
+		Frente estreita
+	</string>
+	<string name="Narrow Lips">
+		Lábios estreitos
+	</string>
+	<string name="Natural">
+		Natural
+	</string>
+	<string name="Neck Length">
+		Comprimento do pescoço
+	</string>
+	<string name="Neck Thickness">
+		Espessura do pescoço
+	</string>
+	<string name="No Blush">
+		Sem blush
+	</string>
+	<string name="No Eyeliner">
+		Sem delineador
+	</string>
+	<string name="No Eyeshadow">
+		Sem sombra
+	</string>
+	<string name="No Lipgloss">
+		Sem brilho
+	</string>
+	<string name="No Lipstick">
+		Sem batom
+	</string>
+	<string name="No Part">
+		Sem parte
+	</string>
+	<string name="No Polish">
+		Sem esmalte
+	</string>
+	<string name="No Red">
+		Sem vermelho
+	</string>
+	<string name="No Spikes">
+		Sem pontas
+	</string>
+	<string name="No White">
+		Sem branco
+	</string>
+	<string name="No Wrinkles">
+		Sem dobras
+	</string>
+	<string name="Normal Lower">
+		Normal inferior
+	</string>
+	<string name="Normal Upper">
+		Normal superior
+	</string>
+	<string name="Nose Left">
+		Nariz para esquerda
+	</string>
+	<string name="Nose Right">
+		Nariz para direita
+	</string>
+	<string name="Nose Size">
+		Tamanho do nariz
+	</string>
+	<string name="Nose Thickness">
+		Espessura do nariz
+	</string>
+	<string name="Nose Tip Angle">
+		Ângulo da ponta do nariz
+	</string>
+	<string name="Nose Tip Shape">
+		Formato da ponta do nariz
+	</string>
+	<string name="Nose Width">
+		Largura do nariz
+	</string>
+	<string name="Nostril Division">
+		Divisão das narinas
+	</string>
+	<string name="Nostril Width">
+		Largura das narinas
+	</string>
+	<string name="Opaque">
+		Opaco
+	</string>
+	<string name="Open">
+		Abrir
+	</string>
+	<string name="Open Back">
+		Aberto atrás
+	</string>
+	<string name="Open Front">
+		Aberto na frente
+	</string>
+	<string name="Open Left">
+		Aberto esquerdo
+	</string>
+	<string name="Open Right">
+		Aberto direito
+	</string>
+	<string name="Orange">
+		Laranja
+	</string>
+	<string name="Out">
+		Fora
+	</string>
+	<string name="Out Shdw Color">
+		Cor da sombra externa
+	</string>
+	<string name="Out Shdw Opacity">
+		Opacidade da sombra externa
+	</string>
+	<string name="Outer Eye Corner">
+		Canto externo do olho
+	</string>
+	<string name="Outer Eye Shadow">
+		Sombra externa do olho
+	</string>
+	<string name="Outer Shadow">
+		Sombra externa
+	</string>
+	<string name="Overbite">
+		Má oclusão
+	</string>
+	<string name="Package">
+		Púbis
+	</string>
+	<string name="Painted Nails">
+		Unhas pintadas
+	</string>
+	<string name="Pale">
+		Pálido
+	</string>
+	<string name="Pants Crotch">
+		Cavalo da calça
+	</string>
+	<string name="Pants Fit">
+		Caimento das calças
+	</string>
+	<string name="Pants Length">
+		Comprimento das calças
+	</string>
+	<string name="Pants Waist">
+		Cintura da calça
+	</string>
+	<string name="Pants Wrinkles">
+		Dobras das calças
+	</string>
+	<string name="Part">
+		Parte
+	</string>
+	<string name="Part Bangs">
+		Divisão da franja
+	</string>
+	<string name="Pectorals">
+		Peitorais
+	</string>
+	<string name="Pigment">
+		Pigmento
+	</string>
+	<string name="Pigtails">
+		Chiquinhas
+	</string>
+	<string name="Pink">
+		Rosa
+	</string>
+	<string name="Pinker">
+		Mais rosado
+	</string>
+	<string name="Platform Height">
+		Altura da plataforma
+	</string>
+	<string name="Platform Width">
+		Largura da plataforma
+	</string>
+	<string name="Pointy">
+		Pontudo
+	</string>
+	<string name="Pointy Heels">
+		Salto agulha
+	</string>
+	<string name="Ponytail">
+		Rabo de cavalo
+	</string>
+	<string name="Poofy Skirt">
+		Saia bufante
+	</string>
+	<string name="Pop Left Eye">
+		Olho saltado esquerdo
+	</string>
+	<string name="Pop Right Eye">
+		Olho saltado direito
+	</string>
+	<string name="Puffy">
+		Inchado
+	</string>
+	<string name="Puffy Eyelids">
+		Pálpebras inchadas
+	</string>
+	<string name="Rainbow Color">
+		Cor do arco íris
+	</string>
+	<string name="Red Hair">
+		Cabelo ruivo
+	</string>
+	<string name="Regular">
+		Normal
+	</string>
+	<string name="Right Part">
+		Parte direita
+	</string>
+	<string name="Rosy Complexion">
+		Rosado da face
+	</string>
+	<string name="Round">
+		Arredondado
+	</string>
+	<string name="Ruddiness">
+		Rubor
+	</string>
+	<string name="Ruddy">
+		Corado
+	</string>
+	<string name="Rumpled Hair">
+		Cabelo desalinhado
+	</string>
+	<string name="Saddle Bags">
+		Culote
+	</string>
+	<string name="Scrawny Leg">
+		Pernas magricelas
+	</string>
+	<string name="Separate">
+		Separar
+	</string>
+	<string name="Shallow">
+		Raso
+	</string>
+	<string name="Shear Back">
+		Trás rente
+	</string>
+	<string name="Shear Face">
+		Face raspada
+	</string>
+	<string name="Shear Front">
+		Frente rente
+	</string>
+	<string name="Shear Left Up">
+		Esquerda rente para cima
+	</string>
+	<string name="Shear Right Up">
+		Trás rente para cima
+	</string>
+	<string name="Sheared Back">
+		Rente atrás
+	</string>
+	<string name="Sheared Front">
+		Rente frente
+	</string>
+	<string name="Shift Left">
+		Deslocar p/ esquerda
+	</string>
+	<string name="Shift Mouth">
+		Deslocar boca
+	</string>
+	<string name="Shift Right">
+		Deslocar p/ direita
+	</string>
+	<string name="Shirt Bottom">
+		Barra da camisa
+	</string>
+	<string name="Shirt Fit">
+		Ajuste da camisa
+	</string>
+	<string name="Shirt Wrinkles">
+		+/- amassada
+	</string>
+	<string name="Shoe Height">
+		Altura do sapato
+	</string>
+	<string name="Short">
+		Curto
+	</string>
+	<string name="Short Arms">
+		Braços curtos
+	</string>
+	<string name="Short Legs">
+		Pernas curtas
+	</string>
+	<string name="Short Neck">
+		Pescoço curto
+	</string>
+	<string name="Short Pigtails">
+		Chiquinhas curtas
+	</string>
+	<string name="Short Ponytail">
+		Rabo de cavalo curto
+	</string>
+	<string name="Short Sideburns">
+		Costeletas curtas
+	</string>
+	<string name="Short Torso">
+		Tronco curto
+	</string>
+	<string name="Short hips">
+		Quadril curto
+	</string>
+	<string name="Shoulders">
+		Ombros
+	</string>
+	<string name="Side Fringe">
+		pontas laterais
+	</string>
+	<string name="Sideburns">
+		Costeletas
+	</string>
+	<string name="Sides Hair">
+		Cabelo lateral
+	</string>
+	<string name="Sides Hair Down">
+		Cabelo lateral long
+	</string>
+	<string name="Sides Hair Up">
+		Cabelo lateral superior
+	</string>
+	<string name="Skinny Neck">
+		Pescoço fino
+	</string>
+	<string name="Skirt Fit">
+		Ajuste de saia
+	</string>
+	<string name="Skirt Length">
+		Comprimento da saia
+	</string>
+	<string name="Slanted Forehead">
+		Testa inclinada
+	</string>
+	<string name="Sleeve Length">
+		Comprimento da manga
+	</string>
+	<string name="Sleeve Looseness">
+		Folga da manga
+	</string>
+	<string name="Slit Back">
+		Abertura : Atrás
+	</string>
+	<string name="Slit Front">
+		Abertura: Frente
+	</string>
+	<string name="Slit Left">
+		Abertura: Esquerda
+	</string>
+	<string name="Slit Right">
+		Abertura: Direita
+	</string>
+	<string name="Small">
+		Pequeno
+	</string>
+	<string name="Small Hands">
+		Mãos pequenas
+	</string>
+	<string name="Small Head">
+		Cabeça pequena
+	</string>
+	<string name="Smooth">
+		Suavizar
+	</string>
+	<string name="Smooth Hair">
+		Suavizar cabelo
+	</string>
+	<string name="Socks Length">
+		Comprimento das meias
+	</string>
+	<string name="Soulpatch">
+		Cavanhaque
+	</string>
+	<string name="Sparse">
+		Disperso
+	</string>
+	<string name="Spiked Hair">
+		Cabelo espetado
+	</string>
+	<string name="Square">
+		Quadrado
+	</string>
+	<string name="Square Toe">
+		Dedo quadrado
+	</string>
+	<string name="Squash Head">
+		Cabeça de Pera
+	</string>
+	<string name="Stretch Head">
+		Cabeça  esticada
+	</string>
+	<string name="Sunken">
+		Afundar
+	</string>
+	<string name="Sunken Chest">
+		Peito afundado
+	</string>
+	<string name="Sunken Eyes">
+		Olhos afundados
+	</string>
+	<string name="Sweep Back">
+		Pentear para trás
+	</string>
+	<string name="Sweep Forward">
+		Pentear para frente
+	</string>
+	<string name="Tall">
+		Alto
+	</string>
+	<string name="Taper Back">
+		Afinar atrás
+	</string>
+	<string name="Taper Front">
+		Afinar a frente
+	</string>
+	<string name="Thick Heels">
+		Salto grosso
+	</string>
+	<string name="Thick Neck">
+		Pescoço grosso
+	</string>
+	<string name="Thick Toe">
+		Dedo grosso
+	</string>
+	<string name="Thin">
+		Fino
+	</string>
+	<string name="Thin Eyebrows">
+		Sobrancelhas finas
+	</string>
+	<string name="Thin Lips">
+		Lábios finos
+	</string>
+	<string name="Thin Nose">
+		Nariz fino
+	</string>
+	<string name="Tight Chin">
+		Queixo apertado
+	</string>
+	<string name="Tight Cuffs">
+		Punho justo
+	</string>
+	<string name="Tight Pants">
+		Calça justa
+	</string>
+	<string name="Tight Shirt">
+		Camisa justa
+	</string>
+	<string name="Tight Skirt">
+		Saia justa
+	</string>
+	<string name="Tight Sleeves">
+		Tight Sleeves
+	</string>
+	<string name="Toe Shape">
+		Formato dos dedos
+	</string>
+	<string name="Toe Thickness">
+		Espessura dos dos dedos
+	</string>
+	<string name="Torso Length">
+		Comprimento do tronco
+	</string>
+	<string name="Torso Muscles">
+		Músculos do tronco
+	</string>
+	<string name="Torso Scrawny">
+		Tronco magricela
+	</string>
+	<string name="Unattached">
+		Desanexado
+	</string>
+	<string name="Uncreased">
+		Uncreased
+	</string>
+	<string name="Underbite">
+		Underbite
+	</string>
+	<string name="Unnatural">
+		Não natural
+	</string>
+	<string name="Upper Bridge">
+		Parte alta do nariz
+	</string>
+	<string name="Upper Cheeks">
+		Bochechas altas
+	</string>
+	<string name="Upper Chin Cleft">
+		fenda do queixo alta
+	</string>
+	<string name="Upper Eyelid Fold">
+		Curvatura dos cílios supériores
+	</string>
+	<string name="Upturned">
+		Voltado para cima
+	</string>
+	<string name="Very Red">
+		Bem vermelho
+	</string>
+	<string name="Waist Height">
+		Altura da cintura
+	</string>
+	<string name="Well-Fed">
+		Corpulento
+	</string>
+	<string name="White Hair">
+		Grisalho
+	</string>
+	<string name="Wide">
+		Amplo
+	</string>
+	<string name="Wide Back">
+		Costas largas
+	</string>
+	<string name="Wide Front">
+		Testa larga
+	</string>
+	<string name="Wide Lips">
+		Lábios amplos
+	</string>
+	<string name="Wild">
+		Selvagem
+	</string>
+	<string name="Wrinkles">
+		Rugas
+	</string>
+	<string name="LocationCtrlAddLandmarkTooltip">
+		Adicionar às minhas Landmarks
+	</string>
+	<string name="LocationCtrlEditLandmarkTooltip">
+		Editar minhas Landmarks
+	</string>
+	<string name="LocationCtrlInfoBtnTooltip">
+		Ver mais informações sobre a localização atual
+	</string>
+	<string name="LocationCtrlComboBtnTooltip">
+		Histórico de localizações
+	</string>
+	<string name="LocationCtrlAdultIconTooltip">
+		Região Adulta
+	</string>
+	<string name="LocationCtrlModerateIconTooltip">
+		Região Moderada
+	</string>
+	<string name="LocationCtrlGeneralIconTooltip">
+		Região em geral
+	</string>
+	<string name="LocationCtrlSeeAVsTooltip">
+		Os avatares neste lote não podem ser vistos ou ouvidos por avatares fora dele
+	</string>
+	<string name="LocationCtrlPathfindingDirtyTooltip">
+		Os objetos que se movem podem não se comportar corretamente nesta região até que ela seja recarregada.
+	</string>
+	<string name="LocationCtrlPathfindingDisabledTooltip">
+		O pathfinding dinâmico não está habilitado nesta região.
+	</string>
+	<string name="UpdaterWindowTitle">
+		[APP_NAME] Atualização
+	</string>
+	<string name="UpdaterNowUpdating">
+		Atualizando agora o [APP_NAME]...
+	</string>
+	<string name="UpdaterNowInstalling">
+		Instalando [APP_NAME]...
+	</string>
+	<string name="UpdaterUpdatingDescriptive">
+		Seu visualizador [APP_NAME] está sendo atualizado para a versão mais recente. Isso pode levar algum tempo, então por favor seja paciente.
+	</string>
+	<string name="UpdaterProgressBarTextWithEllipses">
+		Fazendo o download da atualização...
+	</string>
+	<string name="UpdaterProgressBarText">
+		Fazendo o download da atualização
+	</string>
+	<string name="UpdaterFailDownloadTitle">
+		Falha no download da atualização
+	</string>
+	<string name="UpdaterFailUpdateDescriptive">
+		Um erro ocorreu ao atualizar [APP_NAME]. Por favor, faça o download da versão mais recente em www.secondlife.com.
+	</string>
+	<string name="UpdaterFailInstallTitle">
+		Falha ao instalar a atualização
+	</string>
+	<string name="UpdaterFailStartTitle">
+		Falha ao iniciar o visualizador
+	</string>
+	<string name="ItemsComingInTooFastFrom">
+		[APP_NAME]: Entrada de itens rápida demais de [FROM_NAME], visualização automática suspensa por [TIME] segundos
+	</string>
+	<string name="ItemsComingInTooFast">
+		[APP_NAME]: Entrada de itens rápida demais, visualização automática suspensa por [TIME] segundos
+	</string>
+	<string name="IM_logging_string">
+		-- Log de mensagem instantânea habilitado --
+	</string>
+	<string name="IM_typing_start_string">
+		[NAME] está digitando...
+	</string>
+	<string name="Unnamed">
+		(Anônimo)
+	</string>
+	<string name="IM_moderated_chat_label">
+		(Moderado: Voz desativado por padrão)
+	</string>
+	<string name="IM_unavailable_text_label">
+		Bate-papo de texto não está disponível para esta chamada.
+	</string>
+	<string name="IM_muted_text_label">
+		Seu bate- papo de texto foi desabilitado por um Moderador do Grupo.
+	</string>
+	<string name="IM_default_text_label">
+		Clique aqui para menagem instantânea.
+	</string>
+	<string name="IM_to_label">
+		Para
+	</string>
+	<string name="IM_moderator_label">
+		(Moderador)
+	</string>
+	<string name="Saved_message">
+		(Salvo em [LONG_TIMESTAMP])
+	</string>
+	<string name="IM_unblock_only_groups_friends">
+		Para visualizar esta mensagem, você deve desmarcar "Apenas amigos e grupos podem me ligar ou enviar MIs" em Preferências/Privacidade.
+	</string>
+	<string name="OnlineStatus">
+		Conectado
+	</string>
+	<string name="OfflineStatus">
+		Desconectado
+	</string>
+	<string name="not_online_msg">
+		O usuário não está online. As mensagens serão armazenadas e enviadas mais tarde.
+	</string>
+	<string name="not_online_inventory">
+		O usuário não está online. O inventário foi salvo.
+	</string>
+	<string name="answered_call">
+		Ligação atendida
+	</string>
+	<string name="you_started_call">
+		Você iniciou uma ligação de voz
+	</string>
+	<string name="you_joined_call">
+		Você entrou na ligação
+	</string>
+	<string name="you_auto_rejected_call-im">
+		Você recusou automaticamente a chamada de voz enquanto "Não perturbe" estava ativado.
+	</string>
+	<string name="name_started_call">
+		[NAME] iniciou uma ligação de voz
+	</string>
+	<string name="ringing-im">
+		Entrando em ligação de voz...
+	</string>
+	<string name="connected-im">
+		Conectado. Para sair, clique em Desligar
+	</string>
+	<string name="hang_up-im">
+		Saiu da ligação de voz
+	</string>
+	<string name="conference-title">
+		Bate-papo com várias pessoas
+	</string>
+	<string name="conference-title-incoming">
+		Conversa com [AGENT_NAME]
+	</string>
+	<string name="inventory_item_offered-im">
+		Item do inventário '[ITEM_NAME]' oferecido
+	</string>
+	<string name="inventory_folder_offered-im">
+		Pasta do inventário '[ITEM_NAME]' oferecida
+	</string>
 	<string name="bot_warning">
-Você está conversando com um bot, [NAME]. Não compartilhe informações pessoais.
+		Você está conversando com um bot, [NAME]. Não compartilhe informações pessoais.
 Saiba mais em https://second.life/scripted-agents.
 	</string>
-	<string name="facebook_post_success">Você publicou no Facebook.</string>
-	<string name="flickr_post_success">Você publicou no Flickr.</string>
-	<string name="twitter_post_success">Você publicou no Twitter.</string>
-	<string name="no_session_message">(Sessão de MI inexistente)</string>
-	<string name="only_user_message">Você é o único usuário desta sessão.</string>
-	<string name="offline_message">[NAME] está offline.</string>
-	<string name="invite_message">Clique no botão [BUTTON NAME] para aceitar/ conectar a este bate-papo em voz.</string>
-	<string name="muted_message">Você bloqueou este residente.  Se quiser retirar o bloqueio, basta enviar uma mensagem.</string>
-	<string name="generic">Erro de solicitação, tente novamente mais tarde.</string>
-	<string name="generic_request_error">Erro na requisição, por favor, tente novamente.</string>
-	<string name="insufficient_perms_error">Você não tem permissões suficientes.</string>
-	<string name="session_does_not_exist_error">A sessão deixou de existir</string>
-	<string name="no_ability_error">Você não possui esta habilidade.</string>
-	<string name="no_ability">Você não possui esta habilidade.</string>
-	<string name="not_a_mod_error">Você não é um moderador de sessão.</string>
-	<string name="muted">Bate-papo de texto desativado por um moderador.</string>
-	<string name="muted_error">Um moderador do grupo desabilitou seu bate-papo em texto.</string>
-	<string name="add_session_event">Não foi possível adicionar usuários na sessão de bate-papo com [RECIPIENT].</string>
-	<string name="message">Não foi possível enviar sua mensagem para o bate-papo com [RECIPIENT].</string>
-	<string name="message_session_event">Não foi possível enviar sua mensagem na sessão de bate- papo com [RECIPIENT].</string>
-	<string name="mute">Erro durante a moderação.</string>
-	<string name="removed">Você foi tirado do grupo.</string>
-	<string name="removed_from_group">Você foi removido do grupo.</string>
-	<string name="close_on_no_ability">Você não possui mais a habilidade de estar na sessão de bate-papo.</string>
-	<string name="unread_chat_single">[SOURCES] disse alguma coisa</string>
-	<string name="unread_chat_multiple">[SOURCES] disseram alguma coisa</string>
-	<string name="session_initialization_timed_out_error">A inicialização da sessão expirou</string>
-	<string name="Home position set.">Posição inicial definida.</string>
-	<string name="voice_morphing_url">https://secondlife.com/destination/voice-island</string>
-	<string name="premium_voice_morphing_url">https://secondlife.com/destination/voice-morphing-premium</string>
-	<string name="paid_you_ldollars">[NAME] lhe pagou L$ [AMOUNT] [REASON].</string>
-	<string name="paid_you_ldollars_gift">[NAME] lhe pagou L$ [AMOUNT]: [REASON]</string>
-	<string name="paid_you_ldollars_no_reason">[NAME] lhe pagou L$ [AMOUNT]</string>
-	<string name="you_paid_ldollars">Você pagou L$[AMOUNT] por [REASON] a [NAME].</string>
-	<string name="you_paid_ldollars_gift">Você pagou L$[AMOUNT] a [NAME]: [REASON]</string>
-	<string name="you_paid_ldollars_no_info">Você acaba de pagar L$[AMOUNT].</string>
-	<string name="you_paid_ldollars_no_reason">Você pagou L$[AMOUNT] a [NAME].</string>
-	<string name="you_paid_ldollars_no_name">Você pagou L$[AMOUNT] por [REASON].</string>
-	<string name="you_paid_failure_ldollars">Você não pagou L$[AMOUNT] a [NAME] referentes a [REASON].</string>
-	<string name="you_paid_failure_ldollars_gift">Você não pagou L$[AMOUNT] a [NAME]: [REASON]</string>
-	<string name="you_paid_failure_ldollars_no_info">Você não pagou L$[AMOUNT].</string>
-	<string name="you_paid_failure_ldollars_no_reason">Você não pagou L$[AMOUNT] a [NAME].</string>
-	<string name="you_paid_failure_ldollars_no_name">Você não pagou L$[AMOUNT] referentes a [REASON].</string>
-	<string name="for item">por [ITEM]</string>
-	<string name="for a parcel of land">por uma parcela</string>
-	<string name="for a land access pass">por um passe de acesso</string>
-	<string name="for deeding land">para doar um terreno</string>
-	<string name="to create a group">para criar um grupo</string>
-	<string name="to join a group">para entrar em um grupo</string>
-	<string name="to upload">para carregar</string>
-	<string name="to publish a classified ad">para publicar um anúncio</string>
-	<string name="giving">Dando L$ [AMOUNT]</string>
-	<string name="uploading_costs">O upload custa L$ [AMOUNT]</string>
-	<string name="this_costs">Isso custa L$ [AMOUNT]</string>
-	<string name="buying_selected_land">Comprando terreno selecionado L$ [AMOUNT]</string>
-	<string name="this_object_costs">Esse objeto custa L$ [AMOUNT]</string>
-	<string name="group_role_everyone">Todos</string>
-	<string name="group_role_officers">Oficiais</string>
-	<string name="group_role_owners">Proprietários</string>
-	<string name="group_member_status_online">Conectado</string>
-	<string name="uploading_abuse_report">Carregando...
+	<string name="facebook_post_success">
+		Você publicou no Facebook.
+	</string>
+	<string name="flickr_post_success">
+		Você publicou no Flickr.
+	</string>
+	<string name="twitter_post_success">
+		Você publicou no Twitter.
+	</string>
+	<string name="no_session_message">
+		(Sessão de MI inexistente)
+	</string>
+	<string name="only_user_message">
+		Você é o único usuário desta sessão.
+	</string>
+	<string name="offline_message">
+		[NAME] está offline.
+	</string>
+	<string name="invite_message">
+		Clique no botão [BUTTON NAME] para aceitar/ conectar a este bate-papo em voz.
+	</string>
+	<string name="muted_message">
+		Você bloqueou este residente.  Se quiser retirar o bloqueio, basta enviar uma mensagem.
+	</string>
+	<string name="generic">
+		Erro de solicitação, tente novamente mais tarde.
+	</string>
+	<string name="generic_request_error">
+		Erro na requisição, por favor, tente novamente.
+	</string>
+	<string name="insufficient_perms_error">
+		Você não tem permissões suficientes.
+	</string>
+	<string name="session_does_not_exist_error">
+		A sessão deixou de existir
+	</string>
+	<string name="no_ability_error">
+		Você não possui esta habilidade.
+	</string>
+	<string name="no_ability">
+		Você não possui esta habilidade.
+	</string>
+	<string name="not_a_mod_error">
+		Você não é um moderador de sessão.
+	</string>
+	<string name="muted">
+		Bate-papo de texto desativado por um moderador.
+	</string>
+	<string name="muted_error">
+		Um moderador do grupo desabilitou seu bate-papo em texto.
+	</string>
+	<string name="add_session_event">
+		Não foi possível adicionar usuários na sessão de bate-papo com [RECIPIENT].
+	</string>
+	<string name="message">
+		Não foi possível enviar sua mensagem para o bate-papo com [RECIPIENT].
+	</string>
+	<string name="message_session_event">
+		Não foi possível enviar sua mensagem na sessão de bate- papo com [RECIPIENT].
+	</string>
+	<string name="mute">
+		Erro durante a moderação.
+	</string>
+	<string name="removed">
+		Você foi tirado do grupo.
+	</string>
+	<string name="removed_from_group">
+		Você foi removido do grupo.
+	</string>
+	<string name="close_on_no_ability">
+		Você não possui mais a habilidade de estar na sessão de bate-papo.
+	</string>
+	<string name="unread_chat_single">
+		[SOURCES] disse alguma coisa
+	</string>
+	<string name="unread_chat_multiple">
+		[SOURCES] disseram alguma coisa
+	</string>
+	<string name="session_initialization_timed_out_error">
+		A inicialização da sessão expirou
+	</string>
+	<string name="Home position set.">
+		Posição inicial definida.
+	</string>
+	<string name="voice_morphing_url">
+		https://secondlife.com/destination/voice-island
+	</string>
+	<string name="premium_voice_morphing_url">
+		https://secondlife.com/destination/voice-morphing-premium
+	</string>
+	<string name="paid_you_ldollars">
+		[NAME] lhe pagou L$ [AMOUNT] [REASON].
+	</string>
+	<string name="paid_you_ldollars_gift">
+		[NAME] lhe pagou L$ [AMOUNT]: [REASON]
+	</string>
+	<string name="paid_you_ldollars_no_reason">
+		[NAME] lhe pagou L$ [AMOUNT]
+	</string>
+	<string name="you_paid_ldollars">
+		Você pagou L$[AMOUNT] por [REASON] a [NAME].
+	</string>
+	<string name="you_paid_ldollars_gift">
+		Você pagou L$[AMOUNT] a [NAME]: [REASON]
+	</string>
+	<string name="you_paid_ldollars_no_info">
+		Você acaba de pagar L$[AMOUNT].
+	</string>
+	<string name="you_paid_ldollars_no_reason">
+		Você pagou L$[AMOUNT] a [NAME].
+	</string>
+	<string name="you_paid_ldollars_no_name">
+		Você pagou L$[AMOUNT] por [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars">
+		Você não pagou L$[AMOUNT] a [NAME] referentes a [REASON].
+	</string>
+	<string name="you_paid_failure_ldollars_gift">
+		Você não pagou L$[AMOUNT] a [NAME]: [REASON]
+	</string>
+	<string name="you_paid_failure_ldollars_no_info">
+		Você não pagou L$[AMOUNT].
+	</string>
+	<string name="you_paid_failure_ldollars_no_reason">
+		Você não pagou L$[AMOUNT] a [NAME].
+	</string>
+	<string name="you_paid_failure_ldollars_no_name">
+		Você não pagou L$[AMOUNT] referentes a [REASON].
+	</string>
+	<string name="for item">
+		por [ITEM]
+	</string>
+	<string name="for a parcel of land">
+		por uma parcela
+	</string>
+	<string name="for a land access pass">
+		por um passe de acesso
+	</string>
+	<string name="for deeding land">
+		para doar um terreno
+	</string>
+	<string name="to create a group">
+		para criar um grupo
+	</string>
+	<string name="to join a group">
+		para entrar em um grupo
+	</string>
+	<string name="to upload">
+		para carregar
+	</string>
+	<string name="to publish a classified ad">
+		para publicar um anúncio
+	</string>
+	<string name="giving">
+		Dando L$ [AMOUNT]
+	</string>
+	<string name="uploading_costs">
+		O upload custa L$ [AMOUNT]
+	</string>
+	<string name="this_costs">
+		Isso custa L$ [AMOUNT]
+	</string>
+	<string name="buying_selected_land">
+		Comprando terreno selecionado L$ [AMOUNT]
+	</string>
+	<string name="this_object_costs">
+		Esse objeto custa L$ [AMOUNT]
+	</string>
+	<string name="group_role_everyone">
+		Todos
+	</string>
+	<string name="group_role_officers">
+		Oficiais
+	</string>
+	<string name="group_role_owners">
+		Proprietários
+	</string>
+	<string name="group_member_status_online">
+		Conectado
+	</string>
+	<string name="uploading_abuse_report">
+		Carregando...
 
-Denunciar abuso</string>
-	<string name="New Shape">Nova forma</string>
-	<string name="New Skin">Nova pele</string>
-	<string name="New Hair">Novo cabelo</string>
-	<string name="New Eyes">Novos olhos</string>
-	<string name="New Shirt">Nova camisa</string>
-	<string name="New Pants">Novas calças</string>
-	<string name="New Shoes">Novos sapatos</string>
-	<string name="New Socks">Novas meias</string>
-	<string name="New Jacket">Nova blusa</string>
-	<string name="New Gloves">Novas luvas</string>
-	<string name="New Undershirt">Nova camiseta</string>
-	<string name="New Underpants">Novas roupa de baixo</string>
-	<string name="New Skirt">Nova saia</string>
-	<string name="New Alpha">Novo alpha</string>
-	<string name="New Tattoo">Nova tatuagem</string>
-	<string name="New Universal">Novo universal</string>
-	<string name="New Physics">Novo físico</string>
-	<string name="Invalid Wearable">Item inválido</string>
-	<string name="New Gesture">Novo gesto</string>
-	<string name="New Script">Novo script</string>
-	<string name="New Note">Nova nota</string>
-	<string name="New Folder">Nova pasta</string>
-	<string name="Contents">Conteúdo</string>
-	<string name="Gesture">Gesto</string>
-	<string name="Male Gestures">Gestos masculinos</string>
-	<string name="Female Gestures">Gestos femininos</string>
-	<string name="Other Gestures">Outros gestos</string>
-	<string name="Speech Gestures">Gestos da fala</string>
-	<string name="Common Gestures">Gestos comuns</string>
-	<string name="Male - Excuse me">Perdão - masculino</string>
-	<string name="Male - Get lost">Deixe-me em paz - masculino</string>
-	<string name="Male - Blow kiss">Mandar beijo - masculino</string>
-	<string name="Male - Boo">Vaia - masculino</string>
-	<string name="Male - Bored">Maçante - masculino</string>
-	<string name="Male - Hey">Ôpa! - masculino</string>
-	<string name="Male - Laugh">Risada - masculino</string>
-	<string name="Male - Repulsed">Quero distância! - masculino</string>
-	<string name="Male - Shrug">Encolher de ombros - masculino</string>
-	<string name="Male - Stick tougue out">Mostrar a língua - masculino</string>
-	<string name="Male - Wow">Wow - masculino</string>
-	<string name="Female - Chuckle">Engraçado - Feminino</string>
-	<string name="Female - Cry">Chorar - Feminino</string>
-	<string name="Female - Embarrassed">Com vergonha - Feminino</string>
-	<string name="Female - Excuse me">Perdão - fem</string>
-	<string name="Female - Get lost">Deixe-me em paz - feminino</string>
-	<string name="Female - Blow kiss">Mandar beijo - fem</string>
-	<string name="Female - Boo">Vaia - fem</string>
-	<string name="Female - Bored">Maçante - feminino</string>
-	<string name="Female - Hey">Ôpa - feminino</string>
-	<string name="Female - Hey baby">E aí, beliza? - Feminino</string>
-	<string name="Female - Laugh">Risada - feminina</string>
-	<string name="Female - Looking good">Que chique - Feminino</string>
-	<string name="Female - Over here">Acenar - Feminino</string>
-	<string name="Female - Please">Por favor - Feminino</string>
-	<string name="Female - Repulsed">Quero distância! - feminino</string>
-	<string name="Female - Shrug">Encolher ombros - feminino</string>
-	<string name="Female - Stick tougue out">Mostrar a língua - feminino</string>
-	<string name="Female - Wow">Wow - feminino</string>
-	<string name="New Daycycle">Novo ciclo de dias</string>
-	<string name="New Water">Nova água</string>
-	<string name="New Sky">Novo céu</string>
-	<string name="/bow">/reverência</string>
-	<string name="/clap">/palmas</string>
-	<string name="/count">/contar</string>
-	<string name="/extinguish">/apagar</string>
-	<string name="/kmb">/dane_se</string>
-	<string name="/muscle">/músculos</string>
-	<string name="/no">/não</string>
-	<string name="/no!">/não!</string>
-	<string name="/paper">/papel</string>
-	<string name="/pointme">/apontar_eu</string>
-	<string name="/pointyou">/apontar_você</string>
-	<string name="/rock">/pedra</string>
-	<string name="/scissor">/tesoura</string>
-	<string name="/smoke">/fumar</string>
-	<string name="/stretch">/alongar</string>
-	<string name="/whistle">/assobiar</string>
-	<string name="/yes">/sim</string>
-	<string name="/yes!">/sim!</string>
-	<string name="afk">ldt</string>
-	<string name="dance1">dança1</string>
-	<string name="dance2">dança2</string>
-	<string name="dance3">dança3</string>
-	<string name="dance4">dança4</string>
-	<string name="dance5">dança5</string>
-	<string name="dance6">dança6</string>
-	<string name="dance7">dança7</string>
-	<string name="dance8">dança8</string>
-	<string name="AvatarBirthDateFormat">[mthnum,datetime,slt]/[day,datetime,slt]/[year,datetime,slt]</string>
-	<string name="DefaultMimeType">nenhum/nehum</string>
-	<string name="texture_load_dimensions_error">A imagem excede o limite [WIDTH]*[HEIGHT]</string>
-	<string name="outfit_photo_load_dimensions_error">O tamanho máx. do look é [WIDTH]*[HEIGHT]. Redimensione ou use outra imagem</string>
-	<string name="outfit_photo_select_dimensions_error">O tamanho máx. do look é [WIDTH]*[HEIGHT]. Selecione outra textura</string>
-	<string name="outfit_photo_verify_dimensions_error">Não foi possível confirmar as dimensões da foto. Aguarde até que o tamanho da foto seja exibido no seletor</string>
+Denunciar abuso
+	</string>
+	<string name="New Shape">
+		Nova forma
+	</string>
+	<string name="New Skin">
+		Nova pele
+	</string>
+	<string name="New Hair">
+		Novo cabelo
+	</string>
+	<string name="New Eyes">
+		Novos olhos
+	</string>
+	<string name="New Shirt">
+		Nova camisa
+	</string>
+	<string name="New Pants">
+		Novas calças
+	</string>
+	<string name="New Shoes">
+		Novos sapatos
+	</string>
+	<string name="New Socks">
+		Novas meias
+	</string>
+	<string name="New Jacket">
+		Nova blusa
+	</string>
+	<string name="New Gloves">
+		Novas luvas
+	</string>
+	<string name="New Undershirt">
+		Nova camiseta
+	</string>
+	<string name="New Underpants">
+		Novas roupa de baixo
+	</string>
+	<string name="New Skirt">
+		Nova saia
+	</string>
+	<string name="New Alpha">
+		Novo alpha
+	</string>
+	<string name="New Tattoo">
+		Nova tatuagem
+	</string>
+	<string name="New Universal">
+		Novo universal
+	</string>
+	<string name="New Physics">
+		Novo físico
+	</string>
+	<string name="Invalid Wearable">
+		Item inválido
+	</string>
+	<string name="New Gesture">
+		Novo gesto
+	</string>
+	<string name="New Script">
+		Novo script
+	</string>
+	<string name="New Note">
+		Nova nota
+	</string>
+	<string name="New Folder">
+		Nova pasta
+	</string>
+	<string name="Contents">
+		Conteúdo
+	</string>
+	<string name="Gesture">
+		Gesto
+	</string>
+	<string name="Male Gestures">
+		Gestos masculinos
+	</string>
+	<string name="Female Gestures">
+		Gestos femininos
+	</string>
+	<string name="Other Gestures">
+		Outros gestos
+	</string>
+	<string name="Speech Gestures">
+		Gestos da fala
+	</string>
+	<string name="Common Gestures">
+		Gestos comuns
+	</string>
+	<string name="Male - Excuse me">
+		Perdão - masculino
+	</string>
+	<string name="Male - Get lost">
+		Deixe-me em paz - masculino
+	</string>
+	<string name="Male - Blow kiss">
+		Mandar beijo - masculino
+	</string>
+	<string name="Male - Boo">
+		Vaia - masculino
+	</string>
+	<string name="Male - Bored">
+		Maçante - masculino
+	</string>
+	<string name="Male - Hey">
+		Ôpa! - masculino
+	</string>
+	<string name="Male - Laugh">
+		Risada - masculino
+	</string>
+	<string name="Male - Repulsed">
+		Quero distância! - masculino
+	</string>
+	<string name="Male - Shrug">
+		Encolher de ombros - masculino
+	</string>
+	<string name="Male - Stick tougue out">
+		Mostrar a língua - masculino
+	</string>
+	<string name="Male - Wow">
+		Wow - masculino
+	</string>
+	<string name="Female - Chuckle">
+		Engraçado - Feminino
+	</string>
+	<string name="Female - Cry">
+		Chorar - Feminino
+	</string>
+	<string name="Female - Embarrassed">
+		Com vergonha - Feminino
+	</string>
+	<string name="Female - Excuse me">
+		Perdão - fem
+	</string>
+	<string name="Female - Get lost">
+		Deixe-me em paz - feminino
+	</string>
+	<string name="Female - Blow kiss">
+		Mandar beijo - fem
+	</string>
+	<string name="Female - Boo">
+		Vaia - fem
+	</string>
+	<string name="Female - Bored">
+		Maçante - feminino
+	</string>
+	<string name="Female - Hey">
+		Ôpa - feminino
+	</string>
+	<string name="Female - Hey baby">
+		E aí, beliza? - Feminino
+	</string>
+	<string name="Female - Laugh">
+		Risada - feminina
+	</string>
+	<string name="Female - Looking good">
+		Que chique - Feminino
+	</string>
+	<string name="Female - Over here">
+		Acenar - Feminino
+	</string>
+	<string name="Female - Please">
+		Por favor - Feminino
+	</string>
+	<string name="Female - Repulsed">
+		Quero distância! - feminino
+	</string>
+	<string name="Female - Shrug">
+		Encolher ombros - feminino
+	</string>
+	<string name="Female - Stick tougue out">
+		Mostrar a língua - feminino
+	</string>
+	<string name="Female - Wow">
+		Wow - feminino
+	</string>
+	<string name="New Daycycle">
+		Novo ciclo de dias
+	</string>
+	<string name="New Water">
+		Nova água
+	</string>
+	<string name="New Sky">
+		Novo céu
+	</string>
+	<string name="/bow">
+		/reverência
+	</string>
+	<string name="/clap">
+		/palmas
+	</string>
+	<string name="/count">
+		/contar
+	</string>
+	<string name="/extinguish">
+		/apagar
+	</string>
+	<string name="/kmb">
+		/dane_se
+	</string>
+	<string name="/muscle">
+		/músculos
+	</string>
+	<string name="/no">
+		/não
+	</string>
+	<string name="/no!">
+		/não!
+	</string>
+	<string name="/paper">
+		/papel
+	</string>
+	<string name="/pointme">
+		/apontar_eu
+	</string>
+	<string name="/pointyou">
+		/apontar_você
+	</string>
+	<string name="/rock">
+		/pedra
+	</string>
+	<string name="/scissor">
+		/tesoura
+	</string>
+	<string name="/smoke">
+		/fumar
+	</string>
+	<string name="/stretch">
+		/alongar
+	</string>
+	<string name="/whistle">
+		/assobiar
+	</string>
+	<string name="/yes">
+		/sim
+	</string>
+	<string name="/yes!">
+		/sim!
+	</string>
+	<string name="afk">
+		ldt
+	</string>
+	<string name="dance1">
+		dança1
+	</string>
+	<string name="dance2">
+		dança2
+	</string>
+	<string name="dance3">
+		dança3
+	</string>
+	<string name="dance4">
+		dança4
+	</string>
+	<string name="dance5">
+		dança5
+	</string>
+	<string name="dance6">
+		dança6
+	</string>
+	<string name="dance7">
+		dança7
+	</string>
+	<string name="dance8">
+		dança8
+	</string>
+	<string name="AvatarBirthDateFormat">
+		[mthnum,datetime,slt]/[day,datetime,slt]/[year,datetime,slt]
+	</string>
+	<string name="DefaultMimeType">
+		nenhum/nehum
+	</string>
+	<string name="texture_load_dimensions_error">
+		A imagem excede o limite [WIDTH]*[HEIGHT]
+	</string>
+	<string name="outfit_photo_load_dimensions_error">
+		O tamanho máx. do look é [WIDTH]*[HEIGHT]. Redimensione ou use outra imagem
+	</string>
+	<string name="outfit_photo_select_dimensions_error">
+		O tamanho máx. do look é [WIDTH]*[HEIGHT]. Selecione outra textura
+	</string>
+	<string name="outfit_photo_verify_dimensions_error">
+		Não foi possível confirmar as dimensões da foto. Aguarde até que o tamanho da foto seja exibido no seletor
+	</string>
 	<string name="words_separator" value=","/>
-	<string name="server_is_down">Aconteceu algo inesperado, apesar de termos tentado impedir isso.
+	<string name="server_is_down">
+		Aconteceu algo inesperado, apesar de termos tentado impedir isso.
 
 Visite http://status.secondlifegrid.net para saber se foi detectado um problema com o serviço.
-        Se o problema persistir, cheque a configuração da sua rede e firewall.</string>
-	<string name="dateTimeWeekdaysNames">Domingo:Segunda:Terça:Quarta:Quinta:Sexta:Sábado</string>
-	<string name="dateTimeWeekdaysShortNames">Dom:Seg:Ter:Qua:Qui:Sex:Sab</string>
-	<string name="dateTimeMonthNames">Janeiro:Fevereiro:Março:Abril:Maio:Junho:Julho:Agosto:Setembro:Outubro:Novembro:Dezembro</string>
-	<string name="dateTimeMonthShortNames">Jan:Fev:Mar:Abr:Maio:Jun:Jul:Ago:Set:Out:Nov:Dez</string>
-	<string name="dateTimeDayFormat">[MDAY]</string>
-	<string name="dateTimeAM">AM</string>
-	<string name="dateTimePM">PM</string>
-	<string name="LocalEstimateUSD">US$ [AMOUNT]</string>
-	<string name="Group Ban">Banimento do grupo</string>
-	<string name="Membership">Plano</string>
-	<string name="Roles">Cargos</string>
-	<string name="Group Identity">Identidade do lote</string>
-	<string name="Parcel Management">Gestão do lote</string>
-	<string name="Parcel Identity">ID do lote</string>
-	<string name="Parcel Settings">Configurações do lote</string>
-	<string name="Parcel Powers">Poderes do lote</string>
-	<string name="Parcel Access">Acesso ao lote</string>
-	<string name="Parcel Content">Conteúdo do lote</string>
-	<string name="Object Management">Gestão de objetos</string>
-	<string name="Accounting">Contabilidade</string>
-	<string name="Notices">Avisos</string>
-	<string name="Chat" value="Bate papo">Bate-papo</string>
-	<string name="BaseMembership">Base</string>
-	<string name="DeleteItems">Excluir itens selecionados?</string>
-	<string name="DeleteItem">Excluir item selecionado?</string>
-	<string name="EmptyOutfitText">Este look não possui nenhuma peça</string>
-	<string name="ExternalEditorNotSet">Selecione um editor utilizando a configuração ExternalEditor.</string>
-	<string name="ExternalEditorNotFound">O editor externo especificado não foi localizado.
+        Se o problema persistir, cheque a configuração da sua rede e firewall.
+	</string>
+	<string name="dateTimeWeekdaysNames">
+		Domingo:Segunda:Terça:Quarta:Quinta:Sexta:Sábado
+	</string>
+	<string name="dateTimeWeekdaysShortNames">
+		Dom:Seg:Ter:Qua:Qui:Sex:Sab
+	</string>
+	<string name="dateTimeMonthNames">
+		Janeiro:Fevereiro:Março:Abril:Maio:Junho:Julho:Agosto:Setembro:Outubro:Novembro:Dezembro
+	</string>
+	<string name="dateTimeMonthShortNames">
+		Jan:Fev:Mar:Abr:Maio:Jun:Jul:Ago:Set:Out:Nov:Dez
+	</string>
+	<string name="dateTimeDayFormat">
+		[MDAY]
+	</string>
+	<string name="dateTimeAM">
+		AM
+	</string>
+	<string name="dateTimePM">
+		PM
+	</string>
+	<string name="LocalEstimateUSD">
+		US$ [AMOUNT]
+	</string>
+	<string name="Group Ban">
+		Banimento do grupo
+	</string>
+	<string name="Membership">
+		Plano
+	</string>
+	<string name="Roles">
+		Cargos
+	</string>
+	<string name="Group Identity">
+		Identidade do lote
+	</string>
+	<string name="Parcel Management">
+		Gestão do lote
+	</string>
+	<string name="Parcel Identity">
+		ID do lote
+	</string>
+	<string name="Parcel Settings">
+		Configurações do lote
+	</string>
+	<string name="Parcel Powers">
+		Poderes do lote
+	</string>
+	<string name="Parcel Access">
+		Acesso ao lote
+	</string>
+	<string name="Parcel Content">
+		Conteúdo do lote
+	</string>
+	<string name="Object Management">
+		Gestão de objetos
+	</string>
+	<string name="Accounting">
+		Contabilidade
+	</string>
+	<string name="Notices">
+		Avisos
+	</string>
+	<string name="Chat" value="Bate papo">
+		Bate-papo
+	</string>
+	<string name="BaseMembership">
+		Base
+	</string>
+	<string name="DeleteItems">
+		Excluir itens selecionados?
+	</string>
+	<string name="DeleteItem">
+		Excluir item selecionado?
+	</string>
+	<string name="EmptyOutfitText">
+		Este look não possui nenhuma peça
+	</string>
+	<string name="ExternalEditorNotSet">
+		Selecione um editor utilizando a configuração ExternalEditor.
+	</string>
+	<string name="ExternalEditorNotFound">
+		O editor externo especificado não foi localizado.
 Tente colocar o caminho do editor entre aspas.
-(ex. &quot;/caminho para/editor&quot; &quot;%s&quot;)</string>
-	<string name="ExternalEditorCommandParseError">Error ao analisar o comando do editor externo.</string>
-	<string name="ExternalEditorFailedToRun">Falha de execução do editor externo.</string>
-	<string name="TranslationFailed">Falha na tradução: [REASON]</string>
-	<string name="TranslationResponseParseError">Erro ao analisar resposta de tradução.</string>
-	<string name="Esc">Esc</string>
-	<string name="Space">Space</string>
-	<string name="Enter">Enter</string>
-	<string name="Tab">Tab</string>
-	<string name="Ins">Ins</string>
-	<string name="Del">Del</string>
-	<string name="Backsp">Backsp</string>
-	<string name="Shift">Shift</string>
-	<string name="Ctrl">Ctrl</string>
-	<string name="Alt">Alt</string>
-	<string name="CapsLock">CapsLock</string>
-	<string name="Home">Início</string>
-	<string name="End">End</string>
-	<string name="PgUp">PgUp</string>
-	<string name="PgDn">PgDn</string>
-	<string name="F1">F1</string>
-	<string name="F2">F2</string>
-	<string name="F3">F3</string>
-	<string name="F4">F4</string>
-	<string name="F5">F5</string>
-	<string name="F6">F6</string>
-	<string name="F7">F7</string>
-	<string name="F8">F8</string>
-	<string name="F9">F9</string>
-	<string name="F10">F10</string>
-	<string name="F11">F11</string>
-	<string name="F12">F12</string>
-	<string name="Add">Adicionar</string>
-	<string name="Subtract">Subtrair</string>
-	<string name="Multiply">Multiplicar</string>
-	<string name="Divide">Dividir</string>
-	<string name="PAD_DIVIDE">PAD_DIVIDE</string>
-	<string name="PAD_LEFT">PAD_LEFT</string>
-	<string name="PAD_RIGHT">PAD_RIGHT</string>
-	<string name="PAD_DOWN">PAD_DOWN</string>
-	<string name="PAD_UP">PAD_UP</string>
-	<string name="PAD_HOME">PAD_HOME</string>
-	<string name="PAD_END">PAD_END</string>
-	<string name="PAD_PGUP">PAD_PGUP</string>
-	<string name="PAD_PGDN">PAD_PGDN</string>
-	<string name="PAD_CENTER">PAD_CENTER</string>
-	<string name="PAD_INS">PAD_INS</string>
-	<string name="PAD_DEL">PAD_DEL</string>
-	<string name="PAD_Enter">PAD_Enter</string>
-	<string name="PAD_BUTTON0">PAD_BUTTON0</string>
-	<string name="PAD_BUTTON1">PAD_BUTTON1</string>
-	<string name="PAD_BUTTON2">PAD_BUTTON2</string>
-	<string name="PAD_BUTTON3">PAD_BUTTON3</string>
-	<string name="PAD_BUTTON4">PAD_BUTTON4</string>
-	<string name="PAD_BUTTON5">PAD_BUTTON5</string>
-	<string name="PAD_BUTTON6">PAD_BUTTON6</string>
-	<string name="PAD_BUTTON7">PAD_BUTTON7</string>
-	<string name="PAD_BUTTON8">PAD_BUTTON8</string>
-	<string name="PAD_BUTTON9">PAD_BUTTON9</string>
-	<string name="PAD_BUTTON10">PAD_BUTTON10</string>
-	<string name="PAD_BUTTON11">PAD_BUTTON11</string>
-	<string name="PAD_BUTTON12">PAD_BUTTON12</string>
-	<string name="PAD_BUTTON13">PAD_BUTTON13</string>
-	<string name="PAD_BUTTON14">PAD_BUTTON14</string>
-	<string name="PAD_BUTTON15">PAD_BUTTON15</string>
-	<string name="-">-</string>
-	<string name="=">=</string>
-	<string name="`">`</string>
-	<string name=";">;</string>
-	<string name="[">[</string>
-	<string name="]">]</string>
-	<string name="\">\</string>
-	<string name="0">0</string>
-	<string name="1">1</string>
-	<string name="2">2</string>
-	<string name="3">3</string>
-	<string name="4">4</string>
-	<string name="5">5</string>
-	<string name="6">6</string>
-	<string name="7">7</string>
-	<string name="8">8</string>
-	<string name="9">9</string>
-	<string name="A">A</string>
-	<string name="B">B</string>
-	<string name="C">C</string>
-	<string name="D">D</string>
-	<string name="E">E</string>
-	<string name="F">F</string>
-	<string name="G">G</string>
-	<string name="H">H</string>
-	<string name="I">I</string>
-	<string name="J">J</string>
-	<string name="K">K</string>
-	<string name="L">L</string>
-	<string name="M">M</string>
-	<string name="N">N</string>
-	<string name="O">O</string>
-	<string name="P">P</string>
-	<string name="Q">Q</string>
-	<string name="R">R</string>
-	<string name="S">S</string>
-	<string name="T">T</string>
-	<string name="U">U</string>
-	<string name="V">V</string>
-	<string name="W">W</string>
-	<string name="X">X</string>
-	<string name="Y">Y</string>
-	<string name="Z">Z</string>
-	<string name="BeaconParticle">Vendo balizas de partículas (azul)</string>
-	<string name="BeaconPhysical">Vendo balizas de objetos físicos (verde)</string>
-	<string name="BeaconScripted">Vendo balizas de objetos com script (vermelho)</string>
-	<string name="BeaconScriptedTouch">Vendo objeto com script com balizas com funcionalidade de toque (vermelho)</string>
-	<string name="BeaconSound">Vendo balizas de som (amarelo)</string>
-	<string name="BeaconMedia">Vendo balizas de mídia (branco)</string>
-	<string name="BeaconSun">Visualizando farol de direção do sol (alaranjado)</string>
-	<string name="BeaconMoon">Visualizando farol de direção da lua (roxo)</string>
-	<string name="ParticleHiding">Ocultar partículas</string>
-	<string name="Command_AboutLand_Label">Sobre terrenos</string>
-	<string name="Command_Appearance_Label">Aparência</string>
-	<string name="Command_Avatar_Label">Avatar</string>
-	<string name="Command_Build_Label">Construir</string>
-	<string name="Command_Chat_Label">Bate-papo</string>
-	<string name="Command_Conversations_Label">Conversas</string>
-	<string name="Command_Compass_Label">Bússola</string>
-	<string name="Command_Destinations_Label">Destinos</string>
-	<string name="Command_Environments_Label">Meus ambientes</string>
-	<string name="Command_Facebook_Label">Facebook</string>
-	<string name="Command_Flickr_Label">Flickr</string>
-	<string name="Command_Gestures_Label">Gestos</string>
-	<string name="Command_Grid_Status_Label">Status da grade</string>
-	<string name="Command_HowTo_Label">Como</string>
-	<string name="Command_Inventory_Label">Inventário</string>
-	<string name="Command_Map_Label">Mapa</string>
-	<string name="Command_Marketplace_Label">Mercado</string>
-	<string name="Command_MarketplaceListings_Label">Marketplace</string>
-	<string name="Command_MiniMap_Label">Mini Mapa</string>
-	<string name="Command_Move_Label">Andar/correr/voar</string>
-	<string name="Command_Outbox_Label">Caixa de saída do lojista</string>
-	<string name="Command_People_Label">Pessoas</string>
-	<string name="Command_Picks_Label">Destaques</string>
-	<string name="Command_Places_Label">Lugares</string>
-	<string name="Command_Preferences_Label">Preferências</string>
-	<string name="Command_Profile_Label">Perfil</string>
-	<string name="Command_Report_Abuse_Label">Relatar abuso</string>
-	<string name="Command_Search_Label">Buscar</string>
-	<string name="Command_Snapshot_Label">Foto</string>
-	<string name="Command_Speak_Label">Falar</string>
-	<string name="Command_Twitter_Label">Twitter</string>
-	<string name="Command_View_Label">Controles da câmera</string>
-	<string name="Command_Voice_Label">Configurações de voz</string>
-	<string name="Command_AboutLand_Tooltip">Informações sobre o terreno que você está visitando</string>
-	<string name="Command_Appearance_Tooltip">Mudar seu avatar</string>
-	<string name="Command_Avatar_Tooltip">Escolha um avatar completo</string>
-	<string name="Command_Build_Tooltip">Construindo objetos e redimensionando terreno</string>
-	<string name="Command_Chat_Tooltip">Bater papo com pessoas próximas usando texto</string>
-	<string name="Command_Conversations_Tooltip">Conversar com todos</string>
-	<string name="Command_Compass_Tooltip">Bússola</string>
-	<string name="Command_Destinations_Tooltip">Destinos de interesse</string>
-	<string name="Command_Environments_Tooltip">Meus ambientes</string>
-	<string name="Command_Facebook_Tooltip">Publicar no Facebook</string>
-	<string name="Command_Flickr_Tooltip">Carregar no Flickr</string>
-	<string name="Command_Gestures_Tooltip">Gestos para seu avatar</string>
-	<string name="Command_Grid_Status_Tooltip">Mostrar status da grade atual</string>
-	<string name="Command_HowTo_Tooltip">Como executar tarefas comuns</string>
-	<string name="Command_Inventory_Tooltip">Exibir e usar seus pertences</string>
-	<string name="Command_Map_Tooltip">Mapa-múndi</string>
-	<string name="Command_Marketplace_Tooltip">Faça compras</string>
-	<string name="Command_MarketplaceListings_Tooltip">Venda suas criações</string>
-	<string name="Command_MiniMap_Tooltip">Mostrar quem está aqui</string>
-	<string name="Command_Move_Tooltip">Movendo seu avatar</string>
-	<string name="Command_Outbox_Tooltip">Transferir itens para o seu mercado para venda</string>
-	<string name="Command_People_Tooltip">Amigos, grupos e pessoas próximas</string>
-	<string name="Command_Picks_Tooltip">Lugares mostrados como favoritos em seu perfil</string>
-	<string name="Command_Places_Tooltip">Lugares salvos</string>
-	<string name="Command_Preferences_Tooltip">Preferências</string>
-	<string name="Command_Profile_Tooltip">Edite ou visualize seu perfil</string>
-	<string name="Command_Report_Abuse_Tooltip">Relatar abuso</string>
-	<string name="Command_Search_Tooltip">Encontre lugares, eventos, pessoas</string>
-	<string name="Command_Snapshot_Tooltip">Tirar uma foto</string>
-	<string name="Command_Speak_Tooltip">Fale com pessoas próximas usando seu microfone</string>
-	<string name="Command_Twitter_Tooltip">Twitter</string>
-	<string name="Command_View_Tooltip">Alterar o ângulo da câmera</string>
-	<string name="Command_Voice_Tooltip">Controles de volume das chamadas e pessoas próximas a você no mundo virtual</string>
-	<string name="Toolbar_Bottom_Tooltip">atualmente na sua barra de ferramentas inferior</string>
-	<string name="Toolbar_Left_Tooltip">atualmente na sua barra de ferramentas esquerda</string>
-	<string name="Toolbar_Right_Tooltip">atualmente na sua barra de ferramentas direita</string>
-	<string name="Retain%">Reter%</string>
-	<string name="Detail">Detalhe</string>
-	<string name="Better Detail">Detalhamento maior</string>
-	<string name="Surface">Superfície</string>
-	<string name="Solid">Sólido</string>
-	<string name="Wrap">Conclusão</string>
-	<string name="Preview">Visualizar</string>
-	<string name="Normal">Normal</string>
-	<string name="Pathfinding_Wiki_URL">http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer</string>
-	<string name="Pathfinding_Object_Attr_None">Nenhum</string>
-	<string name="Pathfinding_Object_Attr_Permanent">Afeta o navmesh</string>
-	<string name="Pathfinding_Object_Attr_Character">Personagem</string>
-	<string name="Pathfinding_Object_Attr_MultiSelect">(Múltiplo)</string>
-	<string name="snapshot_quality_very_low">Muito baixo</string>
-	<string name="snapshot_quality_low">Baixo</string>
-	<string name="snapshot_quality_medium">Médio</string>
-	<string name="snapshot_quality_high">Alto</string>
-	<string name="snapshot_quality_very_high">Muito alto</string>
-	<string name="TeleportMaturityExceeded">O residente não pode visitar a região.</string>
-	<string name="UserDictionary">[Usuário]</string>
-	<string name="experience_tools_experience">Experiência</string>
-	<string name="ExperienceNameNull">(nenhuma experiência)</string>
-	<string name="ExperienceNameUntitled">(experiência sem título)</string>
-	<string name="Land-Scope">Dentro do terreno</string>
-	<string name="Grid-Scope">Dentro da grade</string>
-	<string name="Allowed_Experiences_Tab">PERMITIDO</string>
-	<string name="Blocked_Experiences_Tab">BLOQUEADO</string>
-	<string name="Contrib_Experiences_Tab">COLABORADOR</string>
-	<string name="Admin_Experiences_Tab">ADMINISTRADOR</string>
-	<string name="Recent_Experiences_Tab">RECENTE</string>
-	<string name="Owned_Experiences_Tab">PRÓPRIAS</string>
-	<string name="ExperiencesCounter">([EXPERIENCES], máx. [MAXEXPERIENCES])</string>
-	<string name="ExperiencePermission1">assumir seus controles</string>
-	<string name="ExperiencePermission3">acionar animações no seu avatar</string>
-	<string name="ExperiencePermission4">anexar ao avatar</string>
-	<string name="ExperiencePermission9">rastrear sua câmera</string>
-	<string name="ExperiencePermission10">controlar sua câmera</string>
-	<string name="ExperiencePermission11">teletransportar você</string>
-	<string name="ExperiencePermission12">aceitar automaticamente permissões de experiência</string>
-	<string name="ExperiencePermission16">forçar o avatar a sentar</string>
-	<string name="ExperiencePermission17">alterar sua configurações de ambiente</string>
-	<string name="ExperiencePermissionShortUnknown">realizar uma operação desconhecida: [Permission]</string>
-	<string name="ExperiencePermissionShort1">Assumir o controle</string>
-	<string name="ExperiencePermissionShort3">Acionar animações</string>
-	<string name="ExperiencePermissionShort4">Anexar</string>
-	<string name="ExperiencePermissionShort9">Rastrear câmera</string>
-	<string name="ExperiencePermissionShort10">Controlar câmera</string>
-	<string name="ExperiencePermissionShort11">Teletransportar</string>
-	<string name="ExperiencePermissionShort12">Autorização</string>
-	<string name="ExperiencePermissionShort16">Sentar</string>
-	<string name="ExperiencePermissionShort17">Ambiente</string>
-	<string name="logging_calls_disabled_log_empty">As conversas não estão sendo registradas. Para começar a manter um registro, selecione &quot;Salvar: apenas registro&quot; ou &quot;Salvar: registro e transcrições&quot; em Preferências&gt; Bate-papo.</string>
-	<string name="logging_calls_disabled_log_not_empty">Nenhuma conversa será registrada. Para recomeçar a gravação de registros, selecione &quot;Salvar: apenas registro&quot; ou &quot;Salvar: registro e transcrições&quot; em Preferências&gt; Bate-papo.</string>
-	<string name="logging_calls_enabled_log_empty">Não há conversas registradas. Depois que você entrar em contato com alguém, ou alguém entrar em contato com você, um registro será exibido aqui.</string>
-	<string name="loading_chat_logs">Carregando...</string>
-	<string name="na">n/d</string>
-	<string name="preset_combo_label">-Lista vazia-</string>
-	<string name="Default">Padrão</string>
-	<string name="none_paren_cap">(nenhum)</string>
-	<string name="no_limit">Sem limite</string>
-	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">A forma física contém triângulos muito pequenos. Tente simplificar o modelo físico.</string>
-	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">A forma física contém dados de confirmação ruins. Tente consertar o modelo físico.</string>
-	<string name="Mav_Details_MAV_UNKNOWN_VERSION">A forma física não tem a versão correta. Defina a versão correta para o modelo físico.</string>
-	<string name="couldnt_resolve_host">O DNS não pode resolver o nome do host([HOSTNAME]). 
+(ex. "/caminho para/editor" "%s")
+	</string>
+	<string name="ExternalEditorCommandParseError">
+		Error ao analisar o comando do editor externo.
+	</string>
+	<string name="ExternalEditorFailedToRun">
+		Falha de execução do editor externo.
+	</string>
+	<string name="TranslationFailed">
+		Falha na tradução: [REASON]
+	</string>
+	<string name="TranslationResponseParseError">
+		Erro ao analisar resposta de tradução.
+	</string>
+	<string name="Esc">
+		Esc
+	</string>
+	<string name="Space">
+		Space
+	</string>
+	<string name="Enter">
+		Enter
+	</string>
+	<string name="Tab">
+		Tab
+	</string>
+	<string name="Ins">
+		Ins
+	</string>
+	<string name="Del">
+		Del
+	</string>
+	<string name="Backsp">
+		Backsp
+	</string>
+	<string name="Shift">
+		Shift
+	</string>
+	<string name="Ctrl">
+		Ctrl
+	</string>
+	<string name="Alt">
+		Alt
+	</string>
+	<string name="CapsLock">
+		CapsLock
+	</string>
+	<string name="Home">
+		Início
+	</string>
+	<string name="End">
+		End
+	</string>
+	<string name="PgUp">
+		PgUp
+	</string>
+	<string name="PgDn">
+		PgDn
+	</string>
+	<string name="F1">
+		F1
+	</string>
+	<string name="F2">
+		F2
+	</string>
+	<string name="F3">
+		F3
+	</string>
+	<string name="F4">
+		F4
+	</string>
+	<string name="F5">
+		F5
+	</string>
+	<string name="F6">
+		F6
+	</string>
+	<string name="F7">
+		F7
+	</string>
+	<string name="F8">
+		F8
+	</string>
+	<string name="F9">
+		F9
+	</string>
+	<string name="F10">
+		F10
+	</string>
+	<string name="F11">
+		F11
+	</string>
+	<string name="F12">
+		F12
+	</string>
+	<string name="Add">
+		Adicionar
+	</string>
+	<string name="Subtract">
+		Subtrair
+	</string>
+	<string name="Multiply">
+		Multiplicar
+	</string>
+	<string name="Divide">
+		Dividir
+	</string>
+	<string name="PAD_DIVIDE">
+		PAD_DIVIDE
+	</string>
+	<string name="PAD_LEFT">
+		PAD_LEFT
+	</string>
+	<string name="PAD_RIGHT">
+		PAD_RIGHT
+	</string>
+	<string name="PAD_DOWN">
+		PAD_DOWN
+	</string>
+	<string name="PAD_UP">
+		PAD_UP
+	</string>
+	<string name="PAD_HOME">
+		PAD_HOME
+	</string>
+	<string name="PAD_END">
+		PAD_END
+	</string>
+	<string name="PAD_PGUP">
+		PAD_PGUP
+	</string>
+	<string name="PAD_PGDN">
+		PAD_PGDN
+	</string>
+	<string name="PAD_CENTER">
+		PAD_CENTER
+	</string>
+	<string name="PAD_INS">
+		PAD_INS
+	</string>
+	<string name="PAD_DEL">
+		PAD_DEL
+	</string>
+	<string name="PAD_Enter">
+		PAD_Enter
+	</string>
+	<string name="PAD_BUTTON0">
+		PAD_BUTTON0
+	</string>
+	<string name="PAD_BUTTON1">
+		PAD_BUTTON1
+	</string>
+	<string name="PAD_BUTTON2">
+		PAD_BUTTON2
+	</string>
+	<string name="PAD_BUTTON3">
+		PAD_BUTTON3
+	</string>
+	<string name="PAD_BUTTON4">
+		PAD_BUTTON4
+	</string>
+	<string name="PAD_BUTTON5">
+		PAD_BUTTON5
+	</string>
+	<string name="PAD_BUTTON6">
+		PAD_BUTTON6
+	</string>
+	<string name="PAD_BUTTON7">
+		PAD_BUTTON7
+	</string>
+	<string name="PAD_BUTTON8">
+		PAD_BUTTON8
+	</string>
+	<string name="PAD_BUTTON9">
+		PAD_BUTTON9
+	</string>
+	<string name="PAD_BUTTON10">
+		PAD_BUTTON10
+	</string>
+	<string name="PAD_BUTTON11">
+		PAD_BUTTON11
+	</string>
+	<string name="PAD_BUTTON12">
+		PAD_BUTTON12
+	</string>
+	<string name="PAD_BUTTON13">
+		PAD_BUTTON13
+	</string>
+	<string name="PAD_BUTTON14">
+		PAD_BUTTON14
+	</string>
+	<string name="PAD_BUTTON15">
+		PAD_BUTTON15
+	</string>
+	<string name="-">
+		-
+	</string>
+	<string name="=">
+		=
+	</string>
+	<string name="`">
+		`
+	</string>
+	<string name=";">
+		;
+	</string>
+	<string name="[">
+		[
+	</string>
+	<string name="]">
+		]
+	</string>
+	<string name="\">
+		\
+	</string>
+	<string name="0">
+		0
+	</string>
+	<string name="1">
+		1
+	</string>
+	<string name="2">
+		2
+	</string>
+	<string name="3">
+		3
+	</string>
+	<string name="4">
+		4
+	</string>
+	<string name="5">
+		5
+	</string>
+	<string name="6">
+		6
+	</string>
+	<string name="7">
+		7
+	</string>
+	<string name="8">
+		8
+	</string>
+	<string name="9">
+		9
+	</string>
+	<string name="A">
+		A
+	</string>
+	<string name="B">
+		B
+	</string>
+	<string name="C">
+		C
+	</string>
+	<string name="D">
+		D
+	</string>
+	<string name="E">
+		E
+	</string>
+	<string name="F">
+		F
+	</string>
+	<string name="G">
+		G
+	</string>
+	<string name="H">
+		H
+	</string>
+	<string name="I">
+		I
+	</string>
+	<string name="J">
+		J
+	</string>
+	<string name="K">
+		K
+	</string>
+	<string name="L">
+		L
+	</string>
+	<string name="M">
+		M
+	</string>
+	<string name="N">
+		N
+	</string>
+	<string name="O">
+		O
+	</string>
+	<string name="P">
+		P
+	</string>
+	<string name="Q">
+		Q
+	</string>
+	<string name="R">
+		R
+	</string>
+	<string name="S">
+		S
+	</string>
+	<string name="T">
+		T
+	</string>
+	<string name="U">
+		U
+	</string>
+	<string name="V">
+		V
+	</string>
+	<string name="W">
+		W
+	</string>
+	<string name="X">
+		X
+	</string>
+	<string name="Y">
+		Y
+	</string>
+	<string name="Z">
+		Z
+	</string>
+	<string name="BeaconParticle">
+		Vendo balizas de partículas (azul)
+	</string>
+	<string name="BeaconPhysical">
+		Vendo balizas de objetos físicos (verde)
+	</string>
+	<string name="BeaconScripted">
+		Vendo balizas de objetos com script (vermelho)
+	</string>
+	<string name="BeaconScriptedTouch">
+		Vendo objeto com script com balizas com funcionalidade de toque (vermelho)
+	</string>
+	<string name="BeaconSound">
+		Vendo balizas de som (amarelo)
+	</string>
+	<string name="BeaconMedia">
+		Vendo balizas de mídia (branco)
+	</string>
+	<string name="BeaconSun">
+		Visualizando farol de direção do sol (alaranjado)
+	</string>
+	<string name="BeaconMoon">
+		Visualizando farol de direção da lua (roxo)
+	</string>
+	<string name="ParticleHiding">
+		Ocultar partículas
+	</string>
+	<string name="Command_AboutLand_Label">
+		Sobre terrenos
+	</string>
+	<string name="Command_Appearance_Label">
+		Aparência
+	</string>
+	<string name="Command_Avatar_Label">
+		Avatar
+	</string>
+	<string name="Command_Build_Label">
+		Construir
+	</string>
+	<string name="Command_Chat_Label">
+		Bate-papo
+	</string>
+	<string name="Command_Conversations_Label">
+		Conversas
+	</string>
+	<string name="Command_Compass_Label">
+		Bússola
+	</string>
+	<string name="Command_Destinations_Label">
+		Destinos
+	</string>
+	<string name="Command_Environments_Label">
+		Meus ambientes
+	</string>
+	<string name="Command_Facebook_Label">
+		Facebook
+	</string>
+	<string name="Command_Flickr_Label">
+		Flickr
+	</string>
+	<string name="Command_Gestures_Label">
+		Gestos
+	</string>
+	<string name="Command_Grid_Status_Label">
+		Status da grade
+	</string>
+	<string name="Command_HowTo_Label">
+		Como
+	</string>
+	<string name="Command_Inventory_Label">
+		Inventário
+	</string>
+	<string name="Command_Map_Label">
+		Mapa
+	</string>
+	<string name="Command_Marketplace_Label">
+		Mercado
+	</string>
+	<string name="Command_MarketplaceListings_Label">
+		Marketplace
+	</string>
+	<string name="Command_MiniMap_Label">
+		Mini Mapa
+	</string>
+	<string name="Command_Move_Label">
+		Andar/correr/voar
+	</string>
+	<string name="Command_Outbox_Label">
+		Caixa de saída do lojista
+	</string>
+	<string name="Command_People_Label">
+		Pessoas
+	</string>
+	<string name="Command_Picks_Label">
+		Destaques
+	</string>
+	<string name="Command_Places_Label">
+		Lugares
+	</string>
+	<string name="Command_Preferences_Label">
+		Preferências
+	</string>
+	<string name="Command_Profile_Label">
+		Perfil
+	</string>
+	<string name="Command_Report_Abuse_Label">
+		Relatar abuso
+	</string>
+	<string name="Command_Search_Label">
+		Buscar
+	</string>
+	<string name="Command_Snapshot_Label">
+		Foto
+	</string>
+	<string name="Command_Speak_Label">
+		Falar
+	</string>
+	<string name="Command_Twitter_Label">
+		Twitter
+	</string>
+	<string name="Command_View_Label">
+		Controles da câmera
+	</string>
+	<string name="Command_Voice_Label">
+		Configurações de voz
+	</string>
+	<string name="Command_AboutLand_Tooltip">
+		Informações sobre o terreno que você está visitando
+	</string>
+	<string name="Command_Appearance_Tooltip">
+		Mudar seu avatar
+	</string>
+	<string name="Command_Avatar_Tooltip">
+		Escolha um avatar completo
+	</string>
+	<string name="Command_Build_Tooltip">
+		Construindo objetos e redimensionando terreno
+	</string>
+	<string name="Command_Chat_Tooltip">
+		Bater papo com pessoas próximas usando texto
+	</string>
+	<string name="Command_Conversations_Tooltip">
+		Conversar com todos
+	</string>
+	<string name="Command_Compass_Tooltip">
+		Bússola
+	</string>
+	<string name="Command_Destinations_Tooltip">
+		Destinos de interesse
+	</string>
+	<string name="Command_Environments_Tooltip">
+		Meus ambientes
+	</string>
+	<string name="Command_Facebook_Tooltip">
+		Publicar no Facebook
+	</string>
+	<string name="Command_Flickr_Tooltip">
+		Carregar no Flickr
+	</string>
+	<string name="Command_Gestures_Tooltip">
+		Gestos para seu avatar
+	</string>
+	<string name="Command_Grid_Status_Tooltip">
+		Mostrar status da grade atual
+	</string>
+	<string name="Command_HowTo_Tooltip">
+		Como executar tarefas comuns
+	</string>
+	<string name="Command_Inventory_Tooltip">
+		Exibir e usar seus pertences
+	</string>
+	<string name="Command_Map_Tooltip">
+		Mapa-múndi
+	</string>
+	<string name="Command_Marketplace_Tooltip">
+		Faça compras
+	</string>
+	<string name="Command_MarketplaceListings_Tooltip">
+		Venda suas criações
+	</string>
+	<string name="Command_MiniMap_Tooltip">
+		Mostrar quem está aqui
+	</string>
+	<string name="Command_Move_Tooltip">
+		Movendo seu avatar
+	</string>
+	<string name="Command_Outbox_Tooltip">
+		Transferir itens para o seu mercado para venda
+	</string>
+	<string name="Command_People_Tooltip">
+		Amigos, grupos e pessoas próximas
+	</string>
+	<string name="Command_Picks_Tooltip">
+		Lugares mostrados como favoritos em seu perfil
+	</string>
+	<string name="Command_Places_Tooltip">
+		Lugares salvos
+	</string>
+	<string name="Command_Preferences_Tooltip">
+		Preferências
+	</string>
+	<string name="Command_Profile_Tooltip">
+		Edite ou visualize seu perfil
+	</string>
+	<string name="Command_Report_Abuse_Tooltip">
+		Relatar abuso
+	</string>
+	<string name="Command_Search_Tooltip">
+		Encontre lugares, eventos, pessoas
+	</string>
+	<string name="Command_Snapshot_Tooltip">
+		Tirar uma foto
+	</string>
+	<string name="Command_Speak_Tooltip">
+		Fale com pessoas próximas usando seu microfone
+	</string>
+	<string name="Command_Twitter_Tooltip">
+		Twitter
+	</string>
+	<string name="Command_View_Tooltip">
+		Alterar o ângulo da câmera
+	</string>
+	<string name="Command_Voice_Tooltip">
+		Controles de volume das chamadas e pessoas próximas a você no mundo virtual
+	</string>
+	<string name="Toolbar_Bottom_Tooltip">
+		atualmente na sua barra de ferramentas inferior
+	</string>
+	<string name="Toolbar_Left_Tooltip">
+		atualmente na sua barra de ferramentas esquerda
+	</string>
+	<string name="Toolbar_Right_Tooltip">
+		atualmente na sua barra de ferramentas direita
+	</string>
+	<string name="Retain%">
+		Reter%
+	</string>
+	<string name="Detail">
+		Detalhe
+	</string>
+	<string name="Better Detail">
+		Detalhamento maior
+	</string>
+	<string name="Surface">
+		Superfície
+	</string>
+	<string name="Solid">
+		Sólido
+	</string>
+	<string name="Wrap">
+		Conclusão
+	</string>
+	<string name="Preview">
+		Visualizar
+	</string>
+	<string name="Normal">
+		Normal
+	</string>
+	<string name="Pathfinding_Wiki_URL">
+		http://wiki.secondlife.com/wiki/Pathfinding_Tools_in_the_Second_Life_Viewer
+	</string>
+	<string name="Pathfinding_Object_Attr_None">
+		Nenhum
+	</string>
+	<string name="Pathfinding_Object_Attr_Permanent">
+		Afeta o navmesh
+	</string>
+	<string name="Pathfinding_Object_Attr_Character">
+		Personagem
+	</string>
+	<string name="Pathfinding_Object_Attr_MultiSelect">
+		(Múltiplo)
+	</string>
+	<string name="snapshot_quality_very_low">
+		Muito baixo
+	</string>
+	<string name="snapshot_quality_low">
+		Baixo
+	</string>
+	<string name="snapshot_quality_medium">
+		Médio
+	</string>
+	<string name="snapshot_quality_high">
+		Alto
+	</string>
+	<string name="snapshot_quality_very_high">
+		Muito alto
+	</string>
+	<string name="TeleportMaturityExceeded">
+		O residente não pode visitar a região.
+	</string>
+	<string name="UserDictionary">
+		[Usuário]
+	</string>
+	<string name="experience_tools_experience">
+		Experiência
+	</string>
+	<string name="ExperienceNameNull">
+		(nenhuma experiência)
+	</string>
+	<string name="ExperienceNameUntitled">
+		(experiência sem título)
+	</string>
+	<string name="Land-Scope">
+		Dentro do terreno
+	</string>
+	<string name="Grid-Scope">
+		Dentro da grade
+	</string>
+	<string name="Allowed_Experiences_Tab">
+		PERMITIDO
+	</string>
+	<string name="Blocked_Experiences_Tab">
+		BLOQUEADO
+	</string>
+	<string name="Contrib_Experiences_Tab">
+		COLABORADOR
+	</string>
+	<string name="Admin_Experiences_Tab">
+		ADMINISTRADOR
+	</string>
+	<string name="Recent_Experiences_Tab">
+		RECENTE
+	</string>
+	<string name="Owned_Experiences_Tab">
+		PRÓPRIAS
+	</string>
+	<string name="ExperiencesCounter">
+		([EXPERIENCES], máx. [MAXEXPERIENCES])
+	</string>
+	<string name="ExperiencePermission1">
+		assumir seus controles
+	</string>
+	<string name="ExperiencePermission3">
+		acionar animações no seu avatar
+	</string>
+	<string name="ExperiencePermission4">
+		anexar ao avatar
+	</string>
+	<string name="ExperiencePermission9">
+		rastrear sua câmera
+	</string>
+	<string name="ExperiencePermission10">
+		controlar sua câmera
+	</string>
+	<string name="ExperiencePermission11">
+		teletransportar você
+	</string>
+	<string name="ExperiencePermission12">
+		aceitar automaticamente permissões de experiência
+	</string>
+	<string name="ExperiencePermission16">
+		forçar o avatar a sentar
+	</string>
+	<string name="ExperiencePermission17">
+		alterar sua configurações de ambiente
+	</string>
+	<string name="ExperiencePermissionShortUnknown">
+		realizar uma operação desconhecida: [Permission]
+	</string>
+	<string name="ExperiencePermissionShort1">
+		Assumir o controle
+	</string>
+	<string name="ExperiencePermissionShort3">
+		Acionar animações
+	</string>
+	<string name="ExperiencePermissionShort4">
+		Anexar
+	</string>
+	<string name="ExperiencePermissionShort9">
+		Rastrear câmera
+	</string>
+	<string name="ExperiencePermissionShort10">
+		Controlar câmera
+	</string>
+	<string name="ExperiencePermissionShort11">
+		Teletransportar
+	</string>
+	<string name="ExperiencePermissionShort12">
+		Autorização
+	</string>
+	<string name="ExperiencePermissionShort16">
+		Sentar
+	</string>
+	<string name="ExperiencePermissionShort17">
+		Ambiente
+	</string>
+	<string name="logging_calls_disabled_log_empty">
+		As conversas não estão sendo registradas. Para começar a manter um registro, selecione "Salvar: apenas registro" ou "Salvar: registro e transcrições" em Preferências&gt; Bate-papo.
+	</string>
+	<string name="logging_calls_disabled_log_not_empty">
+		Nenhuma conversa será registrada. Para recomeçar a gravação de registros, selecione "Salvar: apenas registro" ou "Salvar: registro e transcrições" em Preferências&gt; Bate-papo.
+	</string>
+	<string name="logging_calls_enabled_log_empty">
+		Não há conversas registradas. Depois que você entrar em contato com alguém, ou alguém entrar em contato com você, um registro será exibido aqui.
+	</string>
+	<string name="loading_chat_logs">
+		Carregando...
+	</string>
+	<string name="na">
+		n/d
+	</string>
+	<string name="preset_combo_label">
+		-Lista vazia-
+	</string>
+	<string name="Default">
+		Padrão
+	</string>
+	<string name="none_paren_cap">
+		(nenhum)
+	</string>
+	<string name="no_limit">
+		Sem limite
+	</string>
+	<string name="Mav_Details_MAV_FOUND_DEGENERATE_TRIANGLES">
+		A forma física contém triângulos muito pequenos. Tente simplificar o modelo físico.
+	</string>
+	<string name="Mav_Details_MAV_CONFIRMATION_DATA_MISMATCH">
+		A forma física contém dados de confirmação ruins. Tente consertar o modelo físico.
+	</string>
+	<string name="Mav_Details_MAV_UNKNOWN_VERSION">
+		A forma física não tem a versão correta. Defina a versão correta para o modelo físico.
+	</string>
+	<string name="couldnt_resolve_host">
+		O DNS não pode resolver o nome do host([HOSTNAME]). 
 Verifique se você pode conectar ao site www.secondlife.com . Se você 
 puder, mas se continuar recebendo esta mensagem de erro, vá à sessão 
-Suporte no site Secondlife.com e informe o problema.</string>
-	<string name="ssl_peer_certificate">O servidor de acesso não pôde verificá-lo pelo SSL. 
+Suporte no site Secondlife.com e informe o problema.
+	</string>
+	<string name="ssl_peer_certificate">
+		O servidor de acesso não pôde verificá-lo pelo SSL. 
 Se você continuar recebendo esta mensagem de erro, 
 vá à sessão Suporte no site Secondlife.com 
-e informe o problema.</string>
-	<string name="ssl_connect_error">Geralmente, esse erro significa que o relógio do seu computador não está com o horário correto. 
+e informe o problema.
+	</string>
+	<string name="ssl_connect_error">
+		Geralmente, esse erro significa que o relógio do seu computador não está com o horário correto. 
 Vá em Painel de Controles e certifique-se de que a hora e data estejam corretos. 
 Além disso, verifique se a sua rede e firewall estejam corretos. Se você continuar 
 recebendo esta mensagem de erro, vá à sessão Suporte no site Secondlife.com 
 e informe o problema. 
 
-[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de conhecimento]</string>
+[https://community.secondlife.com/knowledgebase/english/error-messages-r520/#Section__3 Base de conhecimento]
+	</string>
 </strings>

--- a/indra/newview/skins/default/xui/pt/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/pt/teleport_strings.xml
@@ -1,38 +1,94 @@
 <?xml version="1.0" ?>
 <teleport_messages>
 	<message_set name="errors">
-		<message name="invalid_tport">Houve um problema ao processar o teletransporte. Talvez seja preciso sair e entrar do Second Life para fazer o teletransporte.
-Se você continuar a receber esta mensagem, por favor consulte o [SUPPORT_SITE].</message>
-		<message name="invalid_region_handoff">Problema encontrado ao processar a passagem de regiões. Talvez seja preciso sair e entrar do Second Life atravessar regiões novamente.
-Se você continuar a receber esta mensagem, por favor consulte o [SUPPORT_SITE].</message>
-		<message name="blocked_tport">Desculpe, teletransportes estão atualmente bloqueados. Tente novamente dentro de alguns instantes. Se você continuar com problemas de teletransporte, por favor tente deslogar e relogar para resolver o problema.</message>
-		<message name="nolandmark_tport">Desculpe, mas o sistema não conseguiu localizar a landmark de destino.</message>
-		<message name="timeout_tport">Desculpe, não foi possível para o sistema executar o teletransporte. Tente novamente dentro de alguns instantes.</message>
-		<message name="NoHelpIslandTP">Não é possível se teletransportar de volta à Ilha Welcome.
-Vá para a 'Ilha Welcome Pública' para repetir o tutorial.</message>
-		<message name="noaccess_tport">Desculpe, você não tem acesso ao destino deste teletransporte.</message>
-		<message name="missing_attach_tport">Seu anexos ainda não chegaram. Tente esperar por alguns momentos ou deslogar e logar antes de tentar teleransportar-se novamente.</message>
-		<message name="too_many_uploads_tport">Afluxo nesta região é atualmente tão alto que seu pedido de teletransporte não será possível em tempo oportuno. Por favor, tente novamente em alguns minutos ou vá a uma área menos ocupada.</message>
-		<message name="expired_tport">Desculpe, mas o sistema não conseguiu concluir o seu pedido de teletransporte em tempo hábil. Por favor, tente novamente em alguns minutos.</message>
-		<message name="expired_region_handoff">Desculpe, mas o sistema não pôde concluir a sua travessia de região em tempo hábil. Por favor, tente novamente em alguns minutos.</message>
-		<message name="no_host">Não foi possível encontrar o destino do teletransporte. O destino pode estar temporariamente indisponível ou não existir mais. Por favor, tente novamente em poucos minutos.</message>
-		<message name="no_inventory_host">O sistema de inventário está indisponível no momento.</message>
-		<message name="MustGetAgeRegion">Você deve ter 18 anos ou mais para acessar esta região.</message>
-		<message name="RegionTPSpecialUsageBlocked">Não é possível inserir a região. '[REGION_NAME]' é uma Região de Skill Gaming, portanto você deve atender certos critérios para poder entrar. Para maiores detalhes, consulte as [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ].</message>
-		<message name="preexisting_tport">Desculpe, mas o sistema falhou ao iniciar o seu teletransporte. Por favor, tente novamente dentro de alguns minutos.</message>
+		<message name="invalid_tport">
+			Houve um problema ao processar o teletransporte. Talvez seja preciso sair e entrar do Second Life para fazer o teletransporte.
+Se você continuar a receber esta mensagem, por favor consulte o [SUPPORT_SITE].
+		</message>
+		<message name="invalid_region_handoff">
+			Problema encontrado ao processar a passagem de regiões. Talvez seja preciso sair e entrar do Second Life atravessar regiões novamente.
+Se você continuar a receber esta mensagem, por favor consulte o [SUPPORT_SITE].
+		</message>
+		<message name="blocked_tport">
+			Desculpe, teletransportes estão atualmente bloqueados. Tente novamente dentro de alguns instantes. Se você continuar com problemas de teletransporte, por favor tente deslogar e relogar para resolver o problema.
+		</message>
+		<message name="nolandmark_tport">
+			Desculpe, mas o sistema não conseguiu localizar a landmark de destino.
+		</message>
+		<message name="timeout_tport">
+			Desculpe, não foi possível para o sistema executar o teletransporte. Tente novamente dentro de alguns instantes.
+		</message>
+		<message name="NoHelpIslandTP">
+			Não é possível se teletransportar de volta à Ilha Welcome.
+Vá para a 'Ilha Welcome Pública' para repetir o tutorial.
+		</message>
+		<message name="noaccess_tport">
+			Desculpe, você não tem acesso ao destino deste teletransporte.
+		</message>
+		<message name="missing_attach_tport">
+			Seu anexos ainda não chegaram. Tente esperar por alguns momentos ou deslogar e logar antes de tentar teleransportar-se novamente.
+		</message>
+		<message name="too_many_uploads_tport">
+			Afluxo nesta região é atualmente tão alto que seu pedido de teletransporte não será possível em tempo oportuno. Por favor, tente novamente em alguns minutos ou vá a uma área menos ocupada.
+		</message>
+		<message name="expired_tport">
+			Desculpe, mas o sistema não conseguiu concluir o seu pedido de teletransporte em tempo hábil. Por favor, tente novamente em alguns minutos.
+		</message>
+		<message name="expired_region_handoff">
+			Desculpe, mas o sistema não pôde concluir a sua travessia de região em tempo hábil. Por favor, tente novamente em alguns minutos.
+		</message>
+		<message name="no_host">
+			Não foi possível encontrar o destino do teletransporte. O destino pode estar temporariamente indisponível ou não existir mais. Por favor, tente novamente em poucos minutos.
+		</message>
+		<message name="no_inventory_host">
+			O sistema de inventário está indisponível no momento.
+		</message>
+		<message name="MustGetAgeRegion">
+			Você deve ter 18 anos ou mais para acessar esta região.
+		</message>
+		<message name="RegionTPSpecialUsageBlocked">
+			Não é possível inserir a região. '[REGION_NAME]' é uma Região de Skill Gaming, portanto você deve atender certos critérios para poder entrar. Para maiores detalhes, consulte as [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ].
+		</message>
+		<message name="preexisting_tport">
+			Desculpe, mas o sistema falhou ao iniciar o seu teletransporte. Por favor, tente novamente dentro de alguns minutos.
+		</message>
 	</message_set>
 	<message_set name="progress">
-		<message name="sending_dest">Enviando para o destino.</message>
-		<message name="redirecting">Redirecionando para uma localidade diferente.</message>
-		<message name="relaying">Transferindo para o destino.</message>
-		<message name="sending_home">Enviando solicitação de localização de início.</message>
-		<message name="sending_landmark">Enviando solicitação de localização de landmark.</message>
-		<message name="completing">Completando teletransporte.</message>
-		<message name="completed_from">Teletransporte de [T_SLURL] concluído</message>
-		<message name="resolving">Identificando destino.</message>
-		<message name="contacting">Contactando nova região.</message>
-		<message name="arriving">Chegando...</message>
-		<message name="requesting">Solicitando teletransporte...</message>
-		<message name="pending">Teletransporte pendente...</message>
+		<message name="sending_dest">
+			Enviando para o destino.
+		</message>
+		<message name="redirecting">
+			Redirecionando para uma localidade diferente.
+		</message>
+		<message name="relaying">
+			Transferindo para o destino.
+		</message>
+		<message name="sending_home">
+			Enviando solicitação de localização de início.
+		</message>
+		<message name="sending_landmark">
+			Enviando solicitação de localização de landmark.
+		</message>
+		<message name="completing">
+			Completando teletransporte.
+		</message>
+		<message name="completed_from">
+			Teletransporte de [T_SLURL] concluído
+		</message>
+		<message name="resolving">
+			Identificando destino.
+		</message>
+		<message name="contacting">
+			Contactando nova região.
+		</message>
+		<message name="arriving">
+			Chegando...
+		</message>
+		<message name="requesting">
+			Solicitando teletransporte...
+		</message>
+		<message name="pending">
+			Teletransporte pendente...
+		</message>
 	</message_set>
 </teleport_messages>

--- a/indra/newview/skins/default/xui/ru/strings.xml
+++ b/indra/newview/skins/default/xui/ru/strings.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<!-- This file contains strings that used to be hardcoded in the source.
-     It is only for those strings which do not belong in a floater.
-     For example, the strings used in avatar chat bubbles, and strings
-     that are returned from one component and may appear in many places-->
 <strings>
 	<string name="SECOND_LIFE">
 		Second Life
@@ -1657,7 +1653,7 @@ support@secondlife.com.
 		Тариф зависит от типа вашей подписки. Тарифы для владельцев расширенных пакетов меньше. [https://secondlife.com/my/account/membership.php? Узнать больше]
 	</string>
 	<string name="Open landmarks">
-		Открыть сохраненные локации	
+		Открыть сохраненные локации
 	</string>
 	<string name="Unconstrained">
 		Без ограничений
@@ -2870,8 +2866,8 @@ support@secondlife.com.
 	<string name=".">
 		.
 	</string>
-	<string name="&apos;">
-		&apos;
+	<string name="'">
+		'
 	</string>
 	<string name="---">
 		---
@@ -2983,7 +2979,7 @@ support@secondlife.com.
 		Не удается запустить приложение [APP_NAME], поскольку драйверы видеокарты неправильно установлены, устарели или предназначены для оборудования, которое не поддерживается. Установите или переустановите последние драйверы видеокарты.
 Если это сообщение продолжает отображаться, обратитесь на сайт [SUPPORT_SITE].
 	</string>
-	<string name="5 O&apos;Clock Shadow">
+	<string name="5 O'Clock Shadow">
 		Жидкие
 	</string>
 	<string name="All White">
@@ -4577,7 +4573,7 @@ support@secondlife.com.
 		Предложена папка инвентаря «[ITEM_NAME]»
 	</string>
 	<string name="bot_warning">
-Вы общаетесь с ботом [NAME]. Не передавайте личные данные.
+		Вы общаетесь с ботом [NAME]. Не передавайте личные данные.
 Подробнее на https://second.life/scripted-agents.
 	</string>
 	<string name="share_alert">
@@ -5147,7 +5143,7 @@ support@secondlife.com.
 	<string name="ExternalEditorNotFound">
 		Не удается найти указанный внешний редактор.
 Попробуйте взять путь к редактору в двойные кавычки
-(например &quot;/path to my/editor&quot; &quot;%s&quot;)
+(например "/path to my/editor" "%s")
 	</string>
 	<string name="ExternalEditorCommandParseError">
 		Ошибка анализа командной строки для внешнего редактора.

--- a/indra/newview/skins/default/xui/tr/strings.xml
+++ b/indra/newview/skins/default/xui/tr/strings.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<!-- This file contains strings that used to be hardcoded in the source.
-     It is only for those strings which do not belong in a floater.
-     For example, the strings used in avatar chat bubbles, and strings
-     that are returned from one component and may appear in many places-->
 <strings>
 	<string name="SECOND_LIFE">
 		Second Life
@@ -88,7 +84,7 @@ Ses Sunucusu Sürümü: [VOICE_VERSION]
 		[month, datetime, slt] [day, datetime, slt] [year, datetime, slt] [hour, datetime, slt]:[min, datetime, slt]:[second,datetime,slt]
 	</string>
 	<string name="ErrorFetchingServerReleaseNotesURL">
-		Sunucu sürümü notları URL&apos;si alınırken hata oluştu.
+		Sunucu sürümü notları URL'si alınırken hata oluştu.
 	</string>
 	<string name="BuildConfiguration">
 		Yapı Konfigürasyonu
@@ -205,7 +201,7 @@ Ses Sunucusu Sürümü: [VOICE_VERSION]
 		http://secondlife.com/download
 	</string>
 	<string name="LoginFailedViewerNotPermitted">
-		Kullandığınız görüntüleyici ile artık Second Life&apos;a erişemezsiniz. Yeni bir görüntüleyiciyi karşıdan yüklemek için lütfen şu sayfayı ziyaret edin:
+		Kullandığınız görüntüleyici ile artık Second Life'a erişemezsiniz. Yeni bir görüntüleyiciyi karşıdan yüklemek için lütfen şu sayfayı ziyaret edin:
 http://secondlife.com/download
 
 Daha fazla bilgi edinmek için asağıdaki SSS sayfamızı ziyaret edin:
@@ -247,10 +243,10 @@ Güncelleştirmeler için www.secondlife.com/status adresini kontrol edin.
 	<string name="LoginFailedPremiumOnly">
 		Second Life üzerindeki aktif kullanıcıların olası en iyi deneyimi yaşamasını sağlamak için, oturum açılması geçici olarak kısıtlanmıştır.
 
-Second Life için ödeme yapmış olan kişilere öncelik tanımak amacıyla, ücretsiz hesaplara sahip kişiler bu süre içerisinde Second Life&apos;a erişemeyecekler.
+Second Life için ödeme yapmış olan kişilere öncelik tanımak amacıyla, ücretsiz hesaplara sahip kişiler bu süre içerisinde Second Life'a erişemeyecekler.
 	</string>
 	<string name="LoginFailedComputerProhibited">
-		Second Life&apos;a bu bilgisayardan erişemezsiniz.
+		Second Life'a bu bilgisayardan erişemezsiniz.
 Bunun bir hata olduğunu düşünüyorsanız, lütfen şu adrese başvurun:
 support@secondlife.com.
 	</string>
@@ -286,7 +282,7 @@ Lütfen yeniden oturum açmayı denemeden önce bir dakika bekleyin.
 		Bir simülatöre bağlanılamadı.
 	</string>
 	<string name="LoginFailedRestrictedHours">
-		Hesabınız Second Life&apos;a sadece
+		Hesabınız Second Life'a sadece
 Pasifik Saati ile [START] ve [END] arasında erişebilir.
 Lütfen bu saatler arasında tekrar uğrayın.
 Bunun bir hata olduğunu düşünüyorsanız, lütfen şu adrese başvurun: support@secondlife.com
@@ -369,7 +365,7 @@ Lütfen bir dakika içerisinde tekrar oturum açmayı deneyin.
 		Facebook ile bağlantı kurulurken sorun oluştu
 	</string>
 	<string name="SocialFacebookErrorPosting">
-		Facebook&apos;ta yayınlarken sorun oluştu
+		Facebook'ta yayınlarken sorun oluştu
 	</string>
 	<string name="SocialFacebookErrorDisconnecting">
 		Facebook bağlantısı kesilirken sorun oluştu
@@ -387,7 +383,7 @@ Lütfen bir dakika içerisinde tekrar oturum açmayı deneyin.
 		Flickr bağlantısı kurulurken sorun çıktı
 	</string>
 	<string name="SocialFlickrErrorPosting">
-		Flickr&apos;da yayınlarken sorun çıktı
+		Flickr'da yayınlarken sorun çıktı
 	</string>
 	<string name="SocialFlickrErrorDisconnecting">
 		Flickr bağlantısı kesilirken sorun çıktı
@@ -405,7 +401,7 @@ Lütfen bir dakika içerisinde tekrar oturum açmayı deneyin.
 		Twitter bağlantısı kurulurken sorun çıktı
 	</string>
 	<string name="SocialTwitterErrorPosting">
-		Twitter&apos;da yayınlarken sorun çıktı
+		Twitter'da yayınlarken sorun çıktı
 	</string>
 	<string name="SocialTwitterErrorDisconnecting">
 		Twitter bağlantısı kesilirken sorun çıktı
@@ -414,7 +410,7 @@ Lütfen bir dakika içerisinde tekrar oturum açmayı deneyin.
 		Siyah Beyaz
 	</string>
 	<string name="Colors1970">
-		70&apos;lerin Renkleri
+		70'lerin Renkleri
 	</string>
 	<string name="Intense">
 		Yoğun
@@ -657,7 +653,7 @@ Lütfen bir dakika içerisinde tekrar oturum açmayı deneyin.
 not kartlarına eklenemez.
 	</string>
 	<string name="TooltipNotecardOwnerRestrictedDrop">
-		Sadece kısıtlamasız &apos;sonraki sahip&apos; 
+		Sadece kısıtlamasız 'sonraki sahip' 
 izinlerini içeren öğeler not 
 kartlarına eklenebilir.
 	</string>
@@ -1107,10 +1103,10 @@ http://secondlife.com/support adresini ziyaret edin.
 		Şimdi Yakındaki bir Sesli Sohbete yeniden bağlanılacaksınız.
 	</string>
 	<string name="ScriptQuestionCautionChatGranted">
-		&apos;[OWNERNAME]&apos; adlı kişiye ait, [REGIONPOS] üzerinde [REGIONNAME] içerisinde bulunan &apos;[OBJECTNAME]&apos; nesnesine şunu yapma izni verildi: [PERMISSIONS].
+		'[OWNERNAME]' adlı kişiye ait, [REGIONPOS] üzerinde [REGIONNAME] içerisinde bulunan '[OBJECTNAME]' nesnesine şunu yapma izni verildi: [PERMISSIONS].
 	</string>
 	<string name="ScriptQuestionCautionChatDenied">
-		&apos;[OWNERNAME]&apos; adlı kişiye ait, [REGIONPOS] üzerinde [REGIONNAME] içerisinde bulunan &apos;[OBJECTNAME]&apos; nesnesine şunu yapma izni verilmedi: [PERMISSIONS].
+		'[OWNERNAME]' adlı kişiye ait, [REGIONPOS] üzerinde [REGIONNAME] içerisinde bulunan '[OBJECTNAME]' nesnesine şunu yapma izni verilmedi: [PERMISSIONS].
 	</string>
 	<string name="AdditionalPermissionsRequestHeader">
 		Eğer hesabınıza erişime izin verirseniz, bu nesneye aynı zamanda şunun için izin vermiş olacaksınız:
@@ -1486,7 +1482,7 @@ http://secondlife.com/support adresini ziyaret edin.
 		Yüksek
 	</string>
 	<string name="LeaveMouselook">
-		Dünya Görünümüne dönmek için ESC&apos;e basın
+		Dünya Görünümüne dönmek için ESC'e basın
 	</string>
 	<string name="InventoryNoMatchingItems">
 		Aradığınızı bulamadınız mı? [secondlife:///app/search/all/[SEARCH_TERM] Arama] ile bulmayı deneyin.
@@ -1545,7 +1541,7 @@ http://secondlife.com/support adresini ziyaret edin.
 	</string>
 	<string name="InventoryOutboxNoItemsTooltip"/>
 	<string name="InventoryOutboxNoItems">
-		Bu alana klasörleri sürükleyin ve bunları [[MARKETPLACE_DASHBOARD_URL] Pazaryerinde] satılık olarak duyurmak için &quot;Pazaryerine Gönder&quot; üzerine tıklayın.
+		Bu alana klasörleri sürükleyin ve bunları [[MARKETPLACE_DASHBOARD_URL] Pazaryerinde] satılık olarak duyurmak için "Pazaryerine Gönder" üzerine tıklayın.
 	</string>
 	<string name="InventoryOutboxInitializingTitle">
 		Pazaryeri Başlatılıyor.
@@ -1815,7 +1811,7 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		Satın Al
 	</string>
 	<string name="BuyforL$">
-		L$&apos;a Satın Al
+		L$'a Satın Al
 	</string>
 	<string name="Stone">
 		Taş
@@ -2001,19 +1997,19 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		Hata: Nesne mevcut dış görünüme dahil ama eklenmemiş
 	</string>
 	<string name="YearsMonthsOld">
-		[AGEYEARS] [AGEMONTHS]&apos;lık
+		[AGEYEARS] [AGEMONTHS]'lık
 	</string>
 	<string name="YearsOld">
 		[AGEYEARS] yaşında
 	</string>
 	<string name="MonthsOld">
-		[AGEMONTHS]&apos;lık
+		[AGEMONTHS]'lık
 	</string>
 	<string name="WeeksOld">
-		[AGEWEEKS]&apos;lık
+		[AGEWEEKS]'lık
 	</string>
 	<string name="DaysOld">
-		[AGEDAYS]&apos;lük
+		[AGEDAYS]'lük
 	</string>
 	<string name="TodayOld">
 		Bugün katıldı
@@ -2034,7 +2030,7 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		Çevrenizdeki kimse sizi işleyemeyebilir.
 	</string>
 	<string name="hud_description_total">
-		BÜG&apos;niz
+		BÜG'niz
 	</string>
 	<string name="hud_name_with_joint">
 		[OBJ_NAME] ([JNT_NAME] üzerinde)
@@ -2312,13 +2308,13 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		Kullanılan bellek: [COUNT] kb
 	</string>
 	<string name="ScriptLimitsParcelScriptURLs">
-		Parsel Komut Dosyası URL&apos;leri
+		Parsel Komut Dosyası URL'leri
 	</string>
 	<string name="ScriptLimitsURLsUsed">
-		Kullanılan URL&apos;ler: [COUNT] / [MAX] içerisinden; [AVAILABLE] serbest
+		Kullanılan URL'ler: [COUNT] / [MAX] içerisinden; [AVAILABLE] serbest
 	</string>
 	<string name="ScriptLimitsURLsUsedSimple">
-		Kullanılan URL&apos;ler: [COUNT]
+		Kullanılan URL'ler: [COUNT]
 	</string>
 	<string name="ScriptLimitsRequestError">
 		Bilgi talep edilirken hata oluştu
@@ -2522,7 +2518,7 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		Yeni Komut Dosyası
 	</string>
 	<string name="DoNotDisturbModeResponseDefault">
-		Bu sakin &quot;Rahatsız Etme&quot; seçeneğini devreye almış, mesajınızı sonra görecek.
+		Bu sakin "Rahatsız Etme" seçeneğini devreye almış, mesajınızı sonra görecek.
 	</string>
 	<string name="MuteByName">
 		(Adına göre)
@@ -2633,7 +2629,7 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 		size verdi:
 	</string>
 	<string name="InvOfferDecline">
-		&lt;nolink&gt;[NAME]&lt;/nolink&gt; tarafından gönderilen [DESC]&apos;i reddettiniz.
+		&lt;nolink&gt;[NAME]&lt;/nolink&gt; tarafından gönderilen [DESC]'i reddettiniz.
 	</string>
 	<string name="GroupMoneyTotal">
 		Toplam
@@ -2870,8 +2866,8 @@ Bu mesaj size gelmeye devam ederse lütfen http://support.secondlife.com adresin
 	<string name=".">
 		.
 	</string>
-	<string name="&apos;">
-		&apos;
+	<string name="'">
+		'
 	</string>
 	<string name="---">
 		---
@@ -2986,7 +2982,7 @@ Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 
 Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 	</string>
-	<string name="5 O&apos;Clock Shadow">
+	<string name="5 O'Clock Shadow">
 		Bir Günlük Sakal
 	</string>
 	<string name="All White">
@@ -4490,7 +4486,7 @@ Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 		Görüntüleyici başlatılamadı
 	</string>
 	<string name="ItemsComingInTooFastFrom">
-		[APP_NAME]: [FROM_NAME]&apos;den öğeler çok hızlı geliyor, [TIME] saniye boyunca otomatik ön izleme devre dışı bırakıldı
+		[APP_NAME]: [FROM_NAME]'den öğeler çok hızlı geliyor, [TIME] saniye boyunca otomatik ön izleme devre dışı bırakıldı
 	</string>
 	<string name="ItemsComingInTooFast">
 		[APP_NAME]: Öğeler çok hızlı geliyor, [TIME] saniye boyunca otomatik ön izleme devre dışı bırakıldı
@@ -4526,7 +4522,7 @@ Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 		(Kaydedildi [LONG_TIMESTAMP])
 	</string>
 	<string name="IM_unblock_only_groups_friends">
-		Bu mesajı görmek için Tercihler/Gizlilik&apos;de &apos;Sadece arkadaşlar ve gruplar beni arasın veya Aİ göndersin&apos; seçeneğinin işaretini kaldırmalısınız.
+		Bu mesajı görmek için Tercihler/Gizlilik'de 'Sadece arkadaşlar ve gruplar beni arasın veya Aİ göndersin' seçeneğinin işaretini kaldırmalısınız.
 	</string>
 	<string name="OnlineStatus">
 		Çevrimiçi
@@ -4550,7 +4546,7 @@ Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 		Sesli aramaya katıldınız
 	</string>
 	<string name="you_auto_rejected_call-im">
-		&quot;Rahatsız Etme&quot; seçeneğini devredeyken sesli aramayı otomatik olarak reddettiniz.
+		"Rahatsız Etme" seçeneğini devredeyken sesli aramayı otomatik olarak reddettiniz.
 	</string>
 	<string name="name_started_call">
 		[NAME] bir sesli arama başlattı
@@ -4574,26 +4570,26 @@ Bu iletiyi almaya devam ederseniz, lütfen [SUPPORT_SITE] bölümüne başvurun.
 		[AGENT_NAME] ile konferans
 	</string>
 	<string name="inventory_item_offered-im">
-		&quot;[ITEM_NAME]&quot; envanter öğesi sunuldu
+		"[ITEM_NAME]" envanter öğesi sunuldu
 	</string>
 	<string name="inventory_folder_offered-im">
-		&quot;[ITEM_NAME]&quot; envanter klasörü sunuldu
+		"[ITEM_NAME]" envanter klasörü sunuldu
 	</string>
 	<string name="bot_warning">
-Bir bot ile sohbet ediyorsunuz, [NAME]. Kişisel bilgilerinizi paylaşmayın.
+		Bir bot ile sohbet ediyorsunuz, [NAME]. Kişisel bilgilerinizi paylaşmayın.
 Daha fazla bilgi için: https://second.life/scripted-agents.
 	</string>
 	<string name="share_alert">
 		Envanterinizden buraya öğeler sürükleyin
 	</string>
 	<string name="facebook_post_success">
-		Facebook&apos;ta yayınladınız.
+		Facebook'ta yayınladınız.
 	</string>
 	<string name="flickr_post_success">
-		Flickr&apos;da yayınladınız.
+		Flickr'da yayınladınız.
 	</string>
 	<string name="twitter_post_success">
-		Twitter&apos;da yayınladınız.
+		Twitter'da yayınladınız.
 	</string>
 	<string name="no_session_message">
 		(Aİ Oturumu Mevcut Değil)
@@ -4686,7 +4682,7 @@ Daha fazla bilgi için: https://second.life/scripted-agents.
 		[NAME] size L$[AMOUNT] ödedi.
 	</string>
 	<string name="you_paid_ldollars">
-		[NAME]&apos;e [REASON] L$[AMOUNT]  ödediniz.
+		[NAME]'e [REASON] L$[AMOUNT]  ödediniz.
 	</string>
 	<string name="you_paid_ldollars_gift">
 		[NAME] adlı kullanıcıya [AMOUNT] L$ ödediniz. [REASON]
@@ -4695,13 +4691,13 @@ Daha fazla bilgi için: https://second.life/scripted-agents.
 		L$[AMOUNT] ödediniz.
 	</string>
 	<string name="you_paid_ldollars_no_reason">
-		[NAME]&apos;e L$[AMOUNT] ödediniz.
+		[NAME]'e L$[AMOUNT] ödediniz.
 	</string>
 	<string name="you_paid_ldollars_no_name">
 		[REASON] L$[AMOUNT] ödediniz.
 	</string>
 	<string name="you_paid_failure_ldollars">
-		[REASON] [NAME]&apos;e L$[AMOUNT] ödeyemediniz.
+		[REASON] [NAME]'e L$[AMOUNT] ödeyemediniz.
 	</string>
 	<string name="you_paid_failure_ldollars_gift">
 		[NAME] adlı kullanıcıya [AMOUNT] L$ ödeyemediniz. [REASON]
@@ -4710,7 +4706,7 @@ Daha fazla bilgi için: https://second.life/scripted-agents.
 		L$[AMOUNT] ödeyemediniz.
 	</string>
 	<string name="you_paid_failure_ldollars_no_reason">
-		[NAME]&apos;e L$[AMOUNT] ödeyemediniz.
+		[NAME]'e L$[AMOUNT] ödeyemediniz.
 	</string>
 	<string name="you_paid_failure_ldollars_no_name">
 		[REASON] L$[AMOUNT] ödeyemediniz.
@@ -5142,7 +5138,7 @@ Hizmetle ilişkili bilinen bir sorun olup olmadığını görmek için lütfen h
 	<string name="ExternalEditorNotFound">
 		Belirttiğiniz harici düzenleyici bulunamadı.
 Düzenleyici yolunu çift tırnakla çevrelemeyi deneyin.
-(örn. &quot;/yolum/duzenleyici&quot; &quot;%s&quot;)
+(örn. "/yolum/duzenleyici" "%s")
 	</string>
 	<string name="ExternalEditorCommandParseError">
 		Harici düzenleyici komutu ayrıştırılırken hata oluştu.
@@ -5631,10 +5627,10 @@ Düzenleyici yolunu çift tırnakla çevrelemeyi deneyin.
 		Ortamlarım
 	</string>
 	<string name="Command_Facebook_Tooltip">
-		Facebook&apos;ta Yayınla
+		Facebook'ta Yayınla
 	</string>
 	<string name="Command_Flickr_Tooltip">
-		Flickr&apos;a yükle
+		Flickr'a yükle
 	</string>
 	<string name="Command_Gestures_Tooltip">
 		Avatarınız için mimikler
@@ -5865,10 +5861,10 @@ Düzenleyici yolunu çift tırnakla çevrelemeyi deneyin.
 		Ortam
 	</string>
 	<string name="logging_calls_disabled_log_empty">
-		Sohbetlerin günlüğü tutulmuyor. Bir günlük tutmaya başlamak için, Tercihler &gt; Sohbet altında &quot;Kaydet: Sadece günlük&quot; veya &quot;Kaydet: Günlük ve dökümler&quot; seçimini yapın.
+		Sohbetlerin günlüğü tutulmuyor. Bir günlük tutmaya başlamak için, Tercihler &gt; Sohbet altında "Kaydet: Sadece günlük" veya "Kaydet: Günlük ve dökümler" seçimini yapın.
 	</string>
 	<string name="logging_calls_disabled_log_not_empty">
-		Bundan böyle sohbetlerin günlükleri tutulmayacak. Bir günlük tutmaya devam etmek için, Tercihler &gt; Sohbet altında &quot;Kaydet: Sadece günlük&quot; veya &quot;Kaydet: Günlük ve dökümler&quot; seçimini yapın.
+		Bundan böyle sohbetlerin günlükleri tutulmayacak. Bir günlük tutmaya devam etmek için, Tercihler &gt; Sohbet altında "Kaydet: Sadece günlük" veya "Kaydet: Günlük ve dökümler" seçimini yapın.
 	</string>
 	<string name="logging_calls_enabled_log_empty">
 		Günlüğü tutulmuş sohbet yok. Siz biriyle iletişime geçtikten sonra veya biri sizinle iletişime geçtikten sonra, burada bir günlük girişi gösterilir.
@@ -5914,7 +5910,7 @@ bölümüne gidin ve sorunu bildirin.
 	</string>
 	<string name="ssl_connect_error">
 		Çoğunlukla, bu durum, bilgisayarınızın saatinin yanlış ayarlandığı anlamına gelir. 
-Lütfen Denetim Masası&apos;na gidin ve tarih ve saat ayarlarının doğru yapıldığından emin olun. 
+Lütfen Denetim Masası'na gidin ve tarih ve saat ayarlarının doğru yapıldığından emin olun. 
 Ayrıca, ağınızın ve güvenlik duvarınızın doğru şekilde ayarlanıp ayarlanmadığını kontrol edin. 
 Bu hatayı almaya devam ederseniz, lütfen SecondLife.com web sitesinin Destek bölümüne 
 gidin ve sorunu bildirin. 

--- a/indra/newview/skins/default/xui/tr/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/tr/teleport_strings.xml
@@ -21,8 +21,8 @@ Hala ışınlanamıyorsanız, sorunu çözmek için lütfen çıkış yapıp otu
 Bir dakika sonra tekrar deneyin.
 		</message>
 		<message name="NoHelpIslandTP">
-			Karşılama Ada&apos;sına geri ışınlanamazsınız.
-Öğreticiyi tekrarlamak için &apos;Karşılama Ada&apos;sı Kamusal Alanı&apos;na gidin.
+			Karşılama Ada'sına geri ışınlanamazsınız.
+Öğreticiyi tekrarlamak için 'Karşılama Ada'sı Kamusal Alanı'na gidin.
 		</message>
 		<message name="noaccess_tport">
 			Üzgünüz, bu ışınlanma hedef konumuna erişim hakkına sahip değilsiniz.
@@ -49,7 +49,7 @@ Bir dakika sonra tekrar deneyin.
 			Bu bölgeye girebilmek için 18 veya üzeri bir yaşta olmanız gerekir.
 		</message>
 		<message name="RegionTPSpecialUsageBlocked">
-			Bölgeye girilemiyor. &quot;[REGION_NAME]&quot; bir Yetenek Oyunu Bölgesi. Buraya girebilmek için bazı ölçütleri karşılamanız gerekiyor. Ayrıntılar için lütfen [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ] adresini ziyaret edin.
+			Bölgeye girilemiyor. "[REGION_NAME]" bir Yetenek Oyunu Bölgesi. Buraya girebilmek için bazı ölçütleri karşılamanız gerekiyor. Ayrıntılar için lütfen [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life Skill Gaming FAQ] adresini ziyaret edin.
 		</message>
 	</message_set>
 	<message_set name="progress">

--- a/indra/newview/skins/default/xui/zh/strings.xml
+++ b/indra/newview/skins/default/xui/zh/strings.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<!-- This file contains strings that used to be hardcoded in the source.
-     It is only for those strings which do not belong in a floater.
-     For example, the strings used in avatar chat bubbles, and strings
-     that are returned from one component and may appear in many places-->
 <strings>
 	<string name="SECOND_LIFE">
 		第二人生
@@ -1103,10 +1099,10 @@ http://secondlife.com/support 求助解決問題。
 		現在你將重新聯接到附近的語音聊天
 	</string>
 	<string name="ScriptQuestionCautionChatGranted">
-		物件「[OBJECTNAME]&apos;」（所有人「[OWNERNAME]」，位於「[REGIONNAME]」，方位「[REGIONPOS]」）已獲得下列權限：[PERMISSIONS]。
+		物件「[OBJECTNAME]'」（所有人「[OWNERNAME]」，位於「[REGIONNAME]」，方位「[REGIONPOS]」）已獲得下列權限：[PERMISSIONS]。
 	</string>
 	<string name="ScriptQuestionCautionChatDenied">
-		物件「[OBJECTNAME]&apos;」（所有人「[OWNERNAME]」，位於「[REGIONNAME]」，方位「[REGIONPOS]」）已被撤除下列權限：[PERMISSIONS]。
+		物件「[OBJECTNAME]'」（所有人「[OWNERNAME]」，位於「[REGIONNAME]」，方位「[REGIONPOS]」）已被撤除下列權限：[PERMISSIONS]。
 	</string>
 	<string name="AdditionalPermissionsRequestHeader">
 		你如果打開帳戶權限，也將一併允許該物件：
@@ -2863,8 +2859,8 @@ http://secondlife.com/support 求助解決問題。
 	<string name=".">
 		.
 	</string>
-	<string name="&apos;">
-		&apos;
+	<string name="'">
+		'
 	</string>
 	<string name="---">
 		---
@@ -2979,7 +2975,7 @@ http://secondlife.com/support 求助解決問題。
 
 如果你繼續看到此訊息，請聯絡 [SUPPORT_SITE]。
 	</string>
-	<string name="5 O&apos;Clock Shadow">
+	<string name="5 O'Clock Shadow">
 		下午五點的新鬍渣
 	</string>
 	<string name="All White">
@@ -4567,13 +4563,13 @@ http://secondlife.com/support 求助解決問題。
 		和 [AGENT_NAME] 多方通話
 	</string>
 	<string name="inventory_item_offered-im">
-		收納區物品&apos;[ITEM_NAME]&apos;已向人提供
+		收納區物品'[ITEM_NAME]'已向人提供
 	</string>
 	<string name="inventory_folder_offered-im">
-		收納區資料夾&apos;[ITEM_NAME]&apos;已向人提供
+		收納區資料夾'[ITEM_NAME]'已向人提供
 	</string>
 	<string name="bot_warning">
-您正在与人工智能机器人 [NAME] 聊天。请勿分享任何个人信息。
+		您正在与人工智能机器人 [NAME] 聊天。请勿分享任何个人信息。
 了解更多：https://second.life/scripted-agents。
 	</string>
 	<string name="share_alert">
@@ -5134,7 +5130,7 @@ http://secondlife.com/support 求助解決問題。
 	<string name="ExternalEditorNotFound">
 		找不到你指定的外部編輯器。
 請嘗試在編輯器路經前後加上英文雙括號。
-（例：&quot;/path to my/editor&quot; &quot;%s&quot;）
+（例："/path to my/editor" "%s"）
 	</string>
 	<string name="ExternalEditorCommandParseError">
 		解析外部編輯器指令時出錯。

--- a/indra/newview/skins/default/xui/zh/teleport_strings.xml
+++ b/indra/newview/skins/default/xui/zh/teleport_strings.xml
@@ -49,7 +49,7 @@
 			你必須年滿 18 歲才可進入這地區。
 		</message>
 		<message name="RegionTPSpecialUsageBlocked">
-			無法進入地區。 &apos;[REGION_NAME]&apos; 是個「技巧性博奕」(Skill Gaming)地區，你必須符合一定條件才可進入。 欲知詳情，請參閱 [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life 技巧性博奕常見問題集]。
+			無法進入地區。 '[REGION_NAME]' 是個「技巧性博奕」(Skill Gaming)地區，你必須符合一定條件才可進入。 欲知詳情，請參閱 [http://wiki.secondlife.com/wiki/Linden_Lab_Official:Skill_Gaming_in_Second_Life 技巧性博奕常見問題集]。
 		</message>
 	</message_set>
 	<message_set name="progress">


### PR DESCRIPTION
The aim of this change is to simplify the further merge for 3p devs. 

---

This is basically the output of the following command, excluding the `en` locale:
```
$ python scripts/code_tools/fix_xml_indentations.py indra/newview/skins/default/xui/ --file *strings.xml --recursive --indent-text --indent-tab --rm-space
```

@Ansariel, please check if this format fits into your merges. You may also want to use `-Xignore-all-space` to help reduce further conflicts.
