### PR TITLE
[#5155] Cleaned up unnecessary fake bool usage where appropriate

### DIFF
--- a/indra/integration_tests/llimage_libtest/llimage_libtest.cpp
+++ b/indra/integration_tests/llimage_libtest/llimage_libtest.cpp
@@ -530,7 +530,7 @@ int main(int argc, char** argv)
             }
             else
             {
-                LLFastTimer::sMetricLog = TRUE;
+                LLFastTimer::sMetricLog = true;
                 LLFastTimer::sLogName = test_name;
                 arg += 1;                   // Skip that arg now we know it's a valid test name
                 if ((arg + 1) == argc)      // Break out of the loop if we reach the end of the arg list

--- a/indra/integration_tests/llui_libtest/llui_libtest.cpp
+++ b/indra/integration_tests/llui_libtest/llui_libtest.cpp
@@ -187,7 +187,7 @@ void export_test_floaters()
         LLXMLNodePtr output_node = new LLXMLNode();
         LLFloater* floater = new LLFloater(LLSD());
         floater->buildFromFile( filename,
-                                //   FALSE, // don't open floater
+                                //   false, // don't open floater
                                 output_node);
         std::string out_filename = gDirUtilp->add(xui_dir, filename);
         std::string::size_type extension_pos = out_filename.rfind(".xml");

--- a/indra/llcommon/StackWalker.cpp
+++ b/indra/llcommon/StackWalker.cpp
@@ -904,7 +904,7 @@ bool StackWalker::LoadModules()
     SetLastError(ERROR_DLL_INIT_FAILED);
     return false;
   }
-  if (m_modulesLoaded != FALSE)
+  if (m_modulesLoaded)
     return true;
 
   // Build the sym-path:

--- a/indra/llrender/llrendertarget.h
+++ b/indra/llrender/llrendertarget.h
@@ -42,7 +42,7 @@
     ...
 
     //allocate a 256x256 RGBA render target with depth buffer
-    target.allocate(256,256,GL_RGBA,TRUE);
+    target.allocate(256,256,GL_RGBA,true);
 
     //render to contents of offscreen buffer
     target.bindTarget();

--- a/indra/llui/tests/llurlentry_stub.cpp
+++ b/indra/llui/tests/llurlentry_stub.cpp
@@ -50,16 +50,16 @@ LLAvatarNameCache::callback_connection_t LLAvatarNameCache::get(const LLUUID& ag
 //
 // Stub implementation for LLCacheName
 //
-BOOL LLCacheName::getFullName(const LLUUID& id, std::string& fullname)
+bool LLCacheName::getFullName(const LLUUID& id, std::string& fullname)
 {
     fullname = "Lynx Linden";
-    return TRUE;
+    return true;
 }
 
-BOOL LLCacheName::getGroupName(const LLUUID& id, std::string& group)
+bool LLCacheName::getGroupName(const LLUUID& id, std::string& group)
 {
     group = "My Group";
-    return TRUE;
+    return true;
 }
 
 boost::signals2::connection LLCacheName::get(const LLUUID& id, bool is_group, const LLCacheNameCallback& callback)

--- a/indra/newview/llcallbacklist.cpp
+++ b/indra/newview/llcallbacklist.cpp
@@ -70,33 +70,33 @@ void LLCallbackList::addFunction( callback_t func, void *data)
 }
 
 
-BOOL LLCallbackList::containsFunction( callback_t func, void *data)
+bool LLCallbackList::containsFunction( callback_t func, void *data)
 {
     callback_pair_t t(func, data);
     callback_list_t::iterator iter = std::find(mCallbackList.begin(), mCallbackList.end(), t);
     if (iter != mCallbackList.end())
     {
-        return TRUE;
+        return true;
     }
     else
     {
-        return FALSE;
+        return false;
     }
 }
 
 
-BOOL LLCallbackList::deleteFunction( callback_t func, void *data)
+bool LLCallbackList::deleteFunction( callback_t func, void *data)
 {
     callback_pair_t t(func, data);
     callback_list_t::iterator iter = std::find(mCallbackList.begin(), mCallbackList.end(), t);
     if (iter != mCallbackList.end())
     {
         mCallbackList.erase(iter);
-        return TRUE;
+        return true;
     }
     else
     {
-        return FALSE;
+        return false;
     }
 }
 

--- a/indra/newview/lleventnotifier.h
+++ b/indra/newview/lleventnotifier.h
@@ -47,7 +47,7 @@ struct LLEventInfo
     std::string mSimName;
     LLVector3d  mPosGlobal;
     F64         mUnixTime; // seconds from 1970
-    BOOL        mHasCover;
+    bool        mHasCover;
     U32         mCover;
     U32         mEventFlags;
 };

--- a/indra/newview/llfloaterdirectory.h
+++ b/indra/newview/llfloaterdirectory.h
@@ -76,6 +76,6 @@ private:
     static LLFloaterDirectory *sInstance;
 };
 
-//extern BOOL gDisplayEventHack;
+//extern bool gDisplayEventHack;
 
 #endif  // LL_LLDIRECTORYFLOATER_H

--- a/indra/newview/lllookshistorypanel.h
+++ b/indra/newview/lllookshistorypanel.h
@@ -40,7 +40,7 @@ public:
     LLLooksHistoryPanel();
     virtual ~LLLooksHistoryPanel();
 
-    /*virtual*/ BOOL postBuild();
+    /*virtual*/ bool postBuild();
     /*virtual*/ void onSearchEdit(const std::string& string);
     /*virtual*/ void onShowOnMap();
     /*virtual*/ void onLooks();

