### PR TITLE
#4652 Improve switching of webrtc devices

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -582,6 +582,13 @@ void LLWebRTCImpl::setRenderDevice(const std::string &id)
     deployDevices();
 }
 
+void LLWebRTCImpl::setDevices(const std::string& capture_id, const std::string& render_id)
+{
+    mRecordingDevice = capture_id;
+    mPlayoutDevice = render_id;
+    deployDevices();
+}
+
 // updateDevices needs to happen on the worker thread.
 void LLWebRTCImpl::updateDevices()
 {

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -150,6 +150,7 @@ class LLWebRTCDeviceInterface
     // set the capture and render devices using the unique identifier for the device
     virtual void setCaptureDevice(const std::string& id) = 0;
     virtual void setRenderDevice(const std::string& id) = 0;
+    virtual void setDevices(const std::string& caprure_id, const std::string& render_id) = 0;
 
     // Device observers for device change callbacks.
     virtual void setDevicesObserver(LLWebRTCDevicesObserver *observer) = 0;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -443,6 +443,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
 
     void setCaptureDevice(const std::string& id) override;
     void setRenderDevice(const std::string& id) override;
+    void setDevices(const std::string& caprure_id, const std::string& render_id) override;
 
     void setTuningMode(bool enable) override;
     float getTuningAudioLevel() override;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -699,6 +699,7 @@ void LLWebRTCVoiceClient::setCaptureDevice(const std::string& name)
 {
     if (mWebRTCDeviceInterface)
     {
+        LL_DEBUGS("Voice") << "new capture device is " << name << LL_ENDL;
         mWebRTCDeviceInterface->setCaptureDevice(name);
     }
 }
@@ -727,10 +728,15 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
         return;
     }
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOICE;
+
+    LL_DEBUGS("Voice") << "Reiniting " << LL_ENDL;
+
     std::string inputDevice = gSavedSettings.getString("VoiceInputAudioDevice");
     std::string outputDevice = gSavedSettings.getString("VoiceOutputAudioDevice");
 
     LL_DEBUGS("Voice") << "Setting devices to-input: '" << inputDevice << "' output: '" << outputDevice << "'" << LL_ENDL;
+    bool update_render = false;
+    bool update_capture = false;
 
     // only set the render device if the device list has changed.
     if (mRenderDevices.size() != render_devices.size() || !std::equal(mRenderDevices.begin(),
@@ -744,7 +750,7 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
         {
             addRenderDevice(LLVoiceDevice(device.mDisplayName, device.mID));
         }
-        setRenderDevice(outputDevice);
+        update_render = true;
     }
 
     // only set the capture device if the device list has changed.
@@ -761,6 +767,22 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
 
             addCaptureDevice(LLVoiceDevice(device.mDisplayName, device.mID));
         }
+        update_capture = true;
+    }
+
+    if (update_render && update_capture)
+    {
+        // Do both in one go to avoid multiple deployDevices calls.
+        // And to avoid situation where workerDeployDevices has an
+        // obsolete device id
+        setDevices(inputDevice, outputDevice);
+    }
+    else if (update_render)
+    {
+        setRenderDevice(outputDevice);
+    }
+    else if (update_capture)
+    {
         setCaptureDevice(inputDevice);
     }
 
@@ -789,7 +811,17 @@ void LLWebRTCVoiceClient::setRenderDevice(const std::string& name)
 {
     if (mWebRTCDeviceInterface)
     {
+        LL_DEBUGS("Voice") << "new render device is " << name << LL_ENDL;
         mWebRTCDeviceInterface->setRenderDevice(name);
+    }
+}
+
+void LLWebRTCVoiceClient::setDevices(const std::string& capture_name, const std::string& render_name)
+{
+    if (mWebRTCDeviceInterface)
+    {
+        LL_DEBUGS("Voice") << "new capture device: " << capture_name << " New render device: " << render_name << LL_ENDL;
+        mWebRTCDeviceInterface->setDevices(capture_name, render_name);
     }
 }
 

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -124,6 +124,7 @@ public:
 
     void setCaptureDevice(const std::string& name) override;
     void setRenderDevice(const std::string& name) override;
+    void setDevices(const std::string& capture_name, const std::string& render_name);
 
     LLVoiceDeviceList& getCaptureDevices() override;
     LLVoiceDeviceList& getRenderDevices() override;


### PR DESCRIPTION
Something in device updating code is causing crashes. This likely won't fix the issue, but decided it's a good idea to eliminate risk of calls with obsolete ids (ex: first deploy call is on render device change, with an obsolete recorder).