### PR TITLE
Revert "Improve switching of webrtc devices"

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -582,13 +582,6 @@ void LLWebRTCImpl::setRenderDevice(const std::string &id)
     deployDevices();
 }
 
-void LLWebRTCImpl::setDevices(const std::string& capture_id, const std::string& render_id)
-{
-    mRecordingDevice = capture_id;
-    mPlayoutDevice = render_id;
-    deployDevices();
-}
-
 // updateDevices needs to happen on the worker thread.
 void LLWebRTCImpl::updateDevices()
 {

--- a/indra/llwebrtc/llwebrtc.h
+++ b/indra/llwebrtc/llwebrtc.h
@@ -150,7 +150,6 @@ class LLWebRTCDeviceInterface
     // set the capture and render devices using the unique identifier for the device
     virtual void setCaptureDevice(const std::string& id) = 0;
     virtual void setRenderDevice(const std::string& id) = 0;
-    virtual void setDevices(const std::string& caprure_id, const std::string& render_id) = 0;
 
     // Device observers for device change callbacks.
     virtual void setDevicesObserver(LLWebRTCDevicesObserver *observer) = 0;

--- a/indra/llwebrtc/llwebrtc_impl.h
+++ b/indra/llwebrtc/llwebrtc_impl.h
@@ -443,7 +443,6 @@ class LLWebRTCImpl : public LLWebRTCDeviceInterface, public webrtc::AudioDeviceO
 
     void setCaptureDevice(const std::string& id) override;
     void setRenderDevice(const std::string& id) override;
-    void setDevices(const std::string& caprure_id, const std::string& render_id) override;
 
     void setTuningMode(bool enable) override;
     float getTuningAudioLevel() override;

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -735,8 +735,6 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
     std::string outputDevice = gSavedSettings.getString("VoiceOutputAudioDevice");
 
     LL_DEBUGS("Voice") << "Setting devices to-input: '" << inputDevice << "' output: '" << outputDevice << "'" << LL_ENDL;
-    bool update_render = false;
-    bool update_capture = false;
 
     // only set the render device if the device list has changed.
     if (mRenderDevices.size() != render_devices.size() || !std::equal(mRenderDevices.begin(),
@@ -750,7 +748,7 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
         {
             addRenderDevice(LLVoiceDevice(device.mDisplayName, device.mID));
         }
-        update_render = true;
+        setRenderDevice(outputDevice);
     }
 
     // only set the capture device if the device list has changed.
@@ -767,22 +765,6 @@ void LLWebRTCVoiceClient::OnDevicesChangedImpl(const llwebrtc::LLWebRTCVoiceDevi
 
             addCaptureDevice(LLVoiceDevice(device.mDisplayName, device.mID));
         }
-        update_capture = true;
-    }
-
-    if (update_render && update_capture)
-    {
-        // Do both in one go to avoid multiple deployDevices calls.
-        // And to avoid situation where workerDeployDevices has an
-        // obsolete device id
-        setDevices(inputDevice, outputDevice);
-    }
-    else if (update_render)
-    {
-        setRenderDevice(outputDevice);
-    }
-    else if (update_capture)
-    {
         setCaptureDevice(inputDevice);
     }
 
@@ -813,15 +795,6 @@ void LLWebRTCVoiceClient::setRenderDevice(const std::string& name)
     {
         LL_DEBUGS("Voice") << "new render device is " << name << LL_ENDL;
         mWebRTCDeviceInterface->setRenderDevice(name);
-    }
-}
-
-void LLWebRTCVoiceClient::setDevices(const std::string& capture_name, const std::string& render_name)
-{
-    if (mWebRTCDeviceInterface)
-    {
-        LL_DEBUGS("Voice") << "new capture device: " << capture_name << " New render device: " << render_name << LL_ENDL;
-        mWebRTCDeviceInterface->setDevices(capture_name, render_name);
     }
 }
 

--- a/indra/newview/llvoicewebrtc.h
+++ b/indra/newview/llvoicewebrtc.h
@@ -124,7 +124,6 @@ public:
 
     void setCaptureDevice(const std::string& name) override;
     void setRenderDevice(const std::string& name) override;
-    void setDevices(const std::string& capture_name, const std::string& render_name);
 
     LLVoiceDeviceList& getCaptureDevices() override;
     LLVoiceDeviceList& getRenderDevices() override;


### PR DESCRIPTION
Wrong approach. Might need to split workerDeployDevices into separate recording and rendering variants.
This partiall reverts commit bb26aa3c2cb8ff961668cf0ad8180d3e9c57f941, I left log lines untouched.