### PR TITLE
#4588 Unable to direct silent installation

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -397,6 +397,7 @@ bool idle_startup()
         LL_WARNS_ONCE() << "gViewerWindow is not initialized" << LL_ENDL;
         return false; // No world yet
     }
+    LL_PROFILE_ZONE_SCOPED;
 
     const F32 PRECACHING_DELAY = gSavedSettings.getF32("PrecachingDelay");
     static LLTimer timeout;


### PR DESCRIPTION
1. Copied an stsstr function from nsis
2. Extracted full command line since option in nsis's command line specifically exclude path. This has a downside: it's a subject to string length limit, so it method will fail for long paths.
3. Checked command line for presense of path override and extracted path. NSIS is supposed to do the last part already, but for whatever reason our instal path wasn't overridedn.
4. Overriding install path with extracted path