### PR TITLE
#1825 Use html as a default type for nosniff mime probes

### DIFF
--- a/indra/llcorehttp/llhttpconstants.cpp
+++ b/indra/llcorehttp/llhttpconstants.cpp
@@ -100,6 +100,7 @@ const std::string HTTP_IN_HEADER_LOCATION("location");
 const std::string HTTP_IN_HEADER_RETRY_AFTER("retry-after");
 const std::string HTTP_IN_HEADER_SET_COOKIE("set-cookie");
 const std::string HTTP_IN_HEADER_USER_AGENT("user-agent");
+const std::string HTTP_IN_HEADER_X_CONTENT_TYPE_OPTIONS("x-content-type-options");
 const std::string HTTP_IN_HEADER_X_FORWARDED_FOR("x-forwarded-for");
 
 const std::string HTTP_CONTENT_LLSD_XML("application/llsd+xml");
@@ -122,6 +123,7 @@ const std::string HTTP_CONTENT_IMAGE_BMP("image/bmp");
 
 const std::string HTTP_NO_CACHE("no-cache");
 const std::string HTTP_NO_CACHE_CONTROL("no-cache, max-age=0");
+const std::string HTTP_NOSNIFF("nosniff");
 
 const std::string HTTP_VERB_INVALID("(invalid)");
 const std::string HTTP_VERB_HEAD("HEAD");

--- a/indra/llcorehttp/llhttpconstants.h
+++ b/indra/llcorehttp/llhttpconstants.h
@@ -190,6 +190,7 @@ extern const std::string HTTP_IN_HEADER_LOCATION;
 extern const std::string HTTP_IN_HEADER_RETRY_AFTER;
 extern const std::string HTTP_IN_HEADER_SET_COOKIE;
 extern const std::string HTTP_IN_HEADER_USER_AGENT;
+extern const std::string HTTP_IN_HEADER_X_CONTENT_TYPE_OPTIONS;
 extern const std::string HTTP_IN_HEADER_X_FORWARDED_FOR;
 
 //// HTTP Content Types ////
@@ -215,5 +216,6 @@ extern const std::string HTTP_CONTENT_IMAGE_BMP;
 //// HTTP Cache Settings ////
 extern const std::string HTTP_NO_CACHE;
 extern const std::string HTTP_NO_CACHE_CONTROL;
+extern const std::string HTTP_NOSNIFF;
 
 #endif

--- a/indra/newview/llfloaterurlentry.cpp
+++ b/indra/newview/llfloaterurlentry.cpp
@@ -242,6 +242,16 @@ void LLFloaterURLEntry::getMediaTypeCoro(std::string url, LLHandle<LLFloater> pa
             resolvedMimeType = mimeType;
         }
     }
+    else if (resultHeaders.has(HTTP_IN_HEADER_X_CONTENT_TYPE_OPTIONS))
+    {
+        const std::string& val = resultHeaders[HTTP_IN_HEADER_X_CONTENT_TYPE_OPTIONS];
+        if (val == HTTP_NOSNIFF)
+        {
+            // Doesn't permit 'sniffing' mime type, default to either html or plain
+            // If this doesn't work user will have to choose something manually.
+            resolvedMimeType = HTTP_CONTENT_TEXT_HTML;
+        }
+    }
 
     floaterUrlEntry->headerFetchComplete(status.getType(), resolvedMimeType);
 


### PR DESCRIPTION
Not sure if it's even worth fixing/changing: link returned no type, we don't know what t do with it. But it's probably better to have some default other than none/none when link is correct but prevents mime testing.