### PR TITLE
Fix map search bug causing duplicate requests properly

### DIFF
--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -406,9 +406,12 @@ bool LLFloaterWorldMap::postBuild()
     F32 slider_zoom = mMapView->getZoom();
     mZoomSlider->setValue(slider_zoom);
 
+    mTrackCtrlsPanel = getChild<LLPanel>("layout_panel_4");
+    mSearchButton = getChild<LLButton>("DoSearch");
+
     getChild<LLPanel>("expand_btn_panel")->setMouseDownCallback(boost::bind(&LLFloaterWorldMap::onExpandCollapseBtn, this));
 
-    setDefaultBtn(NULL);
+    mTrackCtrlsPanel->setDefaultBtn(nullptr);
 
     onChangeMaturity();
 
@@ -728,7 +731,7 @@ void LLFloaterWorldMap::trackAvatar( const LLUUID& avatar_id, const std::string&
     {
         LLTracker::stopTracking(false);
     }
-    setDefaultBtn("Teleport");
+    mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
 }
 
 void LLFloaterWorldMap::trackLandmark( const LLUUID& landmark_item_id )
@@ -773,7 +776,7 @@ void LLFloaterWorldMap::trackLandmark( const LLUUID& landmark_item_id )
     {
         LLTracker::stopTracking(false);
     }
-    setDefaultBtn("Teleport");
+    mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
 }
 
 
@@ -782,7 +785,7 @@ void LLFloaterWorldMap::trackEvent(const LLItemInfo &event_info)
     mShowParcelInfo = false;
     mTrackedStatus = LLTracker::TRACKING_LOCATION;
     LLTracker::trackLocation(event_info.getGlobalPosition(), event_info.getName(), event_info.getToolTip(), LLTracker::LOCATION_EVENT);
-    setDefaultBtn("Teleport");
+    mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
 }
 
 void LLFloaterWorldMap::trackGenericItem(const LLItemInfo &item)
@@ -790,7 +793,7 @@ void LLFloaterWorldMap::trackGenericItem(const LLItemInfo &item)
     mShowParcelInfo = false;
     mTrackedStatus = LLTracker::TRACKING_LOCATION;
     LLTracker::trackLocation(item.getGlobalPosition(), item.getName(), item.getToolTip(), LLTracker::LOCATION_ITEM);
-    setDefaultBtn("Teleport");
+    mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
 }
 
 void LLFloaterWorldMap::trackLocation(const LLVector3d& pos_global)
@@ -804,7 +807,7 @@ void LLFloaterWorldMap::trackLocation(const LLVector3d& pos_global)
         S32 world_x = S32(pos_global.mdV[0] / 256);
         S32 world_y = S32(pos_global.mdV[1] / 256);
         LLWorldMapMessage::getInstance()->sendMapBlockRequest(world_x, world_y, world_x, world_y, true);
-        setDefaultBtn("");
+        mTrackCtrlsPanel->setDefaultBtn(nullptr);
 
         // clicked on a non-region - turn off coord display
         enableTeleportCoordsDisplay( false );
@@ -818,7 +821,7 @@ void LLFloaterWorldMap::trackLocation(const LLVector3d& pos_global)
         LLTracker::stopTracking(false);
         LLWorldMap::getInstance()->setTracking(pos_global);
         LLWorldMap::getInstance()->setTrackingInvalid();
-        setDefaultBtn("");
+        mTrackCtrlsPanel->setDefaultBtn(nullptr);
 
         // clicked on a down region - turn off coord display
         enableTeleportCoordsDisplay( false );
@@ -849,7 +852,7 @@ void LLFloaterWorldMap::trackLocation(const LLVector3d& pos_global)
     // we have a valid region - turn on coord display
     enableTeleportCoordsDisplay( true );
 
-    setDefaultBtn("Teleport");
+    mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
 }
 
 // enable/disable teleport destination coordinates
