### PR TITLE
Fix issue where p2p calls were coming up muted even thought speak button indicated they were not muted.

### DIFF
--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2795,8 +2795,12 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
             }
             // update the peer connection with the various characteristics of
             // this connection.
-            // this connection will come up as muted, but will be set to the appropriate
-            // value later on.
+            // For spatial this connection will come up as muted, but will be set to the appropriate
+            // value later on when we determine the regions we connect to.
+            if (!isSpatial())
+            {
+                mWebRTCAudioInterface->setMute(mMuted);
+            }
             mWebRTCAudioInterface->setReceiveVolume(mSpeakerVolume);
             LLWebRTCVoiceClient::getInstance()->OnConnectionEstablished(mChannelID, mRegionID);
             setVoiceConnectionState(VOICE_STATE_WAIT_FOR_DATA_CHANNEL);


### PR DESCRIPTION


## Description

In p2p voice on webrtc, the connection was coming up muted even though the UI indicated the connection was unmuted.  This resulted in one user being unable to hear the other user until the speak button was toggled.

## Related Issues

Issue Link: #4528 


## Test Guidance
* Bring two users up in a webrtc region.
* Initiate a p2p session from one to the other.
* Validate both users can hear one another (don't push the speak buttons, they should already be pressed)
