### PR TITLE
Move 'DetectedEvent' in the lua types xml to classes

### DIFF
--- a/indra/newview/app_settings/types_lua_default.xml
+++ b/indra/newview/app_settings/types_lua_default.xml
@@ -69,38 +69,6 @@
       </map>
       <map>
         <key>name</key>
-        <string>DetectedEvent</string>
-        <key>definition</key>
-        <map>
-          <key>kind</key>
-          <string>table</string>
-          <key>properties</key>
-          <array>
-            <map>
-              <key>name</key>
-              <string>valid</string>
-              <key>type</key>
-              <string>boolean</string>
-            </map>
-            <map>
-              <key>name</key>
-              <string>index</string>
-              <key>type</key>
-              <string>number</string>
-            </map>
-            <map>
-              <key>name</key>
-              <string>can_change_damage</string>
-              <key>type</key>
-              <string>boolean</string>
-            </map>
-          </array>
-          <key>methods</key>
-          <array />
-        </map>
-      </map>
-      <map>
-        <key>name</key>
         <string>DetectedEventName</string>
         <key>definition</key>
         <map>
@@ -824,6 +792,33 @@
             <string>negate a vector</string>
           </map>
         </array>
+      </map>
+      <map>
+        <key>name</key>
+        <string>DetectedEvent</string>
+        <key>properties</key>
+        <array>
+          <map>
+            <key>name</key>
+            <string>valid</string>
+            <key>type</key>
+            <string>boolean</string>
+          </map>
+          <map>
+            <key>name</key>
+            <string>index</string>
+            <key>type</key>
+            <string>number</string>
+          </map>
+          <map>
+            <key>name</key>
+            <string>can_change_damage</string>
+            <key>type</key>
+            <string>boolean</string>
+          </map>
+        </array>
+        <key>methods</key>
+        <array />
       </map>
     </array>
     <key>globalVariables</key>


### PR DESCRIPTION
## Description

Moves the `DetectedEvent` for slua in the types xml to the classes section, as required for https://github.com/secondlife/sl-vscode-plugin/issues/3 

## Related Issues

 - https://github.com/secondlife/sl-vscode-plugin/issues/3

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

Unsure about tests,  don't think there are any.

---

## Additional Notes

This should have no real impact on the viewer itself, as the file is only loaded to be served over the web socket created for the vscode extension.
