### PR TITLE
#4503 Crash at openHeaderEntriesFile

### DIFF
--- a/indra/newview/lltexturecache.cpp
+++ b/indra/newview/lltexturecache.cpp
@@ -1354,6 +1354,7 @@ U32 LLTextureCache::openAndReadEntries(std::vector<Entry>& entries)
             if (bytes_read < sizeof(Entry))
             {
                 LL_WARNS() << "Corrupted header entries, failed at " << idx << " / " << num_entries << LL_ENDL;
+                closeHeaderEntriesFile();
                 return 0;
             }
             entries.push_back(entry);


### PR DESCRIPTION
Didn't close header file so following attempt to purge cache crashed.