### PR TITLE
SL-3609 Fix camera POV jump when avatar crosses a region boundary

### DIFF
--- a/indra/newview/llviewerjoystick.cpp
+++ b/indra/newview/llviewerjoystick.cpp
@@ -36,7 +36,6 @@
 #include "lltoolmgr.h"
 #include "llselectmgr.h"
 #include "llviewermenu.h"
-#include "llviewerwindow.h"
 #include "llwindow.h"
 #include "llagent.h"
 #include "llagentcamera.h"
@@ -1161,7 +1160,7 @@ void LLViewerJoystick::moveAvatar(bool reset)
 void LLViewerJoystick::moveFlycam(bool reset)
 {
     static LLQuaternion         sFlycamRotation;
-    static LLVector3            sFlycamPosition;
+    static LLVector3d           sFlycamPosition;
     static F32                  sFlycamZoom;
 
     if (!gFocusMgr.getAppHasFocus() || mDriverState != JDS_INITIALIZED
@@ -1184,7 +1183,7 @@ void LLViewerJoystick::moveFlycam(bool reset)
     bool in_build_mode = LLToolMgr::getInstance()->inBuildMode();
     if (reset || mResetFlag)
     {
-        sFlycamPosition = LLViewerCamera::getInstance()->getOrigin();
+        sFlycamPosition = gAgentCamera.getCameraPositionGlobal();
         sFlycamRotation = LLViewerCamera::getInstance()->getQuaternion();
         sFlycamZoom = LLViewerCamera::getInstance()->getView();
 
@@ -1287,7 +1286,7 @@ void LLViewerJoystick::moveFlycam(bool reset)
         }
     }
 
-    sFlycamPosition += LLVector3(sDelta) * sFlycamRotation;
+    sFlycamPosition += LLVector3d(sDelta[VX], sDelta[VY], sDelta[VZ]) * sFlycamRotation;
 
     LLMatrix3 rot_mat(sDelta[3], sDelta[4], sDelta[5]);
     sFlycamRotation = LLQuaternion(rot_mat)*sFlycamRotation;
@@ -1322,7 +1321,8 @@ void LLViewerJoystick::moveFlycam(bool reset)
     LLMatrix3 mat(sFlycamRotation);
 
     LLViewerCamera::getInstance()->setView(sFlycamZoom);
-    LLViewerCamera::getInstance()->setOrigin(sFlycamPosition);
+    LLVector3 new_camera_pos = gAgent.getPosAgentFromGlobal(sFlycamPosition);
+    LLViewerCamera::getInstance()->setOrigin(new_camera_pos);
     LLViewerCamera::getInstance()->mXAxis = LLVector3(mat.mMatrix[0]);
     LLViewerCamera::getInstance()->mYAxis = LLVector3(mat.mMatrix[1]);
     LLViewerCamera::getInstance()->mZAxis = LLVector3(mat.mMatrix[2]);


### PR DESCRIPTION
sFlycamPosition was using local coordinates instead of global ones thus was not tracking global changes and was force setting local position to an obsolete value.

Since getPosGlobalFromAgent just adds/substracts global position of origin and LLQuaternion has identical code for both vectors, I assume it's fine to just convert sDelta to Vector3d instead of Vector3.

https://github.com/secondlife/viewer-private/issues/497