### PR TITLE
#4991 Fix showing incorrect alpha

### DIFF
--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -1201,7 +1201,7 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
 
             // See if that's been overridden by a material setting for same...
             //
-            LLSelectedTEMaterial::getCurrentDiffuseAlphaMode(alpha_mode, identical_alpha_mode, mIsAlpha);
+            LLSelectedTEMaterial::getCurrentDiffuseAlphaMode(alpha_mode, identical_alpha_mode);
 
             // it is invalid to have any alpha mode other than blend if transparency is greater than zero ...
             // Want masking? Want emissive? Tough! You get BLEND!
@@ -1211,6 +1211,12 @@ void LLPanelFace::updateUI(bool force_set_values /*false*/)
             alpha_mode = mIsAlpha ? alpha_mode : LLMaterial::DIFFUSE_ALPHA_MODE_NONE;
 
             mComboAlphaMode->getSelectionInterface()->selectNthItem(alpha_mode);
+            mComboAlphaMode->setTentative(!identical_alpha_mode);
+            if (!identical_alpha_mode)
+            {
+                std::string multiple = LLTrans::getString("multiple_textures");
+                mComboAlphaMode->setLabel(multiple);
+            }
             updateAlphaControls();
 
             mExcludeWater &= (LLMaterial::DIFFUSE_ALPHA_MODE_BLEND == alpha_mode);
@@ -5484,32 +5490,41 @@ void LLPanelFace::LLSelectedTEMaterial::getMaxNormalRepeats(F32& repeats, bool& 
     identical = LLSelectMgr::getInstance()->getSelection()->getSelectedTEValue( &max_norm_repeats_func, repeats);
 }
 
-void LLPanelFace::LLSelectedTEMaterial::getCurrentDiffuseAlphaMode(U8& diffuse_alpha_mode, bool& identical, bool diffuse_texture_has_alpha)
+void LLPanelFace::LLSelectedTEMaterial::getCurrentDiffuseAlphaMode(U8& diffuse_alpha_mode, bool& identical)
 {
     struct LLSelectedTEGetDiffuseAlphaMode : public LLSelectedTEGetFunctor<U8>
     {
-        LLSelectedTEGetDiffuseAlphaMode() : _isAlpha(false) {}
-        LLSelectedTEGetDiffuseAlphaMode(bool diffuse_texture_has_alpha) : _isAlpha(diffuse_texture_has_alpha) {}
+        LLSelectedTEGetDiffuseAlphaMode() {}
         virtual ~LLSelectedTEGetDiffuseAlphaMode() {}
 
         U8 get(LLViewerObject* object, S32 face)
         {
-            U8 diffuse_mode = _isAlpha ? LLMaterial::DIFFUSE_ALPHA_MODE_BLEND : LLMaterial::DIFFUSE_ALPHA_MODE_NONE;
-
             LLTextureEntry* tep = object->getTE(face);
             if (tep)
             {
                 LLMaterial* mat = tep->getMaterialParams().get();
                 if (mat)
                 {
-                    diffuse_mode = mat->getDiffuseAlphaMode();
+                    return mat->getDiffuseAlphaMode();
                 }
             }
 
+            bool has_alpha = false;
+            LLViewerTexture* image = object->getTEImage(face);
+            if (image)
+            {
+                LLGLenum format = image->getPrimaryFormat();
+                if (format == GL_RGBA || format == GL_ALPHA)
+                {
+                    has_alpha = true;
+                }
+            }
+
+            U8 diffuse_mode = has_alpha ? LLMaterial::DIFFUSE_ALPHA_MODE_BLEND : LLMaterial::DIFFUSE_ALPHA_MODE_NONE;
             return diffuse_mode;
         }
         bool _isAlpha; // whether or not the diffuse texture selected contains alpha information
-    } get_diff_mode(diffuse_texture_has_alpha);
+    } get_diff_mode;
     identical = LLSelectMgr::getInstance()->getSelection()->getSelectedTEValue( &get_diff_mode, diffuse_alpha_mode);
 }
 

--- a/indra/newview/llpanelface.cpp
+++ b/indra/newview/llpanelface.cpp
@@ -5523,7 +5523,6 @@ void LLPanelFace::LLSelectedTEMaterial::getCurrentDiffuseAlphaMode(U8& diffuse_a
             U8 diffuse_mode = has_alpha ? LLMaterial::DIFFUSE_ALPHA_MODE_BLEND : LLMaterial::DIFFUSE_ALPHA_MODE_NONE;
             return diffuse_mode;
         }
-        bool _isAlpha; // whether or not the diffuse texture selected contains alpha information
     } get_diff_mode;
     identical = LLSelectMgr::getInstance()->getSelection()->getSelectedTEValue( &get_diff_mode, diffuse_alpha_mode);
 }

--- a/indra/newview/llpanelface.h
+++ b/indra/newview/llpanelface.h
@@ -652,7 +652,7 @@ public:
         static void getCurrent(LLMaterialPtr& material_ptr, bool& identical_material);
         static void getMaxSpecularRepeats(F32& repeats, bool& identical);
         static void getMaxNormalRepeats(F32& repeats, bool& identical);
-        static void getCurrentDiffuseAlphaMode(U8& diffuse_alpha_mode, bool& identical, bool diffuse_texture_has_alpha);
+        static void getCurrentDiffuseAlphaMode(U8& diffuse_alpha_mode, bool& identical);
         static void selectionNormalScaleAutofit(LLPanelFace* panel_face, F32 repeats_per_meter);
         static void selectionSpecularScaleAutofit(LLPanelFace* panel_face, F32 repeats_per_meter);
 


### PR DESCRIPTION
Due to _isAlpha alpha was considered as blend even if only one texture had an alpha and was set to anything but blend.