### PR TITLE
Add method to script editor websocket that lists scripts available for subscription

### DIFF
--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -168,17 +168,14 @@ void LLScriptEditorWSServer::unsubscribeEditor(const std::string &script_id)
 
 void LLScriptEditorWSServer::unsubscribeConnection(U32 connection_id)
 {
-    for (auto it = mSubscriptions.begin(); it != mSubscriptions.end(); )
+    for (auto it = mSubscriptions.begin(); it != mSubscriptions.end(); ++it)
     {
         if (it->second.mConnectionID == connection_id)
         {
             LL_DEBUGS("ScriptEditorWS") << "Unsubscribing script " << it->first
                                        << " from connection ID " << connection_id << LL_ENDL;
-            it = mSubscriptions.erase(it);
-        }
-        else
-        {
-            ++it;
+            it->second.mConnectionID = 0;
+            it->second.mConnection.reset();
         }
     }
 }
@@ -287,6 +284,16 @@ void LLScriptEditorWSServer::setupConnectionMethods(LLJSONRPCConnection::ptr_t c
             });
         script_connection->registerMethod("script.unsubscribe", [](const std::string&, const LLSD&, const LLSD& params) -> LLSD
             {   // this is a notification, no response expected
+                return LLSD();
+            });
+        script_connection->registerMethod("script.list",
+            [that, connection_id](const std::string&, const LLSD&, const LLSD& params) -> LLSD
+            {
+                auto server = that.lock();
+                if (server)
+                {
+                    return server->handleFileWatcherFileListRequest();
+                }
                 return LLSD();
             });
         // script_connection->registerMethod("language.syntax", )
@@ -409,6 +416,25 @@ LLSD LLScriptEditorWSServer::handleScriptUnsubscribe(U32 connection_id, const LL
         unsubscribeEditor(script_id);
     }
     return LLSD();
+}
+
+LLSD LLScriptEditorWSServer::handleFileWatcherFileListRequest() const
+{
+    LLSD response;
+
+    response["temp_dir"] = LLFile::tmpdir();
+    
+    // Add array of script_id's from active scripts
+    LLSD script_ids_array = LLSD::emptyArray();
+    for (const auto& [script_id, subinfo] : mSubscriptions)
+    {
+        script_ids_array.append(script_id);
+    }
+    response["script_ids"] = script_ids_array;
+    
+    response["success"] = true;
+    
+    return response;
 }
 
 void LLScriptEditorWSServer::notifyScript(const std::string& script_id, const std::string &method, const LLSD& message) const

--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -423,7 +423,7 @@ LLSD LLScriptEditorWSServer::handleFileWatcherFileListRequest() const
     LLSD response;
 
     response["temp_dir"] = LLFile::tmpdir();
-    
+
     // Add array of script_id's from active scripts
     LLSD script_ids_array = LLSD::emptyArray();
     for (const auto& [script_id, subinfo] : mSubscriptions)
@@ -431,9 +431,9 @@ LLSD LLScriptEditorWSServer::handleFileWatcherFileListRequest() const
         script_ids_array.append(script_id);
     }
     response["script_ids"] = script_ids_array;
-    
+
     response["success"] = true;
-    
+
     return response;
 }
 

--- a/indra/newview/llscripteditorws.cpp
+++ b/indra/newview/llscripteditorws.cpp
@@ -287,7 +287,7 @@ void LLScriptEditorWSServer::setupConnectionMethods(LLJSONRPCConnection::ptr_t c
                 return LLSD();
             });
         script_connection->registerMethod("script.list",
-            [that, connection_id](const std::string&, const LLSD&, const LLSD& params) -> LLSD
+            [that](const std::string&, const LLSD&, const LLSD& params) -> LLSD
             {
                 auto server = that.lock();
                 if (server)

--- a/indra/newview/llscripteditorws.h
+++ b/indra/newview/llscripteditorws.h
@@ -194,6 +194,7 @@ protected:
     LLSD handleSyntaxRequest(const LLSD &params) const;
     LLSD handleScriptSubscribe(U32 connection_id, const LLSD& params);
     LLSD handleScriptUnsubscribe(U32 connection_id, const LLSD& params);
+    LLSD handleFileWatcherFileListRequest() const;
 
 private:
     struct EditorSubscription


### PR DESCRIPTION
## Description

Adds a method for the web socket server to allow 3rd party tools to query scripts available for subscription. Useful for the sl-vscode-plugin to be able to resubscribe after a connection loss (like the user updated vscode, or similar)

Also useful for plans to add support for a cli version of the plugin, to allow broader editor compatibility.

## Related Issues

Issue Link: relates to https://github.com/secondlife/sl-vscode-plugin/issues/43

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

Discussed with @Rider-Linden before, so likely more his wheelhouse for review.

I suspect there may be some issue I am missing with my changes to `LLScriptEditorWSServer::unsubscribeConnection` but they (or something like them) are needed else a websocket connection closing flushes scripts from the subscription list, even though they are still open in viewer, and on disk in the temp directory.
