### PR TITLE
#3612 Don't immediately fail download on startup, wait for the region

### DIFF
--- a/indra/newview/llviewerassetstorage.cpp
+++ b/indra/newview/llviewerassetstorage.cpp
@@ -42,6 +42,7 @@
 #include "llcoproceduremanager.h"
 #include "lleventcoro.h"
 #include "llsdutil.h"
+#include "llstartup.h"
 #include "llworld.h"
 
 ///----------------------------------------------------------------------------
@@ -460,23 +461,62 @@ void LLViewerAssetStorage::assetRequestCoro(
 
     if (!gAgent.getRegion())
     {
-        LL_WARNS_ONCE("ViewerAsset") << "Asset request fails: no region set" << LL_ENDL;
-        result_code = LL_ERR_NO_CAP;
-        ext_status = LLExtStat::NONE;
-        removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
-        return;
+        if (STATE_WORLD_INIT <= LLStartUp::getStartupState())
+        {
+            // Viewer isn't ready, wait for region to become available
+            LL_INFOS_ONCE("ViewerAsset") << "Waiting for agent region to be set" << LL_ENDL;
+
+            LLEventStream region_init("waitForRegion", true);
+            std::string pump_name = region_init.getName();
+
+            boost::signals2::connection region_conn =
+                gAgent.addRegionChangedCallback([pump_name]()
+                {
+                    LLEventPumps::instance().obtain(pump_name).post(LLSD());
+                });
+            F32Seconds timeout_seconds(LL_ASSET_STORAGE_TIMEOUT);
+            llcoro::suspendUntilEventOnWithTimeout(region_init, timeout_seconds, LLSDMap("timeout", LLSD::Boolean(true)));
+            gAgent.removeRegionChangedCallback(region_conn);
+            region_conn.disconnect();
+
+            if (LLApp::isExiting() || !gAssetStorage)
+            {
+                return;
+            }
+
+            // recheck region whether suspend ended on timeout or not
+            if (!gAgent.getRegion())
+            {
+                LL_WARNS_ONCE("ViewerAsset") << "Asset request fails: timeout reached while waiting for region" << LL_ENDL;
+                result_code = LL_ERR_NO_CAP;
+                ext_status = LLExtStat::NONE;
+                removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
+                return;
+            }
+        }
+        else
+        {
+            LL_WARNS_ONCE("ViewerAsset") << "Asset request fails: no region set" << LL_ENDL;
+            result_code = LL_ERR_NO_CAP;
+            ext_status = LLExtStat::NONE;
+            removeAndCallbackPendingDownloads(uuid, atype, uuid, atype, result_code, ext_status, 0);
+            return;
+        }
     }
-    else if (!gAgent.getRegion()->capabilitiesReceived())
+
+    if (!gAgent.getRegion()->capabilitiesReceived())
     {
         LL_WARNS_ONCE("ViewerAsset") << "Waiting for capabilities" << LL_ENDL;
 
         LLEventStream capsRecv("waitForCaps", true);
 
-        gAgent.getRegion()->setCapabilitiesReceivedCallback(
-            boost::bind(&LLViewerAssetStorage::capsRecvForRegion, this, _1, capsRecv.getName()));
+        boost::signals2::connection caps_conn =
+            gAgent.getRegion()->setCapabilitiesReceivedCallback(
+                boost::bind(&LLViewerAssetStorage::capsRecvForRegion, this, _1, capsRecv.getName()));
 
         F32Seconds timeout_seconds(LL_ASSET_STORAGE_TIMEOUT); // from minutes to seconds, by default 5 minutes
         LLSD result = llcoro::suspendUntilEventOnWithTimeout(capsRecv, timeout_seconds, LLSDMap("timeout", LLSD::Boolean(true)));
+        caps_conn.disconnect();
 
         if (LLApp::isExiting() || !gAssetStorage)
         {


### PR DESCRIPTION
After doing some further testing around assets I found out that a lot of assets failed to load on startup because there was no region yet. Hense needing to wait for region to become ready.

It's probably smarter to make asset storage wait with requests in general, but that would require a stronger separation from cache which is functional already and can be loading assets, so I'm pausing individual requests instead, there is a maximum of 12, so there should be no 'bloat' from waiting coros.