### PR TITLE
Restore optimized unloading of mesh volumes

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4271,38 +4271,6 @@ S32 LLMeshRepository::update()
     return static_cast<S32>(size);
 }
 
-#ifdef SHOW_ASSERT
-// Brute-force remove the object from all loading queues. Returns true if
-// something was removed.
-// This function is used in a debug assert to ensure unregisterMesh and
-// unregisterSkinInfo are called as intended.
-// *TODO: Consider removing at some point if we feel confident about the code
-// working as intended.
-bool LLMeshRepository::forceUnregisterMesh(LLVOVolume* vobj)
-{
-    LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
-
-    bool found = false;
-
-    for (auto& lod : mLoadingMeshes)
-    {
-        for (auto& param : lod)
-        {
-            llassert(std::find(param.second.mVolumes.begin(), param.second.mVolumes.end(), vobj) == param.second.mVolumes.end());
-            found = found || vector_replace_with_last(param.second.mVolumes, vobj);
-        }
-    }
-
-    for (auto& skin_pair : mLoadingSkins)
-    {
-        llassert(std::find(skin_pair.mVolumes.second.begin(), skin_pair.mVolumes.second.end(), vobj) == skin_pair.mVolumes.second.end());
-        found = found || vector_replace_with_last(skin_pair.second.mVolumes, vobj);
-    }
-
-    return found;
-}
-#endif
-
 void LLMeshRepository::unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 detail)
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4281,8 +4281,8 @@ void LLMeshRepository::unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& me
     auto param_iter = lod.find(mesh_params.getSculptID());
     if (param_iter != lod.end())
     {
-        vector_replace_with_last(param_iter->second.mVolumes, vobj);
-        llassert(!vector_replace_with_last(param_iter->second.mVolumes, vobj));
+        param_iter->second.mVolumes.erase(vobj);
+        llassert(!param_iter->second.mVolumes.contains(vobj));
         if (param_iter->second.mVolumes.empty())
         {
             lod.erase(param_iter);
@@ -4298,8 +4298,8 @@ void LLMeshRepository::unregisterSkinInfo(const LLUUID& mesh_id, LLVOVolume* vob
     auto skin_pair_iter = mLoadingSkins.find(mesh_id);
     if (skin_pair_iter != mLoadingSkins.end())
     {
-        vector_replace_with_last(skin_pair_iter->second.mVolumes, vobj);
-        llassert(!vector_replace_with_last(skin_pair_iter->second.mVolumes, vobj));
+        skin_pair_iter->second.mVolumes.erase(vobj);
+        llassert(!skin_pair_iter->second.mVolumes.contains(vobj));
         if (skin_pair_iter->second.mVolumes.empty())
         {
             mLoadingSkins.erase(skin_pair_iter);
@@ -4349,7 +4349,7 @@ S32 LLMeshRepository::loadMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_para
         mesh_load_map::iterator iter = mLoadingMeshes[new_lod].find(mesh_id);
         if (iter != mLoadingMeshes[new_lod].end())
         { //request pending for this mesh, append volume id to list
-            auto it = std::find(iter->second.mVolumes.begin(), iter->second.mVolumes.end(), vobj);
+            auto it = iter->second.mVolumes.find(vobj);
             if (it == iter->second.mVolumes.end()) {
                 iter->second.addVolume(vobj);
             }
@@ -4847,7 +4847,7 @@ const LLMeshSkinInfo* LLMeshRepository::getSkinInfo(const LLUUID& mesh_id, LLVOV
             skin_load_map::iterator iter = mLoadingSkins.find(mesh_id);
             if (iter != mLoadingSkins.end())
             { //request pending for this mesh, append volume id to list
-                auto it = std::find(iter->second.mVolumes.begin(), iter->second.mVolumes.end(), requesting_obj);
+                auto it = iter->second.mVolumes.find(requesting_obj);
                 if (it == iter->second.mVolumes.end()) {
                     iter->second.addVolume(requesting_obj);
                 }

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4271,20 +4271,95 @@ S32 LLMeshRepository::update()
     return static_cast<S32>(size);
 }
 
-void LLMeshRepository::unregisterMesh(LLVOVolume* vobj)
+#ifdef SHOW_ASSERT
+// Brute-force remove the object from all loading queues. Returns true if
+// something was removed.
+// This function is used in a debug assert to ensure unregisterMesh and
+// unregisterSkinInfo are called as intended.
+// *TODO: Consider removing at some point if we feel confident about the code
+// working as intended.
+bool LLMeshRepository::forceUnregisterMesh(LLVOVolume* vobj)
 {
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
+
+    bool found = false;
+
     for (auto& lod : mLoadingMeshes)
     {
         for (auto& param : lod)
         {
-            vector_replace_with_last(param.second.mVolumes, vobj);
+            llassert(std::find(param.second.mVolumes.begin(), param.second.mVolumes.end(), vobj) == param.second.mVolumes.end());
+            found = found || vector_replace_with_last(param.second.mVolumes, vobj);
         }
     }
 
     for (auto& skin_pair : mLoadingSkins)
     {
-        vector_replace_with_last(skin_pair.second.mVolumes, vobj);
+        llassert(std::find(skin_pair.mVolumes.second.begin(), skin_pair.mVolumes.second.end(), vobj) == skin_pair.mVolumes.second.end());
+        found = found || vector_replace_with_last(skin_pair.second.mVolumes, vobj);
     }
+
+    return found;
+}
+#endif
+
+void LLMeshRepository::unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 detail)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
+
+    llassert((mesh_params.getSculptType() & LL_SCULPT_TYPE_MASK) == LL_SCULPT_TYPE_MESH);
+    llassert(mesh_params.getSculptID().notNull());
+    auto& lod = mLoadingMeshes[detail];
+    auto param_iter = lod.find(mesh_params.getSculptID());
+    if (param_iter != lod.end())
+    {
+        vector_replace_with_last(param_iter->second.mVolumes, vobj);
+        llassert(!vector_replace_with_last(param_iter->second.mVolumes, vobj));
+        if (param_iter->second.mVolumes.empty())
+        {
+            lod.erase(param_iter);
+        }
+    }
+}
+
+void LLMeshRepository::unregisterSkinInfo(const LLUUID& mesh_id, LLVOVolume* vobj)
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
+
+    llassert(mesh_id.notNull());
+    auto skin_pair_iter = mLoadingSkins.find(mesh_id);
+    if (skin_pair_iter != mLoadingSkins.end())
+    {
+        vector_replace_with_last(skin_pair_iter->second.mVolumes, vobj);
+        llassert(!vector_replace_with_last(skin_pair_iter->second.mVolumes, vobj));
+        if (skin_pair_iter->second.mVolumes.empty())
+        {
+            mLoadingSkins.erase(skin_pair_iter);
+        }
+    }
+}
+
+// Lots of dead objects make expensive calls to
+// LLMeshRepository::unregisterMesh which may delay shutdown. Avoid this by
+// preemptively unregistering all meshes.
+// We can also do this safely if all objects are confirmed dead for some other
+// reason.
+void LLMeshRepository::unregisterAllMeshes()
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_VOLUME;
+
+    // The size of mLoadingMeshes and mLoadingSkins may be large and thus
+    // expensive to iterate over in LLVOVolume::~LLVOVolume.
+    // This is unnecessary during shutdown, so we ignore the referenced objects in the
+    // least expensive way which is still safe: by clearing these containers.
+    // Clear now and not in LLMeshRepository::shutdown because
+    // LLMeshRepository::notifyLoadedMeshes could (depending on invocation
+    // order) reference a pointer to an object after it has been deleted.
+    for (auto& lod : mLoadingMeshes)
+    {
+        lod.clear();
+    }
+    mLoadingSkins.clear();
 }
 
 S32 LLMeshRepository::loadMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 new_lod, S32 last_lod)

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -866,9 +866,6 @@ public:
     void shutdown();
     S32 update();
 
-#ifdef SHOW_ASSERT
-    bool forceUnregisterMesh(LLVOVolume* volume);
-#endif
     void unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 detail);
     void unregisterSkinInfo(const LLUUID& mesh_id, LLVOVolume* vobj);
     //mesh management functions

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -862,10 +862,15 @@ public:
     LLMeshRepository();
 
     void init();
+    void unregisterAllMeshes();
     void shutdown();
     S32 update();
 
-    void unregisterMesh(LLVOVolume* volume);
+#ifdef SHOW_ASSERT
+    bool forceUnregisterMesh(LLVOVolume* volume);
+#endif
+    void unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 detail);
+    void unregisterSkinInfo(const LLUUID& mesh_id, LLVOVolume* vobj);
     //mesh management functions
     S32 loadMesh(LLVOVolume* volume, const LLVolumeParams& mesh_params, S32 new_lod = 0, S32 last_lod = -1);
 

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -290,7 +290,7 @@ private:
 class MeshLoadData
 {
 public:
-    MeshLoadData() {}
+    MeshLoadData() = default;
     ~MeshLoadData()
     {
         if (std::shared_ptr<PendingRequestBase> request = mRequest.lock())
@@ -300,19 +300,19 @@ public:
     }
     void initData(LLVOVolume* vol, std::shared_ptr<PendingRequestBase>& request)
     {
-        mVolumes.push_back(vol);
+        mVolumes.insert(vol);
         request->trackData(this);
         mRequest = request;
     }
     void addVolume(LLVOVolume* vol)
     {
-        mVolumes.push_back(vol);
+        mVolumes.insert(vol);
         if (std::shared_ptr<PendingRequestBase> request = mRequest.lock())
         {
             request->setScoreDirty();
         }
     }
-    std::vector<LLVOVolume*> mVolumes;
+    std::unordered_set<LLVOVolume*> mVolumes;
 private:
     std::weak_ptr<PendingRequestBase> mRequest;
 };

