### PR TITLE
#4980 Crashes when uploading a glTF model

### DIFF
--- a/indra/newview/gltf/asset.h
+++ b/indra/newview/gltf/asset.h
@@ -320,6 +320,8 @@ namespace LL
             void clearData(Asset& asset);
 
             bool prep(Asset& asset, bool loadIntoVRAM);
+        private:
+            bool prepImpl(Asset& asset, const LLUUID& id);
         };
 
         // Render Batch -- vertex buffer and list of primitives to render using

--- a/indra/newview/lldrawpoolbump.cpp
+++ b/indra/newview/lldrawpoolbump.cpp
@@ -55,8 +55,6 @@
 
 // static
 LLStandardBumpmap gStandardBumpmapList[TEM_BUMPMAP_COUNT];
-LL::WorkQueue::weak_t LLBumpImageList::sMainQueue;
-LL::WorkQueue::weak_t LLBumpImageList::sTexUpdateQueue;
 LLRenderTarget LLBumpImageList::sRenderTarget;
 
 // static
@@ -629,8 +627,6 @@ void LLBumpImageList::init()
     llassert( mDarknessEntries.size() == 0 );
 
     LLStandardBumpmap::restoreGL();
-    sMainQueue = LL::WorkQueue::getInstance("mainloop");
-    sTexUpdateQueue = LL::WorkQueue::getInstance("LLImageGL"); // Share work queue with tex loader.
 }
 
 void LLBumpImageList::clear()

--- a/indra/newview/lldrawpoolbump.h
+++ b/indra/newview/lldrawpoolbump.h
@@ -152,8 +152,6 @@ private:
     typedef std::unordered_map<LLUUID, LLPointer<LLViewerTexture> > bump_image_map_t;
     bump_image_map_t mBrightnessEntries;
     bump_image_map_t mDarknessEntries;
-    static LL::WorkQueue::weak_t sMainQueue;
-    static LL::WorkQueue::weak_t sTexUpdateQueue;
     static LLRenderTarget sRenderTarget;
 };
 


### PR DESCRIPTION
Functions used in Image::prep aren't thread safe, pass those calls to the main thread and wait for a result