### PR TITLE
#5217 Treat issues with control variables smarter and show a proper warning

### DIFF
--- a/indra/llxml/llcontrol.cpp
+++ b/indra/llxml/llcontrol.cpp
@@ -157,9 +157,12 @@ LLControlVariable::LLControlVariable(const std::string& name, eControlType type,
 {
     if ((persist != PERSIST_NO) && mComment.empty())
     {
-        // File isn't actually missing, but something is wrong with it
-        // so the main point is to warn user to reinstall
-        LLError::LLUserWarningMsg::showMissingFiles();
+        std::string error_string =
+            "Second Life failed to initialize settings. Setting " + mName + " is invalid. "
+            "Either settings' files were supplied incorrectly or default files were corrupted."
+            "\n\nPlease reinstall viewer from  https://secondlife.com/support/downloads/ and "
+            "contact https://support.secondlife.com if issue persists after reinstall.";
+        LLError::LLUserWarningMsg::show(error_string);
         LL_ERRS() << "Must supply a comment for control " << mName << LL_ENDL;
     }
     //Push back versus setValue'ing here, since we don't want to call a signal yet
@@ -990,7 +993,7 @@ U32 LLControlGroup::saveToFile(const std::string& filename, bool nondefault_only
     return num_saved;
 }
 
-U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_values, bool save_values)
+U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_values, bool save_values, bool error_when_no_comment)
 {
     LLSD settings;
     llifstream infile;
@@ -1105,10 +1108,21 @@ U32 LLControlGroup::loadFromFile(const std::string& filename, bool set_default_v
                 }
             }
 
+            std::string comment = control_map["Comment"].asString();
+            if (!error_when_no_comment && persist != LLControlVariable::PERSIST_NO && comment.empty())
+            {
+                // Only error for default settings, permit this minor transgression in user's file.
+                // Otherwise user might have a hard time figuring out source of the error or how to fix it.
+                // Instead make setting to not persist so that invalid setting won't be saved for the next run.
+                persist = LLControlVariable::PERSIST_NO;
+                comment = "Failed to load comment, setting won't persist";
+                LL_WARNS() << "Control " << name << " is missing a comment value. Setting will be marked as PERSIST_NO" << LL_ENDL;
+            }
+
             declareControl(name,
                            typeStringToEnum(control_map["Type"].asString()),
                            control_map["Value"],
-                           control_map["Comment"].asString(),
+                           comment,
                            persist,
                            hidefromsettingseditor
                            );

--- a/indra/llxml/llcontrol.h
+++ b/indra/llxml/llcontrol.h
@@ -278,7 +278,7 @@ public:
     // as the given type.
     U32 loadFromFileLegacy(const std::string& filename, bool require_declaration = true, eControlType declare_as = TYPE_STRING);
     U32 saveToFile(const std::string& filename, bool nondefault_only);
-    U32 loadFromFile(const std::string& filename, bool default_values = false, bool save_values = true);
+    U32 loadFromFile(const std::string& filename, bool default_values = false, bool save_values = true, bool error_when_no_comment = true);
     void    resetToDefaults();
     void    incrCount(std::string_view name);
 

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -2455,7 +2455,10 @@ bool LLAppViewer::loadSettingsFromDirectory(const std::string& location_key,
                 full_settings_path = gDirUtilp->getExpandedFilename((ELLPath)path_index, file.file_name());
             }
 
-            if(settings_group->loadFromFile(full_settings_path, set_defaults, file.persistent))
+            // be softer for files in user's folders, user can't just reinstall those
+            bool error_when_no_comment = location_key != "User";
+
+            if(settings_group->loadFromFile(full_settings_path, set_defaults, file.persistent, error_when_no_comment))
             {   // success!
                 LL_INFOS("Settings") << "Loaded settings file " << full_settings_path << LL_ENDL;
             }

--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -29,8 +29,6 @@
 
 #include "llavataractions.h"
 
-#include "boost/lambda/lambda.hpp"  // for lambda::constant
-
 #include "llavatarnamecache.h"  // IDEVO
 #include "llsd.h"
 #include "llnotifications.h"

--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -135,9 +135,10 @@ void LLSpatialGroup::clearDrawMap()
     mDrawMap.clear();
 }
 
-bool LLSpatialGroup::isHUDGroup()
+bool LLSpatialGroup::isHUDGroup() const
 {
-    return getSpatialPartition() && getSpatialPartition()->isHUDPartition() ;
+    LLSpatialPartition* part = getSpatialPartition();
+    return part && part->isHUDPartition();
 }
 
 void LLSpatialGroup::validate()

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -264,7 +264,7 @@ public:
 
     LLSpatialGroup(OctreeNode* node, LLSpatialPartition* part);
 
-    bool isHUDGroup() ;
+    bool isHUDGroup() const;
 
     void clearDrawMap();
     void validate();
@@ -310,7 +310,7 @@ public:
     );
 
 
-    LLSpatialPartition* getSpatialPartition() {return (LLSpatialPartition*)mSpatialPartition;}
+    LLSpatialPartition* getSpatialPartition() const {return (LLSpatialPartition*)mSpatialPartition;}
 
      //LISTENER FUNCTIONS
     virtual void handleInsertion(const TreeNode* node, LLViewerOctreeEntry* face);

--- a/indra/newview/llvieweroctree.h
+++ b/indra/newview/llvieweroctree.h
@@ -316,7 +316,6 @@ public:
 
     //virtual
     bool isRecentlyVisible() const;
-    LLViewerOctreePartition* getSpatialPartition()const {return mSpatialPartition;}
     bool isAnyRecentlyVisible() const;
 
     static U32 getNewOcclusionQueryObjectName();

--- a/indra/newview/llviewerwindow.cpp
+++ b/indra/newview/llviewerwindow.cpp
@@ -34,7 +34,6 @@
 #include <fstream>
 #include <algorithm>
 #include <boost/filesystem.hpp>
-#include <boost/lambda/core.hpp>
 #include <boost/regex.hpp>
 
 #include "llagent.h"

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -2729,7 +2729,7 @@ void LLPipeline::clearRebuildGroups()
 
     mGroupQ1Locked = true;
     // Iterate through all drawables on the priority build queue,
-    for (LLSpatialGroup::sg_vector_t::iterator iter = mGroupQ1.begin();
+    for (LLSpatialGroup::sg_vector_t::const_iterator iter = mGroupQ1.begin();
          iter != mGroupQ1.end(); ++iter)
     {
         LLSpatialGroup* group = *iter;


### PR DESCRIPTION
User can't be expected to know where their personal settings are and how to fix them even if user somehow broke the file. Instead of crashing on an invalid settings in personal files, just mark it as not persistant. Keep crashing on code declared, cmd or default files, as either cmd/code is wrong or file got corrupted, but provide a more fitting warning.