### PR TITLE
#5220 do not save 'Highlight Transparent Probes' setting between sessions

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9058,7 +9058,7 @@
         <key>Comment</key>
         <string>Show reflection probes in the transparency debug view</string>
         <key>Persist</key>
-        <integer>1</integer>
+        <integer>0</integer>
         <key>Type</key>
         <string>Boolean</string>
         <key>Value</key>


### PR DESCRIPTION
Reset 'Highlight Transparent Probes' to its default state each session, as Dan suggested.