### PR TITLE
#4190 Provide unsupported extension info in log file

### DIFF
--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -1705,6 +1705,8 @@ void LLGLTFLoader::notifyUnsupportedExtension(bool unsupported)
         }
         args["EXT"] = ext;
         mWarningsArray.append(args);
+
+        LL_WARNS("GLTF_IMPORT") << "Model uses unsupported extension: " << ext << LL_ENDL;
     }
 }
 


### PR DESCRIPTION
Just add an info message to the log file when an unsupported extension is found in the model.