### PR TITLE
#4557 fix lags in outfit search with many outfits

### DIFF
--- a/indra/newview/lloutfitslist.cpp
+++ b/indra/newview/lloutfitslist.cpp
@@ -254,7 +254,11 @@ void LLOutfitsList::updateAddedCategory(LLUUID cat_id)
         // for reliability just fetch it whole, linked items included
         LLInventoryModelBackgroundFetch::instance().fetchFolderAndLinks(cat_id, [cat_id, list]
         {
-            if (list) list->updateList(cat_id);
+            if (list)
+            {
+                list->updateList(cat_id);
+                list->setForceRefresh(true);
+            }
         });
     }
     else
@@ -264,6 +268,7 @@ void LLOutfitsList::updateAddedCategory(LLUUID cat_id)
         // Refresh the list of outfit items after fetch().
         // Further list updates will be triggered by the category observer.
         list->updateList(cat_id);
+        list->setForceRefresh(true);
     }
 
     // If filter is currently applied we store the initial tab state.
@@ -590,7 +595,7 @@ void LLOutfitsList::onFilterSubStringChanged(const std::string& new_string, cons
         LLWearableItemsList* list = dynamic_cast<LLWearableItemsList*>(tab->getAccordionView());
         if (list)
         {
-            list->setFilterSubString(new_string, true);
+            list->setFilterSubString(new_string, tab->getDisplayChildren());
         }
 
         if (old_string.empty())


### PR DESCRIPTION
Caused by change in https://github.com/secondlife/viewer/commit/bd8438f7083643ae5812b14e35e69e69ef1616c6
But I prefer not just reverting it, because search in collapsed tabs will stop working - https://github.com/secondlife/viewer/issues/1619
So instead of refreshing all items lists at once (for each outfit) after changing filter string - let's refresh outfit items just after fetching, which won't happen simultaneously (see LLOutfitListBase::onIdleRefreshList()).