### PR TITLE
Clear font buffers when calling LLLineEditor::clear()

### DIFF
--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -2230,6 +2230,9 @@ void LLLineEditor::clear()
 {
     mText.clear();
     setCursor(0);
+    mFontBufferPreSelection.reset();
+    mFontBufferSelection.reset();
+    mFontBufferPostSelection.reset();
 }
 
 //virtual


### PR DESCRIPTION
This seem to be missing by oversight and causes the previous content of LLLineEditor still being rendered after its `clear` method has been called. This can be observed in the group notices panel:

- Create and send a group notice
- Try creating a new group notice and notice the subject of the previous message is still being shown
- Enter a message without changing the subject and try sending it
- Notice you will get a notification about missing subject