### PR TITLE
#4772 fix group ownership detection for deeded objects

### DIFF
--- a/indra/llinventory/llpermissions.cpp
+++ b/indra/llinventory/llpermissions.cpp
@@ -774,6 +774,7 @@ void LLPermissions::importLLSD(const LLSD& sd_perm)
         }
     }
 
+    fixOwnership();
     fix();
 }
 


### PR DESCRIPTION
The issue appeared after https://github.com/secondlife/viewer/commit/3b8b408b9031f295a936eb5e3342fbb7eb671c7c changeset.
Ensure that mIsGroupOwned is properly set (based on the owner and group IDs) after importing from LLSD data.