### PR TITLE
Remove leftover boost aligned_allocator as this is now handled by c++ aligned allocations

### DIFF
--- a/indra/llprimitive/llmodel.h
+++ b/indra/llprimitive/llmodel.h
@@ -33,8 +33,6 @@
 #include "m4math.h"
 #include <queue>
 
-#include <boost/align/aligned_allocator.hpp>
-
 class daeElement;
 class domMesh;
 

--- a/indra/llrender/llrender.h
+++ b/indra/llrender/llrender.h
@@ -43,7 +43,6 @@
 #include "llglheaders.h"
 #include "llmatrix4a.h"
 #include "glm/mat4x4.hpp"
-#include <boost/align/aligned_allocator.hpp>
 
 #include <array>
 #include <chrono>
@@ -531,8 +530,8 @@ private:
     eBlendFactor mCurrBlendAlphaSFactor;
     eBlendFactor mCurrBlendAlphaDFactor;
 
-    std::vector<LLVector4a, boost::alignment::aligned_allocator<LLVector4a, 16> > mUIOffset;
-    std::vector<LLVector4a, boost::alignment::aligned_allocator<LLVector4a, 16> > mUIScale;
+    std::vector<LLVector4a> mUIOffset;
+    std::vector<LLVector4a> mUIScale;
 
     struct LLVBCache
     {


### PR DESCRIPTION
## Description

Remove leftover boost aligned_allocator as this is now handled by c++ aligned allocations

Missed this when doing the rest of the alignment cleanup.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
