### PR TITLE
#3785 Set default MediaFirstClickInteract value to 31

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -16243,7 +16243,7 @@
       <key>Type</key>
       <string>S32</string>
       <key>Value</key>
-      <integer>1</integer>
+      <integer>31</integer>
     </map>
 </map>
 </llsd>


### PR DESCRIPTION
"Preferences > Sound & Media > Media first-interact" should default to "Landowner objects"