### PR TITLE
Replace boost::assign usage with modern c++ brace initialization

### DIFF
--- a/indra/llcommon/tests/lldependencies_test.cpp
+++ b/indra/llcommon/tests/lldependencies_test.cpp
@@ -31,7 +31,6 @@
 #include <string>
 // std headers
 // external library headers
-#include <boost/assign/list_of.hpp>
 // Precompiled header
 #include "linden_common.h"
 // associated header
@@ -106,8 +105,6 @@ std::ostream& operator<<(std::ostream& out, const std::set<ENTRY>& set)
 /*****************************************************************************
 *   Other helpers
 *****************************************************************************/
-using boost::assign::list_of;
-
 typedef LLDependencies<> StringDeps;
 typedef StringDeps::KeyList StringList;
 
@@ -165,7 +162,7 @@ namespace tut
         // The quick brown fox jumps over the lazy yellow dog.
         // (note, "The" and "the" are distinct, else this test wouldn't work)
         deps.add("lazy");
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")));
+        ensure_equals(sorted_keys(deps), StringList{"lazy"});
         deps.add("jumps");
         ensure("found lazy", deps.get("lazy"));
         ensure("not found dog.", ! deps.get("dog."));
@@ -175,24 +172,23 @@ namespace tut
         // A change to the implementation of boost::topological_sort() would
         // be an acceptable reason, and you can simply update the expected
         // test output.
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("jumps")));
-        deps.add("The", 0, empty, list_of("fox")("dog."));
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "jumps" });
+        deps.add("The", 0, empty, { "fox", "dog." });
         // Test key accessors
         ensure("empty before deps for missing key", is_empty(deps.get_before_range("bogus")));
         ensure("empty before deps for jumps", is_empty(deps.get_before_range("jumps")));
-        ensure_equals(instance_from_range< std::set<std::string> >(deps.get_before_range("The")),
-                      make< std::set<std::string> >(list_of("dog.")("fox")));
+        ensure_equals(instance_from_range< std::set<std::string> >(deps.get_before_range("The")), std::set<std::string>{ "dog.", "fox" });
         // resume building dependencies
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("jumps")("The")));
-        deps.add("the", 0, list_of("The"));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("jumps")("The")("the")));
-        deps.add("fox", 0, list_of("The"), list_of("jumps"));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("the")("fox")("jumps")));
-        deps.add("the", 0, list_of("The")); // same, see if cache works
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("the")("fox")("jumps")));
-        deps.add("jumps", 0, empty, list_of("over")); // update jumps deps
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("the")("fox")("jumps")));
-/*==========================================================================*|
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "jumps", "The" });
+        deps.add("the", 0, { "The" });
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "jumps", "The", "the" });
+        deps.add("fox", 0, { "The" }, { "jumps" });
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "the", "fox", "jumps" });
+        deps.add("the", 0, { "The" }); // same, see if cache works
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "the", "fox", "jumps" });
+        deps.add("jumps", 0, empty, { "over" }); // update jumps deps
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "the", "fox", "jumps" });
+        /*==========================================================================*|
         // It drives me nuts that this test doesn't work in the test
         // framework, because -- for reasons unknown -- running the test
         // framework on Mac OS X 10.5 Leopard and Windows XP Pro, the catch
@@ -216,22 +212,21 @@ namespace tut
             deps.remove("over");
         }
 |*==========================================================================*/
-        deps.add("dog.", 0, list_of("yellow")("lazy"));
-        ensure_equals(instance_from_range< std::set<std::string> >(deps.get_after_range("dog.")),
-                      make< std::set<std::string> >(list_of("lazy")("yellow")));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("the")("fox")("jumps")("dog.")));
-        deps.add("quick", 0, list_of("The"), list_of("fox")("brown"));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("the")("quick")("fox")("jumps")("dog.")));
-        deps.add("over", 0, list_of("jumps"), list_of("yellow")("the"));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("lazy")("The")("quick")("fox")("jumps")("over")("the")("dog.")));
-        deps.add("yellow", 0, list_of("the"), list_of("lazy"));
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("The")("quick")("fox")("jumps")("over")("the")("yellow")("lazy")("dog.")));
+        deps.add("dog.", 0, { "yellow", "lazy" });
+        ensure_equals(instance_from_range< std::set<std::string> >(deps.get_after_range("dog.")), std::set<std::string>{ "lazy", "yellow" });
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "the", "fox", "jumps", "dog." });
+        deps.add("quick", 0, { "The" }, { "fox", "brown" });
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "the", "quick", "fox", "jumps", "dog." });
+        deps.add("over", 0, { "jumps" }, { "yellow", "the" });
+        ensure_equals(sorted_keys(deps), StringList{ "lazy", "The", "quick", "fox", "jumps", "over", "the", "dog." });
+        deps.add("yellow", 0, { "the" }, { "lazy" });
+        ensure_equals(sorted_keys(deps), StringList{ "The", "quick", "fox", "jumps", "over", "the", "yellow", "lazy", "dog." });
         deps.add("brown");
         // By now the dependencies are pretty well in place. A change to THIS
         // order should be viewed with suspicion.
