### PR TITLE
Fix for Mesh missing after TP. Assume MeshRezEnabled if SimFeatures not yet received

### DIFF
--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -3721,6 +3721,10 @@ bool LLViewerRegion::bakesOnMeshEnabled() const
 
 bool LLViewerRegion::meshRezEnabled() const
 {
+    if(!mSimulatorFeaturesReceived)
+    {
+        return true;
+    }
     return (mSimulatorFeatures.has("MeshRezEnabled") &&
                 mSimulatorFeatures["MeshRezEnabled"].asBoolean());
 }


### PR DESCRIPTION
This PR addresses one of the causes of the increased missing meshes following a TP. I do not believe it will fix the "missing mesh on login" which may be related but still occurs. It has completely eliminated the loss of body parts and other meshes going missing after a TP in all of my testing and regular usage.

The check in llvovolume for gMeshRepo.meshRezEnabled() has the side-effect of testing the region asset caps. After TP this is frequently failing and any mesh items in rebuildGeom at that moment will be excluded. 

Another option is to remove the check in llvovolume.cpp but as that was deliberately added as part of SL-5161 it is not clear whether that would be acceptable. 

Monty Linden confirmed that no current server version will decline that asset cap. 

Note that all this does is change the expected response to optimistic. If the region returned false, subsequent updates would be treated correctly.