### PR TITLE
Fix erroneous check for __attribute__ definition introduced with APR 1.7.5

### DIFF
--- a/indra/cmake/APR.cmake
+++ b/indra/cmake/APR.cmake
@@ -31,3 +31,8 @@ if(DARWIN)
 endif()
 
 target_include_directories(ll::apr SYSTEM INTERFACE ${LIBS_PREBUILT_DIR}/include/apr-1)
+
+# Fix erroneous check for __attribute__ definition introduced with APR 1.7.5, causing lots of "this declaration may not have extern 'C' linkage" errors in VS
+file(READ ${LIBS_PREBUILT_DIR}/include/apr-1/apr.h APR_HEADER_CONTENTS)
+string(REPLACE "#if !(defined(__attribute__) || defined(__has_attribute))" "#if !defined(__attribute__)" APR_HEADER_CONTENTS "${APR_HEADER_CONTENTS}")
+file(WRITE ${LIBS_PREBUILT_DIR}/include/apr-1/apr.h "${APR_HEADER_CONTENTS}")


### PR DESCRIPTION
With the update of APR to versoin 1.7.5., we have to deal with an erroneous check for the definition of `__attribute__` added to the APR head file apr.h: The additional check for the definition of `__has_attribute` is nonsense as it is a C++ internal macro to check for the existance of certain attributes, however it has nothing to do with `__attribute__` used in this context.

Since `__attribute__` is not defined in MSVC, the modified, erroneous check now causes said definition becoming missing, resulting in a huge amount of "this declaration may not have extern 'C' linkage" errors within in MSVC.

This change utilizes CMake to patch the extracted APR header file, restoring the original version of the check.