### PR TITLE
#2639 Reapplied GPU benchmark fix

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -7335,7 +7335,7 @@
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>32.0</real>
+    <real>48.0</real>
   </map>
   <key>RenderCPUBasis</key>
   <map>


### PR DESCRIPTION
First test returns quarter to a half the throughput, second one works fine so do two tests. May be caused by driver, may be some 'energy saving', but not important enough to spend time investingating. It was working the same way prior to ExtraFPS, but viewer was running an extra CPU test that 'preheated' the system.

Also increasing minimum throughput as numerous new features, like mirrors and pbr were added and requirements are now higher.