### PR TITLE
Mute list fallback to cache if timed out

### DIFF
--- a/indra/newview/llblocklist.cpp
+++ b/indra/newview/llblocklist.cpp
@@ -101,6 +101,14 @@ BlockListActionType LLBlockList::getCurrentMuteListActionType()
     return type;
 }
 
+void LLBlockList::onChange()
+{
+    // Something changed, not sure what so force a refresh.
+    mShouldAddAll = true;
+    mActionType = NONE;
+    setDirty();
+}
+
 void LLBlockList::onChangeDetailed(const LLMute &mute)
 {
     mActionType = getCurrentMuteListActionType();

--- a/indra/newview/llblocklist.cpp
+++ b/indra/newview/llblocklist.cpp
@@ -48,6 +48,7 @@ LLBlockList::LLBlockList(const Params& p)
 
     LLMuteList::getInstance()->addObserver(this);
     mMuteListSize = static_cast<U32>(LLMuteList::getInstance()->getMutes().size());
+    updateNoItemsCommentText();
 
     // Set up context menu.
     LLUICtrl::CommitCallbackRegistry::ScopedRegistrar registrar;
@@ -101,16 +102,35 @@ BlockListActionType LLBlockList::getCurrentMuteListActionType()
     return type;
 }
 
+void LLBlockList::updateNoItemsCommentText()
+{
+    const LLMuteList* mute_list = LLMuteList::getInstance();
+    if (!mute_list->isLoaded() && !mute_list->isFailed())
+    {
+        setNoItemsCommentText(mLoadingItemsMsg);
+    }
+    else if (mute_list->isFailed())
+    {
+        setNoItemsCommentText(mFailedItemsMsg);
+    }
+    else
+    {
+        updateNoItemsMessage(mNameFilter);
+    }
+}
+
 void LLBlockList::onChange()
 {
     // Something changed, not sure what so force a refresh.
     mShouldAddAll = true;
     mActionType = NONE;
+    updateNoItemsCommentText();
     setDirty();
 }
 
 void LLBlockList::onChangeDetailed(const LLMute &mute)
 {
+    updateNoItemsCommentText();
     mActionType = getCurrentMuteListActionType();
 
     mCurItemId = mute.mID;
@@ -205,6 +225,7 @@ void LLBlockList::addNewItem(const LLMute* mute)
 
 void LLBlockList::refresh()
 {
+    updateNoItemsCommentText();
     bool have_filter = !mNameFilter.empty();
 
     // save selection to restore it after list rebuilt
@@ -216,6 +237,8 @@ void LLBlockList::refresh()
         clear();
         createList();
         mShouldAddAll = false;
+        // Full rebuild supersedes any queued incremental action. This ensures list consistency.
+        mActionType = NONE;
     }
     else
     {
@@ -254,7 +277,9 @@ void LLBlockList::refresh()
         {
             LLBlockedListItem * curItem = dynamic_cast<LLBlockedListItem *> (*it);
             if(curItem)
-    {
+            {
+                // Refresh item text styling each pass so filtering keeps highlight in sync.
+                curItem->highlightName(mNameFilter);
                 hideListItem(curItem, findInsensitive(curItem->getName(), mNameFilter));
             }
         }

--- a/indra/newview/llblocklist.h
+++ b/indra/newview/llblocklist.h
@@ -58,7 +58,7 @@ public:
     LLToggleableMenu*   getContextMenu() const { return mContextMenu.get(); }
     LLBlockedListItem*  getBlockedItem() const;
 
-    virtual void onChange() { }
+    virtual void onChange();
     virtual void onChangeDetailed(const LLMute& );
     virtual void draw();
 

--- a/indra/newview/llblocklist.h
+++ b/indra/newview/llblocklist.h
@@ -68,6 +68,8 @@ public:
     void refresh();
 
     U32 getMuteListSize() { return mMuteListSize; }
+    void setLoadingItemsMsg(const std::string& msg) { mLoadingItemsMsg = msg; updateNoItemsCommentText(); }
+    void setFailedItemsMsg(const std::string& msg) { mFailedItemsMsg = msg; updateNoItemsCommentText(); }
 
 private:
 
@@ -83,6 +85,7 @@ private:
     bool isMenuItemVisible(const LLSD& userdata);
     void toggleMute(U32 flags);
     void createList();
+    void updateNoItemsCommentText();
 
     BlockListActionType getCurrentMuteListActionType();
 
@@ -100,6 +103,8 @@ private:
     LLMute::EType               mCurItemType;
     U32                         mCurItemFlags;
     std::string                 mPrevNameFilter;
+    std::string                 mLoadingItemsMsg;
+    std::string                 mFailedItemsMsg;
 
 };
 

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -1534,7 +1534,7 @@ void LLIMProcessing::requestOfflineMessages()
         && isAgentAvatarValid()
         && gAgent.getRegion()
         && gAgent.getRegion()->capabilitiesReceived()
-        && (LLMuteList::getInstance()->isLoaded() || LLMuteList::getInstance()->getLoadFailed()))
+        && LLMuteList::getInstance()->updateLoadState())
     {
         std::string cap_url = gAgent.getRegionCapability("ReadOfflineMsgs");
 

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -214,9 +214,9 @@ bool LLMuteList::isLinden(const std::string& name)
     return last_name == "linden";
 }
 
