### PR TITLE
Split Viewer and Test builds into separate jobs in GHA to reduce potential for disk space exhaustion

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
       matrix:
         runner: ${{ fromJson((github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/Second_Life')) && '["windows-large","macos-15-xlarge","linux-large"]' || '["windows-2022","macos-15-xlarge","ubuntu-22.04"]') }}
         configuration: ${{ fromJson(needs.setup.outputs.configurations) }}
+        build_variant: [Viewer, Tests]
     runs-on: ${{ matrix.runner }}
     outputs:
       viewer_channel: ${{ steps.build.outputs.viewer_channel }}
@@ -68,9 +69,9 @@ jobs:
       DEVELOPER_DIR: "/Applications/Xcode_16.4.app/Contents/Developer"
       # Ensure that Linden viewer builds engage Bugsplat.
       BUGSPLAT_DB: ${{ needs.setup.outputs.bugsplat_db }}
-      build_coverity: false
       build_log_dir: ${{ github.workspace }}/.logs
-      build_viewer: true
+      build_viewer: ${{ matrix.build_variant == 'Viewer' }}
+      build_tests: ${{ matrix.build_variant == 'Tests' }}
       BUILDSCRIPTS_SHARED: ${{ github.workspace }}/.shared
       # extracted and committed to viewer repo
       BUILDSCRIPTS_SUPPORT_FUNCTIONS: ${{ github.workspace }}/buildscripts_support_functions
@@ -91,9 +92,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Linux Disk Cleanup
-        if: runner.os == 'Linux'
+        if: matrix.build_variant == 'Viewer' && runner.os == 'Linux'
         run: |
-          # Prune various unused files from linux builder to fix runner disk space exhaustion
+          # Prune various unused files from linux builder for Viewer build to fix runner disk space exhaustion
           df -h
           sudo docker container prune -f
           sudo docker image prune -a -f
@@ -102,24 +103,6 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/.ghcup
-          df -h
-
-      - name: macOS Disk Cleanup
-        if: runner.os == 'macOS'
-        run: |
-          # Prune various unused files from macOS builder to fix runner disk space exhaustion
-          df -h
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/google/chrome
-          sudo rm -rf /opt/microsoft/msedge
-          sudo rm -rf /opt/microsoft/powershell
-          sudo rm -rf /usr/lib/mono
-          sudo rm -rf /usr/local/julia*
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/local/share/chromium
-          sudo rm -rf /usr/local/share/powershell
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf /usr/share/dotnet
           df -h
 
       - name: Setup python
@@ -147,8 +130,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .autobuild-installables
-          key: ${{ runner.os }}-64-${{ matrix.configuration }}-${{ hashFiles('autobuild.xml') }}
+          key: ${{ runner.os }}-64-${{ matrix.configuration }}-${{ matrix.build_variant }}-${{ hashFiles('autobuild.xml') }}
           restore-keys: |
+            ${{ runner.os }}-64-${{ matrix.configuration }}-${{ matrix.build_variant }}-
             ${{ runner.os }}-64-${{ matrix.configuration }}-
             ${{ runner.os }}-64-
 
@@ -311,8 +295,8 @@ jobs:
           echo "artifact=$RUNNER_OS$cfg_suffix" >> $GITHUB_OUTPUT
 
       - name: Upload executable
-        if: steps.build.outputs.viewer_app
         uses: actions/upload-artifact@v4
+        if: matrix.build_variant == 'Viewer' && steps.build.outputs.viewer_app
         with:
           name: "${{ steps.build.outputs.artifact }}-app"
           path: |
@@ -321,14 +305,15 @@ jobs:
       # The other upload of nontrivial size is the symbol file. Use a distinct
       # artifact for that too.
       - name: Upload symbol file
-        if: steps.build.outputs.symbolfile
         uses: actions/upload-artifact@v4
+        if: matrix.build_variant == 'Viewer' && steps.build.outputs.symbolfile
         with:
           name: "${{ steps.build.outputs.artifact }}-symbols"
           path: ${{ steps.build.outputs.symbolfile }}
 
       - name: Upload metadata
         uses: actions/upload-artifact@v4
+        if: matrix.build_variant == 'Viewer'
         with:
           name: "${{ steps.build.outputs.artifact }}-metadata"
           # emitted by build.sh, possibly multiple lines
@@ -338,7 +323,7 @@ jobs:
       - name: Upload physics package
         uses: actions/upload-artifact@v4
         # should only be set for viewer-private
-        if: matrix.configuration == 'Release' && steps.build.outputs.physicstpv
+        if: matrix.build_variant == 'Viewer' && matrix.configuration == 'Release' && steps.build.outputs.physicstpv
         with:
           name: "${{ steps.build.outputs.artifact }}-physics"
           # emitted by build.sh, zero or one lines
@@ -347,7 +332,7 @@ jobs:
 
       - name: Upload appearance utility package
         uses: actions/upload-artifact@v4
-        if: steps.build.outputs.appearanceutility
+        if: matrix.build_variant == 'Viewer' && steps.build.outputs.appearanceutility
         with:
           name: "${{ steps.build.outputs.artifact }}-appearanceutility"
           # emitted by build.sh, zero or one lines

--- a/build.sh
+++ b/build.sh
@@ -150,6 +150,7 @@ pre_build()
 
     RELEASE_CRASH_REPORTING=OFF
     HAVOK=OFF
+    TESTING=OFF
     SIGNING=()
     if [[ "$variant" != *OS ]]
     then
@@ -169,6 +170,11 @@ pre_build()
     then
       # RELEASE_CRASH_REPORTING is tuned on unconditionaly, this is fine but not for Linux as of now (due to missing breakpad/crashpad support)
       RELEASE_CRASH_REPORTING=OFF
+    fi
+
+    if $build_tests
+    then
+      TESTING=ON
     fi
 
     if [ "${RELEASE_CRASH_REPORTING:-}" != "OFF" ]
@@ -195,7 +201,7 @@ pre_build()
 
     "$autobuild" configure --quiet -c $variant \
      ${eval_autobuild_configure_parameters:---} \
-     -DLL_TESTS:BOOL=ON \
+     -DLL_TESTS:BOOL="$TESTING" \
      -DPACKAGE:BOOL=ON \
      -DHAVOK:BOOL="$HAVOK" \
      -DRELEASE_CRASH_REPORTING:BOOL="$RELEASE_CRASH_REPORTING" \
@@ -246,7 +252,18 @@ package_llphysicsextensions_tpv()
 build()
 {
   local variant="$1"
-  if $build_viewer
+  if $build_tests
+  then
+    begin_section "autobuild $variant tests"
+    # honor autobuild_build_parameters same as sling-buildscripts
+    export CTEST_OUTPUT_ON_FAILURE=1 # Output log on test failure
+    eval_autobuild_build_parameters=$(eval $(echo echo $autobuild_build_parameters))
+    "$autobuild" build --no-configure -c $variant \
+         $eval_autobuild_build_parameters -- --target BUILD_AND_RUN_TESTS \
+    || fatal "failed building $variant tests"
+    echo true >"$build_dir"/build_ok
+    end_section "autobuild $variant tests"
+  elif $build_viewer
   then
     begin_section "autobuild $variant"
     # honor autobuild_build_parameters same as sling-buildscripts
@@ -254,10 +271,6 @@ build()
     "$autobuild" build --no-configure -c $variant \
          $eval_autobuild_build_parameters \
     || fatal "failed building $variant"
-
-    ctest -C Release --test-dir "${build_dir}" --output-on-failure -j $(nproc --all) \
-    || fatal "failed testing $variant"
-
     echo true >"$build_dir"/build_ok
     end_section "autobuild $variant"
 


### PR DESCRIPTION
## Description

Splits Viewer and Test builds into separate jobs in GHA to reduce potential for disk space exhaustion

## Related Issues

Issue Link: #4677

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
