### PR TITLE
[#5210] Fix looping back to previous marketplace url when using the viewer navigation bar

### DIFF
--- a/indra/newview/llfloatermarketplace.cpp
+++ b/indra/newview/llfloatermarketplace.cpp
@@ -56,6 +56,7 @@ void LLFloaterMarketplace::onOpen(const LLSD& key)
     else
     {
         openMarketplaceURL(params.url);
+        set_current_url(params.url); // Fix looping back to previous url when using the viewer navigation bar
     }
 }
 


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5210
Follow-up to this PR: https://github.com/secondlife/viewer/pull/5211

I noticed an issue with my previous PR where if you try and navigate to a marketplace url using the viewer's navigation bar (not to be confused with the web browsers navigation bar), it would first load the url then immediately load the url it was on previously, essentially resulting in nothing happening.

Discussed in this comment and explains what exactly was happening-
https://github.com/secondlife/viewer/issues/5210#issuecomment-3743874177

This PR simply just makes sure the web browsers current url is set after navigating to it, so when the navigation bars commit callback fires and calls onEnterAddress, it doesn't try and set itself back to the previous url which isn't updated at this point.