### PR TITLE
#4465 modify vertex limit threshold for starting splitting

### DIFF
--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -87,7 +87,8 @@ static const glm::mat4 coord_system_rotationxy(
     0.f, 0.f, 0.f, 1.f
 );
 
-static const S32 VERTICIES_LIMIT = USHRT_MAX - 2;
+static const S32 VERTEX_SPLIT_SAFETY_MARGIN = 3 * 3 + 1; // 10 vertices: 3 complete triangles plus remapping overhead
+static const S32 VERTEX_LIMIT = USHRT_MAX - VERTEX_SPLIT_SAFETY_MARGIN;
 
 LLGLTFLoader::LLGLTFLoader(std::string                filename,
     S32                                               lod,
@@ -951,7 +952,7 @@ bool LLGLTFLoader::populateModelFromMesh(LLModel* pModel, const std::string& bas
         }
 
         // Indices handling
-        if (faceVertices.size() >= VERTICIES_LIMIT)
+        if (faceVertices.size() >= VERTEX_LIMIT)
         {
             // Will have to remap 32 bit indices into 16 bit indices
             // For the sake of simplicity build vector of 32 bit indices first
@@ -1036,7 +1037,7 @@ bool LLGLTFLoader::populateModelFromMesh(LLModel* pModel, const std::string& bas
                 }
                 indices_16.push_back((U16)vert_index);
 
-                if (indices_16.size() % 3 == 0 && face_verts.size() >= VERTICIES_LIMIT - 1)
+                if (indices_16.size() % 3 == 0 && face_verts.size() >= VERTEX_LIMIT)
                 {
                     LLVolumeFace face;
                     face.fillFromLegacyData(face_verts, indices_16);


### PR DESCRIPTION
Use safety margin for split threshold to avoid the issue.