### PR TITLE
Prevent the creation of temporary objects that will be discarded.

### DIFF
--- a/indra/newview/llpathfindingnavmesh.cpp
+++ b/indra/newview/llpathfindingnavmesh.cpp
@@ -139,7 +139,8 @@ void LLPathfindingNavMesh::handleNavMeshResult(const LLSD &pContent, U32 pNavMes
         ENavMeshRequestStatus status;
         if ( pContent.has(NAVMESH_DATA_FIELD) )
         {
-            const LLSD::Binary &value = pContent.get(NAVMESH_DATA_FIELD).asBinary();
+            LLSD nav_data = pContent.get(NAVMESH_DATA_FIELD);
+            const LLSD::Binary& value = nav_data.asBinary();
             auto binSize = value.size();
             std::string newStr(reinterpret_cast<const char *>(&value[0]), binSize);
             std::istringstream streamdecomp( newStr );


### PR DESCRIPTION
By returning the actual object instead of the temporary object's LLSD, we prevent reading undefined areas.