### PR TITLE
[WebRTC] Rework device handling sequence so that we can handle unplugging/re-plugging devices

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -307,10 +307,6 @@ jobs:
     needs: build
     runs-on: windows-2022
     steps:
-      - name: Install NSIS
-        run: choco install nsis -y
-        shell: powershell
-
       - name: Sign and package Windows viewer
         if: env.AZURE_KEY_VAULT_URI && env.AZURE_CERT_NAME && env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET && env.AZURE_TENANT_ID
         uses: secondlife/viewer-build-util/sign-pkg-windows@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -242,11 +242,6 @@ jobs:
           fi
           export PYTHON_COMMAND_NATIVE="$(native_path "$PYTHON_COMMAND")"
 
-          # make sure nsis is installed
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            choco install nsis -y
-          fi
-
           ./build.sh
 
           # Each artifact is downloaded as a distinct .zip file. Multiple jobs
@@ -312,6 +307,10 @@ jobs:
     needs: build
     runs-on: windows-2022
     steps:
+      - name: Install NSIS
+        run: choco install nsis -y
+        shell: powershell
+
       - name: Sign and package Windows viewer
         if: env.AZURE_KEY_VAULT_URI && env.AZURE_CERT_NAME && env.AZURE_CLIENT_ID && env.AZURE_CLIENT_SECRET && env.AZURE_TENANT_ID
         uses: secondlife/viewer-build-util/sign-pkg-windows@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
       - name: Checkout build variables
         uses: actions/checkout@v4
         with:
@@ -242,6 +241,11 @@ jobs:
             export PYTHON_COMMAND="python3"
           fi
           export PYTHON_COMMAND_NATIVE="$(native_path "$PYTHON_COMMAND")"
+
+          # make sure nsis is installed
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            choco install nsis -y
+          fi
 
           ./build.sh
 

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2717,11 +2717,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>e41e3a4e9e07bcbf553e725eb468ba1c1943abfa</string>
+              <string>8c4d1c363da56bf47178831ac9e03560e5a7e50a</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-darwin64-17354044714.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-darwin64-17623092396.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2731,11 +2731,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>586254d0c87cdaf9bb379ad36f161d42c499cfb3</string>
+              <string>995e116e180ff936bef7d40bcd60c845a299d414</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-linux64-17354044714.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-linux64-17623092396.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2745,11 +2745,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>3159f7e003c98a6ba3e286bb5f716a2127fe9843</string>
+              <string>08abe16a6735ab2eabc80d082f51098d6b87af19</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-windows64-17354044714.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-windows64-17623092396.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2762,7 +2762,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m137.7151.04.9.17354044714</string>
+        <string>m137.7151.04.15.17623092396</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2717,11 +2717,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>6314fdcee81a3538a7d960178ade66301c2fa002</string>
+              <string>e41e3a4e9e07bcbf553e725eb468ba1c1943abfa</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.73-alpha/webrtc-m114.5735.08.73-alpha.11958809572-darwin64-11958809572.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-darwin64-17354044714.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2731,11 +2731,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>95d7730a3d6955697e043f3fdf20ebdcc0c71fc0</string>
+              <string>586254d0c87cdaf9bb379ad36f161d42c499cfb3</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.73-alpha/webrtc-m114.5735.08.73-alpha.11958809572-linux64-11958809572.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-linux64-17354044714.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2745,11 +2745,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>c7b329d6409576af6eb5b80655b007f52639c43b</string>
+              <string>3159f7e003c98a6ba3e286bb5f716a2127fe9843</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m114.5735.08.73-alpha/webrtc-m114.5735.08.73-alpha.11958809572-windows64-11958809572.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.9/webrtc-m137.7151.04.9.17354044714-windows64-17354044714.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2762,7 +2762,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m114.5735.08.73-alpha.11958809572</string>
+        <string>m137.7151.04.9.17354044714</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -2717,11 +2717,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>8c4d1c363da56bf47178831ac9e03560e5a7e50a</string>
+              <string>43c5f93517794aeade550e4266b959d1f0cfcb7f</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-darwin64-17623092396.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.20-universal/webrtc-m137.7151.04.20-universal.17630578914-darwin64-17630578914.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -2731,11 +2731,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>995e116e180ff936bef7d40bcd60c845a299d414</string>
+              <string>efc5b176d878cfc16b8f82445d82ddb96815b6ab</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-linux64-17623092396.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.20-universal/webrtc-m137.7151.04.20-universal.17630578914-linux64-17630578914.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -2745,11 +2745,11 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>08abe16a6735ab2eabc80d082f51098d6b87af19</string>
+              <string>1e36f100de32c7c71325497a672fb1659b3f206d</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.15/webrtc-m137.7151.04.15.17623092396-windows64-17623092396.tar.zst</string>
+              <string>https://github.com/secondlife/3p-webrtc-build/releases/download/m137.7151.04.20-universal/webrtc-m137.7151.04.20-universal.17630578914-windows64-17630578914.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -2762,7 +2762,7 @@ Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors</string>
         <key>copyright</key>
         <string>Copyright (c) 2011, The WebRTC project authors. All rights reserved.</string>
         <key>version</key>
-        <string>m137.7151.04.15.17623092396</string>
+        <string>m137.7151.04.20-universal.17630578914</string>
         <key>name</key>
         <string>webrtc</string>
         <key>vcs_branch</key>

--- a/indra/llwebrtc/CMakeLists.txt
+++ b/indra/llwebrtc/CMakeLists.txt
@@ -42,7 +42,7 @@ if (WINDOWS)
                                        iphlpapi
                                        libcmt)
     # as the webrtc libraries are release, build this binary as release as well.
