### PR TITLE
[#4985] Fix crash in handleHover accessing null parent for attachments

### DIFF
--- a/indra/newview/llmaniptranslate.cpp
+++ b/indra/newview/llmaniptranslate.cpp
@@ -695,24 +695,28 @@ bool LLManipTranslate::handleHover(S32 x, S32 y, MASK mask)
                 // handle attachments in local space
                 if (object->isAttachment() && object->mDrawable.notNull())
                 {
-                    // calculate local version of relative move
-                    LLQuaternion objWorldRotation = object->mDrawable->mXform.getParent()->getWorldRotation();
-                    objWorldRotation.transQuat();
-
-                    LLVector3 old_position_local = object->getPosition();
-                    LLVector3 new_position_local = selectNode->mSavedPositionLocal + (clamped_relative_move_f * objWorldRotation);
-
-                    //RN: I forget, but we need to do this because of snapping which doesn't often result
-                    // in position changes even when the mouse moves
-                    object->setPosition(new_position_local);
-                    rebuild(object);
-                    gAgentAvatarp->clampAttachmentPositions();
-                    new_position_local = object->getPosition();
-
-                    if (selectNode->mIndividualSelection)
+                    LLXform* object_xform_parent = object->mDrawable->mXform.getParent();
+                    if (object_xform_parent)
                     {
-                        // counter-translate child objects if we are moving the root as an individual
-                        object->resetChildrenPosition(old_position_local - new_position_local, true);
+                        // calculate local version of relative move
+                        LLQuaternion objWorldRotation = object_xform_parent->getWorldRotation();
+                        objWorldRotation.transQuat();
+
+                        LLVector3 old_position_local = object->getPosition();
+                        LLVector3 new_position_local = selectNode->mSavedPositionLocal + (clamped_relative_move_f * objWorldRotation);
+
+                        //RN: I forget, but we need to do this because of snapping which doesn't often result
+                        // in position changes even when the mouse moves
+                        object->setPosition(new_position_local);
+                        rebuild(object);
+                        gAgentAvatarp->clampAttachmentPositions();
+                        new_position_local = object->getPosition();
+
+                        if (selectNode->mIndividualSelection)
+                        {
+                            // counter-translate child objects if we are moving the root as an individual
+                            object->resetChildrenPosition(old_position_local - new_position_local, true);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/4985

This PR simply null checks object->mDrawable->mXform.getParent() to ensure it is valid before accessing it and updating the attachments position.

**Note:** If some sort of position update should still occur even if the parent is null and unable to grab its worldRotation, please provide a suggestion on what to do instead of just skip updating the position and I'll update this PR.