### PR TITLE
#5000 clear duplicate shortcut used to activate Sunrise

### DIFF
--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -3364,8 +3364,7 @@ function="World.EnvPreset"
             </menu_item_check>
             <menu_item_check
              label="Object-Object Occlusion"
-             name="Object-Object Occlusion"
-             shortcut="control|shift|O">
+             name="Object-Object Occlusion">
                 <menu_item_check.on_check
                  function="CheckControl"
                  parameter="UseOcclusion" />


### PR DESCRIPTION
ctrl+shift+O was used both for activating Sunrise and toggling Object-Object Occlusion setting.