### PR TITLE
feat(upload): Automatically resize images larger than 2048x2048 befor…

### DIFF
--- a/indra/newview/llviewermenufile.cpp
+++ b/indra/newview/llviewermenufile.cpp
@@ -554,21 +554,23 @@ void do_bulk_upload(std::vector<std::string> filenames, bool allow_2k)
                     {
                         S32 width = raw_image->getWidth();
                         S32 height = raw_image->getHeight();
-                    
+
                         if (width > 2048 || height > 2048)
                         {
                             F32 scale_ratio = llmin(2048.f / width, 2048.f / height);
                             S32 new_width = llfloor(width * scale_ratio);
                             S32 new_height = llfloor(height * scale_ratio);
                             raw_image->scale(new_width, new_height);
-                        
+
                             LL_INFOS("ImageUpload") << "Image resized from "
                                                     << width << "x" << height << " to "
                                                     << new_width << "x" << new_height << LL_ENDL;
-                        
+
                             // Re-encode resized image back into image_frmted
                             image_frmted->encode(raw_image);
-                            image_frmted->save(filename); // overwrite original file (or temp copy)
+                            std::string temp_filename = gDirUtilp->getTempFilename();
+                            image_frmted->save(temp_filename);
+                            filename = temp_filename;
                         }
                     }
 


### PR DESCRIPTION
## Description

Automatically resize images larger than 2048×2048 before upload.

This PR modifies the `do_bulk_upload` function to check image dimensions and rescale them if they exceed the maximum allowed size. A log message is printed to inform the user that the image was resized.

## Related Issues

- Closes #4388

---

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Tested with .png and .tga uploads > 4096px. Downscaling to 2048×2048 worked as expected.
