### PR TITLE
#3971 Fix wrong material type when 'editing linked'

### DIFF
--- a/indra/newview/llpanelvolume.cpp
+++ b/indra/newview/llpanelvolume.cpp
@@ -582,13 +582,17 @@ void LLPanelVolume::getState( )
 
     bool enable_material = editable && single_volume && material_same;
     LLCachedControl<bool> edit_linked(gSavedSettings, "EditLinkedParts", false);
-    if (!enable_material && !edit_linked())
+    if (!enable_material)
     {
         LLViewerObject* root = selection->getPrimaryObject();
         while (root && !root->isAvatar() && root->getParent())
         {
             LLViewerObject* parent = (LLViewerObject*)root->getParent();
             if (parent->isAvatar())
+            {
+                break;
+            }
+            if (!parent->isSelected())
             {
                 break;
             }


### PR DESCRIPTION
Code was only looking for root if not 'edit linked' (warranties presense of root) which resulted in an incorrect value when editing linked (not nessesary have a selected root) with multi selections