### PR TITLE
Introduce menu option and key bind(alt+shift+t) to hide transparent reflection probes

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9020,6 +9020,17 @@
     <key>Value</key>
     <integer>16</integer>
   </map>
+    <key>RenderReflectionProbeShowTransparent</key>
+    <map>
+        <key>Comment</key>
+        <string>Show reflection probes in the transparency debug view</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>1</integer>
+    </map>
     <key>RenderReflectionProbeVolumes</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -8999,6 +8999,17 @@ class LLViewHighlightTransparent : public view_listener_t
     }
 };
 
+class LLViewHighlightTransparentProbe : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        gSavedSettings.setBOOL("RenderReflectionProbeShowTransparent", !gSavedSettings.getBOOL("RenderReflectionProbeShowTransparent"));
+        // invisible objects skip building their render batches unless sShowDebugAlpha is true, so rebuild batches whenever toggling this flag
+        gPipeline.rebuildDrawInfo();
+        return true;
+    }
+};
+
 class LLViewCheckHighlightTransparent : public view_listener_t
 {
     bool handleEvent(const LLSD& userdata)
@@ -9742,6 +9753,7 @@ void initialize_menus()
     view_listener_t::addMenu(new LLViewLookAtLastChatter(), "View.LookAtLastChatter");
     view_listener_t::addMenu(new LLViewShowHoverTips(), "View.ShowHoverTips");
     view_listener_t::addMenu(new LLViewHighlightTransparent(), "View.HighlightTransparent");
+    view_listener_t::addMenu(new LLViewHighlightTransparentProbe(), "View.HighlightTransparentProbe");
     view_listener_t::addMenu(new LLViewToggleRenderType(), "View.ToggleRenderType");
     view_listener_t::addMenu(new LLViewShowHUDAttachments(), "View.ShowHUDAttachments");
     view_listener_t::addMenu(new LLZoomer(1.2f), "View.ZoomOut");

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5911,6 +5911,7 @@ void LLVolumeGeometryManager::rebuildGeom(LLSpatialGroup* group)
                         }
                         else
                         {
+                            static LLCachedControl<bool> render_reflection_object(gSavedSettings, "RenderReflectionProbeShowTransparent", false);
                             F32 alpha;
                             if (is_pbr)
                             {
@@ -5925,7 +5926,7 @@ void LLVolumeGeometryManager::rebuildGeom(LLSpatialGroup* group)
                                 drawablep->setState(LLDrawable::HAS_ALPHA);
                                 add_face(sAlphaFaces, alpha_count, facep);
                             }
-                            else if (LLDrawPoolAlpha::sShowDebugAlpha ||
+                            else if ((LLDrawPoolAlpha::sShowDebugAlpha && (render_reflection_object || !vobj->isReflectionProbe())) ||
                                 (gPipeline.sRenderHighlight && !drawablep->getParent() &&
                                 //only root objects are highlighted with red color in this case
                                 drawablep->getVObj() && drawablep->getVObj()->flagScripted() &&

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -1556,6 +1556,18 @@ function="World.EnvPreset"
                   <menu_item_check.on_click
                    function="View.HighlightTransparent" />
                 </menu_item_check>
+                <menu_item_check
+                   label="Highlight Transparent Probes"
+                   name="Highlight Transparent Probes"
+                   shortcut="alt|shift|T">
+                  <menu_item_check.on_check
+                   function="CheckControl"
+                   parameter="RenderReflectionProbeShowTransparent" />
+                  <menu_item_check.on_click
+                   function="View.HighlightTransparentProbe" />
+                  <menu_item_check.on_enable
+                   function="View.CheckHighlightTransparent"/>
+                </menu_item_check>
         <menu_item_separator/>
           
           <menu_item_check


### PR DESCRIPTION
## Description

Introduces a menu option `Highlight Transparent Probes` and a keybind `ALT+SHIFT+T` to show/hide reflection probes in the transparency debug view

## Related Issues

https://feedback.secondlife.com/feature-requests/p/pbr-hide-probes-from-highlight-transparent-when-selection-is-off

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
