### PR TITLE
Selection Hint and LookAt target privacy

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16276,7 +16276,7 @@
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
-      <integer>4</integer>
+      <integer>2</integer>
     </map>
 </map>
 </llsd>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16245,10 +16245,10 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-    <key>EnableLookAtHints</key>
+    <key>EnableLookAtTarget</key>
     <map>
       <key>Comment</key>
-      <string>Whether or not to send animate the avatar head and send look at hints when moving the cursor or focusing on objects</string>
+      <string>Whether or not to send animate the avatar head and send look at targets when moving the cursor or focusing on objects</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
@@ -16256,7 +16256,7 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
-    <key>LimitLookAtHints</key>
+    <key>LimitLookAtTarget</key>
     <map>
       <key>Comment</key>
       <string>Whether or not to clamp the look at targets around the avatar head before sending</string>
@@ -16267,7 +16267,7 @@
       <key>Value</key>
       <integer>0</integer>
     </map>
-    <key>LimitLookAtHintsDistance</key>
+    <key>LimitLookAtTargetDistance</key>
     <map>
       <key>Comment</key>
       <string>Distance to limit look at target to</string>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16245,5 +16245,16 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>EnableLookAtHints</key>
+    <map>
+      <key>Comment</key>
+      <string>Whether or not to send animate the avatar head and send look at hints when moving the cursor or focusing on objects</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
 </map>
 </llsd>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16234,5 +16234,16 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>EnableSelectionHints</key>
+    <map>
+      <key>Comment</key>
+      <string>Whether or not to send editing hints to animate the arm when editing an object.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
 </map>
 </llsd>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16265,7 +16265,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>1</integer>
+      <integer>0</integer>
     </map>
     <key>LimitLookAtHintsDistance</key>
     <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16256,5 +16256,27 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>LimitLookAtHints</key>
+    <map>
+      <key>Comment</key>
+      <string>Whether or not to clamp the look at targets around the avatar head before sending</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <key>LimitLookAtHintsDistance</key>
+    <map>
+      <key>Comment</key>
+      <string>Distance to limit look at target to</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <integer>4</integer>
+    </map>
 </map>
 </llsd>

