### PR TITLE
#4536 Fix clipped setting descriptions

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_settings_debug.xml
+++ b/indra/newview/skins/default/xui/en/floater_settings_debug.xml
@@ -66,6 +66,7 @@
    visible="false"
    name="comment_text"
    follows="left|top"
+   max_length="1024"
    width="240"
    top_delta="20"
    word_wrap="true" />


### PR DESCRIPTION
Field has default length of 512 chars, doubled it.