-        ensure_equals(sorted_keys(deps), make<StringList>(list_of("The")("quick")("brown")("fox")("jumps")("over")("the")("yellow")("lazy")("dog.")));
+        ensure_equals(sorted_keys(deps), StringList{ "The", "quick", "brown", "fox", "jumps", "over", "the", "yellow", "lazy", "dog." });
 
-        StringList keys(make<StringList>(list_of("The")("brown")("dog.")("fox")("jumps")("lazy")("over")("quick")("the")("yellow")));
+        StringList keys(StringList{ "The", "brown", "dog.", "fox", "jumps", "lazy", "over", "quick", "the", "yellow" });
         ensure_equals(instance_from_range<StringList>(deps.get_key_range()), keys);
 #if (! defined(__GNUC__)) || (__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ > 3)
         // This is the succinct way, works on modern compilers
@@ -255,9 +250,9 @@ namespace tut
         typedef LLDependencies<std::string, int> NameIndexDeps;
         NameIndexDeps nideps;
         const NameIndexDeps& const_nideps(nideps);
-        nideps.add("def", 2, list_of("ghi"));
+        nideps.add("def", 2, { "ghi" });
         nideps.add("ghi", 3);
-        nideps.add("abc", 1, list_of("def"));
+        nideps.add("abc", 1, { "def" });
         NameIndexDeps::range range(nideps.get_range());
         ensure_equals(range.begin()->first, "abc");
         ensure_equals(range.begin()->second, 1);
@@ -269,20 +264,20 @@ namespace tut
         ensure_equals(const_iterator->first, "def");
         ensure_equals(const_iterator->second, 2);
 //        NameIndexDeps::node_range node_range(nideps.get_node_range());
-//        ensure_equals(instance_from_range<std::vector<int> >(node_range), make< std::vector<int> >(list_of(1)(2)(3)));
+//        ensure_equals(instance_from_range<std::vector<int> >(node_range), make< std::vector<int> >(list_of(1,2,3)));
 //        *node_range.begin() = 0;
 //        *node_range.begin() = 1;
         NameIndexDeps::const_node_range const_node_range(const_nideps.get_node_range());
-        ensure_equals(instance_from_range<std::vector<int> >(const_node_range), make< std::vector<int> >(list_of(1)(2)(3)));
+        ensure_equals(instance_from_range<std::vector<int>>(const_node_range), std::vector<int>{ 1, 2, 3 });
         NameIndexDeps::const_key_range const_key_range(const_nideps.get_key_range());
-        ensure_equals(instance_from_range<StringList>(const_key_range), make<StringList>(list_of("abc")("def")("ghi")));
+        ensure_equals(instance_from_range<StringList>(const_key_range), StringList{ "abc", "def", "ghi" });
         NameIndexDeps::sorted_range sorted(const_nideps.sort());
         NameIndexDeps::sorted_iterator sortiter(sorted.begin());
         ensure_equals(sortiter->first, "ghi");
         ensure_equals(sortiter->second, 3);
 
         // test all iterator-flavored versions of get_after_range()
-        StringList def(make<StringList>(list_of("def")));
+        StringList def{"def"};
         ensure("empty abc before list", is_empty(nideps.get_before_range(nideps.get_range().begin())));
         ensure_equals(instance_from_range<StringList>(nideps.get_after_range(nideps.get_range().begin())),
                       def);
@@ -296,7 +291,6 @@ namespace tut
                       def);
         // advance from "ghi" to "def", which must come after "ghi"
         ++sortiter;
-        ensure_equals(instance_from_range<StringList>(const_nideps.get_after_range(sortiter)),
-                      make<StringList>(list_of("ghi")));
+        ensure_equals(instance_from_range<StringList>(const_nideps.get_after_range(sortiter)), StringList{ "ghi" });
     }
 } // namespace tut

--- a/indra/llcommon/tests/llstring_test.cpp
+++ b/indra/llcommon/tests/llstring_test.cpp
@@ -28,12 +28,9 @@
 
 #include "linden_common.h"
 
-#include <boost/assign/list_of.hpp>
 #include "../llstring.h"
 #include "StringVec.h"                  // must come BEFORE lltut.h
 #include "../test/lltut.h"
