### PR TITLE
Add missing LLEvents:once to lua_types xml

### DIFF
--- a/indra/newview/app_settings/types_lua_default.xml
+++ b/indra/newview/app_settings/types_lua_default.xml
@@ -252,6 +252,59 @@
             </map>
             <map>
               <key>name</key>
+              <string>once</string>
+              <key>parameters</key>
+              <array>
+                <map>
+                  <key>name</key>
+                  <string>self</string>
+                </map>
+                <map>
+                  <key>name</key>
+                  <string>eventName</string>
+                  <key>type</key>
+                  <string>DetectedEventName</string>
+                </map>
+                <map>
+                  <key>name</key>
+                  <string>handler</string>
+                  <key>type</key>
+                  <string>DetectedEventHandler</string>
+                </map>
+              </array>
+              <key>returnType</key>
+              <string>EventHandler</string>
+              <key>overloads</key>
+              <array>
+                <map>
+                  <key>name</key>
+                  <string>once</string>
+                  <key>parameters</key>
+                  <array>
+                    <map>
+                      <key>name</key>
+                      <string>self</string>
+                    </map>
+                    <map>
+                      <key>name</key>
+                      <string>eventName</string>
+                      <key>type</key>
+                      <string>NonDetectedEventName</string>
+                    </map>
+                    <map>
+                      <key>name</key>
+                      <string>handler</string>
+                      <key>type</key>
+                      <string>EventHandler</string>
+                    </map>
+                  </array>
+                  <key>returnType</key>
+                  <string>EventHandler</string>
+                </map>
+              </array>
+            </map>
+            <map>
+              <key>name</key>
               <string>off</string>
               <key>parameters</key>
               <array>


### PR DESCRIPTION
## Description

Adds the `LLEvents:once` method that was missing from the lua types xml

A matching pr to the vscode plugin has been made https://github.com/secondlife/sl-vscode-plugin/pull/18

## Related Issues

n/a

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

As with #5022 #5015 this should have no impact on the viewer itself.