-bool LLMuteList::getLoadFailed()
+bool LLMuteList::updateLoadState()
 {
-    if (mLoadState == ML_FAILED)
+    if (isLoaded() || isFailed())
     {
         return true;
     }
@@ -227,7 +227,7 @@ bool LLMuteList::getLoadFailed()
         {
             LL_WARNS() << "Mute list request timed out; trying cache fallback once" << LL_ENDL;
             tryLoadCacheFallback(gAgent.getID(), "request timeout");
-            return mLoadState == ML_FAILED;
+            return isLoaded() || isFailed();
         }
     }
     return false;

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -92,7 +92,7 @@ public:
         const LLUUID& invoice,
         const sparam_t& strings)
     {
-        LLMuteList::getInstance()->setLoaded();
+        LLMuteList::getInstance()->setLoaded(LLMuteList::MLS_SERVER_EMPTY);
         return true;
     }
 };
@@ -155,7 +155,9 @@ std::string LLMute::getDisplayType() const
 //-----------------------------------------------------------------------------
 LLMuteList::LLMuteList() :
     mLoadState(ML_INITIAL),
-    mRequestStartTime(0.f)
+    mLoadSource(MLS_NONE),
+    mRequestStartTime(0.f),
+    mTriedCacheFallback(false)
 {
     gGenericDispatcher.addHandler("emptymutelist", &sDispatchEmptyMuteList);
 
@@ -210,7 +212,7 @@ bool LLMuteList::isLinden(const std::string& name)
     return last_name == "linden";
 }
 
-bool LLMuteList::getLoadFailed() const
+bool LLMuteList::getLoadFailed()
 {
     if (mLoadState == ML_FAILED)
     {
@@ -221,9 +223,75 @@ bool LLMuteList::getLoadFailed() const
         constexpr F64 WAIT_SECONDS = 30;
         if (mRequestStartTime + WAIT_SECONDS < LLTimer::getTotalSeconds())
         {
-            return true;
+            LL_WARNS() << "Mute list request timed out; trying cache fallback once" << LL_ENDL;
+            tryLoadCacheFallback(gAgent.getID(), "request timeout");
+            return mLoadState == ML_FAILED;
         }
     }
+    return false;
+}
+
+const char* LLMuteList::sourceToString(EMuteListSource source)
+{
+    switch (source)
+    {
+    case MLS_NONE:
+        return "none";
+    case MLS_SERVER:
+        return "server";
+    case MLS_SERVER_EMPTY:
+        return "server-empty";
+    case MLS_SERVER_CACHE:
+        return "server-cached";
+    case MLS_FALLBACK_CACHE:
+        return "fallback-cache";
+    default:
+        return "unknown";
+    }
+}
+
+std::string LLMuteList::getCacheFilename(const LLUUID& agent_id) const
+{
+    std::string agent_id_string;
+    agent_id.toString(agent_id_string);
+    return gDirUtilp->getExpandedFilename(LL_PATH_CACHE, agent_id_string) + ".cached_mute";
+}
+
+void LLMuteList::setFailed(const std::string& reason)
+{
+    mLoadState = ML_FAILED;
+    if (mLoadSource == MLS_NONE)
+    {
+        LL_WARNS() << "Mute list unavailable: " << reason << LL_ENDL;
+    }
+    else
+    {
+        LL_WARNS() << "Mute list unavailable: " << reason << " (last source=" << sourceToString(mLoadSource) << ")" << LL_ENDL;
+    }
+}
+
+bool LLMuteList::tryLoadCacheFallback(const LLUUID& agent_id, const std::string& reason)
+{
+    if (mTriedCacheFallback)
+    {
+        if (!isLoaded())
+        {
+            setFailed("cache fallback already attempted before " + reason);
+        }
+        return isLoaded();
+    }
+
+    mTriedCacheFallback = true;
+    const std::string filename = getCacheFilename(agent_id);
+    LL_INFOS() << "Trying mute list cache fallback due to " << reason << ": " << filename << LL_ENDL;
+
+    if (loadFromFile(filename, MLS_FALLBACK_CACHE))
+    {
+        LL_WARNS() << "Loaded mute list from cache fallback due to " << reason << LL_ENDL;
+        return true;
+    }
+
+    setFailed("cache fallback failed after " + reason);
     return false;
 }
 
