### PR TITLE
#1965 Properly terminate particles when HUD is off #2

### DIFF
--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -1522,6 +1522,11 @@ void render_ui(F32 zoom_factor, int subfield)
                 render_disconnected_background();
             }
         }
+        else
+        {
+            // Make sure particle effects disappear
+            LLHUDObject::renderAllForTimer();
+        }
 
         if (render_ui)
         {


### PR DESCRIPTION
Another case where particles persisted yet shouldn't have.