### PR TITLE
[#5210] Use the preloaded marketplace floater for SL marketplace URLs

### DIFF
--- a/indra/newview/llfloatermarketplace.cpp
+++ b/indra/newview/llfloatermarketplace.cpp
@@ -39,6 +39,26 @@ LLFloaterMarketplace::~LLFloaterMarketplace()
 {
 }
 
+void LLFloaterMarketplace::onOpen(const LLSD& key)
+{
+    Params params(key);
+
+    if (!params.validateBlock())
+    {
+        closeFloater();
+        return;
+    }
+
+    if (params.url().empty())
+    {
+        openMarketplace();
+    }
+    else
+    {
+        openMarketplaceURL(params.url);
+    }
+}
+
 // just to override LLFloaterWebContent
 void LLFloaterMarketplace::onClose(bool app_quitting)
 {
@@ -67,4 +87,19 @@ void LLFloaterMarketplace::openMarketplace()
     {
         mWebBrowser->navigateTo(url, HTTP_CONTENT_TEXT_HTML);
     }
+}
+
+void LLFloaterMarketplace::openMarketplaceURL(const std::string& url)
+{
+    if (mCurrentURL != url)
+    {
+        mWebBrowser->navigateTo(url, HTTP_CONTENT_TEXT_HTML);
+    }
+}
+
+// static
+bool LLFloaterMarketplace::isMarketplaceURL(const std::string& url)
+{
+    static LLCachedControl<std::string> marketplace_url(gSavedSettings, "MarketplaceURL", "https://marketplace.secondlife.com/");
+    return url.starts_with(marketplace_url());
 }

--- a/indra/newview/llfloatermarketplace.h
+++ b/indra/newview/llfloatermarketplace.h
@@ -36,11 +36,14 @@ class LLFloaterMarketplace:
 
 public:
     void openMarketplace();
+    void openMarketplaceURL(const std::string& url);
+    bool static isMarketplaceURL(const std::string& url);
 
 private:
     LLFloaterMarketplace(const LLSD& key);
     ~LLFloaterMarketplace();
     bool postBuild() override;
+    void onOpen(const LLSD& key) override;
     void onClose(bool app_quitting) override;
 };
 

--- a/indra/newview/llweb.cpp
+++ b/indra/newview/llweb.cpp
@@ -34,6 +34,7 @@
 
 #include "llagent.h"
 #include "llappviewer.h"
+#include "llfloatermarketplace.h"
 #include "llfloaterwebcontent.h"
 #include "llfloaterreg.h"
 #include "lllogininstance.h"
@@ -74,12 +75,20 @@ void LLWeb::loadURL(const std::string& url, const std::string& target, const std
 }
 
 // static
-// Explicitly open a Web URL using the Web content floater
+// Explicitly open a Web URL using the Web content floater or Marketplace floater
 void LLWeb::loadURLInternal(const std::string &url, const std::string& target, const std::string& uuid, bool dev_mode)
 {
     LLFloaterWebContent::Params p;
     p.url(url).target(target).id(uuid).dev_mode(dev_mode);
-    LLFloaterReg::showInstance("web_content", p);
+
+    if (LLFloaterMarketplace::isMarketplaceURL(url))
+    {
+        LLFloaterReg::showInstance("marketplace", p);
+    }
+    else
+    {
+        LLFloaterReg::showInstance("web_content", p);
+    }
 }
 
 // static


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5210

Implements the above enhancement by checking if the url passed to loadURLInternal starts with the MarketplaceURL, and if so, use the marketplace floater instead which is preloaded (on systems with >8GB of RAM).
This allows marketplace links to load almost instantly and not need to wait numerous seconds for the CEF instance to be created and load.