@@ -580,14 +648,14 @@ std::vector<LLMute> LLMuteList::getMutes() const
 //-----------------------------------------------------------------------------
 // loadFromFile()
 //-----------------------------------------------------------------------------
-bool LLMuteList::loadFromFile(const std::string& filename)
+bool LLMuteList::loadFromFile(const std::string& filename, EMuteListSource source)
 {
     LL_PROFILE_ZONE_SCOPED;
 
     if(!filename.size())
     {
         LL_WARNS() << "Mute List Filename is Empty!" << LL_ENDL;
-        mLoadState = ML_FAILED;
+        setFailed("empty filename");
         return false;
     }
 
@@ -595,9 +663,13 @@ bool LLMuteList::loadFromFile(const std::string& filename)
     if (!fp)
     {
         LL_WARNS() << "Couldn't open mute list " << filename << LL_ENDL;
-        mLoadState = ML_FAILED;
+        setFailed("cannot open " + filename);
         return false;
     }
+
+    // Replace previous server-backed state so fallback can be superseded by authoritative data.
+    mMutes.clear();
+    mLegacyMutes.clear();
 
     // *NOTE: Changing the size of these buffers will require changes
     // in the scanf below.
@@ -627,7 +699,7 @@ bool LLMuteList::loadFromFile(const std::string& filename)
         }
     }
     fclose(fp);
-    setLoaded();
+    setLoaded(source);
 
     // server does not maintain up-to date account names (not display names!)
     // in this list, so it falls to viewer.
