### PR TITLE
#4339 World Map Find button shouldn't autocomplete

### DIFF
--- a/indra/newview/llfloaterworldmap.cpp
+++ b/indra/newview/llfloaterworldmap.cpp
@@ -1694,14 +1694,15 @@ void LLFloaterWorldMap::updateSims(bool found_null_sim)
         if (!match.isUndefined())
         {
             mSearchResults->selectByValue(match);
+            mSearchResults->setFocus(true);
+            onCommitSearchResult();
         }
-        // else select first found item
+        // else let user decide
         else
         {
-            mSearchResults->selectFirstItem();
+            mSearchResults->operateOnAll(LLCtrlListInterface::OP_DESELECT);
+            mSearchResults->setFocus(true);
         }
-        mSearchResults->setFocus(true);
-        onCommitSearchResult();
     }
     else
     {


### PR DESCRIPTION
Either don't track (go) or implement trackSearch()
onCommitSearchResult() tracks location and 'autocompletes' as it is meant for selecting and applying items from search list.
