### PR TITLE
#2279 fix for View Angle setting

### DIFF
--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -73,12 +73,14 @@ LLViewerCamera::LLViewerCamera() : LLCamera()
     mAverageSpeed = 0.f;
     mAverageAngularSpeed = 0.f;
 
-    mCameraAngleChangedSignal = gSavedSettings.getControl("CameraAngle")->getCommitSignal()->connect(boost::bind(&LLViewerCamera::updateCameraAngle, this, _2));
-}
-
-LLViewerCamera::~LLViewerCamera()
-{
-    mCameraAngleChangedSignal.disconnect();
+    LLPointer<LLControlVariable> cntrl_ptr = gSavedSettings.getControl("CameraAngle");
+    if (cntrl_ptr.notNull())
+    {
+        cntrl_ptr->getCommitSignal()->connect([](LLControlVariable* control, const LLSD& value, const LLSD& previous)
+        {
+            LLViewerCamera::getInstance()->setDefaultFOV((F32)value.asReal());
+        });
+    }
 }
 
 void LLViewerCamera::updateCameraLocation(const LLVector3 &center, const LLVector3 &up_direction, const LLVector3 &point_of_interest)
@@ -812,10 +814,5 @@ bool LLViewerCamera::isDefaultFOVChanged()
         return !gSavedSettings.getBOOL("IgnoreFOVZoomForLODs");
     }
     return false;
-}
-
-void LLViewerCamera::updateCameraAngle(const LLSD& value)
-{
-    setDefaultFOV((F32)value.asReal());
 }
 

--- a/indra/newview/llviewercamera.h
+++ b/indra/newview/llviewercamera.h
@@ -43,7 +43,6 @@ class alignas(16) LLViewerCamera : public LLCamera, public LLSimpleton<LLViewerC
     LL_ALIGN_NEW
 public:
     LLViewerCamera();
-    ~LLViewerCamera();
 
     typedef enum
     {
@@ -66,7 +65,6 @@ public:
                                 const LLVector3 &point_of_interest);
 
     static void updateFrustumPlanes(LLCamera& camera, bool ortho = false, bool zflip = false, bool no_hacks = false);
-    void updateCameraAngle(const LLSD& value);
     void setPerspective(bool for_selection, S32 x, S32 y_from_bot, S32 width, S32 height, bool limit_select_distance, F32 z_near = 0, F32 z_far = 0);
 
     const LLMatrix4 &getProjection() const;
@@ -125,8 +123,6 @@ protected:
     S32                 mScreenPixelArea; // Pixel area of entire window
     F32                 mZoomFactor;
     S16                 mZoomSubregion;
-
-    boost::signals2::connection mCameraAngleChangedSignal;
 
 public:
 };


### PR DESCRIPTION
The reason View angle setting didn't work: we connected to the control once, but then disconnecting in destr which is firing due to LLViewerWindow::cubeSnapshot implementation. 