### PR TITLE
Improve LLFile to be more consistent between Windows and other platforms.

### DIFF
--- a/indra/llcommon/llfile.h
+++ b/indra/llcommon/llfile.h
@@ -41,8 +41,8 @@ typedef FILE    LLFILE;
 #include <sys/stat.h>
 
 #if LL_WINDOWS
-// windows version of stat function and stat data structure are called _stat
-typedef struct _stat    llstat;
+// windows version of stat function and stat data structure are called _statxx
+typedef struct _stat64    llstat;
 #else
 typedef struct stat     llstat;
 #include <sys/types.h>
@@ -58,33 +58,88 @@ typedef struct stat     llstat;
 
 #include "llstring.h" // safe char* -> std::string conversion
 
+/// LLFile is a class of static functions operating on paths
+/// All the functions with a path string input take UTF8 path/filenames
 class LL_COMMON_API LLFile
 {
 public:
-    // All these functions take UTF8 path/filenames.
-    static  LLFILE* fopen(const std::string& filename,const char* accessmode);  /* Flawfinder: ignore */
-    static  LLFILE* _fsopen(const std::string& filename,const char* accessmode,int  sharingFlag);
+    /// open a file with the specified access mode
+    static  LLFILE* fopen(const std::string& filename, const char* accessmode);  /* Flawfinder: ignore */
+    ///< 'accessmode' follows the rules of the Posix fopen() mode parameter
+    /// "r" open the file for reading only and positions the stream at the beginning
+    /// "r+" open the file for reading and writing and positions the stream at the beginning
+    /// "w" open the file for reading and writing and truncate it to zero length
+    /// "w+" open or create the file for reading and writing and truncate to zero length if it existed
+    /// "a" open the file for reading and writing and position the stream at the end of the file
+    /// "a+" open or create the file for reading and writing and position the stream at the end of the file
+    ///
+    /// in addition to these values, "b" can be appended to indicate binary stream access, but on Linux and Mac
+    /// this is strictly for compatibility and has no effect. On Windows this makes the file functions not
+    /// try to translate line endings. Windows also allows to append "t" to indicate text mode. If neither
+    /// "b" or "t" is defined, Windows uses the value set by _fmode which by default is _O_TEXT.
+    /// This means that it is always a good idea to append "b" specifically for binary file access to
+    /// avoid corruption of the binary consistency of the data stream when reading or writing
+    /// Other characters in 'accessmode' will usually cause an error as fopen will verify this parameter
+    ///< @returns a valid LLFILE* pointer on success or NULL on failure
 
     static  int     close(LLFILE * file);
 
+    /// retrieve the content of a file into a string
     static std::string getContents(const std::string& filename);
+    ///< @returns the content of the file or an empty string on failure
 
-    // perms is a permissions mask like 0777 or 0700.  In most cases it will
-    // be overridden by the user's umask.  It is ignored on Windows.
-    // mkdir() considers "directory already exists" to be SUCCESS.
+    /// create a directory
     static  int     mkdir(const std::string& filename, int perms = 0700);
+    ///< perms is a permissions mask like 0777 or 0700.  In most cases it will be
+    ///  overridden by the user's umask. It is ignored on Windows.
+    ///  mkdir() considers "directory already exists" to be not an error.
+    ///  @returns 0 on success and -1 on failure.
 
-    static  int     rmdir(const std::string& filename);
+    //// remove a directory
+    static  int     rmdir(const std::string& filename, int supress_error = 0);
+    ///< pass ENOENT in the optional 'supress_error' parameter
+    ///  if you don't want a warning in the log when the directory does not exist
+    ///  @returns 0 on success and -1 on failure.
+
+    /// remove a file or directory
     static  int     remove(const std::string& filename, int supress_error = 0);
-    static  int     rename(const std::string& filename,const std::string& newname, int supress_error = 0);
+    ///< pass ENOENT in the optional 'supress_error' parameter
+    ///  if you don't want a warning in the log when the directory does not exist
+    ///  @returns 0 on success and -1 on failure.
+
+    /// rename a file, 
+    static  int     rename(const std::string& filename, const std::string& newname, int supress_error = 0);
+    ///< it will silently overwrite newname if it exists without returning an error
+    ///  @returns 0 on success and -1 on failure.
+
+
+    // copy the contents of file from 'from' to 'to' filename
     static  bool    copy(const std::string& from, const std::string& to);
+    ///< @returns true on success and false on failure.
 
-    static  int     stat(const std::string& filename,llstat*    file_status);
-    static  bool    isdir(const std::string&    filename);
-    static  bool    isfile(const std::string&   filename);
-    static  LLFILE *    _Fiopen(const std::string& filename,
-            std::ios::openmode mode);
+    /// return the file stat structure for filename
+    static  int     stat(const std::string& filename, llstat* file_status, int supress_error = ENOENT);
+    ///< for compatibility with existing uses of LL_File::stat() we use ENOENT as default in the
+    ///  optional 'supress_error' parameter to avoid spamming the log with warnings when the API
+    ///  is used to detect if a file exists
+    ///  @returns 0 on success and -1 on failure.
 
+    /// get the file or directory attributes for filename
+    static  int     getattr(const std::string& filename, unsigned short& st_mode, int supress_error = 0);
+    ///< a more lightweight function on Windows to stat, that just returns the file attribute flags
+    ///  pass ENOENT in the optional 'supress_error' parameter if you don't want a warning
+    ///  in the log when the file or directory does not exist
+    ///  @returns 0 on success and -1 on failure.
+
+    /// check if filename is an existing directory
+    static  bool    isdir(const std::string& filename);
+    ///< @returns true if the path is for an existing directory
+ 
+    /// check if filename is an existing file
+    static  bool    isfile(const std::string& filename);
+    ///< @returns true if the path is for an existing file
+
+    /// return a path to the temporary directory on the system
     static  const char * tmpdir();
 };
 

