### PR TITLE
Permit vertically adjusting label position in inventory

### DIFF
--- a/indra/llui/llfolderviewitem.cpp
+++ b/indra/llui/llfolderviewitem.cpp
@@ -158,9 +158,11 @@ LLFolderViewItem::Params::Params()
     icon_width("icon_width", 0),
     text_pad("text_pad", 0),
     text_pad_right("text_pad_right", 0),
+    text_pad_top("text_pad_top", 1),
     single_folder_mode("single_folder_mode", false),
     double_click_override("double_click_override", false),
     arrow_size("arrow_size", 0),
+    arrow_pad_top("arrow_pad_top", 1),
     max_folder_item_overlap("max_folder_item_overlap", 0)
 { }
 
@@ -200,7 +202,9 @@ LLFolderViewItem::LLFolderViewItem(const LLFolderViewItem::Params& p)
     mIconWidth(p.icon_width),
     mTextPad(p.text_pad),
     mTextPadRight(p.text_pad_right),
+    mTextPadTop(p.text_pad_top),
     mArrowSize(p.arrow_size),
+    mArrowPadTop(p.arrow_pad_top),
     mSingleFolderMode(p.single_folder_mode),
     mMaxFolderItemOverlap(p.max_folder_item_overlap),
     mDoubleClickOverride(p.double_click_override)
@@ -810,7 +814,7 @@ void LLFolderViewItem::drawOpenFolderArrow()
     if (hasVisibleChildren() || !isFolderComplete())
     {
         gl_draw_scaled_rotated_image(
-            mIndentation, getRect().getHeight() - mArrowSize - mTextPad - sTopPad,
+            mIndentation, getRect().getHeight() - mArrowSize - mArrowPadTop - sTopPad,
             mArrowSize, mArrowSize, mControlLabelRotation, sFolderArrowImg->getImage(), sFgColor);
     }
 }
@@ -1044,7 +1048,7 @@ void LLFolderViewItem::draw()
 
     S32 filter_string_length = mViewModelItem->hasFilterStringMatch() ? (S32)mViewModelItem->getFilterStringSize() : 0;
     F32 right_x  = 0;
-    F32 y = (F32)rect_height - line_height - (F32)mTextPad - (F32)sTopPad;
+    F32 y = (F32)rect_height - line_height - (F32)mTextPadTop - (F32)sTopPad;
     F32 text_left = (F32)getLabelXPos();
     LLWString combined_string = mLabel + mLabelSuffix;
 
@@ -1123,7 +1127,7 @@ void LLFolderViewItem::draw()
         if(mLabelSuffix.empty() || (font == sSuffixFont))
         {
             F32 match_string_left = text_left + font->getWidthF32(combined_string.c_str(), 0, filter_offset + filter_string_length) - font->getWidthF32(combined_string.c_str(), filter_offset, filter_string_length);
-            F32 yy = (F32)rect_height - line_height - (F32)mTextPad - (F32)sTopPad;
+            F32 yy = (F32)rect_height - line_height - (F32)mTextPadTop - (F32)sTopPad;
             font->render(combined_string, filter_offset, match_string_left, yy,
                 sFilterTextColor, LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                 filter_string_length, S32_MAX, &right_x);
@@ -1134,7 +1138,7 @@ void LLFolderViewItem::draw()
             if(label_filter_length > 0)
             {
                 F32 match_string_left = text_left + font->getWidthF32(mLabel.c_str(), 0, filter_offset + label_filter_length) - font->getWidthF32(mLabel.c_str(), filter_offset, label_filter_length);
-                F32 yy = (F32)rect_height - line_height - (F32)mTextPad - (F32)sTopPad;
+                F32 yy = (F32)rect_height - line_height - (F32)mTextPadTop - (F32)sTopPad;
                 font->render(mLabel, filter_offset, match_string_left, yy,
                     sFilterTextColor, LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                     label_filter_length, S32_MAX, &right_x);
@@ -1145,7 +1149,7 @@ void LLFolderViewItem::draw()
             {
                 S32 suffix_offset = llmax(0, filter_offset - (S32)mLabel.size());
                 F32 match_string_left = text_left + font->getWidthF32(mLabel.c_str(), 0, static_cast<S32>(mLabel.size())) + sSuffixFont->getWidthF32(mLabelSuffix.c_str(), 0, suffix_offset + suffix_filter_length) - sSuffixFont->getWidthF32(mLabelSuffix.c_str(), suffix_offset, suffix_filter_length);
-                F32 yy = (F32)rect_height - sSuffixFont->getLineHeight() - (F32)mTextPad - (F32)sTopPad;
+                F32 yy = (F32)rect_height - sSuffixFont->getLineHeight() - (F32)mTextPadTop - (F32)sTopPad;
                 sSuffixFont->render(mLabelSuffix, suffix_offset, match_string_left, yy, sFilterTextColor,
                     LLFontGL::LEFT, LLFontGL::BOTTOM, LLFontGL::NORMAL, LLFontGL::NO_SHADOW,
                     suffix_filter_length, S32_MAX, &right_x);

--- a/indra/llui/llfolderviewitem.h
+++ b/indra/llui/llfolderviewitem.h
@@ -73,7 +73,9 @@ public:
                                                     icon_width,
                                                     text_pad,
                                                     text_pad_right,
+                                                    text_pad_top,
                                                     arrow_size,
+                                                    arrow_pad_top,
                                                     max_folder_item_overlap;
         Optional<bool>                              single_folder_mode,
                                                     double_click_override;
@@ -117,7 +119,9 @@ protected:
                                 mIconWidth,
                                 mTextPad,
                                 mTextPadRight,
+                                mTextPadTop,
                                 mArrowSize,
+                                mArrowPadTop,
                                 mMaxFolderItemOverlap;
 
     F32                         mControlLabelRotation;

--- a/indra/newview/skins/default/xui/en/widgets/folder_view_item.xml
+++ b/indra/newview/skins/default/xui/en/widgets/folder_view_item.xml
@@ -14,5 +14,7 @@
   icon_width="16"
   text_pad="1"
   text_pad_right="4"
+  text_pad_top="1"
   arrow_size="12"
+  arrow_pad_top="1"
   max_folder_item_overlap="2"/>


### PR DESCRIPTION
Permit vertically adjusting label position in inventory so that bigger fonts can be centered in relation to icons.