### PR TITLE
Fallback to OS open handler in external editor when no editor is explicitly set

### DIFF
--- a/indra/newview/llexternaleditor.cpp
+++ b/indra/newview/llexternaleditor.cpp
@@ -46,7 +46,7 @@ LLExternalEditor::EErrorCode LLExternalEditor::setCommand(const std::string& env
     {
         LL_INFOS() << "Editor command is empty or not set, falling back to OS open handler" << LL_ENDL;
 #if LL_WINDOWS
-        static const std::string os_cmd = "C:\\Windows\\explorer.exe \"%s\"";
+        static const std::string os_cmd = "%SystemRoot%\\explorer.exe \"%s\"";
 #elif LL_DARWIN
         static const std::string os_cmd = "/usr/bin/open \"%s\"";
 #elif LL_LINUX

--- a/indra/newview/llexternaleditor.cpp
+++ b/indra/newview/llexternaleditor.cpp
@@ -44,8 +44,20 @@ LLExternalEditor::EErrorCode LLExternalEditor::setCommand(const std::string& env
     std::string cmd = findCommand(env_var, override);
     if (cmd.empty())
     {
-        LL_WARNS() << "Editor command is empty or not set" << LL_ENDL;
-        return EC_NOT_SPECIFIED;
+        LL_INFOS() << "Editor command is empty or not set, falling back to OS open handler" << LL_ENDL;
+#if LL_WINDOWS
+        static const std::string os_cmd = "C:\\Windows\\explorer.exe \"%s\"";
+#elif LL_DARWIN
+        static const std::string os_cmd = "/usr/bin/open \"%s\"";
+#elif LL_LINUX
+        static const std::string os_cmd = "/usr/bin/xdg-open \"%s\"";
+#endif
+        cmd = findCommand("", os_cmd);
+        if (cmd.empty())
+        {
+            LL_WARNS() << "Failed to find OS open handler \"" << cmd << "\"" << LL_ENDL;
+            return EC_NOT_SPECIFIED;
+        }
     }
 
     string_vec_t tokens;


### PR DESCRIPTION
## Description

Fallback to OS open handler in external editor when no editor is explicitly set so that it spawns via OS editor preferences

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