--- a/indra/llcommon/llsys.cpp
+++ b/indra/llcommon/llsys.cpp
@@ -1348,10 +1348,6 @@ bool gunzip_file(const std::string& srcfile, const std::string& dstfile)
     } while(gzeof(src) == 0);
     fclose(dst);
     dst = NULL;
-#if LL_WINDOWS
-    // Rename in windows needs the dstfile to not exist.
-    LLFile::remove(dstfile, ENOENT);
-#endif
     if (LLFile::rename(tmpfile, dstfile) == -1) goto err;       /* Flawfinder: ignore */
     retval = true;
 err:
@@ -1399,10 +1395,6 @@ bool gzip_file(const std::string& srcfile, const std::string& dstfile)
 
     gzclose(dst);
     dst = NULL;
-#if LL_WINDOWS
-    // Rename in windows needs the dstfile to not exist.
-    LLFile::remove(dstfile);
-#endif
     if (LLFile::rename(tmpfile, dstfile) == -1) goto err;       /* Flawfinder: ignore */
     retval = true;
  err:

--- a/indra/llcrashlogger/llcrashlogger.cpp
+++ b/indra/llcrashlogger/llcrashlogger.cpp
@@ -576,10 +576,6 @@ bool LLCrashLogger::init()
     std::string old_log_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "crashreport.log.old");
     std::string log_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "crashreport.log");
 
-#if LL_WINDOWS
-    LLAPRFile::remove(old_log_file);
-#endif
-
     LLFile::rename(log_file.c_str(), old_log_file.c_str());
 
     // Set the log file to crashreport.log

--- a/indra/llfilesystem/llfilesystem.cpp
+++ b/indra/llfilesystem/llfilesystem.cpp
@@ -103,9 +103,6 @@ bool LLFileSystem::renameFile(const LLUUID& old_file_id, const LLAssetType::ETyp
     const std::string old_filename = LLDiskCache::metaDataToFilepath(old_file_id, old_file_type);
     const std::string new_filename = LLDiskCache::metaDataToFilepath(new_file_id, new_file_type);
 
-    // Rename needs the new file to not exist.
-    LLFileSystem::removeFile(new_file_id, new_file_type, ENOENT);
-
     if (LLFile::rename(old_filename, new_filename) != 0)
     {
         // We would like to return false here indicating the operation

--- a/indra/llui/llviewereventrecorder.cpp
+++ b/indra/llui/llviewereventrecorder.cpp
@@ -34,8 +34,6 @@ LLViewerEventRecorder::LLViewerEventRecorder() {
   logEvents = false;
   // Remove any previous event log file
   std::string old_log_ui_events_to_llsd_file = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "SecondLife_Events_log.old");
-  LLFile::remove(old_log_ui_events_to_llsd_file, ENOENT);
-
 
   mLogFilename = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "SecondLife_Events_log.llsd");
   LLFile::rename(mLogFilename, old_log_ui_events_to_llsd_file, ENOENT);

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -1014,7 +1014,6 @@ bool LLVivoxVoiceClient::startAndLaunchDaemon()
             std::string old_log = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "SLVoice.old");
             if (gDirUtilp->fileExists(new_log))
             {
-                LLFile::remove(old_log, ENOENT);
                 LLFile::rename(new_log, old_log);
             }
 


### PR DESCRIPTION
## Description

LLFile::remove() will now remove both files and empty directories under Windows, just as its Posix counter part on other platforms

LLFile::rename() will rename the file even if there is already another file at the new location whose permissions allow it to be overwritten.

This allows to remove multiple remove() calls throughout the source code just before rename(), which were placed to circumvent the Windows limitation of rename()

It also prepends "\\\\?\\" to filenames before passing them to the Windows functions, which removes the limitation of Windows file functions to filenames with not more than MAX_PATH characters. It also tries to sanitize filenames be replacing slashes with backslashes, since the above prefix skips certain path sanitation steps.

And it adds introduces a function getattr() which on Windows can query the file attributes without some of the the overhead of _wstat(). This function is then used in isdir() and isfile().

## Related Issues

- [X] #4805
