### PR TITLE
#4483 Fix gltf not opening unicode paths

### DIFF
--- a/indra/newview/gltf/accessor.cpp
+++ b/indra/newview/gltf/accessor.cpp
@@ -159,7 +159,7 @@ bool Buffer::prep(Asset& asset)
         std::string dir = gDirUtilp->getDirName(asset.mFilename);
         std::string bin_file = dir + gDirUtilp->getDirDelimiter() + mUri;
 
-        std::ifstream file(bin_file, std::ios::binary);
+        llifstream file(bin_file.c_str(), std::ios::binary);
         if (!file.is_open())
         {
             LL_WARNS("GLTF") << "Failed to open file: " << bin_file << LL_ENDL;

--- a/indra/newview/gltf/asset.cpp
+++ b/indra/newview/gltf/asset.cpp
@@ -696,7 +696,7 @@ bool Asset::load(std::string_view filename, bool loadIntoVRAM)
     mFilename = filename;
     std::string ext = gDirUtilp->getExtension(mFilename);
 
-    std::ifstream file(filename.data(), std::ios::binary);
+    llifstream file(filename.data(), std::ios::binary);
     if (file.is_open())
     {
         std::string str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());


### PR DESCRIPTION
Fix gltf code using std streams instead of viewer's wrappers