### PR TITLE
#4385 show agent name next to @ mention url in chat logs

### DIFF
--- a/indra/llui/llurlaction.cpp
+++ b/indra/llui/llurlaction.cpp
@@ -142,6 +142,16 @@ void LLUrlAction::copyLabelToClipboard(std::string url)
     }
 }
 
+std::string LLUrlAction::getURLLabel(std::string url)
+{
+    LLUrlMatch match;
+    if (LLUrlRegistry::instance().findUrl(url, match))
+    {
+       return match.getLabel();
+    }
+    return "";
+}
+
 void LLUrlAction::showProfile(std::string url)
 {
     // Get id from 'secondlife:///app/{cmd}/{id}/{action}'

--- a/indra/llui/llurlaction.h
+++ b/indra/llui/llurlaction.h
@@ -72,6 +72,8 @@ public:
     /// copy a Url to the clipboard
     static void copyURLToClipboard(std::string url);
 
+    static std::string getURLLabel(std::string url);
+
     /// if the Url specifies an SL command in the form like 'app/{cmd}/{id}/*', show its profile
     static void showProfile(std::string url);
     static std::string getUserID(std::string url);

--- a/indra/llui/llurlentry.cpp
+++ b/indra/llui/llurlentry.cpp
@@ -42,8 +42,6 @@
 #include "message.h"
 #include "llexperiencecache.h"
 
-#define APP_HEADER_REGEX "((x-grid-location-info://[-\\w\\.]+/app)|(secondlife:///app))"
-
 // Utility functions
 std::string localize_slapp_label(const std::string& url, const std::string& full_name);
 

--- a/indra/llui/llurlentry.h
+++ b/indra/llui/llurlentry.h
@@ -42,6 +42,8 @@
 
 class LLAvatarName;
 
+#define APP_HEADER_REGEX "((x-grid-location-info://[-\\w\\.]+/app)|(secondlife:///app))"
+
 typedef boost::signals2::signal<void (const std::string& url,
                                       const std::string& label,
                                       const std::string& icon)> LLUrlLabelSignal;


### PR DESCRIPTION
Save mention URLs as `[@User Name](secondlife:///app/agent/user_id/mention)` instead of just s`econdlife:///app/agent/user_id/mention` to chat logs.