### PR TITLE
Require PR descriptions

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check-description:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a simple workflow check to ensure PRs have a description.