### PR TITLE
#4399 Crash at load_face_from_dom_triangles

### DIFF
--- a/indra/llprimitive/lldaeloader.cpp
+++ b/indra/llprimitive/lldaeloader.cpp
@@ -204,12 +204,15 @@ LLModel::EModelStatus load_face_from_dom_triangles(
 
     if (idx_stride <= 0
         || (pos_source && pos_offset >= idx_stride)
+        || (pos_source && pos_offset < 0)
         || (tc_source && tc_offset >= idx_stride)
-        || (norm_source && norm_offset >= idx_stride))
+        || (tc_source && tc_offset < 0)
+        || (norm_source && norm_offset >= idx_stride)
+        || (norm_source && norm_offset < 0))
     {
         // Looks like these offsets should fit inside idx_stride
         // Might be good idea to also check idx.getCount()%idx_stride != 0
-        LL_WARNS() << "Invalid pos_offset " << pos_offset <<  ", tc_offset " << tc_offset << " or norm_offset " << norm_offset << LL_ENDL;
+        LL_WARNS() << "Invalid idx_stride " << idx_stride << ", pos_offset " << pos_offset <<  ", tc_offset " << tc_offset << " or norm_offset " << norm_offset << LL_ENDL;
         return LLModel::BAD_ELEMENT;
     }
 


### PR DESCRIPTION
Since these offsets are used for idx[i+offset] where i starts from 0, they shouldn't be below 0 to not go out of bounds.
