### PR TITLE
#4046 Fix hud vs inworld text color mismatch

### DIFF
--- a/indra/newview/llhudtext.cpp
+++ b/indra/newview/llhudtext.cpp
@@ -225,10 +225,6 @@ void LLHUDText::renderText()
             }
 
             text_color = segment_iter->mColor;
-            if (mOnHUDAttachment)
-            {
-                text_color = linearColor4(text_color);
-            }
             text_color.mV[VALPHA] *= alpha_factor;
 
             hud_render_text(segment_iter->getText(), render_position, *fontp, style, shadow, x_offset, y_offset, text_color, mOnHUDAttachment);


### PR DESCRIPTION
This reverts commit e2cf375179b807b847414206bf79617e4e9889ae. Commit e9889ae originaly was meant to fix color mimatch between text and face, but looks like it is no longer needed and instead adds mismatch between inworld and hud.