### PR TITLE
Minimal fix for ctd in lua_editor viewer #5031

### DIFF
--- a/indra/llcorehttp/llwebsocketmgr.cpp
+++ b/indra/llcorehttp/llwebsocketmgr.cpp
@@ -208,15 +208,29 @@ struct Server_impl
     void init()
     {
         mServer.init_asio();
-        if (mLocalOnly)
-        {
-            std::stringstream port_str;
-            port_str << mPort;
-            mServer.listen("127.0.0.1", port_str.str());
+        try {
+            if (mLocalOnly)
+            {
+                std::stringstream port_str;
+                port_str << mPort;
+                mServer.listen("127.0.0.1", port_str.str());
+            }
+            else
+            {
+                mServer.listen(mPort);
+            }
         }
-        else
+        catch (const websocketpp::exception& e)
         {
-            mServer.listen(mPort);
+            LL_WARNS("WebSocket") << "WebSocket server listen exception: " << e.what() << LL_ENDL;
+        }
+        catch (const std::exception& e)
+        {
+            LL_WARNS("WebSocket") << "WebSocket server listen std::exception: " << e.what() << LL_ENDL;
+        }
+        catch (...)
+        {
+            LL_WARNS("WebSocket") << "WebSocket server listen unknown exception" << LL_ENDL;
         }
     }
 


### PR DESCRIPTION
## Description

Adds a try catch around the step to setup the listen for the websocket, preventing crash when port is in use.

## Related Issues

- Relates to #5031

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

This should probably not be the final version of handling this error, as it is silent to the user. But as there are plans to go main grid today, it'd be nice to at least prevent crashed for people that are on main and beta grid, moving content.