### PR TITLE
#5083 Fix external editor default open handling failing to work on mac and windows

### DIFF
--- a/indra/newview/llexternaleditor.cpp
+++ b/indra/newview/llexternaleditor.cpp
@@ -46,9 +46,13 @@ LLExternalEditor::EErrorCode LLExternalEditor::setCommand(const std::string& env
     {
         LL_INFOS() << "Editor command is empty or not set, falling back to OS open handler" << LL_ENDL;
 #if LL_WINDOWS
-        static const std::string os_cmd = "%SystemRoot%\\explorer.exe \"%s\"";
+        std::string os_cmd = LLStringUtil::getenv("SystemRoot", "");
+        if (!os_cmd.empty())
+        {
+            os_cmd.append("\\explorer.exe \"%s\"");
+        }
 #elif LL_DARWIN
-        static const std::string os_cmd = "/usr/bin/open \"%s\"";
+        static const std::string os_cmd = "/usr/bin/open -t \"%s\"";
 #elif LL_LINUX
         static const std::string os_cmd = "/usr/bin/xdg-open \"%s\"";
 #endif


### PR DESCRIPTION
## Description

Fixes external editor default open handling failing to work on mac and windows.

Windows was failing due to the `%S` in `%SystemRoot%` triggering the file path replacement

Mac was due to failing to specify text editor mode to open

## Related Issues

Issue Link: #5083

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