@@ -737,12 +809,11 @@ bool LLMuteList::isMuted(const std::string& username, U32 flags) const
 //-----------------------------------------------------------------------------
 void LLMuteList::requestFromServer(const LLUUID& agent_id)
 {
-    std::string agent_id_string;
-    std::string filename;
-    agent_id.toString(agent_id_string);
-    filename = gDirUtilp->getExpandedFilename(LL_PATH_CACHE,agent_id_string) + ".cached_mute";
+    const std::string filename = getCacheFilename(agent_id);
     LLCRC crc;
     crc.update(filename);
+    mTriedCacheFallback = false;
+    mLoadSource = MLS_NONE;
 
     LLMessageSystem* msg = gMessageSystem;
     msg->newMessageFast(_PREHASH_MuteListRequest);
@@ -755,17 +826,17 @@ void LLMuteList::requestFromServer(const LLUUID& agent_id)
     if (gDisconnected)
     {
         LL_WARNS() << "Trying to request mute list when disconnected!" << LL_ENDL;
-        mLoadState = ML_FAILED;
+        tryLoadCacheFallback(agent_id, "disconnected before request");
         return;
     }
     if (!gAgent.getRegion())
     {
         LL_WARNS() << "No region for agent yet, skipping mute list request!" << LL_ENDL;
-        mLoadState = ML_FAILED;
+        tryLoadCacheFallback(agent_id, "no region for request");
         return;
     }
     mLoadState = ML_REQUESTED;
-    mRequestStartTime = LLTimer::getElapsedSeconds();
+    mRequestStartTime = LLTimer::getTotalSeconds();
     // Double amount of retries due to this request happening during busy stage
     // Ideally this should be turned into a capability
     gMessageSystem->sendReliable(gAgent.getRegionHost(), LL_DEFAULT_RELIABLE_RETRIES * 2, true, LL_PING_BASED_TIMEOUT_DUMMY, NULL, NULL);
@@ -777,14 +848,15 @@ void LLMuteList::requestFromServer(const LLUUID& agent_id)
 
 void LLMuteList::cache(const LLUUID& agent_id)
 {
-    // Write to disk even if empty.
-    if(isLoaded())
+    // Write to disk even if empty, but never from degraded fallback state.
+    if (isLoaded() && mLoadSource != MLS_FALLBACK_CACHE)
     {
-        std::string agent_id_string;
-        std::string filename;
-        agent_id.toString(agent_id_string);
-        filename = gDirUtilp->getExpandedFilename(LL_PATH_CACHE,agent_id_string) + ".cached_mute";
+        const std::string filename = getCacheFilename(agent_id);
         saveToFile(filename);
+    }
+    else if (isLoaded())
+    {
+        LL_WARNS() << "Skipping mute list cache write from fallback-only state" << LL_ENDL;
     }
 }
 
@@ -812,7 +884,7 @@ void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
 
     LLMuteList* mute_list = getInstance();
     mute_list->mLoadState = ML_REQUESTED;
-    mute_list->mRequestStartTime = LLTimer::getElapsedSeconds();
+    mute_list->mRequestStartTime = LLTimer::getTotalSeconds();
 
     // Todo: Based of logs and testing, there is no callback
     // from server if file doesn't exist server side.
@@ -831,12 +903,7 @@ void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
 void LLMuteList::processUseCachedMuteList(LLMessageSystem* msg, void**)
 {
     LL_INFOS() << "LLMuteList::processUseCachedMuteList()" << LL_ENDL;
-
-    std::string agent_id_string;
-    gAgent.getID().toString(agent_id_string);
-    std::string filename;
-    filename = gDirUtilp->getExpandedFilename(LL_PATH_CACHE,agent_id_string) + ".cached_mute";
-    LLMuteList::getInstance()->loadFromFile(filename);
+    LLMuteList::getInstance()->loadFromFile(LLMuteList::getInstance()->getCacheFilename(gAgent.getID()), MLS_SERVER_CACHE);
 }
 
 void LLMuteList::onFileMuteList(void** user_data, S32 error_code, LLExtStat ext_status)
@@ -845,13 +912,13 @@ void LLMuteList::onFileMuteList(void** user_data, S32 error_code, LLExtStat ext_
     if(local_filename_and_path && !local_filename_and_path->empty() && (error_code == 0))
     {
         LL_INFOS() << "Received mute list from server" << LL_ENDL;
-        LLMuteList::getInstance()->loadFromFile(*local_filename_and_path);
+        LLMuteList::getInstance()->loadFromFile(*local_filename_and_path, MLS_SERVER);
         LLFile::remove(*local_filename_and_path);
     }
     else
     {
         LL_INFOS() << "LLMuteList xfer failed with code " << error_code << LL_ENDL;
-        LLMuteList::getInstance()->mLoadState = ML_FAILED;
+        LLMuteList::getInstance()->tryLoadCacheFallback(gAgent.getID(), "xfer failure");
     }
     delete local_filename_and_path;
 }
@@ -908,9 +975,10 @@ void LLMuteList::removeObserver(LLMuteListObserver* observer)
     mObservers.erase(observer);
 }
 
-void LLMuteList::setLoaded()
+void LLMuteList::setLoaded(EMuteListSource source)
 {
     mLoadState = ML_LOADED;
+    mLoadSource = source;
     notifyObservers();
 }
 

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -833,7 +833,9 @@ void LLMuteList::requestFromServer(const LLUUID& agent_id)
     if (gDisconnected)
     {
         LL_WARNS() << "Trying to request mute list when disconnected!" << LL_ENDL;
-        tryLoadCacheFallback(agent_id, "disconnected before request");
+        // Guard against potentially writing back to disk since we're not recovering our connection
+        mLoadState = ML_LOADED;
+        mLoadSource = MLS_FALLBACK_CACHE;
         return;
     }
     if (!gAgent.getRegion())

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -190,6 +190,8 @@ LLMuteList::LLMuteList() :
             // but this way is just more convinient
             onAccountNameChanged(id, av_name.getUserName());
         });
