### PR TITLE
#4559 Crash at killCacheEntry

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3669,7 +3669,7 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
             gObjectList.killObject(objectp);
         }
 
-        if(delete_object)
+        if(delete_object && regionp)
         {
             regionp->killCacheEntry(local_id);
         }


### PR DESCRIPTION
Crash at killCacheEntry, regionp can be null.