### PR TITLE
#4191 skip loading model compressed with Draco

### DIFF
--- a/indra/newview/gltf/asset.cpp
+++ b/indra/newview/gltf/asset.cpp
@@ -50,6 +50,10 @@ namespace LL
             "KHR_texture_transform"
         };
 
+        static std::unordered_set<std::string> ExtensionsIgnored = {
+            "KHR_materials_pbrSpecularGlossiness"
+        };
+
         Material::AlphaMode gltf_alpha_mode_to_enum(const std::string& alpha_mode)
         {
             if (alpha_mode == "OPAQUE")
@@ -494,9 +498,20 @@ bool Asset::prep()
     {
         if (ExtensionsSupported.find(extension) == ExtensionsSupported.end())
         {
-            LL_WARNS() << "Unsupported extension: " << extension << LL_ENDL;
-            mUnsupportedExtensions.push_back(extension);
+            if (ExtensionsIgnored.find(extension) == ExtensionsIgnored.end())
+            {
+                LL_WARNS() << "Unsupported extension: " << extension << LL_ENDL;
+                mUnsupportedExtensions.push_back(extension);
+            }
+            else
+            {
+                mIgnoredExtensions.push_back(extension);
+            }
         }
+    }
+    if (mUnsupportedExtensions.size() > 0)
+    {
+        return false;
     }
 
     // do buffers first as other resources depend on them

--- a/indra/newview/gltf/asset.h
+++ b/indra/newview/gltf/asset.h
@@ -397,6 +397,7 @@ namespace LL
             bool mLoadIntoVRAM = false;
 
             std::vector<std::string> mUnsupportedExtensions;
+            std::vector<std::string> mIgnoredExtensions;
 
             // prepare for first time use
             bool prep();

--- a/indra/newview/gltf/llgltfloader.h
+++ b/indra/newview/gltf/llgltfloader.h
@@ -174,6 +174,8 @@ private:
     S32 findGLTFRootJoint(const LL::GLTF::Skin& gltf_skin) const; // if there are multiple roots, gltf stores them under one commor joint
     LLUUID imageBufferToTextureUUID(const gltf_texture& tex);
 
+    void notifyUnsupportedExtension(bool unsupported);
+
     //    bool mPreprocessGLTF;
 
     /*  Below inherited from dae loader - unknown if/how useful here

--- a/indra/newview/skins/default/xui/en/floater_model_preview.xml
+++ b/indra/newview/skins/default/xui/en/floater_model_preview.xml
@@ -62,7 +62,8 @@
   <string name="ParsingErrorNoScene">Document has no visual_scene</string>
   <string name="ParsingErrorPositionInvalidModel">Unable to process mesh without position data. Invalid model.</string>
   <string name="InvalidGeometryNonTriangulated">Invalid geometry: GLTF files must contain triangulated meshes only.</string>
-  <string name="UnsupportedExtension">Model uses unsupported extension, related material properties are ignored: [EXT]</string>
+  <string name="IgnoredExtension">Model uses unsupported extension: [EXT], related material properties are ignored.</string>
+  <string name="UnsupportedExtension">Unable to load a model, unsupported extension: [EXT]</string>
 
   <panel
     follows="top|left"


### PR DESCRIPTION
Separate ignored extension (when it makes sense to continue upload) from unsupported to avoid crashes like this one - when trying to upload a model compressed with Draco(KHR_draco_mesh_compression)