+    // Register our region change callback handler early, we'll clean it up if/when we don't need it anymore.
+    mRegionChangedCallback = gAgent.addRegionChangedCallback(boost::bind(&LLMuteList::onRegionChanged, this));
 }
 
 //-----------------------------------------------------------------------------
@@ -203,6 +205,10 @@ LLMuteList::~LLMuteList()
 void LLMuteList::cleanupSingleton()
 {
     LLAvatarNameCache::getInstance()->setAccountNameChangedCallback(nullptr);
+    if (mRegionChangedCallback.connected())
+    {
+        mRegionChangedCallback.disconnect();
+    }
 }
 
 bool LLMuteList::isLinden(const std::string& name)
@@ -826,6 +832,11 @@ bool LLMuteList::isMuted(const std::string& username, U32 flags) const
 //-----------------------------------------------------------------------------
 void LLMuteList::requestFromServer(const LLUUID& agent_id)
 {
+    if(isLoadedFromServer())
+    {
+        LL_WARNS() << "Blocked attempt to request mute list from server when already loaded from server!" << LL_ENDL;
+        return;
+    }
     const std::string filename = getCacheFilename(agent_id);
     LLCRC crc;
     crc.update(filename);
@@ -886,6 +897,11 @@ void LLMuteList::cache(const LLUUID& agent_id)
 void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
 {
     LL_INFOS() << "LLMuteList::processMuteListUpdate()" << LL_ENDL;
+    LLMuteList* mute_list = getInstance();
+    if(mute_list->mTriedRegionChangeRetry)
+    {
+        LL_WARNS() << "Received mute list update after retrying region change; success!" << LL_ENDL;
+    }
     LLUUID agent_id;
     msg->getUUIDFast(_PREHASH_MuteData, _PREHASH_AgentID, agent_id);
     if(agent_id != gAgent.getID())
@@ -901,7 +917,6 @@ void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
         LL_WARNS() << "Received empty mute list filename." << LL_ENDL;
     }
 
-    LLMuteList* mute_list = getInstance();
     mute_list->mLoadState = ML_REQUESTED;
     mute_list->mRequestStartTime = LLTimer::getTotalSeconds();
 
@@ -922,7 +937,12 @@ void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
 void LLMuteList::processUseCachedMuteList(LLMessageSystem* msg, void**)
 {
     LL_INFOS() << "LLMuteList::processUseCachedMuteList()" << LL_ENDL;
-    LLMuteList::getInstance()->loadFromFile(LLMuteList::getInstance()->getCacheFilename(gAgent.getID()), MLS_SERVER_CACHE);
+    LLMuteList* mute_list = LLMuteList::getInstance();
+    if(mute_list->mTriedRegionChangeRetry)
+    {
+        LL_WARNS() << "Received use cached mute list message after retrying region change; success!" << LL_ENDL;
+    }
+    mute_list->loadFromFile(mute_list->getCacheFilename(gAgent.getID()), MLS_SERVER_CACHE);
 }
 
 void LLMuteList::onFileMuteList(void** user_data, S32 error_code, LLExtStat ext_status)
@@ -1004,6 +1024,11 @@ void LLMuteList::setLoaded(EMuteListSource source)
     mLoadSource = source;
     notifyObservers();
     LL_INFOS() << "Mute list loaded from " << sourceToString(source) << LL_ENDL;
+    if(isLoadedFromServer() && mRegionChangedCallback.connected())
+    {
+        LL_INFOS() << "Mute list loaded from server, disconnecting region change callback" << LL_ENDL;
+        mRegionChangedCallback.disconnect();
+    }
 }
 
 void LLMuteList::notifyObservers()
