### PR TITLE
#3612 "Copy SLURL" from Favorites bar not working

### DIFF
--- a/indra/newview/llfavoritesbar.cpp
+++ b/indra/newview/llfavoritesbar.cpp
@@ -1395,6 +1395,13 @@ bool LLFavoritesBarCtrl::enableSelected(const LLSD& userdata)
     {
         return !LLAgentPicksInfo::getInstance()->isPickLimitReached();
     }
+    else if (param == "copy_slurl"
+             || param == "show_on_map")
+    {
+        LLVector3d posGlobal;
+        LLLandmarkActions::getLandmarkGlobalPos(mSelectedItemID, posGlobal);
+        return !posGlobal.isExactlyZero();
+    }
 
     return false;
 }

--- a/indra/newview/skins/default/xui/en/menu_favorites.xml
+++ b/indra/newview/skins/default/xui/en/menu_favorites.xml
@@ -35,6 +35,9 @@
         <menu_item_call.on_click
          function="Favorites.DoToSelected"
          parameter="show_on_map" />
+        <menu_item_call.on_enable
+         function="Favorites.EnableSelected"
+         parameter="show_on_map" />
     </menu_item_call>
     <menu_item_call
      label="Copy SLurl"
@@ -42,6 +45,9 @@
      name="Copy slurl">
         <menu_item_call.on_click
          function="Favorites.DoToSelected"
+         parameter="copy_slurl" />
+        <menu_item_call.on_enable
+         function="Favorites.EnableSelected"
          parameter="copy_slurl" />
     </menu_item_call>
     <menu_item_call


### PR DESCRIPTION
If region isn't online (or on the grid), can't get region position and form slurl. Disable position dependent menus in such a case.