### PR TITLE
[#4365] Fix emoji hitboxes in the emoji history list

### DIFF
--- a/indra/newview/llpanelemojicomplete.cpp
+++ b/indra/newview/llpanelemojicomplete.cpp
@@ -463,6 +463,7 @@ void LLPanelEmojiComplete::updateConstraints()
     {
         mEmojiHeight = mRenderRect.getHeight();
         mRenderRect.stretch((mRenderRect.getWidth() - static_cast<S32>(mVisibleEmojis) * mEmojiWidth) / -2, 0);
+        mRenderRect.translate(-mRenderRect.mLeft, 0); // Left align emojis to fix hitboxes
     }
 
     updateScrollPos();


### PR DESCRIPTION
## Description

This PR makes a change to the emoji history at the bottom of the IM floater by ensuring they are always left aligned which fixes their hitboxes when mousing over and clicking them. This is done by ensuring their render rectangle has a left value of 0, and the right value gets offset by how much the left got offset by.

<Details>
<Summary>Video showing new behaviour-</Summary>

https://github.com/user-attachments/assets/cbfe6474-0664-4dd5-9fe4-2700335b99ca

</Details>


## Related Issues

Issue: https://github.com/secondlife/viewer/issues/4365

---

## Additional Notes

The reason the hitboxes don't match where they are rendered is probably worth investigating too, however in my opinion, having them left aligned is more visually ideal regardless. That way an arbitrary gap depending on the floater size doesn't exist before the emoji history, and instead as the window grows in width, it simply adds another emoji if it can fit instead of trying to constantly centre them all.
