### PR TITLE
Fix a crash bug and bogus calculations in LLMeshRepoThread::lodReceived()

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -2362,7 +2362,13 @@ EMeshProcessingResult LLMeshRepoThread::lodReceived(const LLVolumeParams& mesh_p
     LLPointer<LLVolume> volume = new LLVolume(mesh_params, LLVolumeLODGroup::getVolumeScaleFromDetail(lod));
     if (volume->unpackVolumeFaces(data, data_size))
     {
-        if (volume->getNumFaces() > 0)
+        // Use LLVolume::getNumVolumeFaces() here and not LLVolume::getNumFaces(),
+        // because setMeshAssetLoaded() has not yet been called for this volume
+        // (it is set later in LLMeshRepository::notifyMeshLoaded()), and
+        // getNumFaces() would return the number of faces in the LLProfile
+        // instead. HB
+        S32 num_faces = volume->getNumVolumeFaces();
+        if (num_faces > 0)
         {
             // if we have a valid SkinInfo, cache per-joint bounding boxes for this LOD
             LLPointer<LLMeshSkinInfo> skin_info = nullptr;
@@ -2376,7 +2382,7 @@ EMeshProcessingResult LLMeshRepoThread::lodReceived(const LLVolumeParams& mesh_p
             }
             if (skin_info.notNull() && isAgentAvatarValid())
             {
-                for (S32 i = 0; i < volume->getNumFaces(); ++i)
+                for (S32 i = 0; i < num_faces; ++i)
                 {
                     // NOTE: no need to lock gAgentAvatarp as the state being checked is not changed after initialization
                     LLVolumeFace& face = volume->getVolumeFace(i);


### PR DESCRIPTION
## Description

When trying to update the rigging info for a newly received mesh LOD, a wrong usage of LLVolume::getNumFaces() is done to get the number of volume faces, causing the code to iterate over the number of faces in the underlying LLProfile instead. LLVolume::getNumVolumeFaces() must be used here.

This fixes a crash bug seen with low LODs in some meshes (when the number of mesh faces is smaller than the number of faces in the LLProfile), and also properly updates the rigging info for all mesh faces, as it should, when the mesh got more faces than the LLProfile.

## Related Issues

This may relate to crashes seen in LLMeshRepoThread::lodReceived()...

Issue Link: #4357