### PR TITLE
#4107 upload the model ignoring unsupported extension

### DIFF
--- a/indra/newview/gltf/asset.cpp
+++ b/indra/newview/gltf/asset.cpp
@@ -489,20 +489,14 @@ void Asset::update()
 bool Asset::prep()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_GLTF;
-    // check required extensions and fail if not supported
-    bool unsupported = false;
+    // check required extensions
     for (auto& extension : mExtensionsRequired)
     {
         if (ExtensionsSupported.find(extension) == ExtensionsSupported.end())
         {
             LL_WARNS() << "Unsupported extension: " << extension << LL_ENDL;
-            unsupported = true;
+            mUnsupportedExtension = true;
         }
-    }
-
-    if (unsupported)
-    {
-        return false;
     }
 
     // do buffers first as other resources depend on them

--- a/indra/newview/gltf/asset.h
+++ b/indra/newview/gltf/asset.h
@@ -396,6 +396,8 @@ namespace LL
             U32 mMaterialsUBO = 0;
             bool mLoadIntoVRAM = false;
 
+            bool mUnsupportedExtension = false;
+
             // prepare for first time use
             bool prep();
 

--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -127,6 +127,13 @@ bool LLGLTFLoader::OpenFile(const std::string &filename)
         return false;
     }
 
+    if (mGLTFAsset.mUnsupportedExtension)
+    {
+        LLSD args;
+        args["Message"] = "UnsupportedExtension";
+        mWarningsArray.append(args);
+    }
+
     mMeshesLoaded = parseMeshes();
     if (mMeshesLoaded) uploadMeshes();
 

--- a/indra/newview/skins/default/xui/en/floater_model_preview.xml
+++ b/indra/newview/skins/default/xui/en/floater_model_preview.xml
@@ -62,6 +62,7 @@
   <string name="ParsingErrorNoScene">Document has no visual_scene</string>
   <string name="ParsingErrorPositionInvalidModel">Unable to process mesh without position data. Invalid model.</string>
   <string name="InvalidGeometryNonTriangulated">Invalid geometry: GLTF files must contain triangulated meshes only.</string>
+  <string name="UnsupportedExtension">Model uses unsupported extension, related material properties are ignored.</string>
 
   <panel
     follows="top|left"


### PR DESCRIPTION
Allow uploading the mesh even if PBR extension is not supported, so just ignore materials properties.