### PR TITLE
Media first click interact self ownership check fix

### DIFF
--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -1541,12 +1541,6 @@ bool LLToolPie::shouldAllowFirstMediaInteraction(const LLPickInfo& pick, bool mo
         return false;
     }
 
-    // Own objects
-    if((FirstClickPref & MEDIA_FIRST_CLICK_OWN) && object->permYouOwner())
-    {
-        LL_DEBUGS_ONCE() << "FirstClickPref & MEDIA_FIRST_CLICK_OWN" << LL_ENDL;
-        return true;
-    }
     // HUD attachments
     if((FirstClickPref & MEDIA_FIRST_CLICK_HUD) && object->isHUDAttachment())
     {
@@ -1567,6 +1561,13 @@ bool LLToolPie::shouldAllowFirstMediaInteraction(const LLPickInfo& pick, bool mo
     {
         LL_WARNS() << "Owner information was not reliably obtained" << LL_ENDL;
         return false;
+    }
+
+    // Own objects
+    if((FirstClickPref & MEDIA_FIRST_CLICK_OWN) && owner_id == gAgent.getID())
+    {
+        LL_DEBUGS_ONCE() << "FirstClickPref & MEDIA_FIRST_CLICK_OWN" << LL_ENDL;
+        return true;
     }
 
     // Check if the object is owned by a friend of the agent


### PR DESCRIPTION
## Description

This PR fixes an error with how self ownership was computed for media first click interact purposes.

## Related Issues

Issue Link: closes #4406
