### PR TITLE
Skip occlusion and benchmark on RDNA3.5

### DIFF
--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -446,9 +446,9 @@ bool LLFeatureManager::loadGPUClass()
 
     if (gGLManager.getRawGLString().find("Radeon") != std::string::npos && checkRDNA35() && gGLManager.mDriverVersionVendorString.find("25.") != std::string::npos)
     {
-        LL_WARNS("RenderInit") << "Detected AMD RDNA3.5 GPU on a known bad driver; disabling shader profiling to prevent freezes." << LL_ENDL;
-        mSkipProfiling = true;
-        LLGLSLShader::sCanProfile = false;
+        LL_WARNS("RenderInit") << "Detected AMD RDNA3.5 GPU on a known bad driver; disabling benchmark and occlusion culling to prevent freezes." << LL_ENDL;
+        gSavedSettings.setBOOL("SkipBenchmark", true);
+        gSavedSettings.setBOOL("UseOcclusion", false);
     }
 
     if (!gSavedSettings.getBOOL("SkipBenchmark"))


### PR DESCRIPTION
More work on the current RDNA3.5 bug.  Working on finding a path to report this to AMD.

This approach will automatically shunt these machines down to class 1 - which isn't ideal, but I think is fine given we're also killing occlusion culling.