### PR TITLE
#4544 Add source format information to mesh upload statistics

### DIFF
--- a/indra/newview/llfloatermodelpreview.h
+++ b/indra/newview/llfloatermodelpreview.h
@@ -223,6 +223,9 @@ private:
 
     void createSmoothComboBox(LLComboBox* combo_box, float min, float max);
 
+    typedef std::map<std::string, std::string> lod_sources_map_t;
+    void fillLODSourceStatistics(lod_sources_map_t& lod_sources) const;
+
     LLUUID mDestinationFolderId;
     LLButton* mUploadBtn;
     LLButton* mCalculateBtn;

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -691,6 +691,8 @@ public:
     };
     typedef std::map<LLPointer<LLModel>, instance_list, LLUploadModelInstanceLess> instance_map;
     instance_map    mInstance;
+    typedef std::map<std::string, std::string> lod_sources_map_t;
+    lod_sources_map_t mLodSources;
 
     LLMutex*        mMutex;
     S32             mPendingUploads;
@@ -707,7 +709,8 @@ public:
     std::string     mWholeModelUploadURL;
     LLUUID          mDestinationFolderId;
 
-    LLMeshUploadThread(instance_list& data, LLVector3& scale, bool upload_textures,
+    LLMeshUploadThread(instance_list& data, const lod_sources_map_t& sources_list,
+                       LLVector3& scale, bool upload_textures,
                        bool upload_skin, bool upload_joints, bool lock_scale_if_joint_position,
                        const std::string & upload_url,
                        const LLUUID destination_folder_id = LLUUID::null,
@@ -869,7 +872,8 @@ public:
     bool meshUploadEnabled();
     bool meshRezEnabled();
 
-    void uploadModel(std::vector<LLModelInstance>& data, LLVector3& scale, bool upload_textures,
+    void uploadModel(std::vector<LLModelInstance>& data, const std::map<std::string, std::string> &lod_sources,
+                     LLVector3& scale, bool upload_textures,
                      bool upload_skin, bool upload_joints, bool lock_scale_if_joint_position,
                      std::string upload_url,
                      const LLUUID& destination_folder_id = LLUUID::null,


### PR DESCRIPTION
For statistics purposed provide information about source type of the LOD on upload.
This is getting rushed into 2025.06.