-
-using boost::assign::list_of;
 
 namespace tut
 {
@@ -763,14 +760,14 @@ namespace tut
         ensure_equals("only delims",
                       LLStringUtil::getTokens("   \r\n   ", " \r\n"), StringVec());
         ensure_equals("sequence of delims",
-                      LLStringUtil::getTokens(",,, one ,,,", ","), list_of("one"));
+                      LLStringUtil::getTokens(",,, one ,,,", ","), StringVec{"one"});
         // nat considers this a dubious implementation side effect, but I'd
         // hate to change it now...
         ensure_equals("noncontiguous tokens",
-                      LLStringUtil::getTokens(", ,, , one ,,,", ","), list_of("")("")("one"));
+                      LLStringUtil::getTokens(", ,, , one ,,,", ","), StringVec{ "", "", "one" });
         ensure_equals("space-padded tokens",
-                      LLStringUtil::getTokens(",    one  ,  two  ,", ","), list_of("one")("two"));
-        ensure_equals("no delims", LLStringUtil::getTokens("one", ","), list_of("one"));
+                      LLStringUtil::getTokens(",    one  ,  two  ,", ","), StringVec{"one", "two"});
+        ensure_equals("no delims", LLStringUtil::getTokens("one", ","), StringVec{ "one" });
     }
 
     // Shorthand for verifying that getTokens() behaves the same when you
@@ -817,39 +814,33 @@ namespace tut
         ensure_getTokens("only delims",
                          "   \r\n   ", " \r\n", "", StringVec());
         ensure_getTokens("sequence of delims",
-                         ",,, one ,,,", ", ", "", list_of("one"));
+                         ",,, one ,,,", ", ", "", StringVec{"one"});
         // Note contrast with the case in the previous method
         ensure_getTokens("noncontiguous tokens",
-                         ", ,, , one ,,,", ", ", "", list_of("one"));
+                         ", ,, , one ,,,", ", ", "", StringVec{"one"});
         ensure_getTokens("space-padded tokens",
                          ",    one  ,  two  ,", ", ", "",
-                         list_of("one")("two"));
-        ensure_getTokens("no delims", "one", ",", "", list_of("one"));
+                         StringVec{"one", "two"});
+        ensure_getTokens("no delims", "one", ",", "", StringVec{ "one" });
 
         // drop_delims vs. keep_delims
         ensure_getTokens("arithmetic",
-                         " ab+def  / xx*  yy ", " ", "+-*/",
-                         list_of("ab")("+")("def")("/")("xx")("*")("yy"));
+                         " ab+def  / xx*  yy ", " ", "+-*/", { "ab", "+", "def", "/", "xx", "*", "yy" });
 
         // quotes
         ensure_getTokens("no quotes",
-                         "She said, \"Don't go.\"", " ", ",", "",
-                         list_of("She")("said")(",")("\"Don't")("go.\""));
+                         "She said, \"Don't go.\"", " ", ",", "", { "She", "said", ",", "\"Don't", "go.\"" });
         ensure_getTokens("quotes",
-                         "She said, \"Don't go.\"", " ", ",", "\"",
-                         list_of("She")("said")(",")("Don't go."));
+                         "She said, \"Don't go.\"", " ", ",", "\"", { "She", "said", ",", "Don't go." });
         ensure_getTokens("quotes and delims",
                          "run c:/'Documents and Settings'/someone", " ", "", "'",
-                         list_of("run")("c:/Documents and Settings/someone"));
+                         { "run", "c:/Documents and Settings/someone" });
         ensure_getTokens("unmatched quote",
-                         "baby don't leave", " ", "", "'",
-                         list_of("baby")("don't")("leave"));
+                         "baby don't leave", " ", "", "'", { "baby", "don't", "leave" });
         ensure_getTokens("adjacent quoted",
-                         "abc'def \"ghi'\"jkl' mno\"pqr", " ", "", "\"'",
-                         list_of("abcdef \"ghijkl' mnopqr"));
+                         "abc'def \"ghi'\"jkl' mno\"pqr", " ", "", "\"'", { "abcdef \"ghijkl' mnopqr" });
         ensure_getTokens("quoted empty string",
-                         "--set SomeVar ''", " ", "", "'",
-                         list_of("--set")("SomeVar")(""));
+                         "--set SomeVar ''", " ", "", "'", { "--set", "SomeVar", "" });
 
         // escapes
         // Don't use backslash as an escape for these tests -- you'll go nuts
@@ -857,15 +848,12 @@ namespace tut
         // something else!
         ensure_equals("escaped delims",
                       LLStringUtil::getTokens("^ a - dog^-gone^ phrase", " ", "-", "", "^"),
-                      list_of(" a")("-")("dog-gone phrase"));
+                      StringVec{ " a", "-", "dog-gone phrase" });
         ensure_equals("escaped quotes",
                       LLStringUtil::getTokens("say: 'this isn^'t w^orking'.", " ", "", "'", "^"),
-                      list_of("say:")("this isn't working."));
+                      StringVec{ "say:", "this isn't working." });
         ensure_equals("escaped escape",
-                      LLStringUtil::getTokens("want x^^2", " ", "", "", "^"),
-                      list_of("want")("x^2"));
-        ensure_equals("escape at end",
-                      LLStringUtil::getTokens("it's^ up there^", " ", "", "'", "^"),
-                      list_of("it's up")("there^"));
+                      LLStringUtil::getTokens("want x^^2", " ", "", "", "^"), StringVec{ "want", "x^2" });
+        ensure_equals("escape at end", LLStringUtil::getTokens("it's^ up there^", " ", "", "'", "^"), StringVec{ "it's up", "there^" });
     }
 }

