### PR TITLE
#4598 Crash in LLReflectionMapManager::update

### DIFF
--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -145,6 +145,7 @@ static void touch_default_probe(LLReflectionMap* probe)
 LLReflectionMapManager::LLReflectionMapManager()
 {
     mDynamicProbeCount = LL_MAX_REFLECTION_PROBE_COUNT;
+    refreshSettings();
     initCubeFree();
 }
 
@@ -222,25 +223,21 @@ void LLReflectionMapManager::update()
         resume();
     }
 
-    static LLCachedControl<S32> sDetail(gSavedSettings, "RenderReflectionProbeDetail", -1);
-    static LLCachedControl<S32> sLevel(gSavedSettings, "RenderReflectionProbeLevel", 3);
-    static LLCachedControl<U32> sReflectionProbeCount(gSavedSettings, "RenderReflectionProbeCount", 256U);
-    static LLCachedControl<S32> sProbeDynamicAllocation(gSavedSettings, "RenderReflectionProbeDynamicAllocation", -1);
     mResetFade = llmin((F32)(mResetFade + gFrameIntervalSeconds * 2.f), 1.f);
 
     {
         U32 probe_count_temp = mDynamicProbeCount;
-        if (sProbeDynamicAllocation > -1)
+        if (mRenderReflectionProbeDynamicAllocation > -1)
         {
-            if (sLevel == 0)
+            if (mRenderReflectionProbeLevel == 0)
             {
                 mDynamicProbeCount = 1;
             }
-            else if (sLevel == 1)
+            else if (mRenderReflectionProbeLevel == 1)
             {
                 mDynamicProbeCount = (U32)mProbes.size();
             }
-            else if (sLevel == 2)
+            else if (mRenderReflectionProbeLevel == 2)
             {
                 mDynamicProbeCount = llmax((U32)mProbes.size(), 128);
             }
@@ -249,20 +246,20 @@ void LLReflectionMapManager::update()
                 mDynamicProbeCount = 256;
             }
 
-            if (sProbeDynamicAllocation > 1)
+            if (mRenderReflectionProbeDynamicAllocation > 1)
             {
                 // Round mDynamicProbeCount to the nearest increment of 16
-                mDynamicProbeCount = ((mDynamicProbeCount + sProbeDynamicAllocation / 2) / sProbeDynamicAllocation) * 16;
-                mDynamicProbeCount = llclamp(mDynamicProbeCount, 1, sReflectionProbeCount);
+                mDynamicProbeCount = ((mDynamicProbeCount + mRenderReflectionProbeDynamicAllocation / 2) / mRenderReflectionProbeDynamicAllocation) * 16;
+                mDynamicProbeCount = llclamp(mDynamicProbeCount, 1, mRenderReflectionProbeCount);
             }
             else
             {
-                mDynamicProbeCount = llclamp(mDynamicProbeCount + sProbeDynamicAllocation, 1, sReflectionProbeCount);
+                mDynamicProbeCount = llclamp(mDynamicProbeCount + mRenderReflectionProbeDynamicAllocation, 1, mRenderReflectionProbeCount);
             }
         }
         else
         {
-            mDynamicProbeCount = sReflectionProbeCount;
+            mDynamicProbeCount = mRenderReflectionProbeCount;
         }
 
         mDynamicProbeCount = llmin(mDynamicProbeCount, LL_MAX_REFLECTION_PROBE_COUNT);
@@ -328,7 +325,7 @@ void LLReflectionMapManager::update()
 
     bool did_update = false;
 
-    bool realtime = sDetail >= (S32)LLReflectionMapManager::DetailLevel::REALTIME;
+    bool realtime = mRenderReflectionProbeDetail >= (S32)LLReflectionMapManager::DetailLevel::REALTIME;
 
     LLReflectionMap* closestDynamic = nullptr;
 
@@ -457,7 +454,7 @@ void LLReflectionMapManager::update()
             closestDynamic = probe;
         }
 
