### PR TITLE
#5250 use Documents as default save location

### DIFF
--- a/indra/newview/llfilepicker_mac.mm
+++ b/indra/newview/llfilepicker_mac.mm
@@ -241,8 +241,13 @@ void doSaveDialogModeless(const std::string* file,
 
         NSURL* url = [NSURL fileURLWithPath:fileName];
         [panel setNameFieldStringValue: fileName];
-        [panel setDirectoryURL: url];
 
+        NSURL *last_url = [[NSUserDefaults standardUserDefaults] URLForKey:@"NSNavLastRootDirectory"];
+        if(!last_url)
+        {
+            NSURL *documents_url = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask].firstObject;
+            [panel setDirectoryURL:documents_url];
+        }
 
         [panel beginWithCompletionHandler:^(NSModalResponse result)
         {


### PR DESCRIPTION
Use Documents folder as default save location, if NSNavLastRootDirectory is not set.

