### PR TITLE
#4951 Update bugsplat symbol upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -362,8 +362,9 @@ jobs:
 
   post-windows-symbols:
     env:
-      BUGSPLAT_USER: ${{ secrets.BUGSPLAT_USER }}
-      BUGSPLAT_PASS: ${{ secrets.BUGSPLAT_PASS }}
+      BUGSPLAT_DATABASE: "${{ secrets.BUGSPLAT_DATABASE }}"
+      SYMBOL_UPLOAD_CLIENT_ID: "${{ secrets.BUGSPLAT_SYMBOL_UPLOAD_CLIENT_ID }}"
+      SYMBOL_UPLOAD_CLIENT_SECRET: "${{ secrets.BUGSPLAT_SYMBOL_UPLOAD_CLIENT_SECRET }}"
     needs: build
     if: needs.build.outputs.configuration == 'Release'
     runs-on: ubuntu-latest
@@ -374,51 +375,56 @@ jobs:
           name: Windows-app
           path: _artifacts
       - name: Download Windows Symbols
-        if: env.BUGSPLAT_USER && env.BUGSPLAT_PASS
+        if: env.BUGSPLAT_DATABASE && env.SYMBOL_UPLOAD_CLIENT_ID
         uses: actions/download-artifact@v4
         with:
           name: Windows-symbols
       - name: Extract viewer pdb
-        if: env.BUGSPLAT_USER && env.BUGSPLAT_PASS
+        if: env.BUGSPLAT_DATABASE && env.SYMBOL_UPLOAD_CLIENT_ID
         shell: bash
         run: |
           tar -xJf "${{ needs.build.outputs.viewer_channel }}.sym.tar.xz" -C _artifacts
       - name: Post Windows symbols
-        if: env.BUGSPLAT_USER && env.BUGSPLAT_PASS
-        uses: secondlife-3p/symbol-upload@v10
+        if: env.BUGSPLAT_DATABASE && env.SYMBOL_UPLOAD_CLIENT_ID
+        uses: BugSplat-Git/symbol-upload@095d163ae9ceb006d286a731dcd35cf6a1b458c8
         with:
-          username: ${{ env.BUGSPLAT_USER }}
-          password: ${{ env.BUGSPLAT_PASS }}
-          database: "SecondLife_Viewer_2018"
+          clientId: "${{ env.SYMBOL_UPLOAD_CLIENT_ID }}"
+          clientSecret: "${{ env.SYMBOL_UPLOAD_CLIENT_SECRET }}"
+          database: "${{ env.BUGSPLAT_DATABASE }}"
           application: ${{ needs.build.outputs.viewer_channel }}
           version: ${{ needs.build.outputs.viewer_version }}
           directory: _artifacts
           files: "**/{SecondLifeViewer.exe,llwebrtc.dll,*.pdb}"
+          node-version: "22"
+          dumpSyms: false
 
   post-mac-symbols:
     env:
-      BUGSPLAT_USER: ${{ secrets.BUGSPLAT_USER }}
-      BUGSPLAT_PASS: ${{ secrets.BUGSPLAT_PASS }}
+      BUGSPLAT_DATABASE: "${{ secrets.BUGSPLAT_DATABASE }}"
+      SYMBOL_UPLOAD_CLIENT_ID: "${{ secrets.BUGSPLAT_SYMBOL_UPLOAD_CLIENT_ID }}"
+      SYMBOL_UPLOAD_CLIENT_SECRET: "${{ secrets.BUGSPLAT_SYMBOL_UPLOAD_CLIENT_SECRET }}"
     needs: build
     if: needs.build.outputs.configuration == 'Release'
     runs-on: ubuntu-latest
     steps:
       - name: Download Mac Symbols
-        if: env.BUGSPLAT_USER && env.BUGSPLAT_PASS
+        if: env.BUGSPLAT_DATABASE && env.SYMBOL_UPLOAD_CLIENT_ID
         uses: actions/download-artifact@v4
         with:
           name: macOS-symbols
       - name: Post Mac symbols
-        if: env.BUGSPLAT_USER && env.BUGSPLAT_PASS
-        uses: secondlife-3p/symbol-upload@v10
+        if: env.BUGSPLAT_DATABASE && env.SYMBOL_UPLOAD_CLIENT_ID
+        uses: BugSplat-Git/symbol-upload@095d163ae9ceb006d286a731dcd35cf6a1b458c8
         with:
-          username: ${{ env.BUGSPLAT_USER }}
-          password: ${{ env.BUGSPLAT_PASS }}
-          database: "SecondLife_Viewer_2018"
+          clientId: "${{ env.SYMBOL_UPLOAD_CLIENT_ID }}"
+          clientSecret: "${{ env.SYMBOL_UPLOAD_CLIENT_SECRET }}"
+          database: "${{ env.BUGSPLAT_DATABASE }}"
           application: ${{ needs.build.outputs.viewer_channel }}
           version: ${{ needs.build.outputs.viewer_version }} (${{ needs.build.outputs.viewer_version }})
           directory: .
           files: "**/*.xcarchive.zip"
+          node-version: "22"
+          dumpSyms: false
 
   release:
     needs: [setup, build, sign-and-package-windows, sign-and-package-mac]


### PR DESCRIPTION
Bugsplat deprecates old auth and we need to update.
Bugsplat's 'client id' page lists application separately, hopefully we don't need separate secrets for test/release/develop/project.