### PR TITLE
Restore support for wavy avatar cloth

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7263,7 +7263,7 @@
   <key>RenderAvatarCloth</key>
     <map>
       <key>Comment</key>
-      <string>DEPRECATED - only false supported - Controls if avatars use wavy cloth</string>
+      <string>Controls if system avatar clothes use wavy cloth</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/avatarV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/avatarV.glsl
@@ -28,6 +28,9 @@ uniform mat4 projection_matrix;
 in vec3 position;
 in vec3 normal;
 in vec2 texcoord0;
+#ifdef AVATAR_CLOTH
+in vec4 clothing;
+#endif
 
 mat4 getSkinnedTransform();
 
@@ -36,6 +39,15 @@ in vec4 weight;
 out vec3 vary_normal;
 out vec2 vary_texcoord0;
 out vec3 vary_position;
+
+#ifdef AVATAR_CLOTH
+uniform vec4 gWindDir;
+uniform vec4 gSinWaveParams;
+uniform vec4 gGravity;
+
+const vec4 gMinMaxConstants = vec4(1.0, 0.166666, 0.0083143, .00018542);     // #minimax-generated coefficients
+const vec4 gPiConstants = vec4(0.159154943, 6.28318530, 3.141592653, 1.5707963); // # {1/2PI, 2PI, PI, PI/2}
+#endif
 
 void main()
 {
@@ -46,15 +58,77 @@ void main()
 
     vec4 pos_in = vec4(position.xyz, 1.0);
     mat4 trans = getSkinnedTransform();
-    pos.x = dot(trans[0], pos_in);
-    pos.y = dot(trans[1], pos_in);
-    pos.z = dot(trans[2], pos_in);
-    pos.w = 1.0;
 
     norm.x = dot(trans[0].xyz, normal);
     norm.y = dot(trans[1].xyz, normal);
     norm.z = dot(trans[2].xyz, normal);
     norm = normalize(norm);
+
+#ifdef AVATAR_CLOTH
+    //wind
+    vec4 windEffect;
+    windEffect = vec4(dot(norm, gWindDir.xyz));
+    pos.x = dot(trans[2], pos_in);
+    windEffect.xyz = pos.x * vec3(0.015, 0.015, 0.015)
+                        + windEffect.xyz;
+    windEffect.w = windEffect.w * 2.0 + 1.0;                // move wind offset value to [-1, 3]
+    windEffect.w = windEffect.w*gWindDir.w;                 // modulate wind strength
+
+    windEffect.xyz = windEffect.xyz*gSinWaveParams.xyz
+                        +vec3(gSinWaveParams.w);            // use sin wave params to scale and offset input
+
+    //reduce to period of 2 PI
+    vec4 temp1, temp0, temp2, offsetPos;
+    temp1.xyz = windEffect.xyz * gPiConstants.x;            // change input as multiple of [0-2PI] to [0-1]
+    temp0.y = mod(temp1.x,1.0);
+    windEffect.x = temp0.y * gPiConstants.y;                // scale from [0,1] to [0, 2PI]
+    temp1.z = temp1.z - gPiConstants.w;                     // shift normal oscillation by PI/2
+    temp0.y = mod(temp1.z,1.0);
+
+    windEffect.z = temp0.y * gPiConstants.y;                // scale from [0,1] to [0, 2PI]
+    windEffect.xyz = windEffect.xyz + vec3(-3.141592);      // offset to [-PI, PI]
+
+    //calculate sinusoid
+    vec4 sinWave;
+    temp1 = windEffect*windEffect;
+    sinWave = -temp1 * gMinMaxConstants.w
+                + vec4(gMinMaxConstants.z);                 // y = -(x^2)/7! + 1/5!
+    sinWave = sinWave * -temp1 + vec4(gMinMaxConstants.y);  // y = -(x^2) * (-(x^2)/7! + 1/5!) + 1/3!
+    sinWave = sinWave * -temp1 + vec4(gMinMaxConstants.x);  // y = -(x^2) * (-(x^2) * (-(x^2)/7! + 1/5!) + 1/3!) + 1
+    sinWave = sinWave * windEffect;                         // y = x * (-(x^2) * (-(x^2) * (-(x^2)/7! + 1/5!) + 1/3!) + 1)
+
+    // sinWave.x holds sin(norm . wind_direction) with primary frequency
+    // sinWave.y holds sin(norm . wind_direction) with secondary frequency
+    // sinWave.z hold cos(norm . wind_direction) with primary frequency
+    sinWave.xyz = sinWave.xyz * gWindDir.w
+                + vec3(windEffect.w);                       // multiply by wind strength in gWindDir.w [-wind, wind]
+
+    // add normal facing bias offset [-wind,wind] -> [-wind - .25, wind + 1]
+    temp1 = vec4(dot(norm, gGravity.xyz));                  // how much is this normal facing in direction of gGravity?
+    temp1 = min(temp1, vec4(0.2,0.0,0.0,0.0));              // clamp [-1, 1] to [-1, 0.2]
+    temp1 = temp1*vec4(1.5,0.0,0.0,0.0);                    // scale from [-1,0.2] to [-1.5, 0.3]
+    sinWave.x = sinWave.x + temp1.x;                        // add gGravity effect to sinwave (only primary frequency)
+    sinWave.xyz = sinWave.xyz * clothing.w;                 // modulate by clothing coverage
+
+    sinWave.xyz = max(sinWave.xyz, vec3(-1.0, -1.0, -1.0)); // clamp to underlying body shape
+    offsetPos = clothing * sinWave.x;                       // multiply wind effect times clothing displacement
+    temp2 = gWindDir*sinWave.z + vec4(norm,0);              // calculate normal offset due to wind oscillation
+    offsetPos = vec4(1.0,1.0,1.0,0.0)*offsetPos+pos_in;     // add to offset vertex position, and zero out effect from w
+    norm += temp2.xyz*2.0;                                  // add sin wave effect on normals (exaggerated)
+
+    //renormalize normal (again)
+    norm = normalize(norm);
+
+    pos.x = dot(trans[0], offsetPos);
+    pos.y = dot(trans[1], offsetPos);
+    pos.z = dot(trans[2], offsetPos);
+    pos.w = 1.0;
+#else
+    pos.x = dot(trans[0], pos_in);
+    pos.y = dot(trans[1], pos_in);
+    pos.z = dot(trans[2], pos_in);
+    pos.w = 1.0;
+#endif
 
     vary_normal = norm;
 

--- a/indra/newview/lldrawpoolavatar.cpp
+++ b/indra/newview/lldrawpoolavatar.cpp
@@ -794,7 +794,7 @@ void LLDrawPoolAvatar::renderAvatars(LLVOAvatar* single_avatar, S32 pass)
         return;
     }
 
