### PR TITLE
Fix error when adding a widget filename to the mFileNames stack

### DIFF
--- a/indra/llui/lluictrlfactory.cpp
+++ b/indra/llui/lluictrlfactory.cpp
@@ -100,16 +100,19 @@ void LLUICtrlFactory::loadWidgetTemplate(const std::string& widget_tag, LLInitPa
     std::string base_filename = search_paths.front();
     if (!base_filename.empty())
     {
-        LLUICtrlFactory::instance().pushFileName(base_filename);
+        LLUICtrlFactory *factory = LLUICtrlFactory::getInstance();
+        factory->mFileNames.push_back(base_filename);
 
-        if (!LLXMLNode::getLayeredXMLNode(root_node, search_paths))
+        if (LLXMLNode::getLayeredXMLNode(root_node, search_paths))
+        {
+            LLXUIParser parser;
+            parser.readXUI(root_node, block, base_filename);
+        }
+        else
         {
             LL_WARNS() << "Couldn't parse widget from: " << base_filename << LL_ENDL;
-            return;
         }
-        LLXUIParser parser;
-        parser.readXUI(root_node, block, base_filename);
-        LLUICtrlFactory::instance().popFileName();
+        factory->mFileNames.pop_back();
     }
 }
 


### PR DESCRIPTION
## Description

base_filename is already an absolute path that was resolved in findSkinnedFilenames() above but the pushFileName() method tries to do the same again, resulting in an invalid path (the skin directory path is prepended twice)

This went until now undetected since the gDir->fileExists() method used was configured to ignore ENOENT errors but the new std::filesystem based file detection routines in the other PR detect that the filename is invalid before trying to do any actual disk access and report an according Invalid Argument error instead.

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] I have tested the changes locally and verified they work as intended.
- [x] Code follows the project's style guidelines.
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
