### PR TITLE
Media first click interact friend check fix

### DIFF
--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -1572,8 +1572,11 @@ bool LLToolPie::shouldAllowFirstMediaInteraction(const LLPickInfo& pick, bool mo
     // Check if the object is owned by a friend of the agent
     if(FirstClickPref & MEDIA_FIRST_CLICK_FRIEND)
     {
-        LL_DEBUGS_ONCE() << "FirstClickPref & MEDIA_FIRST_CLICK_FRIEND. id: " << owner_id << LL_ENDL;
-        return LLAvatarTracker::instance().isBuddy(owner_id);
+        if(LLAvatarTracker::instance().isBuddy(owner_id))
+        {
+            LL_DEBUGS_ONCE() << "FirstClickPref & MEDIA_FIRST_CLICK_FRIEND. id: " << owner_id << LL_ENDL;
+            return true;
+        }
     }
 
     // Check for objects set to or owned by the active group


### PR DESCRIPTION
## Description

This PR fixes an error with how friendship status was handled for media first click interact purposes. It caused proceeding checks to never be run in the event it itself was run and failed.

## Related Issues

Issue Link: closes #4414
