### PR TITLE
Update LLScriptEditor and friends to index line numbers from 1 when editing in Lua

### DIFF
--- a/indra/newview/llfloatergotoline.cpp
+++ b/indra/newview/llfloatergotoline.cpp
@@ -109,8 +109,9 @@ void LLFloaterGotoLine::handleBtnGoto()
         {
                 if (mEditorCore && mEditorCore->mEditor)
                 {
+            S32 target_row = mEditorCore->mEditor->getIsLuauLanguage() ? (row - 1) : row;
             mEditorCore->mEditor->deselect();
-            mEditorCore->mEditor->setCursor(row, column);
+            mEditorCore->mEditor->setCursor(target_row, column);
             mEditorCore->mEditor->setFocus(true);
                 }
         }
@@ -144,12 +145,13 @@ void LLFloaterGotoLine::onGotoBoxCommit()
         {
                 if (mEditorCore && mEditorCore->mEditor)
                 {
-            mEditorCore->mEditor->setCursor(row, column);
+            S32 target_row = mEditorCore->mEditor->getIsLuauLanguage() ? (row - 1) : row;
+            mEditorCore->mEditor->setCursor(target_row, column);
 
             S32 rownew = 0;
             S32 columnnew = 0;
             mEditorCore->mEditor->getCurrentLineAndColumn( &rownew, &columnnew, false );  // don't include wordwrap
-            if (rownew == row && columnnew == column)
+            if (rownew == target_row && columnnew == column)
             {
                     mEditorCore->mEditor->deselect();
                     mEditorCore->mEditor->setFocus(true);

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -751,6 +751,8 @@ void LLScriptEdCore::draw()
         S32 line = 0;
         S32 column = 0;
         mEditor->getCurrentLineAndColumn( &line, &column, false );  // don't include wordwrap
+        line = mEditor->getIsLuauLanguage() ? (line + 1) : line;
+        column = mEditor->getIsLuauLanguage() ? (column + 1) : column;
         LLStringUtil::format_map_t args;
         std::string cursor_pos;
         args["[LINE]"] = llformat ("%d", line);

--- a/indra/newview/llpreviewscript.cpp
+++ b/indra/newview/llpreviewscript.cpp
@@ -1213,6 +1213,7 @@ void LLScriptEdCore::onErrorList(LLUICtrl*, void* user_data)
         sscanf(line.c_str(), "%d %d", &row, &column);
         //LL_INFOS() << "LLScriptEdCore::onErrorList() - " << row << ", "
         //<< column << LL_ENDL;
+        row = (self->mEditor->getIsLuauLanguage() ? row - 1 : row);
         self->mEditor->setCursor(row, column);
         self->mEditor->setFocus(true);
     }

--- a/indra/newview/llscripteditor.cpp
+++ b/indra/newview/llscripteditor.cpp
@@ -120,7 +120,7 @@ void LLScriptEditor::drawLineNumbers()
             // draw the line numbers
             if(line.mLineNum != last_line_num && line.mRect.mTop <= scrolled_view_rect.mTop)
             {
-                const LLWString ltext = utf8str_to_wstring(llformat("%d", line.mLineNum ));
+                const LLWString ltext = utf8str_to_wstring(llformat("%d", mLuauLanguage ? line.mLineNum + 1 : line.mLineNum));
                 bool is_cur_line = cursor_line == line.mLineNum;
                 const U8 style = is_cur_line ? LLFontGL::BOLD : LLFontGL::NORMAL;
                 const LLColor4& fg_color = is_cur_line ? mCursorColor : mReadOnlyFgColor;


### PR DESCRIPTION
## Description

The errors generated by SLua on the server reference line numbers starting from 1, not 0. This PR updates the script editor to start numbering lines at 1 when the language is Lua, LSL is unchanged by this PR and continues numbering starting from 0.

- Line numbering updated
- Go to line feature updated
- Cursor position display updated
- Script editor error view goto error updated

## Screenshots
Lua error showing matching line number
<img width="779" height="373" alt="Screenshot 2025-12-29 at 12 01 44 PM" src="https://github.com/user-attachments/assets/8553bc7b-8054-4183-bc07-3834261cc405" />

LSL editing is unchanged
<img width="378" height="330" alt="Screenshot 2025-12-29 at 12 02 20 PM" src="https://github.com/user-attachments/assets/1b76c5b3-dccd-4f2d-9c8e-28ae06e9db09" />

Showing both at the same time
<img width="431" height="320" alt="Screenshot 2025-12-29 at 12 48 22 PM" src="https://github.com/user-attachments/assets/5c277f27-421d-4735-97bb-e971f659340d" />

Showing dynamic update when changing compiler dropdown

https://github.com/user-attachments/assets/5fe6219f-65f4-4991-a3a1-055e5c0addfb



## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---
