### PR TITLE
Fix bit logic mistake in PRIM_MEDIA_FIRST_CLICK_INTERACT work

### DIFF
--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -1527,7 +1527,7 @@ bool LLToolPie::shouldAllowFirstMediaInteraction(const LLPickInfo& pick, bool mo
         return false;
     }
     // Any object with PRIM_MEDIA_FIRST_CLICK_INTERACT set to TRUE
-    if(FirstClickPref & MEDIA_FIRST_CLICK_ANY)
+    if((FirstClickPref & MEDIA_FIRST_CLICK_ANY) == MEDIA_FIRST_CLICK_ANY)
     {
         LL_DEBUGS_ONCE() << "FirstClickPref & MEDIA_FIRST_CLICK_ANY" << LL_ENDL;
         return true;


### PR DESCRIPTION
Another bug slipped in with the PRIM_MEDIA_FIRST_CLICK_INTERACT work

The bit field check wasn't correct