### PR TITLE
#4660 Unable to upload GLTF+bin with spaces in the name

### DIFF
--- a/indra/newview/gltf/accessor.cpp
+++ b/indra/newview/gltf/accessor.cpp
@@ -158,6 +158,11 @@ bool Buffer::prep(Asset& asset)
     {
         std::string dir = gDirUtilp->getDirName(asset.mFilename);
         std::string bin_file = dir + gDirUtilp->getDirDelimiter() + mUri;
+        if (!gDirUtilp->fileExists(bin_file))
+        {
+            // Characters might be escaped in the URI
+            bin_file = dir + gDirUtilp->getDirDelimiter() + LLURI::unescape(mUri);
+        }
 
         llifstream file(bin_file.c_str(), std::ios::binary);
         if (!file.is_open())

--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -652,6 +652,14 @@ std::string LLGLTFLoader::processTexture(S32 texture_index, const std::string& t
             filename = filename.substr(pos + 1);
         }
 
+        std::string dir = gDirUtilp->getDirName(mFilename);
+        std::string full_path = dir + gDirUtilp->getDirDelimiter() + filename;
+        if (!gDirUtilp->fileExists(full_path) && filename.find("data:") == std::string::npos)
+        {
+            // Uri might be escaped
+            filename = LLURI::unescape(filename);
+        }
+
         LL_INFOS("GLTF_IMPORT") << "Found texture: " << filename << " for material: " << material_name << LL_ENDL;
 
         LLSD args;


### PR DESCRIPTION
Sometimes gltf's uri that points to the bin file (and I assume textures as well) can be escaped.

@marchcat I think you were the one to do textures, does this make sense to you?