### PR TITLE
[#5002] Fix the cache from being cleared every launch if NewCacheLocation is invalid

### DIFF
--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -4386,6 +4386,8 @@ bool LLAppViewer::initCache()
         LL_WARNS("AppCache") << "Unable to set cache location" << LL_ENDL;
         gSavedSettings.setString("CacheLocation", "");
         gSavedSettings.setString("CacheLocationTopFolder", "");
+        gSavedSettings.setString("NewCacheLocation", "");
+        gSavedSettings.setString("NewCacheLocationTopFolder", "");
     }
 
     const std::string cache_dir = gDirUtilp->getExpandedFilename(LL_PATH_CACHE, cache_dir_name);


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5002

Fixes the above issue by simply setting NewCacheLocation to empty, the same as CacheLocation, if the cache location was unable to be set which was causing the viewer to clear its cache every time it was ran because CacheLocation != NewCacheLocation as NewCacheLocation was never reset.