### PR TITLE
Fix XUI parser warnings:

### DIFF
--- a/indra/newview/llfloatermarketplace.cpp
+++ b/indra/newview/llfloatermarketplace.cpp
@@ -46,9 +46,9 @@ void LLFloaterMarketplace::onClose(bool app_quitting)
 
 bool LLFloaterMarketplace::postBuild()
 {
-    LLFloaterWebContent::postBuild();
-    mWebBrowser = getChild<LLMediaCtrl>("marketplace_contents");
-    mWebBrowser->addObserver(this);
+    if (!LLFloaterWebContent::postBuild())
+        return false;
+
     mWebBrowser->setErrorPageURL(gSavedSettings.getString("GenericErrorPageURL"));
     std::string url = gSavedSettings.getString("MarketplaceURL");
     mWebBrowser->navigateTo(url, HTTP_CONTENT_TEXT_HTML);

--- a/indra/newview/llfloatersearch.cpp
+++ b/indra/newview/llfloatersearch.cpp
@@ -161,15 +161,14 @@ void LLFloaterSearch::initiateSearch(const LLSD& tokens)
 
     // Naviation to the calculated URL - we know it's HTML so we can
     // tell the media system not to bother with the MIME type check.
-    LLMediaCtrl* search_browser = findChild<LLMediaCtrl>("search_contents");
-    search_browser->navigateTo(url, HTTP_CONTENT_TEXT_HTML);
+    mWebBrowser->navigateTo(url, HTTP_CONTENT_TEXT_HTML);
 }
 
 bool LLFloaterSearch::postBuild()
 {
-    LLFloaterWebContent::postBuild();
-    mWebBrowser = getChild<LLMediaCtrl>("search_contents");
-    mWebBrowser->addObserver(this);
+    if (!LLFloaterWebContent::postBuild())
+        return false;
+
     mWebBrowser->setErrorPageURL(gSavedSettings.getString("GenericErrorPageURL"));
 
     // If cookie is there, will set it now, Otherwise will have to wait for login completion

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -1364,7 +1364,7 @@ void LLViewerMedia::getOpenIDCookieCoro(std::string url)
                         std::string browser_name;
                     };
                     struct MediaCookieInstance media_cookie_instances[] = {
-                        {"search", "search_contents" },
+                        {"search", "webbrowser" },
                         {"marketplace", "webbrowser" },
                         {"destinations", "destination_guide_contents" },
                     };

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -1365,7 +1365,7 @@ void LLViewerMedia::getOpenIDCookieCoro(std::string url)
                     };
                     struct MediaCookieInstance media_cookie_instances[] = {
                         {"search", "search_contents" },
-                        {"marketplace", "marketplace_contents" },
+                        {"marketplace", "webbrowser" },
                         {"destinations", "destination_guide_contents" },
                     };
                     for (MediaCookieInstance mci : media_cookie_instances)

--- a/indra/newview/skins/default/xui/en/floater_marketplace.xml
+++ b/indra/newview/skins/default/xui/en/floater_marketplace.xml
@@ -169,7 +169,7 @@
         follows="all"
         layout="topleft"
         left="0"
-        name="marketplace_contents"
+        name="webbrowser"
         top="0"/>
     </layout_panel>
     <layout_panel name="status_bar" 

--- a/indra/newview/skins/default/xui/en/floater_search.xml
+++ b/indra/newview/skins/default/xui/en/floater_search.xml
@@ -170,7 +170,7 @@
         layout="topleft"
         left="0"
         trusted_content="true"
-        name="search_contents"
+        name="webbrowser"
         top="0"/>
     </layout_panel>
     <layout_panel name="status_bar" 

--- a/indra/newview/skins/default/xui/en/panel_preferences_move.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_move.xml
@@ -214,7 +214,7 @@
    left_pad="10"
    top_delta="-6"
    name="mouse_warp_combo"
-   tooltip="Controls warping of the mouse to the center of the screen during alt-zoom and mouse look."
+   tool_tip="Controls warping of the mouse to the center of the screen during alt-zoom and mouse look."
    width="200">
     <combo_box.item
      label="Automatic"


### PR DESCRIPTION
Fixes for XUI parser warnings:

* LLFloaterMarketplace::postBuild calls parent method which already tries to find the webbrowser control with a different name and adds itself as observer
* Incorrect attribute name "tooltip" in panel_preferences_move.xml
