### PR TITLE
#4879 An Emoji in a display name can affect text in chat

### DIFF
--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -87,6 +87,7 @@ public:
     virtual void                updateLayout(const class LLTextBase& editor);
     virtual F32                 draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
     virtual bool                canEdit() const;
+    virtual bool                getPermitsEmoji() const;
     virtual void                unlinkFromDocument(class LLTextBase* editor);
     virtual void                linkToDocument(class LLTextBase* editor);
 
@@ -255,6 +256,7 @@ public:
     /*virtual*/ void        updateLayout(const class LLTextBase& editor);
     /*virtual*/ F32         draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
     /*virtual*/ bool        canEdit() const { return false; }
+    /*virtual*/ bool        getPermitsEmoji() const { return false; }
     /*virtual*/ void        unlinkFromDocument(class LLTextBase* editor);
     /*virtual*/ void        linkToDocument(class LLTextBase* editor);
 


### PR DESCRIPTION
Cherry pick from develop of a High priority fix that was meant for 2025.08
An emoji was spliting inlineview thus affecting displayed text.
