### PR TITLE
#4931 Fix name cache callbacks not having connections

### DIFF
--- a/indra/newview/llconversationlog.cpp
+++ b/indra/newview/llconversationlog.cpp
@@ -157,7 +157,10 @@ void LLConversation::setListenIMFloaterOpened()
     // if floater is already opened or this conversation doesn't have unread offline messages
     if (mHasOfflineIMs && !offline_ims_visible)
     {
-        mIMFloaterShowedConnection = LLFloaterIMSession::setIMFloaterShowedCallback(boost::bind(&LLConversation::onIMFloaterShown, this, _1));
+        mIMFloaterShowedConnection = LLFloaterIMSession::setIMFloaterShowedCallback([this](const LLUUID& session_id)
+        {
+            onIMFloaterShown(session_id);
+        });
     }
     else
     {

--- a/indra/newview/llconversationloglistitem.cpp
+++ b/indra/newview/llconversationloglistitem.cpp
@@ -53,7 +53,10 @@ LLConversationLogListItem::LLConversationLogListItem(const LLConversation* conve
 
     if (mConversation->hasOfflineMessages() && !ims_are_read)
     {
-        mIMFloaterShowedConnection = LLFloaterIMSession::setIMFloaterShowedCallback(boost::bind(&LLConversationLogListItem::onIMFloaterShown, this, _1));
+        mIMFloaterShowedConnection = LLFloaterIMSession::setIMFloaterShowedCallback([this](const LLUUID& session_id)
+        {
+            onIMFloaterShown(session_id);
+        });
     }
 }
 

--- a/indra/newview/llfloaterexperiences.cpp
+++ b/indra/newview/llfloaterexperiences.cpp
@@ -171,7 +171,7 @@ void LLFloaterExperiences::onOpen( const LLSD& key )
             refreshContents();
             return;
         }
-        region->setCapabilitiesReceivedCallback(boost::bind(&LLFloaterExperiences::refreshContents, this));
+        mCapsReceivedConnection = region->setCapabilitiesReceivedCallback(boost::bind(&LLFloaterExperiences::refreshContents, this));
         return;
     }
 }
@@ -231,6 +231,7 @@ bool LLFloaterExperiences::updatePermissions( const LLSD& permission )
 
 void LLFloaterExperiences::onClose( bool app_quitting )
 {
+    mCapsReceivedConnection.disconnect();
     LLEventPumps::instance().obtain("experience_permission").stopListening("LLFloaterExperiences");
     LLFloater::onClose(app_quitting);
 }

--- a/indra/newview/llfloaterexperiences.h
+++ b/indra/newview/llfloaterexperiences.h
@@ -71,6 +71,7 @@ private:
     static void retrieveExperienceListCoro(std::string url, LLHandle<LLFloaterExperiences> hparent,
         NameMap_t tabMapping, std::string errorNotify, Callback_t cback, invokationFn_t invoker);
     std::vector<LLUUID> mPrepurchaseIds;
+    boost::signals2::scoped_connection mCapsReceivedConnection;
 };
 
 #endif //LL_LLFLOATEREXPERIENCES_H

--- a/indra/newview/llfloaterscriptlimits.cpp
+++ b/indra/newview/llfloaterscriptlimits.cpp
@@ -487,13 +487,13 @@ void LLPanelScriptLimitsRegionMemory::setRegionDetails(LLSD content)
                         names_requested.push_back(owner_id);
                         if (is_group_owned)
                         {
-                            gCacheName->getGroup(owner_id,
+                            mGroupNameCacheConnection = gCacheName->getGroup(owner_id,
                                 boost::bind(&LLPanelScriptLimitsRegionMemory::onNameCache,
                                     this, _1, _2));
                         }
                         else
                         {
-                            LLAvatarNameCache::get(owner_id,
+                            mAvatarNameCacheConnection = LLAvatarNameCache::get(owner_id,
                                 boost::bind(&LLPanelScriptLimitsRegionMemory::onAvatarNameCache,
                                     this, _1, _2));
                         }

--- a/indra/newview/llfloaterscriptlimits.h
+++ b/indra/newview/llfloaterscriptlimits.h
@@ -136,6 +136,9 @@ private:
 
     std::vector<LLSD> mObjectListItems;
 
+    boost::signals2::scoped_connection mAvatarNameCacheConnection;
+    boost::signals2::scoped_connection mGroupNameCacheConnection;
+
     void getLandScriptResourcesCoro(std::string url);
     void getLandScriptSummaryCoro(std::string url);
     void getLandScriptDetailsCoro(std::string url);

--- a/indra/newview/llpanelprofile.cpp
+++ b/indra/newview/llpanelprofile.cpp
@@ -710,6 +710,10 @@ LLPanelProfileSecondLife::~LLPanelProfileSecondLife()
     {
         mAvatarNameCacheConnection.disconnect();
     }
+    if (mMenuNameCacheConnection.connected())
+    {
+        mMenuNameCacheConnection.disconnect();
+    }
 }
 
 bool LLPanelProfileSecondLife::postBuild()
@@ -1458,7 +1462,7 @@ void LLPanelProfileSecondLife::onCommitMenu(const LLSD& userdata)
     }
     else if (item_name == "edit_display_name")
     {
-        LLAvatarNameCache::get(getAvatarId(), boost::bind(&LLPanelProfileSecondLife::onAvatarNameCacheSetName, this, _1, _2));
+        mMenuNameCacheConnection = LLAvatarNameCache::get(getAvatarId(), boost::bind(&LLPanelProfileSecondLife::onAvatarNameCacheSetName, this, _1, _2));
         LLFirstUse::setDisplayName(false);
     }
     else if (item_name == "edit_partner")

--- a/indra/newview/llpanelprofile.h
+++ b/indra/newview/llpanelprofile.h
@@ -212,6 +212,7 @@ private:
     bool                mAllowEdit;
     std::string         mDescriptionText;
     boost::signals2::connection mAvatarNameCacheConnection;
+    boost::signals2::connection mMenuNameCacheConnection;
 };
 
 

--- a/indra/newview/llspeakers.cpp
+++ b/indra/newview/llspeakers.cpp
@@ -76,7 +76,7 @@ void LLSpeaker::lookupName()
 {
     if (mDisplayName.empty())
     {
-        LLAvatarNameCache::get(mID, boost::bind(&LLSpeaker::onNameCache, this, _1, _2)); // todo: can be group???
+        mAvatarNameCacheConnection = LLAvatarNameCache::get(mID, boost::bind(&LLSpeaker::onNameCache, this, _1, _2)); // todo: can be group???
     }
 }
 

--- a/indra/newview/llspeakers.h
+++ b/indra/newview/llspeakers.h
@@ -80,6 +80,9 @@ public:
     bool            mIsModerator;
     bool            mModeratorMutedVoice;
     bool            mModeratorMutedText;
+
+private:
+    boost::signals2::scoped_connection mAvatarNameCacheConnection;
 };
 
 class LLSpeakerUpdateSpeakerEvent : public LLOldEvents::LLEvent


### PR DESCRIPTION
Looks like crash happened on LLConversationLogListItem::onIMFloaterShown, but there is not enough details, so for now switched to lambda instead of boost.
Added missing callback connections in a bunch of places.