### PR TITLE
#5084 Ressurect Watchdog

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -4484,13 +4484,24 @@
     <key>MainloopTimeoutDefault</key>
     <map>
       <key>Comment</key>
-      <string>Timeout duration for mainloop lock detection, in seconds.</string>
+      <string>Timeout duration for mainloop lock detection during teleports, login and logout, in seconds.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
-      <real>60.0</real>
+      <real>120.0</real>
+    </map>
+    <key>MainloopTimeoutStarted</key>
+    <map>
+        <key>Comment</key>
+        <string>Timeout duration for mainloop lock detection when logged in and not teleporting, in seconds.</string>
+        <key>Persist</key>
+        <integer>1</integer>
+        <key>Type</key>
+        <string>F32</string>
+        <key>Value</key>
+        <real>30.0</real>
     </map>
     <key>MapScale</key>
     <map>
@@ -13862,13 +13873,13 @@
     <key>WatchdogEnabled</key>
     <map>
       <key>Comment</key>
-      <string>Controls whether the thread watchdog timer is activated. Value is boolean. Set to -1 to defer to built-in default.</string>
+      <string>Controls whether the thread watchdog timer is activated. Value is S32. Set to -1 to defer to built-in default.</string>
       <key>Persist</key>
       <integer>0</integer>
       <key>Type</key>
       <string>S32</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>WaterGLFogDensityScale</key>
     <map>

--- a/indra/newview/llappviewer.h
+++ b/indra/newview/llappviewer.h
@@ -204,11 +204,13 @@ public:
     // For thread debugging.
     // llstartup needs to control init.
     // llworld, send_agent_pause() also controls pause/resume.
-    void initMainloopTimeout(std::string_view state, F32 secs = -1.0f);
+    void initMainloopTimeout(std::string_view state);
     void destroyMainloopTimeout();
     void pauseMainloopTimeout();
-    void resumeMainloopTimeout(std::string_view state = "", F32 secs = -1.0f);
-    void pingMainloopTimeout(std::string_view state, F32 secs = -1.0f);
+    void resumeMainloopTimeout(std::string_view state = "");
+    void pingMainloopTimeout(std::string_view state);
+
+    F32 getMainloopTimeoutSec() const;
 
     // Handle the 'login completed' event.
     // *NOTE:Mani Fix this for login abstraction!!

--- a/indra/newview/llappviewerwin32.cpp
+++ b/indra/newview/llappviewerwin32.cpp
@@ -176,10 +176,17 @@ namespace
             LLAppViewer* app = LLAppViewer::instance();
             if (!app->isSecondInstance() && !app->errorMarkerExists())
             {
-                // If marker doesn't exist, create a marker with 'other' code for next launch
+                // If marker doesn't exist, create a marker with 'other' or 'logout' code for next launch
                 // otherwise don't override existing file
                 // Any unmarked crashes will be considered as freezes
-                app->createErrorMarker(LAST_EXEC_OTHER_CRASH);
+                if (app->logoutRequestSent())
+                {
+                    app->createErrorMarker(LAST_EXEC_LOGOUT_CRASH);
+                }
+                else
+                {
+                    app->createErrorMarker(LAST_EXEC_OTHER_CRASH);
+                }
             }
         } // MDSCB_EXCEPTIONCODE
 

--- a/indra/newview/llwatchdog.cpp
+++ b/indra/newview/llwatchdog.cpp
@@ -28,6 +28,7 @@
 #include "llviewerprecompiledheaders.h"
 #include "llwatchdog.h"
 #include "llthread.h"
+#include "llappviewer.h"
 
 constexpr U32 WATCHDOG_SLEEP_TIME_USEC = 1000000U;
 
@@ -240,7 +241,16 @@ void LLWatchdog::run()
             {
                 mTimer->stop();
             }
-
+            if (LLAppViewer::instance()->logoutRequestSent())
+            {
+                LLAppViewer::instance()->createErrorMarker(LAST_EXEC_LOGOUT_FROZE);
+            }
+            else
+            {
+                LLAppViewer::instance()->createErrorMarker(LAST_EXEC_FROZE);
+            }
+            // Todo1: warn user?
+            // Todo2: We probably want to report even if 5 seconds passed, just not error 'yet'.
             LL_ERRS() << "Watchdog timer expired; assuming viewer is hung and crashing" << LL_ENDL;
         }
     }


### PR DESCRIPTION
Statistic reports a lot of freezes, enable watchdog (and fix it up to not mess statistics) to catch them. For now it's somewhat a test, if it impacts users (in case someone was happy to wait 30s for viewer to unfreeze) we might want to reconsider these values. 