### PR TITLE
#4882 Log textures that failed to be created

### DIFF
--- a/indra/llappearance/lltexlayer.cpp
+++ b/indra/llappearance/lltexlayer.cpp
@@ -1890,7 +1890,10 @@ LLGLTexture* LLTexLayerStaticImageList::getTexture(const std::string& file_name,
 
                 image_raw->copyUnscaledAlphaMask(alpha_image_raw, LLColor4U::black);
             }
-            tex->createGLTexture(0, image_raw, 0, true, LLGLTexture::LOCAL);
+            if (!tex->createGLTexture(0, image_raw, 0, true, LLGLTexture::LOCAL))
+            {
+                LL_WARNS() << "Failed to create GL texture for image: " << file_name << LL_ENDL;
+            }
 
             gGL.getTexUnit(0)->bind(tex);
             tex->setAddressMode(LLTexUnit::TAM_CLAMP);

--- a/indra/llappearance/lltexlayerparams.cpp
+++ b/indra/llappearance/lltexlayerparams.cpp
@@ -338,7 +338,10 @@ bool LLTexLayerParamAlpha::render(S32 x, S32 y, S32 width, S32 height)
                 // Create the GL texture, and then hang onto it for future use.
                 if (mNeedsCreateTexture)
                 {
-                    mCachedProcessedTexture->createGLTexture(0, mStaticImageRaw);
+                    if (!mCachedProcessedTexture->createGLTexture(0, mStaticImageRaw))
+                    {
+                        LL_WARNS() << "Failed to create GL texture for image: " << mCachedProcessedTexture->getID() << LL_ENDL;
+                    }
                     mNeedsCreateTexture = false;
                     gGL.getTexUnit(0)->bind(mCachedProcessedTexture);
                     mCachedProcessedTexture->setAddressMode(LLTexUnit::TAM_CLAMP);

--- a/indra/llrender/llcubemap.cpp
+++ b/indra/llrender/llcubemap.cpp
@@ -86,7 +86,10 @@ void LLCubeMap::initGL()
             #endif
                 mImages[i]->setTarget(mTargets[i], LLTexUnit::TT_CUBE_MAP);
                 mRawImages[i] = new LLImageRaw(RESOLUTION, RESOLUTION, 4);
-                mImages[i]->createGLTexture(0, mRawImages[i], texname);
+                if (!mImages[i]->createGLTexture(0, mRawImages[i], texname))
+                {
+                    LL_WARNS() << "Failed to create GL texture for environment cubemap face " << i << LL_ENDL;
+                }
 
                 gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_CUBE_MAP, texname);
                 mImages[i]->setAddressMode(LLTexUnit::TAM_CLAMP);
@@ -203,7 +206,10 @@ void LLCubeMap::initEnvironmentMap(const std::vector<LLPointer<LLImageRaw> >& ra
         mImages[i] = new LLImageGL(resolution, resolution, components, true);
         mImages[i]->setTarget(mTargets[i], LLTexUnit::TT_CUBE_MAP);
         mRawImages[i] = rawimages[i];
-        mImages[i]->createGLTexture(0, mRawImages[i], texname);
+        if (!mImages[i]->createGLTexture(0, mRawImages[i], texname))
+        {
+            LL_WARNS() << "Failed to create GL texture for environment cubemap face " << i << LL_ENDL;
+        }
 
         gGL.getTexUnit(0)->bindManual(LLTexUnit::TT_CUBE_MAP, texname);
         mImages[i]->setAddressMode(LLTexUnit::TAM_CLAMP);

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -802,7 +802,10 @@ void LLBumpImageList::onSourceStandardLoaded( bool success, LLViewerFetchedTextu
         }
         src_vi->setExplicitFormat(GL_RGBA, GL_RGBA);
         {
-            src_vi->createGLTexture(src_vi->getDiscardLevel(), nrm_image);
+            if (!src_vi->createGLTexture(src_vi->getDiscardLevel(), nrm_image))
+            {
+                LL_WARNS() << "Failed to create bump image texture for image " << src_vi->getID() << LL_ENDL;
+            }
         }
     }
 }