@@ -1029,6 +1054,23 @@ void LLMuteList::notifyObserversDetailed(const LLMute& mute)
         observer->onChangeDetailed(mute);
         // In case onChange() deleted an entry.
         it = mObservers.upper_bound(observer);
+    }
+}
+
+void LLMuteList::onRegionChanged()
+{
+    // If we are in a degraded state, either some protocol messages got lost between us and our login region, or our login region was having a bad day.
+    // Since the previous region might've been unable to provide our mute list, we can try to request it again from our new region.
+    // This is limited to one retry per session.
+    if(isLoadedDegraded() && !mTriedRegionChangeRetry)
+    {
+        if(mRegionChangedCallback.connected())
+        {
+            mRegionChangedCallback.disconnect();
+        }
+        LL_WARNS() << "Region changed while mute list is in degraded state, queueing a retry of the mute list request" << LL_ENDL;
+        mTriedRegionChangeRetry = true;
+        requestFromServer(gAgent.getID());
     }
 }
 

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -92,7 +92,9 @@ public:
         const LLUUID& invoice,
         const sparam_t& strings)
     {
-        LLMuteList::getInstance()->setLoaded(LLMuteList::MLS_SERVER_EMPTY);
+        LLMuteList* mute_list = LLMuteList::getInstance();
+        mute_list->clearCachedMutes();
+        mute_list->setLoaded(LLMuteList::MLS_SERVER_EMPTY);
         return true;
     }
 };
@@ -229,6 +231,12 @@ bool LLMuteList::getLoadFailed()
         }
     }
     return false;
+}
+
+void LLMuteList::clearCachedMutes()
+{
+    mMutes.clear();
+    mLegacyMutes.clear();
 }
 
 const char* LLMuteList::sourceToString(EMuteListSource source)
@@ -668,8 +676,7 @@ bool LLMuteList::loadFromFile(const std::string& filename, EMuteListSource sourc
     }
 
     // Replace previous server-backed state so fallback can be superseded by authoritative data.
-    mMutes.clear();
-    mLegacyMutes.clear();
+    clearCachedMutes();
 
     // *NOTE: Changing the size of these buffers will require changes
     // in the scanf below.

--- a/indra/newview/llmutelist.cpp
+++ b/indra/newview/llmutelist.cpp
@@ -92,8 +92,16 @@ public:
         const LLUUID& invoice,
         const sparam_t& strings)
     {
+        // We've gotten a message from the server that indicates our mute list is empty there.
+
+        // First we want to make sure that if we had a cached mute list, we clear it assuming it is outdated.
         LLMuteList* mute_list = LLMuteList::getInstance();
-        mute_list->clearCachedMutes();
+        if(mute_list->mLoadSource == LLMuteList::MLS_FALLBACK_CACHE && !mute_list->getMutes().empty())
+        {
+            LL_WARNS() << "Our current mute list is not empty, but the server says that it should be. Is our cache outdated, or did our mutes get lost?" << LL_ENDL;
+            mute_list->clearCachedMutes();
+        }
+        // Lastly we set the load state to loaded with the source of server empty. We are now in a clean and ready state.
         mute_list->setLoaded(LLMuteList::MLS_SERVER_EMPTY);
         return true;
     }
@@ -237,6 +245,7 @@ void LLMuteList::clearCachedMutes()
 {
     mMutes.clear();
     mLegacyMutes.clear();
+    LL_WARNS() << "Cached mutes cleared" << LL_ENDL;
 }
 
 const char* LLMuteList::sourceToString(EMuteListSource source)
@@ -276,6 +285,7 @@ void LLMuteList::setFailed(const std::string& reason)
     {
         LL_WARNS() << "Mute list unavailable: " << reason << " (last source=" << sourceToString(mLoadSource) << ")" << LL_ENDL;
     }
+    notifyObservers();
 }
 
 bool LLMuteList::tryLoadCacheFallback(const LLUUID& agent_id, const std::string& reason)
@@ -880,7 +890,7 @@ void LLMuteList::processMuteListUpdate(LLMessageSystem* msg, void**)
     msg->getUUIDFast(_PREHASH_MuteData, _PREHASH_AgentID, agent_id);
     if(agent_id != gAgent.getID())
     {
-        LL_WARNS() << "Got an mute list update for the wrong agent." << LL_ENDL;
+        LL_WARNS() << "Got a mute list update for the wrong agent." << LL_ENDL;
         return;
     }
     std::string unclean_filename;
