### PR TITLE
Fix types for vector multiplication in lua type definitions

### DIFF
--- a/indra/newview/app_settings/types_lua_default.xml
+++ b/indra/newview/app_settings/types_lua_default.xml
@@ -582,13 +582,13 @@
               <key>name</key>
               <string>other</string>
               <key>type</key>
-              <string>vector | quaternion</string>
+              <string>number | vector | quaternion</string>
             </map>
           </array>
           <key>returnType</key>
-          <string>number | vector</string>
+          <string>vector</string>
           <key>comment</key>
-          <string>LSL-style multiplication: vector * vector -&gt; number (Dot Product), vector * quaternion -&gt; vector (Rotation)</string>
+          <string>Multiplication: vector * number or vector * vector -&gt; vector, vector * quaternion -&gt; vector (Rotation)</string>
         </map>
         <map>
           <key>name</key>
@@ -603,13 +603,13 @@
               <key>name</key>
               <string>other</string>
               <key>type</key>
-              <string>number | quaternion</string>
+              <string>number | vector | quaternion</string>
             </map>
           </array>
           <key>returnType</key>
           <string>vector</string>
           <key>comment</key>
-          <string>LSL-style division: vector / number -&gt; vector (Scale), vector / quaternion -&gt; vector (Rotation by inverse)</string>
+          <string>Division: vector / number or vector / vector -&gt; vector (Scale), vector / quaternion -&gt; vector (Rotation by inverse)</string>
         </map>
         <map>
           <key>name</key>


### PR DESCRIPTION
## Description

Fix types for vector multiplication and division in lua types xml


### Issues resolved
 - `vector * number` was left out of multiplication
 - return type of multiplication is always a vector
 - `vector * vector` is not a number, `*` does not perform a dot product in slua
 - `vector / vector` was left out of division

## Related Issues

Resolves https://github.com/secondlife/sl-vscode-plugin/issues/56

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
