### PR TITLE
#5111 change notification type from modal to alert

### DIFF
--- a/indra/newview/llpanellogin.cpp
+++ b/indra/newview/llpanellogin.cpp
@@ -188,7 +188,8 @@ LLPanelLogin::LLPanelLogin(const LLRect &rect,
     mUsernameLength(0),
     mPasswordLength(0),
     mLocationLength(0),
-    mShowFavorites(false)
+    mShowFavorites(false),
+    mAlertNotif(false)
 {
     setBackgroundVisible(false);
     setBackgroundOpaque(true);
@@ -297,8 +298,8 @@ LLPanelLogin::LLPanelLogin(const LLRect &rect,
 
     childSetAction("connect_btn", onClickConnect, this);
 
-    LLButton* def_btn = getChild<LLButton>("connect_btn");
-    setDefaultBtn(def_btn);
+    mLoginBtn = getChild<LLButton>("connect_btn");
+    setDefaultBtn(mLoginBtn);
 
     std::string channel = LLVersionInfo::instance().getChannel();
     std::string version = stringize(LLVersionInfo::instance().getShortVersion(), " (",
@@ -327,6 +328,8 @@ LLPanelLogin::LLPanelLogin(const LLRect &rect,
     LLCheckBoxCtrl* remember_name = getChild<LLCheckBoxCtrl>("remember_name");
     remember_name->setCommitCallback(boost::bind(&LLPanelLogin::onRememberUserCheck, this));
     getChild<LLCheckBoxCtrl>("remember_password")->setCommitCallback(boost::bind(&LLPanelLogin::onRememberPasswordCheck, this));
+
+    mAlertListener = LLNotifications::instance().getChannel("Alerts")->connectChanged([this](const LLSD& notify){ return onUpdateNotification(notify); });
 }
 
 void LLPanelLogin::addFavoritesToStartLocation()
@@ -409,7 +412,7 @@ void LLPanelLogin::addFavoritesToStartLocation()
                 gSavedSettings.setBOOL("RememberPassword", save_password);
                 if (!save_password)
                 {
-                    getChild<LLButton>("connect_btn")->setEnabled(false);
+                    mLoginBtn->setEnabled(false);
                 }
                 update_password_setting = false;
             }
@@ -936,7 +939,7 @@ void LLPanelLogin::handleMediaEvent(LLPluginClassMedia* /*self*/, EMediaEvent ev
 // static
 void LLPanelLogin::onClickConnect(bool commit_fields)
 {
-    if (sInstance && sInstance->mCallback)
+    if (sInstance && sInstance->mCallback && !sInstance->mAlertNotif)
     {
         if (commit_fields)
         {
@@ -1193,9 +1196,7 @@ void LLPanelLogin::updateServer()
 
 void LLPanelLogin::updateLoginButtons()
 {
-    LLButton* login_btn = getChild<LLButton>("connect_btn");
-
-    login_btn->setEnabled(mUsernameLength != 0 && mPasswordLength != 0);
+    mLoginBtn->setEnabled(mUsernameLength != 0 && mPasswordLength != 0 && !mAlertNotif);
 
     if (!mFirstLoginThisInstall)
     {
@@ -1367,3 +1368,22 @@ std::string LLPanelLogin::getUserName(LLPointer<LLCredential> &cred)
     return "unknown";
 }
 
+bool LLPanelLogin::onUpdateNotification(const LLSD& notify)
+{
+    // disable Login button while alert notification is displayed
+    LLNotificationPtr notifyp = LLNotifications::instance().find(notify["id"].asUUID());
+    if (notifyp && notifyp->getName() == "PromptOptionalUpdate")
+    {
+        std::string sigtype = notify["sigtype"].asString();
+        if (sigtype == "add")
+        {
+            mAlertNotif = true;
+        }
+        else if (sigtype == "delete")
+        {
+            mAlertNotif = false;
+        }
+        updateLoginButtons();
+    }
+    return false;
+}

--- a/indra/newview/llpanellogin.h
+++ b/indra/newview/llpanellogin.h
@@ -105,8 +105,11 @@ private:
     static void onRememberPasswordCheck(void*);
     static void onPassKey(LLLineEditor* caller, void* user_data);
 
+    bool onUpdateNotification(const LLSD& notify);
+
 private:
     std::unique_ptr<LLPanelLoginListener> mListener;
+    LLTempBoundListener mAlertListener;
 
     void updateLoginButtons();
     void populateUserList(LLPointer<LLCredential> credential);
@@ -126,6 +129,9 @@ private:
     unsigned int mUsernameLength;
     unsigned int mPasswordLength;
     unsigned int mLocationLength;
+
+    bool mAlertNotif;
+    LLButton* mLoginBtn;
 };
 
 #endif

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -4425,9 +4425,9 @@ Click OK to install.
   </notification>
 
   <notification
-   icon="alertmodal.tga"
+   icon="alert.tga"
    name="PromptOptionalUpdate"
-   type="alertmodal">
+   type="alert">
 Version [VERSION] has been downloaded and is ready to install.
 Release notes: [URL]
 


### PR DESCRIPTION
Don't use modal type for this update notification, so it's possible to check release notes in the web floater.
But still disable Login button while this notification is displayed.