--- a/indra/newview/llpaneldirland.cpp
+++ b/indra/newview/llpaneldirland.cpp
@@ -197,7 +197,7 @@ void LLPanelDirLand::performQuery()
     if (list)
     {
         std::string sort_name = list->getSortColumnName();
-        BOOL sort_asc = list->getSortAscending();
+        bool sort_asc = list->getSortAscending();
 
         if (sort_name == "name")
         {

--- a/indra/newview/llpanelimcontrolpanel.h
+++ b/indra/newview/llpanelimcontrolpanel.h
@@ -40,7 +40,7 @@ public:
         mSessionId(LLUUID()) {};
     ~LLPanelChatControlPanel();
 
-    virtual BOOL postBuild();
+    virtual bool postBuild();
 
     virtual void setSessionId(const LLUUID& session_id);
     const LLUUID& getSessionId() { return mSessionId; }
@@ -58,7 +58,7 @@ public:
     LLPanelGroupControlPanel(const LLUUID& session_id);
     ~LLPanelGroupControlPanel();
 
-    BOOL postBuild();
+    bool postBuild();
 
     void setSessionId(const LLUUID& session_id);
     /*virtual*/ void draw();
@@ -77,7 +77,7 @@ class LLPanelAdHocControlPanel : public LLPanelGroupControlPanel
 public:
     LLPanelAdHocControlPanel(const LLUUID& session_id);
 
-    BOOL postBuild();
+    bool postBuild();
 
 };
 

--- a/indra/newview/lltoolview.cpp
+++ b/indra/newview/lltoolview.cpp
@@ -109,8 +109,8 @@ LLToolView::~LLToolView()
 //  // Can optionally ignore panel
 //  if (contain->mPanel)
 //  {
-//      contain->mPanel->setBackgroundVisible( FALSE );
-//      contain->mPanel->setBorderVisible( FALSE );
+//      contain->mPanel->setBackgroundVisible( false );
+//      contain->mPanel->setBorderVisible( false );
 //      addChild(contain->mPanel);
 //  }
 
@@ -153,7 +153,7 @@ void LLToolView::draw()
          iter != mContainList.end(); ++iter)
     {
         LLToolContainer* contain = *iter;
-        BOOL state = (contain->mTool == selected);
+        bool state = (contain->mTool == selected);
         contain->mButton->setToggleState( state );
         if (contain->mPanel)
         {

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -3623,7 +3623,7 @@ LLViewerMediaImpl::canUndo() const
     if (mMediaSource)
         return mMediaSource->canUndo();
     else
-        return FALSE;
+        return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3643,7 +3643,7 @@ LLViewerMediaImpl::canRedo() const
     if (mMediaSource)
         return mMediaSource->canRedo();
     else
-        return FALSE;
+        return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3723,7 +3723,7 @@ LLViewerMediaImpl::canDoDelete() const
     if (mMediaSource)
         return mMediaSource->canDoDelete();
     else
-        return FALSE;
+        return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3743,7 +3743,7 @@ LLViewerMediaImpl::canSelectAll() const
     if (mMediaSource)
         return mMediaSource->canSelectAll();
     else
-        return FALSE;
+        return false;
 }
 
 void LLViewerMediaImpl::setUpdated(bool updated)

--- a/indra/newview/tests/lldir_stub.cpp
+++ b/indra/newview/tests/lldir_stub.cpp
@@ -28,7 +28,7 @@
 
 LLDir::LLDir() {}
 LLDir::~LLDir() {}
-BOOL LLDir::deleteFilesInDir(const std::string &dirname, const std::string &mask) { return true; }
+S32 LLDir::deleteFilesInDir(const std::string &dirname, const std::string &mask) { return 1; }
 void LLDir::setChatLogsDir(const std::string &path) {}
 void LLDir::setPerAccountChatLogsDir(const std::string &) {}
 void LLDir::updatePerAccountChatLogsDir() {}

--- a/indra/newview/tests/llxmlrpclistener_test.cpp
+++ b/indra/newview/tests/llxmlrpclistener_test.cpp
@@ -62,8 +62,8 @@ namespace tut
             // These variables are required by machinery used by
             // LLXMLRPCTransaction. The values reflect reality for this test
             // executable; hopefully these values are correct.
-            gSavedSettings.declareBOOL("BrowserProxyEnabled", FALSE, "", LLControlVariable::PERSIST_NO); // don't persist
-            gSavedSettings.declareBOOL("NoVerifySSLCert", TRUE, "", LLControlVariable::PERSIST_NO); // don't persist
+            gSavedSettings.declareBOOL("BrowserProxyEnabled", false, "", LLControlVariable::PERSIST_NO); // don't persist
+            gSavedSettings.declareBOOL("NoVerifySSLCert", true, "", LLControlVariable::PERSIST_NO); // don't persist
         }
 
         // LLEventPump listener signature


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5155

~~**Note:** Probably best to wait for Rye's other PR to be merged first and then I'll rebase this one, as there will be a couple conflicts with him deleting source files- https://github.com/secondlife/viewer/pull/5153~~ _Merged_

Simply cleans up usages of fake bools where a regular bool is more appropriate, or where function declarations expect a regular bool but a fake bool was used instead.

Fake bool usages in existing APIs such as WinAPI or gtk and others were left untouched as to follow the standards of those libraries.

I also didn't update the fake bool usage for LLPathingLib::createPhysicsCapsuleRep because this would require a change in the LL Havok library to avoid any implicit conversions.