### PR TITLE
#789 Cannot set the material to Default or None

### DIFF
--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -1012,6 +1012,8 @@ void LLFloaterTexturePicker::onBtnSetToDefault(void* userdata)
     {
         self->setImageID( self->getDefaultImageAssetID() );
         self->setTentative(false);
+        // Deselect in case inventory has a selected item with the same id
+        self->mInventoryPanel->getRootFolder()->clearSelection();
     }
     self->commitIfImmediateSet();
 }
@@ -1023,6 +1025,8 @@ void LLFloaterTexturePicker::onBtnBlank(void* userdata)
     self->setCanApply(true, true);
     self->setImageID( self->getBlankImageAssetID() );
     self->setTentative(false);
+    // Deselect in case inventory has a selected item with the same id
+    self->mInventoryPanel->getRootFolder()->clearSelection();
     self->commitIfImmediateSet();
 }
 
@@ -1034,6 +1038,8 @@ void LLFloaterTexturePicker::onBtnNone(void* userdata)
     self->setCanApply(true, true);
     self->setImageID( LLUUID::null );
     self->setTentative(false);
+    // Deselect in case inventory has a selected item with null id
+    self->mInventoryPanel->getRootFolder()->clearSelection();
     self->commitIfImmediateSet();
 }
 


### PR DESCRIPTION
After setting material to Blank when blank material is present in inventory.

LLFloaterTexturePicker::commitCallback was taking last inventory selection and as long as asset id matched was commiting inventory item as if it was the one selected.