### PR TITLE
[#5038] Fixed LLWindowMacOSX::setCursorPosition scaling gl_pos when it shouldn't

### DIFF
--- a/indra/llwindow/llwindowmacosx.cpp
+++ b/indra/llwindow/llwindowmacosx.cpp
@@ -1259,9 +1259,6 @@ bool LLWindowMacOSX::setCursorPosition(const LLCoordWindow position)
     // trigger mouse move callback
     LLCoordGL gl_pos;
     convertCoords(position, &gl_pos);
-    float scale = getSystemUISize();
-    gl_pos.mX *= scale;
-    gl_pos.mY *= scale;
     mCallbacks->handleMouseMove(this, gl_pos, (MASK)0);
 
     return result;


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5038

Fixes the above issue by simply removing the scaling on gl_pos in LLWindowMacOSX::setCursorPosition, so that way the saveLastMouse call inside handleMouseMove, sets the correct mouse position and matches other calls that set the mouse position.