### PR TITLE
improvement(SLURL): Check for "://" as schema separator in a SLURL

### DIFF
--- a/indra/newview/llslurl.cpp
+++ b/indra/newview/llslurl.cpp
@@ -71,10 +71,10 @@ LLSLURL::LLSLURL(const std::string& slurl)
     {
         LLURI slurl_uri;
         // parse the slurl as a uri
-        if (slurl.find(':') == std::string::npos)
+        if (slurl.find("://") == std::string::npos)
         {
-            // There may be no scheme ('secondlife:' etc.) passed in.  In that case
-            // we want to normalize the slurl by putting the appropriate scheme
+            // There may be no scheme ('secondlife://', 'https://' etc.) passed in. In that
+            // case we want to normalize the slurl by putting the appropriate scheme
             // in front of the slurl.  So, we grab the appropriate slurl base
             // from the grid manager which may be http://slurl.com/secondlife/ for maingrid, or
             // https://<hostname>/region/ for Standalone grid (the word region, not the region name)


### PR DESCRIPTION
## Description

The passed in string may not contain a schema. Instead of just searching for a ':' to see if there is a schema, do an explicit search for the normal "://" schema separator. If the string is a hostname with port, but with no schema, the parsing goes wrong.

## Related Issues

- [*] relates to #4519
