### PR TITLE
Fix occasional build failure observed when llphysicsextensionsos fails to build before secondlife-bin on macos with havok

### DIFF
--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -1983,6 +1983,7 @@ elseif (DARWIN)
           XCODE_ATTRIBUTE_OTHER_LDFLAGS[arch=x86_64] "$(inherited) -L${CMAKE_CURRENT_BINARY_DIR}/llphysicsextensions/$<IF:$<BOOL:${LL_GENERATOR_IS_MULTI_CONFIG}>,$<CONFIG>,${CMAKE_CFG_INTDIR}>/ -lllphysicsextensions  -Xlinker -map -Xlinker ${CMAKE_CURRENT_BINARY_DIR}/${VIEWER_BINARY_NAME}.MAP"
           XCODE_ATTRIBUTE_OTHER_LDFLAGS[arch=arm64]  "$(inherited) -L${CMAKE_BINARY_DIR}/llphysicsextensionsos/$<IF:$<BOOL:${LL_GENERATOR_IS_MULTI_CONFIG}>,$<CONFIG>,${CMAKE_CFG_INTDIR}>/ -lllphysicsextensionsos"
           )
+      add_dependencies(${VIEWER_BINARY_NAME} llphysicsextensionsos)
     elseif(HAVOK_TPV)
       set_target_properties(${VIEWER_BINARY_NAME}
           PROPERTIES
@@ -1993,6 +1994,7 @@ elseif (DARWIN)
           XCODE_ATTRIBUTE_OTHER_LDFLAGS[arch=x86_64] "$(inherited) -L${ARCH_PREBUILT_DIRS}/ -lllphysicsextensions_tpv"
           XCODE_ATTRIBUTE_OTHER_LDFLAGS[arch=arm64]  "$(inherited) -L${CMAKE_BINARY_DIR}/llphysicsextensionsos/$<IF:$<BOOL:${LL_GENERATOR_IS_MULTI_CONFIG}>,$<CONFIG>,${CMAKE_CFG_INTDIR}>/ -lllphysicsextensionsos"
           )
+      add_dependencies(${VIEWER_BINARY_NAME} llphysicsextensionsos)
     else()
       target_link_libraries(${VIEWER_BINARY_NAME} llphysicsextensionsos)
     endif()


### PR DESCRIPTION
## Description

Fix occasional build failure observed when llphysicsextensionsos fails to build before secondlife-bin on macos with havok

Adds build dependency on llphysicsextensionsos manually for macos havok/havok_tpv builds

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
