### PR TITLE
Fix fast cache ignoring its time constraint

### DIFF
--- a/indra/newview/llviewertexturelist.cpp
+++ b/indra/newview/llviewertexturelist.cpp
@@ -1197,6 +1197,8 @@ F32 LLViewerTextureList::updateImagesLoadingFastCache(F32 max_time)
         enditer = iter;
         LLViewerFetchedTexture *imagep = *curiter;
         imagep->loadFromFastCache();
+        if (timer.getElapsedTimeF32() > max_time)
+            break;
     }
     mFastCacheList.erase(mFastCacheList.begin(), enditer);
     return timer.getElapsedTimeF32();
@@ -1308,7 +1310,7 @@ void LLViewerTextureList::decodeAllImages(F32 max_time)
     LLTimer timer;
 
     //loading from fast cache
-    updateImagesLoadingFastCache(max_time);
+    max_time -= updateImagesLoadingFastCache(max_time);
 
     // Update texture stats and priorities
     std::vector<LLPointer<LLViewerFetchedTexture> > image_list;


### PR DESCRIPTION
Loading images from fast cache never checked its time constraint, meaning the viewer would load and decode all images currently in the fast cache in a single frame instead of a max. of 5/3ms - on the main thread. This could lead to very noticable framerate drops if a lot of textures are being loaded from the fast cache.