### PR TITLE
#p473 fix XUI warnings

### DIFF
--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -859,7 +859,7 @@ void LLPanelProfileSecondLife::resetData()
     resetLoading();
 
     // Set default image and 1:1 dimensions for it
-    mSecondLifePic->setValue("Generic_Person_Large");
+    mSecondLifePic->setValue(LLUUID());
 
     LLRect imageRect = mSecondLifePicLayout->getRect();
     mSecondLifePicLayout->reshape(imageRect.getWidth(), imageRect.getWidth());

--- a/indra/newview/skins/default/xui/en/panel_profile_firstlife.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_firstlife.xml
@@ -22,7 +22,6 @@
     <profile_image
      name="real_world_pic"
      image_name="Generic_Person_Large"
-     show_loading="false"
      follows="top|left"
      layout="topleft"
      top="10"

--- a/indra/newview/skins/default/xui/en/panel_profile_secondlife.xml
+++ b/indra/newview/skins/default/xui/en/panel_profile_secondlife.xml
@@ -74,7 +74,6 @@ Account: [ACCTTYPE]
       <profile_image
        name="2nd_life_pic"
        image_name="Generic_Person_Large"
-       show_loading="false"
        layout="topleft"
        follows="all"
        interactable="true"
@@ -191,7 +190,7 @@ Account: [ACCTTYPE]
      visible="false">
       <icon
        name="badge_icon"
-       image_name="Beta_Tester"
+       image_name="Profile_Badge_Beta"
        layout="topleft"
        follows="left|top"
        top="10"


### PR DESCRIPTION
Use null UUID to set default image. 
LLProfileImageCtrl doesn't have 'show_loading' param.
"Beta_Tester" image does not exist, so updated it.