### PR TITLE
#1006 Assume default material is valid for terrain assigment

### DIFF
--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -1492,6 +1492,11 @@ bool LLPanelRegionTerrainInfo::validateMaterials()
         const LLUUID& material_asset_id = material_ctrl->getImageAssetID();
         llassert(material_asset_id.notNull());
         if (material_asset_id.isNull()) { return false; }
+        if (material_asset_id == BLANK_MATERIAL_ASSET_ID)
+        {
+            // Default/Blank material is valid by default
+            continue;
+        }
         const LLFetchedGLTFMaterial* material = gGLTFMaterialList.getMaterial(material_asset_id);
         if (!material->isLoaded())
         {


### PR DESCRIPTION
No point validating default material as it is a predetermined resource.

Not able to repro original issue, I don't think it should be failing at isLoaded check. But if there is some odity, this should cover it.