--- a/indra/newview/llhudeffectlookat.cpp
+++ b/indra/newview/llhudeffectlookat.cpp
@@ -393,14 +393,22 @@ void LLHUDEffectLookAt::setTargetPosGlobal(const LLVector3d &target_pos_global)
 //-----------------------------------------------------------------------------
 bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *object, LLVector3 position)
 {
-    static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtHints", true);
-    if (!enable_lookat_hints)
+    if (!mSourceObject)
     {
         return false;
     }
 
-    if (!mSourceObject)
+    static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtHints", true);
+    if (!enable_lookat_hints)
     {
+        if (mTargetType != LOOKAT_TARGET_IDLE)
+        {
+            mTargetObject = gAgentAvatarp;
+            mTargetType = LOOKAT_TARGET_IDLE;
+            mTargetOffsetGlobal.set(2.f, 0.f, 0.f);
+            setDuration(3.f);
+            setNeedsSendToSim(true);
+        }
         return false;
     }
 

--- a/indra/newview/llhudeffectlookat.cpp
+++ b/indra/newview/llhudeffectlookat.cpp
@@ -391,7 +391,7 @@ void LLHUDEffectLookAt::setTargetPosGlobal(const LLVector3d &target_pos_global)
 // setLookAt()
 // called by agent logic to set look at behavior locally, and propagate to sim
 //-----------------------------------------------------------------------------
-bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject* object, LLVector3 position)
+bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *object, LLVector3 position)
 {
     static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtHints", true);
     if (!enable_lookat_hints)

--- a/indra/newview/llhudeffectlookat.cpp
+++ b/indra/newview/llhudeffectlookat.cpp
@@ -392,6 +392,12 @@ void LLHUDEffectLookAt::setTargetPosGlobal(const LLVector3d &target_pos_global)
 //-----------------------------------------------------------------------------
 bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *object, LLVector3 position)
 {
+    static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtHints", true);
+    if (!enable_lookat_hints)
+    {
+        return false;
+    }
+
     if (!mSourceObject)
     {
         return false;

--- a/indra/newview/llhudeffectlookat.cpp
+++ b/indra/newview/llhudeffectlookat.cpp
@@ -398,7 +398,7 @@ bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *objec
         return false;
     }
 
-    static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtHints", true);
+    static LLCachedControl<bool> enable_lookat_hints(gSavedSettings, "EnableLookAtTarget", true);
     if (!enable_lookat_hints)
     {
         if (mTargetType != LOOKAT_TARGET_IDLE)
@@ -424,7 +424,7 @@ bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *objec
         return false;
     }
 
-    static LLCachedControl<bool> limit_lookat_hints(gSavedSettings, "LimitLookAtHints", true);
+    static LLCachedControl<bool> limit_lookat_hints(gSavedSettings, "LimitLookAtTarget", true);
     // Don't affect the look at if object is gAgentAvatarp (cursor head follow)
     if (limit_lookat_hints && object != gAgentAvatarp)
     {
@@ -438,7 +438,7 @@ bool LLHUDEffectLookAt::setLookAt(ELookAtType target_type, LLViewerObject *objec
         LLVector3 agentHeadPosition = gAgentAvatarp->mHeadp->getWorldPosition();
         float dist = (float)dist_vec(agentHeadPosition, position);
 
-        static LLCachedControl<F32> limit_lookat_hints_distance(gSavedSettings, "LimitLookAtHintsDistance", 2.0f);
+        static LLCachedControl<F32> limit_lookat_hints_distance(gSavedSettings, "LimitLookAtTargetDistance", 2.0f);
         if (dist > limit_lookat_hints_distance)
         {
             LLVector3 headOffset = position - agentHeadPosition;

--- a/indra/newview/llhudeffectpointat.cpp
+++ b/indra/newview/llhudeffectpointat.cpp
@@ -222,14 +222,20 @@ void LLHUDEffectPointAt::setTargetPosGlobal(const LLVector3d &target_pos_global)
 //-----------------------------------------------------------------------------
 bool LLHUDEffectPointAt::setPointAt(EPointAtType target_type, LLViewerObject *object, LLVector3 position)
 {
-    static LLCachedControl<bool> enable_selection_hints(gSavedSettings, "EnableSelectionHints", true);
-    if (!enable_selection_hints)
+    if (!mSourceObject)
     {
         return false;
     }
 
-    if (!mSourceObject)
+    static LLCachedControl<bool> enable_selection_hints(gSavedSettings, "EnableSelectionHints", true);
+    if (!enable_selection_hints)
     {
+        if (mTargetType != POINTAT_TARGET_NONE)
+        {
+            clearPointAtTarget();
+            setDuration(1.f);
+            setNeedsSendToSim(true);
+        }
         return false;
     }
 

--- a/indra/newview/llhudeffectpointat.cpp
+++ b/indra/newview/llhudeffectpointat.cpp
@@ -34,6 +34,7 @@
 #include "llagent.h"
 #include "llagentcamera.h"
 #include "lldrawable.h"
+#include "llviewercontrol.h"
 #include "llviewerobjectlist.h"
 #include "llvoavatar.h"
 #include "message.h"
@@ -221,6 +222,12 @@ void LLHUDEffectPointAt::setTargetPosGlobal(const LLVector3d &target_pos_global)
 //-----------------------------------------------------------------------------
 bool LLHUDEffectPointAt::setPointAt(EPointAtType target_type, LLViewerObject *object, LLVector3 position)
 {
+    static LLCachedControl<bool> enable_selection_hints(gSavedSettings, "EnableSelectionHints", true);
+    if (!enable_selection_hints)
+    {
+        return false;
+    }
+
     if (!mSourceObject)
     {
         return false;

--- a/indra/newview/llvoavatarself.cpp
+++ b/indra/newview/llvoavatarself.cpp
@@ -2830,6 +2830,12 @@ void LLVOAvatarSelf::setHoverOffset(const LLVector3& hover_offset, bool send_upd
 //------------------------------------------------------------------------
 bool LLVOAvatarSelf::needsRenderBeam()
 {
+    static LLCachedControl<bool> enable_selection_hints(gSavedSettings, "EnableSelectionHints", true);
+    if (!enable_selection_hints)
+    {
+        return false;
+    }
+
     LLTool *tool = LLToolMgr::getInstance()->getCurrentTool();
 
     bool is_touching_or_grabbing = (tool == LLToolGrab::getInstance() && LLToolGrab::getInstance()->isEditing());

--- a/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
@@ -63,7 +63,7 @@
       name="online_visibility"
       top_pad="30"
       width="350" />
-    
+
     <check_box
      enabled_control="EnableVoiceChat"
      control_name="AutoDisengageMic"
@@ -72,6 +72,34 @@
      layout="topleft"
      left="30"
      name="auto_disengage_mic_check"
+     top_pad="10"
+     width="350" />
+    <check_box
+     control_name="EnableLookAtHints"
+     height="16"
+     label="Enable LookAt"
+     layout="topleft"
+     left="30"
+     name="enable_lookat_hints"
+     top_pad="10"
+     width="350" />
+    <check_box
+     enabled_control="EnableLookAtHints"
+     control_name="LimitLookAtHints"
+     height="16"
+     label="Limit LookAt Distance"
+     layout="topleft"
+     left="50"
+     name="limit_lookat_distance"
+     top_pad="10"
+     width="350" />
+    <check_box
+     control_name="EnableSelectionHints"
+     height="16"
+     label="Enable Selection Hints"
+     layout="topleft"
+     left="30"
+     name="enable_selection_hints"
      top_pad="10"
      width="350" />
     <button

--- a/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
@@ -75,17 +75,17 @@
      top_pad="10"
      width="350" />
     <check_box
-     control_name="EnableLookAtHints"
+     control_name="EnableLookAtTarget"
      height="16"
      label="Enable LookAt"
      layout="topleft"
      left="30"
-     name="enable_lookat_hints"
+     name="enable_lookat_target"
      top_pad="10"
      width="350" />
     <check_box
-     enabled_control="EnableLookAtHints"
-     control_name="LimitLookAtHints"
+     enabled_control="EnableLookAtTarget"
+     control_name="LimitLookAtTarget"
      height="16"
      label="Limit LookAt Distance"
      layout="topleft"


### PR DESCRIPTION
## Description
Adds the ability to disable look at targets, as well as to clamp their distance around the head.

New settings:
* `EnableSelectionHints` - Whether or not to send editing hints to animate the arm when editing an object.
* `EnableLookAtTarget` - Whether or not to send animate the avatar head and send look at hints when moving the cursor or focusing on objects
* `LimitLookAtTarget` - Whether or not to clamp the look at targets around the avatar head before sending
* `LimitLookAtTargetDistance` - Distance to limit look at target to

New preferences (Translations needed):
* Privacy > Enable LookAt
* Privacy > Limit LookAt Distance
* Privacy > Enable Selection Hints

Test cases:
- [x] Ensure that new settings are persistent across logins
- [x] Ensure that selection hints are not sent when `EnableSelectionHints` is disabled
- [x] Ensure that look at target is set to idle when `EnableLookAtTarget` is disabled
- [x] Ensure that look at target is clamped when to the value `LimitLookAtTargetDistance` (Default 2m) when `LimitLookAtTarget` is enabled
- [x] Ensure that `EnableSelectionHints` and `EnableLookAtTarget` are enabled by default
- [x] Ensure that `LimitLookAtTargetDistance` is disabled by default

## Related Issues

Issue Link: #4447

## Additional Notes
The setting `LimitLookAtTargetDistance` was created just in case people have issues with their avatar. In my testing, 0.25m is too short and causes avatars to go cross eyed. 2m seems to be a sweet spot because it is the default, but gives those edge cases the ability to change this if it *really* needs to be changed.