### PR TITLE
Prune files from macOS GHA runner to fix build failure from disk space exhaustion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Linux Disk Cleanup
         if: runner.os == 'Linux'
         run: |
-          # Prune various unused files from linux builder to fix free runner disk space exhaustion
+          # Prune various unused files from linux builder to fix runner disk space exhaustion
           df -h
           sudo docker container prune -f
           sudo docker image prune -a -f
@@ -102,6 +102,24 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/.ghcup
+          df -h
+
+      - name: macOS Disk Cleanup
+        if: runner.os == 'macOS'
+        run: |
+          # Prune various unused files from macOS builder to fix runner disk space exhaustion
+          df -h
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/google/chrome
+          sudo rm -rf /opt/microsoft/msedge
+          sudo rm -rf /opt/microsoft/powershell
+          sudo rm -rf /usr/lib/mono
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/share/dotnet
           df -h
 
       - name: Setup python


### PR DESCRIPTION
## Description

Prunes various tools and files unused by our build tooling from macOS runner to provide more free disk space for build.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
