### PR TITLE
#4730 Extend login timeout

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -4380,7 +4380,7 @@
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>40.0</real>
+    <real>90.0</real>
   </map>
   <key>LogMessages</key>
     <map>

--- a/indra/newview/lllogininstance.cpp
+++ b/indra/newview/lllogininstance.cpp
@@ -62,7 +62,7 @@
 
 const S32 LOGIN_MAX_RETRIES = 0; // Viewer should not autmatically retry login
 const F32 LOGIN_SRV_TIMEOUT_MIN = 10;
-const F32 LOGIN_SRV_TIMEOUT_MAX = 120;
+const F32 LOGIN_SRV_TIMEOUT_MAX = 180;
 const F32 LOGIN_DNS_TIMEOUT_FACTOR = 0.9; // make DNS wait shorter then retry time
 
 class LLLoginInstance::Disposable {


### PR DESCRIPTION
Curent value of 40s is too small, for larger inventories delivery can run longer than that.