### PR TITLE
#3725 Improve reporting of avatar statistics

### DIFF
--- a/indra/newview/llagentwearables.cpp
+++ b/indra/newview/llagentwearables.cpp
@@ -1094,12 +1094,12 @@ void LLAgentWearables::setWearableOutfit(const LLInventoryItem::item_array_t& it
     {
         gAgentAvatarp->setCompositeUpdatesEnabled(true);
 
-        // If we have not yet declouded, we may want to use
+        // If we have not yet loaded core parts, we may want to use
         // baked texture UUIDs sent from the first objectUpdate message
-        // don't overwrite these. If we have already declouded, we've saved
-        // these ids as the last known good textures and can invalidate without
-        // re-clouding.
-        if (!gAgentAvatarp->getIsCloud())
+        // don't overwrite these. If we have parts already, we've saved
+        // these texture ids as the last known good textures and can
+        // invalidate without having to recloud avatar.
+        if (!gAgentAvatarp->getHasMissingParts())
         {
             gAgentAvatarp->invalidateAll();
         }

--- a/indra/newview/llappearancemgr.cpp
+++ b/indra/newview/llappearancemgr.cpp
@@ -856,7 +856,7 @@ void LLWearableHoldingPattern::checkMissingWearables()
             // was requested but none was found, create a default asset as a replacement.
             // In all other cases, don't do anything.
             // For critical types (shape/hair/skin/eyes), this will keep the avatar as a cloud
-            // due to logic in LLVOAvatarSelf::getIsCloud().
+            // due to logic in LLVOAvatarSelf::getHasMissingParts().
             // For non-critical types (tatoo, socks, etc.) the wearable will just be missing.
             (requested_by_type[type] > 0) &&
             ((type == LLWearableType::WT_PANTS) || (type == LLWearableType::WT_SHIRT) || (type == LLWearableType::WT_SKIRT)))

--- a/indra/newview/llvoavatar.h
+++ b/indra/newview/llvoavatar.h
@@ -400,7 +400,7 @@ public:
 
     bool            isTooComplex() const;
     bool            visualParamWeightsAreDefault();
-    virtual bool    getIsCloud() const;
+    virtual bool    getHasMissingParts() const;
     bool            isFullyTextured() const;
     bool            hasGray() const;
     S32             getRezzedStatus() const; // 0 = cloud, 1 = gray, 2 = textured, 3 = textured and fully downloaded.
@@ -427,6 +427,7 @@ protected:
 
 private:
     bool            mFirstFullyVisible;
+    bool            mWaitingForMeshes;
     F32             mFirstDecloudTime;
     LLFrameTimer    mFirstAppearanceMessageTimer;
 
@@ -723,7 +724,7 @@ public:
 
     bool            isFullyBaked();
     static bool     areAllNearbyInstancesBaked(S32& grey_avatars);
-    static void     getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_time, S32& cloud_avatars);
+    static void     getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_time, S32& cloud_avatars, S32& pending_meshes, S32& control_avatars);
     static std::string rezStatusToString(S32 status);
 
     //--------------------------------------------------------------------

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -1927,7 +1927,7 @@ void LLVOAvatarSelf::dumpTotalLocalTextureByteCount()
     LL_INFOS() << "Total Avatar LocTex GL:" << (gl_bytes/1024) << "KB" << LL_ENDL;
 }
 
-bool LLVOAvatarSelf::getIsCloud() const
+bool LLVOAvatarSelf::getHasMissingParts() const
 {
     // Let people know why they're clouded without spamming them into oblivion.
     bool do_warn = false;
@@ -2237,14 +2237,18 @@ void LLVOAvatarSelf::appearanceChangeMetricsCoro(std::string url)
     std::vector<S32> rez_counts;
     F32 avg_time;
     S32 total_cloud_avatars;
-    LLVOAvatar::getNearbyRezzedStats(rez_counts, avg_time, total_cloud_avatars);
+    S32 waiting_for_meshes;
+    S32 control_avatars;
+    LLVOAvatar::getNearbyRezzedStats(rez_counts, avg_time, total_cloud_avatars, waiting_for_meshes, control_avatars);
     for (S32 rez_stat = 0; rez_stat < rez_counts.size(); ++rez_stat)
     {
         std::string rez_status_name = LLVOAvatar::rezStatusToString(rez_stat);
         msg["nearby"][rez_status_name] = rez_counts[rez_stat];
     }
+    msg["nearby"]["waiting_for_meshes"] = waiting_for_meshes;
     msg["nearby"]["avg_decloud_time"] = avg_time;
     msg["nearby"]["cloud_total"] = total_cloud_avatars;
+    msg["nearby"]["animeshes"] = control_avatars;
 
     //  std::vector<std::string> bucket_fields("timer_name","is_self","grid_x","grid_y","is_using_server_bake");
     std::vector<std::string> by_fields;

--- a/indra/newview/llvoavatarself.h
+++ b/indra/newview/llvoavatarself.h
@@ -129,7 +129,7 @@ public:
     // Loading state
     //--------------------------------------------------------------------
 public:
-    /*virtual*/ bool    getIsCloud() const;
+    /*virtual*/ bool    getHasMissingParts() const;
 
     //--------------------------------------------------------------------
     // Region state

--- a/indra/newview/tests/llviewerassetstats_test.cpp
+++ b/indra/newview/tests/llviewerassetstats_test.cpp
@@ -43,12 +43,15 @@ namespace LLStatViewer
     LLTrace::SampleStatHandle<>     FPS_SAMPLE("fpssample");
 }
 
-void LLVOAvatar::getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_time, S32& cloud_avatars)
+void LLVOAvatar::getNearbyRezzedStats(std::vector<S32>& counts, F32& avg_cloud_time, S32& cloud_avatars, S32& pending_meshes, S32& control_avatars)
 {
     counts.resize(3);
     counts[0] = 0;
     counts[1] = 0;
     counts[2] = 1;
+    cloud_avatars = 0;
+    pending_meshes = 0;
+    control_avatars = 0;
 }
 
 // static


### PR DESCRIPTION
1. Don't report UI avatars, they are local and UI specific
2. Split animeshes from normal avatars, they have different loading process
3. Rename 'cloud' to 'missing parts', it's not directly related to 'cloud' at the moment
4. Exclude self, that's reported separately
5. Report avatars held by meshes