### PR TITLE
Fix lingering inventory after async skeleton failures

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -2695,6 +2695,7 @@ bool idle_startup()
             gAsyncAgentCacheHydrated = false;
             gAsyncLibraryCacheHydrated = false;
             gAsyncParentChildMapPrimed = false;
+            gInventory.cleanupInventory();
             gInventory.setAsyncInventoryLoading(false);
 
             show_connect_box = true;


### PR DESCRIPTION
From review:

**Cache State on Async Failure**: After `markFailed` and cache removal, explicitly call `gInventory.cleanupInventory()` or reset `mCategoryMap`/`mItemMap` to fully purge partial loads. Currently, it resets flags but leaves dangling objects, risking observer fires on stale data during retry login.