### PR TITLE
Fix alpha debug overlay rendering in probes and breaking scene lighting

### DIFF
--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -278,7 +278,7 @@ void LLDrawPoolAlpha::forwardRender(bool rigged)
 
 void LLDrawPoolAlpha::renderDebugAlpha()
 {
-    if (sShowDebugAlpha)
+    if (sShowDebugAlpha && !gCubeSnapshot)
     {
         gHighlightProgram.bind();
         gGL.diffuseColor4f(1, 0, 0, 1);


### PR DESCRIPTION
## Description

Fixes Ctrl-Alt-T alpha debug preview rendering into reflection probes and blowing out scene lighting in alpha heavy sims utilizing probes for lighting.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
