### PR TITLE
Fix model preview floater camera affecting agent fov on simulator

### DIFF
--- a/indra/newview/llmodelpreview.cpp
+++ b/indra/newview/llmodelpreview.cpp
@@ -3461,7 +3461,7 @@ bool LLModelPreview::render()
 
     LLViewerCamera::getInstance()->setAspect(aspect);
 
-    LLViewerCamera::getInstance()->setView(LLViewerCamera::getInstance()->getDefaultFOV() / mCameraZoom);
+    LLViewerCamera::getInstance()->setViewNoBroadcast(LLViewerCamera::getInstance()->getDefaultFOV() / mCameraZoom);
 
     LLVector3 offset = mCameraOffset;
     LLVector3 target_pos = mPreviewTarget + offset;


### PR DESCRIPTION
## Description

Zooming in and out on the model rendered in the preview of the model upload floater, causes teh viewer to send FOV updates to the simulator, this breaks scripted content using `llWorldPosToHUD` or `llGetCameaFOV`.

https://github.com/user-attachments/assets/19b9e5eb-bd96-46cc-b216-2c4fc4a41a18

This fix switches the floater preview camera to use the `setViewNoBroadcast` method instead of `setView` preventing it from sending FOV packets to the sim, this is the same method used by the BVH animation upload preview.

## Related Issues

Canny Issue https://feedback.secondlife.com/bug-reports/p/hud-elements-using-llworldpostohud-become-offset-after-interacting-with-the-mesh

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).
