### PR TITLE
Fix for viewer-private/issues/489 - HTTP Basic Auth dialog should not be present

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -450,11 +450,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>d44256458ff0ef4db4c91e8e8cc83e8f98b4f1b8</string>
+              <string>126e0fa4c16dfd433c9fb7d1d242da98f213d933</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.21.0-CEF_139.0.28/dullahan-1.21.0.202508272158_139.0.28_g55ab8a8_chromium-139.0.7258.139-darwin64-17279703032.tar.zst</string>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.24.0-CEF_139.0.40/dullahan-1.24.0.202510081737_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-18353103947.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -478,11 +478,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>9d5af766a87052808e4062978504e9af124fb558</string>
+              <string>20de62c9e57d9e6539c1e2437ec4b46c3ca237bc</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.21.0-CEF_139.0.28/dullahan-1.21.0.202508272159_139.0.28_g55ab8a8_chromium-139.0.7258.139-windows64-17279703032.tar.zst</string>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.24.0-CEF_139.0.40/dullahan-1.24.0.202510081738_139.0.40_g465474a_chromium-139.0.7258.139-windows64-18353103947.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -495,7 +495,7 @@
         <key>copyright</key>
         <string>Copyright (c) 2017, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.21.0.202508272158_139.0.28_g55ab8a8_chromium-139.0.7258.139</string>
+        <string>1.24.0.202510081737_139.0.40_g465474a_chromium-139.0.7258.139</string>
         <key>name</key>
         <string>dullahan</string>
         <key>description</key>


### PR DESCRIPTION
## Description
When visiting a site that is protected by HTTP Basic Auth, previous Viewer versions would delegate collection of username and password to the Viewer UI  - both in 2D in a dialog and in 3D on a prim.

This behavior changed as of Viewer 7.2.2 after the inclusion of CEF v139 where a dialog (appears to be running in a separate process - task bar gets a new icon for each instance for example) is presented.  You can still use it to enter the username and password for the site but it's (a) ugly and more importantly (b) a griefing vector - bad actors can create prims that spam URLs requiring basic auth and each will force this username/password dialog to be displayed.

This fix reverts that so that the Viewer is now responsible for presenting UI to deal with credential entry and behaves the same way it has done in the past. 

## Testing
Please test both in 2D (Media Floater at login page for example) and 3D (create a prim with one face set to a media texture) and visit these URLS:

* https://httpbin.org/basic-auth/user/passwd (up at time of writing but often 503s. Username: `user`, password: `passwd`)
* https://authenticationtest.com/ (select Basic HTTP/NTLM Authentication. Username: `user`, password: `pass`)
* https://jigsaw.w3.org/HTTP/Basic/ (Username: `guest`, password: `guest`)

Try both entering the correct and incorrect credentials (feedback will indicate success/failure).

Note that in 2D, you have enter the credentials twice.  This has always been the case. 
 
Details captured in https://github.com/secondlife/viewer-private/issues/489