### PR TITLE
[#5186] Fix camera from becoming stuck with DisableCameraConstraints enabled

### DIFF
--- a/indra/newview/llagentcamera.cpp
+++ b/indra/newview/llagentcamera.cpp
@@ -975,6 +975,10 @@ void LLAgentCamera::cameraZoomIn(const F32 fraction)
             new_distance = llclamp(new_distance, APPEARANCE_MIN_ZOOM, APPEARANCE_MAX_ZOOM);
         }
     }
+    else
+    {
+        new_distance = llmin(new_distance, getCameraMaxZoomDistance());
+    }
 
     mCameraFocusOffsetTarget = new_distance * camera_offset_unit;
 }
@@ -1034,6 +1038,10 @@ void LLAgentCamera::cameraOrbitIn(const F32 meters)
             {
                 new_distance = llclamp(new_distance, APPEARANCE_MIN_ZOOM, APPEARANCE_MAX_ZOOM);
             }
+        }
+        else
+        {
+            new_distance = llmin(new_distance, getCameraMaxZoomDistance());
         }
 
         // Compute new camera offset


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5186

Fixes the above issue by ensuring even when DisableCameraConstraints is enabled, the new camera distance is still being clamped to be less than the camera max zoom distance (INT_MAX).

<Details>
<Summary>Video Showcasing the issue being resolved:</Summary>

https://github.com/user-attachments/assets/3a70058e-1c29-413b-806f-1a3cd4e41850

</Details>