### PR TITLE
#3851 Increase cache size

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1153,13 +1153,13 @@
     <key>DiskCachePercentOfTotal</key>
     <map>
       <key>Comment</key>
-      <string>The percent of total cache size (defined by CacheSize) to use for the disk cache</string>
+      <string>The percent of total cache size (defined by CacheSize) to use for the disk cache (ex: asset storage, excludes textures)</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
-      <real>40.0</real>
+      <real>35.0</real>
     </map>
     <key>DiskCacheDirName</key>
     <map>
@@ -1203,7 +1203,7 @@
       <key>Type</key>
       <string>U32</string>
       <key>Value</key>
-      <integer>4096</integer>
+      <integer>6144</integer>
     </map>
     <key>CacheValidateCounter</key>
     <map>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -4282,8 +4282,8 @@ bool LLAppViewer::initCache()
     const std::string cache_dir_name = gSavedSettings.getString("DiskCacheDirName");
 
     const U32 MB = 1024 * 1024;
-    const uintmax_t MIN_CACHE_SIZE = 256 * MB;
-    const uintmax_t MAX_CACHE_SIZE = 9984ll * MB;
+    const uintmax_t MIN_CACHE_SIZE = 896 * MB;
+    const uintmax_t MAX_CACHE_SIZE = 32768ll * MB;
     const uintmax_t setting_cache_total_size = uintmax_t(gSavedSettings.getU32("CacheSize")) * MB;
     const uintmax_t cache_total_size = llclamp(setting_cache_total_size, MIN_CACHE_SIZE, MAX_CACHE_SIZE);
     const F64 disk_cache_percent = gSavedSettings.getF32("DiskCachePercentOfTotal");

--- a/indra/newview/skins/default/xui/en/panel_preferences_advanced.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_advanced.xml
@@ -32,15 +32,15 @@
    height="23"
    increment="64"
    initial_value="1024"
-   label="Cache size (256 - 9984MB)"
+   label="Cache size (896 - 32768MB)"
    label_width="150"
    layout="topleft"
    left="80"
-   max_val="9984"
-   min_val="256"
+   max_val="32768"
+   min_val="896"
    top_pad="10"
    name="cachesizespinner"
-   width="200" />
+   width="210" />
   <text
    type="string"
    length="1"
@@ -59,7 +59,7 @@
    label="Clear Cache"
    label_selected="Clear Cache"
    layout="topleft"
-   left_pad="30"
+   left_pad="20"
    name="clear_cache"
    top_delta="0"
    width="100">


### PR DESCRIPTION
Increases default to 8GB and maximum to 32GB (original limit was there due to virtual filesystem which is no longer a concern).
Viewer now supports 2K textures which require more space, so altered disk cache vs textures space a little.
Made spinner a bit wider to properly fit whole cache string.