### PR TITLE
Fix failure to reconnect after disconnect and occasional dropout issue

### DIFF
--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -1004,7 +1004,7 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection(const LLWebRTCPeerConnecti
             }
 
             webrtc::PeerConnectionInterface::RTCOfferAnswerOptions offerOptions;
-            this->AddRef();
+            this->AddRef(); // CreateOffer will deref this when it's done.  Without this, the callbacks never get called.
             mPeerConnection->CreateOffer(this, offerOptions);
             mPendingJobs--;
         });

--- a/indra/llwebrtc/llwebrtc.cpp
+++ b/indra/llwebrtc/llwebrtc.cpp
@@ -814,6 +814,7 @@ LLWebRTCPeerConnectionImpl::~LLWebRTCPeerConnectionImpl()
 {
     mSignalingObserverList.clear();
     mDataObserverList.clear();
+    mPeerConnectionFactory.release();
     if (mPendingJobs > 0)
     {
         RTC_LOG(LS_ERROR) << __FUNCTION__ << "Destroying a connection that has " << std::to_string(mPendingJobs) << " unfinished jobs that might cause workers to crash";
@@ -877,7 +878,6 @@ void LLWebRTCPeerConnectionImpl::terminate()
             }
             mPendingJobs--;
         });
-    mPeerConnectionFactory.release();
 }
 
 void LLWebRTCPeerConnectionImpl::setSignalingObserver(LLWebRTCSignalingObserver *observer) { mSignalingObserverList.emplace_back(observer); }
@@ -1004,6 +1004,7 @@ bool LLWebRTCPeerConnectionImpl::initializeConnection(const LLWebRTCPeerConnecti
             }
 
             webrtc::PeerConnectionInterface::RTCOfferAnswerOptions offerOptions;
+            this->AddRef();
             mPeerConnection->CreateOffer(this, offerOptions);
             mPendingJobs--;
         });

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2922,6 +2922,10 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
                     LLWebRTCVoiceClient::getInstance()->updatePosition();
                     LLWebRTCVoiceClient::getInstance()->sendPositionUpdate(true);
                 }
+                else
+                {
+                    mWebRTCAudioInterface->setMute(mMuted);
+                }
             }
             break;
         }

--- a/indra/newview/llvoicewebrtc.cpp
+++ b/indra/newview/llvoicewebrtc.cpp
@@ -2549,10 +2549,7 @@ void LLVoiceWebRTCConnection::OnRenegotiationNeeded()
     LL::WorkQueue::postMaybe(mMainQueue,
         [=, this] {
             LL_DEBUGS("Voice") << "Voice channel requires renegotiation." << LL_ENDL;
-            if (!mShutDown)
-            {
-                setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
-            }
+            setVoiceConnectionState(VOICE_STATE_SESSION_RETRY);
             mCurrentStatus = LLVoiceClientStatusObserver::ERROR_UNKNOWN;
         });
 }
@@ -2898,9 +2895,10 @@ bool LLVoiceWebRTCConnection::connectionStateMachine()
             // this connection.
             // For spatial this connection will come up as muted, but will be set to the appropriate
             // value later on when we determine the regions we connect to.
-            if (!isSpatial())
+            if (isSpatial())
             {
-                mWebRTCAudioInterface->setMute(mMuted);
+                // we'll determine primary state later and set mute accordinly
+                mPrimary = false;
             }
             mWebRTCAudioInterface->setReceiveVolume(mSpeakerVolume);
             LLWebRTCVoiceClient::getInstance()->OnConnectionEstablished(mChannelID, mRegionID);


### PR DESCRIPTION
We were occasionally seeing dropouts which may have been caused by ICE renegotiate requests.  The code is there to reconnect in that case, but there were a few bugs, some of which were likely due to the webrtc upgrade.

Also, we were seeing failures to reconnect after voice server restart.

There were some issues with the PTT button that came up after the above issue was fixed.

https://github.com/secondlife/viewer/issues/5120
https://github.com/secondlife/viewer/issues/5118
https://github.com/secondlife/viewer/issues/4743

Test Guidance:
* be in a voice region during a voice server deploy
* validate that you reconnect to voice automatically after the deploy.
* Do so with the speak button pressed.
* Validate that you can still be heard after the deploy.

