### PR TITLE
Fix clang compiler issues due to unused variables

### DIFF
--- a/indra/llrender/llrendertarget.cpp
+++ b/indra/llrender/llrendertarget.cpp
@@ -492,22 +492,6 @@ U32 LLRenderTarget::getNumTextures() const
 void LLRenderTarget::bindTexture(U32 index, S32 channel, LLTexUnit::eTextureFilterOptions filter_options)
 {
     gGL.getTexUnit(channel)->bindManual(mUsage, getTexture(index), filter_options == LLTexUnit::TFO_TRILINEAR || filter_options == LLTexUnit::TFO_ANISOTROPIC);
-
-    bool isSRGB = false;
-    llassert(mInternalFormat.size() > index);
-    switch (mInternalFormat[index])
-    {
-        case GL_SRGB:
-        case GL_SRGB8:
-        case GL_SRGB_ALPHA:
-        case GL_SRGB8_ALPHA8:
-            isSRGB = true;
-            break;
-
-        default:
-            break;
-    }
-
     gGL.getTexUnit(channel)->setTextureFilteringOption(filter_options);
 }
 

--- a/indra/newview/gltf/asset.cpp
+++ b/indra/newview/gltf/asset.cpp
@@ -589,7 +589,9 @@ bool Asset::prep()
 
                 for (U32 variant = 0; variant < LLGLSLShader::NUM_GLTF_VARIANTS; ++variant)
                 {
+#ifdef SHOW_ASSERT
                     U32 attribute_mask = 0;
+#endif
                     // for each mesh
                     for (auto& mesh : mMeshes)
                     {
@@ -607,7 +609,9 @@ bool Asset::prep()
 
                                 // all primitives of a given variant and material should all have the same attribute mask
                                 llassert(attribute_mask == 0 || primitive.mAttributeMask == attribute_mask);
+#ifdef SHOW_ASSERT
                                 attribute_mask |= primitive.mAttributeMask;
+#endif
                             }
                         }
                     }

--- a/indra/newview/lldrawpoolwater.cpp
+++ b/indra/newview/lldrawpoolwater.cpp
@@ -143,7 +143,6 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
     gGL.setColorMask(true, true);
 
     LLColor3 light_diffuse(0, 0, 0);
-    F32      light_exp = 0.0f;
 
     LLEnvironment& environment = LLEnvironment::instance();
     LLSettingsWater::ptr_t pwater = environment.getCurrentWater();
@@ -170,7 +169,6 @@ void LLDrawPoolWater::renderPostDeferred(S32 pass)
     // Apply magic numbers translating light direction into intensities
     light_dir.normalize();
     F32 ground_proj_sq = light_dir.mV[0] * light_dir.mV[0] + light_dir.mV[1] * light_dir.mV[1];
-    light_exp          = llmax(32.f, 256.f * powf(ground_proj_sq, 16.0f));
     if (0.f < light_diffuse.normalize())  // Normalizing a color? Puzzling...
     {
         light_diffuse *= (1.5f + (6.f * ground_proj_sq));

--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -342,13 +342,11 @@ void pump_idle_startup_network(void)
 {
     // while there are message to process:
     //     process one then call display_startup()
-    S32 num_messages = 0;
     {
         LockMessageChecker lmc(gMessageSystem);
         while (lmc.checkAllMessages(gFrameCount, gServicePump))
         {
             display_startup();
-            ++num_messages;
         }
         lmc.processAcks();
     }

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -524,7 +524,6 @@ void LLViewerTexture::updateClass()
     bool is_low = is_sys_low || over_pct > 0.f;
 
     static bool was_low = false;
-    static bool was_sys_low = false;
 
     if (is_low && !was_low)
     {
@@ -542,7 +541,6 @@ void LLViewerTexture::updateClass()
     }
 
     was_low = is_low;
-    was_sys_low = is_sys_low;
 
     if (is_low)
     {

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -4766,14 +4766,6 @@ bool LLVOAvatar::updateCharacter(LLAgent &agent)
     }
 
     bool visible = isVisible();
-    bool is_control_avatar = isControlAvatar(); // capture state to simplify tracing
-    bool is_attachment = false;
-
-    if (is_control_avatar)
-    {
-        LLControlAvatar *cav = dynamic_cast<LLControlAvatar*>(this);
-        is_attachment = cav && cav->mRootVolp && cav->mRootVolp->isAttachment(); // For attached animated objects
-    }
 
     // For fading out the names above heads, only let the timer
     // run if we're visible.

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2264,7 +2264,6 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro(connectionPtr_t connection)
         return;
     }
 
-    bool iceCompleted = false;
     LLSD body;
     if (!connection->mIceCandidates.empty() || connection->mIceCompleted)
     {
@@ -2303,7 +2302,6 @@ void LLVoiceWebRTCConnection::processIceUpdatesCoro(connectionPtr_t connection)
             LLSD body_candidate;
             body_candidate["completed"] = true;
             body["candidate"]           = body_candidate;
-            iceCompleted                = connection->mIceCompleted;
             connection->mIceCompleted   = false;
         }
 
@@ -2926,7 +2924,6 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
             return;
         }
         boost::json::object voice_data = voice_data_parsed.as_object();
-        bool new_participant = false;
         boost::json::object mute;
         boost::json::object user_gain;
         for (auto &participant_elem : voice_data)
@@ -2979,7 +2976,6 @@ void LLVoiceWebRTCConnection::OnDataReceivedImpl(const std::string &data, bool b
                 }
             }
 
-            new_participant |= joined;
             if (!participant && joined && (primary || !isSpatial()))
             {
                 participant = LLWebRTCVoiceClient::getInstance()->addParticipantByID(mChannelID, agent_id, mRegionID);


### PR DESCRIPTION
## Description

A bunch of fixes for clang compiler issues that showed when building Firestorm with the latest clang version and that are also present in the LL viewer, mysteriously haven't been triggered yet.

## Related Issues

No related issue. Do we have to create issues for every tiny fix now?

---

## Checklist

Please ensure the following before requesting review:

- [X] I have provided a clear title and detailed description for this pull request.
- [X] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [X] I have tested the changes locally and verified they work as intended.
- [X] All new and existing tests pass.
- [X] Code follows the project's style guidelines.
- [X] Documentation has been updated if needed.
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