@@ -986,9 +996,14 @@ void LLMuteList::removeObserver(LLMuteListObserver* observer)
 
 void LLMuteList::setLoaded(EMuteListSource source)
 {
+    if(isLoaded())
+    {
+        LL_WARNS() << "Mute list was already loaded from " << sourceToString(mLoadSource) << ", switching to " << sourceToString(source) << LL_ENDL;
+    }
     mLoadState = ML_LOADED;
     mLoadSource = source;
     notifyObservers();
+    LL_INFOS() << "Mute list loaded from " << sourceToString(source) << LL_ENDL;
 }
 
 void LLMuteList::notifyObservers()

--- a/indra/newview/llmutelist.h
+++ b/indra/newview/llmutelist.h
@@ -136,6 +136,7 @@ public:
     void cache(const LLUUID& agent_id);
 
 private:
+    void clearCachedMutes();
     bool loadFromFile(const std::string& filename, EMuteListSource source);
     bool saveToFile(const std::string& filename);
     bool tryLoadCacheFallback(const LLUUID& agent_id, const std::string& reason);

--- a/indra/newview/llmutelist.h
+++ b/indra/newview/llmutelist.h
@@ -125,7 +125,11 @@ public:
     static bool isLinden(const std::string& name);
 
     bool isLoaded() const { return mLoadState == ML_LOADED; }
-    bool getLoadFailed();
+    bool isFailed() const { return mLoadState == ML_FAILED; }
+
+    // Advance the load state machine, trying cache fallback if necessary.
+    // Return value indicates mute list consumption readiness.
+    bool updateLoadState();
 
     std::vector<LLMute> getMutes() const;
 

--- a/indra/newview/llmutelist.h
+++ b/indra/newview/llmutelist.h
@@ -82,6 +82,15 @@ class LLMuteList : public LLSingleton<LLMuteList>
         ML_LOADED,
         ML_FAILED,
     };
+
+    enum EMuteListSource
+    {
+        MLS_NONE,
+        MLS_SERVER,
+        MLS_SERVER_EMPTY,
+        MLS_SERVER_CACHE,
+        MLS_FALLBACK_CACHE,
+    };
 public:
     // reasons for auto-unmuting a resident
     enum EAutoReason
@@ -116,7 +125,7 @@ public:
     static bool isLinden(const std::string& name);
 
     bool isLoaded() const { return mLoadState == ML_LOADED; }
-    bool getLoadFailed() const;
+    bool getLoadFailed();
 
     std::vector<LLMute> getMutes() const;
 
@@ -127,10 +136,14 @@ public:
     void cache(const LLUUID& agent_id);
 
 private:
-    bool loadFromFile(const std::string& filename);
+    bool loadFromFile(const std::string& filename, EMuteListSource source);
     bool saveToFile(const std::string& filename);
+    bool tryLoadCacheFallback(const LLUUID& agent_id, const std::string& reason);
+    void setFailed(const std::string& reason);
+    static const char* sourceToString(EMuteListSource source);
+    std::string getCacheFilename(const LLUUID& agent_id) const;
 
-    void setLoaded();
+    void setLoaded(EMuteListSource source);
     void notifyObservers();
     void notifyObserversDetailed(const LLMute &mute);
 
@@ -177,7 +190,9 @@ private:
     observer_set_t mObservers;
 
     EMuteListState mLoadState;
+    EMuteListSource mLoadSource;
     F64 mRequestStartTime;
+    bool mTriedCacheFallback;
 
     friend class LLDispatchEmptyMuteList;
 };

--- a/indra/newview/llmutelist.h
+++ b/indra/newview/llmutelist.h
@@ -31,6 +31,8 @@
 #include "lluuid.h"
 #include "llextendedstatus.h"
 
+#include <boost/signals2/connection.hpp>
+
 class LLViewerObject;
 class LLMessageSystem;
 class LLMuteListObserver;
@@ -124,8 +126,13 @@ public:
 
     static bool isLinden(const std::string& name);
 
