### PR TITLE
#4671 Fix impractically long am/pm labels

### DIFF
--- a/indra/newview/llstartup.cpp
+++ b/indra/newview/llstartup.cpp
@@ -458,6 +458,32 @@ bool idle_startup()
                 LLStringOps::sAM = LLTrans::getString("dateTimeAM");
                 LLStringOps::sPM = LLTrans::getString("dateTimePM");
             }
+            else
+            {
+                std::wstring utf16str = ll_convert<std::wstring>(val);
+                if (utf16str.size() > 4)
+                {
+                    LL_DEBUGS("InitInfo") << "Current locale \"" << locale << "\" "
+                        << "has impracitcally long AM/PM time format" << LL_ENDL;
+                    // fallback to declarations in strings.xml
+                    LLStringOps::sAM = LLTrans::getString("dateTimeAM");
+                    LLStringOps::sPM = LLTrans::getString("dateTimePM");
+                }
+            }
+        }
+
+        // Some locales (as well some of our own dateTimeAM/PM) return long
+        // strings for AM/PM which aren't practical to display in the UI.
+        // Hardcode to "AM"/"PM" in those cases.
+        std::wstring utf16str = ll_convert<std::wstring>(LLStringOps::sAM);
+        if (utf16str.size() > 4)
+        {
+            LLStringOps::sAM = "AM";
+        }
+        utf16str = ll_convert<std::wstring>(LLStringOps::sPM);
+        if (utf16str.size() > 4)
+        {
+            LLStringOps::sPM = "PM";
         }
     }
 


### PR DESCRIPTION
Some locales use long am/pm labels, like antemeridiane and pomeridiane. Time displays are supposed to be short, replace with shorter ones.