### PR TITLE
Make inventory creation from cache faster

### DIFF
--- a/indra/llinventory/llinventory.h
+++ b/indra/llinventory/llinventory.h
@@ -274,7 +274,8 @@ public:
     virtual bool exportLegacyStream(std::ostream& output_stream, bool include_asset_key = true) const;
 
     virtual void exportLLSD(LLSD& sd) const;
-    bool importLLSD(const LLSD& cat_data);
+    bool importLLSDMap(const LLSD& cat_data);
+    virtual bool importLLSD(const std::string& label, const LLSD& value);
     //--------------------------------------------------------------------
     // Member Variables
     //--------------------------------------------------------------------

--- a/indra/llinventory/llpermissions.cpp
+++ b/indra/llinventory/llpermissions.cpp
@@ -704,6 +704,79 @@ bool LLPermissions::exportLegacyStream(std::ostream& output_stream) const
     return true;
 }
 
+static const std::string PERM_CREATOR_ID_LABEL("creator_id");
+static const std::string PERM_OWNER_ID_LABEL("owner_id");
+static const std::string PERM_LAST_OWNER_ID_LABEL("last_owner_id");
+static const std::string PERM_GROUP_ID_LABEL("group_id");
+static const std::string PERM_IS_OWNER_GROUP_LABEL("is_owner_group");
+static const std::string PERM_BASE_MASK_LABEL("base_mask");
+static const std::string PERM_OWNER_MASK_LABEL("owner_mask");
+static const std::string PERM_GROUP_MASK_LABEL("group_mask");
+static const std::string PERM_EVERYONE_MASK_LABEL("everyone_mask");
+static const std::string PERM_NEXT_OWNER_MASK_LABEL("next_owner_mask");
+
+void LLPermissions::importLLSD(const LLSD& sd_perm)
+{
+    LLSD::map_const_iterator i, end;
+    end = sd_perm.endMap();
+    for (i = sd_perm.beginMap(); i != end; ++i)
+    {
+        const std::string& label = i->first;
+        if (label == PERM_CREATOR_ID_LABEL)
+        {
+            mCreator = i->second.asUUID();
+            continue;
+        }
+        if (label == PERM_OWNER_ID_LABEL)
+        {
+            mOwner = i->second.asUUID();
+            continue;
+        }
+        if (label == PERM_LAST_OWNER_ID_LABEL)
+        {
+            mLastOwner = i->second.asUUID();
+            continue;
+        }
+        if (label == PERM_GROUP_ID_LABEL)
+        {
+            mGroup = i->second.asUUID();
+            continue;
+        }
+        if (label == PERM_BASE_MASK_LABEL)
+        {
+            PermissionMask mask = i->second.asInteger();
+            mMaskBase = mask;
+            continue;
+        }
+        if (label == PERM_OWNER_MASK_LABEL)
+        {
+            PermissionMask mask = i->second.asInteger();
+            mMaskOwner = mask;
+            continue;
+        }
+        if (label == PERM_EVERYONE_MASK_LABEL)
+        {
+            PermissionMask mask = i->second.asInteger();
+            mMaskEveryone = mask;
+            continue;
+        }
+        if (label == PERM_GROUP_MASK_LABEL)
+        {
+            PermissionMask mask = i->second.asInteger();
+            mMaskGroup = mask;
+            continue;
+        }
+        if (label == PERM_NEXT_OWNER_MASK_LABEL)
+        {
+            PermissionMask mask = i->second.asInteger();
+            mMaskNextOwner = mask;
+            continue;
+        }
+    }
+
+    fix();
+}
+
 bool LLPermissions::operator==(const LLPermissions &rhs) const
 {
     return
@@ -998,16 +1071,6 @@ std::string mask_to_string(U32 mask)
 ///----------------------------------------------------------------------------
 /// exported functions
 ///----------------------------------------------------------------------------
-static const std::string PERM_CREATOR_ID_LABEL("creator_id");
-static const std::string PERM_OWNER_ID_LABEL("owner_id");
-static const std::string PERM_LAST_OWNER_ID_LABEL("last_owner_id");
-static const std::string PERM_GROUP_ID_LABEL("group_id");
-static const std::string PERM_IS_OWNER_GROUP_LABEL("is_owner_group");
-static const std::string PERM_BASE_MASK_LABEL("base_mask");
-static const std::string PERM_OWNER_MASK_LABEL("owner_mask");
-static const std::string PERM_GROUP_MASK_LABEL("group_mask");
-static const std::string PERM_EVERYONE_MASK_LABEL("everyone_mask");
-static const std::string PERM_NEXT_OWNER_MASK_LABEL("next_owner_mask");
 
 LLSD ll_create_sd_from_permissions(const LLPermissions& perm)
 {
@@ -1032,25 +1095,6 @@ void ll_fill_sd_from_permissions(LLSD& rv, const LLPermissions& perm)
 LLPermissions ll_permissions_from_sd(const LLSD& sd_perm)
 {
     LLPermissions rv;
-    rv.init(
-        sd_perm[PERM_CREATOR_ID_LABEL].asUUID(),
-        sd_perm[PERM_OWNER_ID_LABEL].asUUID(),
-        sd_perm[PERM_LAST_OWNER_ID_LABEL].asUUID(),
-        sd_perm[PERM_GROUP_ID_LABEL].asUUID());
-
-    // We do a cast to U32 here since LLSD does not attempt to
-    // represent unsigned ints.
-    PermissionMask mask;
-    mask = (U32)(sd_perm[PERM_BASE_MASK_LABEL].asInteger());
-    rv.setMaskBase(mask);
-    mask = (U32)(sd_perm[PERM_OWNER_MASK_LABEL].asInteger());
-    rv.setMaskOwner(mask);
-    mask = (U32)(sd_perm[PERM_EVERYONE_MASK_LABEL].asInteger());
-    rv.setMaskEveryone(mask);
-    mask = (U32)(sd_perm[PERM_GROUP_MASK_LABEL].asInteger());
-    rv.setMaskGroup(mask);
-    mask = (U32)(sd_perm[PERM_NEXT_OWNER_MASK_LABEL].asInteger());
-    rv.setMaskNext(mask);
-    rv.fix();
+    rv.importLLSD(sd_perm);
     return rv;
 }

--- a/indra/llinventory/llpermissions.h
+++ b/indra/llinventory/llpermissions.h
@@ -299,6 +299,8 @@ public:
     bool    importLegacyStream(std::istream& input_stream);
     bool    exportLegacyStream(std::ostream& output_stream) const;
 
+    void importLLSD(const LLSD& sd_perm);
+
     bool operator==(const LLPermissions &rhs) const;
     bool operator!=(const LLPermissions &rhs) const;
 

--- a/indra/llinventory/tests/inventorymisc_test.cpp
+++ b/indra/llinventory/tests/inventorymisc_test.cpp
@@ -518,7 +518,7 @@ namespace tut
         file.close();
 
         LLPointer<LLInventoryCategory> src2 = new LLInventoryCategory();
-        src2->importLLSD(s_item);
+        src2->importLLSDMap(s_item);
 
         ensure_equals("1.item id::getUUID() failed", src1->getUUID(), src2->getUUID());
         ensure_equals("2.parent::getParentUUID() failed", src1->getParentUUID(), src2->getParentUUID());

--- a/indra/newview/llinventorymodel.cpp
+++ b/indra/newview/llinventorymodel.cpp
@@ -2690,6 +2690,7 @@ bool LLInventoryModel::loadSkeleton(
     LL_PROFILE_ZONE_SCOPED;
     LL_DEBUGS(LOG_INV) << "importing inventory skeleton for " << owner_id << LL_ENDL;
 
+    LLTimer timer;
     typedef std::set<LLPointer<LLViewerInventoryCategory>, InventoryIDPtrLess> cat_set_t;
     cat_set_t temp_cats;
     bool rv = true;
@@ -2975,7 +2976,8 @@ bool LLInventoryModel::loadSkeleton(
     }
 
     LL_INFOS(LOG_INV) << "Successfully loaded " << cached_category_count
-                      << " categories and " << cached_item_count << " items from cache."
+                      << " categories and " << cached_item_count << " items from cache"
+                      << " after " << timer.getElapsedTimeF32() << " seconds."
                       << LL_ENDL;
 
     return rv;

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -366,9 +366,28 @@ void LLInventoryPanel::initializeViewBuilding()
         if (mInventory->isInventoryUsable()
             && LLStartUp::getStartupState() <= STATE_WEARABLES_WAIT)
         {
+            LLTimer timer;
             // Usually this happens on login, so we have less time constraits, but too long and we can cause a disconnect
             const F64 max_time = 20.f;
             initializeViews(max_time);
+
+            if (mViewsInitialized == VIEWS_INITIALIZED)
+            {
+                LL_INFOS("Inventory")
+                    << "Fully initialized inventory panel " << getName()
+                    << " with " << (S32)mItemMap.size()
+                    << " views in " << timer.getElapsedTimeF32() << " seconds."
+                    << LL_ENDL;
+            }
+            else
+            {
+                LL_INFOS("Inventory")
+                    << "Partially initialized inventory panel " << getName()
+                    << " with " << (S32)mItemMap.size()
+                    << " views in " << timer.getElapsedTimeF32()
+                    << " seconds. Pending known views: " << (S32)mBuildViewsQueue.size()
+                    << LL_ENDL;
+            }
         }
         else
         {

--- a/indra/newview/llviewerinventory.cpp
+++ b/indra/newview/llviewerinventory.cpp
@@ -761,18 +761,23 @@ void LLViewerInventoryCategory::exportLLSD(LLSD & cat_data) const
     cat_data[INV_VERSION] = mVersion;
 }
 
-bool LLViewerInventoryCategory::importLLSD(const LLSD& cat_data)
+bool LLViewerInventoryCategory::importLLSD(const std::string& label, const LLSD& value)
 {
-    LLInventoryCategory::importLLSD(cat_data);
-    if (cat_data.has(INV_OWNER_ID))
+    if (LLInventoryCategory::importLLSD(label, value))
     {
-        mOwnerID = cat_data[INV_OWNER_ID].asUUID();
+        return true;
     }
-    if (cat_data.has(INV_VERSION))
+    else if (label == INV_OWNER_ID)
     {
-        setVersion(cat_data[INV_VERSION].asInteger());
+        mOwnerID = value.asUUID();
+        return true;
     }
-    return true;
+    else if (label == INV_VERSION)
+    {
+        setVersion(value.asInteger());
+        return true;
+    }
+    return false;
 }
 
 bool LLViewerInventoryCategory::acceptItem(LLInventoryItem* inv_item)

--- a/indra/newview/llviewerinventory.h
+++ b/indra/newview/llviewerinventory.h
@@ -233,7 +233,7 @@ public:
     S32 getViewerDescendentCount() const;
 
     virtual void exportLLSD(LLSD &sd) const;
-    virtual bool importLLSD(const LLSD& cat_data);
+    virtual bool importLLSD(const std::string& label, const LLSD& value);
 
     void determineFolderType();
     void changeType(LLFolderType::EType new_folder_type);


### PR DESCRIPTION
Switch from slow notation parser to faster binary parser.
Still has a lot of space for improvements, but should be 2.5 times faster.
Targeted at 2025.06 due to that branch having related changes.