### PR TITLE
Replace boost noncopyable and undefined function usage with modern c++ deleted operator and constructor

### DIFF
--- a/indra/llcharacter/llmultigesture.h
+++ b/indra/llcharacter/llmultigesture.h
@@ -54,11 +54,10 @@ public:
     void reset();
 
     const std::string& getTrigger() const { return mTrigger; }
-protected:
-    LLMultiGesture(const LLMultiGesture& gest);
-    const LLMultiGesture& operator=(const LLMultiGesture& rhs);
 
-public:
+    LLMultiGesture(const LLMultiGesture& gest) = delete;
+    const LLMultiGesture& operator=(const LLMultiGesture& rhs) = delete;
+
     KEY mKey { 0 };
     MASK mMask { 0 };
 

--- a/indra/llcommon/llapr.h
+++ b/indra/llcommon/llapr.h
@@ -33,7 +33,6 @@
 #include <sys/param.h>  // Need PATH_MAX in APR headers...
 #endif
 
-#include <boost/noncopyable.hpp>
 #include "llwin32headers.h"
 #include "apr_thread_proc.h"
 #include "apr_getopt.h"
@@ -145,7 +144,7 @@ private:
 //      2, a global pool.
 //
 
-class LL_COMMON_API LLAPRFile : boost::noncopyable
+class LL_COMMON_API LLAPRFile
 {
     // make this non copyable since a copy closes the file
 private:
@@ -153,9 +152,12 @@ private:
     LLVolatileAPRPool *mCurrentFilePoolp ; //currently in use apr_pool, could be one of them: sAPRFilePoolp, or a temp pool.
 
 public:
-    LLAPRFile() ;
+    LLAPRFile();
     LLAPRFile(const std::string& filename, apr_int32_t flags, LLVolatileAPRPool* pool = NULL);
-    ~LLAPRFile() ;
+    ~LLAPRFile();
+
+    LLAPRFile(const LLAPRFile&) = delete;
+    LLAPRFile& operator=(const LLAPRFile&) = delete;
 
     apr_status_t open(const std::string& filename, apr_int32_t flags, LLVolatileAPRPool* pool = NULL, S32* sizep = NULL);
     apr_status_t open(const std::string& filename, apr_int32_t flags, bool use_global_pool); //use gAPRPoolp.

--- a/indra/llcommon/lldeadmantimer.h
+++ b/indra/llcommon/lldeadmantimer.h
@@ -99,13 +99,10 @@ public:
     ///                 during updates.  If false, cpu usage data isn't
     ///                 collected and will be zero if queried.
     LLDeadmanTimer(F64 horizon, bool inc_cpu);
+    ~LLDeadmanTimer() = default;
 
-    ~LLDeadmanTimer()
-        {}
-
-private:
-    LLDeadmanTimer(const LLDeadmanTimer &);             // Not defined
-    void operator=(const LLDeadmanTimer &);             // Not defined
+    LLDeadmanTimer(const LLDeadmanTimer &) = delete;
+    LLDeadmanTimer& operator=(const LLDeadmanTimer&) = delete;
 
 public:
     /// Get the current time.  Zero-basis for this time

--- a/indra/llcommon/llevents.h
+++ b/indra/llcommon/llevents.h
@@ -41,7 +41,6 @@
 
 #include <boost/signals2.hpp>
 #include <boost/bind.hpp>
-#include <boost/utility.hpp>        // noncopyable
 #include <boost/optional/optional.hpp>
 #include <boost/visit_each.hpp>
 #include <boost/ref.hpp>            // reference_wrapper

--- a/indra/llcommon/llmutex.h
+++ b/indra/llcommon/llmutex.h
@@ -29,7 +29,6 @@
 
 #include "stdtypes.h"
 #include "llthread.h"
-#include <boost/noncopyable.hpp>
 
 #include "mutex.h"
 #include <shared_mutex>
@@ -249,7 +248,7 @@ private:
 * The constructor handles the lock, and the destructor handles
 * the unlock. Instances of this class are <b>not</b> thread safe.
 */
-class LL_COMMON_API LLScopedLock : private boost::noncopyable
+class LL_COMMON_API LLScopedLock
 {
 public:
     /**
@@ -264,6 +263,12 @@ public:
     * @brief Destructor which unlocks the mutex if still locked.
     */
     ~LLScopedLock();
+
+    /*
+    * @brief Non-copyable constructor and operator
+    */
+    LLScopedLock(const LLScopedLock&) = delete;
+    LLScopedLock& operator=(const LLScopedLock&) = delete;
 
     /**
     * @brief Check lock.

--- a/indra/llcommon/llpounceable.h
+++ b/indra/llcommon/llpounceable.h
@@ -36,7 +36,6 @@
 #define LL_LLPOUNCEABLE_H
 
 #include "llsingleton.h"
-#include <boost/noncopyable.hpp>
 #include <boost/call_traits.hpp>
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/utility/value_init.hpp>
@@ -139,7 +138,7 @@ private:
 // LLPounceable<T> is for an LLPounceable instance on the heap or the stack.
 // LLPounceable<T, LLPounceableStatic> is for a static LLPounceable instance.
 template <typename T, class TAG=LLPounceableQueue>
-class LLPounceable: public boost::noncopyable
+class LLPounceable
 {
 private:
     typedef LLPounceableTraits<T, TAG> traits;
@@ -157,6 +156,10 @@ public:
         mHeld(init),
         mEmpty(empty)
     {}
+
+    // Non-copyable
+    LLPounceable(const LLPounceable&) = delete;
+    LLPounceable& operator=(const LLPounceable&) = delete;
 
     // make read access to mHeld as cheap and transparent as possible
     operator T () const { return mHeld; }

--- a/indra/llcommon/llprocess.h
+++ b/indra/llcommon/llprocess.h
@@ -33,7 +33,6 @@
 #include "apr_thread_proc.h"
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/optional.hpp>
-#include <boost/noncopyable.hpp>
 #include <iosfwd>                   // std::ostream
 
 #if LL_WINDOWS
@@ -67,7 +66,7 @@ typedef std::shared_ptr<LLProcess> LLProcessPtr;
  * indra/llcommon/tests/llprocess_test.cpp for an example of waiting for
  * child-process termination in a standalone test context.
  */
-class LL_COMMON_API LLProcess: public boost::noncopyable
+class LL_COMMON_API LLProcess
 {
     LOG_CLASS(LLProcess);
 public:
@@ -541,6 +540,10 @@ public:
     /// code base
     static std::string basename(const std::string& path);
     static std::string getline(std::istream&);
+
+    // Non-copyable
+    LLProcess(const LLProcess&) = delete;
+    LLProcess& operator=(const LLProcess&) = delete;
 
 private:
     /// constructor is private: use create() instead

--- a/indra/llcommon/llprocinfo.h
+++ b/indra/llcommon/llprocinfo.h
@@ -51,10 +51,10 @@ public:
     typedef U64 time_type;                              /// Relative microseconds
 
 private:
-    LLProcInfo();                                       // Not defined
-    ~LLProcInfo();                                      // Not defined
-    LLProcInfo(const LLProcInfo &);                     // Not defined
-    void operator=(const LLProcInfo &);                 // Not defined
+    LLProcInfo() = delete;
+    ~LLProcInfo() = delete;
+    LLProcInfo(const LLProcInfo&) = delete;
+    LLProcInfo& operator=(const LLProcInfo&) = delete;
 
 public:
     /// Get accumulated system and user CPU time in

--- a/indra/llcommon/llqueuedthread.h
+++ b/indra/llcommon/llqueuedthread.h
@@ -117,11 +117,11 @@ public:
     virtual ~LLQueuedThread();
     virtual void shutdown();
 
-private:
     // No copy constructor or copy assignment
-    LLQueuedThread(const LLQueuedThread&);
-    LLQueuedThread& operator=(const LLQueuedThread&);
+    LLQueuedThread(const LLQueuedThread&) = delete;
+    LLQueuedThread& operator=(const LLQueuedThread&) = delete;
 
+private:
     virtual bool runCondition(void);
     virtual void run(void);
     virtual void startThread(void);

--- a/indra/llcommon/llrefcount.h
+++ b/indra/llcommon/llrefcount.h
@@ -26,7 +26,6 @@
 #ifndef LLREFCOUNT_H
 #define LLREFCOUNT_H
 
-#include <boost/noncopyable.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include "llatomic.h"
 

--- a/indra/llcommon/llsingleton.h
+++ b/indra/llcommon/llsingleton.h
@@ -25,7 +25,6 @@
 #ifndef LLSINGLETON_H
 #define LLSINGLETON_H
 
-#include <boost/noncopyable.hpp>
 #include <boost/unordered_set.hpp>
 #include <initializer_list>
 #include <list>
@@ -43,10 +42,13 @@
 #pragma warning(disable : 4506)   // no definition for inline function
 #endif
 
-class LLSingletonBase: private boost::noncopyable
+class LLSingletonBase
 {
 public:
     class MasterList;
+
+    LLSingletonBase(const LLSingletonBase&) = delete;
+    LLSingletonBase& operator=(const LLSingletonBase&) = delete;
 
 private:
     // All existing LLSingleton instances are tracked in this master list.

--- a/indra/llcorehttp/_httplibcurl.h
+++ b/indra/llcorehttp/_httplibcurl.h
@@ -61,8 +61,8 @@ public:
     virtual ~HttpLibcurl();
 
 private:
-    HttpLibcurl(const HttpLibcurl &);           // Not defined
-    void operator=(const HttpLibcurl &);        // Not defined
+    HttpLibcurl(const HttpLibcurl&) = delete;
+    void operator=(const HttpLibcurl&) = delete;
 
 public:
     typedef std::shared_ptr<HttpOpRequest> opReqPtr_t;
@@ -179,8 +179,8 @@ protected:
         ~HandleCache();
 
     private:
-        HandleCache(const HandleCache &);               // Not defined
-        void operator=(const HandleCache &);            // Not defined
+        HandleCache(const HandleCache&)    = delete;
+        void operator=(const HandleCache&) = delete;
 
     public:
         /// Allocate a curl handle for caller.  May be freed using

--- a/indra/llcorehttp/_httpoperation.h
+++ b/indra/llcorehttp/_httpoperation.h
@@ -68,8 +68,7 @@ class HttpService;
 /// via queue-like interfaces that are thread compatible
 /// and those interfaces establish the access rules.
 
-class HttpOperation : private boost::noncopyable,
-    public std::enable_shared_from_this<HttpOperation>
+class HttpOperation : public std::enable_shared_from_this<HttpOperation>
 {
 public:
     typedef std::shared_ptr<HttpOperation> ptr_t;
@@ -82,6 +81,9 @@ public:
     /// Threading:  called by any thread.
     virtual ~HttpOperation();                           // Use release()
 
+    // Non-copyable
+    HttpOperation(const HttpOperation&) = delete;
+    HttpOperation& operator=(const HttpOperation&) = delete;
 
 public:
     /// Register a reply queue and a handler for completion notifications.
@@ -220,12 +222,10 @@ class HttpOpStop : public HttpOperation
 {
 public:
     HttpOpStop();
-
     virtual ~HttpOpStop();
 
-private:
-    HttpOpStop(const HttpOpStop &);                 // Not defined
-    void operator=(const HttpOpStop &);             // Not defined
+    HttpOpStop(const HttpOpStop &) = delete;
+    HttpOpStop& operator=(const HttpOpStop&) = delete;
 
 public:
     virtual void stageFromRequest(HttpService *);
@@ -242,12 +242,10 @@ class HttpOpNull : public HttpOperation
 {
 public:
     HttpOpNull();
-
     virtual ~HttpOpNull();
 
-private:
-    HttpOpNull(const HttpOpNull &);                 // Not defined
-    void operator=(const HttpOpNull &);             // Not defined
+    HttpOpNull(const HttpOpNull&) = delete;
+    HttpOpNull& operator=(const HttpOpNull&) = delete;
 
 public:
     virtual void stageFromRequest(HttpService *);
@@ -264,12 +262,10 @@ public:
     // 0 does a hard spin in the operation
     // 1 does a soft spin continuously requeuing itself
     HttpOpSpin(int mode);
-
     virtual ~HttpOpSpin();
 
-private:
-    HttpOpSpin(const HttpOpSpin &);                 // Not defined
-    void operator=(const HttpOpSpin &);             // Not defined
+    HttpOpSpin(const HttpOpSpin&) = delete;
+    HttpOpSpin& operator=(const HttpOpSpin&) = delete;
 
 public:
     virtual void stageFromRequest(HttpService *);

--- a/indra/llcorehttp/_httpoprequest.h
+++ b/indra/llcorehttp/_httpoprequest.h
@@ -73,8 +73,8 @@ public:
     virtual ~HttpOpRequest();                           // Use release()
 
 private:
-    HttpOpRequest(const HttpOpRequest &);               // Not defined
-    void operator=(const HttpOpRequest &);              // Not defined
+    HttpOpRequest(const HttpOpRequest&)  = delete;
+    void operator=(const HttpOpRequest&) = delete;
 
 public:
     enum EMethod

--- a/indra/llcorehttp/_httpopsetget.h
+++ b/indra/llcorehttp/_httpopsetget.h
@@ -60,8 +60,8 @@ public:
     virtual ~HttpOpSetGet();                            // Use release()
 
 private:
-    HttpOpSetGet(const HttpOpSetGet &);                 // Not defined
-    void operator=(const HttpOpSetGet &);               // Not defined
+    HttpOpSetGet(const HttpOpSetGet&)   = delete;
+    void operator=(const HttpOpSetGet&) = delete;
 
 public:
     /// Threading:  called by application thread

--- a/indra/llcorehttp/_httppolicy.h
+++ b/indra/llcorehttp/_httppolicy.h
@@ -56,8 +56,8 @@ public:
     virtual ~HttpPolicy();
 
 private:
-    HttpPolicy(const HttpPolicy &);             // Not defined
-    void operator=(const HttpPolicy &);         // Not defined
+    HttpPolicy(const HttpPolicy&) = delete;
+    void operator=(const HttpPolicy&) = delete;
 
 public:
     typedef std::shared_ptr<HttpOpRequest> opReqPtr_t;

--- a/indra/llcorehttp/_httppolicyclass.h
+++ b/indra/llcorehttp/_httppolicyclass.h
@@ -53,7 +53,7 @@ public:
     ~HttpPolicyClass();
 
     HttpPolicyClass & operator=(const HttpPolicyClass &);
-    HttpPolicyClass(const HttpPolicyClass &);           // Not defined
+    HttpPolicyClass(const HttpPolicyClass &);
 
 public:
     HttpStatus set(HttpRequest::EPolicyOption opt, long value);

--- a/indra/llcorehttp/_httppolicyglobal.h
+++ b/indra/llcorehttp/_httppolicyglobal.h
@@ -55,7 +55,7 @@ public:
     HttpPolicyGlobal & operator=(const HttpPolicyGlobal &);
 
 private:
-    HttpPolicyGlobal(const HttpPolicyGlobal &);         // Not defined
+    HttpPolicyGlobal(const HttpPolicyGlobal &) = delete;
 
 public:
     HttpStatus set(HttpRequest::EPolicyOption opt, long value);

--- a/indra/llcorehttp/_httpreadyqueue.h
+++ b/indra/llcorehttp/_httpreadyqueue.h
@@ -77,8 +77,8 @@ public:
         {}
 
 protected:
-    HttpReadyQueue(const HttpReadyQueue &);     // Not defined
-    void operator=(const HttpReadyQueue &);     // Not defined
+    HttpReadyQueue(const HttpReadyQueue&) = delete;
+    void operator=(const HttpReadyQueue&) = delete;
 
 public:
 

--- a/indra/llcorehttp/_httpreplyqueue.h
+++ b/indra/llcorehttp/_httpreplyqueue.h
@@ -30,8 +30,6 @@
 
 #include "_refcounted.h"
 #include "_mutex.h"
-#include "boost/noncopyable.hpp"
-
 
 namespace LLCore
 {
@@ -59,7 +57,7 @@ class HttpOperation;
 /// will be coded anyway so it shouldn't be too much of a
 /// burden.
 
-class HttpReplyQueue : private boost::noncopyable
+class HttpReplyQueue
 {
 
 public:
@@ -68,6 +66,9 @@ public:
 
     HttpReplyQueue();
     virtual ~HttpReplyQueue();
+
+    HttpReplyQueue(const HttpReplyQueue&) = delete;
+    HttpReplyQueue& operator=(const HttpReplyQueue&) = delete;
 
 public:
 

--- a/indra/llcorehttp/_httprequestqueue.h
+++ b/indra/llcorehttp/_httprequestqueue.h
@@ -57,8 +57,8 @@ protected:
     virtual ~HttpRequestQueue();                        // Use release()
 
 private:
-    HttpRequestQueue(const HttpRequestQueue &);         // Not defined
-    void operator=(const HttpRequestQueue &);           // Not defined
+    HttpRequestQueue(const HttpRequestQueue&) = delete;
+    void operator=(const HttpRequestQueue&)   = delete;
 
 public:
     typedef std::shared_ptr<HttpOperation> opPtr_t;

--- a/indra/llcorehttp/_httpservice.h
+++ b/indra/llcorehttp/_httpservice.h
@@ -86,8 +86,8 @@ protected:
     virtual ~HttpService();
 
 private:
-    HttpService(const HttpService &);           // Not defined
-    void operator=(const HttpService &);        // Not defined
+    HttpService(const HttpService&) = delete;
+    void operator=(const HttpService&) = delete;
 
 public:
     enum EState

--- a/indra/llcorehttp/_refcounted.h
+++ b/indra/llcorehttp/_refcounted.h
@@ -44,8 +44,9 @@ namespace LLCoreInt
 class RefCounted
 {
 private:
-    RefCounted();                               // Not defined - may not be default constructed
-    void operator=(const RefCounted &);         // Not defined
+    RefCounted() = delete; // may not be default constructed
+    RefCounted(const RefCounted&) = delete;
+    RefCounted& operator=(const RefCounted&) = delete;
 
 public:
     explicit RefCounted(bool const implicit)

--- a/indra/llcorehttp/_thread.h
+++ b/indra/llcorehttp/_thread.h
@@ -42,8 +42,10 @@ namespace LLCoreInt
 class HttpThread : public RefCounted
 {
 private:
-    HttpThread();                           // Not defined
-    void operator=(const HttpThread &);     // Not defined
+    // May not be default constructed or copied
+    HttpThread() = delete;
+    HttpThread(const HttpThread&) = delete;
+    void operator=(const HttpThread &) = delete;
 
     void at_exit()
         {

--- a/indra/llcorehttp/bufferarray.cpp
+++ b/indra/llcorehttp/bufferarray.cpp
@@ -57,11 +57,11 @@ public:
     void operator delete(void *);
     void operator delete(void *, size_t len);
 
+    Block(const Block&) = delete;
+    Block& operator=(const Block&) = delete;
+
 protected:
     Block(size_t len);
-
-    Block(const Block &);                       // Not defined
-    void operator=(const Block &);              // Not defined
 
     // Allocate the block with the additional space for the
     // buffered data at the end of the object.

--- a/indra/llcorehttp/bufferarray.h
+++ b/indra/llcorehttp/bufferarray.h
@@ -79,8 +79,8 @@ protected:
     virtual ~BufferArray();                     // Use release()
 
 private:
-    BufferArray(const BufferArray &);           // Not defined
-    void operator=(const BufferArray &);        // Not defined
+    BufferArray(const BufferArray&) = delete;
+    void operator=(const BufferArray&) = delete;
 
 public:
     // Internal magic number, may be used by unit tests.

--- a/indra/llcorehttp/bufferstream.h
+++ b/indra/llcorehttp/bufferstream.h
@@ -91,8 +91,8 @@ public:
     virtual ~BufferArrayStreamBuf();
 
 private:
-    BufferArrayStreamBuf(const BufferArrayStreamBuf &); // Not defined
-    void operator=(const BufferArrayStreamBuf &);       // Not defined
+    BufferArrayStreamBuf(const BufferArrayStreamBuf&) = delete;
+    void operator=(const BufferArrayStreamBuf&) = delete;
 
 public:
     // Input interfaces from std::streambuf

--- a/indra/llcorehttp/httpcommon.h
+++ b/indra/llcorehttp/httpcommon.h
@@ -191,7 +191,6 @@
 #include "llsd.h"
 #include <string>
 #include <curl/curl.h>
-#include "boost/noncopyable.hpp"
 
 namespace LLCore
 {

--- a/indra/llcorehttp/httpheaders.h
+++ b/indra/llcorehttp/httpheaders.h
@@ -74,7 +74,7 @@ namespace LLCore
 /// constructor is given a refcount.
 ///
 
-class HttpHeaders: private boost::noncopyable
+class HttpHeaders
 {
 public:
     typedef std::pair<std::string, std::string> header_t;
@@ -94,11 +94,11 @@ public:
     HttpHeaders();
     virtual ~HttpHeaders();                     // Use release()
 
-    //typedef LLCoreInt::IntrusivePtr<HttpHeaders> ptr_t;
-protected:
+    // Non-copyable
+    HttpHeaders(const HttpHeaders&) = delete;
+    HttpHeaders& operator=(const HttpHeaders&) = delete;
 
-    HttpHeaders(const HttpHeaders &);           // Not defined
-    void operator=(const HttpHeaders &);        // Not defined
+    //typedef LLCoreInt::IntrusivePtr<HttpHeaders> ptr_t;
 
 public:
     // Empty the list of headers.

--- a/indra/llcorehttp/httpoptions.h
+++ b/indra/llcorehttp/httpoptions.h
@@ -55,7 +55,7 @@ namespace LLCore
 /// Allocation:  Refcounted, heap only.  Caller of the constructor
 /// is given a refcount.
 ///
-class HttpOptions : private boost::noncopyable
+class HttpOptions
 {
 public:
     HttpOptions();
@@ -64,10 +64,9 @@ public:
 
     virtual ~HttpOptions();                     // Use release()
 
-protected:
-
-    HttpOptions(const HttpOptions &);           // Not defined
-    void operator=(const HttpOptions &);        // Not defined
+    // Non-copyable
+    HttpOptions(const HttpOptions&) = delete;
+    HttpOptions& operator=(const HttpOptions&) = delete;
 
 public:
 

--- a/indra/llcorehttp/httpresponse.h
+++ b/indra/llcorehttp/httpresponse.h
@@ -65,8 +65,8 @@ public:
 protected:
     virtual ~HttpResponse();                            // Use release()
 
-    HttpResponse(const HttpResponse &);                 // Not defined
-    void operator=(const HttpResponse &);               // Not defined
+    HttpResponse(const HttpResponse&) = delete;
+    void operator=(const HttpResponse&) = delete;
 
 public:
     /// Statistics for the HTTP

--- a/indra/llinventory/llsettingsbase.h
+++ b/indra/llinventory/llsettingsbase.h
@@ -49,8 +49,7 @@
 #define SETTINGS_OVERRIDE override
 
 class LLSettingsBase :
-    public PTR_NAMESPACE::enable_shared_from_this<LLSettingsBase>,
-    private boost::noncopyable
+    public PTR_NAMESPACE::enable_shared_from_this<LLSettingsBase>
 {
     friend class LLEnvironment;
     friend class LLSettingsDay;
@@ -96,7 +95,11 @@ public:
 
     typedef PTR_NAMESPACE::shared_ptr<LLSettingsBase> ptr_t;
 
-    virtual ~LLSettingsBase() { };
+    virtual ~LLSettingsBase() = default;
+
+    // Non-copyable
+    LLSettingsBase(const LLSettingsBase&) = delete;
+    LLSettingsBase& operator=(const LLSettingsBase&) = delete;
 
     //---------------------------------------------------------------------
     virtual std::string getSettingsType() const = 0;
@@ -430,7 +433,7 @@ public:
             mFinal = mInitial;
     }
 
-    virtual ~LLSettingsBlender() {}
+    virtual ~LLSettingsBlender() = default;
 
     virtual void reset( LLSettingsBase::ptr_t &initsetting, const LLSettingsBase::ptr_t &endsetting, const LLSettingsBase::TrackPosition&)
     {

--- a/indra/llmath/llrigginginfo.h
+++ b/indra/llmath/llrigginginfo.h
@@ -70,11 +70,10 @@ public:
     LLJointRiggingInfo* begin() { return mRigInfoPtr; }
     LLJointRiggingInfo* end() { return mRigInfoPtr + mSize; }
 
-private:
-    // Not implemented
-    LLJointRiggingInfoTab& operator=(const LLJointRiggingInfoTab& src);
-    LLJointRiggingInfoTab(const LLJointRiggingInfoTab& src);
+    LLJointRiggingInfoTab& operator=(const LLJointRiggingInfoTab& src) = delete;
+    LLJointRiggingInfoTab(const LLJointRiggingInfoTab& src) = delete;
 
+private:
     LLJointRiggingInfo *mRigInfoPtr;
     S32 mSize;
     bool mNeedsUpdate;

--- a/indra/llmath/llvolumeoctree.h
+++ b/indra/llmath/llvolumeoctree.h
@@ -78,16 +78,8 @@ public:
     LLVolumeOctreeListener(LLOctreeNode<LLVolumeTriangle, LLVolumeTriangle*>* node);
     ~LLVolumeOctreeListener();
 
-    LLVolumeOctreeListener(const LLVolumeOctreeListener& rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLVolumeOctreeListener& operator=(const LLVolumeOctreeListener& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLVolumeOctreeListener(const LLVolumeOctreeListener& rhs) = delete;
+    const LLVolumeOctreeListener& operator=(const LLVolumeOctreeListener& rhs) = delete;
 
      //LISTENER FUNCTIONS
     virtual void handleChildAddition(const LLOctreeNode<LLVolumeTriangle, LLVolumeTriangle*>* parent, LLOctreeNode<LLVolumeTriangle, LLVolumeTriangle*>* child);

--- a/indra/llmessage/llcoproceduremanager.cpp
+++ b/indra/llmessage/llcoproceduremanager.cpp
@@ -53,13 +53,17 @@ static const U32 DEFAULT_POOL_SIZE = 5;
 const U32 LLCoprocedureManager::DEFAULT_QUEUE_SIZE = 1024*512;
 
 //=========================================================================
-class LLCoprocedurePool: private boost::noncopyable
+class LLCoprocedurePool
 {
 public:
     typedef LLCoprocedureManager::CoProcedure_t CoProcedure_t;
 
     LLCoprocedurePool(const std::string &name, size_t size, size_t queue_size);
     ~LLCoprocedurePool();
+
+    // Non-copyable
+    LLCoprocedurePool(const LLCoprocedurePool&) = delete;
+    LLCoprocedurePool& operator=(const LLCoprocedurePool&) = delete;
 
     /// Places the coprocedure on the queue for processing.
     ///

--- a/indra/llrender/llatmosphere.h
+++ b/indra/llrender/llatmosphere.h
@@ -133,11 +133,8 @@ public:
     static void initClass();
     static void cleanupClass();
 
-    const LLAtmosphere& operator=(const LLAtmosphere& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLAtmosphere(const LLAtmosphere& rhs) = delete;
+    const LLAtmosphere& operator=(const LLAtmosphere& rhs) = delete;
 
     LLGLTexture* getTransmittance();
     LLGLTexture* getScattering();
@@ -147,11 +144,6 @@ public:
     bool configureAtmosphericModel(AtmosphericModelSettings& settings);
 
 protected:
-    LLAtmosphere(const LLAtmosphere& rhs)
-    {
-        *this = rhs;
-    }
-
     LLPointer<LLGLTexture> m_transmittance;
     LLPointer<LLGLTexture> m_scattering;
     LLPointer<LLGLTexture> m_mie_scatter_texture;

--- a/indra/llrender/llvertexbuffer.h
+++ b/indra/llrender/llvertexbuffer.h
@@ -98,16 +98,8 @@ public:
         U32 mEnd;
     };
 
-    LLVertexBuffer(const LLVertexBuffer& rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLVertexBuffer& operator=(const LLVertexBuffer& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLVertexBuffer(const LLVertexBuffer& rhs) = delete;
+    const LLVertexBuffer& operator=(const LLVertexBuffer& rhs) = delete;
 
     static void initClass(LLWindow* window);
     static void cleanupClass();

--- a/indra/llui/llnotifications.h
+++ b/indra/llui/llnotifications.h
@@ -303,7 +303,6 @@ typedef std::shared_ptr<LLNotificationVisibilityRule> LLNotificationVisibilityRu
  * shared pointer.
  */
 class LLNotification  :
-    boost::noncopyable,
     public std::enable_shared_from_this<LLNotification>
 {
 LOG_CLASS(LLNotification);
@@ -428,6 +427,10 @@ private:
 
 public:
     LLNotification(const LLSDParamAdapter<Params>& p);
+
+    // Non-copyable
+    LLNotification(const LLNotification&) = delete;
+    LLNotification& operator=(const LLNotification&) = delete;
 
     void setResponseFunctor(std::string const &responseFunctorName);
 
@@ -817,10 +820,9 @@ typedef boost::intrusive_ptr<LLNotificationChannel> LLNotificationChannelPtr;
 // manages a list of notifications
 // Note that if this is ever copied around, we might find ourselves with multiple copies
 // of a queue with notifications being added to different nonequivalent copies. So we
-// make it inherit from boost::noncopyable, and then create a map of LLPointer to manage it.
+// delete the copy operator and constructor, and then create a map of LLPointer to manage it.
 //
 class LLNotificationChannel :
-    boost::noncopyable,
     public LLNotificationChannelBase,
     public LLInstanceTracker<LLNotificationChannel, std::string>
 {
@@ -842,6 +844,10 @@ public:
 
     virtual ~LLNotificationChannel();
     typedef LLNotificationSet::iterator Iterator;
+
+    // Non-copyable
+    LLNotificationChannel(const LLNotificationChannel&) = delete;
+    LLNotificationChannel& operator=(const LLNotificationChannel&) = delete;
 
     std::string getName() const { return mName; }
     typedef std::vector<std::string>::const_iterator parents_iter;

--- a/indra/llui/llview.h
+++ b/indra/llui/llview.h
@@ -50,7 +50,6 @@
 
 #include <list>
 #include <boost/function.hpp>
-#include <boost/noncopyable.hpp>
 
 class LLSD;
 
@@ -637,7 +636,7 @@ public:
     //     LLView::TemporaryDrilldownFunc scoped_func(myfunctor);
     //     // ... test with myfunctor ...
     // } // exiting block restores original LLView::sDrilldown
-    class TemporaryDrilldownFunc: public boost::noncopyable
+    class TemporaryDrilldownFunc
     {
     public:
         TemporaryDrilldownFunc(const DrilldownFunc& func):
@@ -650,6 +649,10 @@ public:
         {
             sDrilldown = mOldDrilldown;
         }
+
+        // Non-copyable
+        TemporaryDrilldownFunc(const TemporaryDrilldownFunc&) = delete;
+        TemporaryDrilldownFunc& operator=(const TemporaryDrilldownFunc&) = delete;
 
     private:
         DrilldownFunc mOldDrilldown;

--- a/indra/newview/lldrawable.h
+++ b/indra/newview/lldrawable.h
@@ -67,17 +67,8 @@ class LLDrawable
 public:
     typedef std::vector<LLFace*> face_list_t;
 
-    LLDrawable(const LLDrawable& rhs)
-        : LLViewerOctreeEntryData(rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLDrawable& operator=(const LLDrawable& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLDrawable(const LLDrawable& rhs) = delete;
+    const LLDrawable& operator=(const LLDrawable& rhs) = delete;
 
     static void initClass();
 

--- a/indra/newview/llface.h
+++ b/indra/newview/llface.h
@@ -58,16 +58,8 @@ class alignas(16) LLFace
 {
     LL_ALIGN_NEW
 public:
-    LLFace(const LLFace& rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLFace& operator=(const LLFace& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLFace(const LLFace& rhs) = delete;
+    const LLFace& operator=(const LLFace& rhs) = delete;
 
     enum EMasks
     {

--- a/indra/newview/llinventorymodel.h
+++ b/indra/newview/llinventorymodel.h
@@ -122,9 +122,8 @@ public:
         FetchItemHttpHandler(const LLSD & request_sd);
         virtual ~FetchItemHttpHandler();
 
-    protected:
-        FetchItemHttpHandler(const FetchItemHttpHandler &);             // Not defined
-        void operator=(const FetchItemHttpHandler &);                   // Not defined
+        FetchItemHttpHandler(const FetchItemHttpHandler&) = delete;
+        FetchItemHttpHandler& operator=(const FetchItemHttpHandler&) = delete;
 
     public:
         virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * response);

--- a/indra/newview/llinventorymodelbackgroundfetch.cpp
+++ b/indra/newview/llinventorymodelbackgroundfetch.cpp
@@ -125,9 +125,8 @@ public:
             LLInventoryModelBackgroundFetch::instance().incrFetchCount(-1);
         }
 
-protected:
-    BGItemHttpHandler(const BGItemHttpHandler&);               // Not defined
-    void operator=(const BGItemHttpHandler&);                  // Not defined
+    BGItemHttpHandler(const BGItemHttpHandler&) = delete;
+    BGItemHttpHandler& operator=(const BGItemHttpHandler&) = delete;
 };
 
 
@@ -159,8 +158,8 @@ public:
         }
 
 protected:
-    BGFolderHttpHandler(const BGFolderHttpHandler&);           // Not defined
-    void operator=(const BGFolderHttpHandler&);                // Not defined
+    BGFolderHttpHandler(const BGFolderHttpHandler&) = delete;
+    BGFolderHttpHandler& operator=(const BGFolderHttpHandler&) = delete;
 
 public:
     virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse* response);

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -654,12 +654,10 @@ public:
           mRequestedBytes(requested_bytes)
         {}
 
-    virtual ~LLMeshHandlerBase()
-        {}
+    virtual ~LLMeshHandlerBase() = default;
 
-protected:
-    LLMeshHandlerBase(const LLMeshHandlerBase &);               // Not defined
-    void operator=(const LLMeshHandlerBase &);                  // Not defined
+    LLMeshHandlerBase(const LLMeshHandlerBase &) = delete;
+    LLMeshHandlerBase& operator=(const LLMeshHandlerBase&) = delete;
 
 public:
     virtual void onCompleted(LLCore::HttpHandle handle, LLCore::HttpResponse * response);
@@ -693,9 +691,8 @@ public:
     }
     virtual ~LLMeshHeaderHandler();
 
-protected:
-    LLMeshHeaderHandler(const LLMeshHeaderHandler &);           // Not defined
-    void operator=(const LLMeshHeaderHandler &);                // Not defined
+    LLMeshHeaderHandler(const LLMeshHeaderHandler&) = delete;
+    LLMeshHeaderHandler& operator=(const LLMeshHeaderHandler&) = delete;
 
 public:
     virtual void processData(LLCore::BufferArray * body, S32 body_offset, U8 * data, S32 data_size);
@@ -719,9 +716,8 @@ public:
         }
     virtual ~LLMeshLODHandler();
 
-protected:
-    LLMeshLODHandler(const LLMeshLODHandler &);                 // Not defined
-    void operator=(const LLMeshLODHandler &);                   // Not defined
+    LLMeshLODHandler(const LLMeshLODHandler&) = delete;
+    LLMeshLODHandler& operator=(const LLMeshLODHandler&) = delete;
 
 public:
     virtual void processData(LLCore::BufferArray * body, S32 body_offset, U8 * data, S32 data_size);
@@ -750,9 +746,8 @@ public:
     }
     virtual ~LLMeshSkinInfoHandler();
 
-protected:
-    LLMeshSkinInfoHandler(const LLMeshSkinInfoHandler &);       // Not defined
-    void operator=(const LLMeshSkinInfoHandler &);              // Not defined
+    LLMeshSkinInfoHandler(const LLMeshSkinInfoHandler&) = delete;
+    LLMeshSkinInfoHandler& operator=(const LLMeshSkinInfoHandler&) = delete;
 
     void processSkin(U8* data, S32 data_size);
 
@@ -778,9 +773,8 @@ public:
     {}
     virtual ~LLMeshDecompositionHandler();
 
-protected:
-    LLMeshDecompositionHandler(const LLMeshDecompositionHandler &);     // Not defined
-    void operator=(const LLMeshDecompositionHandler &);                 // Not defined
+    LLMeshDecompositionHandler(const LLMeshDecompositionHandler&) = delete;
+    LLMeshDecompositionHandler& operator=(const LLMeshDecompositionHandler&) = delete;
 
 public:
     virtual void processData(LLCore::BufferArray * body, S32 body_offset, U8 * data, S32 data_size);
@@ -804,9 +798,8 @@ public:
     {}
     virtual ~LLMeshPhysicsShapeHandler();
 
-protected:
-    LLMeshPhysicsShapeHandler(const LLMeshPhysicsShapeHandler &);   // Not defined
-    void operator=(const LLMeshPhysicsShapeHandler &);              // Not defined
+    LLMeshPhysicsShapeHandler(const LLMeshPhysicsShapeHandler&) = delete;
+    LLMeshPhysicsShapeHandler& operator=(const LLMeshPhysicsShapeHandler&) = delete;
 
 public:
     virtual void processData(LLCore::BufferArray * body, S32 body_offset, U8 * data, S32 data_size);

--- a/indra/newview/llnotificationlistitem.h
+++ b/indra/newview/llnotificationlistitem.h
@@ -156,8 +156,8 @@ protected:
     LLTextBox*  mGroupNameBoxExp;
 
 private:
-    LLGroupNotificationListItem(const LLGroupNotificationListItem &);
-    LLGroupNotificationListItem & operator=(LLGroupNotificationListItem &);
+    LLGroupNotificationListItem(const LLGroupNotificationListItem&) = delete;
+    LLGroupNotificationListItem& operator=(LLGroupNotificationListItem&) = delete;
 
     void setGroupName(std::string name);
     bool updateFromCache();
@@ -175,8 +175,8 @@ public:
 private:
     friend class LLNotificationListItem;
     LLGroupInviteNotificationListItem(const Params& p);
-    LLGroupInviteNotificationListItem(const LLGroupInviteNotificationListItem &);
-    LLGroupInviteNotificationListItem & operator=(LLGroupInviteNotificationListItem &);
+    LLGroupInviteNotificationListItem(const LLGroupInviteNotificationListItem&) = delete;
+    LLGroupInviteNotificationListItem& operator=(LLGroupInviteNotificationListItem&) = delete;
 
     void setFee(S32 fee);
 
@@ -202,8 +202,8 @@ public:
 private:
     friend class LLNotificationListItem;
     LLGroupNoticeNotificationListItem(const Params& p);
-    LLGroupNoticeNotificationListItem(const LLGroupNoticeNotificationListItem &);
-    LLGroupNoticeNotificationListItem & operator=(LLGroupNoticeNotificationListItem &);
+    LLGroupNoticeNotificationListItem(const LLGroupNoticeNotificationListItem&) = delete;
+    LLGroupNoticeNotificationListItem& operator=(LLGroupNoticeNotificationListItem&) = delete;
 
     void setSender(std::string sender);
     void onClickAttachment();
@@ -226,8 +226,8 @@ public:
 private:
     friend class LLNotificationListItem;
     LLTransactionNotificationListItem(const Params& p);
-    LLTransactionNotificationListItem(const LLTransactionNotificationListItem &);
-    LLTransactionNotificationListItem & operator=(LLTransactionNotificationListItem &);
+    LLTransactionNotificationListItem(const LLTransactionNotificationListItem&) = delete;
+    LLTransactionNotificationListItem& operator=(LLTransactionNotificationListItem&) = delete;
     LLAvatarIconCtrl* mAvatarIcon;
     LLAvatarIconCtrl* mAvatarIconExp;
 };
@@ -239,8 +239,8 @@ public:
 private:
     friend class LLNotificationListItem;
     LLSystemNotificationListItem(const Params& p);
-    LLSystemNotificationListItem(const LLSystemNotificationListItem &);
-    LLSystemNotificationListItem & operator=(LLSystemNotificationListItem &);
+    LLSystemNotificationListItem(const LLSystemNotificationListItem&) = delete;
+    LLSystemNotificationListItem & operator=(LLSystemNotificationListItem &) = delete;
     LLIconCtrl* mSystemNotificationIcon;
     LLIconCtrl* mSystemNotificationIconExp;
     bool mIsCaution;

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -71,16 +71,8 @@ protected:
     ~LLDrawInfo();
 
 public:
-    LLDrawInfo(const LLDrawInfo& rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLDrawInfo& operator=(const LLDrawInfo& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLDrawInfo(const LLDrawInfo& rhs) = delete;
+    const LLDrawInfo& operator=(const LLDrawInfo& rhs) = delete;
 
     // return a hash of this LLDrawInfo as a debug color
     LLColor4U getDebugColor() const;
@@ -206,16 +198,8 @@ class LLSpatialGroup : public LLOcclusionCullingGroup
     friend class LLOctreeStateCheck;
 public:
 
-    LLSpatialGroup(const LLSpatialGroup& rhs) : LLOcclusionCullingGroup(rhs)
-    {
-        *this = rhs;
-    }
-
-    const LLSpatialGroup& operator=(const LLSpatialGroup& rhs)
-    {
-        LL_ERRS() << "Illegal operation!" << LL_ENDL;
-        return *this;
-    }
+    LLSpatialGroup(const LLSpatialGroup& rhs) = delete;
+    const LLSpatialGroup& operator=(const LLSpatialGroup& rhs) = delete;
 
     static U32 sNodeCount;
     static bool sNoDelete; //deletion of spatial groups and draw info not allowed if true

--- a/indra/newview/lltexturefetch.cpp
+++ b/indra/newview/lltexturefetch.cpp
@@ -743,10 +743,10 @@ public:
         : LLTextureFetch::TFRequest(),
           mRegionHandle(region_handle)
         {}
-    TFReqSetRegion & operator=(const TFReqSetRegion &); // Not defined
+    TFReqSetRegion(const TFReqSetRegion&) = delete;
+    TFReqSetRegion& operator=(const TFReqSetRegion&) = delete;
 
-    virtual ~TFReqSetRegion()
-        {}
+    virtual ~TFReqSetRegion() = default;
 
     virtual bool doWork(LLTextureFetch * fetcher);
 
@@ -793,7 +793,9 @@ public:
         const LLUUID & session_id,
         const LLUUID & agent_id,
         LLSD& stats_sd);
-    TFReqSendMetrics & operator=(const TFReqSendMetrics &); // Not defined
+
+    TFReqSendMetrics(const TFReqSendMetrics&) = delete;
+    TFReqSendMetrics& operator=(const TFReqSendMetrics&) = delete;
 
     virtual ~TFReqSendMetrics();
 

--- a/indra/newview/llviewerassetstats.h
+++ b/indra/newview/llviewerassetstats.h
@@ -182,7 +182,7 @@ public:
     LLViewerAssetStats(const LLViewerAssetStats &);
 
     // Default destructor is correct.
-    LLViewerAssetStats & operator=(const LLViewerAssetStats &);         // Not defined
+    LLViewerAssetStats& operator=(const LLViewerAssetStats&) = delete;
 
     // Clear all metrics data.  This leaves the currently-active region
     // in place but with zero'd data for all metrics.  All other regions

--- a/indra/newview/llviewerassetstorage.cpp
+++ b/indra/newview/llviewerassetstorage.cpp
@@ -68,7 +68,7 @@ public:
     {
     }
 
-    LLViewerAssetRequest & operator=(const LLViewerAssetRequest &); // Not defined
+    LLViewerAssetRequest& operator=(const LLViewerAssetRequest&) = delete;
     // Default assignment operator valid
 
     // virtual


### PR DESCRIPTION
## Description

This modernizes non-copyable classes with deleted constructors and operators and removes a dependency on boost noncopyable

## Related Issues

- [x] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
