### PR TITLE
#4861 Crash at LLVolumeFace::createOctree

### DIFF
--- a/indra/llappearance/llpolymesh.cpp
+++ b/indra/llappearance/llpolymesh.cpp
@@ -283,6 +283,7 @@ bool LLPolyMeshSharedData::loadMesh( const std::string& fileName )
         LLFILE* fp = LLFile::fopen(fileName, "rb");                     /*Flawfinder: ignore*/
         if (!fp)
         {
+                LLError::LLUserWarningMsg::showMissingFiles();
                 LL_ERRS() << "can't open: " << fileName << LL_ENDL;
                 return false;
         }

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5025,7 +5025,7 @@ void LLRiggedVolume::update(
     else
     {
         face_begin = face_index;
-        face_end = face_begin + 1;
+        face_end = llmin(face_begin + 1, volume->getNumVolumeFaces());
     }
     for (S32 i = face_begin; i < face_end; ++i)
     {


### PR DESCRIPTION
Looks like LLRiggedVolume::update goes out of bounds when selecting a face