@@ -896,7 +899,10 @@ void LLBumpImageList::onSourceUpdated(LLViewerTexture* src, EBumpEffect bump_cod
 
         LLImageGL* src_img = src->getGLTexture();
         LLImageGL* dst_img = bump->getGLTexture();
-        dst_img->setSize(src->getWidth(), src->getHeight(), 4, 0);
+        if (!dst_img->setSize(src->getWidth(), src->getHeight(), 4, 0))
+        {
+            LL_WARNS() << "Failed to setSize for image " << bump->getID() << LL_ENDL;
+        }
         dst_img->setUseMipMaps(true);
         dst_img->setDiscardLevel(0);
         dst_img->createGLTexture();

--- a/indra/newview/lllocalbitmaps.cpp
+++ b/indra/newview/lllocalbitmaps.cpp
@@ -219,7 +219,10 @@ bool LLLocalBitmap::updateSelf(EUpdateType optional_firstupdate)
                     LLPointer<LLViewerFetchedTexture> texture = new LLViewerFetchedTexture
                         ("file://"+mFilename, FTT_LOCAL_FILE, mWorldID, LL_LOCAL_USE_MIPMAPS);
 
-                    texture->createGLTexture(LL_LOCAL_DISCARD_LEVEL, raw_image);
+                    if (!texture->createGLTexture(LL_LOCAL_DISCARD_LEVEL, raw_image))
+                    {
+                        LL_WARNS() << "Failed to create GL texture for local bitmap: " << mFilename << " " << mWorldID << LL_ENDL;
+                    }
                     texture->ref();
 
                     gTextureList.addImage(texture, TEX_LIST_STANDARD);

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -3001,7 +3001,10 @@ void LLViewerMediaImpl::doMediaTexUpdate(LLViewerMediaTexture* media_tex, U8* da
     // -Cosmic,2023-04-04
     // Allocate GL texture based on LLImageRaw but do NOT copy to GL
     LLGLuint tex_name = 0;
-    media_tex->createGLTexture(0, raw, 0, true, LLGLTexture::OTHER, true, &tex_name);
+    if (!media_tex->createGLTexture(0, raw, 0, true, LLGLTexture::OTHER, true, &tex_name))
+    {
+        LL_WARNS("Media") << "Failed to create media texture" << LL_ENDL;
+    }
 
     // copy just the subimage covered by the image raw to GL
     media_tex->setSubImage(data, data_width, data_height, x_pos, y_pos, width, height, tex_name);
@@ -3070,7 +3073,10 @@ LLViewerMediaTexture* LLViewerMediaImpl::updateMediaImage()
             mMediaSource->getTextureFormatSwapBytes());
 
         int discard_level = 0;
-        media_tex->createGLTexture(discard_level, raw);
+        if (!media_tex->createGLTexture(discard_level, raw))
+        {
+            LL_WARNS("Media") << "Failed to create media texture" << LL_ENDL;
+        }
 
         // MEDIAOPT: set this dynamically on play/stop
         // FIXME

--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -406,7 +406,10 @@ void LLViewerTextureManager::init()
             }
         }
     }
-    imagep->createGLTexture(0, image_raw);
+    if (!imagep->createGLTexture(0, image_raw))
+    {
+        LL_WARNS() << "Failed to create default texture " << IMG_DEFAULT << LL_ENDL;
+    }
     image_raw = NULL;
 #else
     LLViewerFetchedTexture::sDefaultImagep = LLViewerTextureManager::getFetchedTexture(IMG_DEFAULT, true, LLGLTexture::BOOST_UI);


### PR DESCRIPTION
A bunch of 36x36 failed to create, there shouldn't have been any 36x36 textures, log the ids/type.

As far as I can tell, this shouldn't spam. Creatuion failure is rare.