### PR TITLE
#4811 #4813 Fixed RemoveItemWarn invalid notification and deleting no-mod content

### DIFF
--- a/indra/newview/llpanelobjectinventory.cpp
+++ b/indra/newview/llpanelobjectinventory.cpp
@@ -385,10 +385,7 @@ bool LLTaskInvFVBridge::removeItem()
                 return true;
             }
 
-            LLSD payload;
-            payload["task_id"] = mPanel->getTaskUUID();
-            payload["inventory_ids"].append(mUUID);
-            LLNotificationsUtil::add("CantModifyContentInNoModTask", LLSD(), payload, boost::bind(&remove_task_inventory_callback, _1, _2, mPanel));
+            LLNotificationsUtil::add("CantModifyContentInNoModTask");
             return false;
         }
     }
@@ -411,13 +408,7 @@ void LLTaskInvFVBridge::removeBatch(std::vector<LLFolderViewModelItem*>& batch)
 
     if (!object->permModify())
     {
-        LLSD payload;
-        payload["task_id"] = mPanel->getTaskUUID();
-        for (LLFolderViewModelItem* item : batch)
-        {
-            payload["inventory_ids"].append(((LLTaskInvFVBridge*)item)->getUUID());
-        }
-        LLNotificationsUtil::add("CantModifyContentInNoModTask", LLSD(), payload, boost::bind(&remove_task_inventory_callback, _1, _2, mPanel));
+        LLNotificationsUtil::add("CantModifyContentInNoModTask");
     }
     else
     {


### PR DESCRIPTION
Fixes issues mentioned here-
https://github.com/secondlife/viewer/issues/4811
https://github.com/secondlife/viewer/issues/4813

In 2025.06, the notification "RemoveItemWarn" was removed but two places that referenced it were not updated to the notification which replaced it. This PR corrects those two locations so an invalid notification pop-up doesn't appear.

Correct notification now shows following the reproduction steps of the issue above-
<img width="434" height="88" alt="image" src="https://github.com/user-attachments/assets/c07205fc-a368-4fd0-8b96-e0d3e976c41a" />

Also if you delete the no-mod content using the delete key twice, the 2nd time causes the content to appear deleted. This PR also fixes that and here is a recording showing that-

https://github.com/user-attachments/assets/08fa6963-3a32-4682-b4ef-445a63bef835