-    bool isLoaded() const { return mLoadState == ML_LOADED; }
-    bool isFailed() const { return mLoadState == ML_FAILED; }
+    // Load state accessors.
+    bool isLoaded() const { return mLoadState == ML_LOADED; } // Loaded, but not necessarily from server.
+    bool isFailed() const { return mLoadState == ML_FAILED; } // Unable to load any mute list. Server did not reply.
+    // Loaded from server, which is the only source we consider authoritative.
+    bool isLoadedFromServer() const { return isLoaded() && (mLoadSource == MLS_SERVER || mLoadSource == MLS_SERVER_EMPTY); }
+    // Loaded, but from cache. Would be nice to upgrade to a server load from here if possible.
+    bool isLoadedDegraded() const { return isLoaded() && !isLoadedFromServer(); }
 
     // Advance the load state machine, trying cache fallback if necessary.
     // Return value indicates mute list consumption readiness.
@@ -138,6 +145,9 @@ public:
 
     // call this method on logout to save everything.
     void cache(const LLUUID& agent_id);
+
+    // Handler for region change event, used for server request retries if isLoadedDegraded() is true
+    void onRegionChanged();
 
 private:
     void clearCachedMutes();
@@ -198,6 +208,8 @@ private:
     EMuteListSource mLoadSource;
     F64 mRequestStartTime;
     bool mTriedCacheFallback;
+    bool mTriedRegionChangeRetry;
+    boost::signals2::connection mRegionChangedCallback;
 
     friend class LLDispatchEmptyMuteList;
 };

--- a/indra/newview/llpanelblockedlist.cpp
+++ b/indra/newview/llpanelblockedlist.cpp
@@ -78,6 +78,10 @@ bool LLPanelBlockedList::postBuild()
 {
     mBlockedList = getChild<LLBlockList>("blocked");
     mBlockedList->setCommitOnSelectionChange(true);
+    mBlockedList->setNoItemsMsg(getString("no_blocked"));
+    mBlockedList->setNoFilteredItemsMsg(getString("no_filtered_blocked"));
+    mBlockedList->setLoadingItemsMsg(getString("loading_blocked"));
+    mBlockedList->setFailedItemsMsg(getString("failed_blocked"));
     this->setVisibleCallback(boost::bind(&LLPanelBlockedList::removePicker, this));
 
     switch (gSavedSettings.getU32("BlockPeopleSortOrder"))

--- a/indra/newview/skins/default/xui/en/panel_block_list_sidetray.xml
+++ b/indra/newview/skins/default/xui/en/panel_block_list_sidetray.xml
@@ -10,6 +10,18 @@
  min_height="350"
  min_width="240"
  width="323">
+   <string
+    name="no_blocked"
+    value="No blocked residents or objects." />
+   <string
+    name="no_filtered_blocked"
+    value="No blocked residents or objects match your search." />
+   <string
+    name="loading_blocked"
+    value="Loading blocked residents and objects..." />
+   <string
+    name="failed_blocked"
+    value="Blocked list is currently unavailable." />
      <panel
       follows="left|top|right"
       height="27"


### PR DESCRIPTION
## Description

This PR aims to reduce user impact of unsent or dropped simulator messages during login regarding the mute list. The current behavior when this occurs is to have an empty mute list, and not fallback to cache even if it is present. This PR updates this behavior in the following ways:

- fall back to the cached mute list on request timeout or transfer failure so the list never stays empty if we can help it
- retry mute list requests on region change with a short cool-down to avoid being too noisy, if still in timeout window
- cancel pending timeout once the list loads to stop unnecessary potential fallback behaviors
- push an update to the blocked list people floater when a cached or deferred load populates the list
- notify the user of a forced cache fallback because recent changes may be missing

## Related Issues

https://feedback.secondlife.com/bug-reports/p/block-list-empties

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

I've tested this locally with success, however I am not able to test all platforms. Bugs based on packet loss are a challenge to reproduce so my testing was based on artificially induced drops. I do not think that this is a perfect solution as the existing comments in code suggest this would ideally be moved to a capability, but this is intended keep people from too much hardship until that more comprehensive effort can be prioritized.

Very much open to feedback and willing to make reasonable requested changes.