### PR TITLE
Migrate sky/cloud rendering to fragment shader and introduce high precision post process option

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10118,6 +10118,17 @@
         <key>Value</key>
         <integer>1</integer>
     </map>
+    <key>RenderHighPrecisionPostProcess</key>
+    <map>
+        <key>Comment</key>
+        <string>Use 16-bit floating point buffers for post process rendering</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>Boolean</string>
+        <key>Value</key>
+        <integer>0</integer>
+    </map>
     <key>ReplaySession</key>
     <map>
       <key>Comment</key>
@@ -13851,7 +13862,7 @@
     <key>WLSkyDetail</key>
     <map>
       <key>Comment</key>
-      <string>Controls vertex detail on the WindLight sky.  Lower numbers will give better performance and uglier skies.</string>
+      <string>[OBSOLETE]</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/cloudsF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/cloudsF.glsl
@@ -30,9 +30,13 @@ out vec4 frag_data[4];
 // The fragment shader for the sky
 /////////////////////////////////////////////////////////////////////////
 
-in vec3 vary_CloudColorSun;
-in vec3 vary_CloudColorAmbient;
-in float vary_CloudDensity;
+// In
+in vec3 pos;
+
+in vec2 vary_texcoord0;
+in vec2 vary_texcoord1;
+in vec2 vary_texcoord2;
+in vec2 vary_texcoord3;
 
 uniform sampler2D cloud_noise_texture;
 uniform sampler2D cloud_noise_texture_next;
@@ -42,11 +46,26 @@ uniform vec3 cloud_pos_density2;
 uniform float cloud_scale;
 uniform float cloud_variance;
 
