### PR TITLE
#4358 Fix 'Microphone in use' task bar icon

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -670,7 +670,10 @@ LLWebRTCPeerConnectionInterface *LLWebRTCImpl::newPeerConnection()
     peerConnection->init(this);
 
     mPeerConnections.emplace_back(peerConnection);
-    peerConnection->enableSenderTracks(!mMute);
+    // Should it really start disabled?
+    // Seems like something doesn't get the memo and senders need to be reset later
+    // to remove the voice indicator from taskbar
+    peerConnection->enableSenderTracks(false);
     if (mPeerConnections.empty())
     {
         setRecording(true);
@@ -704,7 +707,7 @@ void LLWebRTCImpl::freePeerConnection(LLWebRTCPeerConnectionInterface* peer_conn
 LLWebRTCPeerConnectionImpl::LLWebRTCPeerConnectionImpl() :
     mWebRTCImpl(nullptr),
     mPeerConnection(nullptr),
-    mMute(true),
+    mMute(MUTE_INITIAL),
     mAnswerReceived(false)
 {
 }
@@ -738,6 +741,19 @@ void LLWebRTCPeerConnectionImpl::terminate()
                         mDataChannel = nullptr;
                     }
                 }
+
+                // to remove 'Secondlife is recording' icon from taskbar
+                // if user was speaking
+                auto senders = mPeerConnection->GetSenders();
+                for (auto& sender : senders)
+                {
+                    auto track = sender->track();
+                    if (track)
+                    {
+                        track->set_enabled(false);
+                    }
+                }
+                mPeerConnection->SetAudioRecording(false);
 
                 mPeerConnection->Close();
                 if (mLocalStream)
@@ -828,6 +844,7 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection(const LLWebRTCPeerConnecti
             audioOptions.auto_gain_control = true;
             audioOptions.echo_cancellation = true;
             audioOptions.noise_suppression = true;
+            audioOptions.init_recording_on_send = false;
 
             mLocalStream = mPeerConnectionFactory->CreateLocalMediaStream("SLStream");
 
@@ -892,6 +909,7 @@ void LLWebRTCPeerConnectionImpl::enableSenderTracks(bool enable)
         {
             sender->track()->set_enabled(enable);
         }
+        mPeerConnection->SetAudioRecording(enable);
     }
 }
 
@@ -932,9 +950,17 @@ void LLWebRTCPeerConnectionImpl::AnswerAvailable(const std::string &sdp)
 
 void LLWebRTCPeerConnectionImpl::setMute(bool mute)
 {
-    mMute = mute;
+    EMicMuteState new_state = mute ? MUTE_MUTED : MUTE_UNMUTED;
+    if (new_state == mMute)
+    {
+        return; // no change
+    }
+    bool force_reset = mMute == MUTE_INITIAL && mute;
+    bool enable = !mute;
+    mMute = new_state;
+
     mWebRTCImpl->PostSignalingTask(
-        [this]()
+        [this, force_reset, enable]()
         {
         if (mPeerConnection)
         {
@@ -946,16 +972,34 @@ void LLWebRTCPeerConnectionImpl::setMute(bool mute)
                 auto track = sender->track();
                 if (track)
                 {
-                    track->set_enabled(!mMute);
+                    if (force_reset)
+                    {
+                        // Force notify observers
+                        // Was it disabled too early?
+                        // Without this microphone icon in Win's taskbar will stay
+                        track->set_enabled(true);
+                    }
+                    track->set_enabled(enable);
                 }
             }
+            mPeerConnection->SetAudioRecording(enable);
         }
     });
 }
 
 void LLWebRTCPeerConnectionImpl::resetMute()
 {
-    setMute(mMute);
+    switch(mMute)
+    {
+    case MUTE_MUTED:
+         setMute(true);
+         break;
+    case MUTE_UNMUTED:
+         setMute(false);
+         break;
+    default:
+        break;
+    }
 }
 
 void LLWebRTCPeerConnectionImpl::setReceiveVolume(float volume)

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -417,7 +417,12 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
 
-    bool mMute;
+    typedef enum {
+        MUTE_INITIAL,
+        MUTE_MUTED,
+        MUTE_UNMUTED,
+    } EMicMuteState;
+    EMicMuteState mMute;
 
     // signaling
     std::vector<LLWebRTCSignalingObserver *>  mSignalingObserverList;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -336,35 +336,37 @@ void LLWebRTCVoiceClient::updateSettings()
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOICE;
 
     setVoiceEnabled(LLVoiceClient::getInstance()->voiceEnabled());
