### PR TITLE
#4675 Voice indicator did not reappear after tuning

### DIFF
--- a/indra/newview/llconversationview.cpp
+++ b/indra/newview/llconversationview.cpp
@@ -543,7 +543,7 @@ void LLConversationViewSession::onCurrentVoiceSessionChanged(const LLUUID& sessi
     {
         bool old_value = mIsInActiveVoiceChannel;
         mIsInActiveVoiceChannel = vmi->getUUID() == session_id;
-        mCallIconLayoutPanel->setVisible(mIsInActiveVoiceChannel);
+        mCallIconLayoutPanel->setVisible(mIsInActiveVoiceChannel && !LLVoiceChannel::isSuspended());
         if (old_value != mIsInActiveVoiceChannel)
         {
             refresh();

--- a/indra/newview/llspeakingindicatormanager.cpp
+++ b/indra/newview/llspeakingindicatormanager.cpp
@@ -200,8 +200,17 @@ void SpeakingIndicatorManager::cleanupSingleton()
 
 void SpeakingIndicatorManager::sOnCurrentChannelChanged(const LLUUID& /*session_id*/)
 {
-    switchSpeakerIndicators(mSwitchedIndicatorsOn, false);
-    mSwitchedIndicatorsOn.clear();
+    if (LLVoiceChannel::isSuspended())
+    {
+        switchSpeakerIndicators(mSwitchedIndicatorsOn, false);
+        mSwitchedIndicatorsOn.clear();
+    }
+    else
+    {
+        // Multiple onParticipantsChanged can arrive at the same time
+        // from different sources, might want to filter by some factor.
+        onParticipantsChanged();
+    }
 }
 
 void SpeakingIndicatorManager::onParticipantsChanged()

--- a/indra/newview/llvoicechannel.cpp
+++ b/indra/newview/llvoicechannel.cpp
@@ -357,6 +357,8 @@ void LLVoiceChannel::suspend()
     {
         sSuspendedVoiceChannel = sCurrentVoiceChannel;
         sSuspended = true;
+
+        sCurrentVoiceChannelChangedSignal(sSuspendedVoiceChannel->mSessionID);
     }
 }
 
@@ -365,6 +367,7 @@ void LLVoiceChannel::resume()
 {
     if (sSuspended)
     {
+        sSuspended = false; // needs to be before activate() so that observers will be able to read state
         if (LLVoiceClient::getInstance()->voiceEnabled())
         {
             if (sSuspendedVoiceChannel)
@@ -382,7 +385,6 @@ void LLVoiceChannel::resume()
                 LLVoiceChannelProximal::getInstance()->activate();
             }
         }
-        sSuspended = false;
     }
 }
 

--- a/indra/newview/llvoicechannel.h
+++ b/indra/newview/llvoicechannel.h
@@ -103,6 +103,7 @@ public:
 
     static void suspend();
     static void resume();
+    static bool isSuspended() { return sSuspended; }
 
   protected:
     virtual void setState(EState state);


### PR DESCRIPTION
resume() was trigggering sOnCurrentChannelChanged which was wiping participant list with no follow up updates.