### PR TITLE
#4687 Fix audio device selection showing a bunch of zeros

### DIFF
--- a/indra/newview/llpanelvoicedevicesettings.cpp
+++ b/indra/newview/llpanelvoicedevicesettings.cpp
@@ -240,13 +240,38 @@ void LLPanelVoiceDeviceSettings::refresh()
         if(mCtrlInputDevices)
         {
             mCtrlInputDevices->removeall();
-            mCtrlInputDevices->add(getLocalizedDeviceName(mInputDevice), mInputDevice, ADD_BOTTOM);
+            auto it = mLocalizedDeviceNames.find(mInputDevice);
+            if (it != mLocalizedDeviceNames.end())
+            {
+                mCtrlInputDevices->add(getLocalizedDeviceName(mInputDevice), mInputDevice, ADD_BOTTOM);
+            }
+            else
+            {
+                // Display name generaly doesn't match value.
+                // Value is an id so it's not nessesary readable,
+                // might not even be valid (disconnected usb).
+                // Until we get the data, don't change the device,
+                // otherwise box might override the control.
+                // But show a readable placeholder.
+                // Combo is disabled so it's safe to show
+                // a placeholder.
+                mCtrlInputDevices->add(getString("device_not_loaded"), mInputDevice, ADD_BOTTOM);
+            }
             mCtrlInputDevices->setValue(mInputDevice);
         }
         if(mCtrlOutputDevices)
         {
             mCtrlOutputDevices->removeall();
-            mCtrlOutputDevices->add(getLocalizedDeviceName(mOutputDevice), mOutputDevice, ADD_BOTTOM);
+            auto it = mLocalizedDeviceNames.find(mOutputDevice);
+            if (it != mLocalizedDeviceNames.end())
+            {
+                mCtrlOutputDevices->add(getLocalizedDeviceName(mOutputDevice), mOutputDevice, ADD_BOTTOM);
+            }
+            else
+            {
+                // Don't change the device, only the label
+                mCtrlOutputDevices->add(getString("device_not_loaded"), mOutputDevice, ADD_BOTTOM);
+            }
             mCtrlOutputDevices->setValue(mOutputDevice);
         }
     }

--- a/indra/newview/skins/default/xui/en/panel_sound_devices.xml
+++ b/indra/newview/skins/default/xui/en/panel_sound_devices.xml
@@ -20,6 +20,10 @@
      name="name_default_system_device">
         Default System Device
     </string>
+    <string
+     name="device_not_loaded">
+        Device not loaded
+    </string>
     <icon
      follows="left|top"
      height="18"


### PR DESCRIPTION
Don't show unreadable index plus uuid, show a placeholder.