### PR TITLE
Check what state LLProcess is in for a failed test (#4877)

### DIFF
--- a/indra/llcommon/llprocess.cpp
+++ b/indra/llcommon/llprocess.cpp
@@ -457,7 +457,8 @@ public:
                        ("slot", LLSD::Integer(mIndex))
                        ("name", whichfile(mIndex))
                        ("desc", mDesc)
-                       ("eof", state == CLOSED));
+                       ("eof", state == CLOSED)
+                       ("exhst", state == EXHAUSTED));
         }
 
         return false;

--- a/indra/llcommon/tests/llprocess_test.cpp
+++ b/indra/llcommon/tests/llprocess_test.cpp
@@ -1207,8 +1207,8 @@ namespace tut
     {
         set_test_name("ReadPipe \"eof\" event");
         PythonProcessLauncher py(get_test_name(),
-            "from __future__ import print_function\n"
-            "print('Hello from Python!')\n");
+            "import time\n"
+            "time.sleep(1.5)\n");
         py.mParams.files.add(LLProcess::FileParam()); // stdin
         py.mParams.files.add(LLProcess::FileParam("pipe")); // stdout
         py.launch();


### PR DESCRIPTION
One of the process tests ocationally fails with no clear reason, make test print out 'exhaustion' state.

Theory: Process got unexpected input, got EXHAUSTED, failed to eof?