### PR TITLE
Crashfixes for 2025.06

### DIFF
--- a/indra/llui/lltextbase.cpp
+++ b/indra/llui/lltextbase.cpp
@@ -1069,6 +1069,14 @@ S32 LLTextBase::insertStringNoUndo(S32 pos, const LLWString &wstr, LLTextBase::s
 
 S32 LLTextBase::removeStringNoUndo(S32 pos, S32 length)
 {
+    S32 text_length = (S32)getLength();
+    if (pos >= text_length || pos < 0)
+    {
+        return 0; // nothing to remove
+    }
+    // Clamp length to not go past the end of the text
+    length = std::min(length, text_length - pos);
+
     beforeValueChange();
     segment_set_t::iterator seg_iter = getSegIterContaining(pos);
     while(seg_iter != mSegments.end())

--- a/indra/newview/gltf/buffer_util.h
+++ b/indra/newview/gltf/buffer_util.h
@@ -147,6 +147,12 @@ namespace LL
         }
 
         template<>
+        inline void copyVec3<F32, LLVector2>(F32* src, LLVector2& dst)
+        {
+            dst.set(src[0], src[1]);
+        }
+
+        template<>
         inline void copyVec3<F32, vec3>(F32* src, vec3& dst)
         {
             dst = vec3(src[0], src[1], src[2]);
@@ -375,12 +381,18 @@ namespace LL
         template<class T>
         inline void copy(Asset& asset, Accessor& accessor, LLStrider<T>& dst)
         {
-            if (accessor.mBufferView == INVALID_INDEX)
+            if (accessor.mBufferView == INVALID_INDEX
+                || accessor.mBufferView >= asset.mBufferViews.size())
             {
                 LL_WARNS("GLTF") << "Invalid buffer" << LL_ENDL;
                 return;
             }
             const BufferView& bufferView = asset.mBufferViews[accessor.mBufferView];
+            if (bufferView.mBuffer >= asset.mBuffers.size())
+            {
+                LL_WARNS("GLTF") << "Invalid buffer view" << LL_ENDL;
+                return;
+            }
             const Buffer& buffer = asset.mBuffers[bufferView.mBuffer];
             const U8* src = buffer.mData.data() + bufferView.mByteOffset + accessor.mByteOffset;
 

--- a/indra/newview/llinventorypanel.cpp
+++ b/indra/newview/llinventorypanel.cpp
@@ -770,6 +770,7 @@ void LLInventoryPanel::itemChanged(const LLUUID& item_id, U32 mask, const LLInve
             // Remove the item's UI.
             LLFolderViewFolder* parent = view_item->getParentFolder();
             removeItemID(viewmodel_item->getUUID());
+            bool was_favorite = view_item->isFavorite();
             view_item->destroyView();
             if(parent)
             {
@@ -783,7 +784,7 @@ void LLInventoryPanel::itemChanged(const LLUUID& item_id, U32 mask, const LLInve
                         updateFolderLabel(viewmodel_folder->getUUID());
                     }
                 }
-                if (view_item->isFavorite())
+                if (was_favorite)
                 {
                     parent->updateHasFavorites(false); // favorite was removed
                 }
@@ -2452,6 +2453,7 @@ bool LLInventoryFavoritesItemsPanel::removeFavorite(const LLUUID& id, const LLIn
         {
             removeItemID(viewmodel_item->getUUID());
         }
+        bool was_favorite = view_item->isFavorite();
         view_item->destroyView();
         if (parent)
         {
@@ -2461,7 +2463,7 @@ bool LLInventoryFavoritesItemsPanel::removeFavorite(const LLUUID& id, const LLIn
             {
                 updateFolderLabel(viewmodel_folder->getUUID());
             }
-            if (view_item->isFavorite())
+            if (was_favorite)
             {
                 parent->updateHasFavorites(false); // favorite was removed
             }


### PR DESCRIPTION
1. #4582  Crash at removeStringNoUndo - tried to remove text at unexisting position
2. #4583 Crash on LLInventoryPanel::itemChanged - checked item after deleting it
3. #4581 Crash on LL::GLTF::copy - new copyVec3 should be enough to fix it, but just in case sanity checked data
 