### PR TITLE
Add support for Memory Map and 64 bit files in LLAPRFile class

### DIFF
--- a/indra/llcommon/llapr.h
+++ b/indra/llcommon/llapr.h
@@ -124,7 +124,7 @@ private:
 // File IO convenience functions.
 // Returns NULL if the file fails to open, sets *sizep to file size if not NULL
 // abbreviated flags
-// Updated to match the newer #define as the older API_ defines are depricated.
+// Updated to match the newer #define as the older API_ defines are deprecated.
 #define LL_APR_R (APR_FOPEN_READ) // "r"
 #define LL_APR_W (APR_FOPEN_CREATE|APR_FOPEN_TRUNCATE|APR_FOPEN_WRITE) // "w"
 #define LL_APR_A (APR_FOPEN_CREATE|APR_FOPEN_WRITE|APR_FOPEN_APPEND) // "w"
@@ -163,11 +163,11 @@ private:
 public:
     LLAPRFile() ;
     LLAPRFile(const std::string& filename, apr_int32_t flags, LLVolatileAPRPool* pool = NULL);
-    // Open existing memory map file (File must be fixed size)
+    // Open an existing memory map file (File must be fixed size)
     LLAPRFile(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, LLVolatileAPRPool* pool = NULL );
-    // Opens a initialized 64 bit memory map file (File must be fixed size)
+    // Opens an initialized 64 bit memory map file (File must be fixed size)
     LLAPRFile(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, S64 init_file_size, bool zero_out, LLVolatileAPRPool* pool = NULL);
-    // Opens a initialized 32 bit memory map file (File must be fixed size)
+    // Opens an initialized 32 bit memory map file (File must be fixed size)
     LLAPRFile(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, S32 init_file_size, bool zero_out, LLVolatileAPRPool* pool = NULL);
     ~LLAPRFile() ;
 
@@ -179,9 +179,9 @@ public:
     apr_status_t openMemoryMap(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, LLVolatileAPRPool* pool = NULL, S32* sizep = NULL);
     // 64 bit Memory map version of open file (File must be fixed size)
     apr_status_t openMemoryMap64(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, LLVolatileAPRPool* pool = NULL, S64* sizep = NULL);
-    // 32 bit Memory map version of open file and initalizes with size and can zero out (File must be fixed size)
+    // 32 bit Memory map version of open file and initializes with size and can zero out (File must be fixed size)
     apr_status_t openMemoryMap(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, S32 init_file_size, bool zero_out, LLVolatileAPRPool* pool = NULL, S32* sizep = NULL);
-    // 64 bit Memory map version of open file and initalizes with size and can zero out (File must be fixed size)
+    // 64 bit Memory map version of open file and initializes with size and can zero out (File must be fixed size)
     apr_status_t openMemoryMap64(const std::string& filename, apr_int32_t flags, apr_int32_t mmap_flags, S64 init_file_size, bool zero_out, LLVolatileAPRPool* pool = NULL, S64* sizep = NULL);
     // Memory map version of open file allowing for manual opening of the memory map file (File must be fixed size)
     apr_status_t openMemoryMap(const std::string& filename, apr_int32_t flags, bool use_global_pool, apr_int32_t mmap_flags); // use gAPRPoolp.
@@ -203,9 +203,9 @@ public:
 
     apr_file_t* getFileHandle() {return mFile;}
 
-    // Assignes a variable to a memory map address (used for setting a variable pointer to the memory map (input needs to be casted) with 32 bit offset
+    // Assigns a variable to a memory map address (used for setting a variable pointer to the memory map (input needs to be casted) with 32 bit offset
     apr_status_t memoryMapAssign(void** addr, S32 offset);
-    // Assignes a variable to a memory map address (used for setting a variable pointer to the memory map (input needs to be casted) with 64 bit offset
+    // Assigns a variable to a memory map address (used for setting a variable pointer to the memory map (input needs to be casted) with 64 bit offset
     apr_status_t memoryMapAssign64(void** addr, S64 offset);
 
     // Helper method to get 32 bit size of file


### PR DESCRIPTION
## Description

Currently the LLAPRFile class only supports 32 bit files and 2 GB file limits. Also, memory mapped files are not supported.

This PR adds additional native 64 bit methods using new 64 bit named versions of the existing LLAPRFile methods. This will allow files over 2 GB from being accessed and loaded.

This PR also adds new methods for loading a memory map file, creating and zeroing out a memory map file as well as assign object pointers to a memory map region.

With a memory map, you could map a data structure directly to memory, with out have to first load the object to RAM, then create a new object, then copy from the read in memory from file to the new object. This also removes the need for File IO commands for accessing data stored in the file.

This could be helpful for such things as the Texture Fast Cache, or other resources which are cached in a native format that does not require conversion of the data. Could be also used for normal Texture Cache for mapping to a Raw texture to be decoded which would remove the need for File IO to read the data in. If a cache is larger then 2GB for a unified file, 64 file support would allow the file to be used or memory mapped.

Also, the #defines of the LLAPR.h file are using deprecated APR defines. Propose to update to the correct naming from the library which will remove deprecated warnings.

Change summary:

Added support for 64 Bit files to llapr.cpp
- open64
- seek64
- read64
- write64
- static size64
- static seek64
- static readEx64
- static writeEx64

Added support for Memory map files
- LLARPFile with mmap Read/Write flags
- openMemoryMap
- openMemoryMap64
- openMemoryMap - no size specified
- memoryMapAssign
- memoryMapAssign64

Updated #define's for LL_APR_R etc. to use newer ARP_FOPEN_READ as the old ARP_READ is deprecated

Updated llassert_always to use signed 64bit limit instead of signed 32bit

## Related Issues

Issue Link: Address issue: https://github.com/secondlife/viewer/issues/4566

## Additional Notes

This will be a basis for a possible enhanced Texture Fast Cache system.
