### PR TITLE
#4695 Fix missing voice cleanup

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -342,8 +342,11 @@ void LLWebRTCImpl::init()
     mWorkerThread->PostTask(
         [this]()
         {
-            mDeviceModule->EnableBuiltInAEC(false);
-            updateDevices();
+            if (mDeviceModule)
+            {
+                mDeviceModule->EnableBuiltInAEC(false);
+                updateDevices();
+            }
         });
 
 }
@@ -449,6 +452,11 @@ void LLWebRTCImpl::unsetDevicesObserver(LLWebRTCDevicesObserver *observer)
 // must be run in the worker thread.
 void LLWebRTCImpl::workerDeployDevices()
 {
+    if (!mDeviceModule)
+    {
+        return;
+    }
+
     int16_t recordingDevice = RECORD_DEVICE_DEFAULT;
     int16_t recording_device_start = 0;
 
@@ -571,6 +579,11 @@ void LLWebRTCImpl::setRenderDevice(const std::string &id)
 // updateDevices needs to happen on the worker thread.
 void LLWebRTCImpl::updateDevices()
 {
+    if (!mDeviceModule)
+    {
+        return;
+    }
+
     int16_t renderDeviceCount  = mDeviceModule->PlayoutDevices();
 
     mPlayoutDeviceList.clear();
@@ -1491,6 +1504,7 @@ void terminate()
     if (gWebRTCImpl)
     {
         gWebRTCImpl->terminate();
+        delete gWebRTCImpl;
         gWebRTCImpl = nullptr;
     }
 }

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -75,7 +75,7 @@ public:
     LLWebRTCLogSink(LLWebRTCLogCallback* callback) : mCallback(callback) {}
 
     // Destructor: close the log file
-    ~LLWebRTCLogSink() override {}
+    ~LLWebRTCLogSink() override { mCallback = nullptr; }
 
     void OnLogMessage(const std::string& msg, webrtc::LoggingSeverity severity) override
     {

--- a/indra/newview/llvoiceclient.cpp
+++ b/indra/newview/llvoiceclient.cpp
@@ -292,7 +292,14 @@ void LLVoiceClient::setHidden(bool hidden)
 
 void LLVoiceClient::terminate()
 {
-    if (mSpatialVoiceModule) mSpatialVoiceModule->terminate();
+    if (LLVivoxVoiceClient::instanceExists())
+    {
+        LLWebRTCVoiceClient::getInstance()->terminate();
+    }
+    if (LLVivoxVoiceClient::instanceExists())
+    {
+        LLVivoxVoiceClient::getInstance()->terminate();
+    }
     mSpatialVoiceModule = NULL;
     m_servicePump = NULL;
 


### PR DESCRIPTION
Fixed cleanup in LLVoiceClient::terminate(), only one module was cleaned instead of both.
gWebRTCImpl was never deleted
Added mDeviceModule security