### PR TITLE
Disable shader profiles on RDNA3.5 to prevent freezes on startup.

### DIFF
--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -57,6 +57,7 @@ S32 LLGLSLShader::sIndexedTextureChannels = 0;
 U32 LLGLSLShader::sMaxGLTFMaterials = 0;
 U32 LLGLSLShader::sMaxGLTFNodes = 0;
 bool LLGLSLShader::sProfileEnabled = false;
+bool LLGLSLShader::sCanProfile = true;
 std::set<LLGLSLShader*> LLGLSLShader::sInstances;
 LLGLSLShader::defines_map_t LLGLSLShader::sGlobalDefines;
 U64 LLGLSLShader::sTotalTimeElapsed = 0;
@@ -267,7 +268,7 @@ void LLGLSLShader::placeProfileQuery(bool for_runtime)
 
 bool LLGLSLShader::readProfileQuery(bool for_runtime, bool force_read)
 {
-    if (sProfileEnabled || for_runtime)
+    if ((sProfileEnabled || for_runtime) && sCanProfile)
     {
         if (!mProfilePending)
         {

--- a/indra/llrender/llglslshader.h
+++ b/indra/llrender/llglslshader.h
@@ -160,6 +160,7 @@ public:
 
     static std::set<LLGLSLShader*> sInstances;
     static bool sProfileEnabled;
+    static bool sCanProfile;
 
     LLGLSLShader();
     ~LLGLSLShader();

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -407,7 +407,7 @@ F32 logExceptionBenchmark()
 bool checkRDNA35()
 {
     // This checks if we're running on an RDNA3.5 GPU.  You're only going to see these on AMD's APUs.
-    // As of driver version 32, we're seeing stalls in some of our queries.
+    // As of driver version 25, we're seeing stalls in some of our queries.
     // This appears to be a driver bug, and appears to be specific RDNA3.5 APUs.
     // There's multiples of these guys, so we just use this function to check if that GPU is on the list of known RDNA3.5 APUs.
     // - Geenz 11/12/2025

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -444,7 +444,7 @@ bool LLFeatureManager::loadGPUClass()
     // As a result, we filter out these GPUs for shader profiling.
     // - Geenz 11/11/2025
 
-    if (checkRDNA35() && gGLManager.mDriverVersionVendorString.find("25.") != std::string::npos)
+    if (gGLManager.getRawGLString().find("Radeon") != std::string::npos && checkRDNA35() && gGLManager.mDriverVersionVendorString.find("25.") != std::string::npos)
     {
         LL_WARNS("RenderInit") << "Detected AMD RDNA3.5 GPU on a known bad driver; disabling shader profiling to prevent freezes." << LL_ENDL;
         mSkipProfiling = true;

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -406,6 +406,23 @@ F32 logExceptionBenchmark()
 
 bool LLFeatureManager::loadGPUClass()
 {
+    // This is a hack for certain AMD cards in newer driver versions on certain APUs.
+    // These GPUs will show inconsistent freezes when attempting to run shader profiles against them.
+    // This is extremely problematic as it can lead to:
+    // - Login freezes
+    // - Inability to start the client
+    // - Completely random avatars triggering a freeze
+    // As a result, we filter out these GPUs for shader profiling.
+    // - Geenz 11/11/2025
+
+    if (gGLManager.getRawGLString().find("Radeon") != std::string::npos && gGLManager.getRawGLString().find("8060") != std::string::npos)
+    {
+        //gGLManager.mDriverVersionMajor = 27; // Example driver version for testing
+        LL_WARNS("RenderInit") << "Detected AMD Radeon 8060 GPU; disabling shader profiling to prevent freezes." << LL_ENDL;
+        mSkipProfiling = true;
+        LLGLSLShader::sCanProfile = false;
+    }
+
     if (!gSavedSettings.getBOOL("SkipBenchmark"))
     {
         F32 class1_gbps = gSavedSettings.getF32("RenderClass1MemoryBandwidth");

--- a/indra/newview/llfeaturemanager.h
+++ b/indra/newview/llfeaturemanager.h
@@ -123,6 +123,7 @@ public:
     S32 getVersion() const              { return mTableVersion; }
     void setSafe(const bool safe)       { mSafe = safe; }
     bool isSafe() const                 { return mSafe; }
+    bool skipProfiling() const          { return mSkipProfiling; }
 
     LLFeatureList *findMask(const std::string& name);
     bool maskFeatures(const std::string& name);
@@ -170,6 +171,7 @@ protected:
     F32         mExpectedGLVersion;     //expected GL version according to gpu table
     std::string mGPUString;
     bool        mGPUSupported;
+    bool        mSkipProfiling = false;
 };
 
 inline


### PR DESCRIPTION
Disables shader profiles on RDNA3.5 due to some quirky query behavior on the current driver version.  To test: run this on an AMD Radeon:
- 8060S
- 8050S
- 8040S
- 860M
- 840M
- 890M
- 880M
