### PR TITLE
#4932 fix @mention being displayed twice if the name has a TM symbol

### DIFF
--- a/indra/llui/lltextbase.h
+++ b/indra/llui/lltextbase.h
@@ -142,6 +142,7 @@ public:
     /*virtual*/ void                updateLayout(const class LLTextBase& editor);
     /*virtual*/ F32                 draw(S32 start, S32 end, S32 selection_start, S32 selection_end, const LLRectf& draw_rect);
     /*virtual*/ bool                canEdit() const { return mCanEdit; }
+    /*virtual*/ bool                getPermitsEmoji() const { return false; }
     /*virtual*/ const LLUIColor&     getColor() const                    { return mStyle->getColor(); }
     /*virtual*/ LLStyleConstSP      getStyle() const                    { return mStyle; }
     /*virtual*/ void                setStyle(LLStyleConstSP style)  { mStyle = style; }


### PR DESCRIPTION
Emoji (TM) shouldn't split the segment with the mention.