### PR TITLE
Fix invalid symbol in gstreamer 1.0 plugin dlopen load crashing

### DIFF
--- a/indra/media_plugins/gstreamer10/llmediaimplgstreamer_syms_raw.inc
+++ b/indra/media_plugins/gstreamer10/llmediaimplgstreamer_syms_raw.inc
@@ -32,7 +32,7 @@ LL_GRAB_SYM(G, false, gst_registry_fork_set_enabled, void, gboolean enabled)
 LL_GRAB_SYM(G, false, gst_segtrap_set_enabled, void, gboolean enabled)
 LL_GRAB_SYM(G, false, gst_message_parse_buffering, void, GstMessage *message, gint *percent)
 LL_GRAB_SYM(G, false, gst_message_parse_info, void, GstMessage *message, GError **gerror, gchar **debug)
-LL_GRAB_SYM(G, false, gst_element_query_position, gboolean, GstElement *element, GstFormat *format, gint64 *cur)
+LL_GRAB_SYM(G, false, gst_element_query_position, gboolean, GstElement *element, GstFormat format, gint64 *cur)
 LL_GRAB_SYM(G, false, gst_version, void, guint *major, guint *minor, guint *micro, guint *nano)
 
 LL_GRAB_SYM(G, true, gst_message_parse_tag, void, GstMessage *, GstTagList **)

--- a/indra/media_plugins/gstreamer10/media_plugin_gstreamer10.cpp
+++ b/indra/media_plugins/gstreamer10/media_plugin_gstreamer10.cpp
@@ -506,7 +506,7 @@ bool MediaPluginGStreamer10::getTimePos(double &sec_out)
         got_position =
             llgst_element_query_position &&
             llgst_element_query_position(mPlaybin,
-                             &timefmt,
+                             timefmt,
                              &pos);
         got_position = got_position
             && (timefmt == GST_FORMAT_TIME);


### PR DESCRIPTION
## Description

Fixes an invalid symbol in gstreamer 1.0 plugin dlopen load crashing the plugin spuriously. I compared against the actual gstreamer header to confirm the api.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
