### PR TITLE
Optimize away repeated map finds for getParameterEntry* functions

### DIFF
--- a/indra/llprimitive/llprimitive.h
+++ b/indra/llprimitive/llprimitive.h
@@ -109,11 +109,12 @@ public:
         PARAMS_EXTENDED_MESH = 0x70,
         PARAMS_RENDER_MATERIAL = 0x80,
         PARAMS_REFLECTION_PROBE = 0x90,
+        PARAMS_MAX = PARAMS_REFLECTION_PROBE,
     };
 
 public:
     U16 mType;
-    virtual ~LLNetworkData() {};
+    virtual ~LLNetworkData() = default;
     virtual bool pack(LLDataPacker &dp) const = 0;
     virtual bool unpack(LLDataPacker &dp) = 0;
     virtual bool operator==(const LLNetworkData& data) const = 0;
@@ -319,7 +320,7 @@ public:
     bool fromLLSD(LLSD& sd);
 
     void setSculptTexture(const LLUUID& texture_id, U8 sculpt_type);
-    LLUUID getSculptTexture() const         { return mSculptTexture; }
+    const LLUUID& getSculptTexture() const  { return mSculptTexture; }
     U8 getSculptType() const                { return mSculptType; }
 };
 
@@ -340,10 +341,10 @@ public:
     bool fromLLSD(LLSD& sd);
 
     void setLightTexture(const LLUUID& id) { mLightTexture = id; }
-    LLUUID getLightTexture() const         { return mLightTexture; }
+    const LLUUID& getLightTexture() const         { return mLightTexture; }
     bool isLightSpotlight() const         { return mLightTexture.notNull(); }
     void setParams(const LLVector3& params) { mParams = params; }
-    LLVector3 getParams() const            { return mParams; }
+    const LLVector3& getParams() const            { return mParams; }
 
 };
 

--- a/indra/newview/lllocalbitmaps.cpp
+++ b/indra/newview/lllocalbitmaps.cpp
@@ -596,7 +596,7 @@ void LLLocalBitmap::updateUserVolumes(LLUUID old_id, LLUUID new_id, U32 channel)
             if (object->isSculpted() && object->getVolume() &&
                 object->getVolume()->getParams().getSculptID() == old_id)
             {
-                LLSculptParams* old_params = (LLSculptParams*)object->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+                LLSculptParams* old_params = object->getSculptParams();
                 LLSculptParams new_params(*old_params);
                 new_params.setSculptTexture(new_id, (*old_params).getSculptType());
                 object->setParameterEntry(LLNetworkData::PARAMS_SCULPT, new_params, true);

--- a/indra/newview/llpanelobject.cpp
+++ b/indra/newview/llpanelobject.cpp
@@ -625,7 +625,7 @@ void LLPanelObject::getState( )
         }
 
 
-        if (objectp->getParameterEntryInUse(LLNetworkData::PARAMS_SCULPT))
+        if (objectp->getSculptParams())
         {
             selected_item = MI_SCULPT;
             //LLFirstUse::useSculptedPrim();
@@ -1078,7 +1078,7 @@ void LLPanelObject::getState( )
 
 
         LLUUID id;
-        LLSculptParams *sculpt_params = (LLSculptParams *)objectp->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = objectp->getSculptParams();
 
 
         if (sculpt_params) // if we have a legal sculpt param block for this object:
@@ -1246,13 +1246,13 @@ void LLPanelObject::onCommitParametric( LLUICtrl* ctrl, void* userdata )
     if (selected_type == MI_SCULPT)
     {
         self->mObject->setParameterEntryInUse(LLNetworkData::PARAMS_SCULPT, true, true);
-        LLSculptParams *sculpt_params = (LLSculptParams *)self->mObject->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = self->mObject->getSculptParams();
         if (sculpt_params)
             volume_params.setSculptID(sculpt_params->getSculptTexture(), sculpt_params->getSculptType());
     }
     else
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)self->mObject->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = self->mObject->getSculptParams();
         if (sculpt_params)
             self->mObject->setParameterEntryInUse(LLNetworkData::PARAMS_SCULPT, false, true);
     }
@@ -2264,24 +2264,21 @@ void LLPanelObject::onCopyParams()
     mClipboardParams["volume_params"] = params.asLLSD();
 
     // Sculpted Prim
-    if (objectp->getParameterEntryInUse(LLNetworkData::PARAMS_SCULPT))
+    LLSculptParams *sculpt_params = objectp->getSculptParams();
+    if (sculpt_params)
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)objectp->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
-        if (sculpt_params)
+        LLUUID texture_id = sculpt_params->getSculptTexture();
+        if (get_can_copy_texture(texture_id))
         {
-            LLUUID texture_id = sculpt_params->getSculptTexture();
-            if (get_can_copy_texture(texture_id))
-            {
-                LL_DEBUGS("FloaterTools") << "Recording texture" << LL_ENDL;
-                mClipboardParams["sculpt"]["id"] = texture_id;
-            }
-            else
-            {
-                mClipboardParams["sculpt"]["id"] = SCULPT_DEFAULT_TEXTURE;
-            }
-
-            mClipboardParams["sculpt"]["type"] = sculpt_params->getSculptType();
+            LL_DEBUGS("FloaterTools") << "Recording texture" << LL_ENDL;
+            mClipboardParams["sculpt"]["id"] = texture_id;
         }
