### PR TITLE
calcDataSizeJ2C Adjust curve for more than 6 layers

### DIFF
--- a/indra/llimage/llimagej2c.cpp
+++ b/indra/llimage/llimagej2c.cpp
@@ -281,10 +281,11 @@ S32 LLImageJ2C::calcDataSizeJ2C(S32 w, S32 h, S32 comp, S32 discard_level, F32 r
     S32 height = (h > 0) ? h : 2048;
     S32 max_dimension = llmax(width, height); // Find largest dimension
     S32 block_area = MAX_BLOCK_SIZE * MAX_BLOCK_SIZE; // Calculated initial block area from established max block size (currently 64)
-    block_area *= llmax((max_dimension / MAX_BLOCK_SIZE / max_components), 1); // Adjust initial block area by ratio of largest dimension to block size per component
-    S32 totalbytes = (S32) (block_area * max_components * precision); // First block layer computed before loop without compression rate
-    S32 block_layers = 1; // Start at layer 1 since first block layer is computed outside loop
-    while (block_layers < 6) // Walk five layers for the five discards in JPEG2000
+    S32 max_layers = (S32)llmax(llround(log2f((float)max_dimension) - log2f((float)MAX_BLOCK_SIZE)), 4); // Find number of powers of two between extents and block size to a minimum of 4
+    block_area *= llmax(max_layers, 1); // Adjust initial block area by max number of layers
+    S32 totalbytes = (S32) (MIN_LAYER_SIZE * max_components * precision); // Start estimation with a minimum reasonable size
+    S32 block_layers = 0;
+    while (block_layers <= max_layers) // Walk the layers
     {
         if (block_layers <= (5 - discard_level))  // Walk backwards from discard 5 to required discard layer.
             totalbytes += (S32) (block_area * max_components * precision * rate); // Add each block layer reduced by assumed compression rate


### PR DESCRIPTION
KDU is uploading 2k files with 7 and 8 layers which is shifting the location of discard 1 and 2.

To accommodate, this commit adds a max_layer check based on max_dimension and the MAX_BLOCK_SIZE to allow the extra layers for 2k and larger sizes.

Also shifted the starting total size to the MIN_LAYER_SIZE instead of MAX_BLOCK_SIZE's area to allow smaller files to be decoded at discard 5 completely.

Finally able to walk around Fantasy Faire without any gray blobs!