### PR TITLE
Discord without auth & "Hidden Region" instead of blank

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1159,7 +1159,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>ShowDiscordActivityDetails</key>
     <map>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5956,37 +5956,39 @@ void LLAppViewer::updateDiscordActivity()
         activity.SetDetails(gDiscordActivityDetails);
     }
 
+    auto agent_pos_region = gAgent.getPositionAgent();
+    S32 pos_x = S32(agent_pos_region.mV[VX] + 0.5f);
+    S32 pos_y = S32(agent_pos_region.mV[VY] + 0.5f);
+    S32 pos_z = S32(agent_pos_region.mV[VZ] + 0.5f);
+    F32 velocity_mag_sq = gAgent.getVelocity().magVecSquared();
+    const F32 FLY_CUTOFF = 6.f;
+    const F32 FLY_CUTOFF_SQ = FLY_CUTOFF * FLY_CUTOFF;
+    const F32 WALK_CUTOFF = 1.5f;
+    const F32 WALK_CUTOFF_SQ = WALK_CUTOFF * WALK_CUTOFF;
+    if (velocity_mag_sq > FLY_CUTOFF_SQ)
+    {
+        pos_x -= pos_x % 4;
+        pos_y -= pos_y % 4;
+    }
+    else if (velocity_mag_sq > WALK_CUTOFF_SQ)
+    {
+        pos_x -= pos_x % 2;
+        pos_y -= pos_y % 2;
+    }
+
+    std::string location = "Hidden Region";
     static LLCachedControl<bool> show_state(gSavedSettings, "ShowDiscordActivityState", false);
     if (show_state)
     {
-        auto agent_pos_region = gAgent.getPositionAgent();
-        S32 pos_x = S32(agent_pos_region.mV[VX] + 0.5f);
-        S32 pos_y = S32(agent_pos_region.mV[VY] + 0.5f);
-        S32 pos_z = S32(agent_pos_region.mV[VZ] + 0.5f);
-        F32 velocity_mag_sq = gAgent.getVelocity().magVecSquared();
-        const F32 FLY_CUTOFF = 6.f;
-        const F32 FLY_CUTOFF_SQ = FLY_CUTOFF * FLY_CUTOFF;
-        const F32 WALK_CUTOFF = 1.5f;
-        const F32 WALK_CUTOFF_SQ = WALK_CUTOFF * WALK_CUTOFF;
-        if (velocity_mag_sq > FLY_CUTOFF_SQ)
-        {
-            pos_x -= pos_x % 4;
-            pos_y -= pos_y % 4;
-        }
-        else if (velocity_mag_sq > WALK_CUTOFF_SQ)
-        {
-            pos_x -= pos_x % 2;
-            pos_y -= pos_y % 2;
-        }
-        auto location = llformat("%s (%d, %d, %d)", gAgent.getRegion()->getName().c_str(), pos_x, pos_y, pos_z);
-        activity.SetState(location);
-
-        discordpp::ActivityParty party;
-        party.SetId(location);
-        party.SetCurrentSize(gDiscordPartyCurrentSize);
-        party.SetMaxSize(gDiscordPartyMaxSize);
-        activity.SetParty(party);
+        location = llformat("%s (%d, %d, %d)", gAgent.getRegion()->getName().c_str(), pos_x, pos_y, pos_z);
     }
+    activity.SetState(location);
+
+    discordpp::ActivityParty party;
+    party.SetId(location);
+    party.SetCurrentSize(gDiscordPartyCurrentSize);
+    party.SetMaxSize(gDiscordPartyMaxSize);
+    activity.SetParty(party);
 
     gDiscordClient->UpdateRichPresence(activity, [](discordpp::ClientResult) {});
 }

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -5914,100 +5914,21 @@ void LLAppViewer::initDiscordSocial()
     gDiscordPartyMaxSize = 0;
     gDiscordTimestampsStart = time(nullptr);
     gDiscordClient = std::make_shared<discordpp::Client>();
