### PR TITLE
#4623 Shared Media on HUDs not loading

### DIFF
--- a/indra/newview/llviewercamera.cpp
+++ b/indra/newview/llviewercamera.cpp
@@ -157,9 +157,9 @@ bool LLViewerCamera::updateCameraLocation(const LLVector3 &center, const LLVecto
     // update pixel meter ratio using default fov, not modified one
     mPixelMeterRatio = (F32)(getViewHeightInPixels()/ (2.f*tanf(mCameraFOVDefault*0.5f)));
     // update screen pixel area
+    mScreenPixelArea =(S32)((F32)getViewHeightInPixels() * ((F32)getViewHeightInPixels() * getAspect()));
 
     return true;
-    mScreenPixelArea =(S32)((F32)getViewHeightInPixels() * ((F32)getViewHeightInPixels() * getAspect()));
 }
 
 const LLMatrix4 &LLViewerCamera::getProjection() const


### PR DESCRIPTION
Looks like a merge between a commit that affected mScreenPixelArea and a commit that added a return value resulted in reordered calls.