### PR TITLE
Fix build failure introduced in boost::function cleanup from missing bind header

### DIFF
--- a/indra/llui/llmenugl.h
+++ b/indra/llui/llmenugl.h
@@ -38,6 +38,8 @@
 #include "lluistring.h"
 #include "llview.h"
 
+#include <boost/bind.hpp>
+
 extern S32 MENU_BAR_HEIGHT;
 extern S32 MENU_BAR_WIDTH;
 

--- a/indra/llui/lluictrl.h
+++ b/indra/llui/lluictrl.h
@@ -32,6 +32,7 @@
 #include "llrect.h"
 #include "llsd.h"
 #include <functional>
+#include <boost/bind.hpp>
 #include <boost/signals2.hpp>
 
 #include "llinitparam.h"


### PR DESCRIPTION
## Description

Fix build failure introduced in boost::function cleanup from missing bind header

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