--- a/indra/llfilesystem/lldir.cpp
+++ b/indra/llfilesystem/lldir.cpp
@@ -44,15 +44,8 @@
 #include "stringize.h"
 #include "llstring.h"
 #include <boost/filesystem.hpp>
-#include <boost/range/begin.hpp>
-#include <boost/range/end.hpp>
-#include <boost/assign/list_of.hpp>
 #include <boost/bind.hpp>
-#include <boost/ref.hpp>
 #include <algorithm>
-
-using boost::assign::list_of;
-using boost::assign::map_list_of;
 
 #if LL_WINDOWS
 #include "lldir_win32.h"
@@ -448,28 +441,28 @@ const std::string &LLDir::getUserName() const
 static std::string ELLPathToString(ELLPath location)
 {
     typedef std::map<ELLPath, const char*> ELLPathMap;
-#define ENT(symbol) (symbol, #symbol)
-    static const ELLPathMap sMap = map_list_of
-        ENT(LL_PATH_NONE)
-        ENT(LL_PATH_USER_SETTINGS)
-        ENT(LL_PATH_APP_SETTINGS)
-        ENT(LL_PATH_PER_SL_ACCOUNT) // returns/expands to blank string if we don't know the account name yet
-        ENT(LL_PATH_CACHE)
-        ENT(LL_PATH_CHARACTER)
-        ENT(LL_PATH_HELP)
-        ENT(LL_PATH_LOGS)
-        ENT(LL_PATH_TEMP)
-        ENT(LL_PATH_SKINS)
-        ENT(LL_PATH_TOP_SKIN)
-        ENT(LL_PATH_CHAT_LOGS)
-        ENT(LL_PATH_PER_ACCOUNT_CHAT_LOGS)
-        ENT(LL_PATH_USER_SKIN)
-        ENT(LL_PATH_LOCAL_ASSETS)
-        ENT(LL_PATH_EXECUTABLE)
-        ENT(LL_PATH_DEFAULT_SKIN)
-        ENT(LL_PATH_FONTS)
-        ENT(LL_PATH_LAST)
-    ;
+#define ENT(symbol) { symbol, #symbol }
+    static const ELLPathMap sMap = {
+        ENT(LL_PATH_NONE),
+        ENT(LL_PATH_USER_SETTINGS),
+        ENT(LL_PATH_APP_SETTINGS),
+        ENT(LL_PATH_PER_SL_ACCOUNT), // returns/expands to blank string if we don't know the account name yet
+        ENT(LL_PATH_CACHE),
+        ENT(LL_PATH_CHARACTER),
+        ENT(LL_PATH_HELP),
+        ENT(LL_PATH_LOGS),
+        ENT(LL_PATH_TEMP),
+        ENT(LL_PATH_SKINS),
+        ENT(LL_PATH_TOP_SKIN),
+        ENT(LL_PATH_CHAT_LOGS),
+        ENT(LL_PATH_PER_ACCOUNT_CHAT_LOGS),
+        ENT(LL_PATH_USER_SKIN),
+        ENT(LL_PATH_LOCAL_ASSETS),
+        ENT(LL_PATH_EXECUTABLE),
+        ENT(LL_PATH_DEFAULT_SKIN),
+        ENT(LL_PATH_FONTS),
+        ENT(LL_PATH_LAST),
+    };
 #undef ENT
 
     ELLPathMap::const_iterator found = sMap.find(location);
@@ -725,10 +718,10 @@ std::vector<std::string> LLDir::findSkinnedFilenames(const std::string& subdir,
     LL_PROFILE_ZONE_SCOPED_CATEGORY_UI;
 
     // Recognize subdirs that have no localization.
-    static const std::set<std::string> sUnlocalized = list_of
-        ("")                        // top-level directory not localized
-        ("textures")                // textures not localized
-    ;
+    static const std::set<std::string> sUnlocalized = {
+        "",        // top-level directory not localized
+        "textures" // textures not localized
+    };
 
     LL_DEBUGS("LLDir") << "subdir '" << subdir << "', filename '" << filename
                        << "', constraint "

--- a/indra/llfilesystem/tests/lldir_test.cpp
+++ b/indra/llfilesystem/tests/lldir_test.cpp
@@ -34,19 +34,6 @@
 
 #include "../test/lltut.h"
 #include "stringize.h"
-#include <boost/assign/list_of.hpp>
-
-using boost::assign::list_of;
-
-// We use ensure_equals(..., vec(list_of(...))) not because it's functionally
-// required, but because ensure_equals() knows how to format a StringVec.
-// Turns out that when ensure_equals() displays a test failure with just
-// list_of("string")("another"), you see 'stringanother' vs. '("string",
-// "another")'.
-StringVec vec(const StringVec& v)
-{
-    return v;
-}
 
 // For some tests, use a dummy LLDir that uses memory data instead of touching
 // the filesystem
@@ -590,20 +577,18 @@ namespace tut
 
         // top-level directory of a skin isn't localized
         ensure_equals(lldir.findSkinnedFilenames(LLDir::SKINBASE, "colors.xml", LLDir::ALL_SKINS),
-                      vec(list_of("install/skins/default/colors.xml")
-                                 ("user/skins/default/colors.xml")));
+                      StringVec{ "install/skins/default/colors.xml", "user/skins/default/colors.xml" });
         // We should not have needed to check for skins/default/en. We should
         // just "know" that SKINBASE is not localized.
         lldir.ensure_not_checked("install/skins/default/en");
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::TEXTURES, "only_default.jpeg"),
-                      vec(list_of("install/skins/default/textures/only_default.jpeg")));
+                      StringVec{ "install/skins/default/textures/only_default.jpeg" });
         // Nor should we have needed to check skins/default/textures/en
         // because textures is known not to be localized.
         lldir.ensure_not_checked("install/skins/default/textures/en");
 
