### PR TITLE
#4216 Pressing cancel on picker reverts an override

### DIFF
--- a/indra/newview/llselectmgr.cpp
+++ b/indra/newview/llselectmgr.cpp
@@ -2249,6 +2249,7 @@ void LLSelectMgr::selectionRevertGLTFMaterials()
             {
                 // Restore base material
                 LLUUID asset_id = nodep->mSavedGLTFMaterialIds[te];
+                LLUUID old_asset_id = objectp->getRenderMaterialID(te);
 
                 // Update material locally
                 objectp->setRenderMaterialID(te, asset_id, false /*wait for LLGLTFMaterialList update*/);
@@ -2259,18 +2260,29 @@ void LLSelectMgr::selectionRevertGLTFMaterials()
                     objectp->setTEGLTFMaterialOverride(te, material);
                 }
 
-                // Enqueue update to server
-                if (asset_id.notNull() && material)
-                {
-                    // Restore overrides and base material
-                    LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
-                }
-                else
+                if (asset_id.isNull() || !material)
                 {
                     //blank override out
                     LLGLTFMaterialList::queueApply(objectp, te, asset_id);
                 }
-
+                if (old_asset_id != asset_id)
+                {
+                    // Restore overrides and base material
+                    // Note: might not work reliably if asset is already there, might
+                    // have a server sided problem where servers applies override
+                    // first then resets it by adding asset, in which case need
+                    // to create a server ticket and chain asset then override
+                    // application.
+                    LLGLTFMaterialList::queueApply(objectp, te, asset_id, material);
+                }
+                else
+                {
+                    // Enqueue override update to server
+                    // Note: this is suboptimal, better to send asset id as well
+                    // but there seems to be a server problem with queueApply
+                    // that ignores override in some cases
+                    LLGLTFMaterialList::queueModify(objectp, te, material);
+                }
             }
             return true;
         }

--- a/indra/newview/lltooldraganddrop.cpp
+++ b/indra/newview/lltooldraganddrop.cpp
@@ -1125,28 +1125,33 @@ void set_texture_to_material(LLViewerObject* hit_obj,
         case LLGLTFMaterial::GLTF_TEXTURE_INFO_BASE_COLOR:
         default:
             {
-                material->setBaseColorId(asset_id);
+                material->setBaseColorId(asset_id, true);
             }
             break;
 
         case LLGLTFMaterial::GLTF_TEXTURE_INFO_METALLIC_ROUGHNESS:
             {
-                material->setOcclusionRoughnessMetallicId(asset_id);
+                material->setOcclusionRoughnessMetallicId(asset_id, true);
             }
             break;
 
         case LLGLTFMaterial::GLTF_TEXTURE_INFO_EMISSIVE:
             {
-                material->setEmissiveId(asset_id);
+                material->setEmissiveId(asset_id, true);
             }
             break;
 
         case LLGLTFMaterial::GLTF_TEXTURE_INFO_NORMAL:
             {
-                material->setNormalId(asset_id);
+                material->setNormalId(asset_id, true);
             }
             break;
     }
+    // Update viewer side, needed for updating mSavedGLTFOverrideMaterials.
+    // Also for parity, we are immediately setting textures and materials,
+    // so we should immediate set overrides to.
+    hit_obj->setTEGLTFMaterialOverride(hit_face, material);
+    // update server
     LLGLTFMaterialList::queueModify(hit_obj, hit_face, material);
 }
 


### PR DESCRIPTION
 Pressing cancel on picker reverts an override even when it shouldn't revert material override

queueApply() was resulting in a response override message first, then in a message that resets overrides. Two responses from single call. I don't see any issues with the request itself. Viewer can live with queueModify so for now switched to using that.
