### PR TITLE
fix multi column comboboxes not honoring width parameter

### DIFF
--- a/indra/llui/llscrolllistctrl.cpp
+++ b/indra/llui/llscrolllistctrl.cpp
@@ -3185,6 +3185,7 @@ LLScrollListItem* LLScrollListCtrl::addRow(LLScrollListItem *new_item, const LLS
             if (cell_p.width.isProvided())
             {
                 new_column.width.pixel_width = cell_p.width;
+                new_column.width.pixel_width.choose();
             }
             addColumn(new_column);
             columnp = mColumns[column];


### PR DESCRIPTION
## Description

This fix makes the "width" parameter work correctly in <combo_box.items><column> XUI definition. Previously, all columns added were rendered the same width, which also was a bit too small for the longest line, so you always got [...] at the end. marking the pixel_width as chosen width alternative fixes this problem.

---

## Checklist

Please ensure the following before requesting review:

- [X] I have provided a clear title and detailed description for this pull request.
- [X] If useful, I have included media such as screenshots and video to show off my changes.
- [/] The PR is linked to a relevant issue with sufficient context.
- [X] I have tested the changes locally and verified they work as intended.
- [/] All new and existing tests pass.
- [X] Code follows the project's style guidelines.
- [/] Documentation has been updated if needed.
- [/] Any dependent changes have been merged and published in downstream modules
- [X] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
