### PR TITLE
Add mac self-hosted runner to QA workflow

### DIFF
--- a/.github/workflows/qatest.yaml
+++ b/.github/workflows/qatest.yaml
@@ -514,13 +514,28 @@ jobs:
           APP_NAME=$(basename "$APP_PATH")
           DEST_PATH="/Applications/$APP_NAME"
 
-          # Remove existing installation if it exists to avoid permission conflicts
+          # Handle existing installation
           if [ -d "$DEST_PATH" ]; then
-            echo "Removing existing installation..."
-            sudo rm -rf "$DEST_PATH"
+            echo "Found existing installation at: $DEST_PATH"
+            echo "Moving existing installation to trash..."
+
+            # Move to trash instead of force removing
+            TRASH_PATH="$HOME/.Trash/$(date +%Y%m%d_%H%M%S)_$APP_NAME"
+            mv "$DEST_PATH" "$TRASH_PATH" || {
+              echo "⚠️ Could not move to trash, trying direct removal..."
+              rm -rf "$DEST_PATH" || {
+                echo "❌ Could not remove existing installation"
+                echo "Please manually remove: $DEST_PATH"
+                exit 1
+              }
+            }
+
+            echo "✅ Existing installation handled successfully"
           fi
 
           # Copy the .app to /Applications
+          echo "Copying app from: $APP_PATH"
+          echo "To destination: /Applications/"
           cp -R "$APP_PATH" /Applications/
 
           # Verify the app was copied successfully


### PR DESCRIPTION
Uncommenting mac runner lines to enable newly set up self-hosted runner with the QA GHA workflow.