-    static LLCachedControl<S32> sVoiceEarLocation(gSavedSettings, "VoiceEarLocation");
-    setEarLocation(sVoiceEarLocation);
+    if (mVoiceEnabled)
+    {
+        static LLCachedControl<S32> sVoiceEarLocation(gSavedSettings, "VoiceEarLocation");
+        setEarLocation(sVoiceEarLocation);
 
-    static LLCachedControl<std::string> sInputDevice(gSavedSettings, "VoiceInputAudioDevice");
-    setCaptureDevice(sInputDevice);
+        static LLCachedControl<std::string> sInputDevice(gSavedSettings, "VoiceInputAudioDevice");
+        setCaptureDevice(sInputDevice);
 
-    static LLCachedControl<std::string> sOutputDevice(gSavedSettings, "VoiceOutputAudioDevice");
-    setRenderDevice(sOutputDevice);
+        static LLCachedControl<std::string> sOutputDevice(gSavedSettings, "VoiceOutputAudioDevice");
+        setRenderDevice(sOutputDevice);
 
-    LL_INFOS("Voice") << "Input device: " << std::quoted(sInputDevice()) << ", output device: " << std::quoted(sOutputDevice()) << LL_ENDL;
+        LL_INFOS("Voice") << "Input device: " << std::quoted(sInputDevice()) << ", output device: " << std::quoted(sOutputDevice()) << LL_ENDL;
 
-    static LLCachedControl<F32> sMicLevel(gSavedSettings, "AudioLevelMic");
-    setMicGain(sMicLevel);
+        static LLCachedControl<F32> sMicLevel(gSavedSettings, "AudioLevelMic");
+        setMicGain(sMicLevel);
 
-    llwebrtc::LLWebRTCDeviceInterface::AudioConfig config;
+        llwebrtc::LLWebRTCDeviceInterface::AudioConfig config;
 
-    static LLCachedControl<bool> sEchoCancellation(gSavedSettings, "VoiceEchoCancellation", true);
-    config.mEchoCancellation = sEchoCancellation;
+        static LLCachedControl<bool> sEchoCancellation(gSavedSettings, "VoiceEchoCancellation", true);
+        config.mEchoCancellation = sEchoCancellation;
 
-    static LLCachedControl<bool> sAGC(gSavedSettings, "VoiceAutomaticGainControl", true);
-    config.mAGC = sAGC;
+        static LLCachedControl<bool> sAGC(gSavedSettings, "VoiceAutomaticGainControl", true);
+        config.mAGC = sAGC;
 
-    static LLCachedControl<U32> sNoiseSuppressionLevel(gSavedSettings,
-                                                       "VoiceNoiseSuppressionLevel",
-                                                       llwebrtc::LLWebRTCDeviceInterface::AudioConfig::ENoiseSuppressionLevel::NOISE_SUPPRESSION_LEVEL_VERY_HIGH);
-    config.mNoiseSuppressionLevel = (llwebrtc::LLWebRTCDeviceInterface::AudioConfig::ENoiseSuppressionLevel) (U32)sNoiseSuppressionLevel;
+        static LLCachedControl<U32> sNoiseSuppressionLevel(gSavedSettings,
+            "VoiceNoiseSuppressionLevel",
+            llwebrtc::LLWebRTCDeviceInterface::AudioConfig::ENoiseSuppressionLevel::NOISE_SUPPRESSION_LEVEL_VERY_HIGH);
+        config.mNoiseSuppressionLevel = (llwebrtc::LLWebRTCDeviceInterface::AudioConfig::ENoiseSuppressionLevel)(U32)sNoiseSuppressionLevel;
 
-    mWebRTCDeviceInterface->setAudioConfig(config);
-
+        mWebRTCDeviceInterface->setAudioConfig(config);
+    }
 }
 
 // Observers


### PR DESCRIPTION
1. set_enabled(false) failed to apply, force set it to trigger observers and remove the icon
2. Don't set audio devices if voice was disabled
3. set init_recording_on_send to false, viewer is micromanaging that

This might be a sign of bigger issues with how we handle tracks, or webrtc just isn't meant to start muted.