@@ -964,7 +967,7 @@ void LLFloaterWorldMap::trackURL(const std::string& region_name, S32 x_coord, S3
         local_pos.mV[VZ] = (F32)z_coord;
         LLVector3d global_pos = sim_info->getGlobalPos(local_pos);
         trackLocation(global_pos);
-        setDefaultBtn("Teleport");
+        mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
     }
     else
     {
@@ -1375,11 +1378,11 @@ void LLFloaterWorldMap::updateSearchEnabled()
     if (childHasKeyboardFocus("location") &&
         mLocationEditor->getValue().asString().length() > 0)
     {
-        setDefaultBtn("DoSearch");
+        mTrackCtrlsPanel->setDefaultBtn(mSearchButton);
     }
     else
     {
-        setDefaultBtn(NULL);
+        mTrackCtrlsPanel->setDefaultBtn(nullptr);
     }
 }
 
@@ -1800,7 +1803,7 @@ void LLFloaterWorldMap::onCommitSearchResult()
 
             mLocationEditor->setValue(sim_name);
             trackLocation(pos_global);
-            setDefaultBtn("Teleport");
+            mTrackCtrlsPanel->setDefaultBtn(mTeleportButton);
             break;
         }
     }

--- a/indra/newview/llfloaterworldmap.h
+++ b/indra/newview/llfloaterworldmap.h
@@ -226,6 +226,7 @@ private:
     LLButton*               mShowDestinationButton = nullptr;
     LLButton*               mCopySlurlButton = nullptr;
     LLButton*               mGoHomeButton = nullptr;
+    LLButton*               mSearchButton = nullptr;
 
     LLCheckBoxCtrl*         mPeopleCheck = nullptr;
     LLCheckBoxCtrl*         mInfohubCheck = nullptr;
@@ -244,6 +245,8 @@ private:
     LLUICtrl*               mTeleportCoordSpinZ = nullptr;
 
     LLSliderCtrl*           mZoomSlider = nullptr;
+
+    LLPanel*                mTrackCtrlsPanel = nullptr;
 
     boost::signals2::connection mTeleportFinishConnection;
 };

--- a/indra/newview/skins/default/xui/en/floater_world_map.xml
+++ b/indra/newview/skins/default/xui/en/floater_world_map.xml
@@ -532,9 +532,9 @@
      width="16" />
     <search_editor
      follows="top|right"
-  search_button_visible="false"
+     search_button_visible="false"
      height="22"
-  text_readonly_color="DkGray"
+     text_readonly_color="DkGray"
      label="Regions by Name"
      layout="topleft"
      top_delta="-2"
@@ -542,10 +542,7 @@
      name="location"
      select_on_focus="true"
      tool_tip="Type the name of a region"
-     width="152">
-               <search_editor.commit_callback
-                function="WMap.Location" />
-  </search_editor>
+     width="152"/>
    <button
      follows="top|right"
      height="23"
@@ -556,7 +553,7 @@
      name="DoSearch"
      tool_tip="Search for region"
      width="62">
-		<button.mouse_down_callback
+		<button.commit_callback
 		function="WMap.Location" />
     </button>
    <button


### PR DESCRIPTION
This fix merged in #4038 is wrong as well as the explanation to it. The duplicated request stems from the fact that the search editor `"location"` triggers the same commit callback as the "Search" button, which happens as soon as the search editor loses focus. All that change does is reducing the time between the execution of the callbacks from the search editor and the button (the callback from the button is now called immediately as the button is pressed and not when the mouse button is released), the search is still triggered twice. That only works purely by coincidence because the second search request is sent before the result of the first request is received, Effectively it is the same if you click the search button fast (as in press and release the mouse button quickly).

The actual cause is - as already pointed out - the slightly delayed execution of the second search request after the result of the first request has already been received: A result containing at least one entry will select the an entry in the result list, which then updates the search editor. The then executed search request will use the updated text in the search editor and will then obviously return only the one entry with the exact match.

This fix causes the actual issue by removing the unnecessary commit callback for the search editor and instead fixing the incorrect setting of the default button, which is applied to the floater. However, the panel actually evaluating the default button in its `LLPanel::handleKeyHere` method is `layout_panel_4`, which is the parent of all tracking-related controls. Removing the commit callback for the search editor and fixing the correct default button handling will now properly invoke the commit callback from the default search button without sending a duplicate request. This also fixes the unexpected behavior of actually triggering a search when the search editor loses focus.

Also changed it so the pointer to the widgets is directly passed into the `LLPanel::setDefaultBtn` method as passing the name will cause a `getChild` XUI lookup each time it is called - and it is called each time you enter anything in the search editor.