### PR TITLE
Add missing eventName parameter in default lua types xml

### DIFF
--- a/indra/newview/app_settings/types_lua_default.xml
+++ b/indra/newview/app_settings/types_lua_default.xml
@@ -261,6 +261,12 @@
                 </map>
                 <map>
                   <key>name</key>
+                  <string>eventName</string>
+                  <key>type</key>
+                  <string>EventName</string>
+                </map>
+                <map>
+                  <key>name</key>
                   <string>handler</string>
                   <key>type</key>
                   <string>EventHandler</string>


### PR DESCRIPTION
## Description

Added a missing property to the lua types xml, for the slua `LLEvents:off` method

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Should have no effect on main viewer this file is, for now, purely for serving over the web socket.