### PR TITLE
#4907 use shortcut to pan camera down

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -724,8 +724,7 @@
         
 <menu_item_call
          label="360 snapshot"
-         name="Capture 360"
-         shortcut="control|alt|shift|s">
+         name="Capture 360">
             <menu_item_call.on_click
              function="Floater.Show"
              parameter="360capture" />


### PR DESCRIPTION
Ctrl-Alt-Shift-S should pan the camera down, so remove shortcut from 360 snapshot.