-in vec2 vary_texcoord0;
-in vec2 vary_texcoord1;
-in vec2 vary_texcoord2;
-in vec2 vary_texcoord3;
-in float altitude_blend_factor;
+uniform vec3 camPosLocal;
+
+uniform vec3 lightnorm;
+uniform vec3 sunlight_color;
+uniform vec3 moonlight_color;
+uniform int sun_up_factor;
+uniform vec3 ambient_color;
+uniform vec3 blue_horizon;
+uniform vec3 blue_density;
+uniform float haze_horizon;
+uniform float haze_density;
+
+uniform float cloud_shadow;
+uniform float density_multiplier;
+uniform float max_y;
+
+uniform vec3 glow;
+uniform float sun_moon_glow_factor;
+
+uniform vec3 cloud_color;
 
 vec4 cloudNoise(vec2 uv)
 {
@@ -58,21 +77,111 @@ vec4 cloudNoise(vec2 uv)
 
 void main()
 {
-    // Set variables
-    vec2 uv1 = vary_texcoord0.xy;
-    vec2 uv2 = vary_texcoord1.xy;
-
-    vec3 cloudColorSun = vary_CloudColorSun;
-    vec3 cloudColorAmbient = vary_CloudColorAmbient;
-    float cloudDensity = vary_CloudDensity;
-    vec2 uv3 = vary_texcoord2.xy;
-    vec2 uv4 = vary_texcoord3.xy;
-
     if (cloud_scale < 0.001)
     {
         discard;
     }
 
+    // Set variables
+    vec2 uv1 = vary_texcoord0.xy;
+    vec2 uv2 = vary_texcoord1.xy;
+    vec2 uv3 = vary_texcoord2.xy;
+    vec2 uv4 = vary_texcoord3.xy;
+
+    // Get relative position
+    vec3 rel_pos = pos.xyz - camPosLocal.xyz + vec3(0, 50, 0);
+
+    float altitude_blend_factor = clamp((rel_pos.y + 512.0) / max_y, 0.0, 1.0);
+
+    // Set altitude
+    if (rel_pos.y > 0)
+    {
+        rel_pos *= (max_y / rel_pos.y);
+    }
+    if (rel_pos.y < 0)
+    {
+        altitude_blend_factor = 0; // SL-11589 Fix clouds drooping below horizon
+        rel_pos *= (-32000. / rel_pos.y);
+    }
+
+    // Can normalize then
+    vec3  rel_pos_norm = normalize(rel_pos);
+    float rel_pos_len  = length(rel_pos);
+
+    // Initialize temp variables
+    vec3 sunlight = sunlight_color;
+    vec3 light_atten;
+
+    // Sunlight attenuation effect (hue and brightness) due to atmosphere
+    // this is used later for sunlight modulation at various altitudes
+    light_atten = (blue_density + vec3(haze_density * 0.25)) * (density_multiplier * max_y);
+
+    // Calculate relative weights
+    vec3 combined_haze = abs(blue_density) + vec3(abs(haze_density));
+    vec3 blue_weight   = blue_density / combined_haze;
+    vec3 haze_weight   = haze_density / combined_haze;
+
+    // Compute sunlight from rel_pos & lightnorm (for long rays like sky)
+    float off_axis = 1.0 / max(1e-6, max(0., rel_pos_norm.y) + lightnorm.y);
+    sunlight *= exp(-light_atten * off_axis);
+
+    // Distance
+    float density_dist = rel_pos_len * density_multiplier;
+
+    // Transparency (-> combined_haze)
+    // ATI Bugfix -- can't store combined_haze*density_dist in a variable because the ati
+    // compiler gets confused.
+    combined_haze = exp(-combined_haze * density_dist);
+
+    // Compute haze glow
+    float haze_glow = 1.0 - dot(rel_pos_norm, lightnorm.xyz);
+    // haze_glow is 0 at the sun and increases away from sun
+    haze_glow = max(haze_glow, .001);
+    // Set a minimum "angle" (smaller glow.y allows tighter, brighter hotspot)
+    haze_glow *= glow.x;
+    // Higher glow.x gives dimmer glow (because next step is 1 / "angle")
+    haze_glow = pow(haze_glow, glow.z);
+    // glow.z should be negative, so we're doing a sort of (1 / "angle") function
+
+    haze_glow *= sun_moon_glow_factor;
+
+    // Add "minimum anti-solar illumination"
+    // For sun, add to glow.  For moon, remove glow entirely. SL-13768
+    haze_glow = (sun_moon_glow_factor < 1.0) ? 0.0 : (haze_glow + 0.25);
+
+    // Increase ambient when there are more clouds
+    vec3 tmpAmbient = ambient_color;
+    tmpAmbient += (1. - tmpAmbient) * cloud_shadow * 0.5;
+
+    // Dim sunlight by cloud shadow percentage
+    sunlight *= (1. - cloud_shadow);
+
+    // Haze color below cloud
+    vec3 additiveColorBelowCloud =
+        (blue_horizon * blue_weight * (sunlight + tmpAmbient) + (haze_horizon * haze_weight) * (sunlight * haze_glow + tmpAmbient));
+
+    // CLOUDS
+    sunlight = sunlight_color;
+    off_axis = 1.0 / max(1e-6, lightnorm.y * 2.);
+    sunlight *= exp(-light_atten * off_axis);
+
+    // Cloud color out
+    vec3 cloudColorSun = (sunlight * haze_glow) * cloud_color;
+    vec3 cloudColorAmbient = tmpAmbient * cloud_color;
+
+    // Attenuate cloud color by atmosphere
+    combined_haze = sqrt(combined_haze);  // less atmos opacity (more transparency) below clouds
+    cloudColorSun *= combined_haze;
+    cloudColorAmbient *= combined_haze;
+    vec3 oHazeColorBelowCloud = additiveColorBelowCloud * (1. - combined_haze);
+
+    // Make a nice cloud density based on the cloud_shadow value that was passed in.
+    float cloudDensity = 2. * (cloud_shadow - 0.25);
+
+    // Combine these to minimize register use
+    cloudColorAmbient += oHazeColorBelowCloud;
+
+    // Cloud Fragment
     vec2 disturbance  = vec2(cloudNoise(uv1 / 8.0f).x, cloudNoise((uv3 + uv1) / 16.0f).x) * cloud_variance * (1.0f - cloud_scale * 0.25f);
     vec2 disturbance2 = vec2(cloudNoise((uv1 + uv3) / 4.0f).x, cloudNoise((uv4 + uv2) / 8.0f).x) * cloud_variance * (1.0f - cloud_scale * 0.25f);
 

--- a/indra/newview/app_settings/shaders/class1/deferred/cloudsV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/cloudsV.glsl
@@ -1,5 +1,5 @@
 /**
- * @file WLCloudsV.glsl
+ * @file class1/deferred/cloudsV.glsl
  *
  * $LicenseInfo:firstyear=2005&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -33,38 +33,15 @@ in vec2 texcoord0;
 ///////////////////////////////////////////////////////////////////////////////
 
 // Output parameters
-out vec3 vary_CloudColorSun;
-out vec3 vary_CloudColorAmbient;
-out float vary_CloudDensity;
+out vec3 pos;
 
 out vec2 vary_texcoord0;
 out vec2 vary_texcoord1;
 out vec2 vary_texcoord2;
 out vec2 vary_texcoord3;
-out float altitude_blend_factor;
 
 // Inputs
-uniform vec3 camPosLocal;
-
 uniform vec3 lightnorm;
-uniform vec3 sunlight_color;
-uniform vec3 moonlight_color;
-uniform int sun_up_factor;
-uniform vec3 ambient_color;
-uniform vec3 blue_horizon;
-uniform vec3 blue_density;
-uniform float haze_horizon;
-uniform float haze_density;
-
-uniform float cloud_shadow;
-uniform float density_multiplier;
-uniform float max_y;
-
-uniform vec3 glow;
-uniform float sun_moon_glow_factor;
-
-uniform vec3 cloud_color;
-
 uniform float cloud_scale;
 
 // NOTE: Keep these in sync!
@@ -76,6 +53,7 @@ uniform float cloud_scale;
 void main()
 {
     // World / view / projection
+    pos = position.xyz;
     gl_Position = modelview_projection_matrix * vec4(position.xyz, 1.0);
 
     // Texture coords
@@ -92,102 +70,4 @@ void main()
 
     vary_texcoord2 = vary_texcoord0 * 16.;
     vary_texcoord3 = vary_texcoord1 * 16.;
-
-    // Get relative position
-    vec3 rel_pos = position.xyz - camPosLocal.xyz + vec3(0, 50, 0);
-
-    altitude_blend_factor = clamp((rel_pos.y + 512.0) / max_y, 0.0, 1.0);
-
-    // Set altitude
-    if (rel_pos.y > 0)
-    {
-        rel_pos *= (max_y / rel_pos.y);
-    }
-    if (rel_pos.y < 0)
-    {
-        altitude_blend_factor = 0; // SL-11589 Fix clouds drooping below horizon
-        rel_pos *= (-32000. / rel_pos.y);
-    }
-
-    // Can normalize then
-    vec3  rel_pos_norm = normalize(rel_pos);
-    float rel_pos_len  = length(rel_pos);
-
-    // Initialize temp variables
-    vec3 sunlight = sunlight_color;
-    vec3 light_atten;
-
-    // Sunlight attenuation effect (hue and brightness) due to atmosphere
-    // this is used later for sunlight modulation at various altitudes
-    light_atten = (blue_density + vec3(haze_density * 0.25)) * (density_multiplier * max_y);
-
-    // Calculate relative weights
-    vec3 combined_haze = abs(blue_density) + vec3(abs(haze_density));
-    vec3 blue_weight   = blue_density / combined_haze;
-    vec3 haze_weight   = haze_density / combined_haze;
-
-    // Compute sunlight from rel_pos & lightnorm (for long rays like sky)
-    float off_axis = 1.0 / max(1e-6, max(0., rel_pos_norm.y) + lightnorm.y);
-    sunlight *= exp(-light_atten * off_axis);
-
-    // Distance
-    float density_dist = rel_pos_len * density_multiplier;
-
-    // Transparency (-> combined_haze)
-    // ATI Bugfix -- can't store combined_haze*density_dist in a variable because the ati
-    // compiler gets confused.
-    combined_haze = exp(-combined_haze * density_dist);
-
-    // Compute haze glow
-    float haze_glow = 1.0 - dot(rel_pos_norm, lightnorm.xyz);
-    // haze_glow is 0 at the sun and increases away from sun
-    haze_glow = max(haze_glow, .001);
-        // Set a minimum "angle" (smaller glow.y allows tighter, brighter hotspot)
-    haze_glow *= glow.x;
-        // Higher glow.x gives dimmer glow (because next step is 1 / "angle")
-    haze_glow = pow(haze_glow, glow.z);
-        // glow.z should be negative, so we're doing a sort of (1 / "angle") function
-
-    haze_glow *= sun_moon_glow_factor;
-
-    // Add "minimum anti-solar illumination"
-    // For sun, add to glow.  For moon, remove glow entirely. SL-13768
-    haze_glow = (sun_moon_glow_factor < 1.0) ? 0.0 : (haze_glow + 0.25);
-
-    // Increase ambient when there are more clouds
-    vec3 tmpAmbient = ambient_color;
-    tmpAmbient += (1. - tmpAmbient) * cloud_shadow * 0.5;
-
-    // Dim sunlight by cloud shadow percentage
-    sunlight *= (1. - cloud_shadow);
-
-    // Haze color below cloud
-    vec3 additiveColorBelowCloud =
-        (blue_horizon * blue_weight * (sunlight + tmpAmbient) + (haze_horizon * haze_weight) * (sunlight * haze_glow + tmpAmbient));
-
-    // CLOUDS
-    sunlight = sunlight_color;
-    off_axis = 1.0 / max(1e-6, lightnorm.y * 2.);
-    sunlight *= exp(-light_atten * off_axis);
-
-    // Cloud color out
-    vary_CloudColorSun     = (sunlight * haze_glow) * cloud_color;
-    vary_CloudColorAmbient = tmpAmbient * cloud_color;
-
-    // Attenuate cloud color by atmosphere
-    combined_haze = sqrt(combined_haze);  // less atmos opacity (more transparency) below clouds
-    vary_CloudColorSun *= combined_haze;
-    vary_CloudColorAmbient *= combined_haze;
-    vec3 oHazeColorBelowCloud = additiveColorBelowCloud * (1. - combined_haze);
-
-    // Make a nice cloud density based on the cloud_shadow value that was passed in.
-    vary_CloudDensity = 2. * (cloud_shadow - 0.25);
-
-    // Combine these to minimize register use
-    vary_CloudColorAmbient += oHazeColorBelowCloud;
-
-    // needs this to compile on mac
-    //vary_AtmosAttenuation = vec3(0.0,0.0,0.0);
-
-    // END CLOUDS
 }

--- a/indra/newview/app_settings/shaders/class1/deferred/skyF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/skyF.glsl
@@ -23,13 +23,14 @@
  * $/LicenseInfo$
  */
 
+// Outputs
+out vec4 frag_data[4];
+
 // Inputs
-in vec3 vary_HazeColor;
-in float vary_LightNormPosDot;
+in vec3 pos;
 
 #ifdef HAS_HDRI
 in vec4 vary_position;
-in vec3 vary_rel_pos;
 uniform float sky_hdr_scale;
 uniform float hdri_split_screen;
 uniform mat3 env_mat;
@@ -43,7 +44,27 @@ uniform float moisture_level;
 uniform float droplet_radius;
 uniform float ice_level;
 
-out vec4 frag_data[4];
+uniform vec3 camPosLocal;
+
+uniform vec3  lightnorm;
+uniform vec3  sunlight_color;
+uniform vec3  moonlight_color;
+uniform int   sun_up_factor;
+uniform vec3  ambient_color;
+uniform vec3  blue_horizon;
+uniform vec3  blue_density;
+uniform float haze_horizon;
+uniform float haze_density;
+
+uniform float cloud_shadow;
+uniform float density_multiplier;
+uniform float distance_multiplier;
+uniform float max_y;
+
+uniform vec3  glow;
+uniform float sun_moon_glow_factor;
+
+uniform int cube_snapshot;
 
 vec3 srgb_to_linear(vec3 c);
 vec3 linear_to_srgb(vec3 c);
@@ -83,12 +104,25 @@ vec3 halo22(float d)
 
 void main()
 {
+    // Get relative position
+    vec3 rel_pos = pos.xyz - camPosLocal.xyz + vec3(0, 50, 0);
+
+    // Adj position vector to clamp altitude
+    if (rel_pos.y > 0.)
+    {
+        rel_pos *= (max_y / rel_pos.y);
+    }
+    if (rel_pos.y < 0.)
+    {
+        rel_pos *= (-32000. / rel_pos.y);
+    }
+
     vec3 color;
 #ifdef HAS_HDRI
     vec3 frag_coord = vary_position.xyz/vary_position.w;
     if (-frag_coord.x > ((1.0-hdri_split_screen)*2.0-1.0))
     {
-        vec3 pos = normalize(vary_rel_pos);
+        vec3 pos = normalize(rel_pos);
         pos = env_mat * pos;
         vec2 texCoord = vec2(atan(pos.z, pos.x) + PI, acos(pos.y)) / vec2(2.0 * PI, PI);
         color = textureLod(environmentMap, texCoord.xy, 0).rgb * sky_hdr_scale;
@@ -99,15 +133,75 @@ void main()
     else
 #endif
     {
-        // Potential Fill-rate optimization.  Add cloud calculation
-        // back in and output alpha of 0 (so that alpha culling kills
-        // the fragment) if the sky wouldn't show up because the clouds
-        // are fully opaque.
+        // Normalized
+        vec3  rel_pos_norm = normalize(rel_pos);
+        float rel_pos_len  = length(rel_pos);
 
-        color = vary_HazeColor;
+        // Grab this value and pass to frag shader for rainbows
+        float rel_pos_lightnorm_dot = dot(rel_pos_norm, lightnorm.xyz);
 
-        float  rel_pos_lightnorm = vary_LightNormPosDot;
-        float optic_d = rel_pos_lightnorm;
+        // Initialize temp variables
+        vec3 sunlight = (sun_up_factor == 1) ? sunlight_color : moonlight_color * 0.7; //magic 0.7 to match legacy color
+
+        // Sunlight attenuation effect (hue and brightness) due to atmosphere
+        // this is used later for sunlight modulation at various altitudes
+        vec3 light_atten = (blue_density + vec3(haze_density * 0.25)) * (density_multiplier * max_y);
+
+        // Calculate relative weights
+        vec3 combined_haze = max(abs(blue_density) + vec3(abs(haze_density)), vec3(1e-6));
+        vec3 blue_weight   = blue_density / combined_haze;
+        vec3 haze_weight   = haze_density / combined_haze;
+
+        // Compute sunlight from rel_pos & lightnorm (for long rays like sky)
+        float off_axis = 1.0 / max(1e-6, max(0., rel_pos_norm.y) + lightnorm.y);
+        sunlight *= exp(-light_atten * off_axis);
+
+        // Distance
+        float density_dist = rel_pos_len * density_multiplier;
+
+        // Transparency (-> combined_haze)
+        // ATI Bugfix -- can't store combined_haze*density_dist in a variable because the ati
+        // compiler gets confused.
+        combined_haze = exp(-combined_haze * density_dist);
+
+        // Compute haze glow
+        float haze_glow = 1.0 - rel_pos_lightnorm_dot;
+        // haze_glow is 0 at the sun and increases away from sun
+        haze_glow = max(haze_glow, .001);
+        // Set a minimum "angle" (smaller glow.y allows tighter, brighter hotspot)
+        haze_glow *= glow.x;
+        // Higher glow.x gives dimmer glow (because next step is 1 / "angle")
+        haze_glow = pow(haze_glow, glow.z);
+        // glow.z should be negative, so we're doing a sort of (1 / "angle") function
+
+        // Add "minimum anti-solar illumination"
+        // For sun, add to glow.  For moon, remove glow entirely. SL-13768
+        haze_glow = (sun_moon_glow_factor < 1.0) ? 0.0 : (sun_moon_glow_factor * (haze_glow + 0.25));
+
+        // Haze color above cloud
+        color = (blue_horizon * blue_weight * (sunlight + ambient_color)
+                + (haze_horizon * haze_weight) * (sunlight * haze_glow + ambient_color));
+
+        // Final atmosphere additive
+        color *= (1. - combined_haze);
+
+        // Increase ambient when there are more clouds
+        vec3 ambient = ambient_color + max(vec3(0), (1. - ambient_color)) * cloud_shadow * 0.5;
+
+        // Dim sunlight by cloud shadow percentage
+        sunlight *= max(0.0, (1. - cloud_shadow));
+
+        // Haze color below cloud
+        vec3 add_below_cloud = (blue_horizon * blue_weight * (sunlight + ambient)
+                            + (haze_horizon * haze_weight) * (sunlight * haze_glow + ambient));
+
+        // Attenuate cloud color by atmosphere
+        combined_haze = sqrt(combined_haze);  // less atmos opacity (more transparency) below clouds
+
+        // At horizon, blend high altitude sky color towards the darker color below the clouds
+        color += (add_below_cloud - color) * (1. - sqrt(combined_haze));
+
+        float optic_d = rel_pos_lightnorm_dot;
         vec3  halo_22 = halo22(optic_d);
         color.rgb += rainbow(optic_d);
         color.rgb += halo_22;

--- a/indra/newview/app_settings/shaders/class1/deferred/skyV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/skyV.glsl
@@ -1,5 +1,5 @@
 /**
- * @file WLSkyV.glsl
+ * @file class1/deferred/skyV.glsl
  *
  * $LicenseInfo:firstyear=2005&license=viewerlgpl$
  * Second Life Viewer Source Code
@@ -32,36 +32,13 @@ in vec3 position;
 ///////////////////////////////////////////////////////////////////////////////
 
 // Output parameters
-out vec3 vary_HazeColor;
-out float vary_LightNormPosDot;
+out vec3 pos;
 
 #ifdef HAS_HDRI
 out vec4 vary_position;
-out vec3 vary_rel_pos;
 #endif
 
 // Inputs
-uniform vec3 camPosLocal;
-
-uniform vec3  lightnorm;
-uniform vec3  sunlight_color;
-uniform vec3  moonlight_color;
-uniform int   sun_up_factor;
-uniform vec3  ambient_color;
-uniform vec3  blue_horizon;
-uniform vec3  blue_density;
-uniform float haze_horizon;
-uniform float haze_density;
-
-uniform float cloud_shadow;
-uniform float density_multiplier;
-uniform float distance_multiplier;
-uniform float max_y;
-
-uniform vec3  glow;
-uniform float sun_moon_glow_factor;
-
-uniform int cube_snapshot;
 
 // NOTE: Keep these in sync!
 //       indra\newview\app_settings\shaders\class1\deferred\skyV.glsl
@@ -70,97 +47,13 @@ uniform int cube_snapshot;
 void main()
 {
     // World / view / projection
-    vec4 pos = modelview_projection_matrix * vec4(position.xyz, 1.0);
+    pos = position.xyz;
 
-    gl_Position = pos;
+    vec4 transformed_pos = modelview_projection_matrix * vec4(position.xyz, 1.0);
 
-    // Get relative position
-    vec3 rel_pos = position.xyz - camPosLocal.xyz + vec3(0, 50, 0);
+    gl_Position = transformed_pos;
 
-#ifdef HAS_HDRI
-    vary_rel_pos = rel_pos;
-    vary_position = pos;
-#endif
-
-    // Adj position vector to clamp altitude
-    if (rel_pos.y > 0.)
-    {
-        rel_pos *= (max_y / rel_pos.y);
-    }
-    if (rel_pos.y < 0.)
-    {
-        rel_pos *= (-32000. / rel_pos.y);
-    }
-
-    // Normalized
-    vec3  rel_pos_norm = normalize(rel_pos);
-    float rel_pos_len  = length(rel_pos);
-
-    // Grab this value and pass to frag shader for rainbows
-    float rel_pos_lightnorm_dot = dot(rel_pos_norm, lightnorm.xyz);
-    vary_LightNormPosDot = rel_pos_lightnorm_dot;
-
-    // Initialize temp variables
-    vec3 sunlight = (sun_up_factor == 1) ? sunlight_color : moonlight_color * 0.7; //magic 0.7 to match legacy color
-
-    // Sunlight attenuation effect (hue and brightness) due to atmosphere
-    // this is used later for sunlight modulation at various altitudes
-    vec3 light_atten = (blue_density + vec3(haze_density * 0.25)) * (density_multiplier * max_y);
-
-    // Calculate relative weights
-    vec3 combined_haze = max(abs(blue_density) + vec3(abs(haze_density)), vec3(1e-6));
-    vec3 blue_weight   = blue_density / combined_haze;
-    vec3 haze_weight   = haze_density / combined_haze;
-
-    // Compute sunlight from rel_pos & lightnorm (for long rays like sky)
-    float off_axis = 1.0 / max(1e-6, max(0., rel_pos_norm.y) + lightnorm.y);
-    sunlight *= exp(-light_atten * off_axis);
-
-    // Distance
-    float density_dist = rel_pos_len * density_multiplier;
-
-    // Transparency (-> combined_haze)
-    // ATI Bugfix -- can't store combined_haze*density_dist in a variable because the ati
-    // compiler gets confused.
-    combined_haze = exp(-combined_haze * density_dist);
-
-    // Compute haze glow
-    float haze_glow = 1.0 - rel_pos_lightnorm_dot;
-    // haze_glow is 0 at the sun and increases away from sun
-    haze_glow = max(haze_glow, .001);
-    // Set a minimum "angle" (smaller glow.y allows tighter, brighter hotspot)
-    haze_glow *= glow.x;
-    // Higher glow.x gives dimmer glow (because next step is 1 / "angle")
-    haze_glow = pow(haze_glow, glow.z);
-    // glow.z should be negative, so we're doing a sort of (1 / "angle") function
-
-    // Add "minimum anti-solar illumination"
-    // For sun, add to glow.  For moon, remove glow entirely. SL-13768
-    haze_glow = (sun_moon_glow_factor < 1.0) ? 0.0 : (sun_moon_glow_factor * (haze_glow + 0.25));
-
-    // Haze color above cloud
-    vec3 color = (blue_horizon * blue_weight * (sunlight + ambient_color)
-               + (haze_horizon * haze_weight) * (sunlight * haze_glow + ambient_color));
-
-    // Final atmosphere additive
-    color *= (1. - combined_haze);
-
-    // Increase ambient when there are more clouds
-    vec3 ambient = ambient_color + max(vec3(0), (1. - ambient_color)) * cloud_shadow * 0.5;
-
-    // Dim sunlight by cloud shadow percentage
-    sunlight *= max(0.0, (1. - cloud_shadow));
-
-    // Haze color below cloud
-    vec3 add_below_cloud = (blue_horizon * blue_weight * (sunlight + ambient)
-                         + (haze_horizon * haze_weight) * (sunlight * haze_glow + ambient));
-
-    // Attenuate cloud color by atmosphere
-    combined_haze = sqrt(combined_haze);  // less atmos opacity (more transparency) below clouds
-
-    // At horizon, blend high altitude sky color towards the darker color below the clouds
-    color += (add_below_cloud - color) * (1. - sqrt(combined_haze));
-
-    // Haze color above cloud
-    vary_HazeColor = color;
+ #ifdef HAS_HDRI
+     vary_position = transformed_pos;
+ #endif
 }

--- a/indra/newview/featuretable.txt
+++ b/indra/newview/featuretable.txt
@@ -1,4 +1,4 @@
-version 75
+version 76
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -56,7 +56,6 @@ RenderVolumeLODFactor		1	2.0
 UseStartScreen				1	1
 UseOcclusion				1	1
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 Disregard128DefaultDrawDistance	1	1
 Disregard96DefaultDrawDistance	1	1
 RenderCompressTextures		1	1
@@ -87,6 +86,7 @@ RenderTonemapMix			1   1
 RenderDisableVintageMode           1   1
 RenderMaxTextureResolution         1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Low Graphics Settings
@@ -113,7 +113,6 @@ RenderTreeLODFactor			1	0
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
@@ -130,6 +129,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   512
 RenderReflectionProbeCount  1   1
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Low Graphics Settings
@@ -156,7 +156,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
@@ -173,6 +172,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   1024
 RenderReflectionProbeCount  1   32
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Graphics Settings (standard)
@@ -197,7 +197,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
@@ -215,6 +214,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium High Graphics Settings
@@ -239,7 +239,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
@@ -257,6 +256,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Graphics Settings (SSAO + sun shadows)
@@ -281,7 +281,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.5
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	1
-WLSkyDetail					1	96
 RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -299,6 +298,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   128
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Ultra Graphics Settings (SSAO + all shadows)
@@ -323,7 +323,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.75
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
-WLSkyDetail					1	96
 RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -341,6 +340,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -363,7 +363,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	1.0
 RenderVolumeLODFactor		1	2.0
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
 RenderFSAAType  			1	2
@@ -383,6 +382,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Class Unknown Hardware (unknown)

--- a/indra/newview/featuretable_linux.txt
+++ b/indra/newview/featuretable_linux.txt
@@ -1,4 +1,4 @@
-version 34
+version 35
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -56,7 +56,6 @@ RenderVolumeLODFactor		1	2.0
 UseStartScreen				1	1
 UseOcclusion				1	1
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 Disregard128DefaultDrawDistance	1	1
 Disregard96DefaultDrawDistance	1	1
 RenderCompressTextures		1	1
@@ -87,6 +86,7 @@ RenderTonemapMix			1   1
 RenderDisableVintageMode           1   1
 RenderMaxTextureResolution         1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Low Graphics Settings
@@ -113,7 +113,6 @@ RenderTreeLODFactor			1	0
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
@@ -130,6 +129,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   512
 RenderReflectionProbeCount  1   1
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Low Graphics Settings
@@ -156,7 +156,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	0
 RenderFSAASamples			1	0
 RenderScreenSpaceReflections 1  0
@@ -173,6 +172,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   1024
 RenderReflectionProbeCount  1   32
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Graphics Settings (standard)
@@ -197,7 +197,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
@@ -215,6 +214,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium High Graphics Settings
@@ -239,7 +239,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType  			1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
@@ -257,6 +256,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Graphics Settings (SSAO + sun shadows)
@@ -281,7 +281,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.5
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	1
-WLSkyDetail					1	96
 RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -299,6 +298,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   128
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Ultra Graphics Settings (SSAO + all shadows)
@@ -323,7 +323,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.75
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
-WLSkyDetail					1	96
 RenderFSAAType  			1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -341,6 +340,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -363,7 +363,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	1.0
 RenderVolumeLODFactor		1	2.0
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
 RenderFSAAType  			1	2
@@ -383,6 +382,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Class Unknown Hardware (unknown)

--- a/indra/newview/featuretable_mac.txt
+++ b/indra/newview/featuretable_mac.txt
@@ -1,4 +1,4 @@
-version 74
+version 75
 // The version number above should be incremented IF AND ONLY IF some
 // change has been made that is sufficiently important to justify
 // resetting the graphics preferences of all users to the recommended
@@ -54,7 +54,6 @@ RenderVolumeLODFactor		1	2.0
 UseStartScreen				1	1
 UseOcclusion				1	1
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 Disregard128DefaultDrawDistance	1	1
 Disregard96DefaultDrawDistance	1	1
 RenderCompressTextures		1	1
@@ -87,6 +86,7 @@ RenderDisableVintageMode           1   1
 RenderDownScaleMethod       1   0
 RenderMaxTextureResolution         1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Low Graphics Settings
@@ -111,7 +111,6 @@ RenderTreeLODFactor			1	0
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType			    1	0
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   0
@@ -130,6 +129,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   512
 RenderReflectionProbeCount  1   1
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Low Graphics Settings
@@ -154,7 +154,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.125
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType			    1	0
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   1
@@ -173,6 +172,7 @@ RenderTonemapMix			1   0.7
 RenderDisableVintageMode           1   0
 RenderMaxTextureResolution         1   1024
 RenderReflectionProbeCount  1   32
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium Graphics Settings (standard)
@@ -197,7 +197,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.25
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType			    1	1
 RenderFSAASamples			1	0
 RenderReflectionsEnabled    1   1
@@ -215,6 +214,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // Medium High Graphics Settings
@@ -239,7 +239,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.375
 RenderDeferredSSAO			1	0
 RenderShadowDetail			1	0
-WLSkyDetail					1	96
 RenderFSAAType			    1	1
 RenderFSAASamples			1	1
 RenderReflectionsEnabled    1   1
@@ -257,6 +256,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   64
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Graphics Settings (SSAO + sun shadows)
@@ -281,7 +281,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.5
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	1
-WLSkyDetail					1	96
 RenderFSAAType			    1	1
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -299,6 +298,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   128
+RenderHighPrecisionPostProcess 1 0
 
 //
 // High Ultra Graphics Settings (SSAO + all shadows)
@@ -323,7 +323,6 @@ RenderTreeLODFactor			1	0.5
 RenderVolumeLODFactor		1	1.75
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
-WLSkyDetail					1	96
 RenderFSAAType			    1	2
 RenderFSAASamples			1	2
 RenderReflectionsEnabled    1   1
@@ -341,6 +340,7 @@ RenderTonemapType			1   1
 RenderTonemapMix			1   0.7
 RenderMaxTextureResolution  1   2048
 RenderReflectionProbeCount  1   256
+RenderHighPrecisionPostProcess 1 1
 
 //
 // Ultra graphics (REALLY PURTY!)
@@ -363,7 +363,6 @@ RenderTransparentWater		1	1
 RenderTreeLODFactor			1	1.0
 RenderVolumeLODFactor		1	2.0
 WindLightUseAtmosShaders	1	1
-WLSkyDetail					1	128
 RenderDeferredSSAO			1	1
 RenderShadowDetail			1	2
 RenderFSAAType			    1	2

--- a/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
+++ b/indra/newview/llfloaterpreferencesgraphicsadvanced.cpp
@@ -158,7 +158,7 @@ void LLFloaterPreferenceGraphicsAdvanced::refresh()
     updateSliderText(getChild<LLSliderCtrl>("AvatarPhysicsDetail",  true), getChild<LLTextBox>("AvatarPhysicsDetailText",       true));
     updateSliderText(getChild<LLSliderCtrl>("TerrainMeshDetail",    true), getChild<LLTextBox>("TerrainMeshDetailText",     true));
     updateSliderText(getChild<LLSliderCtrl>("RenderPostProcess",    true), getChild<LLTextBox>("PostProcessText",           true));
-    updateSliderText(getChild<LLSliderCtrl>("SkyMeshDetail",        true), getChild<LLTextBox>("SkyMeshDetailText",         true));
+    updateSliderText(getChild<LLSliderCtrl>("GlowResolution",        true), getChild<LLTextBox>("GlowResolutionText",         true));
     LLAvatarComplexityControls::setIndirectControls();
     setMaxNonImpostorsText(
         gSavedSettings.getU32("RenderAvatarMaxNonImpostors"),
@@ -277,16 +277,11 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
     LLTextBox* shadows_text = getChild<LLTextBox>("RenderShadowDetailText");
     LLCheckBoxCtrl* ctrl_ssao = getChild<LLCheckBoxCtrl>("UseSSAO");
     LLCheckBoxCtrl* ctrl_dof = getChild<LLCheckBoxCtrl>("UseDoF");
-    LLSliderCtrl* sky = getChild<LLSliderCtrl>("SkyMeshDetail");
-    LLTextBox* sky_text = getChild<LLTextBox>("SkyMeshDetailText");
     LLSliderCtrl* cas_slider = getChild<LLSliderCtrl>("RenderSharpness");
 
     // disabled windlight
     if (!LLFeatureManager::getInstance()->isFeatureAvailable("WindLightUseAtmosShaders"))
     {
-        sky->setEnabled(false);
-        sky_text->setEnabled(false);
-
         //deferred needs windlight, disable deferred
         ctrl_shadows->setEnabled(false);
         ctrl_shadows->setValue(0);
@@ -350,12 +345,6 @@ void LLFloaterPreferenceGraphicsAdvanced::disableUnavailableSettings()
 
 void LLFloaterPreferenceGraphicsAdvanced::refreshEnabledState()
 {
-    // WindLight
-    LLSliderCtrl* sky = getChild<LLSliderCtrl>("SkyMeshDetail");
-    LLTextBox* sky_text = getChild<LLTextBox>("SkyMeshDetailText");
-    sky->setEnabled(true);
-    sky_text->setEnabled(true);
-
     bool enabled = true;
 
     LLCheckBoxCtrl* ctrl_ssao = getChild<LLCheckBoxCtrl>("UseSSAO");

--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -446,16 +446,6 @@ static bool handleUploadBakedTexOldChanged(const LLSD& newvalue)
     return true;
 }
 
-
-static bool handleWLSkyDetailChanged(const LLSD&)
-{
-    if (gSky.mVOWLSkyp.notNull())
-    {
-        gSky.mVOWLSkyp->updateGeometry(gSky.mVOWLSkyp->mDrawable);
-    }
-    return true;
-}
-
 static bool handleRepartition(const LLSD&)
 {
     if (gPipeline.isInit())
@@ -840,6 +830,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderUIBuffer", handleWindowResized);
     setting_setup_signal_listener(gSavedSettings, "RenderDepthOfField", handleReleaseGLBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderFSAAType", handleReleaseGLBufferChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderHighPrecisionPostProcess", handleReleaseGLBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularResX", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularResY", handleLUTBufferChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderSpecularExponent", handleLUTBufferChanged);
@@ -900,7 +891,6 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "MuteVoice", handleAudioVolumeChanged);
     setting_setup_signal_listener(gSavedSettings, "MuteAmbient", handleAudioVolumeChanged);
     setting_setup_signal_listener(gSavedSettings, "MuteUI", handleAudioVolumeChanged);
-    setting_setup_signal_listener(gSavedSettings, "WLSkyDetail", handleWLSkyDetailChanged);
     setting_setup_signal_listener(gSavedSettings, "JoystickAxis0", handleJoystickChanged);
     setting_setup_signal_listener(gSavedSettings, "JoystickAxis1", handleJoystickChanged);
     setting_setup_signal_listener(gSavedSettings, "JoystickAxis2", handleJoystickChanged);

--- a/indra/newview/llvowlsky.cpp
+++ b/indra/newview/llvowlsky.cpp
@@ -36,17 +36,16 @@
 #include "llenvironment.h"
 #include "llsettingssky.h"
 
-constexpr U32 MIN_SKY_DETAIL = 8;
-constexpr U32 MAX_SKY_DETAIL = 180;
+constexpr U32 SKY_DETAIL = 18; // Any lower and there will be artifacts
 
 inline U32 LLVOWLSky::getNumStacks(void)
 {
-    return llmin(MAX_SKY_DETAIL, llmax(MIN_SKY_DETAIL, gSavedSettings.getU32("WLSkyDetail")));
+    return SKY_DETAIL;
 }
 
 inline U32 LLVOWLSky::getNumSlices(void)
 {
-    return 2 * llmin(MAX_SKY_DETAIL, llmax(MIN_SKY_DETAIL, gSavedSettings.getU32("WLSkyDetail")));
+    return 2 * SKY_DETAIL;
 }
 
 inline U32 LLVOWLSky::getStripsNumVerts(void)

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -818,9 +818,8 @@ LLPipeline::eFBOStatus LLPipeline::doAllocateScreenBuffer(U32 resX, U32 resY)
 bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;
-
-    static LLCachedControl<bool> has_hdr(gSavedSettings, "RenderHDREnabled", true);
-    bool hdr = gGLManager.mGLVersion > 4.05f && has_hdr();
+    bool has_hdr = gSavedSettings.getBOOL("RenderHDREnabled");
+    bool hdr = gGLManager.mGLVersion > 4.05f && has_hdr;
 
     if (mRT == &mMainRT)
     { // hacky -- allocate auxillary buffer
@@ -886,6 +885,8 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
 
     if (!gCubeSnapshot) // hack to not re-allocate various targets for cube snapshots
     {
+        U32 post_color_fmt = gSavedSettings.getBOOL("RenderHighPrecisionPostProcess") ? GL_RGBA16F : GL_RGBA;
+
         if (RenderUIBuffer)
         {
             if (!mUIScreen.allocate(resX, resY, GL_RGBA))
@@ -896,10 +897,10 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
 
         if (RenderFSAAType > 0)
         {
-            if (!mFXAAMap.allocate(resX, resY, GL_RGBA)) return false;
+            if (!mFXAAMap.allocate(resX, resY, post_color_fmt)) return false;
             if (RenderFSAAType == 2)
             {
-                if (!mSMAABlendBuffer.allocate(resX, resY, GL_RGBA, false)) return false;
+                if (!mSMAABlendBuffer.allocate(resX, resY, post_color_fmt, false)) return false;
             }
         }
         else
@@ -920,8 +921,8 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
             mSceneMap.release();
         }
 
-        mPostPingMap.allocate(resX, resY, GL_RGBA);
-        mPostPongMap.allocate(resX, resY, GL_RGBA);
+        mPostPingMap.allocate(resX, resY, post_color_fmt);
+        mPostPongMap.allocate(resX, resY, post_color_fmt);
 
         // The water exclusion mask needs its own depth buffer so we can take care of the problem of multiple water planes.
         // Should we ever make water not just a plane, it also aids with that as well as the water planes will be rendered into the mask.

--- a/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences_graphics_advanced.xml
@@ -76,19 +76,19 @@
     height="16"
     increment="1"
     initial_value="8"
-    label="Post process quality:"
+    label="Glow quality:"
     label_width="185"
     layout="topleft"
     left="30"
     min_val="8"
     max_val="9"
-    name="RenderPostProcess"
+    name="GlowResolution"
     show_text="false"
     top_delta="16"
     width="300">
     <slider.commit_callback
       function="Pref.UpdateSliderText"
-      parameter="PostProcessText" />
+      parameter="GlowResolutionText" />
   </slider>
   <text
     type="string"
@@ -96,7 +96,7 @@
     follows="left|top"
     height="16"
     layout="topleft"
-    name="PostProcessText"
+    name="GlowResolutionText"
     top_delta="0"
     left_delta="304"
     width="65">
@@ -689,25 +689,25 @@
   </check_box>
 
   <slider
-    control_name="WLSkyDetail"
+    control_name="RenderHighPrecisionPostProcess"
     decimal_digits="0"
     follows="left|top"
     height="16"
-    increment="8"
+    increment="1"
     initial_value="160"
-    label="Sky:"
+    label="Post Process Quality:"
     label_width="145"
     layout="topleft"
     left="420"
-    min_val="16"
-    max_val="128"
-    name="SkyMeshDetail"
+    min_val="0"
+    max_val="1"
+    name="RenderPostProcess"
     show_text="false"
     top_delta="22"
     width="260">
     <slider.commit_callback
       function="Pref.UpdateSliderText"
-      parameter="SkyMeshDetailText" />
+      parameter="PostProcessText" />
   </slider>
   <text
     type="string"
@@ -716,7 +716,7 @@
     height="16"
     layout="topleft"
     left_delta="264"
-    name="SkyMeshDetailText"
+    name="PostProcessText"
     text_readonly_color="LabelDisabledColor"
     top_delta="0"
     width="65">


### PR DESCRIPTION
## Description

Introduces optimizations to sky rendering to reduce vertex shaded overdraw and fix banding introduced as part of the apple silicon optimizations.

This also fixes artifacts in the sky rendering from vertex shading around the sun.

#### Vertex Shaded with WLSkyDetail of 8
```
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(191) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(192) LLGLSLShader::dumpStats : Deferred Windlight Sky Shader
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyV.glsl
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyF.glsl
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(198) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(215) LLGLSLShader::dumpStats : Triangles Drawn: 351 (0.07 pct of total, 2.880 million/sec)
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(216) LLGLSLShader::dumpStats : Binds: 1 (0.20 pct of total)
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(217) LLGLSLShader::dumpStats : SamplesDrawn: 4999789 (6.63 pct of total, 41.030 billion/sec)
2025-11-26T05:53:52Z INFO # llrender/llglslshader.cpp(218) LLGLSLShader::dumpStats : Time Elapsed: 121856 (5.65 pct of total, 0.12186 ms)
```

#### Vertex Shaded with WLSkyDetail of 128
```
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(191) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(192) LLGLSLShader::dumpStats : Deferred Windlight Sky Shader
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyV.glsl
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyF.glsl
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(198) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(215) LLGLSLShader::dumpStats : Triangles Drawn: 21930 (4.22 pct of total, 121.682 million/sec)
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(216) LLGLSLShader::dumpStats : Binds: 1 (0.20 pct of total)
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(217) LLGLSLShader::dumpStats : SamplesDrawn: 4865099 (6.48 pct of total, 26.995 billion/sec)
2025-11-26T05:50:57Z INFO # llrender/llglslshader.cpp(218) LLGLSLShader::dumpStats : Time Elapsed: 180224 (7.94 pct of total, 0.18022 ms)
```

#### Pixel Shaded
```
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(191) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(192) LLGLSLShader::dumpStats : Deferred Windlight Sky Shader
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyV.glsl
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(195) LLGLSLShader::dumpStats : deferred/skyF.glsl
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(198) LLGLSLShader::dumpStats : =============================================
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(215) LLGLSLShader::dumpStats : Triangles Drawn: 351 (0.07 pct of total, 2.856 million/sec)
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(216) LLGLSLShader::dumpStats : Binds: 1 (0.20 pct of total)
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(217) LLGLSLShader::dumpStats : SamplesDrawn: 4999789 (6.64 pct of total, 40.688 billion/sec)
2025-11-26T05:50:25Z INFO # llrender/llglslshader.cpp(218) LLGLSLShader::dumpStats : Time Elapsed: 122880 (5.67 pct of total, 0.12288 ms)
```

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Post Process Quality slider now controls color precision of post processing rendering. Previous slider now named Glow quality.

<img width="806" height="479" alt="image" src="https://github.com/user-attachments/assets/3a5eb765-fdd0-41ea-b61f-4bb1e052dc1d" />