-        StringVec expected(vec(list_of("install/skins/default/xui/en/strings.xml")
-                               ("user/skins/default/xui/en/strings.xml")));
+        StringVec expected(StringVec{ "install/skins/default/xui/en/strings.xml", "user/skins/default/xui/en/strings.xml" });
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml", LLDir::ALL_SKINS),
                       expected);
         // The first time, we had to probe to find out whether xui was localized.
@@ -616,23 +601,19 @@ namespace tut
         lldir.ensure_not_checked("install/skins/default/xui/en");
 
         // localized subdir with "en-us" instead of "en"
-        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"),
-                      vec(list_of("install/skins/default/html/en-us/welcome.html")));
+        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"), StringVec{ "install/skins/default/html/en-us/welcome.html" });
         lldir.ensure_checked("install/skins/default/html/en");
         lldir.ensure_checked("install/skins/default/html/en-us");
         lldir.clear_checked();
-        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"),
-                      vec(list_of("install/skins/default/html/en-us/welcome.html")));
+        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"), StringVec{ "install/skins/default/html/en-us/welcome.html" });
         lldir.ensure_not_checked("install/skins/default/html/en");
         lldir.ensure_not_checked("install/skins/default/html/en-us");
 
-        ensure_equals(lldir.findSkinnedFilenames("future", "somefile.txt"),
-                      vec(list_of("install/skins/default/future/somefile.txt")));
+        ensure_equals(lldir.findSkinnedFilenames("future", "somefile.txt"), StringVec{ "install/skins/default/future/somefile.txt" });
         // Test probing for an unrecognized unlocalized future subdir.
         lldir.ensure_checked("install/skins/default/future/en");
         lldir.clear_checked();
-        ensure_equals(lldir.findSkinnedFilenames("future", "somefile.txt"),
-                      vec(list_of("install/skins/default/future/somefile.txt")));
+        ensure_equals(lldir.findSkinnedFilenames("future", "somefile.txt"), StringVec{ "install/skins/default/future/somefile.txt" });
         // Second time it should remember that future is unlocalized.
         lldir.ensure_not_checked("install/skins/default/future/en");
 
@@ -643,8 +624,7 @@ namespace tut
         // make the default localization be "en" and allow "en-gb" (or
         // whatever) localizations, which would work much more the way you'd
         // expect.
-        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"),
-                      vec(list_of("install/skins/default/html/en-us/welcome.html")));
+        ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"), StringVec{ "install/skins/default/html/en-us/welcome.html" });
 
         /*------------------------ "default", "fr" -------------------------*/
         // We start being able to distinguish localized subdirs from
