### PR TITLE
[#4221] 

### DIFF
--- a/indra/llinventory/llsettingsbase.cpp
+++ b/indra/llinventory/llsettingsbase.cpp
@@ -361,14 +361,12 @@ LLSD LLSettingsBase::interpolateSDValue(const std::string& key_name, const LLSD 
                 new_array = q.getValue();
             }
             else
-            {   // TODO: We could expand this to inspect the type and do a deep lerp based on type.
-                // for now assume a heterogeneous array of reals.
+            {
                 size_t len = std::max(value.size(), other_value.size());
 
                 for (size_t i = 0; i < len; ++i)
                 {
-
-                    new_array[i] = lerp((F32)value[i].asReal(), (F32)other_value[i].asReal(), (F32)mix);
+                    new_array[i] = interpolateSDValue(key_name, value[i], other_value[i], defaults, mix, skip, slerps);
                 }
             }
 

--- a/indra/llinventory/llsettingssky.cpp
+++ b/indra/llinventory/llsettingssky.cpp
@@ -664,9 +664,9 @@ void LLSettingsSky::blend(LLSettingsBase::ptr_t &end, F64 blendf)
         parammapping_t defaults = other->getParameterMap();
         stringset_t skip = getSkipInterpolateKeys();
         stringset_t slerps = getSlerpKeys();
-        mAbsorptionConfigs = interpolateSDMap(mAbsorptionConfigs, other->mAbsorptionConfigs, defaults, blendf, skip, slerps);
-        mMieConfigs = interpolateSDMap(mMieConfigs, other->mMieConfigs, defaults, blendf, skip, slerps);
-        mRayleighConfigs = interpolateSDMap(mRayleighConfigs, other->mRayleighConfigs, defaults, blendf, skip, slerps);
+        mAbsorptionConfigs = interpolateSDValue("absorption_config", mAbsorptionConfigs, other->mAbsorptionConfigs, defaults, blendf, skip, slerps);
+        mMieConfigs = interpolateSDValue("mie_config", mMieConfigs, other->mMieConfigs, defaults, blendf, skip, slerps);
+        mRayleighConfigs = interpolateSDValue("rayleigh_config", mRayleighConfigs, other->mRayleighConfigs, defaults, blendf, skip, slerps);
 
         setDirtyFlag(true);
         setReplaced();


### PR DESCRIPTION
https://github.com/secondlife/viewer/issues/4221

Fixes the above issue which was caused by mAbsorptionConfigs, mMieConfigs and mRayleighConfigs becoming null since interpolateSDMap wasn't interpolating and combining them properly as they are arrays and not maps. This causes the sky settings to fail the validation check when trying to save them, which resulted in the added sky not being saved into the day cycle. Now those 3 configs correctly get interpolated and should no longer end up null and failing the validation, and allow them to be saved correctly.