### PR TITLE
No confirmation is shown when gifting all your money

### DIFF
--- a/indra/newview/llfloaterpay.cpp
+++ b/indra/newview/llfloaterpay.cpp
@@ -502,7 +502,7 @@ void LLFloaterPay::onGive(give_money_ptr info)
         amount = atoi(text_field->getValue().asString().c_str());
     }
 
-    if (amount > PAY_AMOUNT_NOTIFICATION && gStatusBar && gStatusBar->getBalance() > amount)
+    if (amount > PAY_AMOUNT_NOTIFICATION)
     {
         LLUUID payee_id = LLUUID::null;
         bool is_group = false;


### PR DESCRIPTION
## Description

When the payment amount to another avatar is your total L balance it fails to pop up the notification confirming you want to do that. The related issue appears to be closed without actually being fixed. Cherry-picked the commit from `archive/develop`

## Related Issues

Issue Link: #3322

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
