### PR TITLE
Fix loading name of banned residents in group bulk ban panel

### DIFF
--- a/indra/newview/llpanelgroupbulkimpl.h
+++ b/indra/newview/llpanelgroupbulkimpl.h
@@ -59,7 +59,7 @@ public:
     void handleSelection();
 
     void addUsers(const std::vector<std::string>& names, const uuid_vec_t& agent_ids);
-    void setGroupName(std::string name);
+    void setGroupName(const std::string& name);
 
 
 public:
@@ -84,7 +84,7 @@ public:
 
     void (*mCloseCallback)(void* data);
     void* mCloseCallbackUserData;
-    boost::signals2::connection mAvatarNameCacheConnection;
+    std::map<LLUUID, boost::signals2::connection> mAvatarNameCacheConnections;
 
     // The following are for the LLPanelGroupInvite subclass only.
     // These aren't needed for LLPanelGroupBulkBan, but if we have to add another


### PR DESCRIPTION
Requesting more than one avatar name in the group bulk ban panel causes avatars not getting resolved properly, because each time a name request is issued the callback for the previous request is canceled. Instead of using a single signal connection for the callbacks, use a connection for each request.