### PR TITLE
#5083 Fix external editor default open handling failing to work on mac and windows

### DIFF
--- a/indra/newview/llexternaleditor.cpp
+++ b/indra/newview/llexternaleditor.cpp
@@ -46,9 +46,13 @@ LLExternalEditor::EErrorCode LLExternalEditor::setCommand(const std::string& env
     {
         LL_INFOS() << "Editor command is empty or not set, falling back to OS open handler" << LL_ENDL;
 #if LL_WINDOWS
-        static const std::string os_cmd = "%SystemRoot%\\explorer.exe \"%s\"";
+        std::string os_cmd = LLStringUtil::getenv("SystemRoot", "");
+        if (!os_cmd.empty())
+        {
+            os_cmd.append("\\explorer.exe \"%s\"");
+        }
 #elif LL_DARWIN
-        static const std::string os_cmd = "/usr/bin/open \"%s\"";
+        static const std::string os_cmd = "/usr/bin/open -t \"%s\"";
 #elif LL_LINUX
         static const std::string os_cmd = "/usr/bin/xdg-open \"%s\"";
 #endif


### PR DESCRIPTION
Cherry pick from develop, since half of the fix is already in 2026.1