### PR TITLE
#4535 Revert "Fix: ignore *pass-on* counters when detecting left-button grabs from `llTakeControl`"

### DIFF
--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -3469,14 +3469,11 @@ void LLAgent::initOriginGlobal(const LLVector3d &origin_global)
 
 bool LLAgent::leftButtonGrabbed() const
 {
-    if (gAgentCamera.cameraMouselook())
-    {
-        return mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0;
-    }
-    else
-    {
-        return mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0;
-    }
+    const bool camera_mouse_look = gAgentCamera.cameraMouselook();
+    return (!camera_mouse_look && mControlsTakenCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
+        || (camera_mouse_look && mControlsTakenCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0)
+        || (!camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_LBUTTON_DOWN_INDEX] > 0)
+        || (camera_mouse_look && mControlsTakenPassedOnCount[CONTROL_ML_LBUTTON_DOWN_INDEX] > 0);
 }
 
 bool LLAgent::rotateGrabbed() const


### PR DESCRIPTION
Reverts secondlife/viewer#3990