### PR TITLE
#4679 Logging for crash on updateMenuOptions

### DIFF
--- a/indra/llui/llfolderview.cpp
+++ b/indra/llui/llfolderview.cpp
@@ -1510,6 +1510,7 @@ bool LLFolderView::handleRightMouseDown( S32 x, S32 y, MASK mask )
         && ( count > 0 && (hasVisibleChildren()) ))) && // show menu only if selected items are visible
         !hide_folder_menu)
     {
+        LL_INFOS("Inventory") << "Opening inventory menu from path: " << getPathname() << LL_ENDL;
         if (mCallbackRegistrar)
         {
             mCallbackRegistrar->pushScope();

--- a/indra/newview/llsettingspicker.cpp
+++ b/indra/newview/llsettingspicker.cpp
@@ -152,7 +152,11 @@ void LLFloaterSettingsPicker::onClose(bool app_quitting)
         owner->setFocus(true);
     }
     mSettingItemID.setNull();
-    mInventoryPanel->getRootFolder()->clearSelection();
+    mInventoryPanel->clearSelection();
+    if (mInventoryPanel->getRootFolder())
+    {
+        mInventoryPanel->getRootFolder()->clearSelection();
+    }
 }
 
 void LLFloaterSettingsPicker::setValue(const LLSD& value)


### PR DESCRIPTION
Logs say that viewer closed settings picker and immediately crashed Yet callstack indicates that some inventory was right clicked, which shouldn't be possible if picker already closed.
May be some click is closing the picker and opens menu at the same time, but it's better to gather information first.