@@ -654,100 +634,74 @@ namespace tut
 
         // pass merge=true to request this filename in all relevant skins
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml", LLDir::ALL_SKINS),
-                      vec(list_of
-                          ("install/skins/default/xui/en/strings.xml")
-                          ("install/skins/default/xui/fr/strings.xml")
-                          ("user/skins/default/xui/en/strings.xml")
-                          ("user/skins/default/xui/fr/strings.xml")));
+                      StringVec{ "install/skins/default/xui/en/strings.xml", "install/skins/default/xui/fr/strings.xml",
+                                 "user/skins/default/xui/en/strings.xml", "user/skins/default/xui/fr/strings.xml" });
 
         // pass (or default) merge=false to request only most specific skin
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"),
-                      vec(list_of
-                          ("user/skins/default/xui/en/strings.xml")
-                          ("user/skins/default/xui/fr/strings.xml")));
+                      StringVec{ "user/skins/default/xui/en/strings.xml", "user/skins/default/xui/fr/strings.xml" });
 
         // Our dummy floater.xml has a user localization (for "fr") but no
         // English override. This is a case in which CURRENT_SKIN nonetheless
         // returns paths from two different skins.
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "floater.xml"),
-                      vec(list_of
-                          ("install/skins/default/xui/en/floater.xml")
-                          ("user/skins/default/xui/fr/floater.xml")));
+                      StringVec{ "install/skins/default/xui/en/floater.xml", "user/skins/default/xui/fr/floater.xml" });
 
         // Our dummy newfile.xml has an English override but no user
         // localization. This is another case in which CURRENT_SKIN
         // nonetheless returns paths from two different skins.
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "newfile.xml"),
-                      vec(list_of
-                          ("user/skins/default/xui/en/newfile.xml")
-                          ("install/skins/default/xui/fr/newfile.xml")));
+                      StringVec{ "user/skins/default/xui/en/newfile.xml", "install/skins/default/xui/fr/newfile.xml" });
 
         ensure_equals(lldir.findSkinnedFilenames("html", "welcome.html"),
-                      vec(list_of
-                          ("install/skins/default/html/en-us/welcome.html")
-                          ("install/skins/default/html/fr/welcome.html")));
+                      StringVec{ "install/skins/default/html/en-us/welcome.html", "install/skins/default/html/fr/welcome.html" });
 
         /*------------------------ "default", "zh" -------------------------*/
         lldir.setSkinFolder("default", "zh");
         // Because strings.xml has only a "fr" override but no "zh" override
         // in any skin, the most localized version we can find is "en".
-        ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"),
-                      vec(list_of("user/skins/default/xui/en/strings.xml")));
+        ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"), StringVec{ "user/skins/default/xui/en/strings.xml" });
 
         /*------------------------- "steam", "en" --------------------------*/
         lldir.setSkinFolder("steam", "en");
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::SKINBASE, "colors.xml", LLDir::ALL_SKINS),
-                      vec(list_of
-                          ("install/skins/default/colors.xml")
-                          ("install/skins/steam/colors.xml")
-                          ("user/skins/default/colors.xml")
-                          ("user/skins/steam/colors.xml")));
+                      StringVec{ "install/skins/default/colors.xml", "install/skins/steam/colors.xml", "user/skins/default/colors.xml",
+                                 "user/skins/steam/colors.xml" });
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::TEXTURES, "only_default.jpeg"),
-                      vec(list_of("install/skins/default/textures/only_default.jpeg")));
+                      StringVec{ "install/skins/default/textures/only_default.jpeg" });
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::TEXTURES, "only_steam.jpeg"),
-                      vec(list_of("install/skins/steam/textures/only_steam.jpeg")));
+                      StringVec{ "install/skins/steam/textures/only_steam.jpeg" });
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::TEXTURES, "only_user_default.jpeg"),
-                      vec(list_of("user/skins/default/textures/only_user_default.jpeg")));
+                      StringVec{ "user/skins/default/textures/only_user_default.jpeg" });
 
         ensure_equals(lldir.findSkinnedFilenames(LLDir::TEXTURES, "only_user_steam.jpeg"),
-                      vec(list_of("user/skins/steam/textures/only_user_steam.jpeg")));
+                      StringVec{ "user/skins/steam/textures/only_user_steam.jpeg" });
 
         // CURRENT_SKIN
-        ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"),
-                      vec(list_of("user/skins/steam/xui/en/strings.xml")));
+        ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"), StringVec{ "user/skins/steam/xui/en/strings.xml" });
 
         // pass constraint=ALL_SKINS to request this filename in all relevant skins
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml", LLDir::ALL_SKINS),
-                      vec(list_of
-                          ("install/skins/default/xui/en/strings.xml")
-                          ("install/skins/steam/xui/en/strings.xml")
-                          ("user/skins/default/xui/en/strings.xml")
-                          ("user/skins/steam/xui/en/strings.xml")));
+                      StringVec{ "install/skins/default/xui/en/strings.xml", "install/skins/steam/xui/en/strings.xml",
+                                 "user/skins/default/xui/en/strings.xml", "user/skins/steam/xui/en/strings.xml" });
 
         /*------------------------- "steam", "fr" --------------------------*/
         lldir.setSkinFolder("steam", "fr");
 
         // pass CURRENT_SKIN to request only the most specialized files
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml"),
-                      vec(list_of
-                          ("user/skins/steam/xui/en/strings.xml")
-                          ("user/skins/steam/xui/fr/strings.xml")));
+                      StringVec{ "user/skins/steam/xui/en/strings.xml", "user/skins/steam/xui/fr/strings.xml" });
 
         // pass ALL_SKINS to request this filename in all relevant skins
         ensure_equals(lldir.findSkinnedFilenames(LLDir::XUI, "strings.xml", LLDir::ALL_SKINS),
-                      vec(list_of
-                          ("install/skins/default/xui/en/strings.xml")
-                          ("install/skins/default/xui/fr/strings.xml")
-                          ("install/skins/steam/xui/en/strings.xml")
-                          ("install/skins/steam/xui/fr/strings.xml")
-                          ("user/skins/default/xui/en/strings.xml")
-                          ("user/skins/default/xui/fr/strings.xml")
-                          ("user/skins/steam/xui/en/strings.xml")
-                          ("user/skins/steam/xui/fr/strings.xml")));
+                      StringVec{ "install/skins/default/xui/en/strings.xml", "install/skins/default/xui/fr/strings.xml",
+                                 "install/skins/steam/xui/en/strings.xml", "install/skins/steam/xui/fr/strings.xml",
+                                 "user/skins/default/xui/en/strings.xml", "user/skins/default/xui/fr/strings.xml",
+                                 "user/skins/steam/xui/en/strings.xml", "user/skins/steam/xui/fr/strings.xml" });
     }
 
     template<> template<>

