### PR TITLE
#4939 Test for bugplat thread crash detection on mac silicon

### DIFF
--- a/indra/llcommon/llcoros.cpp
+++ b/indra/llcommon/llcoros.cpp
@@ -403,6 +403,7 @@ void LLCoros::toplevel(std::string name, callable_t callable)
         // viewer will carry on.
         LOG_UNHANDLED_EXCEPTION(STRINGIZE("coroutine " << name));
     }
+#ifndef LL_ARM64
     catch (...)
     {
         // Stash any OTHER kind of uncaught exception in the rethrow() queue
@@ -411,6 +412,7 @@ void LLCoros::toplevel(std::string name, callable_t callable)
                             << name << LL_ENDL;
         LLCoros::instance().saveException(name, std::current_exception());
     }
+#endif
 #endif // else LL_WINDOWS
 }
 

--- a/indra/llcommon/llthread.cpp
+++ b/indra/llcommon/llthread.cpp
@@ -225,12 +225,13 @@ void LLThread::tryRun()
         LL::WorkQueue::ptr_t main_queue = LL::WorkQueue::getInstance("mainloop");
         main_queue->post(
             // Bind the current exception, rethrow it in main loop.
+            // TODO: what happens if main loop waits for response from this thread?
             []() {
             LLError::LLUserWarningMsg::showOutOfMemory();
             LL_ERRS("THREAD") << "Out of memory in a thread" << LL_ENDL;
         });
     }
-#ifndef LL_WINDOWS
+#if !defined(LL_ARM64) && !defined(LL_WINDOWS)
     catch (...)
     {
         // Stash any other kind of uncaught exception to be rethrown by main thread.

--- a/indra/llcommon/workqueue.cpp
+++ b/indra/llcommon/workqueue.cpp
@@ -210,6 +210,7 @@ void LL::WorkQueueBase::callWork(const Work& work)
     }
     catch (...)
     {
+#ifndef LL_ARM64
         if (getKey() != "mainloop")
         {
             // Stash any other kind of uncaught exception to be rethrown by main thread.
@@ -222,6 +223,7 @@ void LL::WorkQueueBase::callWork(const Work& work)
                              [exc = std::current_exception()]() { std::rethrow_exception(exc); });
         }
         else
+#endif // !LL_ARM64
         {
             // let main loop crash
             throw;


### PR DESCRIPTION
Bugsplat somehow fails to catch 'rethrow' crashes, see if crashing threads the normal way works. If not LLError in a Thread does trigger, but it's a fallback since it won't provide a callstack.