### PR TITLE
#1759 Fix texture picker using IMG_WHITE for blank materials

### DIFF
--- a/indra/newview/lltexturectrl.cpp
+++ b/indra/newview/lltexturectrl.cpp
@@ -1704,10 +1704,16 @@ LLTextureCtrl::LLTextureCtrl(const LLTextureCtrl::Params& p)
     mDefaultImageName(p.default_image_name),
     mFallbackImage(p.fallback_image)
 {
-
-    // Default of defaults is white image for diff tex
-    //
-    setBlankImageAssetID(IMG_WHITE);
+    if (mInventoryPickType == PICK_MATERIAL)
+    {
+        setBlankImageAssetID(BLANK_MATERIAL_ASSET_ID);
+    }
+    else
+    {
+        // Default of defaults is white image for diff tex
+        //
+        setBlankImageAssetID(IMG_WHITE);
+    }
 
     setAllowNoTexture(p.allow_no_texture);
     setCanApplyImmediately(p.can_apply_immediately);


### PR DESCRIPTION
Fix texture picker using IMG_WHITE for blank materials

For now removed the 'register blank material part', as fixing image seems sufficient, will make a separate review if it isn't, image needs fixing regardless.