--- a/indra/newview/llcommandlineparser.cpp
+++ b/indra/newview/llcommandlineparser.cpp
@@ -32,7 +32,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/bind.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/assign/list_of.hpp>
 
 #include "llsdserialize.h"
 #include "llerror.h"
@@ -61,14 +60,7 @@ namespace
     // List of command-line switches that can't map-to settings variables.
     // Going forward, we want every new command-line switch to map-to some
     // settings variable. This list is used to validate that.
-    const std::set<std::string> unmapped_options = boost::assign::list_of
-        ("help")
-        ("set")
-        ("setdefault")
-        ("settings")
-        ("sessionsettings")
-        ("usersessionsettings")
-    ;
+    const std::set<std::string> unmapped_options = { "help", "set", "setdefault", "settings", "sessionsettings", "usersessionsettings" };
 
     po::options_description gOptionsDesc;
     po::positional_options_description gPositionalOptions;

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -30,7 +30,6 @@
 #include <fstream>
 
 #include <boost/regex.hpp>
-#include <boost/assign/list_of.hpp>
 
 #include "llfeaturemanager.h"
 #include "lldir.h"
@@ -184,15 +183,15 @@ void LLFeatureList::dump()
     }
 }
 
-static const std::vector<std::string> sGraphicsLevelNames = boost::assign::list_of
-    ("Low")
-    ("LowMid")
-    ("Mid")
-    ("MidHigh")
-    ("High")
-    ("HighUltra")
-    ("Ultra")
-;
+static const std::vector<std::string> sGraphicsLevelNames = {
+    "Low",
+    "LowMid",
+    "Mid",
+    "MidHigh",
+    "High",
+    "HighUltra",
+    "Ultra"
+};
 
 U32 LLFeatureManager::getMaxGraphicsLevel() const
 {

--- a/indra/newview/llpresetsmanager.cpp
+++ b/indra/newview/llpresetsmanager.cpp
@@ -26,8 +26,6 @@
 
 #include "llviewerprecompiledheaders.h"
 
-#include <boost/assign/list_of.hpp>
-
 #include "llpresetsmanager.h"
 
 #include "lldiriterator.h"
@@ -250,17 +248,17 @@ void LLPresetsManager::settingChanged()
 
 void LLPresetsManager::getControlNames(std::vector<std::string>& names)
 {
-    const std::vector<std::string> camera_controls = boost::assign::list_of
+    const std::vector<std::string> camera_controls = {
         // From panel_preferences_move.xml
-        ("CameraAngle")
-        ("CameraOffsetScale")
+        "CameraAngle",
+        "CameraOffsetScale",
         // From llagentcamera.cpp
-        ("CameraOffsetBuild")
-        ("TrackFocusObject")
-        ("CameraOffsetRearView")
-        ("FocusOffsetRearView")
-        ("AvatarSitRotation")
-        ;
+        "CameraOffsetBuild",
+        "TrackFocusObject",
+        "CameraOffsetRearView",
+        "FocusOffsetRearView",
+        "AvatarSitRotation",
+    };
     names = camera_controls;
 }
 

--- a/indra/test/llevents_tut.cpp
+++ b/indra/test/llevents_tut.cpp
@@ -44,14 +44,11 @@
 #include <typeinfo>
 // external library headers
 #include <boost/bind.hpp>
-#include <boost/assign/list_of.hpp>
 // other Linden headers
 #include "tests/listener.h"             // must PRECEDE lltut.h
 #include "lltut.h"
 #include "catch_and_store_what_in.h"
 #include "stringize.h"
-
-using boost::assign::list_of;
 
 template<typename T>
 T make(const T& value)
@@ -178,7 +175,7 @@ void events_object::test<2>()
     LLBoundListener bound0 = listener0.listenTo(per_frame, &Listener::callstop);
     LLBoundListener bound1 = listener1.listenTo(per_frame, &Listener::call,
                                                 // after listener0
-                                                make<LLEventPump::NameList>(list_of(listener0.getName())));
+                                                make<LLEventPump::NameList>(LLEventPump::NameList{ listener0.getName() }));
     ensure("enabled", per_frame.enabled());
     ensure("connected 0", bound0.connected());
     ensure("unblocked 0", !bound0.blocked());
