### PR TITLE
Fix indexing problem with mac devices

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -350,6 +350,16 @@ void LLWebRTCImpl::init()
 
 void LLWebRTCImpl::terminate()
 {
+    mWorkerThread->BlockingCall(
+        [this]()
+        {
+            if (mDeviceModule)
+            {
+                mDeviceModule->ForceStopRecording();
+                mDeviceModule->StopPlayout();
+            }
+        });
+
     for (auto &connection : mPeerConnections)
     {
         connection->terminate();
@@ -368,8 +378,6 @@ void LLWebRTCImpl::terminate()
         {
             if (mDeviceModule)
             {
-                mDeviceModule->StopRecording();
-                mDeviceModule->StopPlayout();
                 mDeviceModule->Terminate();
             }
             mDeviceModule     = nullptr;
@@ -442,11 +450,7 @@ void LLWebRTCImpl::unsetDevicesObserver(LLWebRTCDevicesObserver *observer)
 void LLWebRTCImpl::workerDeployDevices()
 {
     int16_t recordingDevice = RECORD_DEVICE_DEFAULT;
-#if WEBRTC_WIN
     int16_t recording_device_start = 0;
-#else
-    int16_t recording_device_start = 1;
-#endif
 
     if (mRecordingDevice != "Default")
     {
@@ -455,6 +459,12 @@ void LLWebRTCImpl::workerDeployDevices()
             if (mRecordingDeviceList[i].mID == mRecordingDevice)
             {
                 recordingDevice = i;
+#if !WEBRTC_WIN
+                // linux and mac devices range from 1 to the end of the list, with the index 0 being the
+                // 'default' device.  Windows has a special 'default' device and other devices are indexed
+                // from 0
+                recordingDevice++;
+#endif
                 break;
             }
         }
@@ -479,11 +489,7 @@ void LLWebRTCImpl::workerDeployDevices()
     mDeviceModule->InitRecording();
 
     int16_t playoutDevice = PLAYOUT_DEVICE_DEFAULT;
-#if WEBRTC_WIN
     int16_t playout_device_start = 0;
-#else
-    int16_t playout_device_start = 1;
-#endif
     if (mPlayoutDevice != "Default")
     {
         for (int16_t i = playout_device_start; i < mPlayoutDeviceList.size(); i++)
@@ -491,6 +497,12 @@ void LLWebRTCImpl::workerDeployDevices()
             if (mPlayoutDeviceList[i].mID == mPlayoutDevice)
             {
                 playoutDevice = i;
+#if !WEBRTC_WIN
+                // linux and mac devices range from 1 to the end of the list, with the index 0 being the
+                // 'default' device.  Windows has a special 'default' device and other devices are indexed
+                // from 0
+                playoutDevice++;
+#endif
                 break;
             }
         }

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -558,20 +558,14 @@ void LLWebRTCImpl::workerDeployDevices()
 void LLWebRTCImpl::setCaptureDevice(const std::string &id)
 {
 
-    if (mRecordingDevice != id)
-    {
-        mRecordingDevice = id;
-        deployDevices();
-    }
+    mRecordingDevice = id;
+    deployDevices();
 }
 
 void LLWebRTCImpl::setRenderDevice(const std::string &id)
 {
-    if (mPlayoutDevice != id)
-    {
-        mPlayoutDevice = id;
-        deployDevices();
-    }
+    mPlayoutDevice = id;
+    deployDevices();
 }
 
 // updateDevices needs to happen on the worker thread.
@@ -621,7 +615,7 @@ void LLWebRTCImpl::updateDevices()
 
 void LLWebRTCImpl::OnDevicesUpdated()
 {
-    deployDevices();
+    updateDevices();
 }
 
 

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -239,8 +239,10 @@ public:
         return 0;
     }
     int32_t StopRecording() override {
-        if (tuning_) return 0;  // if we're tuning, disregard the StopRecording we get from disabling the streams
-        return inner_->StopRecording();
+        // ignore stop recording as webrtc.lib will send one when streams shut down,
+        // even if there are other streams in place.  Start/Stop recording are entirely
+        // controlled by the app
+        return 0;
     }
     int32_t ForceStartRecording() { return inner_->StartRecording(); }
     int32_t ForceStopRecording() { return inner_->StopRecording(); }


### PR DESCRIPTION
This resulted in the wrong device being selected.

Also, fix a shutdown crash where recording was not being stopped, hence the recording thread was still running on shutdown and crashed because it lost access to resources.

Fix an issue with p2p calls where they're coming up muted even though the button indicates they are unmuted.

Issues:
#4669
#4670 
#4684

## Description

Test guidance
- repro the issues in the above tickets.

Also
- Bring up a viewer on windows, in a webrtc region.
- Click on the speak button
- shut down the viewer
- validate there is no crash.
