### PR TITLE
#4415 fix crash when cancelling large model process on MacOS

### DIFF
--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -3084,9 +3084,12 @@ void LLModelPreview::loadedCallback(
     S32 lod,
     void* opaque)
 {
+    if(LLModelPreview::sIgnoreLoadedCallback)
+        return;
+
     LLModelPreview* pPreview = static_cast<LLModelPreview*>(opaque);
     LLMutexLock lock(pPreview);
-    if (pPreview && pPreview->mModelLoader && !LLModelPreview::sIgnoreLoadedCallback)
+    if (pPreview && pPreview->mModelLoader)
     {
         // Load loader's warnings into floater's log tab
         const LLSD out = pPreview->mModelLoader->logOut();


### PR DESCRIPTION
Viewer crashed due to inappropriate attempt to lock mutex.