### PR TITLE
#4604 Tweak range decrease

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -3366,13 +3366,10 @@ void send_agent_update(bool force_send, bool send_reliable)
     static F32 last_draw_disatance_step = 1024;
     F32 memory_limited_draw_distance = gAgentCamera.mDrawDistance;
 
-    if (LLViewerTexture::sDesiredDiscardBias > 2.f && LLViewerTexture::isSystemMemoryLow())
+    if (LLViewerTexture::isSystemMemoryCritical())
     {
         // If we are low on memory, reduce requested draw distance
-        // Discard's bias is clamped to 4 so we need to check 2 to 4 range
-        // Factor is intended to go from 1.0 to 2.0
-        F32 factor = 1.f + (LLViewerTexture::sDesiredDiscardBias - 2.f) / 2.f;
-        memory_limited_draw_distance = llmax(gAgentCamera.mDrawDistance / factor, gAgentCamera.mDrawDistance / 2.f);
+        memory_limited_draw_distance = llmax(gAgentCamera.mDrawDistance / LLViewerTexture::getSystemMemoryBudgetFactor(), gAgentCamera.mDrawDistance / 2.f);
     }
 
     if (tp_state == LLAgent::TELEPORT_ARRIVING || LLStartUp::getStartupState() < STATE_MISC)

--- a/indra/newview/llviewertexture.h
+++ b/indra/newview/llviewertexture.h
@@ -115,6 +115,7 @@ public:
     static void initClass();
     static void updateClass();
     static bool isSystemMemoryLow();
+    static bool isSystemMemoryCritical();
     static F32 getSystemMemoryBudgetFactor();
 
     LLViewerTexture(bool usemipmaps = true);

--- a/indra/newview/llvocache.cpp
+++ b/indra/newview/llvocache.cpp
@@ -488,13 +488,11 @@ void LLVOCacheEntry::updateDebugSettings()
     static const F32 MIN_RADIUS = 1.0f;
 
     F32 draw_radius = gAgentCamera.mDrawDistance;
-    if (LLViewerTexture::sDesiredDiscardBias > 2.f && LLViewerTexture::isSystemMemoryLow())
+    if (LLViewerTexture::isSystemMemoryCritical())
     {
-        // Discard's bias maximum is 4 so we need to check 2 to 4 range
         // Factor is intended to go from 1.0 to 2.0
-        F32 factor = 1.f + (LLViewerTexture::sDesiredDiscardBias - 2.f) / 2.f;
         // For safety cap reduction at 50%, we don't want to go below half of draw distance
-        draw_radius = llmax(draw_radius / factor, draw_radius / 2.f);
+        draw_radius = llmax(draw_radius / LLViewerTexture::getSystemMemoryBudgetFactor(), draw_radius / 2.f);
     }
     const F32 clamped_min_radius = llclamp((F32) min_radius, MIN_RADIUS, draw_radius); // [1, mDrawDistance]
     sNearRadius = MIN_RADIUS + ((clamped_min_radius - MIN_RADIUS) * adjust_factor);


### PR DESCRIPTION
isSystemMemoryLow() and factor check were too agressive for draw range. For purposes of range decrease use half the value.