-    target_compile_options(llwebrtc PRIVATE "/MT")
+    target_compile_options(llwebrtc PRIVATE "/MT" "/Zc:wchar_t")
     if (USE_BUGSPLAT)
         set_target_properties(llwebrtc PROPERTIES PDB_OUTPUT_DIRECTORY "${SYMBOLS_STAGING_DIR}")
     endif (USE_BUGSPLAT)

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -481,18 +481,6 @@ void LLWebRTCImpl::workerDeployDevices()
     {
         mDeviceModule->ForceStartRecording();
     }
-    uint32_t min_v = 0, max_v = 0, cur_v = 0;
-    bool     have_hw = false;
-
-    mDeviceModule->MicrophoneVolumeIsAvailable(&have_hw);
-    if (have_hw)
-    {
-        mDeviceModule->MinMicrophoneVolume(&min_v);
-        mDeviceModule->MaxMicrophoneVolume(&max_v);
-        uint32_t target = min_v + (max_v - min_v) * 8 / 10; // ~80%
-        mDeviceModule->SetMicrophoneVolume(target);
-        mDeviceModule->MicrophoneVolume(&cur_v);
-    }
     mDeviceModule->StartPlayout();
 }
 
@@ -522,11 +510,11 @@ void LLWebRTCImpl::setCaptureDevice(const std::string &id)
         }
     }
 
-    // Always deploy devices, as we may have received a device update
-    // for the default device, which may be the same as mRecordingDevice
-    // but still needs to be refreshed.
-    mRecordingDevice = recordingDevice;
-    deployDevices();
+    if (mRecordingDevice != recordingDevice)
+    {
+        mRecordingDevice = recordingDevice;
+        deployDevices();
+    }
 }
 
 void LLWebRTCImpl::setRenderDevice(const std::string &id)
@@ -554,11 +542,11 @@ void LLWebRTCImpl::setRenderDevice(const std::string &id)
         }
     }
 
-    // Always deploy devices, as we may have received a device update
-    // for the default device, which may be the same as mPlayoutDevice
-    // but still needs to be refreshed.
-    mPlayoutDevice = playoutDevice;
-    deployDevices();
+    if (mPlayoutDevice != playoutDevice)
+    {
+        mPlayoutDevice = playoutDevice;
+        deployDevices();
+    }
 }
 
 // updateDevices needs to happen on the worker thread.
@@ -611,7 +599,7 @@ void LLWebRTCImpl::OnDevicesUpdated()
     mRecordingDevice = RECORD_DEVICE_DEFAULT;
     mPlayoutDevice   = PLAYOUT_DEVICE_DEFAULT;
 
-    updateDevices();
+    deployDevices();
 }
 
 

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -162,6 +162,7 @@ LLWebRTCImpl::LLWebRTCImpl(LLWebRTCLogCallback* logCallback) :
     mPeerCustomProcessor(nullptr),
     mMute(true),
     mTuningMode(false),
+    mDevicesDeploying(false),
     mPlayoutDevice(0),
     mRecordingDevice(0),
     mTuningAudioDeviceObserver(nullptr)
@@ -553,6 +554,11 @@ void LLWebRTCImpl::setTuningMode(bool enable)
 
 void LLWebRTCImpl::deployDevices()
 {
+    if (mDevicesDeploying)
+    {
+        return;
+    }
+    mDevicesDeploying = true;
     mWorkerThread->PostTask(
         [this] {
             if (mTuningMode)
@@ -596,6 +602,7 @@ void LLWebRTCImpl::deployDevices()
                         }
                         connection->enableReceiverTracks(!mTuningMode);
                     }
+                    mDevicesDeploying = false;
                 });
         });
 }

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -735,7 +735,7 @@ LLWebRTCPeerConnectionInterface *LLWebRTCImpl::newPeerConnection()
         intSetMute(mMute);
     }
     mPeerConnections.emplace_back(peerConnection);
-    
+
     peerConnection->enableSenderTracks(false);
     peerConnection->resetMute();
     return peerConnection.get();

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -159,7 +159,7 @@ class LLWebRTCDeviceInterface
     virtual void setTuningMode(bool enable) = 0;
     virtual float getTuningAudioLevel() = 0; // for use during tuning
     virtual float getPeerConnectionAudioLevel() = 0; // for use when not tuning
-    virtual void setPeerConnectionGain(float gain) = 0;
+    virtual void setMicGain(float gain) = 0;
 
     virtual void setMute(bool mute, int delay_ms = 0) = 0;
 };

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -160,6 +160,8 @@ class LLWebRTCDeviceInterface
     virtual float getTuningAudioLevel() = 0; // for use during tuning
     virtual float getPeerConnectionAudioLevel() = 0; // for use when not tuning
     virtual void setPeerConnectionGain(float gain) = 0;
+
+    virtual void setMute(bool mute, int delay_ms = 0) = 0;
 };
 
 // LLWebRTCAudioInterface provides the viewer with a way

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -160,6 +160,7 @@ class LLWebRTCDeviceInterface
     virtual float getTuningAudioLevel() = 0; // for use during tuning
     virtual float getPeerConnectionAudioLevel() = 0; // for use when not tuning
     virtual void setMicGain(float gain) = 0;
+    virtual void setTuningMicGain(float gain)        = 0;
 
     virtual void setMute(bool mute, int delay_ms = 0) = 0;
 };

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -300,6 +300,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     // Devices
     void updateDevices();
     void deployDevices();
+    bool                                                       mDevicesDeploying;
     rtc::scoped_refptr<webrtc::AudioDeviceModule>              mTuningDeviceModule;
     rtc::scoped_refptr<webrtc::AudioDeviceModule>              mPeerDeviceModule;
     std::vector<LLWebRTCDevicesObserver *>                     mVoiceDevicesObserverList;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -299,6 +299,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
 
     // Devices
     void updateDevices();
+    void deployDevices();
     rtc::scoped_refptr<webrtc::AudioDeviceModule>              mTuningDeviceModule;
     rtc::scoped_refptr<webrtc::AudioDeviceModule>              mPeerDeviceModule;
     std::vector<LLWebRTCDevicesObserver *>                     mVoiceDevicesObserverList;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -448,6 +448,8 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
 
     void setMute(bool mute, int delay_ms = 20) override;
 
