### PR TITLE
#5012 Switch 'chat' from untrusted, to click only

### DIFF
--- a/indra/newview/llfloaterimnearbychat.cpp
+++ b/indra/newview/llfloaterimnearbychat.cpp
@@ -907,7 +907,7 @@ class LLChatCommandHandler : public LLCommandHandler
 {
 public:
     // not allowed from outside the app
-    LLChatCommandHandler() : LLCommandHandler("chat", UNTRUSTED_BLOCK) { }
+    LLChatCommandHandler() : LLCommandHandler("chat", UNTRUSTED_CLICK_ONLY) { }
 
     // Your code here
     bool handle(const LLSD& tokens,


### PR DESCRIPTION
This command shouldn't be allowed from outside the app, but clicks should be valid