### PR TITLE
#4701 Fix incorrect architecture in package's name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ installer_Darwin()
 {
   local package_name="$1"
   local package_dir="$(build_dir_Darwin)/newview/"
-  local pattern=".*$(viewer_channel_suffix ${package_name})_[0-9]+_[0-9]+_[0-9]+_[0-9]+_x86_64\\.dmg\$"
+  local pattern=".*$(viewer_channel_suffix ${package_name})_[0-9]+_[0-9]+_[0-9]+_[0-9]+_universal\\.dmg\$"
   # since the additional packages are built after the base package,
   # sorting oldest first ensures that the unqualified package is returned
   # even if someone makes a qualified name that duplicates the last word of the base name

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -245,6 +245,16 @@ class ViewerManifest(LLManifest):
             }
         return "%(channel_vendor_base)s%(channel_variant_underscores)s_%(version_underscores)s_%(arch)s" % substitution_strings
 
+    def installer_base_name_mac(self):
+        global CHANNEL_VENDOR_BASE
+        # a standard map of strings for replacing in the templates
+        substitution_strings = {
+            'channel_vendor_base' : '_'.join(CHANNEL_VENDOR_BASE.split()),
+            'channel_variant_underscores':self.channel_variant_app_suffix(),
+            'version_underscores' : '_'.join(self.args['version'])
+            }
+        return "%(channel_vendor_base)s%(channel_variant_underscores)s_%(version_underscores)s_universal" % substitution_strings
+
     def app_name(self):
         global CHANNEL_VENDOR_BASE
         channel_type=self.channel_type()
@@ -1068,7 +1078,7 @@ class Darwin_x86_64_Manifest(ViewerManifest):
 
 
     def package_finish(self):
-        imagename = self.installer_base_name()
+        imagename = self.installer_base_name_mac()
         self.set_github_output('imagename', imagename)
         finalname = imagename + ".dmg"
         self.package_file = finalname


### PR DESCRIPTION
Pack into univeral instead of x86.

Might have been smarter to check platform or to find and switch what provides arch, but I think arch would have ended as arm64, so just swapped to universal for mac only.