+    void intSetMute(bool mute, int delay_ms = 20);
+
     //
     // AudioDeviceObserver
     //
@@ -523,22 +525,22 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
     webrtc::scoped_refptr<webrtc::AudioProcessing>                mAudioProcessingModule;
 
     // more native webrtc stuff
-    std::unique_ptr<webrtc::TaskQueueFactory>                  mTaskQueueFactory;
+    std::unique_ptr<webrtc::TaskQueueFactory>                     mTaskQueueFactory;
 
 
     // Devices
     void updateDevices();
     void deployDevices();
-    bool                                                       mDevicesDeploying;
-    webrtc::scoped_refptr<LLWebRTCAudioDeviceModule>              mDeviceModule;
+    std::atomic<int>                                           mDevicesDeploying;
+    webrtc::scoped_refptr<LLWebRTCAudioDeviceModule>           mDeviceModule;
     std::vector<LLWebRTCDevicesObserver *>                     mVoiceDevicesObserverList;
 
     // accessors in native webrtc for devices aren't apparently implemented yet.
     bool                                                       mTuningMode;
-    int32_t                                                    mRecordingDevice;
+    std::string                                                mRecordingDevice;
     LLWebRTCVoiceDeviceList                                    mRecordingDeviceList;
 
-    int32_t                                                    mPlayoutDevice;
+    std::string                                                mPlayoutDevice;
     LLWebRTCVoiceDeviceList                                    mPlayoutDeviceList;
 
     bool                                                       mMute;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -231,9 +231,12 @@ public:
     int32_t InitRecording() override { return inner_->InitRecording(); }
     bool    RecordingIsInitialized() const override { return inner_->RecordingIsInitialized(); }
     int32_t StartRecording() override {
-        if (tuning_)
-            return 0; // For tuning, we'll force a Start when we're ready
-        return inner_->StartRecording();
+        // ignore start recording as webrtc.lib will
+        // send one when streams first connect, resulting
+        // in an inadvertant 'recording' when mute is on.
+        // We take full control of StartRecording via
+        // ForceStartRecording below.
+        return 0;
     }
     int32_t StopRecording() override {
         if (tuning_) return 0;  // if we're tuning, disregard the StopRecording we get from disabling the streams

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -306,6 +306,8 @@ public:
 
     virtual int32_t GetPlayoutDevice() const override { return inner_->GetPlayoutDevice(); }
     virtual int32_t GetRecordingDevice() const override { return inner_->GetRecordingDevice(); }
+    virtual int32_t SetObserver(webrtc::AudioDeviceObserver* observer) override { return inner_->SetObserver(observer); }
+
 
     // tuning microphone energy calculations
     float GetMicrophoneEnergy() { return audio_transport_.GetMicrophoneEnergy(); }

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -437,7 +437,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
     float getTuningAudioLevel() override;
     float getPeerConnectionAudioLevel() override;
 
-    void setPeerConnectionGain(float gain) override;
+    void setMicGain(float gain) override;
 
     void setMute(bool mute, int delay_ms = 20) override;
 

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -54,12 +54,12 @@
 #include "rtc_base/ref_counted_object.h"
 #include "rtc_base/ssl_adapter.h"
 #include "rtc_base/thread.h"
+#include "rtc_base/logging.h"
 #include "api/peer_connection_interface.h"
 #include "api/media_stream_interface.h"
 #include "api/create_peerconnection_factory.h"
 #include "modules/audio_device/include/audio_device.h"
 #include "modules/audio_device/include/audio_device_data_observer.h"
-#include "rtc_base/task_queue.h"
 #include "api/task_queue/task_queue_factory.h"
 #include "api/task_queue/default_task_queue_factory.h"
 #include "modules/audio_device/include/audio_device_defines.h"
@@ -69,35 +69,30 @@ namespace llwebrtc
 
 class LLWebRTCPeerConnectionImpl;
 
-class LLWebRTCLogSink : public rtc::LogSink {
+class LLWebRTCLogSink : public webrtc::LogSink
+{
 public:
-    LLWebRTCLogSink(LLWebRTCLogCallback* callback) :
-    mCallback(callback)
-    {
-    }
+    LLWebRTCLogSink(LLWebRTCLogCallback* callback) : mCallback(callback) {}
 
     // Destructor: close the log file
-    ~LLWebRTCLogSink() override
-    {
-    }
+    ~LLWebRTCLogSink() override {}
 
-    void OnLogMessage(const std::string& msg,
-                      rtc::LoggingSeverity severity) override
+    void OnLogMessage(const std::string& msg, webrtc::LoggingSeverity severity) override
     {
         if (mCallback)
         {
-            switch(severity)
+            switch (severity)
             {
-                case rtc::LS_VERBOSE:
+                case webrtc::LS_VERBOSE:
                     mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
                     break;
-                case rtc::LS_INFO:
+                case webrtc::LS_INFO:
                     mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
                     break;
-                case rtc::LS_WARNING:
+                case webrtc::LS_WARNING:
                     mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
                     break;
-                case rtc::LS_ERROR:
+                case webrtc::LS_ERROR:
                     mCallback->LogMessage(LLWebRTCLogCallback::LOG_LEVEL_VERBOSE, msg);
                     break;
                 default:
@@ -118,44 +113,250 @@ private:
     LLWebRTCLogCallback* mCallback;
 };
 
-// Implements a class allowing capture of audio data
-// to determine audio level of the microphone.
-class LLAudioDeviceObserver : public webrtc::AudioDeviceDataObserver
+// -----------------------------------------------------------------------------
+// A proxy transport that forwards capture data to two AudioTransport sinks:
+//  - the "engine" (libwebrtc's VoiceEngine)
+//  - the "user" (your app's listener)
+//
+// Playout (NeedMorePlayData) goes only to the engine by default to avoid
+// double-writing into the output buffer. See notes below if you want a tap.
+// -----------------------------------------------------------------------------
+class LLWebRTCAudioTransport : public webrtc::AudioTransport
 {
-  public:
-    LLAudioDeviceObserver();
+public:
+    LLWebRTCAudioTransport();
 
-    // Retrieve the RMS audio loudness
-    float getMicrophoneEnergy();
+    void SetEngineTransport(webrtc::AudioTransport* t);
 
-    // Data retrieved from the caputure device is
-    // passed in here for processing.
-    void OnCaptureData(const void    *audio_samples,
-                       const size_t   num_samples,
-                       const size_t   bytes_per_sample,
-                       const size_t   num_channels,
-                       const uint32_t samples_per_sec) override;
+    // -------- Capture path: fan out to both sinks --------
+    int32_t RecordedDataIsAvailable(const void* audio_data,
+                                    size_t      number_of_samples,
+                                    size_t      bytes_per_sample,
+                                    size_t      number_of_channels,
+                                    uint32_t    samples_per_sec,
+                                    uint32_t    total_delay_ms,
+                                    int32_t     clock_drift,
+                                    uint32_t    current_mic_level,
+                                    bool        key_pressed,
+                                    uint32_t&   new_mic_level) override;
 
-    // This is for data destined for the render device.
-    // not currently used.
-    void OnRenderData(const void    *audio_samples,
-                      const size_t   num_samples,
-                      const size_t   bytes_per_sample,
-                      const size_t   num_channels,
-                      const uint32_t samples_per_sec) override;
+    // -------- Playout path: delegate to engine only --------
+    int32_t NeedMorePlayData(size_t   number_of_samples,
+                             size_t   bytes_per_sample,
+                             size_t   number_of_channels,
+                             uint32_t samples_per_sec,
+                             void*    audio_data,
+                             size_t&  number_of_samples_out,
+                             int64_t* elapsed_time_ms,
+                             int64_t* ntp_time_ms) override;
 
-  protected:
-    static const int NUM_PACKETS_TO_FILTER = 30;  // 300 ms of smoothing (30 frames)
-    float mSumVector[NUM_PACKETS_TO_FILTER];
-    float mMicrophoneEnergy;
+    // Method to pull mixed render audio data from all active VoE channels.
+    // The data will not be passed as reference for audio processing internally.
+    void PullRenderData(int      bits_per_sample,
+                        int      sample_rate,
+                        size_t   number_of_channels,
+                        size_t   number_of_frames,
+                        void*    audio_data,
+                        int64_t* elapsed_time_ms,
+                        int64_t* ntp_time_ms) override;
+
+    float GetMicrophoneEnergy() { return mMicrophoneEnergy; }
+
+private:
+    std::atomic<webrtc::AudioTransport*> engine_{ nullptr };
+    static const int                     NUM_PACKETS_TO_FILTER = 30; // 300 ms of smoothing (30 frames)
+    float                                mSumVector[NUM_PACKETS_TO_FILTER];
+    float                                mMicrophoneEnergy;
 };
+
+
+// -----------------------------------------------------------------------------
+// LLWebRTCAudioDeviceModule
+// - Wraps a real ADM to provide microphone energy for tuning
+// -----------------------------------------------------------------------------
+class LLWebRTCAudioDeviceModule : public webrtc::AudioDeviceModule
+{
+public:
+    explicit LLWebRTCAudioDeviceModule(webrtc::scoped_refptr<webrtc::AudioDeviceModule> inner) : inner_(std::move(inner)), tuning_(false)
+    {
+        RTC_CHECK(inner_);
+    }
+
+    // ----- AudioDeviceModule interface: we mostly forward to |inner_| -----
+    int32_t ActiveAudioLayer(AudioLayer* audioLayer) const override { return inner_->ActiveAudioLayer(audioLayer); }
+
+    int32_t RegisterAudioCallback(webrtc::AudioTransport* engine_transport) override
+    {
+        // The engine registers its transport here. We put our audio transport between engine and ADM.
+        audio_transport_.SetEngineTransport(engine_transport);
+        // Register our proxy with the real ADM.
+        return inner_->RegisterAudioCallback(&audio_transport_);
+    }
+
+    int32_t Init() override { return inner_->Init(); }
+    int32_t Terminate() override { return inner_->Terminate(); }
+    bool    Initialized() const override { return inner_->Initialized(); }
+
+    // --- Device enumeration/selection (forward) ---
+    int16_t PlayoutDevices() override { return inner_->PlayoutDevices(); }
+    int16_t RecordingDevices() override { return inner_->RecordingDevices(); }
+    int32_t PlayoutDeviceName(uint16_t index, char name[webrtc::kAdmMaxDeviceNameSize], char guid[webrtc::kAdmMaxGuidSize]) override
+    {
+        return inner_->PlayoutDeviceName(index, name, guid);
+    }
+    int32_t RecordingDeviceName(uint16_t index, char name[webrtc::kAdmMaxDeviceNameSize], char guid[webrtc::kAdmMaxGuidSize]) override
+    {
+        return inner_->RecordingDeviceName(index, name, guid);
+    }
+    int32_t SetPlayoutDevice(uint16_t index) override { return inner_->SetPlayoutDevice(index); }
+    int32_t SetRecordingDevice(uint16_t index) override { return inner_->SetRecordingDevice(index); }
+
+    // Windows default/communications selectors, if your branch exposes them:
+    int32_t SetPlayoutDevice(WindowsDeviceType type) override { return inner_->SetPlayoutDevice(type); }
+    int32_t SetRecordingDevice(WindowsDeviceType type) override { return inner_->SetRecordingDevice(type); }
+
+    // --- Init/start/stop (forward) ---
+    int32_t InitPlayout() override { return inner_->InitPlayout(); }
+    bool    PlayoutIsInitialized() const override { return inner_->PlayoutIsInitialized(); }
+    int32_t StartPlayout() override {
+        if (tuning_) return 0;  // For tuning, don't allow playout
+        return inner_->StartPlayout();
+    }
+    int32_t StopPlayout() override { return inner_->StopPlayout(); }
+    bool    Playing() const override { return inner_->Playing(); }
+
+    int32_t InitRecording() override { return inner_->InitRecording(); }
+    bool    RecordingIsInitialized() const override { return inner_->RecordingIsInitialized(); }
+    int32_t StartRecording() override { return inner_->StartRecording(); }
+    int32_t StopRecording() override {
+        if (tuning_) return 0;  // if we're tuning, disregard the StopRecording we get from disabling the streams
+        return inner_->StopRecording();
+    }
+    int32_t ForceStartRecording() { return inner_->StartRecording(); }
+    int32_t ForceStopRecording() { return inner_->StopRecording(); }
+    bool    Recording() const override { return inner_->Recording(); }
+
+    // --- Stereo opts (forward if available on your branch) ---
+    int32_t SetStereoPlayout(bool enable) override { return inner_->SetStereoPlayout(enable); }
+    int32_t SetStereoRecording(bool enable) override { return inner_->SetStereoRecording(enable); }
+    int32_t PlayoutIsAvailable(bool* available) override { return inner_->PlayoutIsAvailable(available); }
+    int32_t RecordingIsAvailable(bool* available) override { return inner_->RecordingIsAvailable(available); }
+
+    // --- AGC/Volume/Mute/etc. (forward) ---
+    int32_t SetMicrophoneVolume(uint32_t volume) override { return inner_->SetMicrophoneVolume(volume); }
+    int32_t MicrophoneVolume(uint32_t* volume) const override { return inner_->MicrophoneVolume(volume); }
+
+    // --- Speaker/Microphone init (forward) ---
+    int32_t InitSpeaker() override { return inner_->InitSpeaker(); }
+    bool    SpeakerIsInitialized() const override { return inner_->SpeakerIsInitialized(); }
+    int32_t InitMicrophone() override { return inner_->InitMicrophone(); }
+    bool    MicrophoneIsInitialized() const override { return inner_->MicrophoneIsInitialized(); }
+
+    // --- Speaker Volume (forward) ---
+    int32_t SpeakerVolumeIsAvailable(bool* available) override { return inner_->SpeakerVolumeIsAvailable(available); }
+    int32_t SetSpeakerVolume(uint32_t volume) override { return inner_->SetSpeakerVolume(volume); }
+    int32_t SpeakerVolume(uint32_t* volume) const override { return inner_->SpeakerVolume(volume); }
+    int32_t MaxSpeakerVolume(uint32_t* maxVolume) const override { return inner_->MaxSpeakerVolume(maxVolume); }
+    int32_t MinSpeakerVolume(uint32_t* minVolume) const override { return inner_->MinSpeakerVolume(minVolume); }
+
+    // --- Microphone Volume (forward) ---
+    int32_t MicrophoneVolumeIsAvailable(bool* available) override { return inner_->MicrophoneVolumeIsAvailable(available); }
+    int32_t MaxMicrophoneVolume(uint32_t* maxVolume) const override { return inner_->MaxMicrophoneVolume(maxVolume); }
+    int32_t MinMicrophoneVolume(uint32_t* minVolume) const override { return inner_->MinMicrophoneVolume(minVolume); }
+
+    // --- Speaker Mute (forward) ---
+    int32_t SpeakerMuteIsAvailable(bool* available) override { return inner_->SpeakerMuteIsAvailable(available); }
+    int32_t SetSpeakerMute(bool enable) override { return inner_->SetSpeakerMute(enable); }
+    int32_t SpeakerMute(bool* enabled) const override { return inner_->SpeakerMute(enabled); }
+
+    // --- Microphone Mute (forward) ---
+    int32_t MicrophoneMuteIsAvailable(bool* available) override { return inner_->MicrophoneMuteIsAvailable(available); }
+    int32_t SetMicrophoneMute(bool enable) override { return inner_->SetMicrophoneMute(enable); }
+    int32_t MicrophoneMute(bool* enabled) const override { return inner_->MicrophoneMute(enabled); }
+
+    // --- Stereo Support (forward) ---
+    int32_t StereoPlayoutIsAvailable(bool* available) const override { return inner_->StereoPlayoutIsAvailable(available); }
+    int32_t StereoPlayout(bool* enabled) const override { return inner_->StereoPlayout(enabled); }
+    int32_t StereoRecordingIsAvailable(bool* available) const override { return inner_->StereoRecordingIsAvailable(available); }
+    int32_t StereoRecording(bool* enabled) const override { return inner_->StereoRecording(enabled); }
+
+    // --- Delay/Timing (forward) ---
+    int32_t PlayoutDelay(uint16_t* delayMS) const override { return inner_->PlayoutDelay(delayMS); }
+
+    // --- Built-in Audio Processing (forward) ---
+    bool    BuiltInAECIsAvailable() const override { return inner_->BuiltInAECIsAvailable(); }
+    bool    BuiltInAGCIsAvailable() const override { return inner_->BuiltInAGCIsAvailable(); }
+    bool    BuiltInNSIsAvailable() const override { return inner_->BuiltInNSIsAvailable(); }
+    int32_t EnableBuiltInAEC(bool enable) override { return inner_->EnableBuiltInAEC(enable); }
+    int32_t EnableBuiltInAGC(bool enable) override { return inner_->EnableBuiltInAGC(enable); }
+    int32_t EnableBuiltInNS(bool enable) override { return inner_->EnableBuiltInNS(enable); }
+
+    // --- Additional AudioDeviceModule methods (forward) ---
+    int32_t GetPlayoutUnderrunCount() const override { return inner_->GetPlayoutUnderrunCount(); }
+
+    // Used to generate RTC stats. If not implemented, RTCAudioPlayoutStats will
+    // not be present in the stats.
+    std::optional<Stats> GetStats() const override { return inner_->GetStats(); }
+
+// Only supported on iOS.
+#if defined(WEBRTC_IOS)
+    virtual int GetPlayoutAudioParameters(AudioParameters* params) const override { return inner_->GetPlayoutAudioParameters(params); }
+    virtual int GetRecordAudioParameters(AudioParameters* params) override { return inner_->GetRecordAudioParameters(params); }
+#endif // WEBRTC_IOS
+
+    virtual int32_t GetPlayoutDevice() const override { return inner_->GetPlayoutDevice(); }
+    virtual int32_t GetRecordingDevice() const override { return inner_->GetRecordingDevice(); }
+
+    // tuning microphone energy calculations
+    float GetMicrophoneEnergy() { return audio_transport_.GetMicrophoneEnergy(); }
+    void  SetTuning(bool tuning)
+    {
+        tuning_ = tuning;
+        inner_->InitRecording();
+        inner_->StartRecording();
+        if (tuning)
+        {
+            inner_->StopPlayout();
+        }
+        else
+        {
+            inner_->StartPlayout();
+        }
+    }
+
+protected:
+    ~LLWebRTCAudioDeviceModule() override = default;
+
+private:
+    webrtc::scoped_refptr<webrtc::AudioDeviceModule> inner_;
+    LLWebRTCAudioTransport                        audio_transport_;
+
+    bool tuning_;
+};
+
+class LLCustomProcessorState
+{
+
+public:
+    float getMicrophoneEnergy() { return mMicrophoneEnergy.load(std::memory_order_relaxed); }
+    void setMicrophoneEnergy(float energy) { mMicrophoneEnergy.store(energy, std::memory_order_relaxed); }
+
+    void setGain(float gain) { mGain.store(gain, std::memory_order_relaxed); }
+    float getGain() { return mGain.load(std::memory_order_relaxed); }
+
+ protected:
+    std::atomic<float> mMicrophoneEnergy{ 0.0f };
+    std::atomic<float> mGain{ 0.0f };
+};
+
+using LLCustomProcessorStatePtr = std::shared_ptr<LLCustomProcessorState>;
 
 // Used to process/retrieve audio levels after
 // all of the processing (AGC, AEC, etc.) for display in-world to the user.
 class LLCustomProcessor : public webrtc::CustomProcessing
 {
   public:
-    LLCustomProcessor();
+    LLCustomProcessor(LLCustomProcessorStatePtr state);
     ~LLCustomProcessor() override {}
 
     // (Re-) Initializes the submodule.
@@ -167,24 +368,20 @@ class LLCustomProcessor : public webrtc::CustomProcessing
     // Returns a string representation of the module state.
     std::string ToString() const override { return ""; }
 
-    float getMicrophoneEnergy() { return mMicrophoneEnergy; }
-
-    void setGain(float gain) { mGain = gain; }
-
   protected:
     static const int NUM_PACKETS_TO_FILTER = 30;  // 300 ms of smoothing
     int              mSampleRateHz;
     int              mNumChannels;
 
     float mSumVector[NUM_PACKETS_TO_FILTER];
-    float mMicrophoneEnergy;
-    float mGain;
+    friend LLCustomProcessorState;
+    LLCustomProcessorStatePtr mState;
 };
 
 
 // Primary singleton implementation for interfacing
 // with the native webrtc library.
-class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceSink
+class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceObserver
 {
   public:
     LLWebRTCImpl(LLWebRTCLogCallback* logCallback);
@@ -217,7 +414,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     void setPeerConnectionGain(float gain) override;
 
     //
-    // AudioDeviceSink
+    // AudioDeviceObserver
     //
     void OnDevicesUpdated() override;
 
@@ -246,19 +443,19 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
         mNetworkThread->PostTask(std::move(task), location);
     }
 
-    void WorkerBlockingCall(rtc::FunctionView<void()> functor,
+    void WorkerBlockingCall(webrtc::FunctionView<void()> functor,
                   const webrtc::Location& location = webrtc::Location::Current())
     {
         mWorkerThread->BlockingCall(std::move(functor), location);
     }
 
-    void SignalingBlockingCall(rtc::FunctionView<void()> functor,
+    void SignalingBlockingCall(webrtc::FunctionView<void()> functor,
                   const webrtc::Location& location = webrtc::Location::Current())
     {
         mSignalingThread->BlockingCall(std::move(functor), location);
     }
 
-    void NetworkBlockingCall(rtc::FunctionView<void()> functor,
+    void NetworkBlockingCall(webrtc::FunctionView<void()> functor,
                   const webrtc::Location& location = webrtc::Location::Current())
     {
         mNetworkThread->BlockingCall(std::move(functor), location);
@@ -266,7 +463,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
 
     // Allows the LLWebRTCPeerConnectionImpl class to retrieve the
     // native webrtc PeerConnectionFactory.
-    rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> getPeerConnectionFactory()
+    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> getPeerConnectionFactory()
     {
         return mPeerConnectionFactory;
     }
@@ -275,23 +472,20 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     LLWebRTCPeerConnectionInterface* newPeerConnection();
     void freePeerConnection(LLWebRTCPeerConnectionInterface* peer_connection);
 
-    // enables/disables capture via the capture device
-    void setRecording(bool recording);
-
-    void setPlayout(bool playing);
-
   protected:
+
+    void workerDeployDevices();
     LLWebRTCLogSink*                                           mLogSink;
 
     // The native webrtc threads
-    std::unique_ptr<rtc::Thread>                               mNetworkThread;
-    std::unique_ptr<rtc::Thread>                               mWorkerThread;
-    std::unique_ptr<rtc::Thread>                               mSignalingThread;
+    std::unique_ptr<webrtc::Thread>                            mNetworkThread;
+    std::unique_ptr<webrtc::Thread>                            mWorkerThread;
+    std::unique_ptr<webrtc::Thread>                            mSignalingThread;
 
     // The factory that allows creation of native webrtc PeerConnections.
-    rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
+    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
 
-    rtc::scoped_refptr<webrtc::AudioProcessing>                mAudioProcessingModule;
+    webrtc::scoped_refptr<webrtc::AudioProcessing>                mAudioProcessingModule;
 
     // more native webrtc stuff
     std::unique_ptr<webrtc::TaskQueueFactory>                  mTaskQueueFactory;
@@ -301,8 +495,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
     void updateDevices();
     void deployDevices();
     bool                                                       mDevicesDeploying;
-    rtc::scoped_refptr<webrtc::AudioDeviceModule>              mTuningDeviceModule;
-    rtc::scoped_refptr<webrtc::AudioDeviceModule>              mPeerDeviceModule;
+    webrtc::scoped_refptr<LLWebRTCAudioDeviceModule>              mDeviceModule;
     std::vector<LLWebRTCDevicesObserver *>                     mVoiceDevicesObserverList;
 
     // accessors in native webrtc for devices aren't apparently implemented yet.
@@ -315,11 +508,10 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceS
 
     bool                                                       mMute;
 
-    LLAudioDeviceObserver *                                    mTuningAudioDeviceObserver;
-    LLCustomProcessor *                                        mPeerCustomProcessor;
+    LLCustomProcessorStatePtr                                  mPeerCustomProcessor;
 
     // peer connections
-    std::vector<rtc::scoped_refptr<LLWebRTCPeerConnectionImpl>>     mPeerConnections;
+    std::vector<webrtc::scoped_refptr<LLWebRTCPeerConnectionImpl>> mPeerConnections;
 };
 
 
@@ -344,7 +536,7 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
     void terminate();
 
     virtual void AddRef() const override = 0;
-    virtual rtc::RefCountReleaseStatus Release() const override = 0;
+    virtual webrtc::RefCountReleaseStatus Release() const override = 0;
 
     //
     // LLWebRTCPeerConnection
@@ -375,10 +567,10 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
     //
 
     void OnSignalingChange(webrtc::PeerConnectionInterface::SignalingState new_state) override {}
-    void OnAddTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
-                    const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>> &streams) override;
-    void OnRemoveTrack(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override;
-    void OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> channel) override;
+    void OnAddTrack(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
+                    const std::vector<webrtc::scoped_refptr<webrtc::MediaStreamInterface>> &streams) override;
+    void OnRemoveTrack(webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override;
+    void OnDataChannel(webrtc::scoped_refptr<webrtc::DataChannelInterface> channel) override;
     void OnRenegotiationNeeded() override {}
     void OnIceConnectionChange(webrtc::PeerConnectionInterface::IceConnectionState new_state) override {};
     void OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState new_state) override;
@@ -417,7 +609,7 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
 
     LLWebRTCImpl * mWebRTCImpl;
 
-    rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
+    webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> mPeerConnectionFactory;
 
     typedef enum {
         MUTE_INITIAL,
@@ -431,12 +623,12 @@ class LLWebRTCPeerConnectionImpl : public LLWebRTCPeerConnectionInterface,
     std::vector<std::unique_ptr<webrtc::IceCandidateInterface>>  mCachedIceCandidates;
     bool mAnswerReceived;
 
-    rtc::scoped_refptr<webrtc::PeerConnectionInterface> mPeerConnection;
-    rtc::scoped_refptr<webrtc::MediaStreamInterface> mLocalStream;
+    webrtc::scoped_refptr<webrtc::PeerConnectionInterface> mPeerConnection;
+    webrtc::scoped_refptr<webrtc::MediaStreamInterface> mLocalStream;
 
     // data
     std::vector<LLWebRTCDataObserver *> mDataObserverList;
-    rtc::scoped_refptr<webrtc::DataChannelInterface> mDataChannel;
+    webrtc::scoped_refptr<webrtc::DataChannelInterface> mDataChannel;
 };
 
 }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -84,7 +84,7 @@ namespace {
 
     const F32 MAX_AUDIO_DIST      = 50.0f;
     const F32 VOLUME_SCALE_WEBRTC = 0.01f;
-    const F32 LEVEL_SCALE_WEBRTC  = 0.008f;
+    const F32 LEVEL_SCALE_WEBRTC  = 0.015f;
     const uint32_t SET_HIDDEN_RESTORE_DELAY_MS = 200;  // 200 ms to unmute again after hiding during teleport
     const uint32_t MUTE_FADE_DELAY_MS       = 500;   // 20ms fade followed by 480ms silence gets rid of the click just after unmuting.
                                                      // This is because the buffers and processing is cleared by the silence.
@@ -781,7 +781,14 @@ bool LLWebRTCVoiceClient::inTuningMode()
 
 void LLWebRTCVoiceClient::tuningSetMicVolume(float volume)
 {
-    mTuningMicGain      = volume;
+    if (volume != mTuningMicGain)
+    {
+        mTuningMicGain = volume;
+        if (mWebRTCDeviceInterface)
+        {
+            mWebRTCDeviceInterface->setTuningMicGain(volume);
+        }
+    }
 }
 
 void LLWebRTCVoiceClient::tuningSetSpeakerVolume(float volume)
@@ -795,7 +802,7 @@ void LLWebRTCVoiceClient::tuningSetSpeakerVolume(float volume)
 
 float LLWebRTCVoiceClient::tuningGetEnergy(void)
 {
-    return (1.0f - mWebRTCDeviceInterface->getTuningAudioLevel() * LEVEL_SCALE_WEBRTC) * mTuningMicGain / 2.1f;
+    return (1.0f - mWebRTCDeviceInterface->getTuningAudioLevel() * LEVEL_SCALE_WEBRTC)/1.5f;
 }
 
 bool LLWebRTCVoiceClient::deviceSettingsAvailable()
@@ -1127,7 +1134,7 @@ void LLWebRTCVoiceClient::sendPositionUpdate(bool force)
 // in the UI.  This is done on all sessions, so switching
 // sessions retains consistent volume levels.
 void LLWebRTCVoiceClient::updateOwnVolume() {
-    F32 audio_level = (1.0f - mWebRTCDeviceInterface->getPeerConnectionAudioLevel() * LEVEL_SCALE_WEBRTC) / 2.1f;
+    F32 audio_level = (1.0f - mWebRTCDeviceInterface->getPeerConnectionAudioLevel() * LEVEL_SCALE_WEBRTC) / 4.0f;
 
     sessionState::for_each(boost::bind(predUpdateOwnVolume, _1, audio_level));
 }
@@ -1569,7 +1576,10 @@ void LLWebRTCVoiceClient::setMicGain(F32 gain)
     if (gain != mMicGain)
     {
         mMicGain = gain;
-        mWebRTCDeviceInterface->setMicGain(gain);
+        if (mWebRTCDeviceInterface)
+        {
+            mWebRTCDeviceInterface->setMicGain(gain);
+        }
     }
 }
 

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -695,21 +695,38 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
     std::string outputDevice = gSavedSettings.getString("VoiceOutputAudioDevice");
 
     LL_DEBUGS("Voice") << "Setting devices to-input: '" << inputDevice << "' output: '" << outputDevice << "'" << LL_ENDL;
-    clearRenderDevices();
-    for (auto &device : render_devices)
-    {
-        addRenderDevice(LLVoiceDevice(device.mDisplayName, device.mID));
-    }
-    setRenderDevice(outputDevice);
 
-    clearCaptureDevices();
-    for (auto &device : capture_devices)
+    // only set the render device if the device list has changed.
+    if (mRenderDevices.size() != render_devices.size() || !std::equal(mRenderDevices.begin(),
+                    mRenderDevices.end(),
+                    render_devices.begin(),
+                    [](const LLVoiceDevice& a, const llwebrtc::LLWebRTCVoiceDevice& b) {
+            return a.display_name == b.mDisplayName && a.full_name == b.mID; }))
     {
-        LL_DEBUGS("Voice") << "Checking capture device:'" << device.mID << "'" << LL_ENDL;
-
-        addCaptureDevice(LLVoiceDevice(device.mDisplayName, device.mID));
+        clearRenderDevices();
+        for (auto& device : render_devices)
+        {
+            addRenderDevice(LLVoiceDevice(device.mDisplayName, device.mID));
+        }
+        setRenderDevice(outputDevice);
     }
-    setCaptureDevice(inputDevice);
+
+    // only set the capture device if the device list has changed.
+    if (mCaptureDevices.size() != capture_devices.size() ||!std::equal(mCaptureDevices.begin(),
+                    mCaptureDevices.end(),
+                    capture_devices.begin(),
+                    [](const LLVoiceDevice& a, const llwebrtc::LLWebRTCVoiceDevice& b)
+                    { return a.display_name == b.mDisplayName && a.full_name == b.mID; }))
+    {
+        clearCaptureDevices();
+        for (auto& device : capture_devices)
+        {
+            LL_DEBUGS("Voice") << "Checking capture device:'" << device.mID << "'" << LL_ENDL;
+
+            addCaptureDevice(LLVoiceDevice(device.mDisplayName, device.mID));
+        }
+        setCaptureDevice(inputDevice);
+    }
 
     setDevicesListUpdated(true);
 }

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -444,10 +444,6 @@ public:
 
 private:
 
-    // helper function to retrieve the audio level
-    // Used in multiple places.
-    float getAudioLevel();
-
     // Coroutine support methods
     //---
     void voiceConnectionCoro();
@@ -458,7 +454,6 @@ private:
 
     LL::WorkQueue::weak_t mMainQueue;
 
-    bool mTuningMode;
     F32 mTuningMicGain;
     int mTuningSpeakerVolume;
     bool mDevicesListUpdated;            // set to true when the device list has been updated


### PR DESCRIPTION
Issues:
Maybe #3919 
Maybe #3225
#3085 
#2509 
#4004 
Maybe #4596 
#4627 
#4648 
#4652 
#4653 
#4642 

The device handling was not processing device updates in the proper sequence as
things like AEC use of both input and output devices.  Devices like headsets are both
so unplugging them resulted in various mute conditions and sometimes even a crash.

Now, we update both capture and render devices at once in the proper sequence.

Additionally, this included an update from m114 to m137 of the webrtc library, which allowed
us to add support for 192khz.

### Test Guidance:
**Device Handling**
* Bring two users in the same place in webrtc regions.
* The 'listening' one should have a headset or something set oas 'Default'
* Press 'talk' on one, and verify the other can hear.
* Unplug the headset from the listening one.
* Validate that audio changes from the headset to the speakers.
* Plug the headset back in.
* Validate that audio changes from speakers to headset.
* Do the same type of test with the headset viewer talking.
* The microphone used should switch from the headset to the computer (it should have one)

Do other various device tests, such as setting devices explicitly, messing with the device selector, etc.

**m137 Update**
Additionally, as this is an upgrade from m114 to m137, we'll need to do a fairly thorough general voice pass.
* general voice
* cross-region voice
* parcel voice in various combinations.
* calls of various types (exercises bringing up and tearing down connections.)

**Multi-Channel Devices**
Support was added for surround (4 channel and 8 channel and more) output devices, as well as multi-channel input devices (mixers.)  To test:
* Attach a surround output device to your computer (if you don't have one)
* Attach a multi-channel input device to your computer
* Select them in the viewer
* Test audio in both directions.
You may be able to test with virtual multi-channel devices.

**AGC**
We now support AGC 2 in webrtc (digital agc) which is the recommended.  AGC1 may be deprecated in that version.  To test:
* send audio with AGC turned off
* send audio with AGC turned on
* Validate they sound different.

**Self Audio Level Handling**
Audio level handling was tweaked for both tuning and in-world for self.  Validate it looks reasonable.