-    if ((sShaderLevel >= SHADER_LEVEL_CLOTH))
+    if (LLPipeline::RenderAvatarCloth)
     {
         LLMatrix4 rot_mat;
         LLViewerCamera::getInstance()->getMatrixToLocal(rot_mat);

--- a/indra/newview/lldrawpoolavatar.h
+++ b/indra/newview/lldrawpoolavatar.h
@@ -46,12 +46,6 @@ class LLDrawPoolAvatar : public LLFacePool
 public:
     enum
     {
-        SHADER_LEVEL_BUMP = 2,
-        SHADER_LEVEL_CLOTH = 3
-    };
-
-    enum
-    {
         VERTEX_DATA_MASK =  LLVertexBuffer::MAP_VERTEX |
                             LLVertexBuffer::MAP_NORMAL |
                             LLVertexBuffer::MAP_TEXCOORD0 |

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -871,6 +871,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderShadowDetail", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderDeferredSSAO", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderPerformanceTest", handleRenderPerfTestChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderAvatarCloth", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "ChatFontSize", handleChatFontSizeChanged);
     setting_setup_signal_listener(gSavedSettings, "ConsoleMaxLines", handleConsoleMaxLinesChanged);
     setting_setup_signal_listener(gSavedSettings, "UploadBakedTexOld", handleUploadBakedTexOldChanged);

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -582,6 +582,7 @@ void LLViewerShaderMgr::setShaders()
     unloadShaders();
 
     LLPipeline::sRenderGlow = gSavedSettings.getBOOL("RenderGlow");
+    LLPipeline::RenderAvatarCloth = gSavedSettings.getBOOL("RenderAvatarCloth");
 
     if (gViewerWindow)
     {
@@ -2357,7 +2358,9 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gDeferredAvatarProgram.mShaderFiles.push_back(make_pair("deferred/avatarF.glsl", GL_FRAGMENT_SHADER));
         gDeferredAvatarProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
 
+        gDeferredAvatarProgram.clearPermutations();
         add_common_permutations(&gDeferredAvatarProgram);
+        gDeferredAvatarProgram.addPermutation("AVATAR_CLOTH", LLPipeline::RenderAvatarCloth ? "1" : "0");
 
         success = gDeferredAvatarProgram.createShader();
         llassert(success);

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -3300,7 +3300,7 @@ void LLVOAvatar::idleUpdateLoadingEffect()
 void LLVOAvatar::idleUpdateWindEffect()
 {
     // update wind effect
-    if ((LLViewerShaderMgr::instance()->getShaderLevel(LLViewerShaderMgr::SHADER_AVATAR) >= LLDrawPoolAvatar::SHADER_LEVEL_CLOTH))
+    if (LLPipeline::RenderAvatarCloth)
     {
         F32 hover_strength = 0.f;
         F32 time_delta = mRippleTimer.getElapsedTimeF32() - mRippleTimeLast;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -218,6 +218,7 @@ S32 LLPipeline::RenderBufferVisualization;
 bool LLPipeline::RenderMirrors;
 S32 LLPipeline::RenderHeroProbeUpdateRate;
 S32 LLPipeline::RenderHeroProbeConservativeUpdateMultiplier;
+bool LLPipeline::RenderAvatarCloth;
 LLTrace::EventStatHandle<S64> LLPipeline::sStatBatchSize("renderbatchsize");
 
 const U32 LLPipeline::MAX_PREVIEW_WIDTH = 512;
@@ -601,6 +602,7 @@ void LLPipeline::init()
     connectRefreshCachedSettingsSafe("RenderMirrors");
     connectRefreshCachedSettingsSafe("RenderHeroProbeUpdateRate");
     connectRefreshCachedSettingsSafe("RenderHeroProbeConservativeUpdateMultiplier");
+    connectRefreshCachedSettingsSafe("RenderAvatarCloth");
 
     LLPointer<LLControlVariable> cntrl_ptr = gSavedSettings.getControl("CollectFontVertexBuffers");
     if (cntrl_ptr.notNull())
@@ -1133,6 +1135,7 @@ void LLPipeline::refreshCachedSettings()
     RenderMirrors = gSavedSettings.getBOOL("RenderMirrors");
     RenderHeroProbeUpdateRate = gSavedSettings.getS32("RenderHeroProbeUpdateRate");
     RenderHeroProbeConservativeUpdateMultiplier = gSavedSettings.getS32("RenderHeroProbeConservativeUpdateMultiplier");
+    RenderAvatarCloth = gSavedSettings.getBOOL("RenderAvatarCloth");
 
     sReflectionProbesEnabled = LLFeatureManager::getInstance()->isFeatureAvailable("RenderReflectionsEnabled") && gSavedSettings.getBOOL("RenderReflectionsEnabled");
     RenderSpotLight = nullptr;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -1087,6 +1087,7 @@ public:
     static bool RenderMirrors;
     static S32 RenderHeroProbeUpdateRate;
     static S32 RenderHeroProbeConservativeUpdateMultiplier;
+    static bool RenderAvatarCloth;
 };
 
 void render_bbox(const LLVector3 &min, const LLVector3 &max);

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3492,6 +3492,16 @@ function="World.EnvPreset"
                  parameter="RenderAttachedParticles" />
             </menu_item_check>
             <menu_item_check
+              label="Render Avatar Cloth"
+             name="Render Avatar Cloth">
+                <menu_item_check.on_check
+                 function="CheckControl"
+                 parameter="RenderAvatarCloth" />
+                <menu_item_check.on_click
+                 function="ToggleControl"
+                 parameter="RenderAvatarCloth" />
+            </menu_item_check>
+            <menu_item_check
              label="Collect Font Vertex Buffers"
              name="Collect Font Vertex Buffers">
                 <menu_item_check.on_check


### PR DESCRIPTION
## Description

Restores support for wavy avatar cloth under the debug setting `RenderAvatarCloth` currently defaulted off.

https://github.com/user-attachments/assets/14c959d5-1cbb-4437-9f4a-07c32c6a0e5d


## Related Issues

Issue Link: #4963

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