-    gDiscordClient->SetStatusChangedCallback([](discordpp::Client::Status status, discordpp::Client::Error, int32_t) {
-        if (status == discordpp::Client::Status::Ready)
-        {
-            updateDiscordActivity();
-        }
-    });
-    if (gSavedSettings.getBOOL("EnableDiscord"))
-    {
-        auto credential = gSecAPIHandler->loadCredential("Discord");
-        if (credential.notNull())
-        {
-            gDiscordClient->UpdateToken(discordpp::AuthorizationTokenType::Bearer, credential->getAuthenticator()["token"].asString(), [](discordpp::ClientResult result) {
-                if (result.Successful())
-                    gDiscordClient->Connect();
-                else
-                    LL_WARNS("Discord") << result.Error() << LL_ENDL;
-            });
-        }
-        else
-        {
-            LL_WARNS("Discord") << "Integration was enabled, but no credentials. Disabling integration." << LL_ENDL;
-            gSavedSettings.setBOOL("EnableDiscord", false);
-        }
-    }
-}
-
-void LLAppViewer::toggleDiscordIntegration(const LLSD& value)
-{
-    static const uint64_t APPLICATION_ID = 1394782217405862001;
-    if (value.asBoolean())
-    {
-        discordpp::AuthorizationArgs args{};
-        args.SetClientId(APPLICATION_ID);
-        args.SetScopes(discordpp::Client::GetDefaultPresenceScopes());
-        auto codeVerifier = gDiscordClient->CreateAuthorizationCodeVerifier();
-        args.SetCodeChallenge(codeVerifier.Challenge());
-        gDiscordClient->Authorize(args, [codeVerifier](auto result, auto code, auto redirectUri) {
-            if (result.Successful())
-            {
-                gDiscordClient->GetToken(APPLICATION_ID, code, codeVerifier.Verifier(), redirectUri, [](discordpp::ClientResult result, std::string accessToken, std::string, discordpp::AuthorizationTokenType, int32_t, std::string) {
-                    if (result.Successful())
-                    {
-                        gDiscordClient->UpdateToken(discordpp::AuthorizationTokenType::Bearer, accessToken, [accessToken](discordpp::ClientResult result) {
-                            if (result.Successful())
-                            {
-                                LLSD authenticator = LLSD::emptyMap();
-                                authenticator["token"] = accessToken;
-                                gSecAPIHandler->saveCredential(gSecAPIHandler->createCredential("Discord", LLSD::emptyMap(), authenticator), true);
-                                gDiscordClient->Connect();
-                            }
-                            else
-                            {
-                                LL_WARNS("Discord") << result.Error() << LL_ENDL;
-                            }
-                        });
-                    }
-                    else
-                    {
-                        LL_WARNS("Discord") << result.Error() << LL_ENDL;
-                    }
-                });
-            }
-            else
-            {
-                LL_WARNS("Discord") << result.Error() << LL_ENDL;
-                gSavedSettings.setBOOL("EnableDiscord", false);
-            }
-        });
-    }
-    else
-    {
-        gDiscordClient->Disconnect();
-        auto credential = gSecAPIHandler->loadCredential("Discord");
-        if (credential.notNull())
-        {
-            gDiscordClient->RevokeToken(APPLICATION_ID, credential->getAuthenticator()["token"].asString(), [](discordpp::ClientResult result) {
-                if (result.Successful())
-                    LL_INFOS("Discord") << "Access token successfully revoked." << LL_ENDL;
-                else
-                    LL_WARNS("Discord") << "No access token to revoke." << LL_ENDL;
-            });
-            auto cred = new LLCredential("Discord");
-            gSecAPIHandler->deleteCredential(cred);
-        }
-        else
-        {
-            LL_WARNS("Discord") << "Credentials are already nonexistent." << LL_ENDL;
-        }
-    }
+    gDiscordClient->SetApplicationId(1394782217405862001);
+    updateDiscordActivity();
 }
 
 void LLAppViewer::updateDiscordActivity()
 {
     LL_PROFILE_ZONE_SCOPED;
+
+    static LLCachedControl<bool> integration_enabled(gSavedSettings, "EnableDiscord", true);
+    if (!integration_enabled)
+    {
+        gDiscordClient->ClearRichPresence();
+        return;
+    }
+
     discordpp::Activity activity;
     activity.SetType(discordpp::ActivityTypes::Playing);
     discordpp::ActivityTimestamps timestamps;

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -253,7 +253,6 @@ public:
 
 #ifdef LL_DISCORD
     static void initDiscordSocial();
-    static void toggleDiscordIntegration(const LLSD& value);
     static void updateDiscordActivity();
     static void updateDiscordPartyCurrentSize(int32_t size);
     static void updateDiscordPartyMaxSize(int32_t size);

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -367,7 +367,7 @@ LLFloaterPreference::LLFloaterPreference(const LLSD& key)
     mCommitCallbackRegistrar.add("Pref.DeleteTranscripts",      boost::bind(&LLFloaterPreference::onDeleteTranscripts, this));
     mCommitCallbackRegistrar.add("UpdateFilter", boost::bind(&LLFloaterPreference::onUpdateFilterTerm, this, false)); // <FS:ND/> Hook up for filtering
 #ifdef LL_DISCORD
-    gSavedSettings.getControl("EnableDiscord")->getCommitSignal()->connect(boost::bind(&LLAppViewer::toggleDiscordIntegration, _2));
+    gSavedSettings.getControl("EnableDiscord")->getCommitSignal()->connect(boost::bind(&LLAppViewer::updateDiscordActivity));
     gSavedSettings.getControl("ShowDiscordActivityDetails")->getCommitSignal()->connect(boost::bind(&LLAppViewer::updateDiscordActivity));
     gSavedSettings.getControl("ShowDiscordActivityState")->getCommitSignal()->connect(boost::bind(&LLAppViewer::updateDiscordActivity));
 #endif


### PR DESCRIPTION
## Description

This PR improves https://github.com/secondlife/viewer/pull/4457 especially by removing a significant but unnecessary process.

- Rich Presence without requiring access to friends list
- Discord integration is enabled by default per specification
- "Hidden Region" if Discord location sharing is off instead of blank. The coords are hidden too, but the Party numbers are still shown, for consistency with TPVs' implementations.

## Related Issues

Issue Link: https://github.com/secondlife/viewer/issues/4418

---

## Checklist

I have tested:

-  checking and unchecking the preferences buttons, before and after login;
-  the persistence of the preferences across viewer launches.

---

## Additional Notes

The Discord app "PUBLIC CLIENT" toggle button in the OAuth2 tab on the Discord Developer Portal can be set back to the default off, now that the users don't need to authorise anything.