### PR TITLE
[#3954] Fix OpenJPEG uploading small textures (again)

### DIFF
--- a/indra/llimagej2coj/llimagej2coj.cpp
+++ b/indra/llimagej2coj/llimagej2coj.cpp
@@ -554,11 +554,6 @@ public:
 
         }
 
-        if (!opj_setup_encoder(encoder, &parameters, image))
-        {
-            return false;
-        }
-
         U32 width_tiles = (rawImageIn.getWidth() >> 6);
         U32 height_tiles = (rawImageIn.getHeight() >> 6);
 
@@ -570,6 +565,19 @@ public:
         if (height_tiles == 0 && (rawImageIn.getHeight() >= MIN_IMAGE_SIZE))
         {
             height_tiles = 1;
+        }
+
+        if (width_tiles == 1 || height_tiles == 1)
+        {
+            // Images with either dimension less than 32 need less number of resolutions otherwise they error
+            int min_dim = rawImageIn.getWidth() < rawImageIn.getHeight() ? rawImageIn.getWidth() : rawImageIn.getHeight();
+            int max_res = 1 + (int)floor(log2(min_dim));
+            parameters.numresolution = max_res;
+        }
+
+        if (!opj_setup_encoder(encoder, &parameters, image))
+        {
+            return false;
         }
 
         U32 tile_count = width_tiles * height_tiles;


### PR DESCRIPTION
## Description

The previous fix provided here- https://github.com/secondlife/viewer/pull/3955 turned out to only be a partial fix.
There continued to be an issue where if either width or height was MIN_IMAGE_SIZE <= x <=16 it would also error out and fail to encode. The cause of this was opj_start_compress was failing internally and outputting the error "Number of resolutions is too high in comparison to the size of tiles". This is because the parameter.numresolution was never being changed and left the default 6, however the maximum number of resolutions cannot exceed the following formula-
1+lower(log2(min(width, height)))

This PR changes it so, if either dimension is <=64, it calculates the new maximum parameter.numresolution based on the formula mentioned above. This means the value will never exceed the default value of 6 that has always existed, but will lower it where necessary when either dimension is too low.

## Related Issues

- https://github.com/secondlife/viewer/issues/3954
Specifically this comment from that issue-
https://github.com/secondlife/viewer/issues/3954#issuecomment-3310890375

## Testing steps:
1. Use a Viewer without the fix and using OpenJPEG instead of KDU
2. Attempt to upload a image where either width or height is <=16 (such as 128x16 or 16x16, etc)
3. Observe it error out
4. Use a viewer with the fix using OpenJPEG instead of KDU
5. Attempt to upload a texture where either width or height is <=16 (such as 128x16 or 16x16, etc)
6. Observe it correctly upload 
7. Test that the texture correctly applies to objects and is decoded properly on both an OpenJPEG and KDU viewer