+        else
+        {
+            mClipboardParams["sculpt"]["id"] = SCULPT_DEFAULT_TEXTURE;
+        }
+
+        mClipboardParams["sculpt"]["type"] = sculpt_params->getSculptType();
     }
 }
 
@@ -2304,7 +2301,7 @@ void LLPanelObject::onPasteParams()
     }
     else
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)objectp->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = objectp->getSculptParams();
         if (sculpt_params)
         {
             objectp->setParameterEntryInUse(LLNetworkData::PARAMS_SCULPT, false, true);

--- a/indra/newview/llpanelvolume.cpp
+++ b/indra/newview/llpanelvolume.cpp
@@ -532,7 +532,7 @@ void LLPanelVolume::getState( )
         getChildView("FlexForceY")->setEnabled(true);
         getChildView("FlexForceZ")->setEnabled(true);
 
-        LLFlexibleObjectData *attributes = (LLFlexibleObjectData *)objectp->getParameterEntry(LLNetworkData::PARAMS_FLEXIBLE);
+        LLFlexibleObjectData *attributes = objectp->getFlexibleObjectData();
 
         getChild<LLUICtrl>("FlexNumSections")->setValue((F32)attributes->getSimulateLOD());
         getChild<LLUICtrl>("FlexGravity")->setValue(attributes->getGravity());
@@ -643,7 +643,7 @@ void LLPanelVolume::getState( )
     mComboPhysicsShapeType->add(getString("None"), LLSD(1));
 
     bool isMesh = false;
-    LLSculptParams *sculpt_params = (LLSculptParams *)objectp->getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+    LLSculptParams *sculpt_params = objectp->getSculptParams();
     if (sculpt_params)
     {
         U8 sculpt_type = sculpt_params->getSculptType();
@@ -1043,7 +1043,7 @@ void LLPanelVolume::onCopyFeatures()
     // Flexi Prim
     if (volobjp && volobjp->isFlexible())
     {
-        LLFlexibleObjectData *attributes = (LLFlexibleObjectData *)objectp->getParameterEntry(LLNetworkData::PARAMS_FLEXIBLE);
+        LLFlexibleObjectData *attributes = objectp->getFlexibleObjectData();
         if (attributes)
         {
             clipboard["flex"]["lod"] = attributes->getSimulateLOD();
@@ -1141,7 +1141,7 @@ void LLPanelVolume::onPasteFeatures()
             objectp->setClickAction(CLICK_ACTION_NONE);
         }
 
-        LLFlexibleObjectData *attributes = (LLFlexibleObjectData *)objectp->getParameterEntry(LLNetworkData::PARAMS_FLEXIBLE);
+        LLFlexibleObjectData *attributes = objectp->getFlexibleObjectData();
         if (attributes)
         {
             LLFlexibleObjectData new_attributes;
@@ -1568,7 +1568,7 @@ void LLPanelVolume::onCommitFlexible( LLUICtrl* ctrl, void* userdata )
         return;
     }
 
-    LLFlexibleObjectData *attributes = (LLFlexibleObjectData *)objectp->getParameterEntry(LLNetworkData::PARAMS_FLEXIBLE);
+    LLFlexibleObjectData *attributes = objectp->getFlexibleObjectData();
     if (attributes)
     {
         LLFlexibleObjectData new_attributes;

--- a/indra/newview/llviewerobject.cpp
+++ b/indra/newview/llviewerobject.cpp
@@ -310,6 +310,7 @@ LLViewerObject::LLViewerObject(const LLUUID &id, const LLPCode pcode, LLViewerRe
     mAttachmentItemID(LLUUID::null),
     mLastUpdateType(OUT_UNKNOWN),
     mLastUpdateCached(false),
+    mExtraParameterList(LLNetworkData::PARAMS_MAX >> 4),
     mCachedMuteListUpdateTime(0),
     mCachedOwnerInMuteList(false),
     mRiggedAttachedWarned(false)
@@ -367,15 +368,6 @@ LLViewerObject::~LLViewerObject()
     }
 
     // Delete memory associated with extra parameters.
-    std::unordered_map<U16, ExtraParameter*>::iterator iter;
-    for (iter = mExtraParameterList.begin(); iter != mExtraParameterList.end(); ++iter)
-    {
-        if(iter->second != NULL)
-        {
-            delete iter->second->data;
-            delete iter->second;
-        }
-    }
     mExtraParameterList.clear();
 
     for_each(mNameValuePairs.begin(), mNameValuePairs.end(), DeletePairedPointer()) ;
@@ -1508,10 +1500,9 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
                 unpackParticleSource(block_num, owner_id);
 
                 // Mark all extra parameters not used
-                std::unordered_map<U16, ExtraParameter*>::iterator iter;
-                for (iter = mExtraParameterList.begin(); iter != mExtraParameterList.end(); ++iter)
+                for (auto& entry : mExtraParameterList)
                 {
-                    iter->second->in_use = false;
+                    if (entry.in_use) *entry.in_use = false;
                 }
 
                 // Unpack extra parameters
@@ -1543,12 +1534,13 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
                     delete[] buffer;
                 }
 
-                for (iter = mExtraParameterList.begin(); iter != mExtraParameterList.end(); ++iter)
+                for (size_t i = 0; i < mExtraParameterList.size(); ++i)
                 {
-                    if (!iter->second->in_use)
+                    auto& entry = mExtraParameterList[i];
+                    if (entry.in_use && !*entry.in_use)
                     {
                         // Send an update message in case it was formerly in use
-                        parameterChanged(iter->first, iter->second->data, false, false);
+                        parameterChanged(((U16)i + 1) << 4, entry.data, false, false);
                     }
                 }
 
@@ -1850,10 +1842,9 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
                 }
 
                 // Mark all extra parameters not used
-                std::unordered_map<U16, ExtraParameter*>::iterator iter;
-                for (iter = mExtraParameterList.begin(); iter != mExtraParameterList.end(); ++iter)
+                for (auto& entry : mExtraParameterList)
                 {
-                    iter->second->in_use = false;
+                    if (entry.in_use) *entry.in_use = false;
                 }
 
                 // Unpack extra params
@@ -1871,12 +1862,13 @@ U32 LLViewerObject::processUpdateMessage(LLMessageSystem *mesgsys,
                     unpackParameterEntry(param_type, &dp2);
                 }
 
-                for (iter = mExtraParameterList.begin(); iter != mExtraParameterList.end(); ++iter)
+                for (size_t i = 0; i < mExtraParameterList.size(); ++i)
                 {
-                    if (!iter->second->in_use)
+                    auto& entry = mExtraParameterList[i];
+                    if (entry.in_use && !*entry.in_use)
                     {
                         // Send an update message in case it was formerly in use
-                        parameterChanged(iter->first, iter->second->data, false, false);
+                        parameterChanged(((U16)i + 1) << 4, entry.data, false, false);
                     }
                 }
 
@@ -4183,7 +4175,7 @@ void LLViewerObject::boostTexturePriority(bool boost_children /* = true */)
 
     if (isSculpted() && !isMesh())
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = getSculptParams();
         if (sculpt_params)
         {
             LLUUID sculpt_id = sculpt_params->getSculptTexture();
@@ -6494,7 +6486,7 @@ bool LLViewerObject::unpackParameterEntry(U16 param_type, LLDataPacker *dp)
     if (param)
     {
         param->data->unpack(*dp);
-        param->in_use = true;
+        *param->in_use = true;
         parameterChanged(param_type, param->data, true, false);
         return true;
     }
@@ -6506,108 +6498,79 @@ bool LLViewerObject::unpackParameterEntry(U16 param_type, LLDataPacker *dp)
 
 LLViewerObject::ExtraParameter* LLViewerObject::createNewParameterEntry(U16 param_type)
 {
-    LLNetworkData* new_block = NULL;
+    LLNetworkData* new_block = nullptr;
+    bool* in_use = NULL;
     switch (param_type)
     {
       case LLNetworkData::PARAMS_FLEXIBLE:
       {
-          new_block = new LLFlexibleObjectData();
+          mFlexibleObjectData = std::make_unique<LLFlexibleObjectData>();
+          new_block = mFlexibleObjectData.get();
+          in_use = &mFlexibleObjectDataInUse;
           break;
       }
       case LLNetworkData::PARAMS_LIGHT:
       {
-          new_block = new LLLightParams();
+          mLightParams = std::make_unique<LLLightParams>();
+          new_block = mLightParams.get();
+          in_use = &mLightParamsInUse;
           break;
       }
       case LLNetworkData::PARAMS_SCULPT:
       {
-          new_block = new LLSculptParams();
+          mSculptParams = std::make_unique<LLSculptParams>();
+          new_block = mSculptParams.get();
+          in_use = &mSculptParamsInUse;
           break;
       }
       case LLNetworkData::PARAMS_LIGHT_IMAGE:
       {
-          new_block = new LLLightImageParams();
+          mLightImageParams = std::make_unique<LLLightImageParams>();
+          new_block = mLightImageParams.get();
+          in_use = &mLightImageParamsInUse;
           break;
       }
       case LLNetworkData::PARAMS_EXTENDED_MESH:
       {
-          new_block = new LLExtendedMeshParams();
+          mExtendedMeshParams = std::make_unique<LLExtendedMeshParams>();
+          new_block = mExtendedMeshParams.get();
+          in_use = &mExtendedMeshParamsInUse;
           break;
       }
       case LLNetworkData::PARAMS_RENDER_MATERIAL:
       {
-          new_block = new LLRenderMaterialParams();
+          mRenderMaterialParams = std::make_unique<LLRenderMaterialParams>();
+          new_block = mRenderMaterialParams.get();
+          in_use = &mRenderMaterialParamsInUse;
           break;
       }
       case LLNetworkData::PARAMS_REFLECTION_PROBE:
       {
-          new_block = new LLReflectionProbeParams();
+          mReflectionProbeParams = std::make_unique<LLReflectionProbeParams>();
+          new_block = mReflectionProbeParams.get();
+          in_use = &mReflectionProbeParamsInUse;
           break;
       }
       default:
       {
-          LL_INFOS_ONCE() << "Unknown param type: " << param_type << LL_ENDL;
+          LL_INFOS_ONCE() << "Unknown param type. (" << llformat("0x%2x", param_type) << ")" << LL_ENDL;
           break;
       }
     };
 
+    ExtraParameter& entry = mExtraParameterList[U32(param_type >> 4) - 1];
     if (new_block)
     {
-        ExtraParameter* new_entry = new ExtraParameter;
-        new_entry->data = new_block;
-        new_entry->in_use = false; // not in use yet
-        llassert(mExtraParameterList[param_type] == nullptr); // leak -- redundantly allocated parameter entry
-        mExtraParameterList[param_type] = new_entry;
-        return new_entry;
-    }
-    return NULL;
-}
-
-LLViewerObject::ExtraParameter* LLViewerObject::getExtraParameterEntry(U16 param_type) const
-{
-    LL_PROFILE_ZONE_SCOPED_CATEGORY_VIEWER;
-    std::unordered_map<U16, ExtraParameter*>::const_iterator itor = mExtraParameterList.find(param_type);
-    if (itor != mExtraParameterList.end())
-    {
-        return itor->second;
-    }
-    return NULL;
-}
-
-LLViewerObject::ExtraParameter* LLViewerObject::getExtraParameterEntryCreate(U16 param_type)
-{
-    ExtraParameter* param = getExtraParameterEntry(param_type);
-    if (!param)
-    {
-        param = createNewParameterEntry(param_type);
-    }
-    return param;
-}
-
-LLNetworkData* LLViewerObject::getParameterEntry(U16 param_type) const
-{
-    ExtraParameter* param = getExtraParameterEntry(param_type);
-    if (param)
-    {
-        return param->data;
+        entry.in_use = in_use;
+        *entry.in_use = false; // not in use yet
+        entry.data = new_block;
+        return &entry;
     }
     else
     {
-        return NULL;
+        entry.is_invalid = true;
     }
-}
-
-bool LLViewerObject::getParameterEntryInUse(U16 param_type) const
-{
-    ExtraParameter* param = getExtraParameterEntry(param_type);
-    if (param)
-    {
-        return param->in_use;
-    }
-    else
-    {
-        return false;
-    }
+    return nullptr;
 }
 
 bool LLViewerObject::setParameterEntry(U16 param_type, const LLNetworkData& new_value, bool local_origin)
@@ -6615,11 +6578,11 @@ bool LLViewerObject::setParameterEntry(U16 param_type, const LLNetworkData& new_
     ExtraParameter* param = getExtraParameterEntryCreate(param_type);
     if (param)
     {
-        if (param->in_use && new_value == *(param->data))
+        if (*(param->in_use) && new_value == *(param->data))
         {
             return false;
         }
-        param->in_use = true;
+        *param->in_use = true;
         param->data->copy(new_value);
         parameterChanged(param_type, param->data, true, local_origin);
         return true;
@@ -6635,22 +6598,28 @@ bool LLViewerObject::setParameterEntry(U16 param_type, const LLNetworkData& new_
 // Should always return true.
 bool LLViewerObject::setParameterEntryInUse(U16 param_type, bool in_use, bool local_origin)
 {
-    ExtraParameter* param = getExtraParameterEntryCreate(param_type);
-    if (param && param->in_use != in_use)
+    if (param_type <= LLNetworkData::PARAMS_MAX)
     {
-        param->in_use = in_use;
-        parameterChanged(param_type, param->data, in_use, local_origin);
-        return true;
+        ExtraParameter* param = (in_use ? getExtraParameterEntryCreate(param_type) : &getExtraParameterEntry(param_type));
+        if (param && param->data && *param->in_use != in_use)
+        {
+            *param->in_use = in_use;
+            parameterChanged(param_type, param->data, in_use, local_origin);
+            return true;
+        }
     }
     return false;
 }
 
 void LLViewerObject::parameterChanged(U16 param_type, bool local_origin)
 {
-    ExtraParameter* param = getExtraParameterEntry(param_type);
-    if (param)
+    if (param_type <= LLNetworkData::PARAMS_MAX)
     {
-        parameterChanged(param_type, param->data, param->in_use, local_origin);
+        const ExtraParameter& param = getExtraParameterEntry(param_type);
+        if (param.data)
+        {
+            parameterChanged(param_type, param.data, *param.in_use, local_origin);
+        }
     }
 }
 
@@ -6698,7 +6667,7 @@ void LLViewerObject::parameterChanged(U16 param_type, LLNetworkData* data, bool 
     {
         if (param_type == LLNetworkData::PARAMS_RENDER_MATERIAL)
         {
-            const LLRenderMaterialParams* params = in_use ? (LLRenderMaterialParams*)getParameterEntry(LLNetworkData::PARAMS_RENDER_MATERIAL) : nullptr;
+            const LLRenderMaterialParams* params = in_use ? getRenderMaterialParams() : nullptr;
             setRenderMaterialIDs(params, local_origin);
         }
     }
@@ -7491,7 +7460,7 @@ LLVOAvatar* LLViewerObject::getAvatar() const
 
 bool LLViewerObject::hasRenderMaterialParams() const
 {
-    return getParameterEntryInUse(LLNetworkData::PARAMS_RENDER_MATERIAL);
+    return mRenderMaterialParamsInUse;
 }
 
 void LLViewerObject::setHasRenderMaterialParams(bool has_materials)
@@ -7513,7 +7482,7 @@ void LLViewerObject::setHasRenderMaterialParams(bool has_materials)
 
 const LLUUID& LLViewerObject::getRenderMaterialID(U8 te) const
 {
-    LLRenderMaterialParams* param_block = (LLRenderMaterialParams*)getParameterEntry(LLNetworkData::PARAMS_RENDER_MATERIAL);
+    const LLRenderMaterialParams* param_block = getRenderMaterialParams();
     if (param_block)
     {
         return param_block->getMaterial(te);
@@ -7554,7 +7523,7 @@ void LLViewerObject::setRenderMaterialID(S32 te_in, const LLUUID& id, bool updat
     start_idx = llmax(start_idx, 0);
     end_idx = llmin(end_idx, (S32) getNumTEs());
 
-    LLRenderMaterialParams* param_block = (LLRenderMaterialParams*)getParameterEntry(LLNetworkData::PARAMS_RENDER_MATERIAL);
+    LLRenderMaterialParams* param_block = getRenderMaterialParams();
     if (!param_block && id.notNull())
     { // block doesn't exist, but it will need to
         param_block = (LLRenderMaterialParams*)createNewParameterEntry(LLNetworkData::PARAMS_RENDER_MATERIAL)->data;

--- a/indra/newview/llviewerobject.h
+++ b/indra/newview/llviewerobject.h
@@ -126,13 +126,15 @@ class LLViewerObject
 protected:
     virtual ~LLViewerObject(); // use unref()
 
+private:
     // TomY: Provide for a list of extra parameter structures, mapped by structure name
     struct ExtraParameter
     {
-        bool in_use;
-        LLNetworkData *data;
+        bool is_invalid = false;
+        bool* in_use = nullptr;
+        LLNetworkData* data = nullptr;
     };
-    std::unordered_map<U16, ExtraParameter*> mExtraParameterList;
+    std::vector<ExtraParameter> mExtraParameterList;
 
 public:
     typedef std::list<LLPointer<LLViewerObject> > child_list_t;
@@ -630,10 +632,16 @@ public:
     void dirtySpatialGroup() const;
     virtual void dirtyMesh();
 
-    virtual LLNetworkData* getParameterEntry(U16 param_type) const;
-    virtual bool setParameterEntry(U16 param_type, const LLNetworkData& new_value, bool local_origin);
-    virtual bool getParameterEntryInUse(U16 param_type) const;
-    virtual bool setParameterEntryInUse(U16 param_type, bool in_use, bool local_origin);
+    LLFlexibleObjectData* getFlexibleObjectData() const { return mFlexibleObjectDataInUse ? mFlexibleObjectData.get() : nullptr; }
+    LLLightParams* getLightParams() const { return mLightParamsInUse ? mLightParams.get() : nullptr; }
+    LLSculptParams* getSculptParams() const { return mSculptParamsInUse ? mSculptParams.get() : nullptr; }
+    LLLightImageParams* getLightImageParams() const { return mLightImageParamsInUse ? mLightImageParams.get() : nullptr; }
+    LLExtendedMeshParams* getExtendedMeshParams() const { return mExtendedMeshParamsInUse ? mExtendedMeshParams.get() : nullptr; }
+    LLRenderMaterialParams* getRenderMaterialParams() const { return mRenderMaterialParamsInUse ? mRenderMaterialParams.get() : nullptr; }
+    LLReflectionProbeParams* getReflectionProbeParams() const { return mReflectionProbeParamsInUse ? mReflectionProbeParams.get() : nullptr; }
+
+    bool setParameterEntry(U16 param_type, const LLNetworkData& new_value, bool local_origin);
+    bool setParameterEntryInUse(U16 param_type, bool in_use, bool local_origin);
     // Called when a parameter is changed
     virtual void parameterChanged(U16 param_type, bool local_origin);
     virtual void parameterChanged(U16 param_type, LLNetworkData* data, bool in_use, bool local_origin);
@@ -675,8 +683,31 @@ private:
     bool isAssetInInventory(LLViewerInventoryItem* item, LLAssetType::EType type);
 
     ExtraParameter* createNewParameterEntry(U16 param_type);
-    ExtraParameter* getExtraParameterEntry(U16 param_type) const;
-    ExtraParameter* getExtraParameterEntryCreate(U16 param_type);
+    const ExtraParameter& getExtraParameterEntry(U16 param_type) const
+    {
+        return mExtraParameterList[U32(param_type >> 4) - 1];
+    }
+    ExtraParameter& getExtraParameterEntry(U16 param_type)
+    {
+        return mExtraParameterList[U32(param_type >> 4) - 1];
+    }
+    ExtraParameter* getExtraParameterEntryCreate(U16 param_type)
+    {
+        if (param_type <= LLNetworkData::PARAMS_MAX)
+        {
+            ExtraParameter& param = getExtraParameterEntry(param_type);
+            if (!param.is_invalid)
+            {
+                if (!param.data)
+                {
+                    ExtraParameter* new_entry = createNewParameterEntry(param_type);
+                    return new_entry;
+                }
+                return &param;
+            }
+        }
+        return nullptr;
+    }
     bool unpackParameterEntry(U16 param_type, LLDataPacker *dp);
 
     // This function checks to see if the given media URL has changed its version
@@ -748,6 +779,21 @@ public:
 private:
     // Grabbed from UPDATE_FLAGS
     U32             mFlags;
+
+    bool mFlexibleObjectDataInUse = false,
+        mLightParamsInUse = false,
+        mSculptParamsInUse = false,
+        mLightImageParamsInUse = false,
+        mExtendedMeshParamsInUse = false,
+        mRenderMaterialParamsInUse = false,
+        mReflectionProbeParamsInUse = false;
+    std::unique_ptr<LLFlexibleObjectData> mFlexibleObjectData;
+    std::unique_ptr<LLLightParams> mLightParams;
+    std::unique_ptr<LLSculptParams> mSculptParams;
+    std::unique_ptr<LLLightImageParams> mLightImageParams;
+    std::unique_ptr<LLExtendedMeshParams> mExtendedMeshParams;
+    std::unique_ptr<LLRenderMaterialParams> mRenderMaterialParams;
+    std::unique_ptr<LLReflectionProbeParams> mReflectionProbeParams;
 
     static std::map<std::string, U32> sObjectDataMap;
 public:

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -351,7 +351,7 @@ U32 LLVOVolume::processUpdateMessage(LLMessageSystem *mesgsys,
     U8 sculpt_type = 0;
     if (isSculpted())
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = getSculptParams();
         if (sculpt_params)
         {
             sculpt_id = sculpt_params->getSculptTexture();
@@ -924,7 +924,7 @@ void LLVOVolume::updateTextureVirtualSize(bool forced)
 
     if (getLightTextureID().notNull())
     {
-        LLLightImageParams* params = (LLLightImageParams*) getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
+        LLLightImageParams* params = getLightImageParams();
         LLUUID id = params->getLightTexture();
         mLightTexture = LLViewerTextureManager::getFetchedTexture(id, FTT_DEFAULT, true, LLGLTexture::BOOST_NONE);
         if (mLightTexture.notNull())
@@ -1082,7 +1082,7 @@ bool LLVOVolume::setVolume(const LLVolumeParams &params_in, const S32 detail, bo
         setParameterEntryInUse(LLNetworkData::PARAMS_FLEXIBLE, true, false);
         if (!mVolumeImpl)
         {
-            LLFlexibleObjectData* data = (LLFlexibleObjectData*)getParameterEntry(LLNetworkData::PARAMS_FLEXIBLE);
+            LLFlexibleObjectData* data = getFlexibleObjectData();
             mVolumeImpl = new LLVolumeImplFlexible(this, data);
         }
     }
@@ -1193,7 +1193,7 @@ void LLVOVolume::updateSculptTexture()
 
     if (isSculpted() && !isMesh())
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        LLSculptParams *sculpt_params = getSculptParams();
         if (sculpt_params)
         {
             LLUUID id = sculpt_params->getSculptTexture();
@@ -3053,7 +3053,7 @@ void LLVOVolume::setLightTextureID(LLUUID id)
         {
             old_texturep->removeVolume(LLRender::LIGHT_TEX, this);
         }
-        LLLightImageParams* param_block = (LLLightImageParams*) getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
+        LLLightImageParams* param_block = getLightImageParams();
         if (param_block && param_block->getLightTexture() != id)
         {
             param_block->setLightTexture(id);
@@ -3083,7 +3083,7 @@ void LLVOVolume::setLightTextureID(LLUUID id)
 
 void LLVOVolume::setSpotLightParams(LLVector3 params)
 {
-    LLLightImageParams* param_block = (LLLightImageParams*) getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
+    LLLightImageParams* param_block = getLightImageParams();
     if (param_block && param_block->getParams() != params)
     {
         param_block->setParams(params);
@@ -3125,7 +3125,7 @@ void LLVOVolume::setLightSRGBColor(const LLColor3& color)
 
 void LLVOVolume::setLightLinearColor(const LLColor3& color)
 {
-    LLLightParams *param_block = (LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         if (param_block->getLinearColor() != color)
@@ -3140,7 +3140,7 @@ void LLVOVolume::setLightLinearColor(const LLColor3& color)
 
 void LLVOVolume::setLightIntensity(F32 intensity)
 {
-    LLLightParams *param_block = (LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         if (param_block->getLinearColor().mV[3] != intensity)
@@ -3153,7 +3153,7 @@ void LLVOVolume::setLightIntensity(F32 intensity)
 
 void LLVOVolume::setLightRadius(F32 radius)
 {
-    LLLightParams *param_block = (LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         if (param_block->getRadius() != radius)
@@ -3166,7 +3166,7 @@ void LLVOVolume::setLightRadius(F32 radius)
 
 void LLVOVolume::setLightFalloff(F32 falloff)
 {
-    LLLightParams *param_block = (LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         if (param_block->getFalloff() != falloff)
@@ -3179,7 +3179,7 @@ void LLVOVolume::setLightFalloff(F32 falloff)
 
 void LLVOVolume::setLightCutoff(F32 cutoff)
 {
-    LLLightParams *param_block = (LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         if (param_block->getCutoff() != cutoff)
@@ -3194,7 +3194,7 @@ void LLVOVolume::setLightCutoff(F32 cutoff)
 
 bool LLVOVolume::getIsLight() const
 {
-    mIsLight = getParameterEntryInUse(LLNetworkData::PARAMS_LIGHT);
+    mIsLight = getLightParams() != nullptr;
     return mIsLight;
 }
 
@@ -3210,7 +3210,7 @@ LLColor3 LLVOVolume::getLightSRGBBaseColor() const
 
 LLColor3 LLVOVolume::getLightLinearBaseColor() const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return LLColor3(param_block->getLinearColor());
@@ -3223,7 +3223,7 @@ LLColor3 LLVOVolume::getLightLinearBaseColor() const
 
 LLColor3 LLVOVolume::getLightLinearColor() const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return LLColor3(param_block->getLinearColor()) * param_block->getLinearColor().mV[3];
@@ -3241,33 +3241,27 @@ LLColor3 LLVOVolume::getLightSRGBColor() const
     return ret;
 }
 
-LLUUID LLVOVolume::getLightTextureID() const
+const LLUUID& LLVOVolume::getLightTextureID() const
 {
-    if (getParameterEntryInUse(LLNetworkData::PARAMS_LIGHT_IMAGE))
+    const LLLightImageParams *param_block = getLightImageParams();
+    if (param_block)
     {
-        const LLLightImageParams *param_block = (const LLLightImageParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
-        if (param_block)
-        {
-            return param_block->getLightTexture();
-        }
+        return param_block->getLightTexture();
     }
 
     return LLUUID::null;
 }
 
 
-LLVector3 LLVOVolume::getSpotLightParams() const
+const LLVector3& LLVOVolume::getSpotLightParams() const
 {
-    if (getParameterEntryInUse(LLNetworkData::PARAMS_LIGHT_IMAGE))
+    const LLLightImageParams *param_block = getLightImageParams();
+    if (param_block)
     {
-        const LLLightImageParams *param_block = (const LLLightImageParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
-        if (param_block)
-        {
-            return param_block->getParams();
-        }
+        return param_block->getParams();
     }
 
-    return LLVector3();
+    return LLVector3::zero;
 }
 
 F32 LLVOVolume::getSpotLightPriority() const
@@ -3304,8 +3298,8 @@ void LLVOVolume::updateSpotLightPriority()
 
 bool LLVOVolume::isLightSpotlight() const
 {
-    LLLightImageParams* params = (LLLightImageParams*) getParameterEntry(LLNetworkData::PARAMS_LIGHT_IMAGE);
-    if (params && getParameterEntryInUse(LLNetworkData::PARAMS_LIGHT_IMAGE))
+    const LLLightImageParams* params = getLightImageParams();
+    if (params)
     {
         return params->isLightSpotlight();
     }
@@ -3315,7 +3309,7 @@ bool LLVOVolume::isLightSpotlight() const
 
 LLViewerTexture* LLVOVolume::getLightTexture()
 {
-    LLUUID id = getLightTextureID();
+    const LLUUID& id = getLightTextureID();
 
     if (id.notNull())
     {
@@ -3326,7 +3320,7 @@ LLViewerTexture* LLVOVolume::getLightTexture()
     }
     else
     {
-        mLightTexture = NULL;
+        mLightTexture = nullptr;
     }
 
     return mLightTexture;
@@ -3334,7 +3328,7 @@ LLViewerTexture* LLVOVolume::getLightTexture()
 
 F32 LLVOVolume::getLightIntensity() const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return param_block->getLinearColor().mV[3];
@@ -3347,7 +3341,7 @@ F32 LLVOVolume::getLightIntensity() const
 
 F32 LLVOVolume::getLightRadius() const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return param_block->getRadius();
@@ -3360,7 +3354,7 @@ F32 LLVOVolume::getLightRadius() const
 
 F32 LLVOVolume::getLightFalloff(const F32 fudge_factor) const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return param_block->getFalloff() * fudge_factor;
@@ -3373,7 +3367,7 @@ F32 LLVOVolume::getLightFalloff(const F32 fudge_factor) const
 
 F32 LLVOVolume::getLightCutoff() const
 {
-    const LLLightParams *param_block = (const LLLightParams *)getParameterEntry(LLNetworkData::PARAMS_LIGHT);
+    const LLLightParams *param_block = getLightParams();
     if (param_block)
     {
         return param_block->getCutoff();
@@ -3386,7 +3380,7 @@ F32 LLVOVolume::getLightCutoff() const
 
 bool LLVOVolume::isReflectionProbe() const
 {
-    return getParameterEntryInUse(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    return getReflectionProbeParams() != nullptr;
 }
 
 bool LLVOVolume::setIsReflectionProbe(bool is_probe)
@@ -3411,7 +3405,7 @@ bool LLVOVolume::setIsReflectionProbe(bool is_probe)
 
 bool LLVOVolume::setReflectionProbeAmbiance(F32 ambiance)
 {
-    LLReflectionProbeParams* param_block = (LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         if (param_block->getAmbiance() != ambiance)
@@ -3427,7 +3421,7 @@ bool LLVOVolume::setReflectionProbeAmbiance(F32 ambiance)
 
 bool LLVOVolume::setReflectionProbeNearClip(F32 near_clip)
 {
-    LLReflectionProbeParams* param_block = (LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         if (param_block->getClipDistance() != near_clip)
@@ -3443,7 +3437,7 @@ bool LLVOVolume::setReflectionProbeNearClip(F32 near_clip)
 
 bool LLVOVolume::setReflectionProbeIsBox(bool is_box)
 {
-    LLReflectionProbeParams* param_block = (LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         if (param_block->getIsBox() != is_box)
@@ -3459,7 +3453,7 @@ bool LLVOVolume::setReflectionProbeIsBox(bool is_box)
 
 bool LLVOVolume::setReflectionProbeIsDynamic(bool is_dynamic)
 {
-    LLReflectionProbeParams* param_block = (LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         if (param_block->getIsDynamic() != is_dynamic)
@@ -3475,7 +3469,7 @@ bool LLVOVolume::setReflectionProbeIsDynamic(bool is_dynamic)
 
 bool LLVOVolume::setReflectionProbeIsMirror(bool is_mirror)
 {
-    LLReflectionProbeParams *param_block = (LLReflectionProbeParams *) getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         if (param_block->getIsMirror() != is_mirror)
@@ -3498,7 +3492,7 @@ bool LLVOVolume::setReflectionProbeIsMirror(bool is_mirror)
 
 F32 LLVOVolume::getReflectionProbeAmbiance() const
 {
-    const LLReflectionProbeParams* param_block = (const LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    const LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         return param_block->getAmbiance();
@@ -3511,7 +3505,7 @@ F32 LLVOVolume::getReflectionProbeAmbiance() const
 
 F32 LLVOVolume::getReflectionProbeNearClip() const
 {
-    const LLReflectionProbeParams* param_block = (const LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    const LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         return param_block->getClipDistance();
@@ -3524,7 +3518,7 @@ F32 LLVOVolume::getReflectionProbeNearClip() const
 
 bool LLVOVolume::getReflectionProbeIsBox() const
 {
-    const LLReflectionProbeParams* param_block = (const LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    const LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         return param_block->getIsBox();
@@ -3535,7 +3529,7 @@ bool LLVOVolume::getReflectionProbeIsBox() const
 
 bool LLVOVolume::getReflectionProbeIsDynamic() const
 {
-    const LLReflectionProbeParams* param_block = (const LLReflectionProbeParams*)getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    const LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         return param_block->getIsDynamic();
@@ -3546,8 +3540,7 @@ bool LLVOVolume::getReflectionProbeIsDynamic() const
 
 bool LLVOVolume::getReflectionProbeIsMirror() const
 {
-    const LLReflectionProbeParams *param_block =
-        (const LLReflectionProbeParams *) getParameterEntry(LLNetworkData::PARAMS_REFLECTION_PROBE);
+    const LLReflectionProbeParams* param_block = getReflectionProbeParams();
     if (param_block)
     {
         return param_block->getIsMirror();
@@ -3568,7 +3561,7 @@ U32 LLVOVolume::getVolumeInterfaceID() const
 
 bool LLVOVolume::isFlexible() const
 {
-    if (getParameterEntryInUse(LLNetworkData::PARAMS_FLEXIBLE))
+    if (getFlexibleObjectData())
     {
         LLVolume* volume = getVolume();
         if (volume && volume->getParams().getPathParams().getCurveType() != LL_PCODE_PATH_FLEXIBLE)
@@ -3587,7 +3580,7 @@ bool LLVOVolume::isFlexible() const
 
 bool LLVOVolume::isSculpted() const
 {
-    if (getParameterEntryInUse(LLNetworkData::PARAMS_SCULPT))
+    if (getSculptParams())
     {
         return true;
     }
@@ -3599,7 +3592,7 @@ bool LLVOVolume::isMesh() const
 {
     if (isSculpted())
     {
-        LLSculptParams *sculpt_params = (LLSculptParams *)getParameterEntry(LLNetworkData::PARAMS_SCULPT);
+        const LLSculptParams *sculpt_params = getSculptParams();
         if (sculpt_params)
         {
             U8 sculpt_type = sculpt_params->getSculptType();
@@ -3617,7 +3610,7 @@ bool LLVOVolume::isMesh() const
 
 bool LLVOVolume::hasLightTexture() const
 {
-    if (getParameterEntryInUse(LLNetworkData::PARAMS_LIGHT_IMAGE))
+    if (getLightImageParams())
     {
         return true;
     }
@@ -3737,8 +3730,7 @@ bool LLVOVolume::isRiggedMesh() const
 //----------------------------------------------------------------------------
 U32 LLVOVolume::getExtendedMeshFlags() const
 {
-    const LLExtendedMeshParams *param_block =
-        (const LLExtendedMeshParams *)getParameterEntry(LLNetworkData::PARAMS_EXTENDED_MESH);
+    const LLExtendedMeshParams *param_block = getExtendedMeshParams();
     if (param_block)
     {
         return param_block->getFlags();
@@ -3783,8 +3775,7 @@ void LLVOVolume::setExtendedMeshFlags(U32 flags)
     {
         bool in_use = true;
         setParameterEntryInUse(LLNetworkData::PARAMS_EXTENDED_MESH, in_use, true);
-        LLExtendedMeshParams *param_block =
-            (LLExtendedMeshParams *)getParameterEntry(LLNetworkData::PARAMS_EXTENDED_MESH);
+        LLExtendedMeshParams *param_block = (LLExtendedMeshParams *)getExtendedMeshParams();
         if (param_block)
         {
             param_block->setFlags(flags);

--- a/indra/newview/llvovolume.h
+++ b/indra/newview/llvovolume.h
@@ -283,9 +283,9 @@ public:
     // Get the light color in sRGB color space scaled by intensity.
     LLColor3 getLightSRGBColor() const;
 
-    LLUUID  getLightTextureID() const;
+    const LLUUID&  getLightTextureID() const;
     bool isLightSpotlight() const;
-    LLVector3 getSpotLightParams() const;
+    const LLVector3& getSpotLightParams() const;
     void    updateSpotLightPriority();
     F32     getSpotLightPriority() const;
 


### PR DESCRIPTION
## Description

This mitigates a significant number of map.find calls made throughout the render pipe querying various object parameters

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
