### PR TITLE
#3612 Handle missing capabilities instead of blocking further downloads

### DIFF
--- a/indra/llmessage/llassetstorage.cpp
+++ b/indra/llmessage/llassetstorage.cpp
@@ -1316,6 +1316,9 @@ const char* LLAssetStorage::getErrorString(S32 status)
         case LL_ERR_ASSET_REQUEST_NOT_IN_DATABASE:
             return "Asset request: asset not found in database";
 
+        case LL_ERR_NO_CAP:
+            return "Asset request: region or asset capability not available";
+
         case LL_ERR_EOF:
             return "End of file";
 

--- a/indra/llmessage/llassetstorage.h
+++ b/indra/llmessage/llassetstorage.h
@@ -57,6 +57,7 @@ const int LL_ERR_ASSET_REQUEST_FAILED = -1;
 const int LL_ERR_ASSET_REQUEST_NONEXISTENT_FILE = -3;
 const int LL_ERR_ASSET_REQUEST_NOT_IN_DATABASE = -4;
 const int LL_ERR_INSUFFICIENT_PERMISSIONS = -5;
+const int LL_ERR_NO_CAP = -6;
 const int LL_ERR_PRICE_MISMATCH = -23018;
 
 // *TODO: these typedefs are passed into the cache via a legacy C function pointer

--- a/indra/newview/lllandmarklist.h
+++ b/indra/newview/lllandmarklist.h
@@ -72,6 +72,7 @@ protected:
 
     typedef std::set<LLUUID> landmark_uuid_list_t;
     landmark_uuid_list_t mBadList;
+    landmark_uuid_list_t mRetryList;
 
     typedef std::map<LLUUID,F32> landmark_requested_list_t;
     landmark_requested_list_t mRequestedList;

--- a/indra/newview/llviewerassetstorage.cpp
+++ b/indra/newview/llviewerassetstorage.cpp
@@ -461,7 +461,7 @@ void LLViewerAssetStorage::assetRequestCoro(
     if (!gAgent.getRegion())
     {
         LL_WARNS_ONCE("ViewerAsset") << "Asset request fails: no region set" << LL_ENDL;
-        result_code = LL_ERR_ASSET_REQUEST_FAILED;
+        result_code = LL_ERR_NO_CAP;
         ext_status = LLExtStat::NONE;
         removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
         return;
@@ -475,10 +475,21 @@ void LLViewerAssetStorage::assetRequestCoro(
         gAgent.getRegion()->setCapabilitiesReceivedCallback(
             boost::bind(&LLViewerAssetStorage::capsRecvForRegion, this, _1, capsRecv.getName()));
 
-        llcoro::suspendUntilEventOn(capsRecv);
+        F32Seconds timeout_seconds(LL_ASSET_STORAGE_TIMEOUT); // from minutes to seconds, by default 5 minutes
+        LLSD result = llcoro::suspendUntilEventOnWithTimeout(capsRecv, timeout_seconds, LLSDMap("timeout", LLSD::Boolean(true)));
 
         if (LLApp::isExiting() || !gAssetStorage)
         {
+            return;
+        }
+
+        if (result.has("timeout"))
+        {
+            // Caps failed to arrive in 5 minutes
+            LL_WARNS_ONCE("ViewerAsset") << "Asset " << uuid << " request fails : capabilities took too long to arrive" << LL_ENDL;
+            result_code = LL_ERR_NO_CAP;
+            ext_status = LLExtStat::NONE;
+            removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
             return;
         }
 
@@ -492,7 +503,7 @@ void LLViewerAssetStorage::assetRequestCoro(
     if (mViewerAssetUrl.empty())
     {
         LL_WARNS_ONCE("ViewerAsset") << "asset request fails: caps received but no viewer asset cap found" << LL_ENDL;
-        result_code = LL_ERR_ASSET_REQUEST_FAILED;
+        result_code = LL_ERR_NO_CAP;
         ext_status = LLExtStat::NONE;
         removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
         return;


### PR DESCRIPTION
Landmarks that failed due to missing caps were blocked from being rerequested. Ideally need to rerequest once we get a new cap, but for now just avoiding from blacklisting it.