### PR TITLE
Provide SL Grid Map coordinates for Official Viewer Users please

### DIFF
--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -122,6 +122,7 @@ LLLineEditor::Params::Params()
 
 LLLineEditor::LLLineEditor(const LLLineEditor::Params& p)
 :   LLUICtrl(p),
+    mDefaultText(p.default_text),
     mMaxLengthBytes(p.max_length.bytes),
     mMaxLengthChars(p.max_length.chars),
     mCursorPos( 0 ),

--- a/indra/llui/lllineeditor.h
+++ b/indra/llui/lllineeditor.h
@@ -202,6 +202,7 @@ public:
     void            setLabel(const LLStringExplicit &new_label) { mLabel = new_label; }
     const std::string&  getLabel()  { return mLabel.getString(); }
 
+    void            setDefaultText() { setText(mDefaultText); }
     void            setText(const LLStringExplicit &new_text);
 
     const std::string& getText() const override { return mText.getString(); }
@@ -347,6 +348,7 @@ protected:
     LLFontVertexBuffer mFontBufferSelection;
     LLFontVertexBuffer mFontBufferPostSelection;
     LLFontVertexBuffer mFontBufferLabel;
+    std::string mDefaultText;
     S32         mMaxLengthBytes;            // Max length of the UTF8 string in bytes
     S32         mMaxLengthChars;            // Maximum number of characters in the string
     S32         mCursorPos;                 // I-beam is just after the mCursorPos-th character.

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -4591,6 +4591,17 @@
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>MapShowGridCoords</key>
+    <map>
+      <key>Comment</key>
+      <string>Shows/hides the grid coordinates of each region on the world map.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>MiniMapAutoCenter</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/llfloaterregioninfo.cpp
+++ b/indra/newview/llfloaterregioninfo.cpp
@@ -538,6 +538,18 @@ void LLFloaterRegionInfo::processRegionInfo(LLMessageSystem* msg)
     panel->getChildView("access_combo")->setEnabled(gAgent.isGodlike() || (region && region->canManageEstate() && !teen_grid));
     panel->setCtrlsEnabled(allow_modify);
 
+    panel->getChild<LLLineEditor>("estate_id")->setValue((S32)region_info.mEstateID);
+
+    if (region)
+    {
+        panel->getChild<LLLineEditor>("grid_position_x")->setValue((S32)(region->getOriginGlobal()[VX] / 256));
+        panel->getChild<LLLineEditor>("grid_position_y")->setValue((S32)(region->getOriginGlobal()[VY] / 256));
+    }
+    else
+    {
+        panel->getChild<LLLineEditor>("grid_position_x")->setDefaultText();
+        panel->getChild<LLLineEditor>("grid_position_y")->setDefaultText();
+    }
 
     // DEBUG PANEL
     panel = tab->getChild<LLPanel>("Debug");
@@ -902,6 +914,9 @@ bool LLPanelRegionGeneralInfo::refreshFromRegion(LLViewerRegion* region)
     getChildView("apply_btn")->setEnabled(false);
     getChildView("access_text")->setEnabled(allow_modify);
     // getChildView("access_combo")->setEnabled(allow_modify);
+    getChildView("estate_id")->setEnabled(false);
+    getChildView("grid_position_x")->setEnabled(false);
+    getChildView("grid_position_y")->setEnabled(false);
     // now set in processRegionInfo for teen grid detection
     getChildView("kick_btn")->setEnabled(allow_modify);
     getChildView("kick_all_btn")->setEnabled(allow_modify);

--- a/indra/newview/llworldmap.cpp
+++ b/indra/newview/llworldmap.cpp
@@ -118,6 +118,7 @@ LLVector3d LLSimInfo::getGlobalOrigin() const
 {
     return from_region_handle(mHandle);
 }
