### PR TITLE
Make sure irradiance gen unbind is within the proper scope.

### DIFF
--- a/indra/newview/llreflectionmapmanager.cpp
+++ b/indra/newview/llreflectionmapmanager.cpp
@@ -998,11 +998,11 @@ void LLReflectionMapManager::updateProbeFace(LLReflectionMap* probe, U32 face)
                     mTexture->bind(channel);
                 }
             }
+
+            gIrradianceGenProgram.unbind();
         }
 
         mMipChain[0].flush();
-
-        gIrradianceGenProgram.unbind();
     }
 }
 


### PR DESCRIPTION
Moves a stray unbind from outside of the irradiance gen's scope back into its scope.

Fixes an edge case where I noticed irradiance gen would sometimes fail when the viewer was in the background.