### PR TITLE
#4515 Improve ordering of sub-meshes upon upload

### DIFF
--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -668,11 +668,11 @@ public:
     LLPointer<DecompRequest> mFinalDecomp;
     volatile bool   mPhysicsComplete;
 
-    typedef std::map<LLPointer<LLModel>, std::vector<LLVector3> > hull_map;
-    hull_map        mHullMap;
+    typedef std::map<LLPointer<LLModel>, std::vector<LLVector3> > hull_map_t;
+    hull_map_t      mHullMap;
 
-    typedef std::vector<LLModelInstance> instance_list;
-    instance_list   mInstanceList;
+    typedef std::vector<LLModelInstance> instance_list_t;
+    instance_list_t mInstanceList;
 
     // Upload should happen in deterministic order, so sort instances by model name.
     struct LLUploadModelInstanceLess
@@ -686,11 +686,11 @@ public:
             }
             // Note: probably can sort by mBaseModel->mSubmodelID here as well to avoid
             // running over the list twice in wholeModelToLLSD.
-            return a->mLabel < b->mLabel;
+            return a->mLabel > b->mLabel;
         }
     };
-    typedef std::map<LLPointer<LLModel>, instance_list, LLUploadModelInstanceLess> instance_map;
-    instance_map    mInstance;
+    typedef std::map<LLPointer<LLModel>, instance_list_t, LLUploadModelInstanceLess> instance_map_t;
+    instance_map_t    mInstance;
     typedef std::map<std::string, std::string> lod_sources_map_t;
     lod_sources_map_t mLodSources;
 
@@ -709,7 +709,7 @@ public:
     std::string     mWholeModelUploadURL;
     LLUUID          mDestinationFolderId;
 
-    LLMeshUploadThread(instance_list& data, const lod_sources_map_t& sources_list,
+    LLMeshUploadThread(instance_list_t& data, const lod_sources_map_t& sources_list,
                        LLVector3& scale, bool upload_textures,
                        bool upload_skin, bool upload_joints, bool lock_scale_if_joint_position,
                        const std::string & upload_url,
@@ -744,6 +744,22 @@ public:
     virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * response);
 
     static LLViewerFetchedTexture* FindViewerTexture(const LLImportMaterial& material);
+
+protected:
+    void packModelIntance(
+        LLModel* model,
+        LLMeshUploadThread::instance_list_t& instance_list,
+        std::string& model_name,
+        LLSD& res,
+        S32& mesh_num,
+        S32& texture_num,
+        S32& instance_num,
+        std::unordered_set<LLViewerTexture* > &textures,
+        std::unordered_map<LLViewerTexture*, S32> texture_index,
+        std::unordered_map<LLModel*, S32>& mesh_index,
+        std::vector<std::string>& texture_list_dest,
+        bool include_textures
+        );
 
 private:
     LLHandle<LLWholeModelFeeObserver> mFeeObserverHandle;

--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -576,7 +576,7 @@ void LLModelPreview::rebuildUploadData()
         for (U32 model_ind = 0; model_ind < mModel[lod].size(); ++model_ind)
         {
             bool found_model = false;
-            for (LLMeshUploadThread::instance_list::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
+            for (LLMeshUploadThread::instance_list_t::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
             {
                 LLModelInstance& instance = *iter;
                 if (instance.mLOD[lod] == mModel[lod][model_ind])
@@ -2209,7 +2209,7 @@ void LLModelPreview::updateStatusMessages()
         total_submeshes[i] = 0;
     }
 
-    for (LLMeshUploadThread::instance_list::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
+    for (LLMeshUploadThread::instance_list_t::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
     {
         LLModelInstance& instance = *iter;
 
@@ -3530,7 +3530,7 @@ bool LLModelPreview::render()
 
         if (!show_skin_weight)
         {
-            for (LLMeshUploadThread::instance_list::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
+            for (LLMeshUploadThread::instance_list_t::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
             {
                 LLModelInstance& instance = *iter;
 
@@ -3616,7 +3616,7 @@ bool LLModelPreview::render()
 
                     gGL.blendFunc(LLRender::BF_SOURCE_ALPHA, LLRender::BF_ONE_MINUS_SOURCE_ALPHA);
 
-                    for (LLMeshUploadThread::instance_list::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
+                    for (LLMeshUploadThread::instance_list_t::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
                     {
                         LLModelInstance& instance = *iter;
 
@@ -3738,7 +3738,7 @@ bool LLModelPreview::render()
                         gGL.diffuseColor4f(1.f, 0.f, 0.f, 1.f);
                         const LLVector4a scale(0.5f);
 
-                        for (LLMeshUploadThread::instance_list::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
+                        for (LLMeshUploadThread::instance_list_t::iterator iter = mUploadData.begin(); iter != mUploadData.end(); ++iter)
                         {
                             LLModelInstance& instance = *iter;
 

--- a/indra/newview/llmodelpreview.h
+++ b/indra/newview/llmodelpreview.h
@@ -319,7 +319,7 @@ protected:
     // Amount of triangles in original(base) model
     U32 mMaxTriangleLimit;
 
-    LLMeshUploadThread::instance_list mUploadData;
+    LLMeshUploadThread::instance_list_t mUploadData;
     std::set<LLViewerFetchedTexture * > mTextureSet;
     LLLoadedCallbackEntry::source_callback_list_t mCallbackTextureList;
 


### PR DESCRIPTION
If server gets a m1, m2, m3, m4 list, m1 becomes the root and the rest go as m4, m3, m2.
To counter that mInstance is now sorted as m4, m3, m2, m1 and we grab m1 from the end and send it first.