### PR TITLE
#4455 Division by zero in updateFrameStats

### DIFF
--- a/indra/newview/llviewerstats.h
+++ b/indra/newview/llviewerstats.h
@@ -277,9 +277,9 @@ private:
     F64Seconds mLastTimeDiff;  // used for time stat updates
     F64Seconds mTotalFrametimeJitter;
 
-    U32 mFrameJitterEvents;
-    U32 mFrameJitterEventsLastMinute;
-    U32 mEventMinutes;
+    U32 mFrameJitterEvents = 0;
+    U32 mFrameJitterEventsLastMinute = 0;
+    U32 mEventMinutes = 0;
     F64Seconds mTotalTime;
 
     F64Seconds              mLastFrameTimeSample; // used for frame time stats


### PR DESCRIPTION
mEventMinutes was not initialized, crash happened at

```
mEventMinutes++;
U64 frame_time_events_per_minute = (U64)mFrameJitterEvents / mEventMinutes;
```