### PR TITLE
#4841 #4860 Update APR library and remove hotfix patch in APR cmake

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -46,11 +46,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>a21487f4e3a68721fd97edef117795a1b7212a77</string>
+              <string>3f8e58fe74e144b771858e89a5514bf354964c76</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r1/apr_suite-1.7.5-12259255574-darwin64-12259255574.tar.zst</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r2/apr_suite-1.7.5-18696779749-darwin64-18696779749.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -60,11 +60,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>45baf82d3366734e542a2a3749f495b64f5513b4</string>
+              <string>df36114eb8fb66fdcbb190011222a7d336791d98</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r1/apr_suite-1.7.5-12259255574-linux64-12259255574.tar.zst</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r2/apr_suite-1.7.5-18696779749-linux64-18696779749.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -74,11 +74,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>bdd35d3b9580d3cdcb98afae639936aaa40e24c4</string>
+              <string>164705831819d247753c9fd608c2c1ac8dca1883</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r1/apr_suite-1.7.5-12259255574-windows64-12259255574.tar.zst</string>
+              <string>https://github.com/secondlife/3p-apr_suite/releases/download/v1.7.5-r2/apr_suite-1.7.5-18696779749-windows64-18696779749.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -91,7 +91,7 @@
         <key>copyright</key>
         <string>Copyright © 2012 The Apache Software Foundation, Licensed under the Apache License, Version 2.0.</string>
         <key>version</key>
-        <string>1.7.5-12259255574</string>
+        <string>1.7.5-18696779749</string>
         <key>name</key>
         <string>apr_suite</string>
         <key>description</key>

--- a/indra/cmake/APR.cmake
+++ b/indra/cmake/APR.cmake
@@ -31,8 +31,3 @@ if(DARWIN)
 endif()
 
 target_include_directories(ll::apr SYSTEM INTERFACE ${LIBS_PREBUILT_DIR}/include/apr-1)
-
-# Fix erroneous check for __attribute__ definition introduced with APR 1.7.5, causing lots of "this declaration may not have extern 'C' linkage" errors in VS
-file(READ ${LIBS_PREBUILT_DIR}/include/apr-1/apr.h APR_HEADER_CONTENTS)
-string(REPLACE "#if !(defined(__attribute__) || defined(__has_attribute))" "#if !defined(__attribute__)" APR_HEADER_CONTENTS "${APR_HEADER_CONTENTS}")
-file(WRITE ${LIBS_PREBUILT_DIR}/include/apr-1/apr.h "${APR_HEADER_CONTENTS}")


### PR DESCRIPTION
Fixed issues:
https://github.com/secondlife/viewer/issues/4841
https://github.com/secondlife/viewer/issues/4860

1. Updates autobuild.xml to use the fixed APR 1.7.5-r2 library to address the first issue above
2. Removes the now unnecessary patch in APR.cmake to address the second issue above