--- a/indra/newview/llviewerobjectlist.cpp
+++ b/indra/newview/llviewerobjectlist.cpp
@@ -65,6 +65,7 @@
 #include "lltoolmgr.h"
 #include "lltoolpie.h"
 #include "llkeyboard.h"
+#include "llmeshrepository.h"
 #include "u64.h"
 #include "llviewertexturelist.h"
 #include "lldatapacker.h"
@@ -1397,6 +1398,8 @@ void LLViewerObjectList::killAllObjects()
         // Object must be dead, or it's the LLVOAvatarSelf which never dies.
         llassert((objectp == gAgentAvatarp) || objectp->isDead());
     }
+
+    gMeshRepo.unregisterAllMeshes();
 
     cleanDeadObjects(false);
 

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -251,7 +251,6 @@ LLVOVolume::~LLVOVolume()
     mVolumeImpl = NULL;
 
     unregisterOldMeshAndSkin();
-    llassert(!gMeshRepo.forceUnregisterMesh(this));
 
     if(!mMediaImplList.empty())
     {

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -250,10 +250,13 @@ LLVOVolume::~LLVOVolume()
     delete mVolumeImpl;
     mVolumeImpl = NULL;
 
-    gMeshRepo.unregisterMesh(this);
+    unregisterOldMeshAndSkin();
+    llassert(!gMeshRepo.forceUnregisterMesh(this));
 
     if(!mMediaImplList.empty())
     {
+        LL_PROFILE_ZONE_NAMED_CATEGORY_MEDIA("delete volume media list");
+
         for(U32 i = 0 ; i < mMediaImplList.size() ; i++)
         {
             if(mMediaImplList[i].notNull())
@@ -1047,6 +1050,28 @@ LLDrawable *LLVOVolume::createDrawable(LLPipeline *pipeline)
 
     return mDrawable;
 }
+
+// Inverse of gMeshRepo.loadMesh and gMeshRepo.getSkinInfo, combined into one function
+// Assume a Collada mesh never changes after being set.
+void LLVOVolume::unregisterOldMeshAndSkin()
+{
+    if (mVolumep)
+    {
+        const LLVolumeParams& params = mVolumep->getParams();
+        if ((params.getSculptType() & LL_SCULPT_TYPE_MASK) == LL_SCULPT_TYPE_MESH)
+        {
+            // object is being deleted, so it will no longer need to request
+            // meshes.
+            for (S32 lod = 0; lod != LLVolumeLODGroup::NUM_LODS; ++lod)
+            {
+                gMeshRepo.unregisterMesh(this, params, lod);
+            }
+            // This volume may or may not have a skin
+            gMeshRepo.unregisterSkinInfo(params.getSculptID(), this);
+        }
+    }
+}
+
 
 bool LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bool unique_volume)
 {

--- a/indra/newview/llvovolume.h
+++ b/indra/newview/llvovolume.h
@@ -227,6 +227,7 @@ public:
 
                 void    setTexture(const S32 face);
                 S32     getIndexInTex(U32 ch) const {return mIndexInTex[ch];}
+                void    unregisterOldMeshAndSkin();
     /*virtual*/ bool    setVolume(const LLVolumeParams &volume_params, const S32 detail, bool unique_volume = false) override;
                 void    updateSculptTexture();
                 void    setIndexInTex(U32 ch, S32 index) { mIndexInTex[ch] = index ;}


### PR DESCRIPTION
## Description

I was profiling in Tracy and noted this as a hotspot when flying around the world. Found this fix in `archive/develop`

I touched up and rebased the commits from #2623 and did some additional profiling and swapped the mVolumes vector to an unordered_set as that's better suited to the repeated find/erase patterns used.

## Related Issues

Issue Link: #2462 

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
