### PR TITLE
revert #4735 Remove the word "Viewer" from application shortcut

### DIFF
--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -259,9 +259,10 @@ class ViewerManifest(LLManifest):
         global CHANNEL_VENDOR_BASE
         channel_type=self.channel_type()
         if channel_type == 'release':
-            return CHANNEL_VENDOR_BASE
+            app_suffix='Viewer'
         else:
-            return CHANNEL_VENDOR_BASE + ' ' + self.channel_variant()
+            app_suffix=self.channel_variant()
+        return CHANNEL_VENDOR_BASE + ' ' + app_suffix
 
     def exec_name(self):
         return "SecondLifeViewer"


### PR DESCRIPTION
Revert naming change to avoid collisions.