### PR TITLE
#4147 Move mAlternateBindMatrices

### DIFF
--- a/indra/newview/gltf/llgltfloader.h
+++ b/indra/newview/gltf/llgltfloader.h
@@ -174,6 +174,7 @@ protected:
     // vector of vectors because of a posibility of having more than one skin
     typedef std::vector<LLMeshSkinInfo::matrix_list_t> bind_matrices_t;
     bind_matrices_t                     mInverseBindMatrices;
+    bind_matrices_t                     mAlternateBindMatrices;
 
 private:
     bool parseMeshes();


### PR DESCRIPTION
For reduced log spam and calculutions and to make further modifications easier.