### PR TITLE
[#4037] Fix world map Find button potentially removing results undesirably

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_world_map.xml
+++ b/indra/newview/skins/default/xui/en/floater_world_map.xml
@@ -556,7 +556,7 @@
      name="DoSearch"
      tool_tip="Search for region"
      width="62">
-		<button.commit_callback
+		<button.mouse_down_callback
 		function="WMap.Location" />
     </button>
    <button


### PR DESCRIPTION
https://github.com/secondlife/viewer/issues/4037

Fixes the above issue by ensuring the World Map Find button only triggers the callback on mouse down and not mouse up, resulting in it only sending 1 request, disallowing it to update the search query before the user lets go of mouse down and it sending a 2nd request with a now-changed search query on mouse-up.

Video showing fix-
https://github.com/user-attachments/assets/59877f8d-6063-4106-95f6-a4cd3b05b51a

