### PR TITLE
Avoid using boost's wstring path to string conversion

### DIFF
--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -122,7 +122,16 @@ std::vector<std::string> LLDir::getFilesInDir(const std::string &dirname)
             {
                 if (boost::filesystem::is_regular_file(dir_itr->status()))
                 {
-                    v.push_back(dir_itr->path().filename().string());
+#ifdef LL_WINDOWS
+                    // Path and filename can be converted directly to string(),
+                    // but that uses system locale.
+                    // While locale can be UTF-8, typicaly it is ANSI, so it's
+                    // better to convert explicitly.
+                    std::string filename = ll_convert<std::string>(dir_itr->path().filename().wstring());
+#else
+                    std::string filename = dir_itr->path().filename().string();
+#endif
+                    v.push_back(filename);
                 }
             }
         }

--- a/indra/llfilesystem/lldiriterator.cpp
+++ b/indra/llfilesystem/lldiriterator.cpp
@@ -72,7 +72,7 @@ LLDirIterator::Impl::Impl(const std::string &dirname, const std::string &mask)
 
     if (!is_dir)
     {
-        LL_WARNS() << "Invalid path: \"" << dir_path.string() << "\"" << LL_ENDL;
+        LL_WARNS() << "Invalid path: \"" << dirname << "\"" << LL_ENDL;
         return;
     }
 
@@ -129,8 +129,16 @@ bool LLDirIterator::Impl::next(std::string &fname)
     {
         while (mIter != end_itr && !found)
         {
-            boost::smatch match;
+#ifdef LL_WINDOWS
+            // Path and filename can be converted directly to string(),
+            // but that uses system locale.
+            // While locale can be UTF-8, typicaly it is ANSI, so it's
+            // better to convert explicitly.
+            std::string name = ll_convert<std::string>(mIter->path().filename().wstring());
+#else
             std::string name = mIter->path().filename().string();
+#endif
+            boost::smatch match;
             found = ll_regex_match(name, match, mFilterExp);
             if (found)
             {


### PR DESCRIPTION
Boost's wstring path to string conversion is supposed to work based of system's locale, avoid it and convert to utf-8 explicitly.

Draft because I need to wrap this in windows/not windows checks.

P.S. Will make a ticket with a scenarion on a fresher head.