### PR TITLE
#1112 Add 1024x1024 size to Snapshot to Inventory

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
@@ -60,6 +60,10 @@
          name="Large(512x512)"
          value="[i512,i512]" />
         <combo_box.item
+         label="Huge (1024x1024)"
+         name="Huge(1024x1024)"
+         value="[i1024,i1024]" />
+        <combo_box.item
          label="Current Window"
          name="CurrentWindow"
          value="[i0,i0]" />


### PR DESCRIPTION
Added 'Huge' 1024x1024 size to Snapshot to Inventory.

By modern standards it's definetely not huge, so might be better to shift things a bit (start with tiny), but for now decided to leave as is.