### PR TITLE
Cherry-pick packages-formatter fix from archive/develop

### DIFF
--- a/scripts/packages-formatter.py
+++ b/scripts/packages-formatter.py
@@ -42,7 +42,7 @@ _autobuild_env=os.environ.copy()
 # Coerce stdout encoding to utf-8 as cygwin's will be detected as cp1252 otherwise.
 _autobuild_env["PYTHONIOENCODING"] = "utf-8"
 
-pkg_line=re.compile('^([\w-]+):\s+(.*)$')
+pkg_line=re.compile(r'^([\w-]+):\s+(.*)$')
 
 def autobuild(*args):
     """


### PR DESCRIPTION
## Description

As recently [reminded](https://github.com/secondlife/viewer/commit/e7c506ba455f32eb8532f5e07bf83419126b5212#commitcomment-164120851), we need to cherry-pick this old fix for a warning when running packages-formatter.py

## Related Issues

Issue Link:  none.  build only issue


## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

