### PR TITLE
#4604 Reduce draw distance when low on RAM

### DIFF
--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -218,6 +218,7 @@ private:
     bool mGotPersonalInfo;
     bool mLanguageChanged;
     bool mAvatarDataInitialized;
+    U32 mLastQualityLevel = 0;
     std::string mPriorInstantMessageLogPath;
 
     bool mOriginalHideOnlineStatus;

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -115,6 +115,7 @@ public:
     static void initClass();
     static void updateClass();
     static bool isSystemMemoryLow();
+    static F32 getSystemMemoryBudgetFactor();
 
     LLViewerTexture(bool usemipmaps = true);
     LLViewerTexture(const LLUUID& id, bool usemipmaps) ;
@@ -188,6 +189,8 @@ protected:
 private:
     friend class LLBumpImageList;
     friend class LLUIImageList;
+
+    static U32Megabytes getFreeSystemMemory();
 
 protected:
     friend class LLViewerTextureList;

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -486,14 +486,23 @@ void LLVOCacheEntry::updateDebugSettings()
     //min radius: all objects within this radius remain loaded in memory
     static LLCachedControl<F32> min_radius(gSavedSettings,"SceneLoadMinRadius");
     static const F32 MIN_RADIUS = 1.0f;
-    const F32 draw_radius = gAgentCamera.mDrawDistance;
+
+    F32 draw_radius = gAgentCamera.mDrawDistance;
+    if (LLViewerTexture::sDesiredDiscardBias > 2.f && LLViewerTexture::isSystemMemoryLow())
+    {
+        // Discard's bias maximum is 4 so we need to check 2 to 4 range
+        // Factor is intended to go from 1.0 to 2.0
+        F32 factor = 1.f + (LLViewerTexture::sDesiredDiscardBias - 2.f) / 2.f;
+        // For safety cap reduction at 50%, we don't want to go below half of draw distance
+        draw_radius = llmax(draw_radius / factor, draw_radius / 2.f);
+    }
     const F32 clamped_min_radius = llclamp((F32) min_radius, MIN_RADIUS, draw_radius); // [1, mDrawDistance]
     sNearRadius = MIN_RADIUS + ((clamped_min_radius - MIN_RADIUS) * adjust_factor);
 
     // a percentage of draw distance beyond which all objects outside of view frustum will be unloaded, regardless of pixel threshold
     static LLCachedControl<F32> rear_max_radius_frac(gSavedSettings,"SceneLoadRearMaxRadiusFraction");
     const F32 min_radius_plus_one = sNearRadius + 1.f;
-    const F32 max_radius = rear_max_radius_frac * gAgentCamera.mDrawDistance;
+    const F32 max_radius = rear_max_radius_frac * draw_radius;
     const F32 clamped_max_radius = llclamp(max_radius, min_radius_plus_one, draw_radius); // [sNearRadius, mDrawDistance]
     sRearFarRadius = min_radius_plus_one + ((clamped_max_radius - min_radius_plus_one) * adjust_factor);
 

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -12147,6 +12147,17 @@ Cannot create large prims that intersect other residents.  Please re-try when ot
 
   <notification
    icon="alertmodal.tga"
+   name="PreferenceQualityWithLowMemory"
+   type="alert">
+Your system has [TOTAL_MEM]MB of memory, which might not be enough to run viewer at higher settings and might result in issues.
+      <usetemplate
+       name="okcancelbuttons"
+       notext="Cancel"
+       yestext="Continue"/>
+  </notification>
+
+  <notification
+   icon="alertmodal.tga"
    name="DefaultObjectPermissions"
    type="alert">
 	There was a problem saving the default object permissions: [REASON].  Please try setting the default permissions later.


### PR DESCRIPTION
#4604 Reduce draw distance when low on RAM
Textures already affect draw distance to some extent, so decided to expand that code to cut draw distance up to two times when ram is low.
Please doublecheck logic in LLViewerTexture::updateClass()

#4604 Warn user off high settings when on low-RAM hardware
A basic ok/cancel warning that throws user to 'med+' if canceled
Please check new notification's wording.
