### PR TITLE
#4619 Don't crash on LLHUDEffect::render

### DIFF
--- a/indra/newview/llhudeffectresetskeleton.cpp
+++ b/indra/newview/llhudeffectresetskeleton.cpp
@@ -56,6 +56,15 @@ LLHUDEffectResetSkeleton::~LLHUDEffectResetSkeleton()
 //-----------------------------------------------------------------------------
 // packData()
 //-----------------------------------------------------------------------------
+void LLHUDEffectResetSkeleton::render()
+{
+    // HUDEffectResetSkeleton is a fake effect meant to reset skeleton only.
+    // Just wait for an update() call to do its work and then die.
+}
+
+//-----------------------------------------------------------------------------
+// packData()
+//-----------------------------------------------------------------------------
 void LLHUDEffectResetSkeleton::packData(LLMessageSystem *mesgsys)
 {
     // Pack the default data

--- a/indra/newview/llhudeffectresetskeleton.h
+++ b/indra/newview/llhudeffectresetskeleton.h
@@ -38,20 +38,21 @@ class LLHUDEffectResetSkeleton final : public LLHUDEffect
 public:
     friend class LLHUDObject;
 
-    /*virtual*/ void markDead();
-    /*virtual*/ void setSourceObject(LLViewerObject* objectp);
+    /*virtual*/ void markDead() override;
+    /*virtual*/ void setSourceObject(LLViewerObject* objectp) override;
 
-    void setTargetObject(LLViewerObject *objp);
+    void setTargetObject(LLViewerObject *objp) override;
     void setResetAnimations(bool enable){ mResetAnimations = enable; };
 
 protected:
     LLHUDEffectResetSkeleton(const U8 type);
     ~LLHUDEffectResetSkeleton();
 
-    /*virtual*/ void packData(LLMessageSystem *mesgsys);
-    /*virtual*/ void unpackData(LLMessageSystem *mesgsys, S32 blocknum);
+    void render() override;
+    void packData(LLMessageSystem *mesgsys) override;
+    void unpackData(LLMessageSystem *mesgsys, S32 blocknum) override;
 
-    void update();
+    void update() override;
 private:
     bool                        mResetAnimations;
 };

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -2310,6 +2310,7 @@ EMeshProcessingResult LLMeshRepoThread::headerReceived(const LLVolumeParams& mes
             }
             if (request_skin)
             {
+                LLMutexLock lock(mMutex);
                 mSkinRequests.push_back(UUIDBasedRequest(mesh_id));
             }
         }


### PR DESCRIPTION
LLHUDEffectResetSkeleton needs to override LLHUDEffect::render to not cause an LL_ERRS if it stays alive for too long.

Added a single line 'missed mutex' fix.