### PR TITLE
#4604 Account for free page file memory

### DIFF
--- a/indra/llcommon/llmemory.cpp
+++ b/indra/llcommon/llmemory.cpp
@@ -58,6 +58,7 @@
 // NOTE: this number MAY be less than the actual available memory on systems with more than MaxHeapSize64 GB of physical memory (default 16GB)
 //  In that case, should report min(available, sMaxHeapSizeInKB-sAllocateMemInKB)
 U32Kilobytes LLMemory::sAvailPhysicalMemInKB(U32_MAX);
+U32Kilobytes LLMemory::sAvailPageMemInKB(U32_MAX);
 
 // Installed physical memory
 U32Kilobytes LLMemory::sMaxPhysicalMemInKB(0);
@@ -105,8 +106,10 @@ void LLMemory::updateMemoryInfo()
     sMaxPhysicalMemInKB = gSysMemory.getPhysicalMemoryKB();
 
     U32Kilobytes avail_mem;
-    LLMemoryInfo::getAvailableMemoryKB(avail_mem);
+    U32Kilobytes avail_page;
+    LLMemoryInfo::getAvailableMemoryKB(avail_mem, avail_page);
     sAvailPhysicalMemInKB = avail_mem;
+    sAvailPageMemInKB     = avail_page;
 
 #if LL_WINDOWS
     PROCESS_MEMORY_COUNTERS counters;
@@ -205,6 +208,12 @@ void LLMemory::logMemoryInfo(bool update)
 U32Kilobytes LLMemory::getAvailableMemKB()
 {
     return sAvailPhysicalMemInKB ;
+}
+
+//static
+U32Kilobytes LLMemory::getAvailablePageKB()
+{
+    return sAvailPageMemInKB; // at the moment Win only
 }
 
 //static

--- a/indra/llcommon/llmemory.h
+++ b/indra/llcommon/llmemory.h
@@ -430,10 +430,12 @@ public:
     static void logMemoryInfo(bool update = false);
 
     static U32Kilobytes getAvailableMemKB() ;
+    static U32Kilobytes getAvailablePageKB();
     static U32Kilobytes getMaxMemKB() ;
     static U32Kilobytes getAllocatedMemKB() ;
 private:
     static U32Kilobytes sAvailPhysicalMemInKB ;
+    static U32Kilobytes sAvailPageMemInKB; // at the moment Win only
     static U32Kilobytes sMaxPhysicalMemInKB ;
     static U32Kilobytes sAllocatedMemInKB;
     static U32Kilobytes sAllocatedPageSizeInKB ;

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -805,7 +805,7 @@ U32Kilobytes LLMemoryInfo::getPhysicalMemoryKB() const
 }
 
 //static
-void LLMemoryInfo::getAvailableMemoryKB(U32Kilobytes& avail_mem_kb)
+void LLMemoryInfo::getAvailableMemoryKB(U32Kilobytes& avail_mem_kb, U32Kilobytes& avail_page_kb)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_MEMORY;
 #if LL_WINDOWS
@@ -814,6 +814,7 @@ void LLMemoryInfo::getAvailableMemoryKB(U32Kilobytes& avail_mem_kb)
     LLSD statsMap(loadStatsMap());
 
     avail_mem_kb = (U32Kilobytes)statsMap["Avail Physical KB"].asInteger();
+    avail_page_kb = (U32Kilobytes)statsMap["Avail page KB"].asInteger();
 
 #elif LL_DARWIN
     // use host_statistics64 to get memory info
@@ -831,6 +832,7 @@ void LLMemoryInfo::getAvailableMemoryKB(U32Kilobytes& avail_mem_kb)
     {
         avail_mem_kb = (U32Kilobytes)-1;
     }
+    avail_page_kb = (U32Kilobytes)0; // not implemented
 
 #elif LL_LINUX
     // mStatsMap is derived from MEMINFO_FILE:
@@ -884,11 +886,13 @@ void LLMemoryInfo::getAvailableMemoryKB(U32Kilobytes& avail_mem_kb)
     LLSD statsMap(loadStatsMap());
 
     avail_mem_kb = (U32Kilobytes)statsMap["MemFree"].asInteger();
+    avail_page_kb = (U32Kilobytes)0; // not implemented
 #else
     //do not know how to collect available memory info for other systems.
     //leave it blank here for now.
 
     avail_mem_kb = (U32Kilobytes)-1 ;
+    avail_page_kb = (U32Kilobytes)-1;
 #endif
 }
 

--- a/indra/llcommon/llsys.h
+++ b/indra/llcommon/llsys.h
@@ -135,7 +135,7 @@ public:
 #endif
 
     //get the available memory in KiloBytes.
-    static void getAvailableMemoryKB(U32Kilobytes& avail_mem_kb);
+    static void getAvailableMemoryKB(U32Kilobytes& avail_mem_kb, U32Kilobytes& avail_page_kb);
 
     // Retrieve a map of memory statistics. The keys of the map are platform-
     // dependent. The values are in kilobytes to try to avoid integer overflow.

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3366,6 +3366,9 @@ void send_agent_update(bool force_send, bool send_reliable)
     static F32 last_draw_disatance_step = 1024;
     F32 memory_limited_draw_distance = gAgentCamera.mDrawDistance;
 
+#if LL_WINDOWS
+    // Until we have page file info for other platforms, only do this on Windows.
+    // Otherwise isSystemMemoryLow is going to be too agressive for draw range.
     if (LLViewerTexture::sDesiredDiscardBias > 2.f && LLViewerTexture::isSystemMemoryLow())
     {
         // If we are low on memory, reduce requested draw distance
@@ -3374,6 +3377,7 @@ void send_agent_update(bool force_send, bool send_reliable)
         F32 factor = 1.f + (LLViewerTexture::sDesiredDiscardBias - 2.f) / 2.f;
         memory_limited_draw_distance = llmax(gAgentCamera.mDrawDistance / factor, gAgentCamera.mDrawDistance / 2.f);
     }
+#endif
 
     if (tp_state == LLAgent::TELEPORT_ARRIVING || LLStartUp::getStartupState() < STATE_MISC)
     {


### PR DESCRIPTION
Draw range reduction logic appears to work, but isSystemMemoryLow() is too agressive and triggered when there was plenty of page file memory. So account for that.