### PR TITLE
[#4987] Follow-up null checks on mVObjp to prevent crashes

### DIFF
--- a/indra/newview/lldrawable.cpp
+++ b/indra/newview/lldrawable.cpp
@@ -954,6 +954,11 @@ void LLDrawable::updateTexture()
         return;
     }
 
+    if (!mVObjp)
+    {
+        return;
+    }
+
     if (getNumFaces() != mVObjp->getNumTEs())
     { //drawable is transitioning its face count
         return;

--- a/indra/newview/llface.h
+++ b/indra/newview/llface.h
@@ -127,7 +127,7 @@ public:
     void            setIndexInTex(U32 ch, S32 index) { llassert(ch < LLRender::NUM_TEXTURE_CHANNELS); mIndexInTex[ch] = index; }
 
     void            setWorldMatrix(const LLMatrix4& mat);
-    const LLTextureEntry* getTextureEntry() const { return mVObjp->getTE(mTEOffset); }
+    const LLTextureEntry* getTextureEntry() const { return mVObjp ? mVObjp->getTE(mTEOffset) : nullptr; }
 
     LLFacePool*     getPool()           const   { return mDrawPoolp; }
     U32             getPoolType()       const   { return mPoolType; }

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -7235,7 +7235,7 @@ void LLAlphaObject::getBlendFunc(S32 face, LLRender::eBlendFactor& src, LLRender
 void LLStaticViewerObject::updateDrawable(bool force_damped)
 {
     // Force an immediate rebuild on any update
-    if (mDrawable.notNull())
+    if (mDrawable.notNull() && mDrawable->getVObj())
     {
         mDrawable->updateXform(true);
         gPipeline.markRebuild(mDrawable, LLDrawable::REBUILD_ALL);

--- a/indra/newview/llvograss.cpp
+++ b/indra/newview/llvograss.cpp
@@ -736,7 +736,7 @@ void LLGrassPartition::getGeometry(LLSpatialGroup* group)
 void LLVOGrass::updateDrawable(bool force_damped)
 {
     // Force an immediate rebuild on any update
-    if (mDrawable.notNull())
+    if (mDrawable.notNull() && mDrawable->getVObj())
     {
         mDrawable->updateXform(true);
         gPipeline.markRebuild(mDrawable, LLDrawable::REBUILD_ALL);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -2955,7 +2955,7 @@ void LLPipeline::markMoved(LLDrawable *drawablep, bool damped_motion)
 
 void LLPipeline::markShift(LLDrawable *drawablep)
 {
-    if (!drawablep || drawablep->isDead())
+    if (!drawablep || drawablep->isDead() || !drawablep->getVObj())
     {
         return;
     }
@@ -2989,7 +2989,7 @@ void LLPipeline::shiftObjects(const LLVector3 &offset)
             iter != mShiftList.end(); iter++)
     {
         LLDrawable *drawablep = *iter;
-        if (drawablep->isDead())
+        if (drawablep->isDead() || !drawablep->getVObj())
         {
             continue;
         }


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/4987
Previous PR: https://github.com/secondlife/viewer/pull/4988

Added additional null checks on mVObjp in a few places where it was being accessed without any prior null checking in the current functions or the calling functions.
These additional checks are a follow-up to the previous PR mentioned above to hopefully prevent any other crashes relating to mVObjp being null in rare conditions.