### PR TITLE
#4651 Try distinguishing freezes from crashes

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3945,8 +3945,15 @@ void LLAppViewer::processMarkerFiles()
         else if (marker_is_same_version)
         {
             // the file existed, is ours, and matched our version, so we can report on what it says
-            LL_INFOS("MarkerFile") << "Exec marker '"<< mMarkerFileName << "' found; last exec crashed" << LL_ENDL;
+            LL_INFOS("MarkerFile") << "Exec marker '"<< mMarkerFileName << "' found; last exec crashed or froze" << LL_ENDL;
+#if LL_WINDOWS && LL_BUGSPLAT
+            // bugsplat will set correct state in bugsplatSendLog
+            // Might be more accurate to rename this one into 'unknown'
+            gLastExecEvent = LAST_EXEC_FROZE;
+#else
             gLastExecEvent = LAST_EXEC_OTHER_CRASH;
+#endif // LL_WINDOWS
+
         }
         else
         {

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -172,6 +172,18 @@ namespace
                                     << '/' << loc.mV[1]
                                     << '/' << loc.mV[2])));
             }
+
+            if (!LLAppViewer::instance()->isSecondInstance())
+            {
+                std::string error_marker_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, ERROR_MARKER_FILE_NAME);
+                if (!LLAPRFile::isExist(error_marker_file, NULL, LL_APR_RB))
+                {
+                    // If marker doesn't exist, create a marker with 'other' code for next launch
+                    // otherwise don't override existing file
+                    // Any unmarked crashes will be considered as freezes
+                    LLAppViewer::instance()->createErrorMarker(LAST_EXEC_OTHER_CRASH);
+                }
+            }
         } // MDSCB_EXCEPTIONCODE
 
         return false;


### PR DESCRIPTION
Mark unmarked crashes caught by bugsplat as 'other', everything that is left unmarked after bugsplat is a 'freeze'.

The 'gLastExecEvent = LAST_EXEC_OTHER_CRASH;' part was originaly a freeze but got changed to 'other' when bugsplat replaced previous crash mechanics.