### PR TITLE
#4297 Crash on LLVOCache::writeToCache

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -529,7 +529,8 @@ bool LLFloaterPreference::postBuild()
     }
 
 #ifndef LL_DISCORD
-    getChild<LLTabContainer>("privacy_tab_container")->childDisable("privacy_preferences_discord");
+    LLPanel* panel = getChild<LLPanel>("privacy_preferences_discord");
+    getChild<LLTabContainer>("privacy_tab_container")->removeTabPanel(panel);
 #endif
 
     return true;

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -1875,11 +1875,11 @@ void LLVOCache::removeGenericExtrasForHandle(U64 handle)
     }
 
     // NOTE: when removing the extras, we must also remove the objects so the simulator will send us a full upddate with the valid overrides
-    auto* entry = mHandleEntryMap[handle];
-    if (entry)
+    handle_entry_map_t::iterator iter = mHandleEntryMap.find(handle);
+    if (iter != mHandleEntryMap.end())
     {
-        LL_WARNS("GLTF", "VOCache") << "Removing generic extras for handle " << entry->mHandle << "Filename: " << getObjectCacheExtrasFilename(handle) << LL_ENDL;
-        removeEntry(entry);
+        LL_WARNS("GLTF", "VOCache") << "Removing generic extras for handle " << handle << "Filename: " << getObjectCacheExtrasFilename(handle) << LL_ENDL;
+        removeEntry(iter->second);
     }
     else
     {


### PR DESCRIPTION
#4297 Crash on LLVOCache::writeToCache
handle/iter existed, but entry was null, made sure mHandleEntryMap won't create a null entry for a handle
and

#4470 Hide discord panel when set to build without discord