@@ -278,24 +275,24 @@ void events_object::test<6>()
     button.listen("Mary",
                   boost::bind(&Collect::add, boost::ref(collector), "Mary", _1),
                   // state that "Mary" must come after "checked"
-                  make<NameList> (list_of("checked")));
+                  make<NameList>(NameList{ "checked" }));
     button.listen("checked",
                   boost::bind(&Collect::add, boost::ref(collector), "checked", _1),
                   // "checked" must come after "spot"
-                  make<NameList> (list_of("spot")));
+                  make<NameList>(NameList{ "spot" }));
     button.listen("spot",
                   boost::bind(&Collect::add, boost::ref(collector), "spot", _1));
     button.post(1);
-    ensure_equals(collector.result, make<StringVec>(list_of("spot")("checked")("Mary")));
+    ensure_equals(collector.result, make<StringVec>(StringVec{ "spot", "checked", "Mary" }));
     collector.clear();
     button.stopListening("Mary");
     button.listen("Mary",
             boost::bind(&Collect::add, boost::ref(collector), "Mary", _1),
             LLEventPump::empty, // no after dependencies
             // now "Mary" must come before "spot"
-            make<NameList>(list_of("spot")));
+                  make<NameList>(NameList{ "spot" }));
     button.post(2);
-    ensure_equals(collector.result, make<StringVec>(list_of("Mary")("spot")("checked")));
+    ensure_equals(collector.result, make<StringVec>(StringVec{ "Mary", "spot", "checked" }));
     collector.clear();
     button.stopListening("spot");
     std::string threw = catch_what<LLEventPump::Cycle>(
@@ -303,7 +300,7 @@ void events_object::test<6>()
             button.listen("spot",
                           boost::bind(&Collect::add, boost::ref(collector), "spot", _1),
                           // after "Mary" and "checked" -- whoops!
-                          make<NameList>(list_of("Mary")("checked")));
+                          make<NameList>(NameList{ "Mary", "checked" }));
         });
     // Obviously the specific wording of the exception text can
     // change; go ahead and change the test to match.
@@ -321,20 +318,18 @@ void events_object::test<6>()
     ensure_contains("cyclic dependencies", threw,
                     "after (\"Mary\", \"checked\") -> \"spot\"");
     button.listen("yellow",
-                  boost::bind(&Collect::add, boost::ref(collector), "yellow", _1),
-                  make<NameList>(list_of("checked")));
+                  boost::bind(&Collect::add, boost::ref(collector), "yellow", _1), make<NameList>(NameList{ "checked" }));
     button.listen("shoelaces",
-                  boost::bind(&Collect::add, boost::ref(collector), "shoelaces", _1),
-                  make<NameList>(list_of("checked")));
+                  boost::bind(&Collect::add, boost::ref(collector), "shoelaces", _1), make<NameList>(NameList{ "checked" }));
     button.post(3);
-    ensure_equals(collector.result, make<StringVec>(list_of("Mary")("checked")("yellow")("shoelaces")));
+    ensure_equals(collector.result, make<StringVec>(StringVec{ "Mary", "checked", "yellow", "shoelaces" }));
     collector.clear();
     threw = catch_what<LLEventPump::OrderChange>(
         [&button, &collector](){
             button.listen("of",
                           boost::bind(&Collect::add, boost::ref(collector), "of", _1),
-                          make<NameList>(list_of("shoelaces")),
-                          make<NameList>(list_of("yellow")));
+                          make<NameList>(NameList{ "shoelaces" }),
+                          make<NameList>(NameList{ "yellow" }));
         });
     // Same remarks about the specific wording of the exception. Just
     // ensure that it contains enough information to clarify the
@@ -347,7 +342,7 @@ void events_object::test<6>()
     ensure_contains("old order", threw, "was: Mary, checked, yellow, shoelaces");
     ensure_contains("new order", threw, "now: Mary, checked, shoelaces, of, yellow");
     button.post(4);
-    ensure_equals(collector.result, make<StringVec>(list_of("Mary")("checked")("yellow")("shoelaces")));
+    ensure_equals(collector.result, make<StringVec>(StringVec{ "Mary", "checked", "yellow", "shoelaces" }));
 }
 
 template<> template<>


### PR DESCRIPTION
## Description

Replace boost::assign usage with modern c++ brace initialization to reduce dependency on boost

## Related Issues

- [x] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
