### PR TITLE
Fix issue where mac was crashing during an attempt to unplug or replug headset.

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -572,14 +572,20 @@ void LLWebRTCImpl::workerDeployDevices()
 void LLWebRTCImpl::setCaptureDevice(const std::string &id)
 {
 
-    mRecordingDevice = id;
-    deployDevices();
+    if (mRecordingDevice != id)
+    {
+        mRecordingDevice = id;
+        deployDevices();
+    }
 }
 
 void LLWebRTCImpl::setRenderDevice(const std::string &id)
 {
-    mPlayoutDevice = id;
-    deployDevices();
+    if (mPlayoutDevice != id)
+    {
+        mPlayoutDevice = id;
+        deployDevices();
+    }
 }
 
 // updateDevices needs to happen on the worker thread.


### PR DESCRIPTION
The mac audio device manager was being "helpful" by restarting playout and recording if the Default device was changed, assuming the application wouldn't care.
However, we received an update of device change, and attempted to stop and start playout anyway, causing a conflict. The fix was simply to not deploy new devices when the device id didn't change.

This hopefully fixes #4652

Testing Guidance (both mac and windows)

Default Device
* Plug in a headset.
* Set it to the default system device.
* Start the viewer
* Select the default devices in preferences
* Validate WebRTC speech works.
* Unplug the headset
* Validate that WebRTC speech works through the system's other devices (laptop speaker / microphone)
* Replug the headset
* Validate that WebRTC speech works through the headset.
* Do this many times.

Non-default device
* Plug in headset
* Start the viewer
* Set the device to the headset explicitly in preferences.
* Validate WebRTC speech works.
* Unplug the headset.
* Validate WebRTC speech works through the alternate devices.
* Validate that preferences revert back to Default.
* Plug in the headset.
* WebRTC speech will work through the Default device
* Set the device to the headset (speaker and microphone)
* WebRTC speech will work through the headset.

In preferences.
* Bring up preferences.
* Set the default device.
* Validate that microphone records from the default (headset) device (mute it to see the bars go away)
* Unplug the device.
* Validate the microphone reverts to the laptop or other mic.
* Plug in the device.  Validate it returns to the headset mic.
* Set the devices to the headset
* Unplug
* Validate the devices revert to Default and bars come from the computer microphone.
* Plug in
* Validate we're using the default device (headset)
* Switch to computer microphone and speaker.
* Validate
* Unplug the headset.
* Validate things still work
* Replug the headset
* Validate things still work as expected.


