### PR TITLE
#4651 Distinguish logout crashes from other crashes

### DIFF
--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -179,7 +179,14 @@ namespace
                 // If marker doesn't exist, create a marker with 'other' code for next launch
                 // otherwise don't override existing file
                 // Any unmarked crashes will be considered as freezes
-                app->createErrorMarker(LAST_EXEC_OTHER_CRASH);
+                if (app->logoutRequestSent())
+                {
+                    app->createErrorMarker(LAST_EXEC_LOGOUT_CRASH);
+                }
+                else
+                {
+                    app->createErrorMarker(LAST_EXEC_OTHER_CRASH);
+                }
             }
         } // MDSCB_EXCEPTIONCODE
 


### PR DESCRIPTION
Logout crashes were incorrectly logged under 'other' crashes.