### PR TITLE
Nearby tab slider

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -181,14 +181,21 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
               control_name="NearMeRange"
               decimal_digits="0"
               increment="1"
-              follows="top|left"
+              follows="left|top"
               left="5"
               min_val="0"
               max_val="4096"
               label="Range:"
               name="near_me_range"
               tool_tip="Nearby people range"
-              width="250" />
+              width="230"/>
+            <text
+              type="string"
+              follows="left|top"
+              left_delta="225"
+              name="near_me_range_text2">
+              m
+            </text>
          <layout_stack
            clip="false"
            follows="all"

--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -235,7 +235,7 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
              <avatar_list
                allow_select="true"
                follows="all"
-               height="200"
+               height="197"
                ignore_online_status="true"
                layout="topleft"
                left="3"

--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -177,6 +177,18 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
                      function="People.DelFriend" />
                  </dnd_button>
             </panel>
+            <slider
+              control_name="NearMeRange"
+              decimal_digits="0"
+              increment="1"
+              follows="top|left"
+              left="5"
+              min_val="0"
+              max_val="4096"
+              label="Range:"
+              name="near_me_range"
+              tool_tip="Nearby people range"
+              width="250" />
          <layout_stack
            clip="false"
            follows="all"

--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -235,7 +235,7 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
              <avatar_list
                allow_select="true"
                follows="all"
-               height="211"
+               height="200"
                ignore_online_status="true"
                layout="topleft"
                left="3"


### PR DESCRIPTION
## Description

Add a slider to the "NEARBY" tab of `panel_people.xml` allowing users to adjust `NearMeRange`. 

## Related Issues

"Improve usability and experience of the Nearby People pane": https://github.com/secondlife/viewer/issues/3667

## Screenshot (as implemented in a TPV)

<img width="384" height="650" alt="Screenshot_20250806_042033" src="https://github.com/user-attachments/assets/182081d6-c771-45b9-951e-fc0cf9bda85b" />