+
 LLVector3 LLSimInfo::getLocalPos(LLVector3d global_pos) const
 {
     LLVector3d sim_origin = from_region_handle(mHandle);

--- a/indra/newview/llworldmapview.cpp
+++ b/indra/newview/llworldmapview.cpp
@@ -517,26 +517,38 @@ void LLWorldMapView::draw()
         // Draw the region name in the lower left corner
         if (mMapScale >= DRAW_TEXT_THRESHOLD)
         {
-            std::string mesg;
+            static LLCachedControl<bool> print_coords(gSavedSettings, "MapShowGridCoords");
+            static LLFontGL* font = LLFontGL::getFontSansSerifSmallBold();
+
+            auto print = [&](std::string text, F32 x, F32 y, bool use_ellipses)
+                {
+                    font->renderUTF8(text, 0,
+                        (F32)llfloor(left + x), (F32)llfloor(bottom + y),
+                        LLColor4::white,
+                        LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::DROP_SHADOW,
+                        S32_MAX, //max_chars
+                        (S32)mMapScale, //max_pixels
+                        NULL,
+                        use_ellipses);
+                };
+
+            std::string grid_name = info->getName();
             if (info->isDown())
             {
-                mesg = llformat( "%s (%s)", info->getName().c_str(), sStringsMap["offline"].c_str());
+                grid_name += " (" + sStringsMap["offline"] + ")";
+            }
+
+            if (print_coords)
+            {
+                print(grid_name, 3, 14, true);
+                // Obtain and print the grid map coordinates
+                LLVector3d region_pos = info->getGlobalOrigin();
+                std::string grid_coords = llformat("[%.0f, %.0f]", region_pos[VX] / 256, region_pos[VY] / 256);
+                print(grid_coords, 3, 2, false);
             }
             else
             {
-                mesg = info->getName();
-            }
-            if (!mesg.empty())
-            {
-                LLFontGL::getFontSansSerifSmallBold()->renderUTF8(
-                    mesg, 0,
-                    (F32)llfloor(left + 3), (F32)llfloor(bottom + 2),
-                    LLColor4::white,
-                    LLFontGL::LEFT, LLFontGL::BASELINE, LLFontGL::NORMAL, LLFontGL::DROP_SHADOW,
-                    S32_MAX, //max_chars
-                    (S32)mMapScale, //max_pixels
-                    NULL,
-                    /*use_ellipses*/true);
+                print(grid_name, 3, 2, true);
             }
         }
     }

--- a/indra/newview/skins/default/xui/en/floater_world_map.xml
+++ b/indra/newview/skins/default/xui/en/floater_world_map.xml
@@ -109,7 +109,7 @@
     </panel>
     <panel
      follows="right|top"
-     height="126"
+     height="150"
      top_pad="4"
      width="238"
      left="1"
@@ -285,6 +285,30 @@
        by owner
     </text>
 
+    <check_box
+     name="grid_coords_chk"
+     control_name="MapShowGridCoords"
+     layout="topleft"
+     follows="top|right"
+     top_pad="2"
+     left="3"
+     height="16"
+     width="22"
+    />
+    <text
+     name="grid_coords_label"
+     type="string"
+     layout="topleft"
+     follows="top|right"
+     top_delta="2"
+     left_pad="3"
+     height="16"
+     width="220"
+     halign="left"
+     length="1" >
+       Show grid map coordinates
+     </text>
+
     <button
      follows="top|right"
      height="22"
@@ -455,7 +479,7 @@
 
     <panel
      follows="right|top|bottom"
-	 height="235"
+	 height="220"
 	 top_pad="0"
 	 width="238"
 	 name="layout_panel_4">
@@ -573,7 +597,7 @@
      draw_stripes="false"
      bg_writeable_color="MouseGray"
      follows="all"
-     height="145"
+     height="130"
      layout="topleft"
      left="28"
      name="search_results"

--- a/indra/newview/skins/default/xui/en/panel_region_general.xml
+++ b/indra/newview/skins/default/xui/en/panel_region_general.xml
@@ -33,6 +33,28 @@
         unknown
     </text>
     <text
+     follows="right|top"
+     font="SansSerif"
+     height="20"
+     layout="topleft"
+     top_delta="0"
+     right="-100"
+     name="estate_id_lbl"
+     width="80">
+        Estate ID:
+    </text>
+    <line_editor
+     follows="right|top"
+     font="SansSerif"
+     height="20"
+     layout="topleft"
+     top_delta="0"
+     name="estate_id"
+     enabled="false"
+     right="-10"
+     initial_value="unknown"
+     width="85" />
+    <text
      follows="left|top"
      font="SansSerif"
      height="20"
@@ -54,6 +76,39 @@
      width="400">
         unknown
     </text>
+    <text
+     follows="right|top"
+     font="SansSerif"
+     height="20"
+     layout="topleft"
+     top_delta="0"
+     right="-100"
+     name="grid_position_lbl"
+     width="80">
+        Grid Position:
+    </text>
+    <line_editor
+     follows="right|top"
+     font="SansSerif"
+     height="20"
+     layout="topleft"
+     right="-55"
+     name="grid_position_x"
+     enabled="false"
+     top_delta="0"
+     default_text="n/a"
+     width="40" />
+    <line_editor
+     follows="right|top"
+     font="SansSerif"
+     height="20"
+     layout="topleft"
+     right="-10"
+     name="grid_position_y"
+     enabled="false"
+     top_delta="0"
+     default_text="n/a"
+     width="40" />
     <text
      follows="left|top"
      font="SansSerif"


### PR DESCRIPTION
## Description

This restores the option and ui to display the grid coordinates on the map and in the region estate floater from PR #2829 in `archive/develop`

## Related Issues

Issue Link: #2112

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
