### PR TITLE
#4204 Fix GLTF texture loading to match DAE loader behavior

### DIFF
--- a/indra/newview/llfloatermodelpreview.cpp
+++ b/indra/newview/llfloatermodelpreview.cpp
@@ -114,11 +114,6 @@ void LLMeshFilePicker::notify(const std::vector<std::string>& filenames)
     if (filenames.size() > 0)
     {
         mMP->loadModel(filenames[0], mLOD);
-
-        if (filenames[0].substr(filenames[0].length() - 4) == ".glb" || filenames[0].substr(filenames[0].length() - 5) == ".gltf")
-        {
-            LLMaterialEditor::loadMaterialFromFile(filenames[0], -1);
-        }
     }
     else
     {


### PR DESCRIPTION
For base color textures, the GLTF loader now uses the same behavior as the DAE loader.

![image](https://github.com/user-attachments/assets/549f5016-2635-4220-9fef-aed9db1ac3ed)
