### PR TITLE
#4652 webrtc crash when switching devices

### DIFF
--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -149,7 +149,7 @@ class LLWebRTCDeviceInterface
 
     // set the capture and render devices using the unique identifier for the device
     virtual void setCaptureDevice(const std::string& id) = 0;
-    virtual void setRenderDevice(const std::string& id) = 0;
+    virtual void setRenderDevice(const std::string& id, bool stop_playout) = 0;
     virtual void setDevices(const std::string& caprure_id, const std::string& render_id) = 0;
 
     // Device observers for device change callbacks.

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -442,7 +442,7 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
     void unsetDevicesObserver(LLWebRTCDevicesObserver *observer) override;
 
     void setCaptureDevice(const std::string& id) override;
-    void setRenderDevice(const std::string& id) override;
+    void setRenderDevice(const std::string& id, bool stop_playout) override;
     void setDevices(const std::string& caprure_id, const std::string& render_id) override;
 
     void setTuningMode(bool enable) override;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -779,7 +779,11 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
     }
     else if (update_render)
     {
-        setRenderDevice(outputDevice);
+        if (mWebRTCDeviceInterface)
+        {
+            LL_DEBUGS("Voice") << "new render device is " << outputDevice << LL_ENDL;
+            mWebRTCDeviceInterface->setRenderDevice(outputDevice, false);
+        }
     }
     else if (update_capture)
     {
@@ -812,7 +816,7 @@ void LLWebRTCVoiceClient::setRenderDevice(const std::string& name)
     if (mWebRTCDeviceInterface)
     {
         LL_DEBUGS("Voice") << "new render device is " << name << LL_ENDL;
-        mWebRTCDeviceInterface->setRenderDevice(name);
+        mWebRTCDeviceInterface->setRenderDevice(name, true);
     }
 }
 


### PR DESCRIPTION
stopPlayout crash when called from 2 different threads. suppress webrtc's internal stopPlayout calls.