### PR TITLE
p#480 Collada vs GLTF Mesh Import Naming Convention

### DIFF
--- a/indra/newview/gltf/llgltfloader.cpp
+++ b/indra/newview/gltf/llgltfloader.cpp
@@ -412,17 +412,14 @@ void LLGLTFLoader::processNodeHierarchy(S32 node_idx, std::map<std::string, S32>
     // Process this node's mesh if it has one
     if (node.mMesh >= 0 && node.mMesh < mGLTFAsset.mMeshes.size())
     {
-        LLMatrix4    transformation;
-        material_map mats;
-
-        LLModel* pModel = new LLModel(volume_params, 0.f);
-        const LL::GLTF::Mesh& mesh = mGLTFAsset.mMeshes[node.mMesh];
-
-        // Get base mesh name and track usage
-        std::string base_name = getLodlessLabel(mesh);
+        // Get base node name and track usage
+        // Potentially multiple nodes can reuse the same mesh and Collada used
+        // node name instead of mesh name, so for consistency use node name if
+        // avaliable, node index otherwise.
+        std::string base_name = getLodlessLabel(node);
         if (base_name.empty())
         {
-            base_name = "mesh_" + std::to_string(node.mMesh);
+            base_name = "node_" + std::to_string(node_idx);
         }
 
         S32 instance_count = mesh_name_counts[base_name]++;
@@ -432,6 +429,12 @@ void LLGLTFLoader::processNodeHierarchy(S32 node_idx, std::map<std::string, S32>
         {
             base_name = base_name + "_copy_" + std::to_string(instance_count);
         }
+
+        LLMatrix4    transformation;
+        material_map mats;
+
+        LLModel* pModel = new LLModel(volume_params, 0.f);
+        const LL::GLTF::Mesh& mesh = mGLTFAsset.mMeshes[node.mMesh];
 
         if (populateModelFromMesh(pModel, base_name, mesh, node, mats) &&
             (LLModel::NO_ERRORS == pModel->getStatus()) &&
@@ -1818,13 +1821,13 @@ size_t LLGLTFLoader::getSuffixPosition(const std::string &label)
     return -1;
 }
 
-std::string LLGLTFLoader::getLodlessLabel(const LL::GLTF::Mesh& mesh)
+std::string LLGLTFLoader::getLodlessLabel(const LL::GLTF::Node& node)
 {
-    size_t ext_pos = getSuffixPosition(mesh.mName);
+    size_t ext_pos = getSuffixPosition(node.mName);
     if (ext_pos != -1)
     {
-        return mesh.mName.substr(0, ext_pos);
+        return node.mName.substr(0, ext_pos);
     }
-    return mesh.mName;
+    return node.mName;
 }
 

--- a/indra/newview/gltf/llgltfloader.h
+++ b/indra/newview/gltf/llgltfloader.h
@@ -170,7 +170,7 @@ private:
     void notifyUnsupportedExtension(bool unsupported);
 
     static size_t getSuffixPosition(const std::string& label);
-    static std::string getLodlessLabel(const LL::GLTF::Mesh& mesh);
+    static std::string getLodlessLabel(const LL::GLTF::Node& mesh);
 
     //    bool mPreprocessGLTF;
 


### PR DESCRIPTION
Both collada and gltf have a node and a mesh. Collada uses node-name, gltf was using mesh-name. GLTF format permits reusing single mesh for multiple nodes, but nodes are warrantied to not be reused.

Switch to using node-names for better dupplicate avoidance and to be more in line with collada.