### PR TITLE
Replace boost::hof::invocable with c++17 std::is_invocable

### DIFF
--- a/indra/llcommon/lleventdispatcher.h
+++ b/indra/llcommon/lleventdispatcher.h
@@ -35,7 +35,6 @@
 #include <boost/fiber/fss.hpp>
 #include <boost/function_types/is_member_function_pointer.hpp>
 #include <boost/function_types/is_nonmember_callable_builtin.hpp>
-#include <boost/hof/is_invocable.hpp> // until C++17, when we get std::is_invocable
 #include <boost/iterator/transform_iterator.hpp>
 #include <functional>               // std::function
 #include <memory>                   // std::unique_ptr
@@ -99,7 +98,7 @@ public:
 
     template <typename CALLABLE,
               typename=typename std::enable_if<
-                  boost::hof::is_invocable<CALLABLE, LLSD>::value
+                  std::is_invocable<CALLABLE, LLSD>::value
              >::type>
     void add(const std::string& name,
              const std::string& desc,
@@ -295,9 +294,8 @@ public:
      * converted to the corresponding parameter type using LLSDParam.
      */
     template <typename CALLABLE,
-              typename=typename std::enable_if<
-                  ! boost::hof::is_invocable<CALLABLE, LLSD>()
-             >::type>
+              typename=typename std::enable_if_t<
+                  ! std::is_invocable<CALLABLE, LLSD>()>>
     void add(const std::string& name,
              const std::string& desc,
              CALLABLE&& f)
@@ -338,7 +336,7 @@ public:
     template<typename Function,
              typename = typename std::enable_if<
                  boost::function_types::is_nonmember_callable_builtin<Function>::value &&
-                 ! boost::hof::is_invocable<Function, LLSD>::value
+                 ! std::is_invocable<Function, LLSD>::value
              >::type>
     void add(const std::string& name, const std::string& desc, Function f,
              const LLSD& params, const LLSD& defaults=LLSD());


### PR DESCRIPTION
## Description

Replace boost::hof::invocable with c++17 std::is_invocable to reduce boost header dependency

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
