### PR TITLE
#5109 LLExperienceCache crashes on a coroutine

### DIFF
--- a/indra/llmessage/llexperiencecache.h
+++ b/indra/llmessage/llexperiencecache.h
@@ -144,9 +144,9 @@ private:
     std::string     mCacheFileName;
     static bool     sShutdown; // control for coroutines, they exist out of LLExperienceCache's scope, so they need a static control
 
-    void idleCoro();
+    static void idleCoro();
     void eraseExpired();
-    void requestExperiencesCoro(LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t &, std::string, RequestQueue_t);
+    static void requestExperiencesCoro(LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t &, std::string, RequestQueue_t);
     void requestExperiences();
 
     void fetchAssociatedExperienceCoro(LLCoreHttpUtil::HttpCoroutineAdapter::ptr_t &, LLUUID, LLUUID, std::string, ExperienceGetFn_t);

--- a/indra/newview/llpanelplaceprofile.cpp
+++ b/indra/newview/llpanelplaceprofile.cpp
@@ -517,7 +517,7 @@ void LLPanelPlaceProfile::displaySelectedParcelInfo(LLParcel* parcel,
             std::string parcel_owner =
                 LLSLURL("agent", parcel->getOwnerID(), "inspect").getSLURLString();
             mParcelOwner->setText(parcel_owner);
-            LLAvatarNameCache::get(region->getOwner(), boost::bind(&LLPanelPlaceInfo::onAvatarNameCache, _1, _2, mRegionOwnerText));
+            mAvatarNameCacheConnection = LLAvatarNameCache::get(region->getOwner(), boost::bind(&LLPanelPlaceInfo::onAvatarNameCache, _1, _2, mRegionOwnerText));
             mRegionGroupText->setText( getString("none_text"));
         }
 
@@ -548,7 +548,7 @@ void LLPanelPlaceProfile::displaySelectedParcelInfo(LLParcel* parcel,
         const LLUUID& auth_buyer_id = parcel->getAuthorizedBuyerID();
         if(auth_buyer_id.notNull())
         {
-            LLAvatarNameCache::get(auth_buyer_id, boost::bind(&LLPanelPlaceInfo::onAvatarNameCache, _1, _2, mSaleToText));
+            mAvatarNameCacheConnection = LLAvatarNameCache::get(auth_buyer_id, boost::bind(&LLPanelPlaceInfo::onAvatarNameCache, _1, _2, mSaleToText));
 
             // Show sales info to a specific person or a group he belongs to.
             if (auth_buyer_id != gAgent.getID() && !gAgent.isInGroup(auth_buyer_id))

--- a/indra/newview/llpanelplaceprofile.h
+++ b/indra/newview/llpanelplaceprofile.h
@@ -118,6 +118,8 @@ private:
     LLTextEditor*       mResaleText;
     LLTextBox*          mSaleToText;
     LLAccordionCtrl*    mAccordionCtrl;
+
+    boost::signals2::scoped_connection mAvatarNameCacheConnection;
 };
 
 #endif // LL_LLPANELPLACEPROFILE_H


### PR DESCRIPTION
Something weird is going on inside of a coroutine, but given their usual track record, adding protections to make sure they don't carry something over from a dead parent.