### PR TITLE
#4918 Crash at LLPluginProcessParent::poll

### DIFF
--- a/indra/llplugin/llpluginprocessparent.cpp
+++ b/indra/llplugin/llpluginprocessparent.cpp
@@ -982,15 +982,18 @@ void LLPluginProcessParent::poll(F64 timeout)
         }
     }
 
-    // Remove instances in the done state from the sInstances map.
-    LLCoros::LockType lock(*sInstancesMutex);
-    mapInstances_t::iterator itClean = sInstances.begin();
-    while (itClean != sInstances.end())
+    if (sInstancesMutex)
     {
-        if ((*itClean).second->isDone())
-            itClean = sInstances.erase(itClean);
-        else
-            ++itClean;
+        // Remove instances in the done state from the sInstances map.
+        LLCoros::LockType lock(*sInstancesMutex);
+        mapInstances_t::iterator itClean = sInstances.begin();
+        while (itClean != sInstances.end())
+        {
+            if ((*itClean).second->isDone())
+                itClean = sInstances.erase(itClean);
+            else
+                ++itClean;
+        }
     }
 }
 


### PR DESCRIPTION
Bugsplat shows that mutex is null.
It's possible that no instances exist thus mutex wasn't initialized.