### PR TITLE
macOS 26 build changes

### DIFF
--- a/indra/cmake/Linking.cmake
+++ b/indra/cmake/Linking.cmake
@@ -72,7 +72,6 @@ else()
   find_library(COCOA_LIBRARY Cocoa)
   find_library(IOKIT_LIBRARY IOKit)
 
-  find_library(AGL_LIBRARY AGL)
   find_library(APPKIT_LIBRARY AppKit)
   find_library(COREAUDIO_LIBRARY CoreAudio)
 
@@ -81,7 +80,6 @@ else()
           ${IOKIT_LIBRARY}
           ${COREFOUNDATION_LIBRARY}
           ${CARBON_LIBRARY}
-          ${AGL_LIBRARY}
           ${APPKIT_LIBRARY}
           ${COREAUDIO_LIBRARY}
           )

--- a/indra/llplugin/llpluginprocessparent.cpp
+++ b/indra/llplugin/llpluginprocessparent.cpp
@@ -575,7 +575,7 @@ void LLPluginProcessParent::idle(void)
                             params.args.add("-e");
                             params.args.add("tell application \"Terminal\"");
                             params.args.add("-e");
-                            params.args.add(STRINGIZE("set win to do script \"lldb -pid "
+                            params.args.add(STRINGIZE("set win to do script \"lldb -p "
                                                       << mProcess->getProcessID() << "\""));
                             params.args.add("-e");
                             params.args.add("do script \"continue\" in win");

--- a/indra/llwindow/llopenglview-objc.mm
+++ b/indra/llwindow/llopenglview-objc.mm
@@ -657,7 +657,7 @@ attributedStringInfo getSegments(NSAttributedString *str)
         };
         
         int string_length = [aString length];
-        unichar text[string_length];
+        unichar *text = new unichar[string_length];
         attributedStringInfo segments;
         // I used 'respondsToSelector:@selector(string)'
         // to judge aString is an attributed string or not.
@@ -685,6 +685,8 @@ attributedStringInfo getSegments(NSAttributedString *str)
             // we must clear the marked text when aString is null.
             [self unmarkText];
         }
+        
+        delete [] text;
     } else {
         if (mHasMarkedText)
         {

--- a/indra/llwindow/llopenglview-objc.mm
+++ b/indra/llwindow/llopenglview-objc.mm
@@ -685,7 +685,7 @@ attributedStringInfo getSegments(NSAttributedString *str)
             // we must clear the marked text when aString is null.
             [self unmarkText];
         }
-        
+
         delete [] text;
     } else {
         if (mHasMarkedText)

--- a/indra/newview/llfloateruipreview.cpp
+++ b/indra/newview/llfloateruipreview.cpp
@@ -1042,16 +1042,20 @@ void LLFloaterUIPreview::getExecutablePath(const std::vector<std::string>& filen
         {
             CFStringRef executable_cfstr = (CFStringRef)CFDictionaryGetValue(bundleInfoDict, CFSTR("CFBundleExecutable"));  // get the name of the actual executable (e.g. TextEdit or firefox-bin)
             int max_file_length = 256;                                                                                      // (max file name length is 255 in OSX)
-            char executable_buf[max_file_length];
+            
+            // Xcode 26: VLAs are a clang extension.  Just create the buffer and delete it after.
+            char *executable_buf = new char [max_file_length];
             if(CFStringGetCString(executable_cfstr, executable_buf, max_file_length, kCFStringEncodingMacRoman))            // convert CFStringRef to char*
             {
                 executable_path += std::string("/Contents/MacOS/") + std::string(executable_buf);                           // append path to executable directory and then executable name to exec path
+                
             }
             else
             {
                 std::string warning = "Unable to get CString from CFString for executable path";
                 popupAndPrintWarning(warning);
             }
+            delete [] executable_buf;
         }
         else
         {

--- a/indra/newview/llfloateruipreview.cpp
+++ b/indra/newview/llfloateruipreview.cpp
@@ -1042,13 +1042,12 @@ void LLFloaterUIPreview::getExecutablePath(const std::vector<std::string>& filen
         {
             CFStringRef executable_cfstr = (CFStringRef)CFDictionaryGetValue(bundleInfoDict, CFSTR("CFBundleExecutable"));  // get the name of the actual executable (e.g. TextEdit or firefox-bin)
             int max_file_length = 256;                                                                                      // (max file name length is 255 in OSX)
-            
+
             // Xcode 26: VLAs are a clang extension.  Just create the buffer and delete it after.
             char *executable_buf = new char [max_file_length];
             if(CFStringGetCString(executable_cfstr, executable_buf, max_file_length, kCFStringEncodingMacRoman))            // convert CFStringRef to char*
             {
                 executable_path += std::string("/Contents/MacOS/") + std::string(executable_buf);                           // append path to executable directory and then executable name to exec path
-                
             }
             else
             {


### PR DESCRIPTION
You may need to set LL_SKIP_REQUIRE_SYSROOT to ON if you're using Xcode 26 beta.

Takes care of the AGL deprecation (this was removed from the macOS 26 SDK - and I can't find any notes or deprecation notices for it).
Takes care of VLAs now emitting a warning on Xcode 26 creating an error in the viewer compile.

Still determining the best and fastest solution to the CEF missing Info.plist error when you attempt to run the viewer from Xcode - but produced builds will still work.  May just add a post-build fixup to create the missing versions folder for the framework for now until we can produce a new CEF build that has this fix built-in.  Will produce a separate PR for that.
 
Carbon is still (somehow) present despite AGL's removal.