### PR TITLE
Allow self-hosted runners to operate independently

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -16,7 +16,7 @@ on:
         default: '14806728332'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ matrix.runner }}
   cancel-in-progress: false # Prevents cancellation of in-progress jobs
 
 jobs:


### PR DESCRIPTION
Currently if there are multiple workflow runs queued and a runner is offline, the online runner will wait for the offline runner to either timeout or complete the job before moving to the next job. 
This adjustment should allow the online runner/s to move onto new workflow runs regardless of what other runners are up to.