### PR TITLE
#5228 crash at updateLoginButtons

### DIFF
--- a/indra/newview/llpanellogin.cpp
+++ b/indra/newview/llpanellogin.cpp
@@ -220,6 +220,11 @@ LLPanelLogin::LLPanelLogin(const LLRect &rect,
     // STEAM-14: When user presses Enter with this field in focus, initiate login
     password_edit->setCommitCallback(boost::bind(&LLPanelLogin::onClickConnect, false));
 
+    childSetAction("connect_btn", onClickConnect, this);
+
+    mLoginBtn = getChild<LLButton>("connect_btn");
+    setDefaultBtn(mLoginBtn);
+
     // change z sort of clickable text to be behind buttons
     sendChildToBack(getChildView("forgot_password_text"));
     sendChildToBack(getChildView("sign_up_text"));
@@ -295,11 +300,6 @@ LLPanelLogin::LLPanelLogin(const LLRect &rect,
     {
         onUpdateStartSLURL(start_slurl); // updates grid if needed
     }
-
-    childSetAction("connect_btn", onClickConnect, this);
-
-    mLoginBtn = getChild<LLButton>("connect_btn");
-    setDefaultBtn(mLoginBtn);
 
     std::string channel = LLVersionInfo::instance().getChannel();
     std::string version = stringize(LLVersionInfo::instance().getShortVersion(), " (",


### PR DESCRIPTION
`mLoginBtn` was initialized too late, and `onUpdateStartSLURL` might be called before it which caused crash.