### PR TITLE
Improve fix for line width crashes under certain Mesa GL drivers

### DIFF
--- a/indra/llrender/llgl.cpp
+++ b/indra/llrender/llgl.cpp
@@ -1329,11 +1329,7 @@ bool LLGLManager::initGL()
     glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &mMaxUniformBlockSize);
 
     // If outside the allowed range, glLineWidth fails with "invalid value".
-    // On Darwin, the range is [1, 1].
-    GLfloat line_width_range[2]{0.f};
-    glGetFloatv(GL_SMOOTH_LINE_WIDTH_RANGE, line_width_range);
-    mMinSmoothLineWidth = line_width_range[0];
-    mMaxSmoothLineWidth = line_width_range[1];
+    glGetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, mAliasedLineRange.mV);
 
     // sanity clamp max uniform block size to 64k just in case
     // there's some implementation that reports a crazy value

--- a/indra/llrender/llgl.h
+++ b/indra/llrender/llgl.h
@@ -92,8 +92,7 @@ public:
     F32 mMaxAnisotropy = 0.f;
     S32 mMaxUniformBlockSize = 0;
     S32 mMaxVaryingVectors = 0;
-    F32 mMinSmoothLineWidth = 1.f;
-    F32 mMaxSmoothLineWidth = 1.f;
+    LLVector2 mAliasedLineRange = LLVector2(1.f, 1.f);
 
     // GL 4.x capabilities
     bool mHasCubeMapArray = false;

--- a/indra/llrender/llrender.cpp
+++ b/indra/llrender/llrender.cpp
@@ -1930,14 +1930,7 @@ void LLRender::setLineWidth(F32 width)
 {
     gGL.flush();
 
-    if(sGLCoreProfile)
-    {
-        width = 1.f;
-    }
-    else
-    {
-        width = llclamp(width, gGLManager.mMinSmoothLineWidth, gGLManager.mMaxSmoothLineWidth);
-    }
+    width = llclamp(width, gGLManager.mAliasedLineRange[0], gGLManager.mAliasedLineRange[1]);
     if(mLineWidth != width)
     {
         mLineWidth = width;


### PR DESCRIPTION
## Description

We default to and only use aliased lines so check correct line width type.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
