### PR TITLE
#4671 Some locales are missing AM/PM labels

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -439,7 +439,26 @@ bool idle_startup()
     system = osString.substr (begIdx, endIdx - begIdx);
     system += "Locale";
 
-    LLStringUtil::setLocale (LLTrans::getString(system));
+    std::string locale = LLTrans::getString(system);
+    if (locale != LLStringUtil::getLocale()) // is there a reason to do this on repeat?
+    {
+        LLStringUtil::setLocale(locale);
+
+        // Not all locales have AMPM, test it
+        if (LLStringOps::sAM.empty()) // Might already be overriden from LLAppViewer::init()
+        {
+            LLDate datetime(0.0);
+            std::string val = datetime.toHTTPDateString("%p");
+            if (val.empty())
+            {
+                LL_DEBUGS("InitInfo") << "Current locale \"" << locale << "\" "
+                    << "doesn't support AM/PM time format" << LL_ENDL;
+                // fallback to declarations in strings.xml
+                LLStringOps::sAM = LLTrans::getString("dateTimeAM");
+                LLStringOps::sPM = LLTrans::getString("dateTimePM");
+            }
+        }
+    }
 
     //note: Removing this line will cause incorrect button size in the login screen. -- bao.
     gTextureList.updateImages(0.01f) ;

--- a/indra/newview/skins/default/xui/de/strings.xml
+++ b/indra/newview/skins/default/xui/de/strings.xml
@@ -5074,10 +5074,10 @@ Bitte überprüfen Sie http://status.secondlifegrid.net, um herauszufinden, ob e
 		[MDAY]
 	</string>
 	<string name="dateTimeAM">
-		Uhr
+		AM
 	</string>
 	<string name="dateTimePM">
-		Uhr
+		PM
 	</string>
 	<string name="LocalEstimateUSD">
 		[AMOUNT] US$


### PR DESCRIPTION
Test locale to see if declares AM/PM. Appears to be working without issues, but I'm confused about why locale was set on a loop.