### PR TITLE
#4651 Improve session shutdown detection

### DIFF
--- a/indra/llwindow/llwindowwin32.cpp
+++ b/indra/llwindow/llwindowwin32.cpp
@@ -2502,16 +2502,13 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
             // Comes after WM_QUERYENDSESSION
             LL_PROFILE_ZONE_NAMED_CATEGORY_WIN32("mwp - WM_ENDSESSION");
             LL_INFOS("Window") << "Received WM_ENDSESSION with wParam: " << (U32)w_param << " lParam: " << (U32)l_param << LL_ENDL;
-            unsigned int end_session_flags = (U32)w_param;
-            if (end_session_flags == 0)
-            {
-                // session is not actually ending
-                return 0;
-            }
+            unsigned int end_session_flags = (U32)l_param;
 
-            if ((end_session_flags & ENDSESSION_CLOSEAPP)
-                || (end_session_flags & ENDSESSION_CRITICAL)
-                || (end_session_flags & ENDSESSION_LOGOFF))
+            if (w_param == TRUE // if true, session is ending
+                || end_session_flags == 0 // not possible to determine type of the event
+                // || (end_session_flags & ENDSESSION_CLOSEAPP)) system update or low resources, must be acompanied by w_param == TRUE
+                || (end_session_flags & ENDSESSION_CRITICAL) // will shutdown regardless of app state
+                || (end_session_flags & ENDSESSION_LOGOFF)) // logoff, can delay shutdown
             {
                 window_imp->post([=]()
                 {
@@ -2520,13 +2517,13 @@ LRESULT CALLBACK LLWindowWin32::mainWindowProc(HWND h_wnd, UINT u_msg, WPARAM w_
                     {
                         // Get the app to initiate cleanup.
                         window_imp->mCallbacks->handleQuit(window_imp);
-                        // The app is responsible for calling destroyWindow when done with GL
                     }
                 });
                 // Give app a second to finish up. That's not enough for a clean exit,
                 // but better than nothing.
                 // Todo: sync this better, some kind of waitForResult? Can't wait forever,
-                // but can potentially use ShutdownBlockReasonCreate for a bigger delay.
+                // but for ENDSESSION_LOGOFF can potentially use ShutdownBlockReasonCreate
+                // for a bigger delay.
                 ms_sleep(1000);
             }
             // Don't need to post quit or destroy window,


### PR DESCRIPTION
Not sure how I managed to mix up values, but state should have been L value, not W.

if wParam is true, session is ending, if lparam is 0 - it's restart or shutdown regardless of wParam, same for two other covered states.
The odd one is ENDSESSION_CLOSEAPP since it can come with wParam == false, in which case it should not terminate.