-        if (sLevel == 0)
+        if (mRenderReflectionProbeLevel == 0)
         {
             // only update default probe when coverage is set to none
             llassert(probe == mDefaultProbe);
@@ -489,12 +486,12 @@ void LLReflectionMapManager::update()
     static LLCachedControl<F32> sUpdatePeriod(gSavedSettings, "RenderDefaultProbeUpdatePeriod", 2.f);
     if ((gFrameTimeSeconds - mDefaultProbe->mLastUpdateTime) < sUpdatePeriod)
     {
-        if (sLevel == 0)
+        if (mRenderReflectionProbeLevel == 0)
         { // when probes are disabled don't update the default probe more often than the prescribed update period
             oldestProbe = nullptr;
         }
     }
-    else if (sLevel > 0)
+    else if (mRenderReflectionProbeLevel > 0)
     { // when probes are enabled don't update the default probe less often than the prescribed update period
       oldestProbe = mDefaultProbe;
     }
@@ -518,6 +515,14 @@ void LLReflectionMapManager::update()
         oldestOccluded->autoAdjustOrigin();
         oldestOccluded->mLastUpdateTime = gFrameTimeSeconds;
     }
+}
+
+void LLReflectionMapManager::refreshSettings()
+{
+    mRenderReflectionProbeDetail = gSavedSettings.getS32("RenderReflectionProbeDetail");
+    mRenderReflectionProbeLevel = gSavedSettings.getS32("RenderReflectionProbeLevel");
+    mRenderReflectionProbeCount = gSavedSettings.getU32("RenderReflectionProbeCount");
+    mRenderReflectionProbeDynamicAllocation = gSavedSettings.getS32("RenderReflectionProbeDynamicAllocation");
 }
 
 LLReflectionMap* LLReflectionMapManager::addProbe(LLSpatialGroup* group)
@@ -782,7 +787,7 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
     }
     else
     {
-        llassert(gSavedSettings.getS32("RenderReflectionProbeLevel") > 0); // should never update a probe that's not the default probe if reflection coverage is none
+        llassert(mRenderReflectionProbeLevel > 0); // should never update a probe that's not the default probe if reflection coverage is none
         probe->update(mRenderTarget.getWidth(), face);
     }
 

--- a/indra/newview/llreflectionmapmanager.h
+++ b/indra/newview/llreflectionmapmanager.h
@@ -110,6 +110,8 @@ public:
     // maintain reflection probes
     void update();
 
+    void refreshSettings();
+
     // add a probe for the given spatial group
     LLReflectionMap* addProbe(LLSpatialGroup* group = nullptr);
 
@@ -247,6 +249,12 @@ private:
     U32 mReflectionProbeCount;
 
     U32 mDynamicProbeCount;
+
+    // cached settings from gSavedSettings
+    S32 mRenderReflectionProbeDetail = -1;
+    S32 mRenderReflectionProbeLevel = 3;
+    U32 mRenderReflectionProbeCount = 256U;
+    S32 mRenderReflectionProbeDynamicAllocation = -1;
 
     // resolution of reflection probes
     U32 mProbeResolution = 128;

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -447,6 +447,7 @@ static bool handleRenderDynamicLODChanged(const LLSD& newvalue)
 
 static bool handleReflectionProbeDetailChanged(const LLSD& newvalue)
 {
+    gPipeline.mReflectionMapManager.refreshSettings();
     if (gPipeline.isInit())
     {
         LLPipeline::refreshCachedSettings();
@@ -456,6 +457,12 @@ static bool handleReflectionProbeDetailChanged(const LLSD& newvalue)
         gPipeline.createGLBuffers();
         LLViewerShaderMgr::instance()->setShaders();
     }
+    return true;
+}
+
+static bool handleReflectionProbeCountChanged(const LLSD& newvalue)
+{
+    gPipeline.mReflectionMapManager.refreshSettings();
     return true;
 }
 
@@ -836,6 +843,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderResolutionDivisor", handleRenderResolutionDivisorChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeLevel", handleReflectionProbeDetailChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeDetail", handleReflectionProbeDetailChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderReflectionProbeCount", handleReflectionProbeCountChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderReflectionsEnabled", handleReflectionProbeDetailChanged);
 #if LL_DARWIN
     setting_setup_signal_listener(gSavedSettings, "RenderAppleUseMultGL", handleAppleUseMultGLChanged);


### PR DESCRIPTION
Crash finding/iterating settings.

Not enough data for a solid conclusion (does something create settings in a thread thus iterators break?), but should be avoidable if we cache settings differently.