### PR TITLE
Type-fixes

### DIFF
--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -24650,6 +24650,6 @@ If another state is defined before the default state, the compiler will report a
          </map>
       </map>
       <key>llsd-lsl-syntax-version</key>
-      <integer>2</integer>
+      <integer>2</integer><!-- increment only when the file format changes, not just the content -->
    </map>
 </llsd>

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <llsd>
    <map>
       <key>controls</key>
@@ -30,7 +31,7 @@
          <key>return</key>
          <map>
             <key>tooltip</key>
-            <string>Leave current event or function.\nreturn [&lt;variable&gt;];\nOptionally pass back a variable&apos;s value, from a function.</string>
+            <string>Leave current event or function.\nreturn [&lt;variable&gt;];\nOptionally pass back a variable's value, from a function.</string>
          </map>
          <key>state</key>
          <map>
@@ -40,7 +41,7 @@
          <key>while</key>
          <map>
             <key>tooltip</key>
-            <string>while loop\nwhile (&lt;condition&gt;) {\n,,,\n}</string>
+            <string>while loop\nwhile (&lt;condition&gt;) {\n...\n}</string>
          </map>
       </map>
       <key>types</key>
@@ -58,22 +59,24 @@
          <key>key</key>
          <map>
             <key>tooltip</key>
-            <string>A 128 bit unique identifier (UUID).\nThe key is represented as hexidecimal characters (A-F and 0-9), grouped into sections (8,4,4,4,12 characters) and separated by hyphens (for a total of 36 characters). e.g. &quot;A822FF2B-FF02-461D-B45D-DCD10A2DE0C2&quot;.</string>
+            <string>A 128 bit unique identifier (UUID).\nThe key is represented as hexidecimal characters (A-F and 0-9), grouped into sections (8,4,4,4,12 characters) and separated by hyphens (for a total of 36 characters). e.g. "A822FF2B-FF02-461D-B45D-DCD10A2DE0C2".</string>
          </map>
          <key>list</key>
          <map>
             <key>tooltip</key>
-            <string>A collection of other data types.\nLists are signified by square brackets surrounding their elements; the elements inside are separated by commas. e.g. [0, 1, 2, 3, 4] or [&quot;Yes&quot;, &quot;No&quot;, &quot;Perhaps&quot;].</string>
+            <string>A collection of other data types.\nLists are signified by square brackets surrounding their elements; the elements inside are separated by commas. e.g. [0, 1, 2, 3, 4] or ["Yes", "No", "Perhaps"].</string>
          </map>
          <key>quaternion</key>
          <map>
+            <key>private</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string>The quaternion type is a left over from way back when LSL was created. It was later renamed to &lt;rotation&gt; to make it more user friendly, but it appears someone forgot to remove it ;-)</string>
          </map>
          <key>rotation</key>
          <map>
             <key>tooltip</key>
-            <string>The rotation type is one of several ways to represent an orientation in 3D.\nIt is a mathematical object called a quaternion. You can think of a quaternion as four numbers (x, y, z, w), three of which represent the direction an object is facing and a fourth that represents the object&apos;s banking left or right around that direction.</string>
+            <string>The rotation type is one of several ways to represent an orientation in 3D.\nIt is a mathematical object called a quaternion. You can think of a quaternion as four numbers (x, y, z, w), three of which represent the direction an object is facing and a fourth that represents the object's banking left or right around that direction.</string>
          </map>
          <key>string</key>
          <map>
@@ -325,7 +328,7 @@
          <key>ATTACH_AVATAR_CENTER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s geometric centre.</string>
+            <string>Attach to the avatar's geometric centre.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -334,7 +337,7 @@
          <key>ATTACH_BACK</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s back.</string>
+            <string>Attach to the avatar's back.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -343,7 +346,7 @@
          <key>ATTACH_BELLY</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s belly.</string>
+            <string>Attach to the avatar's belly.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -352,7 +355,7 @@
          <key>ATTACH_CHEST</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s chest.</string>
+            <string>Attach to the avatar's chest.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -361,7 +364,7 @@
          <key>ATTACH_CHIN</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s chin.</string>
+            <string>Attach to the avatar's chin.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -370,7 +373,7 @@
          <key>ATTACH_FACE_JAW</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s jaw.</string>
+            <string>Attach to the avatar's jaw.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -379,7 +382,7 @@
          <key>ATTACH_FACE_LEAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ear (extended).</string>
+            <string>Attach to the avatar's left ear (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -388,7 +391,7 @@
          <key>ATTACH_FACE_LEYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left eye (extended).</string>
+            <string>Attach to the avatar's left eye (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -397,7 +400,7 @@
          <key>ATTACH_FACE_REAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ear (extended).</string>
+            <string>Attach to the avatar's right ear (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -406,7 +409,7 @@
          <key>ATTACH_FACE_REYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right eye (extended).</string>
+            <string>Attach to the avatar's right eye (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -415,7 +418,7 @@
          <key>ATTACH_FACE_TONGUE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tongue.</string>
+            <string>Attach to the avatar's tongue.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -424,7 +427,7 @@
          <key>ATTACH_GROIN</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s groin.</string>
+            <string>Attach to the avatar's groin.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -433,7 +436,7 @@
          <key>ATTACH_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s head.</string>
+            <string>Attach to the avatar's head.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -442,7 +445,7 @@
          <key>ATTACH_HIND_LFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hind foot.</string>
+            <string>Attach to the avatar's left hind foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -451,7 +454,7 @@
          <key>ATTACH_HIND_RFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hind foot.</string>
+            <string>Attach to the avatar's right hind foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -532,7 +535,7 @@
          <key>ATTACH_LEAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ear.</string>
+            <string>Attach to the avatar's left ear.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -541,7 +544,7 @@
          <key>ATTACH_LEFT_PEC</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left pectoral.</string>
+            <string>Attach to the avatar's left pectoral.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -550,7 +553,7 @@
          <key>ATTACH_LEYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left eye.</string>
+            <string>Attach to the avatar's left eye.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -559,7 +562,7 @@
          <key>ATTACH_LFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left foot.</string>
+            <string>Attach to the avatar's left foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -568,7 +571,7 @@
          <key>ATTACH_LHAND</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hand.</string>
+            <string>Attach to the avatar's left hand.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -577,7 +580,7 @@
          <key>ATTACH_LHAND_RING1</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ring finger.</string>
+            <string>Attach to the avatar's left ring finger.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -586,7 +589,7 @@
          <key>ATTACH_LHIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hip.</string>
+            <string>Attach to the avatar's left hip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -595,7 +598,7 @@
          <key>ATTACH_LLARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left lower arm.</string>
+            <string>Attach to the avatar's left lower arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -604,7 +607,7 @@
          <key>ATTACH_LLLEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s lower left leg.</string>
+            <string>Attach to the avatar's lower left leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -615,7 +618,7 @@
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
+            <string>Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -624,7 +627,7 @@
          <key>ATTACH_LSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left shoulder.</string>
+            <string>Attach to the avatar's left shoulder.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -633,7 +636,7 @@
          <key>ATTACH_LUARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left upper arm.</string>
+            <string>Attach to the avatar's left upper arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -642,7 +645,7 @@
          <key>ATTACH_LULEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s lower upper leg.</string>
+            <string>Attach to the avatar's lower upper leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -651,7 +654,7 @@
          <key>ATTACH_LWING</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left wing.</string>
+            <string>Attach to the avatar's left wing.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -660,7 +663,7 @@
          <key>ATTACH_MOUTH</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s mouth.</string>
+            <string>Attach to the avatar's mouth.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -669,7 +672,7 @@
          <key>ATTACH_NECK</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s neck.</string>
+            <string>Attach to the avatar's neck.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -678,7 +681,7 @@
          <key>ATTACH_NOSE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s nose.</string>
+            <string>Attach to the avatar's nose.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -687,7 +690,7 @@
          <key>ATTACH_PELVIS</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s pelvis.</string>
+            <string>Attach to the avatar's pelvis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -696,7 +699,7 @@
          <key>ATTACH_REAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ear.</string>
+            <string>Attach to the avatar's right ear.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -705,7 +708,7 @@
          <key>ATTACH_REYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right eye.</string>
+            <string>Attach to the avatar's right eye.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -714,7 +717,7 @@
          <key>ATTACH_RFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right foot.</string>
+            <string>Attach to the avatar's right foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -723,7 +726,7 @@
          <key>ATTACH_RHAND</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hand.</string>
+            <string>Attach to the avatar's right hand.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -732,7 +735,7 @@
          <key>ATTACH_RHAND_RING1</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ring finger.</string>
+            <string>Attach to the avatar's right ring finger.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -741,7 +744,7 @@
          <key>ATTACH_RHIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hip.</string>
+            <string>Attach to the avatar's right hip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -750,7 +753,7 @@
          <key>ATTACH_RIGHT_PEC</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right pectoral.</string>
+            <string>Attach to the avatar's right pectoral.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -759,7 +762,7 @@
          <key>ATTACH_RLARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right lower arm.</string>
+            <string>Attach to the avatar's right lower arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -768,7 +771,7 @@
          <key>ATTACH_RLLEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right lower leg.</string>
+            <string>Attach to the avatar's right lower leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -779,7 +782,7 @@
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
+            <string>Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -788,7 +791,7 @@
          <key>ATTACH_RSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right shoulder.</string>
+            <string>Attach to the avatar's right shoulder.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -797,7 +800,7 @@
          <key>ATTACH_RUARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right upper arm.</string>
+            <string>Attach to the avatar's right upper arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -806,7 +809,7 @@
          <key>ATTACH_RULEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right upper leg.</string>
+            <string>Attach to the avatar's right upper leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -815,7 +818,7 @@
          <key>ATTACH_RWING</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right wing.</string>
+            <string>Attach to the avatar's right wing.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -824,7 +827,7 @@
          <key>ATTACH_TAIL_BASE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tail base.</string>
+            <string>Attach to the avatar's tail base.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -833,7 +836,7 @@
          <key>ATTACH_TAIL_TIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tail tip.</string>
+            <string>Attach to the avatar's tail tip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -869,7 +872,7 @@
          <key>BEACON_MAP</key>
          <map>
             <key>tooltip</key>
-            <string>Cause llMapBeacon to optionally display and focus the world map on the avatar&apos;s viewer.</string>
+            <string>Cause llMapBeacon to optionally display and focus the world map on the avatar's viewer.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1049,7 +1052,7 @@
          <key>CHANGED_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The object has changed ownership.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1058,7 +1061,7 @@
          <key>CHANGED_REGION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The object has changed region.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1067,7 +1070,7 @@
          <key>CHANGED_REGION_START</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The region this object is in has just come online.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1103,7 +1106,7 @@
          <key>CHANGED_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The avatar to whom this object is attached has teleported.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1175,7 +1178,7 @@
          <key>CHARACTER_DESIRED_TURN_SPEED</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum speed while turning about the Z axis. - Note that this is only loosely enforced.</string>
+            <string>The character's maximum speed while turning about the Z axis. - Note that this is only loosely enforced.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1193,7 +1196,7 @@
          <key>CHARACTER_MAX_ACCEL</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum acceleration rate.</string>
+            <string>The character's maximum acceleration rate.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1202,7 +1205,7 @@
          <key>CHARACTER_MAX_DECEL</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum deceleration rate.</string>
+            <string>The character's maximum deceleration rate.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1211,7 +1214,7 @@
          <key>CHARACTER_MAX_SPEED</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum speed.</string>
+            <string>The character's maximum speed.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1220,7 +1223,7 @@
          <key>CHARACTER_MAX_TURN_RADIUS</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s turn radius when travelling at CHARACTER_MAX_TURN_SPEED.</string>
+            <string>The character's turn radius when travelling at CHARACTER_MAX_TURN_SPEED.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1418,7 +1421,7 @@
          <key>COMBAT_LOG_ID</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>Messages from the region to the COMBAT_CHANNEL will all be from this ID.\n Scripts may filter llListen calls on this ID to receive only system generated combat log messages.</string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -1427,7 +1430,7 @@
          <key>CONTENT_TYPE_ATOM</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/atom+xml&quot;</string>
+            <string>"application/atom+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1436,7 +1439,7 @@
          <key>CONTENT_TYPE_FORM</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/x-www-form-urlencoded&quot;</string>
+            <string>"application/x-www-form-urlencoded"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1445,7 +1448,7 @@
          <key>CONTENT_TYPE_HTML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;text/html&quot;, only valid for embedded browsers on content owned by the person viewing. Falls back to &quot;text/plain&quot; otherwise.</string>
+            <string>"text/html", only valid for embedded browsers on content owned by the person viewing. Falls back to "text/plain" otherwise.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1454,7 +1457,7 @@
          <key>CONTENT_TYPE_JSON</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/json&quot;</string>
+            <string>"application/json"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1463,7 +1466,7 @@
          <key>CONTENT_TYPE_LLSD</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/llsd+xml&quot;</string>
+            <string>"application/llsd+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1472,7 +1475,7 @@
          <key>CONTENT_TYPE_RSS</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/rss+xml&quot;</string>
+            <string>"application/rss+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1481,7 +1484,7 @@
          <key>CONTENT_TYPE_TEXT</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;text/plain&quot;</string>
+            <string>"text/plain"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1490,7 +1493,7 @@
          <key>CONTENT_TYPE_XHTML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/xhtml+xml&quot;</string>
+            <string>"application/xhtml+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1499,7 +1502,7 @@
          <key>CONTENT_TYPE_XML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/xml&quot;</string>
+            <string>"application/xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1679,7 +1682,7 @@
          <key>DAMAGE_TYPE_IMPACT</key>
          <map>
             <key>tooltip</key>
-            <string>System damage generated by imapact with land or a prim.</string>
+            <string>System damage generated by impact with land or a prim.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1787,15 +1790,13 @@
          <key>DATA_RATING</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Returns the agent ratings as a comma separated string of six integers. They are:
-               1) Positive rated behaviour
-               2) Negative rated behaviour
-               3) Positive rated appearance
-               4) Negative rated appearance
-               5) Positive rated building
-               6) Negative rated building
-            </string>
+            <string>Returns the agent ratings as a comma separated string of six integers. They are:
+			1) Positive rated behaviour
+			2) Negative rated behaviour
+			3) Positive rated appearance
+			4) Negative rated appearance
+			5) Positive rated building
+			6) Negative rated building</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1840,10 +1841,8 @@
          <key>DEG_TO_RAD</key>
          <map>
             <key>tooltip</key>
-            <string>
-               0.017453293 - Number of radians per degree.
-               You can use this to convert degrees to radians by multiplying the degrees by this number.
-            </string>
+            <string>0.017453293 - Number of radians per degree.
+			You can use this to convert degrees to radians by multiplying the degrees by this number.</string>
             <key>type</key>
             <string>float</string>
             <key>value</key>
@@ -1875,6 +1874,15 @@
             <string>integer</string>
             <key>value</key>
             <string>1</string>
+         </map>
+         <key>DEREZ_TO_INVENTORY</key>
+         <map>
+            <key>tooltip</key>
+            <string>The object is returned to the inventory of the rezzer.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
          </map>
          <key>ENVIRONMENT_DAYINFO</key>
          <map>
@@ -2023,7 +2031,7 @@
          <key>ESTATE_ACCESS_ALLOWED_AGENT_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the agent to this estate&apos;s Allowed Residents list.</string>
+            <string>Add the agent to this estate's Allowed Residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2032,7 +2040,7 @@
          <key>ESTATE_ACCESS_ALLOWED_AGENT_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the agent from this estate&apos;s Allowed Residents list.</string>
+            <string>Remove the agent from this estate's Allowed Residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2041,7 +2049,7 @@
          <key>ESTATE_ACCESS_ALLOWED_GROUP_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the group to this estate&apos;s Allowed groups list.</string>
+            <string>Add the group to this estate's Allowed groups list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2050,7 +2058,7 @@
          <key>ESTATE_ACCESS_ALLOWED_GROUP_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the group from this estate&apos;s Allowed groups list.</string>
+            <string>Remove the group from this estate's Allowed groups list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2059,7 +2067,7 @@
          <key>ESTATE_ACCESS_BANNED_AGENT_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the agent to this estate&apos;s Banned residents list.</string>
+            <string>Add the agent to this estate's Banned residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2068,7 +2076,7 @@
          <key>ESTATE_ACCESS_BANNED_AGENT_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the agent from this estate&apos;s Banned residents list.</string>
+            <string>Remove the agent from this estate's Banned residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2077,7 +2085,7 @@
          <key>FALSE</key>
          <map>
             <key>tooltip</key>
-            <string>An integer constant for boolean comparisons. Has the value &apos;0&apos;.</string>
+            <string>An integer constant for boolean comparisons. Has the value '0'.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2410,10 +2418,8 @@
          <key>HTTP_ACCEPT</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Provide a string value to be included in the HTTP
-               accepts header value. This replaces the default Second Life HTTP accepts header.
-            </string>
+            <string>Provide a string value to be included in the HTTP
+            accepts header value. This replaces the default Second Life HTTP accepts header.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2440,7 +2446,7 @@
          <key>HTTP_CUSTOM_HEADER</key>
          <map>
             <key>tooltip</key>
-            <string>Add an extra custom HTTP header to the request. The first string is the name of the parameter to change, e.g. &quot;Pragma&quot;, and the second string is the value, e.g. &quot;no-cache&quot;. Up to 8 custom headers may be configured per request. Note that certain headers, such as the default headers, are blocked for security reasons.</string>
+            <string>Add an extra custom HTTP header to the request. The first string is the name of the parameter to change, e.g. "Pragma", and the second string is the value, e.g. "no-cache". Up to 8 custom headers may be configured per request. Note that certain headers, such as the default headers, are blocked for security reasons.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2476,7 +2482,7 @@
          <key>HTTP_PRAGMA_NO_CACHE</key>
          <map>
             <key>tooltip</key>
-            <string>Allows enabling/disbling of the &quot;Pragma: no-cache&quot; header.\nUsage: [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the &quot;Pragma: no-cache&quot; header is sent by the script. This matches the default behavior. When SendHeader is FALSE, no &quot;Pragma&quot; header is sent by the script.</string>
+            <string>Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage: [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the "Pragma: no-cache" header is sent by the script. This matches the default behavior. When SendHeader is FALSE, no "Pragma" header is sent by the script.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2485,10 +2491,8 @@
          <key>HTTP_USER_AGENT</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Provide a string value to be included in the HTTP
-               User-Agent header value. This is appended to the default value.
-            </string>
+            <string>Provide a string value to be included in the HTTP
+            User-Agent header value. This is appended to the default value.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3370,7 +3374,7 @@
          <key>OBJECT_BODY_SHAPE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>This is a flag used with llGetObjectDetails to get the body type of the avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis is normally between 0 and 1.0, with 0.5 and larger considered &apos;male&apos;</string>
+            <string>This is a flag used with llGetObjectDetails to get the body type of the avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis is normally between 0 and 1.0, with 0.5 and larger considered 'male'</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3406,7 +3410,7 @@
          <key>OBJECT_CREATOR</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s creator key. If id is an avatar, a NULL_KEY is returned.</string>
+            <string>Gets the object's creator key. If id is an avatar, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3433,7 +3437,7 @@
          <key>OBJECT_DESC</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s description. If id is an avatar, an empty string is returned.</string>
+            <string>Gets the object's description. If id is an avatar, an empty string is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3442,7 +3446,7 @@
          <key>OBJECT_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the prims&apos;s group key. If id is an avatar, a NULL_KEY is returned.</string>
+            <string>Gets the prims's group key. If id is an avatar, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3451,7 +3455,7 @@
          <key>OBJECT_GROUP_TAG</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the agent&apos;s current group role tag. If id is an object, an empty is returned.</string>
+            <string>Gets the agent's current group role tag. If id is an object, an empty is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3478,7 +3482,7 @@
          <key>OBJECT_LAST_OWNER_ID</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s last owner ID.</string>
+            <string>Gets the object's last owner ID.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3487,7 +3491,7 @@
          <key>OBJECT_LINK_NUMBER</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s link number or 0 if unlinked.</string>
+            <string>Gets the object's link number or 0 if unlinked.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3496,7 +3500,7 @@
          <key>OBJECT_MASS</key>
          <map>
             <key>tooltip</key>
-            <string>Get the object&apos;s mass</string>
+            <string>Get the object's mass</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3505,7 +3509,7 @@
          <key>OBJECT_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string>Get an object&apos;s material setting.</string>
+            <string>Get an object's material setting.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3514,7 +3518,7 @@
          <key>OBJECT_NAME</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s name.</string>
+            <string>Gets the object's name.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3523,7 +3527,7 @@
          <key>OBJECT_OMEGA</key>
          <map>
             <key>tooltip</key>
-            <string>Gets an object&apos;s angular velocity.</string>
+            <string>Gets an object's angular velocity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3532,7 +3536,7 @@
          <key>OBJECT_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string>Gets an object&apos;s owner&apos;s key. If id is group owned, a NULL_KEY is returned.</string>
+            <string>Gets an object's owner's key. If id is group owned, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3559,7 +3563,7 @@
          <key>OBJECT_PERMS_COMBINED</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s permissions including any inventory.</string>
+            <string>Gets the object's permissions including any inventory.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3595,7 +3599,7 @@
          <key>OBJECT_POS</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s position in region coordinates.</string>
+            <string>Gets the object's position in region coordinates.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3676,7 +3680,7 @@
          <key>OBJECT_ROOT</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the id of the root prim of the object requested.\nIf id is an avatar, return the id of the root prim of the linkset the avatar is sitting on (or the avatar&apos;s own id if the avatar is not sitting on an object within the region).</string>
+            <string>Gets the id of the root prim of the object requested.\nIf id is an avatar, return the id of the root prim of the linkset the avatar is sitting on (or the avatar's own id if the avatar is not sitting on an object within the region).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3685,7 +3689,7 @@
          <key>OBJECT_ROT</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s rotation.</string>
+            <string>Gets the object's rotation.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3703,7 +3707,7 @@
          <key>OBJECT_SCALE</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s size.</string>
+            <string>Gets the object's size.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3838,7 +3842,7 @@
          <key>OBJECT_VELOCITY</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s velocity.</string>
+            <string>Gets the object's velocity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3916,6 +3920,78 @@
             <key>value</key>
             <string>3</string>
          </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA_MASK</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>4</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA_MODE</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_COLOR_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_DOUBLE_SIDED</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>5</string>
+         </map>
+         <key>OVERRIDE_GLTF_EMISSIVE_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>8</string>
+         </map>
+         <key>OVERRIDE_GLTF_METALLIC_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>6</string>
+         </map>
+         <key>OVERRIDE_GLTF_ROUGHNESS_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>7</string>
+         </map>
          <key>PARCEL_COUNT_GROUP</key>
          <map>
             <key>tooltip</key>
@@ -3973,7 +4049,7 @@
          <key>PARCEL_DETAILS_AREA</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s area, in square meters. (5 chars.).</string>
+            <string>The parcel's area, in square meters. (5 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4000,7 +4076,7 @@
          <key>PARCEL_DETAILS_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel group&apos;s key. (36 chars.).</string>
+            <string>The parcel group's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4009,7 +4085,7 @@
          <key>PARCEL_DETAILS_ID</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s key. (36 chars.).</string>
+            <string>The parcel's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4027,7 +4103,7 @@
          <key>PARCEL_DETAILS_LANDING_POINT</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s landing point, if any.</string>
+            <string>The parcel's landing point, if any.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4045,7 +4121,7 @@
          <key>PARCEL_DETAILS_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel owner&apos;s key. (36 chars.).</string>
+            <string>The parcel owner's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4054,7 +4130,7 @@
          <key>PARCEL_DETAILS_PRIM_CAPACITY</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s prim capacity.</string>
+            <string>The parcel's prim capacity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4081,7 +4157,7 @@
          <key>PARCEL_DETAILS_SEE_AVATARS</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s avatar visibility setting. (1 char.).</string>
+            <string>The parcel's avatar visibility setting. (1 char.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4090,7 +4166,7 @@
          <key>PARCEL_DETAILS_TP_ROUTING</key>
          <map>
             <key>tooltip</key>
-            <string>Parcel&apos;s teleport routing setting.</string>
+            <string>Parcel's teleport routing setting.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4279,7 +4355,7 @@
          <key>PARCEL_MEDIA_COMMAND_LOOP_SET</key>
          <map>
             <key>tooltip</key>
-            <string>Used to get or set the parcel&apos;s media looping variable.</string>
+            <string>Used to get or set the parcel's media looping variable.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4342,7 +4418,7 @@
          <key>PARCEL_MEDIA_COMMAND_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>Use this to get or set the parcel media MIME type (e.g. &quot;text/html&quot;).</string>
+            <string>Use this to get or set the parcel media MIME type (e.g. "text/html").</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4675,7 +4751,7 @@
          <key>PRIM_ALPHA_MODE_BLEND</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as alpha-blended.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as alpha-blended.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4684,7 +4760,7 @@
          <key>PRIM_ALPHA_MODE_EMISSIVE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as an emissivity mask.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as an emissivity mask.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4693,7 +4769,7 @@
          <key>PRIM_ALPHA_MODE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as fully opaque for alpha values above alpha_cutoff and fully transparent otherwise.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as fully opaque for alpha values above alpha_cutoff and fully transparent otherwise.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4702,7 +4778,7 @@
          <key>PRIM_ALPHA_MODE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be ignored.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be ignored.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4893,7 +4969,7 @@
          <key>PRIM_CLICK_ACTION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_CLICK_ACTION, integer CLICK_ACTION_*]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4911,7 +4987,12 @@
          <key>PRIM_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_COLOR, integer face, vector color, float alpha]
+
+integer face – face number or ALL_SIDES
+vector color – color in RGB &lt;R, G, B&gt; (&lt;0.0, 0.0, 0.0&gt; = black, &lt;1.0, 1.0, 1.0&gt; = white)
+float alpha – from 0.0 (clear) to 1.0 (solid) (0.0 &lt;= alpha &lt;= 1.0)
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4929,7 +5010,7 @@
          <key>PRIM_DESC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_DESC, string description]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4938,7 +5019,16 @@
          <key>PRIM_FLEXIBLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float friction, float wind, float tension, vector force ]
+
+integer boolean – TRUE enables, FALSE disables
+integer softness – ranges from 0 to 3
+float gravity – ranges from -10.0 to 10.0
+float friction – ranges from 0.0 to 10.0
+float wind – ranges from 0.0 to 10.0
+float tension – ranges from 0.0 to 10.0
+vector force
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4947,7 +5037,7 @@
          <key>PRIM_FULLBRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_FULLBRIGHT, integer face, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4956,7 +5046,7 @@
          <key>PRIM_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string>PRIM_GLOW is used to get or set the glow status of the face.</string>
+            <string>PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW, integer face, float intensity ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4965,7 +5055,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_BLEND</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;BLEND&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "BLEND".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4974,7 +5064,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;MASK&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "MASK".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4983,7 +5073,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_OPAQUE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;OPAQUE&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "OPAQUE".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4992,7 +5082,7 @@
          <key>PRIM_GLTF_BASE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode, integer alpha_cutoff, boolean double_sided.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.</string>
+            <string>Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode, float alpha_cutoff, boolean double_sided.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5073,7 +5163,10 @@
          <key>PRIM_LINK_TARGET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_LINK_TARGET, integer link_target ]
+
+Used to get or set multiple links with a single PrimParameters call.
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5082,7 +5175,7 @@
          <key>PRIM_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_MATERIAL, integer PRIM_MATERIAL_* ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5163,7 +5256,7 @@
          <key>PRIM_MEDIA_ALT_IMAGE_ENABLE</key>
          <map>
             <key>tooltip</key>
-            <string>Boolean. Gets/Sets the default image state (the image that the user sees before a piece of media is active) for the chosen face. The default image is specified by Second Life&apos;s server for that media type.</string>
+            <string>Boolean. Gets/Sets the default image state (the image that the user sees before a piece of media is active) for the chosen face. The default image is specified by Second Life's server for that media type.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5406,7 +5499,7 @@
          <key>PRIM_NAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_NAME, string name ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5424,7 +5517,12 @@
          <key>PRIM_OMEGA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_OMEGA, vector axis, float spinrate, float gain ]
+
+vector axis – arbitrary axis to rotate the object around
+float spinrate – rate of rotation in radians per second
+float gain – also modulates the final spinrate and disables the rotation behavior if zero
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5433,7 +5531,7 @@
          <key>PRIM_PHANTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PHANTOM, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5442,7 +5540,7 @@
          <key>PRIM_PHYSICS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PHYSICS, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5478,10 +5576,8 @@
          <key>PRIM_PHYSICS_SHAPE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Allows you to set the physics shape type of a prim via lsl. Permitted values are:
-               PRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX
-            </string>
+            <string>Allows you to set the physics shape type of a prim via lsl. Permitted values are:
+			PRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5490,7 +5586,14 @@
          <key>PRIM_POINT_LIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity, float radius, float falloff ]
+
+integer boolean – TRUE enables, FALSE disables
+vector linear_color – linear color in RGB &lt;R, G, B&amp;&gt; (&lt;0.0, 0.0, 0.0&gt; = black, &lt;1.0, 1.0, 1.0&gt; = white)
+float intensity – ranges from 0.0 to 1.0
+float radius – ranges from 0.1 to 20.0
+float falloff – ranges from 0.01 to 2.0
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5499,7 +5602,10 @@
          <key>PRIM_POSITION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POSITION, vector position ]
+
+vector position – position in region or local coordinates depending upon the situation
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5508,7 +5614,10 @@
          <key>PRIM_POS_LOCAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POS_LOCAL, vector position ]
+
+vector position - position in local coordinates
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5517,7 +5626,7 @@
          <key>PRIM_PROJECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5562,7 +5671,7 @@
          <key>PRIM_RENDER_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_RENDER_MATERIAL, integer face, string material ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5571,7 +5680,7 @@
          <key>PRIM_ROTATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_ROT_LOCAL, rotation global_rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5580,7 +5689,7 @@
          <key>PRIM_ROT_LOCAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_ROT_LOCAL, rotation local_rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5724,7 +5833,7 @@
          <key>PRIM_SIT_TARGET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5733,7 +5842,7 @@
          <key>PRIM_SIZE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SIZE, vector size ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5742,7 +5851,7 @@
          <key>PRIM_SLICE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SLICE, vector slice ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5769,7 +5878,7 @@
          <key>PRIM_TEXGEN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXGEN, integer face, PRIM_TEXGEN_* ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5796,7 +5905,7 @@
          <key>PRIM_TEXT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXT, string text, vector color, float alpha ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5805,7 +5914,7 @@
          <key>PRIM_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXTURE, integer face, string texture, vector repeats, vector offsets, float rotation_in_radians ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6129,7 +6238,7 @@
          <key>PSYS_PART_START_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string>A vector &lt;r.r, g.g, b.b&gt; which determines the starting color of the object.</string>
+            <string>A vector &lt;r, g, b&gt; which determines the starting color of the object.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6255,10 +6364,8 @@
          <key>PSYS_SRC_INNERANGLE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
-               The area specified will NOT have particles in it.
-            </string>
+            <string>Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
+			The area specified will NOT have particles in it.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6285,10 +6392,8 @@
          <key>PSYS_SRC_OUTERANGLE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
-               The area between the outer and inner angle will be filled with particles.
-            </string>
+            <string>Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
+			The area between the outer and inner angle will be filled with particles.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6297,10 +6402,8 @@
          <key>PSYS_SRC_PATTERN</key>
          <map>
             <key>tooltip</key>
-            <string>
-               The pattern which is used to generate particles.
-               Use one of the following values: PSYS_SRC_PATTERN Values.
-            </string>
+            <string>The pattern which is used to generate particles.
+			Use one of the following values: PSYS_SRC_PATTERN Values.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6399,7 +6502,7 @@
          <key>PURSUIT_INTERCEPT</key>
          <map>
             <key>tooltip</key>
-            <string>Define whether the character attempts to predict the target&apos;s location.</string>
+            <string>Define whether the character attempts to predict the target's location.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6758,6 +6861,8 @@
          </map>
          <key>REMOTE_DATA_CHANNEL</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6767,6 +6872,8 @@
          </map>
          <key>REMOTE_DATA_REPLY</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6776,6 +6883,8 @@
          </map>
          <key>REMOTE_DATA_REQUEST</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6831,7 +6940,7 @@
          <key>REZ_DAMAGE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>Set the damage type applied when this object collides.</string>
+            <string>Set the damage type applied when this object collides. [integer damage_type]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7047,7 +7156,7 @@
          <key>SIM_STAT_AGENT_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;agent&apos; segment of simulation frame.</string>
+            <string>Time spent in 'agent' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7110,7 +7219,7 @@
          <key>SIM_STAT_IMAGE_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;image&apos; segment of simulation frame.</string>
+            <string>Time spent in 'image' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7128,7 +7237,7 @@
          <key>SIM_STAT_NET_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;network&apos; segment of simulation frame.</string>
+            <string>Time spent in 'network' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7137,7 +7246,7 @@
          <key>SIM_STAT_OTHER_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;other&apos; segment of simulation frame.</string>
+            <string>Time spent in 'other' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7164,7 +7273,7 @@
          <key>SIM_STAT_PCT_CHARS_STEPPED</key>
          <map>
             <key>tooltip</key>
-            <string>Returns the % of pathfinding characters skipped each frame, averaged over the last minute.\nThe returned value corresponds to the &quot;Characters Updated&quot; stat in the viewer&apos;s Statistics Bar.</string>
+            <string>Returns the % of pathfinding characters skipped each frame, averaged over the last minute.\nThe returned value corresponds to the "Characters Updated" stat in the viewer's Statistics Bar.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7182,7 +7291,7 @@
          <key>SIM_STAT_PHYSICS_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;physics&apos; segment of simulation frame.</string>
+            <string>Time spent in 'physics' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7227,7 +7336,7 @@
          <key>SIM_STAT_SCRIPT_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;script&apos; segment of simulation frame.</string>
+            <string>Time spent in 'script' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7281,7 +7390,7 @@
          <key>SIT_FLAG_NO_COLLIDE</key>
          <map>
             <key>tooltip</key>
-            <string>The seated avatar&apos;s hit box is disabled when seated on this prim.</string>
+            <string>The seated avatar's hit box is disabled when seated on this prim.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7587,7 +7696,7 @@
          <key>SOUND_TRIGGER</key>
          <map>
             <key>tooltip</key>
-            <string>Sound will be triggered at the prim&apos;s location and not attached.</string>
+            <string>Sound will be triggered at the prim's location and not attached.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7605,7 +7714,7 @@
          <key>STATUS_BLOCK_GRAB</key>
          <map>
             <key>tooltip</key>
-            <string>Controls whether the object can be grabbed.\nA grab is the default action when in third person, and is available as the hand tool in build mode. This is useful for physical objects that you don&apos;t want other people to be able to trivially disturb. The default is FALSE</string>
+            <string>Controls whether the object can be grabbed.\nA grab is the default action when in third person, and is available as the hand tool in build mode. This is useful for physical objects that you don't want other people to be able to trivially disturb. The default is FALSE</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7641,7 +7750,7 @@
          <key>STATUS_DIE_AT_EDGE</key>
          <map>
             <key>tooltip</key>
-            <string>Controls whether the object is returned to the owners inventory if it wanders off the edge of the world.\nIt is useful to set this status TRUE for things like bullets or rockets. The default is TRUE</string>
+            <string>Controls whether the object is returned to the owner's inventory if it wanders off the edge of the world.\nIt is useful to set this status TRUE for things like bullets or rockets. The default is TRUE</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7749,16 +7858,14 @@
          <key>STATUS_ROTATE_Z</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Controls/indicates whether the object can physically rotate around
-               the specific axis or not. This flag has no meaning
-               for non-physical objects. Set the value to FALSE
-               if you want to disable rotation around that axis. The
-               default is TRUE for a physical object.
-               A useful example to think about when visualizing
-               the effect is a sit-and-spin device. They spin around the
-               Z axis (up) but not around the X or Y axis.
-            </string>
+            <string>Controls/indicates whether the object can physically rotate around
+			the specific axis or not. This flag has no meaning
+			for non-physical objects. Set the value to FALSE
+			if you want to disable rotation around that axis. The
+			default is TRUE for a physical object.
+			A useful example to think about when visualizing
+			the effect is a sit-and-spin device. They spin around the
+			Z axis (up) but not around the X or Y axis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7767,11 +7874,9 @@
          <key>STATUS_SANDBOX</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Controls/indicates whether the object can cross region boundaries
-               and move more than 20 meters from its creation
-               point. The default if FALSE.
-            </string>
+            <string>Controls/indicates whether the object can cross region boundaries
+			and move more than 20 meters from its creation
+			point. The default if FALSE.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8275,7 +8380,7 @@
          <key>TRUE</key>
          <map>
             <key>tooltip</key>
-            <string>An integer constant for boolean comparisons. Has the value &apos;1&apos;.</string>
+            <string>An integer constant for boolean comparisons. Has the value '1'.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8392,10 +8497,8 @@
          <key>VEHICLE_ANGULAR_FRICTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               A vector of timescales for exponential decay of the vehicles angular velocity about its preferred axes of motion (at, left, up).
-               Range = [0.07, inf) seconds for each element of the vector.
-            </string>
+            <string>A vector of timescales for exponential decay of the vehicle's angular velocity about its preferred axes of motion (at, left, up).
+			Range = [0.07, inf) seconds for each element of the vector.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8413,7 +8516,7 @@
          <key>VEHICLE_ANGULAR_MOTOR_DIRECTION</key>
          <map>
             <key>tooltip</key>
-            <string>The direction and magnitude (in preferred frame) of the vehicles angular motor.The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.</string>
+            <string>The direction and magnitude (in preferred frame) of the vehicle's angular motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8440,7 +8543,7 @@
          <key>VEHICLE_BANKING_MIX</key>
          <map>
             <key>tooltip</key>
-            <string>A slider between static (0.0) and dynamic (1.0) banking. &quot;Static&quot; means the banking scales only with the angle of roll, whereas &quot;dynamic&quot; is a term that also scales with the vehicles linear speed.</string>
+            <string>A slider between static (0.0) and dynamic (1.0) banking. "Static" means the banking scales only with the angle of roll, whereas "dynamic" is a term that also scales with the vehicles linear speed.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8613,7 +8716,7 @@
          <key>VEHICLE_LINEAR_DEFLECTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>The timescale for exponential success of linear deflection deflection. It is another way to specify how much time it takes for the vehicles linear velocity to be redirected to its preferred axis of motion.</string>
+            <string>The timescale for exponential success of linear deflection deflection. It is another way to specify how much time it takes for the vehicle's linear velocity to be redirected to its preferred axis of motion.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8622,10 +8725,8 @@
          <key>VEHICLE_LINEAR_FRICTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               A vector of timescales for exponential decay of the vehicles linear velocity along its preferred axes of motion (at, left, up).
-               Range = [0.07, inf) seconds for each element of the vector.
-            </string>
+            <string>A vector of timescales for exponential decay of the vehicle's linear velocity along its preferred axes of motion (at, left, up).
+			Range = [0.07, inf) seconds for each element of the vector.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8643,10 +8744,8 @@
          <key>VEHICLE_LINEAR_MOTOR_DIRECTION</key>
          <map>
             <key>tooltip</key>
-            <string>
-               The direction and magnitude (in preferred frame) of the vehicles linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.
-               Range of magnitude = [0, 30] meters/second.
-            </string>
+            <string>The direction and magnitude (in preferred frame) of the vehicle's linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.
+			Range of magnitude = [0, 30] meters/second.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8673,7 +8772,7 @@
          <key>VEHICLE_REFERENCE_FRAME</key>
          <map>
             <key>tooltip</key>
-            <string>A rotation of the vehicles preferred axes of motion and orientation (at, left, up) with respect to the vehicles local frame (x, y, z).</string>
+            <string>A rotation of the vehicle's preferred axes of motion and orientation (at, left, up) with respect to the vehicle's local frame (x, y, z).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8745,7 +8844,7 @@
          <key>VEHICLE_VERTICAL_ATTRACTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>The period of wobble, or timescale for exponential approach, of the vehicle to rotate such that its preferred &quot;up&quot; axis is oriented along the worlds &quot;up&quot; axis.</string>
+            <string>The period of wobble, or timescale for exponential approach, of the vehicle to rotate such that its preferred "up" axis is oriented along the world's "up" axis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -9033,10 +9132,8 @@
          <key>default</key>
          <map>
             <key>tooltip</key>
-            <string>
-               All scripts must have a default state, which is the first state entered when the script starts.
-               If another state is defined before the default state, the compiler will report a syntax error.
-            </string>
+            <string>All scripts must have a default state, which is the first state entered when the script starts.
+If another state is defined before the default state, the compiler will report a syntax error.</string>
          </map>
       </map>
       <key>events</key>
@@ -9074,7 +9171,7 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>This event is triggered when a script comes within a defined angle of a target rotation. The range and rotation, are set by a call to llRotTarget.</string>
+            <string>This event is triggered when a script comes within a defined angle of a target rotation. The range and rotation are set by a call to llRotTarget.</string>
          </map>
          <key>at_target</key>
          <map>
@@ -9160,10 +9257,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised while another object, or avatar, is colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* functions.
-            </string>
+            <string>This event is raised while another object, or avatar, is colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* functions.</string>
          </map>
          <key>collision_end</key>
          <map>
@@ -9180,10 +9275,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when another object, or avatar, stops colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when another object, or avatar, stops colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>collision_start</key>
          <map>
@@ -9200,10 +9293,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when another object, or avatar, starts colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when another object, or avatar, starts colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>control</key>
          <map>
@@ -9238,10 +9329,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               Once a script has the ability to grab control inputs from the avatar, this event will be used to pass the commands into the script.
-               The levels and edges are bit-fields of control constants.
-            </string>
+            <string>Once a script has the ability to grab control inputs from the avatar, this event will be used to pass the commands into the script.
+			The levels and edges are bit-fields of control constants.</string>
          </map>
          <key>dataserver</key>
          <map>
@@ -9267,10 +9356,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is triggered when the requested data is returned to the script.
-               Data may be requested by the llRequestAgentData, llRequestInventoryData, and llGetNotecardLine function calls, for example.
-            </string>
+            <string>This event is triggered when the requested data is returned to the script.
+			Data may be requested by the llRequestAgentData, llRequestInventoryData, and llGetNotecardLine function calls, for example.</string>
          </map>
          <key>email</key>
          <map>
@@ -9323,10 +9410,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is triggered when an email sent to this script arrives.
-               The number remaining tells how many more emails are known to be still pending.
-            </string>
+            <string>This event is triggered when an email sent to this script arrives.
+			The number remaining tells how many more emails are known to be still pending.</string>
          </map>
          <key>experience_permissions</key>
          <map>
@@ -9674,10 +9759,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised whenever a chat message matching the constraints set in the llListen command is received. The name and ID of the speaker, as well as the message, are passed in as parameters.
-               Channel 0 is the public chat channel that all avatars see as chat text. Channels 1 through 2,147,483,648 are private channels that are not sent to avatars but other scripts can listen on those channels.
-            </string>
+            <string>This event is raised whenever a chat message matching the constraints set in the llListen command is received. The name and ID of the speaker, as well as the message, are passed in as parameters.
+			Channel 0 is the public chat channel that all avatars see as chat text. Channels 1 through 2,147,483,648 are private channels that are not sent to avatars but other scripts can listen on those channels.</string>
          </map>
          <key>money</key>
          <map>
@@ -9822,10 +9905,12 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>This event is called to inform the script of changes within the object&apos;s path-finding status.</string>
+            <string>This event is called to inform the script of changes within the object's path-finding status.</string>
          </map>
          <key>remote_data</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>arguments</key>
             <array>
                <map>
@@ -9901,10 +9986,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               Scripts need permission from either the owner or the avatar they wish to act on before they may perform certain functions, such as debiting money from their owners account, triggering an animation on an avatar, or capturing control inputs. The llRequestPermissions library function is used to request these permissions and the various permissions integer constants can be supplied.
-               The integer returned to this event handler contains the current set of permissions flags, so if permissions equal 0 then no permissions are set.
-            </string>
+            <string>Scripts need permission from either the owner or the avatar they wish to act on before they may perform certain functions, such as debiting money from their owners account, triggering an animation on an avatar, or capturing control inputs. The llRequestPermissions library function is used to request these permissions and the various permissions integer constants can be supplied.
+			The integer returned to this event handler contains the current set of permissions flags, so if permissions equal 0 then no permissions are set.</string>
          </map>
          <key>sensor</key>
          <map>
@@ -9921,10 +10004,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised whenever objects matching the constraints of the llSensor command are detected.
-               The number of detected objects is passed to the script in the parameter. Information on those objects may be gathered via the llDetected* functions.
-            </string>
+            <string>This event is raised whenever objects matching the constraints of the llSensor command are detected.
+			The number of detected objects is passed to the script in the parameter. Information on those objects may be gathered via the llDetected* functions.</string>
          </map>
          <key>state_entry</key>
          <map>
@@ -9962,11 +10043,9 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised while a user is touching the object the script is attached to.
-               The number of touching objects is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised while a user is touching the object the script is attached to.
+			The number of touching objects is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>touch_end</key>
          <map>
@@ -9983,10 +10062,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when a user stops touching the object the script is attached to. The number of touches is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when a user stops touching the object the script is attached to. The number of touches is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>touch_start</key>
          <map>
@@ -10003,10 +10080,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when a user first touches the object the script is attached to. The number of touches is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected() library functions.
-            </string>
+            <string>This event is raised when a user first touches the object the script is attached to. The number of touches is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected() library functions.</string>
          </map>
          <key>transaction_result</key>
          <map>
@@ -10233,8 +10308,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
-            </string>
+                   Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
+                </string>
          </map>
          <key>llAllowInventoryDrop</key>
          <map>
@@ -10477,7 +10552,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If an avatar is sitting on the link&apos;s sit target, return the avatar&apos;s key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link&apos;s prim.</string>
+            <string>If an avatar is sitting on the link's sit target, return the avatar's key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link's prim.</string>
          </map>
          <key>llAvatarOnSitTarget</key>
          <map>
@@ -10490,7 +10565,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If an avatar is seated on the sit target, returns the avatar&apos;s key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
+            <string>If an avatar is seated on the sit target, returns the avatar's key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
          </map>
          <key>llAxes2Rot</key>
          <map>
@@ -10709,7 +10784,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Casts a ray into the physics world from &apos;start&apos; to &apos;end&apos; and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
+            <string>Casts a ray into the physics world from 'start' to 'end' and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
          </map>
          <key>llCeil</key>
          <map>
@@ -10839,6 +10914,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -10862,6 +10939,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -10869,7 +10948,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the cloud density at the object&apos;s position + Offset.</string>
+            <string>Returns the cloud density at the object's position + Offset.</string>
          </map>
          <key>llCollisionFilter</key>
          <map>
@@ -10958,6 +11037,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -11043,7 +11124,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a &quot;character&quot;, from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
+            <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a "character", from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
          </map>
          <key>llCreateKeyValue</key>
          <map>
@@ -11076,8 +11157,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
-            </string>
+                   Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
+                </string>
          </map>
          <key>llCreateLink</key>
          <map>
@@ -11096,7 +11177,7 @@
                   <key>Parent</key>
                   <map>
                      <key>tooltip</key>
-                     <string>If FALSE, then TargetPrim becomes the root. If TRUE, then the script&apos;s object becomes the root.</string>
+                     <string>If FALSE, then TargetPrim becomes the root. If TRUE, then the script's object becomes the root.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11164,8 +11245,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
-            </string>
+                   Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
+                </string>
          </map>
          <key>llDeleteCharacter</key>
          <map>
@@ -11202,8 +11283,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-            </string>
+                   Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                </string>
          </map>
          <key>llDeleteSubList</key>
          <map>
@@ -11244,7 +11325,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th. list entry.</string>
+            <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th list entry.</string>
          </map>
          <key>llDeleteSubString</key>
          <map>
@@ -11285,7 +11366,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th. character.</string>
+            <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th character.</string>
          </map>
          <key>llDerezObject</key>
          <map>
@@ -11491,7 +11572,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the key of detected object&apos;s owner.\nReturns invalid key if Number is not a valid index.</string>
+            <string>Returns the key of detected object's owner.\nReturns invalid key if Number is not a valid index.</string>
          </map>
          <key>llDetectedPos</key>
          <map>
@@ -11794,18 +11875,16 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>
-               Shows a dialog box on the avatar&apos;s screen with the message.\n
-               Up to 12 strings in the list form buttons.\n
-               If a button is clicked, the name is chatted on Channel.\nOpens a &quot;notify box&quot; in the given avatars screen displaying the message.\n
-               Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
-               Channels work just like llSay(), so channel 0 can be heard by everyone.\n
-               The chat originates at the object&apos;s position, not the avatar&apos;s position, even though it is said as the avatar (uses avatar&apos;s UUID and Name etc.).\n
-               Examples:\n
-               llDialog(who, &quot;Are you a boy or a girl?&quot;, [ &quot;Boy&quot;, &quot;Girl&quot; ], -4913);\n
-               llDialog(who, &quot;This shows only an OK button.&quot;, [], -192);\n
-               llDialog(who, &quot;This chats so you can &apos;hear&apos; it.&quot;, [&quot;Hooray&quot;], 0);
-            </string>
+            <string>Shows a dialog box on the avatar's screen with the message.\n
+                    Up to 12 strings in the list form buttons.\n
+                    If a button is clicked, the name is chatted on Channel.\nOpens a "notify box" in the given avatars screen displaying the message.\n
+                Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
+                Channels work just like llSay(), so channel 0 can be heard by everyone.\n
+                The chat originates at the object's position, not the avatar's position, even though it is said as the avatar (uses avatar's UUID and Name etc.).\n
+                Examples:\n
+                llDialog(who, "Are you a boy or a girl?", [ "Boy", "Girl" ], -4913);\n
+                llDialog(who, "This shows only an OK button.", [], -192);\n
+                llDialog(who, "This chats so you can 'hear' it.", ["Hooray"], 0);</string>
          </map>
          <key>llDie</key>
          <map>
@@ -11969,10 +12048,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
-               This function returns the UTF-8 encoded escape codes for selected characters.
-            </string>
+            <string>Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
+                This function returns the UTF-8 encoded escape codes for selected characters.</string>
          </map>
          <key>llEuler2Rot</key>
          <map>
@@ -12123,9 +12200,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Searches the text of a cached notecard for lines containing the given pattern and returns the
-               number of matches found through a dataserver event.
+            <string>Searches the text of a cached notecard for lines containing the given pattern and returns the 
+            number of matches found through a dataserver event.
             </string>
          </map>
          <key>llFindNotecardTextSync</key>
@@ -12185,12 +12261,10 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Searches the text of a cached notecard for lines containing the given pattern.
-               Returns a list of line numbers and column where a match is found. If the notecard is not in
-               the cache it returns a list containing a single entry of NAK. If no matches are found an
-               empty list is returned.
-            </string>
+            <string>Searches the text of a cached notecard for lines containing the given pattern. 
+            Returns a list of line numbers and column where a match is found. If the notecard is not in
+            the cache it returns a list containing a single entry of NAK. If no matches are found an
+            empty list is returned.</string>
          </map>
          <key>llFleeFrom</key>
          <map>
@@ -12326,7 +12400,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the acceleration of the object relative to the region&apos;s axes.\nGets the acceleration of the object.</string>
+            <string>Returns the acceleration of the object relative to the region's axes.\nGets the acceleration of the object.</string>
          </map>
          <key>llGetAgentInfo</key>
          <map>
@@ -12349,10 +12423,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Returns an integer bit-field containing the agent information about id.\n
-               Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.
-            </string>
+            <string>Returns an integer bit-field containing the agent information about id.\n
+                    Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.</string>
          </map>
          <key>llGetAgentLanguage</key>
          <map>
@@ -12453,7 +12525,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the alpha value of Face.\nReturns the &apos;alpha&apos; of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
+            <string>Returns the alpha value of Face.\nReturns the 'alpha' of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
          </map>
          <key>llGetAndResetTime</key>
          <map>
@@ -12548,7 +12620,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the object&apos;s attachment point, or 0 if not attached.</string>
+            <string>Returns the object's attachment point, or 0 if not attached.</string>
          </map>
          <key>llGetAttachedList</key>
          <map>
@@ -12691,7 +12763,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the prim&apos;s centre of mass (unless called from the root prim, where it returns the object&apos;s centre of mass).</string>
+            <string>Returns the prim's centre of mass (unless called from the root prim, where it returns the object's centre of mass).</string>
          </map>
          <key>llGetClosestNavPoint</key>
          <map>
@@ -12759,7 +12831,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a key for the creator of the prim.\nReturns the key of the object&apos;s original creator. Similar to llGetOwner.</string>
+            <string>Returns a key for the creator of the prim.\nReturns the key of the object's original creator. Similar to llGetOwner.</string>
          </map>
          <key>llGetDate</key>
          <map>
@@ -12899,7 +12971,7 @@
                   <key>ExperienceID</key>
                   <map>
                      <key>tooltip</key>
-                     <string>May be NULL_KEY to retrieve the details for the script&apos;s Experience</string>
+                     <string>May be NULL_KEY to retrieve the details for the script's Experience</string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12913,8 +12985,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
-            </string>
+                   Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
+                </string>
          </map>
          <key>llGetExperienceErrorMessage</key>
          <map>
@@ -12938,8 +13010,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
-            </string>
+                   Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
+                </string>
          </map>
          <key>llGetForce</key>
          <map>
@@ -13082,7 +13154,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the time at which the item was placed into this prim&apos;s inventory as a timestamp.</string>
+            <string>Returns the time at which the item was placed into this prim's inventory as a timestamp.</string>
          </map>
          <key>llGetInventoryCreator</key>
          <map>
@@ -13105,7 +13177,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says &quot;No item named &apos;name&apos;&quot;.</string>
+            <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says "No item named 'name'".</string>
          </map>
          <key>llGetInventoryDesc</key>
          <map>
@@ -13128,7 +13200,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says &quot;No item named &apos;name&apos;&quot; to the debug channel and returns an empty string.</string>
+            <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says "No item named 'name'" to the debug channel and returns an empty string.</string>
          </map>
          <key>llGetInventoryKey</key>
          <map>
@@ -13206,7 +13278,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim&apos;s inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
+            <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim's inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
          <key>llGetInventoryPermMask</key>
          <map>
@@ -13238,7 +13310,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object&apos;s inventory, llGetInventoryPermMask returns FALSE and causes the object to say &quot;No item named &apos;&lt;item&gt;&apos;&quot;, where &quot;&lt;item&gt;&quot; is item.</string>
+            <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object's inventory, llGetInventoryPermMask returns FALSE and causes the object to say "No item named '&lt;item&gt;'", where "&lt;item&gt;" is item.</string>
          </map>
          <key>llGetInventoryType</key>
          <map>
@@ -13339,7 +13411,7 @@
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The prim&apos;s side number</string>
+                     <string>The prim's side number</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13452,7 +13524,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flags attributes.\n* Face flags require the user to also supply a face index parameter.</string>
+            <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flag's attributes.\n* Face flags require the user to also supply a face index parameter.</string>
          </map>
          <key>llGetLinkSitFlags</key>
          <map>
@@ -13569,7 +13641,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the mass of object that the script is attached to.\nReturns the scripted object&apos;s mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it&apos;s attached to, not its own.</string>
+            <string>Returns the mass of object that the script is attached to.\nReturns the scripted object's mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it's attached to, not its own.</string>
          </map>
          <key>llGetMassMKS</key>
          <map>
@@ -13634,7 +13706,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon&apos;s direction on the simulator in the parcel.</string>
+            <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon's direction on the simulator in the parcel.</string>
          </map>
          <key>llGetMoonRotation</key>
          <map>
@@ -13711,7 +13783,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
+            <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero in LSL, one in Lua.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
          </map>
          <key>llGetNotecardLineSync</key>
          <map>
@@ -13743,7 +13815,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns LineNumber from NotecardName. The line index starts at zero.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
+            <string>Returns LineNumber from NotecardName. The line index starts at zero in LSL, one in Lua.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
          </map>
          <key>llGetNumberOfNotecardLines</key>
          <map>
@@ -13990,7 +14062,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the object owner&apos;s UUID.\nReturns the key for the owner of the object.</string>
+            <string>Returns the object owner's UUID.\nReturns the key for the owner of the object.</string>
          </map>
          <key>llGetOwnerKey</key>
          <map>
@@ -14087,7 +14159,7 @@
                   <key>SimWide</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel&apos;s owner.</string>
+                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -14141,7 +14213,7 @@
                   <key>SimWide</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel&apos;s owner.</string>
+                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -14190,7 +14262,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise &quot;and&quot; operation against the PERMISSION_* constants</string>
+            <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise "and" operation against the PERMISSION_* constants</string>
          </map>
          <key>llGetPermissionsKey</key>
          <map>
@@ -14375,7 +14447,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon&apos;s direction on the simulator.</string>
+            <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon's direction on the simulator.</string>
          </map>
          <key>llGetRegionMoonRotation</key>
          <map>
@@ -14414,7 +14486,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun&apos;s direction on the simulator.</string>
+            <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun's direction on the simulator.</string>
          </map>
          <key>llGetRegionSunRotation</key>
          <map>
@@ -14476,7 +14548,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim&apos;s inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
+            <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim's inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
          <key>llGetRootPosition</key>
          <map>
@@ -14515,7 +14587,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the rotation relative to the region&apos;s axes.\nReturns the rotation.</string>
+            <string>Returns the rotation relative to the region's axes.\nReturns the rotation.</string>
          </map>
          <key>llGetSPMaxMemory</key>
          <map>
@@ -14613,7 +14685,7 @@
             <key>sleep</key>
             <real>10</real>
             <key>tooltip</key>
-            <string>Returns the host-name of the machine which the script is running on.\nFor example, &quot;sim225.agni.lindenlab.com&quot;.</string>
+            <string>Returns the host-name of the machine which the script is running on.\nFor example, "sim225.agni.lindenlab.com".</string>
          </map>
          <key>llGetStartParameter</key>
          <map>
@@ -14639,7 +14711,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns an string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
+            <string>Returns a string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
          </map>
          <key>llGetStaticPath</key>
          <map>
@@ -14753,7 +14825,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a sub-string from String, in a range specified by the Start and End indicies (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
+            <string>Returns a sub-string from String, in a range specified by the Start and End indices (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
          <key>llGetSunDirection</key>
          <map>
@@ -14766,7 +14838,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun&apos;s direction on the simulator in the parcel.</string>
+            <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun's direction on the simulator in the parcel.</string>
          </map>
          <key>llGetSunRotation</key>
          <map>
@@ -14802,7 +14874,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim&apos;s inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
+            <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim's inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
          <key>llGetTextureOffset</key>
          <map>
@@ -15030,7 +15102,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator&apos;s time-zone midnight (Pacific Time).</string>
+            <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator's time-zone midnight (Pacific Time).</string>
          </map>
          <key>llGiveAgentInventory</key>
          <map>
@@ -15242,7 +15314,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object&apos;s position + Offset.</string>
+            <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object's position + Offset.</string>
          </map>
          <key>llGroundContour</key>
          <map>
@@ -15265,7 +15337,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object&apos;s position + Offset.</string>
+            <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
          <key>llGroundNormal</key>
          <map>
@@ -15288,7 +15360,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object&apos;s position + Offset.</string>
+            <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
          <key>llGroundRepel</key>
          <map>
@@ -15329,11 +15401,9 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
-               The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
-               Do not use with vehicles. Only works in physics-enabled objects.
-            </string>
+            <string>Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
+                    The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
+                    Do not use with vehicles. Only works in physics-enabled objects.</string>
          </map>
          <key>llGroundSlope</key>
          <map>
@@ -15623,6 +15693,38 @@
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is a friend of the script owner.</string>
          </map>
+         <key>llIsLinkGLTFMaterial</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>link</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Link number to check.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>face</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Side to check for a PBR material. Use ALL_SIDES to check for all.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>integer</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Checks the face for a PBR render material.</string>
+         </map>
          <key>llJson2List</key>
          <map>
             <key>arguments</key>
@@ -15786,8 +15888,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
-            </string>
+                   Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
+                </string>
          </map>
          <key>llKeysKeyValue</key>
          <map>
@@ -15820,8 +15922,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
-            </string>
+                   Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
+                </string>
          </map>
          <key>llLinear2sRGB</key>
          <map>
@@ -16041,7 +16143,7 @@
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Position for the sit target, relative to the prim&apos;s position.</string>
+                     <string>Position for the sit target, relative to the prim's position.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -16050,7 +16152,7 @@
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Rotation (relative to the prim&apos;s rotation) for the avatar.</string>
+                     <string>Rotation (relative to the prim's rotation) for the avatar.</string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -16063,7 +16165,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim&apos;s position and rotation.</string>
+            <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim's position and rotation.</string>
          </map>
          <key>llLinkStopSound</key>
          <map>
@@ -16099,7 +16201,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the number of bytes remaining in the linkset&apos;s datastore.</string>
+            <string>Returns the number of bytes remaining in the linkset's datastore.</string>
          </map>
          <key>llLinksetDataCountFound</key>
          <map>
@@ -16135,7 +16237,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the number of keys in the linkset&apos;s datastore.</string>
+            <string>Returns the number of keys in the linkset's datastore.</string>
          </map>
          <key>llLinksetDataDelete</key>
          <map>
@@ -16145,7 +16247,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to delete from the linkset&apos;s datastore.</string>
+                     <string>Key to delete from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16158,7 +16260,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Deletes a name:value pair from the linkset&apos;s datastore.</string>
+            <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
          <key>llLinksetDataDeleteFound</key>
          <map>
@@ -16200,7 +16302,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to delete from the linkset&apos;s datastore.</string>
+                     <string>Key to delete from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16222,7 +16324,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Deletes a name:value pair from the linkset&apos;s datastore.</string>
+            <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
          <key>llLinksetDataFindKeys</key>
          <map>
@@ -16263,7 +16365,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a list of keys from the linkset&apos;s data store matching the search parameter.</string>
+            <string>Returns a list of keys from the linkset's data store matching the search parameter.</string>
          </map>
          <key>llLinksetDataListKeys</key>
          <map>
@@ -16305,7 +16407,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to retrieve from the linkset&apos;s datastore.</string>
+                     <string>Key to retrieve from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16328,7 +16430,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to retrieve from the linkset&apos;s datastore.</string>
+                     <string>Key to retrieve from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16363,7 +16465,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Resets the linkset&apos;s data store, erasing all key-value pairs.</string>
+            <string>Resets the linkset's data store, erasing all key-value pairs.</string>
          </map>
          <key>llLinksetDataWrite</key>
          <map>
@@ -16382,7 +16484,7 @@
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string>value to store in the linkset&apos;s datastore.</string>
+                     <string>value to store in the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16395,7 +16497,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets a name:value pair in the linkset&apos;s datastore</string>
+            <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
          <key>llLinksetDataWriteProtected</key>
          <map>
@@ -16414,7 +16516,7 @@
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string>value to store in the linkset&apos;s datastore.</string>
+                     <string>value to store in the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16436,7 +16538,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets a name:value pair in the linkset&apos;s datastore</string>
+            <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
          <key>llList2CSV</key>
          <map>
@@ -17508,7 +17610,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a &quot;Sync Master&quot;, causing &quot;Slave&quot; sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
+            <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a "Sync Master", causing "Slave" sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
          </map>
          <key>llLoopSoundSlave</key>
          <map>
@@ -17540,7 +17642,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a &quot;Sync Master&quot; present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
+            <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a "Sync Master" present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
          </map>
          <key>llMD5String</key>
          <map>
@@ -17938,7 +18040,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Adds or removes agents from the estate&apos;s agent access or ban lists, or groups to the estate&apos;s group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
+            <string>Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
          </map>
          <key>llMapBeacon</key>
          <map>
@@ -18020,7 +18122,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Opens world map for avatar who touched is is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
+            <string>Opens world map for avatar who touched it or is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
          </map>
          <key>llMessageLinked</key>
          <map>
@@ -18428,7 +18530,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object&apos;s simulator since logging into Second Life, regardless of where they may be in-world.</string>
+            <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object's simulator since logging into Second Life, regardless of where they may be in-world.</string>
          </map>
          <key>llParcelMediaCommandList</key>
          <map>
@@ -18721,7 +18823,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a &quot;Sync Master&quot; present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
+            <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a "Sync Master" present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
          </map>
          <key>llPow</key>
          <map>
@@ -18776,7 +18878,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Causes nearby viewers to preload the Sound from the object&apos;s inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
+            <string>Causes nearby viewers to preload the Sound from the object's inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
          </map>
          <key>llPursue</key>
          <map>
@@ -18882,13 +18984,15 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-            </string>
+                   Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                </string>
          </map>
          <key>llRefreshPrimURL</key>
          <map>
             <key>arguments</key>
             <array />
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -19248,7 +19352,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the enabled bits in &apos;flags&apos;.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
+            <string>Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
          </map>
          <key>llReplaceAgentEnvironment</key>
          <map>
@@ -19308,10 +19412,8 @@
                   <key>environment</key>
                   <map>
                      <key>tooltip</key>
-                     <string>
-                        Name of inventory item, or UUID of environment resource to apply.
-                        Use NULL_KEY or empty string to remove environment.
-                     </string>
+                     <string>Name of inventory item, or UUID of environment resource to apply.
+                         Use NULL_KEY or empty string to remove environment.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19388,7 +19490,7 @@
                   <key>Count</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The max number of replacements to make. Zero Count means &quot;replace all&quot;. Positive Count moves left to right. Negative moves right to left.</string>
+                     <string>The max number of replacements to make. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19401,7 +19503,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means &quot;replace all&quot;. Positive Count moves left to right. Negative moves right to left.</string>
+            <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
          </map>
          <key>llRequestAgentData</key>
          <map>
@@ -19475,7 +19577,7 @@
                   <key>unused</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Not used, should be &quot;&quot;</string>
+                     <string>Not used, should be ""</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19489,8 +19591,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
-            </string>
+                   Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
+                </string>
          </map>
          <key>llRequestInventoryData</key>
          <map>
@@ -19513,7 +19615,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form &quot;&lt;float, float, float&gt;&quot; which can be cast to a vector. This position is in region local coordinates.</string>
+            <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form "&lt;float, float, float&gt;" which can be cast to a vector. This position is in region local coordinates.</string>
          </map>
          <key>llRequestPermissions</key>
          <map>
@@ -19672,7 +19774,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals &quot;ALL&quot;, then all animation states are reset.</string>
+            <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals "ALL", then all animation states are reset.</string>
          </map>
          <key>llResetLandBanList</key>
          <map>
@@ -19780,7 +19882,7 @@
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Object owner&apos;s UUID.</string>
+                     <string>Object owner's UUID.</string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19861,7 +19963,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owner&apos;s InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object&apos;s location will be set to Position.\nCreates object&apos;s inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
+            <string>Instantiate owner's InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object's location will be set to Position.\nCreates object's inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
          </map>
          <key>llRezObject</key>
          <map>
@@ -19920,7 +20022,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object&apos;s inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
+            <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object's inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
          </map>
          <key>llRezObjectWithParams</key>
          <map>
@@ -19936,7 +20038,7 @@
                   </map>
                </map>
                <map>
-                  <key>Parms</key>
+                  <key>Params</key>
                   <map>
                      <key>tooltip</key>
                      <string />
@@ -19952,7 +20054,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owner&apos;s InventoryItem with the given parameters.</string>
+            <string>Instantiate owner's InventoryItem with the given parameters.</string>
          </map>
          <key>llRot2Angle</key>
          <map>
@@ -20461,7 +20563,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns TRUE if Position is over public land, sandbox land, land that doesn&apos;t allow everyone to edit and build, or land that doesn&apos;t allow outside scripts.\nReturns true if the position is over public land, land that doesn&apos;t allow everyone to edit and build, or land that doesn&apos;t allow outside scripts.</string>
+            <string>Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.</string>
          </map>
          <key>llScriptProfiler</key>
          <map>
@@ -20717,7 +20819,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets an agent&apos;s environmental values to the specified values. Must be used as part of an experience.</string>
+            <string>Sets an agent's environmental values to the specified values. Must be used as part of an experience.</string>
          </map>
          <key>llSetAgentRot</key>
          <map>
@@ -20813,7 +20915,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets an object&apos;s angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
+            <string>Sets an object's angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
          </map>
          <key>llSetAnimationOverride</key>
          <map>
@@ -20891,7 +20993,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar&apos;s camera will be moved to if the avatar sits on the object.</string>
+            <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar's camera will be moved to if the avatar sits on the object.</string>
          </map>
          <key>llSetCameraEyeOffset</key>
          <map>
@@ -21226,7 +21328,7 @@
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string>An item in the prim&apos;s inventory</string>
+                     <string>An item in the prim's inventory</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21351,7 +21453,7 @@
                   <key>EyeOffset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Offset, relative to the object&apos;s centre and expressed in local coordinates, that the camera looks from.</string>
+                     <string>Offset, relative to the object's centre and expressed in local coordinates, that the camera looks from.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21360,7 +21462,7 @@
                   <key>LookOffset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Offset, relative to the object&apos;s centre and expressed in local coordinates, that the camera looks toward.</string>
+                     <string>Offset, relative to the object's centre and expressed in local coordinates, that the camera looks toward.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21414,7 +21516,48 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child&apos;s side, specified by LinkNumber.</string>
+            <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child's side, specified by LinkNumber.</string>
+         </map>
+         <key>llSetLinkGLTFOverrides</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>link</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Link number to check.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>face</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Side to check for a PBR material. Use ALL_SIDES to check for all.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>options</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>List of individual overrides to set.</string>
+                     <key>type</key>
+                     <string>list</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>void</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Sets or changes GLTF Overrides set on the selected faces.</string>
          </map>
          <key>llSetLinkMedia</key>
          <map>
@@ -21480,6 +21623,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -21487,7 +21632,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>Set primitive parameters for LinkNumber based on Parameters.\nSets the parameters (or properties) of any linked prim in one step.</string>
+            <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
          <key>llSetLinkPrimitiveParamsFast</key>
          <map>
@@ -21560,7 +21705,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Materail may be a UUID or name of a material in prim inventory.</string>
+            <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Material may be a UUID or name of a material in prim inventory.</string>
          </map>
          <key>llSetLinkSitFlags</key>
          <map>
@@ -21592,7 +21737,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the sit flags set on the specified prim in a linkset.</string>
+            <string>Sets the sit flags for the specified prim in a linkset.</string>
          </map>
          <key>llSetLinkTexture</key>
          <map>
@@ -21811,7 +21956,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the prim&apos;s name to Name.</string>
+            <string>Sets the prim's name to Name.</string>
          </map>
          <key>llSetObjectPermMask</key>
          <map>
@@ -21878,7 +22023,7 @@
                   <key>Price</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The default price shown in the textu input field.</string>
+                     <string>The default price shown in the text input field.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21887,7 +22032,7 @@
                   <key>QuickButtons</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Specifies the 4 payment values shown in the payment dialog&apos;s buttons (or PAY_HIDE).</string>
+                     <string>Specifies the 4 payment values shown in the payment dialog's buttons (or PAY_HIDE).</string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21900,7 +22045,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the textu input field.  QuickButtons specifies the 4 payment values shown in the payment dialog&apos;s buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
+            <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the text input field.  QuickButtons specifies the 4 payment values shown in the payment dialog's buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
          </map>
          <key>llSetPhysicsMaterial</key>
          <map>
@@ -21959,7 +22104,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the selected parameters of the object&apos;s physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
+            <string>Sets the selected parameters of the object's physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
          </map>
          <key>llSetPos</key>
          <map>
@@ -22055,6 +22200,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -22062,7 +22209,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>This function changes the many properties (or &quot;parameters&quot;) of a prim in one operation. Parameters is a list of changes.</string>
+            <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
          <key>llSetRegionPos</key>
          <map>
@@ -22186,7 +22333,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the prim&apos;s scale (size) to Scale.</string>
+            <string>Sets the prim's scale (size) to Scale.</string>
          </map>
          <key>llSetScriptState</key>
          <map>
@@ -22241,7 +22388,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Displays Text rather than &apos;Sit&apos; in the viewer&apos;s context menu.</string>
+            <string>Displays Text rather than 'Sit' in the viewer's context menu.</string>
          </map>
          <key>llSetSoundQueueing</key>
          <map>
@@ -22524,7 +22671,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the Torque acting on the script&apos;s object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
+            <string>Sets the Torque acting on the script's object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
          <key>llSetTouchText</key>
          <map>
@@ -22721,7 +22868,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If the object is physics-enabled, sets the object&apos;s linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
+            <string>If the object is physics-enabled, sets the object's linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
          </map>
          <key>llShout</key>
          <map>
@@ -22849,7 +22996,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link&apos;s sit target.</string>
+            <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link's sit target.</string>
          </map>
          <key>llSitTarget</key>
          <map>
@@ -23027,7 +23174,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>This function plays the specified animation from playing on the avatar who received the script&apos;s most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
+            <string>This function plays the specified animation from playing on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
          <key>llStartObjectAnimation</key>
          <map>
@@ -23073,7 +23220,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>This function stops the specified animation on the avatar who received the script&apos;s most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
+            <string>This function stops the specified animation on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
          <key>llStopHover</key>
          <map>
@@ -23484,7 +23631,7 @@
             <key>sleep</key>
             <real>20</real>
             <key>tooltip</key>
-            <string>Sends an email with Subject and Message to the owner or creator of an object .</string>
+            <string>Sends an email with Subject and Message to the owner or creator of an object.</string>
          </map>
          <key>llTeleportAgent</key>
          <map>
@@ -23534,7 +23681,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Requests a teleport of avatar to a landmark stored in the object&apos;s inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
+            <string>Requests a teleport of avatar to a landmark stored in the object's inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
          <key>llTeleportAgentGlobalCoords</key>
          <map>
@@ -23607,7 +23754,7 @@
             <key>sleep</key>
             <real>5</real>
             <key>tooltip</key>
-            <string>Teleport agent over the owner&apos;s land to agent&apos;s home location.</string>
+            <string>Teleport agent over the owner's land to agent's home location.</string>
          </map>
          <key>llTextBox</key>
          <map>
@@ -23648,7 +23795,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the &quot;OK&quot; button is clicked.</string>
+            <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the "OK" button is clicked.</string>
          </map>
          <key>llToLower</key>
          <map>
@@ -23872,7 +24019,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the objects owner, the agent is forced to stand up.</string>
+            <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the object's owner, the agent is forced to stand up.</string>
          </map>
          <key>llUnescapeURL</key>
          <map>
@@ -23895,7 +24042,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the string that is the URL unescaped, replacing &quot;%20&quot; with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
+            <string>Returns the string that is the URL unescaped, replacing "%20" with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
          </map>
          <key>llUpdateCharacter</key>
          <map>
@@ -23969,8 +24116,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
-            </string>
+                   Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
+                </string>
          </map>
          <key>llVecDist</key>
          <map>
@@ -24390,6 +24537,6 @@
          </map>
       </map>
       <key>llsd-lsl-syntax-version</key>
-      <integer>2</integer><!-- increment only when the file format changes, not just the content -->
+      <integer>2</integer>
    </map>
 </llsd>

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -4442,6 +4442,87 @@
             <key>value</key>
             <string>5</string>
          </map>
+         <key>PARCEL_SALE_AGENT</key>
+         <map>
+            <key>tooltip</key>
+            <string>The agent authorized to purchase the parcel.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_BAD_PARAMS</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parameters provided to set the sale information are invalid.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>5</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_INVALID_PRICE</key>
+         <map>
+            <key>tooltip</key>
+            <string>The price set for the parcel is invalid (e.g., less than or equal to 0).</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>4</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_IN_ESCROW</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parcel is currently in escrow and cannot be set for sale.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_NO_PARCEL</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parcel could not be found.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_NO_PERMISSIONS</key>
+         <map>
+            <key>tooltip</key>
+            <string>The script does not have the required permissions to set the sale information.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>PARCEL_SALE_OBJECTS</key>
+         <map>
+            <key>tooltip</key>
+            <string>Are the objects on the parcel included in the sale?</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>PARCEL_SALE_OK</key>
+         <map>
+            <key>tooltip</key>
+            <string>The sale information was successfully set.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>0</string>
+         </map>
+         <key>PARCEL_SALE_PRICE</key>
+         <map>
+            <key>tooltip</key>
+            <string>The price of the parcel. If no authorized agent is set, must be greater than 0.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
          <key>PASSIVE</key>
          <map>
             <key>tooltip</key>
@@ -21991,6 +22072,38 @@ If another state is defined before the default state, the compiler will report a
             <real>0</real>
             <key>tooltip</key>
             <string>Sets the specified PermissionFlag permission to the value specified by PermissionMask on the object the script is attached to.</string>
+         </map>
+         <key>llSetParcelForSale</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>ForSale</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>If TRUE, the parcel is put up for sale.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>Options</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>A list of options to set for the sale.</string>
+                     <key>type</key>
+                     <string>list</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>integer</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE the parcel is put up for sale. Options is a list of options to set for the sale, such as price, authorized buyer, and whether to include objects on the parcel.\n Setting ForSale to FALSE will remove the parcel from sale and clear any options that were set.</string>
          </map>
          <key>llSetParcelMusicURL</key>
          <map>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -149,16 +149,28 @@
          <map>
             <key>tooltip</key>
             <string>Lua nil: represents the absence of a useful value.</string>
+            <key>type</key>
+            <string>nil</string>
+            <key>value</key>
+            <string>nil</string>
          </map>
          <key>true</key>
          <map>
             <key>tooltip</key>
             <string>Lua true: Boolean true value.</string>
+            <key>type</key>
+            <string>boolean</string>
+            <key>value</key>
+            <string>true</string>
          </map>
          <key>false</key>
          <map>
             <key>tooltip</key>
             <string>Lua false: Boolean false value.</string>
+            <key>type</key>
+            <string>boolean</string>
+            <key>value</key>
+            <string>false</string>
          </map>
          <!-- Same as for LSL -->
          <key>ACTIVE</key>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -398,7 +398,7 @@
          <key>ATTACH_AVATAR_CENTER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s geometric centre.</string>
+            <string>Attach to the avatar's geometric centre.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -407,7 +407,7 @@
          <key>ATTACH_BACK</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s back.</string>
+            <string>Attach to the avatar's back.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -416,7 +416,7 @@
          <key>ATTACH_BELLY</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s belly.</string>
+            <string>Attach to the avatar's belly.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -425,7 +425,7 @@
          <key>ATTACH_CHEST</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s chest.</string>
+            <string>Attach to the avatar's chest.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -434,7 +434,7 @@
          <key>ATTACH_CHIN</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s chin.</string>
+            <string>Attach to the avatar's chin.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -443,7 +443,7 @@
          <key>ATTACH_FACE_JAW</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s jaw.</string>
+            <string>Attach to the avatar's jaw.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -452,7 +452,7 @@
          <key>ATTACH_FACE_LEAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ear (extended).</string>
+            <string>Attach to the avatar's left ear (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -461,7 +461,7 @@
          <key>ATTACH_FACE_LEYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left eye (extended).</string>
+            <string>Attach to the avatar's left eye (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -470,7 +470,7 @@
          <key>ATTACH_FACE_REAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ear (extended).</string>
+            <string>Attach to the avatar's right ear (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -479,7 +479,7 @@
          <key>ATTACH_FACE_REYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right eye (extended).</string>
+            <string>Attach to the avatar's right eye (extended).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -488,7 +488,7 @@
          <key>ATTACH_FACE_TONGUE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tongue.</string>
+            <string>Attach to the avatar's tongue.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -497,7 +497,7 @@
          <key>ATTACH_GROIN</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s groin.</string>
+            <string>Attach to the avatar's groin.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -506,7 +506,7 @@
          <key>ATTACH_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s head.</string>
+            <string>Attach to the avatar's head.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -515,7 +515,7 @@
          <key>ATTACH_HIND_LFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hind foot.</string>
+            <string>Attach to the avatar's left hind foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -524,7 +524,7 @@
          <key>ATTACH_HIND_RFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hind foot.</string>
+            <string>Attach to the avatar's right hind foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -605,7 +605,7 @@
          <key>ATTACH_LEAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ear.</string>
+            <string>Attach to the avatar's left ear.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -614,7 +614,7 @@
          <key>ATTACH_LEFT_PEC</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left pectoral.</string>
+            <string>Attach to the avatar's left pectoral.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -623,7 +623,7 @@
          <key>ATTACH_LEYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left eye.</string>
+            <string>Attach to the avatar's left eye.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -632,7 +632,7 @@
          <key>ATTACH_LFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left foot.</string>
+            <string>Attach to the avatar's left foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -641,7 +641,7 @@
          <key>ATTACH_LHAND</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hand.</string>
+            <string>Attach to the avatar's left hand.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -650,7 +650,7 @@
          <key>ATTACH_LHAND_RING1</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left ring finger.</string>
+            <string>Attach to the avatar's left ring finger.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -659,7 +659,7 @@
          <key>ATTACH_LHIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left hip.</string>
+            <string>Attach to the avatar's left hip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -668,7 +668,7 @@
          <key>ATTACH_LLARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left lower arm.</string>
+            <string>Attach to the avatar's left lower arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -677,7 +677,7 @@
          <key>ATTACH_LLLEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s lower left leg.</string>
+            <string>Attach to the avatar's lower left leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -688,7 +688,7 @@
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
+            <string>Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -697,7 +697,7 @@
          <key>ATTACH_LSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left shoulder.</string>
+            <string>Attach to the avatar's left shoulder.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -706,7 +706,7 @@
          <key>ATTACH_LUARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left upper arm.</string>
+            <string>Attach to the avatar's left upper arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -715,7 +715,7 @@
          <key>ATTACH_LULEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s lower upper leg.</string>
+            <string>Attach to the avatar's lower upper leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -724,7 +724,7 @@
          <key>ATTACH_LWING</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left wing.</string>
+            <string>Attach to the avatar's left wing.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -733,7 +733,7 @@
          <key>ATTACH_MOUTH</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s mouth.</string>
+            <string>Attach to the avatar's mouth.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -742,7 +742,7 @@
          <key>ATTACH_NECK</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s neck.</string>
+            <string>Attach to the avatar's neck.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -751,7 +751,7 @@
          <key>ATTACH_NOSE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s nose.</string>
+            <string>Attach to the avatar's nose.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -760,7 +760,7 @@
          <key>ATTACH_PELVIS</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s pelvis.</string>
+            <string>Attach to the avatar's pelvis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -769,7 +769,7 @@
          <key>ATTACH_REAR</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ear.</string>
+            <string>Attach to the avatar's right ear.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -778,7 +778,7 @@
          <key>ATTACH_REYE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right eye.</string>
+            <string>Attach to the avatar's right eye.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -787,7 +787,7 @@
          <key>ATTACH_RFOOT</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right foot.</string>
+            <string>Attach to the avatar's right foot.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -796,7 +796,7 @@
          <key>ATTACH_RHAND</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hand.</string>
+            <string>Attach to the avatar's right hand.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -805,7 +805,7 @@
          <key>ATTACH_RHAND_RING1</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right ring finger.</string>
+            <string>Attach to the avatar's right ring finger.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -814,7 +814,7 @@
          <key>ATTACH_RHIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right hip.</string>
+            <string>Attach to the avatar's right hip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -823,7 +823,7 @@
          <key>ATTACH_RIGHT_PEC</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right pectoral.</string>
+            <string>Attach to the avatar's right pectoral.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -832,7 +832,7 @@
          <key>ATTACH_RLARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right lower arm.</string>
+            <string>Attach to the avatar's right lower arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -841,7 +841,7 @@
          <key>ATTACH_RLLEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right lower leg.</string>
+            <string>Attach to the avatar's right lower leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -852,7 +852,7 @@
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
+            <string>Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -861,7 +861,7 @@
          <key>ATTACH_RSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right shoulder.</string>
+            <string>Attach to the avatar's right shoulder.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -870,7 +870,7 @@
          <key>ATTACH_RUARM</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right upper arm.</string>
+            <string>Attach to the avatar's right upper arm.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -879,7 +879,7 @@
          <key>ATTACH_RULEG</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right upper leg.</string>
+            <string>Attach to the avatar's right upper leg.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -888,7 +888,7 @@
          <key>ATTACH_RWING</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s right wing.</string>
+            <string>Attach to the avatar's right wing.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -897,7 +897,7 @@
          <key>ATTACH_TAIL_BASE</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tail base.</string>
+            <string>Attach to the avatar's tail base.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -906,7 +906,7 @@
          <key>ATTACH_TAIL_TIP</key>
          <map>
             <key>tooltip</key>
-            <string>Attach to the avatar&apos;s tail tip.</string>
+            <string>Attach to the avatar's tail tip.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -942,7 +942,7 @@
          <key>BEACON_MAP</key>
          <map>
             <key>tooltip</key>
-            <string>Cause llMapBeacon to optionally display and focus the world map on the avatar&apos;s viewer.</string>
+            <string>Cause llMapBeacon to optionally display and focus the world map on the avatar's viewer.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1122,7 +1122,7 @@
          <key>CHANGED_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The object has changed ownership.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1131,7 +1131,7 @@
          <key>CHANGED_REGION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The object has changed region.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1140,7 +1140,7 @@
          <key>CHANGED_REGION_START</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The region this object is in has just come online.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1176,7 +1176,7 @@
          <key>CHANGED_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>The avatar to whom this object is attached has teleported.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1248,7 +1248,7 @@
          <key>CHARACTER_DESIRED_TURN_SPEED</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum speed while turning about the Z axis. - Note that this is only loosely enforced.</string>
+            <string>The character's maximum speed while turning about the Z axis. - Note that this is only loosely enforced.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1266,7 +1266,7 @@
          <key>CHARACTER_MAX_ACCEL</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum acceleration rate.</string>
+            <string>The character's maximum acceleration rate.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1275,7 +1275,7 @@
          <key>CHARACTER_MAX_DECEL</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum deceleration rate.</string>
+            <string>The character's maximum deceleration rate.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1284,7 +1284,7 @@
          <key>CHARACTER_MAX_SPEED</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s maximum speed.</string>
+            <string>The character's maximum speed.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1293,7 +1293,7 @@
          <key>CHARACTER_MAX_TURN_RADIUS</key>
          <map>
             <key>tooltip</key>
-            <string>The character&apos;s turn radius when travelling at CHARACTER_MAX_TURN_SPEED.</string>
+            <string>The character's turn radius when travelling at CHARACTER_MAX_TURN_SPEED.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1491,7 +1491,7 @@
          <key>COMBAT_LOG_ID</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>Messages from the region to the COMBAT_CHANNEL will all be from this ID.\n Scripts may filter llListen calls on this ID to receive only system generated combat log messages.</string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -1500,7 +1500,7 @@
          <key>CONTENT_TYPE_ATOM</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/atom+xml&quot;</string>
+            <string>"application/atom+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1509,7 +1509,7 @@
          <key>CONTENT_TYPE_FORM</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/x-www-form-urlencoded&quot;</string>
+            <string>"application/x-www-form-urlencoded"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1518,7 +1518,7 @@
          <key>CONTENT_TYPE_HTML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;text/html&quot;, only valid for embedded browsers on content owned by the person viewing. Falls back to &quot;text/plain&quot; otherwise.</string>
+            <string>"text/html", only valid for embedded browsers on content owned by the person viewing. Falls back to "text/plain" otherwise.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1527,7 +1527,7 @@
          <key>CONTENT_TYPE_JSON</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/json&quot;</string>
+            <string>"application/json"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1536,7 +1536,7 @@
          <key>CONTENT_TYPE_LLSD</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/llsd+xml&quot;</string>
+            <string>"application/llsd+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1545,7 +1545,7 @@
          <key>CONTENT_TYPE_RSS</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/rss+xml&quot;</string>
+            <string>"application/rss+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1554,7 +1554,7 @@
          <key>CONTENT_TYPE_TEXT</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;text/plain&quot;</string>
+            <string>"text/plain"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1563,7 +1563,7 @@
          <key>CONTENT_TYPE_XHTML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/xhtml+xml&quot;</string>
+            <string>"application/xhtml+xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1572,7 +1572,7 @@
          <key>CONTENT_TYPE_XML</key>
          <map>
             <key>tooltip</key>
-            <string>&quot;application/xml&quot;</string>
+            <string>"application/xml"</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1752,7 +1752,7 @@
          <key>DAMAGE_TYPE_IMPACT</key>
          <map>
             <key>tooltip</key>
-            <string>System damage generated by imapact with land or a prim.</string>
+            <string>System damage generated by impact with land or a prim.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1860,15 +1860,13 @@
          <key>DATA_RATING</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Returns the agent ratings as a comma separated string of six integers. They are:
-               1) Positive rated behaviour
-               2) Negative rated behaviour
-               3) Positive rated appearance
-               4) Negative rated appearance
-               5) Positive rated building
-               6) Negative rated building
-            </string>
+            <string>Returns the agent ratings as a comma separated string of six integers. They are:
+			1) Positive rated behaviour
+			2) Negative rated behaviour
+			3) Positive rated appearance
+			4) Negative rated appearance
+			5) Positive rated building
+			6) Negative rated building</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1913,10 +1911,8 @@
          <key>DEG_TO_RAD</key>
          <map>
             <key>tooltip</key>
-            <string>
-               0.017453293 - Number of radians per degree.
-               You can use this to convert degrees to radians by multiplying the degrees by this number.
-            </string>
+            <string>0.017453293 - Number of radians per degree.
+			You can use this to convert degrees to radians by multiplying the degrees by this number.</string>
             <key>type</key>
             <string>float</string>
             <key>value</key>
@@ -1948,6 +1944,15 @@
             <string>integer</string>
             <key>value</key>
             <string>1</string>
+         </map>
+         <key>DEREZ_TO_INVENTORY</key>
+         <map>
+            <key>tooltip</key>
+            <string>The object is returned to the inventory of the rezzer.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
          </map>
          <key>ENVIRONMENT_DAYINFO</key>
          <map>
@@ -2096,7 +2101,7 @@
          <key>ESTATE_ACCESS_ALLOWED_AGENT_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the agent to this estate&apos;s Allowed Residents list.</string>
+            <string>Add the agent to this estate's Allowed Residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2105,7 +2110,7 @@
          <key>ESTATE_ACCESS_ALLOWED_AGENT_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the agent from this estate&apos;s Allowed Residents list.</string>
+            <string>Remove the agent from this estate's Allowed Residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2114,7 +2119,7 @@
          <key>ESTATE_ACCESS_ALLOWED_GROUP_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the group to this estate&apos;s Allowed groups list.</string>
+            <string>Add the group to this estate's Allowed groups list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2123,7 +2128,7 @@
          <key>ESTATE_ACCESS_ALLOWED_GROUP_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the group from this estate&apos;s Allowed groups list.</string>
+            <string>Remove the group from this estate's Allowed groups list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2132,7 +2137,7 @@
          <key>ESTATE_ACCESS_BANNED_AGENT_ADD</key>
          <map>
             <key>tooltip</key>
-            <string>Add the agent to this estate&apos;s Banned residents list.</string>
+            <string>Add the agent to this estate's Banned residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2141,7 +2146,7 @@
          <key>ESTATE_ACCESS_BANNED_AGENT_REMOVE</key>
          <map>
             <key>tooltip</key>
-            <string>Remove the agent from this estate&apos;s Banned residents list.</string>
+            <string>Remove the agent from this estate's Banned residents list.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2474,10 +2479,8 @@
          <key>HTTP_ACCEPT</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Provide a string value to be included in the HTTP
-               accepts header value. This replaces the default Second Life HTTP accepts header.
-            </string>
+            <string>Provide a string value to be included in the HTTP
+            accepts header value. This replaces the default Second Life HTTP accepts header.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2504,7 +2507,7 @@
          <key>HTTP_CUSTOM_HEADER</key>
          <map>
             <key>tooltip</key>
-            <string>Add an extra custom HTTP header to the request. The first string is the name of the parameter to change, e.g. &quot;Pragma&quot;, and the second string is the value, e.g. &quot;no-cache&quot;. Up to 8 custom headers may be configured per request. Note that certain headers, such as the default headers, are blocked for security reasons.</string>
+            <string>Add an extra custom HTTP header to the request. The first string is the name of the parameter to change, e.g. "Pragma", and the second string is the value, e.g. "no-cache". Up to 8 custom headers may be configured per request. Note that certain headers, such as the default headers, are blocked for security reasons.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2540,7 +2543,7 @@
          <key>HTTP_PRAGMA_NO_CACHE</key>
          <map>
             <key>tooltip</key>
-            <string>Allows enabling/disbling of the &quot;Pragma: no-cache&quot; header.\nUsage: [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the &quot;Pragma: no-cache&quot; header is sent by the script. This matches the default behavior. When SendHeader is FALSE, no &quot;Pragma&quot; header is sent by the script.</string>
+            <string>Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage: [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the "Pragma: no-cache" header is sent by the script. This matches the default behavior. When SendHeader is FALSE, no "Pragma" header is sent by the script.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2549,10 +2552,8 @@
          <key>HTTP_USER_AGENT</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Provide a string value to be included in the HTTP
-               User-Agent header value. This is appended to the default value.
-            </string>
+            <string>Provide a string value to be included in the HTTP
+            User-Agent header value. This is appended to the default value.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3434,7 +3435,7 @@
          <key>OBJECT_BODY_SHAPE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>This is a flag used with llGetObjectDetails to get the body type of the avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis is normally between 0 and 1.0, with 0.5 and larger considered &apos;male&apos;</string>
+            <string>This is a flag used with llGetObjectDetails to get the body type of the avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis is normally between 0 and 1.0, with 0.5 and larger considered 'male'</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3470,7 +3471,7 @@
          <key>OBJECT_CREATOR</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s creator key. If id is an avatar, a NULL_KEY is returned.</string>
+            <string>Gets the object's creator key. If id is an avatar, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3497,7 +3498,7 @@
          <key>OBJECT_DESC</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s description. If id is an avatar, an empty string is returned.</string>
+            <string>Gets the object's description. If id is an avatar, an empty string is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3506,7 +3507,7 @@
          <key>OBJECT_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the prims&apos;s group key. If id is an avatar, a NULL_KEY is returned.</string>
+            <string>Gets the prims's group key. If id is an avatar, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3515,7 +3516,7 @@
          <key>OBJECT_GROUP_TAG</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the agent&apos;s current group role tag. If id is an object, an empty is returned.</string>
+            <string>Gets the agent's current group role tag. If id is an object, an empty is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3542,7 +3543,7 @@
          <key>OBJECT_LAST_OWNER_ID</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s last owner ID.</string>
+            <string>Gets the object's last owner ID.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3551,7 +3552,7 @@
          <key>OBJECT_LINK_NUMBER</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s link number or 0 if unlinked.</string>
+            <string>Gets the object's link number or 0 if unlinked.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3560,7 +3561,7 @@
          <key>OBJECT_MASS</key>
          <map>
             <key>tooltip</key>
-            <string>Get the object&apos;s mass</string>
+            <string>Get the object's mass</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3569,7 +3570,7 @@
          <key>OBJECT_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string>Get an object&apos;s material setting.</string>
+            <string>Get an object's material setting.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3578,7 +3579,7 @@
          <key>OBJECT_NAME</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s name.</string>
+            <string>Gets the object's name.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3587,7 +3588,7 @@
          <key>OBJECT_OMEGA</key>
          <map>
             <key>tooltip</key>
-            <string>Gets an object&apos;s angular velocity.</string>
+            <string>Gets an object's angular velocity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3596,7 +3597,7 @@
          <key>OBJECT_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string>Gets an object&apos;s owner&apos;s key. If id is group owned, a NULL_KEY is returned.</string>
+            <string>Gets an object's owner's key. If id is group owned, a NULL_KEY is returned.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3623,7 +3624,7 @@
          <key>OBJECT_PERMS_COMBINED</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s permissions including any inventory.</string>
+            <string>Gets the object's permissions including any inventory.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3659,7 +3660,7 @@
          <key>OBJECT_POS</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s position in region coordinates.</string>
+            <string>Gets the object's position in region coordinates.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3740,7 +3741,7 @@
          <key>OBJECT_ROOT</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the id of the root prim of the object requested.\nIf id is an avatar, return the id of the root prim of the linkset the avatar is sitting on (or the avatar&apos;s own id if the avatar is not sitting on an object within the region).</string>
+            <string>Gets the id of the root prim of the object requested.\nIf id is an avatar, return the id of the root prim of the linkset the avatar is sitting on (or the avatar's own id if the avatar is not sitting on an object within the region).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3749,7 +3750,7 @@
          <key>OBJECT_ROT</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s rotation.</string>
+            <string>Gets the object's rotation.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3767,7 +3768,7 @@
          <key>OBJECT_SCALE</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s size.</string>
+            <string>Gets the object's size.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3902,7 +3903,7 @@
          <key>OBJECT_VELOCITY</key>
          <map>
             <key>tooltip</key>
-            <string>Gets the object&apos;s velocity.</string>
+            <string>Gets the object's velocity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3980,6 +3981,78 @@
             <key>value</key>
             <string>3</string>
          </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA_MASK</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>4</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_ALPHA_MODE</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_COLOR_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
+         <key>OVERRIDE_GLTF_BASE_DOUBLE_SIDED</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>5</string>
+         </map>
+         <key>OVERRIDE_GLTF_EMISSIVE_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>8</string>
+         </map>
+         <key>OVERRIDE_GLTF_METALLIC_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>6</string>
+         </map>
+         <key>OVERRIDE_GLTF_ROUGHNESS_FACTOR</key>
+         <map>
+            <key>tooltip</key>
+            <string />
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>7</string>
+         </map>
          <key>PARCEL_COUNT_GROUP</key>
          <map>
             <key>tooltip</key>
@@ -4037,7 +4110,7 @@
          <key>PARCEL_DETAILS_AREA</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s area, in square meters. (5 chars.).</string>
+            <string>The parcel's area, in square meters. (5 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4064,7 +4137,7 @@
          <key>PARCEL_DETAILS_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel group&apos;s key. (36 chars.).</string>
+            <string>The parcel group's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4073,7 +4146,7 @@
          <key>PARCEL_DETAILS_ID</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s key. (36 chars.).</string>
+            <string>The parcel's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4091,7 +4164,7 @@
          <key>PARCEL_DETAILS_LANDING_POINT</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s landing point, if any.</string>
+            <string>The parcel's landing point, if any.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4109,7 +4182,7 @@
          <key>PARCEL_DETAILS_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel owner&apos;s key. (36 chars.).</string>
+            <string>The parcel owner's key. (36 chars.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4118,7 +4191,7 @@
          <key>PARCEL_DETAILS_PRIM_CAPACITY</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s prim capacity.</string>
+            <string>The parcel's prim capacity.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4145,7 +4218,7 @@
          <key>PARCEL_DETAILS_SEE_AVATARS</key>
          <map>
             <key>tooltip</key>
-            <string>The parcel&apos;s avatar visibility setting. (1 char.).</string>
+            <string>The parcel's avatar visibility setting. (1 char.).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4154,7 +4227,7 @@
          <key>PARCEL_DETAILS_TP_ROUTING</key>
          <map>
             <key>tooltip</key>
-            <string>Parcel&apos;s teleport routing setting.</string>
+            <string>Parcel's teleport routing setting.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4343,7 +4416,7 @@
          <key>PARCEL_MEDIA_COMMAND_LOOP_SET</key>
          <map>
             <key>tooltip</key>
-            <string>Used to get or set the parcel&apos;s media looping variable.</string>
+            <string>Used to get or set the parcel's media looping variable.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4406,7 +4479,7 @@
          <key>PARCEL_MEDIA_COMMAND_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>Use this to get or set the parcel media MIME type (e.g. &quot;text/html&quot;).</string>
+            <string>Use this to get or set the parcel media MIME type (e.g. "text/html").</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4429,6 +4502,87 @@
             <string>integer</string>
             <key>value</key>
             <string>5</string>
+         </map>
+         <key>PARCEL_SALE_AGENT</key>
+         <map>
+            <key>tooltip</key>
+            <string>The agent authorized to purchase the parcel.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_BAD_PARAMS</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parameters provided to set the sale information are invalid.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>5</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_INVALID_PRICE</key>
+         <map>
+            <key>tooltip</key>
+            <string>The price set for the parcel is invalid (e.g., less than or equal to 0).</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>4</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_IN_ESCROW</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parcel is currently in escrow and cannot be set for sale.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_NO_PARCEL</key>
+         <map>
+            <key>tooltip</key>
+            <string>The parcel could not be found.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
+         <key>PARCEL_SALE_ERROR_NO_PERMISSIONS</key>
+         <map>
+            <key>tooltip</key>
+            <string>The script does not have the required permissions to set the sale information.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>2</string>
+         </map>
+         <key>PARCEL_SALE_OBJECTS</key>
+         <map>
+            <key>tooltip</key>
+            <string>Are the objects on the parcel included in the sale?</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>3</string>
+         </map>
+         <key>PARCEL_SALE_OK</key>
+         <map>
+            <key>tooltip</key>
+            <string>The sale information was successfully set.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>0</string>
+         </map>
+         <key>PARCEL_SALE_PRICE</key>
+         <map>
+            <key>tooltip</key>
+            <string>The price of the parcel. If no authorized agent is set, must be greater than 0.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
          </map>
          <key>PASSIVE</key>
          <map>
@@ -4739,7 +4893,7 @@
          <key>PRIM_ALPHA_MODE_BLEND</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as alpha-blended.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as alpha-blended.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4748,7 +4902,7 @@
          <key>PRIM_ALPHA_MODE_EMISSIVE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as an emissivity mask.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as an emissivity mask.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4757,7 +4911,7 @@
          <key>PRIM_ALPHA_MODE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be rendered as fully opaque for alpha values above alpha_cutoff and fully transparent otherwise.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be rendered as fully opaque for alpha values above alpha_cutoff and fully transparent otherwise.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4766,7 +4920,7 @@
          <key>PRIM_ALPHA_MODE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture&apos;s alpha channel should be ignored.</string>
+            <string>Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse texture's alpha channel should be ignored.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4957,7 +5111,7 @@
          <key>PRIM_CLICK_ACTION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_CLICK_ACTION, integer CLICK_ACTION_*]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4975,7 +5129,12 @@
          <key>PRIM_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_COLOR, integer face, vector color, float alpha]
+
+integer face – face number or ALL_SIDES
+vector color – color in RGB &lt;R, G, B&gt; (&lt;0.0, 0.0, 0.0&gt; = black, &lt;1.0, 1.0, 1.0&gt; = white)
+float alpha – from 0.0 (clear) to 1.0 (solid) (0.0 &lt;= alpha &lt;= 1.0)
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4993,7 +5152,7 @@
          <key>PRIM_DESC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[PRIM_DESC, string description]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5002,7 +5161,16 @@
          <key>PRIM_FLEXIBLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float friction, float wind, float tension, vector force ]
+
+integer boolean – TRUE enables, FALSE disables
+integer softness – ranges from 0 to 3
+float gravity – ranges from -10.0 to 10.0
+float friction – ranges from 0.0 to 10.0
+float wind – ranges from 0.0 to 10.0
+float tension – ranges from 0.0 to 10.0
+vector force
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5011,7 +5179,7 @@
          <key>PRIM_FULLBRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_FULLBRIGHT, integer face, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5020,7 +5188,7 @@
          <key>PRIM_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string>PRIM_GLOW is used to get or set the glow status of the face.</string>
+            <string>PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW, integer face, float intensity ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5029,7 +5197,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_BLEND</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;BLEND&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "BLEND".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5038,7 +5206,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;MASK&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "MASK".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5047,7 +5215,7 @@
          <key>PRIM_GLTF_ALPHA_MODE_OPAQUE</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode &quot;OPAQUE&quot;.</string>
+            <string>Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "OPAQUE".</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5056,7 +5224,7 @@
          <key>PRIM_GLTF_BASE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string>Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode, integer alpha_cutoff, boolean double_sided.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.</string>
+            <string>Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode, float alpha_cutoff, boolean double_sided.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5137,7 +5305,10 @@
          <key>PRIM_LINK_TARGET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_LINK_TARGET, integer link_target ]
+
+Used to get or set multiple links with a single PrimParameters call.
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5146,7 +5317,7 @@
          <key>PRIM_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_MATERIAL, integer PRIM_MATERIAL_* ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5227,7 +5398,7 @@
          <key>PRIM_MEDIA_ALT_IMAGE_ENABLE</key>
          <map>
             <key>tooltip</key>
-            <string>Boolean. Gets/Sets the default image state (the image that the user sees before a piece of media is active) for the chosen face. The default image is specified by Second Life&apos;s server for that media type.</string>
+            <string>Boolean. Gets/Sets the default image state (the image that the user sees before a piece of media is active) for the chosen face. The default image is specified by Second Life's server for that media type.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5470,7 +5641,7 @@
          <key>PRIM_NAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_NAME, string name ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5488,7 +5659,12 @@
          <key>PRIM_OMEGA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_OMEGA, vector axis, float spinrate, float gain ]
+
+vector axis – arbitrary axis to rotate the object around
+float spinrate – rate of rotation in radians per second
+float gain – also modulates the final spinrate and disables the rotation behavior if zero
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5497,7 +5673,7 @@
          <key>PRIM_PHANTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PHANTOM, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5506,7 +5682,7 @@
          <key>PRIM_PHYSICS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PHYSICS, integer boolean ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5542,10 +5718,8 @@
          <key>PRIM_PHYSICS_SHAPE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Allows you to set the physics shape type of a prim via lsl. Permitted values are:
-               PRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX
-            </string>
+            <string>Allows you to set the physics shape type of a prim via lsl. Permitted values are:
+			PRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5554,7 +5728,14 @@
          <key>PRIM_POINT_LIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity, float radius, float falloff ]
+
+integer boolean – TRUE enables, FALSE disables
+vector linear_color – linear color in RGB &lt;R, G, B&amp;&gt; (&lt;0.0, 0.0, 0.0&gt; = black, &lt;1.0, 1.0, 1.0&gt; = white)
+float intensity – ranges from 0.0 to 1.0
+float radius – ranges from 0.1 to 20.0
+float falloff – ranges from 0.01 to 2.0
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5563,7 +5744,10 @@
          <key>PRIM_POSITION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POSITION, vector position ]
+
+vector position – position in region or local coordinates depending upon the situation
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5572,7 +5756,10 @@
          <key>PRIM_POS_LOCAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_POS_LOCAL, vector position ]
+
+vector position - position in local coordinates
+</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5581,7 +5768,7 @@
          <key>PRIM_PROJECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5626,7 +5813,7 @@
          <key>PRIM_RENDER_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_RENDER_MATERIAL, integer face, string material ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5635,7 +5822,7 @@
          <key>PRIM_ROTATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_ROT_LOCAL, rotation global_rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5644,7 +5831,7 @@
          <key>PRIM_ROT_LOCAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_ROT_LOCAL, rotation local_rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5788,7 +5975,7 @@
          <key>PRIM_SIT_TARGET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5797,7 +5984,7 @@
          <key>PRIM_SIZE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SIZE, vector size ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5806,7 +5993,7 @@
          <key>PRIM_SLICE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_SLICE, vector slice ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5833,7 +6020,7 @@
          <key>PRIM_TEXGEN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXGEN, integer face, PRIM_TEXGEN_* ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5860,7 +6047,7 @@
          <key>PRIM_TEXT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXT, string text, vector color, float alpha ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5869,7 +6056,7 @@
          <key>PRIM_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string>[ PRIM_TEXTURE, integer face, string texture, vector repeats, vector offsets, float rotation_in_radians ]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6193,7 +6380,7 @@
          <key>PSYS_PART_START_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string>A vector &lt;r.r, g.g, b.b&gt; which determines the starting color of the object.</string>
+            <string>A vector &lt;r, g, b&gt; which determines the starting color of the object.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6319,10 +6506,8 @@
          <key>PSYS_SRC_INNERANGLE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
-               The area specified will NOT have particles in it.
-            </string>
+            <string>Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
+			The area specified will NOT have particles in it.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6349,10 +6534,8 @@
          <key>PSYS_SRC_OUTERANGLE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
-               The area between the outer and inner angle will be filled with particles.
-            </string>
+            <string>Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.
+			The area between the outer and inner angle will be filled with particles.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6361,10 +6544,8 @@
          <key>PSYS_SRC_PATTERN</key>
          <map>
             <key>tooltip</key>
-            <string>
-               The pattern which is used to generate particles.
-               Use one of the following values: PSYS_SRC_PATTERN Values.
-            </string>
+            <string>The pattern which is used to generate particles.
+			Use one of the following values: PSYS_SRC_PATTERN Values.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6463,7 +6644,7 @@
          <key>PURSUIT_INTERCEPT</key>
          <map>
             <key>tooltip</key>
-            <string>Define whether the character attempts to predict the target&apos;s location.</string>
+            <string>Define whether the character attempts to predict the target's location.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6822,6 +7003,8 @@
          </map>
          <key>REMOTE_DATA_CHANNEL</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6831,6 +7014,8 @@
          </map>
          <key>REMOTE_DATA_REPLY</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6840,6 +7025,8 @@
          </map>
          <key>REMOTE_DATA_REQUEST</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6895,7 +7082,7 @@
          <key>REZ_DAMAGE_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string>Set the damage type applied when this object collides.</string>
+            <string>Set the damage type applied when this object collides. [integer damage_type]</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7111,7 +7298,7 @@
          <key>SIM_STAT_AGENT_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;agent&apos; segment of simulation frame.</string>
+            <string>Time spent in 'agent' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7174,7 +7361,7 @@
          <key>SIM_STAT_IMAGE_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;image&apos; segment of simulation frame.</string>
+            <string>Time spent in 'image' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7192,7 +7379,7 @@
          <key>SIM_STAT_NET_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;network&apos; segment of simulation frame.</string>
+            <string>Time spent in 'network' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7201,7 +7388,7 @@
          <key>SIM_STAT_OTHER_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;other&apos; segment of simulation frame.</string>
+            <string>Time spent in 'other' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7228,7 +7415,7 @@
          <key>SIM_STAT_PCT_CHARS_STEPPED</key>
          <map>
             <key>tooltip</key>
-            <string>Returns the % of pathfinding characters skipped each frame, averaged over the last minute.\nThe returned value corresponds to the &quot;Characters Updated&quot; stat in the viewer&apos;s Statistics Bar.</string>
+            <string>Returns the % of pathfinding characters skipped each frame, averaged over the last minute.\nThe returned value corresponds to the "Characters Updated" stat in the viewer's Statistics Bar.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7246,7 +7433,7 @@
          <key>SIM_STAT_PHYSICS_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;physics&apos; segment of simulation frame.</string>
+            <string>Time spent in 'physics' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7291,7 +7478,7 @@
          <key>SIM_STAT_SCRIPT_MS</key>
          <map>
             <key>tooltip</key>
-            <string>Time spent in &apos;script&apos; segment of simulation frame.</string>
+            <string>Time spent in 'script' segment of simulation frame.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7345,7 +7532,7 @@
          <key>SIT_FLAG_NO_COLLIDE</key>
          <map>
             <key>tooltip</key>
-            <string>The seated avatar&apos;s hit box is disabled when seated on this prim.</string>
+            <string>The seated avatar's hit box is disabled when seated on this prim.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7651,7 +7838,7 @@
          <key>SOUND_TRIGGER</key>
          <map>
             <key>tooltip</key>
-            <string>Sound will be triggered at the prim&apos;s location and not attached.</string>
+            <string>Sound will be triggered at the prim's location and not attached.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7669,7 +7856,7 @@
          <key>STATUS_BLOCK_GRAB</key>
          <map>
             <key>tooltip</key>
-            <string>Controls whether the object can be grabbed.\nA grab is the default action when in third person, and is available as the hand tool in build mode. This is useful for physical objects that you don&apos;t want other people to be able to trivially disturb. The default is FALSE</string>
+            <string>Controls whether the object can be grabbed.\nA grab is the default action when in third person, and is available as the hand tool in build mode. This is useful for physical objects that you don't want other people to be able to trivially disturb. The default is FALSE</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7705,7 +7892,7 @@
          <key>STATUS_DIE_AT_EDGE</key>
          <map>
             <key>tooltip</key>
-            <string>Controls whether the object is returned to the owners inventory if it wanders off the edge of the world.\nIt is useful to set this status TRUE for things like bullets or rockets. The default is TRUE</string>
+            <string>Controls whether the object is returned to the owner's inventory if it wanders off the edge of the world.\nIt is useful to set this status TRUE for things like bullets or rockets. The default is TRUE</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7813,16 +8000,14 @@
          <key>STATUS_ROTATE_Z</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Controls/indicates whether the object can physically rotate around
-               the specific axis or not. This flag has no meaning
-               for non-physical objects. Set the value to FALSE
-               if you want to disable rotation around that axis. The
-               default is TRUE for a physical object.
-               A useful example to think about when visualizing
-               the effect is a sit-and-spin device. They spin around the
-               Z axis (up) but not around the X or Y axis.
-            </string>
+            <string>Controls/indicates whether the object can physically rotate around
+			the specific axis or not. This flag has no meaning
+			for non-physical objects. Set the value to FALSE
+			if you want to disable rotation around that axis. The
+			default is TRUE for a physical object.
+			A useful example to think about when visualizing
+			the effect is a sit-and-spin device. They spin around the
+			Z axis (up) but not around the X or Y axis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7831,11 +8016,9 @@
          <key>STATUS_SANDBOX</key>
          <map>
             <key>tooltip</key>
-            <string>
-               Controls/indicates whether the object can cross region boundaries
-               and move more than 20 meters from its creation
-               point. The default if FALSE.
-            </string>
+            <string>Controls/indicates whether the object can cross region boundaries
+			and move more than 20 meters from its creation
+			point. The default if FALSE.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8447,10 +8630,8 @@
          <key>VEHICLE_ANGULAR_FRICTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               A vector of timescales for exponential decay of the vehicles angular velocity about its preferred axes of motion (at, left, up).
-               Range = [0.07, inf) seconds for each element of the vector.
-            </string>
+            <string>A vector of timescales for exponential decay of the vehicle's angular velocity about its preferred axes of motion (at, left, up).
+			Range = [0.07, inf) seconds for each element of the vector.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8468,7 +8649,7 @@
          <key>VEHICLE_ANGULAR_MOTOR_DIRECTION</key>
          <map>
             <key>tooltip</key>
-            <string>The direction and magnitude (in preferred frame) of the vehicles angular motor.The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.</string>
+            <string>The direction and magnitude (in preferred frame) of the vehicle's angular motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8495,7 +8676,7 @@
          <key>VEHICLE_BANKING_MIX</key>
          <map>
             <key>tooltip</key>
-            <string>A slider between static (0.0) and dynamic (1.0) banking. &quot;Static&quot; means the banking scales only with the angle of roll, whereas &quot;dynamic&quot; is a term that also scales with the vehicles linear speed.</string>
+            <string>A slider between static (0.0) and dynamic (1.0) banking. "Static" means the banking scales only with the angle of roll, whereas "dynamic" is a term that also scales with the vehicles linear speed.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8668,7 +8849,7 @@
          <key>VEHICLE_LINEAR_DEFLECTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>The timescale for exponential success of linear deflection deflection. It is another way to specify how much time it takes for the vehicles linear velocity to be redirected to its preferred axis of motion.</string>
+            <string>The timescale for exponential success of linear deflection deflection. It is another way to specify how much time it takes for the vehicle's linear velocity to be redirected to its preferred axis of motion.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8677,10 +8858,8 @@
          <key>VEHICLE_LINEAR_FRICTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>
-               A vector of timescales for exponential decay of the vehicles linear velocity along its preferred axes of motion (at, left, up).
-               Range = [0.07, inf) seconds for each element of the vector.
-            </string>
+            <string>A vector of timescales for exponential decay of the vehicle's linear velocity along its preferred axes of motion (at, left, up).
+			Range = [0.07, inf) seconds for each element of the vector.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8698,10 +8877,8 @@
          <key>VEHICLE_LINEAR_MOTOR_DIRECTION</key>
          <map>
             <key>tooltip</key>
-            <string>
-               The direction and magnitude (in preferred frame) of the vehicles linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.
-               Range of magnitude = [0, 30] meters/second.
-            </string>
+            <string>The direction and magnitude (in preferred frame) of the vehicle's linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.
+			Range of magnitude = [0, 30] meters/second.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8728,7 +8905,7 @@
          <key>VEHICLE_REFERENCE_FRAME</key>
          <map>
             <key>tooltip</key>
-            <string>A rotation of the vehicles preferred axes of motion and orientation (at, left, up) with respect to the vehicles local frame (x, y, z).</string>
+            <string>A rotation of the vehicle's preferred axes of motion and orientation (at, left, up) with respect to the vehicle's local frame (x, y, z).</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8800,7 +8977,7 @@
          <key>VEHICLE_VERTICAL_ATTRACTION_TIMESCALE</key>
          <map>
             <key>tooltip</key>
-            <string>The period of wobble, or timescale for exponential approach, of the vehicle to rotate such that its preferred &quot;up&quot; axis is oriented along the worlds &quot;up&quot; axis.</string>
+            <string>The period of wobble, or timescale for exponential approach, of the vehicle to rotate such that its preferred "up" axis is oriented along the world's "up" axis.</string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -9088,10 +9265,8 @@
          <key>default</key>
          <map>
             <key>tooltip</key>
-            <string>
-               All scripts must have a default state, which is the first state entered when the script starts.
-               If another state is defined before the default state, the compiler will report a syntax error.
-            </string>
+            <string>All scripts must have a default state, which is the first state entered when the script starts.
+If another state is defined before the default state, the compiler will report a syntax error.</string>
          </map>
       </map>
       <key>events</key>
@@ -9129,7 +9304,7 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>This event is triggered when a script comes within a defined angle of a target rotation. The range and rotation, are set by a call to llRotTarget.</string>
+            <string>This event is triggered when a script comes within a defined angle of a target rotation. The range and rotation are set by a call to llRotTarget.</string>
          </map>
          <key>at_target</key>
          <map>
@@ -9215,10 +9390,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised while another object, or avatar, is colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* functions.
-            </string>
+            <string>This event is raised while another object, or avatar, is colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* functions.</string>
          </map>
          <key>collision_end</key>
          <map>
@@ -9235,10 +9408,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when another object, or avatar, stops colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when another object, or avatar, stops colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>collision_start</key>
          <map>
@@ -9255,10 +9426,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when another object, or avatar, starts colliding with the object the script is attached to.
-               The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when another object, or avatar, starts colliding with the object the script is attached to.
+			The number of detected objects is passed to the script. Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>control</key>
          <map>
@@ -9293,10 +9462,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               Once a script has the ability to grab control inputs from the avatar, this event will be used to pass the commands into the script.
-               The levels and edges are bit-fields of control constants.
-            </string>
+            <string>Once a script has the ability to grab control inputs from the avatar, this event will be used to pass the commands into the script.
+			The levels and edges are bit-fields of control constants.</string>
          </map>
          <key>dataserver</key>
          <map>
@@ -9322,10 +9489,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is triggered when the requested data is returned to the script.
-               Data may be requested by the llRequestAgentData, llRequestInventoryData, and llGetNotecardLine function calls, for example.
-            </string>
+            <string>This event is triggered when the requested data is returned to the script.
+			Data may be requested by the llRequestAgentData, llRequestInventoryData, and llGetNotecardLine function calls, for example.</string>
          </map>
          <key>email</key>
          <map>
@@ -9378,10 +9543,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is triggered when an email sent to this script arrives.
-               The number remaining tells how many more emails are known to be still pending.
-            </string>
+            <string>This event is triggered when an email sent to this script arrives.
+			The number remaining tells how many more emails are known to be still pending.</string>
          </map>
          <key>experience_permissions</key>
          <map>
@@ -9729,10 +9892,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised whenever a chat message matching the constraints set in the llListen command is received. The name and ID of the speaker, as well as the message, are passed in as parameters.
-               Channel 0 is the public chat channel that all avatars see as chat text. Channels 1 through 2,147,483,648 are private channels that are not sent to avatars but other scripts can listen on those channels.
-            </string>
+            <string>This event is raised whenever a chat message matching the constraints set in the llListen command is received. The name and ID of the speaker, as well as the message, are passed in as parameters.
+			Channel 0 is the public chat channel that all avatars see as chat text. Channels 1 through 2,147,483,648 are private channels that are not sent to avatars but other scripts can listen on those channels.</string>
          </map>
          <key>money</key>
          <map>
@@ -9877,10 +10038,12 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>This event is called to inform the script of changes within the object&apos;s path-finding status.</string>
+            <string>This event is called to inform the script of changes within the object's path-finding status.</string>
          </map>
          <key>remote_data</key>
          <map>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>arguments</key>
             <array>
                <map>
@@ -9956,10 +10119,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               Scripts need permission from either the owner or the avatar they wish to act on before they may perform certain functions, such as debiting money from their owners account, triggering an animation on an avatar, or capturing control inputs. The llRequestPermissions library function is used to request these permissions and the various permissions integer constants can be supplied.
-               The integer returned to this event handler contains the current set of permissions flags, so if permissions equal 0 then no permissions are set.
-            </string>
+            <string>Scripts need permission from either the owner or the avatar they wish to act on before they may perform certain functions, such as debiting money from their owners account, triggering an animation on an avatar, or capturing control inputs. The llRequestPermissions library function is used to request these permissions and the various permissions integer constants can be supplied.
+			The integer returned to this event handler contains the current set of permissions flags, so if permissions equal 0 then no permissions are set.</string>
          </map>
          <key>sensor</key>
          <map>
@@ -9976,10 +10137,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised whenever objects matching the constraints of the llSensor command are detected.
-               The number of detected objects is passed to the script in the parameter. Information on those objects may be gathered via the llDetected* functions.
-            </string>
+            <string>This event is raised whenever objects matching the constraints of the llSensor command are detected.
+			The number of detected objects is passed to the script in the parameter. Information on those objects may be gathered via the llDetected* functions.</string>
          </map>
          <key>state_entry</key>
          <map>
@@ -10017,11 +10176,9 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised while a user is touching the object the script is attached to.
-               The number of touching objects is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised while a user is touching the object the script is attached to.
+			The number of touching objects is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>touch_end</key>
          <map>
@@ -10038,10 +10195,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when a user stops touching the object the script is attached to. The number of touches is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected* library functions.
-            </string>
+            <string>This event is raised when a user stops touching the object the script is attached to. The number of touches is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected* library functions.</string>
          </map>
          <key>touch_start</key>
          <map>
@@ -10058,10 +10213,8 @@
                </map>
             </array>
             <key>tooltip</key>
-            <string>
-               This event is raised when a user first touches the object the script is attached to. The number of touches is passed to the script in the parameter.
-               Information on those objects may be gathered via the llDetected() library functions.
-            </string>
+            <string>This event is raised when a user first touches the object the script is attached to. The number of touches is passed to the script in the parameter.
+			Information on those objects may be gathered via the llDetected() library functions.</string>
          </map>
          <key>transaction_result</key>
          <map>
@@ -15113,8 +15266,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
-            </string>
+                   Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
+                </string>
          </map>
          <key>ll.AllowInventoryDrop</key>
          <map>
@@ -15357,7 +15510,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If an avatar is sitting on the link&apos;s sit target, return the avatar&apos;s key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link&apos;s prim.</string>
+            <string>If an avatar is sitting on the link's sit target, return the avatar's key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link's prim.</string>
          </map>
          <key>ll.AvatarOnSitTarget</key>
          <map>
@@ -15370,7 +15523,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If an avatar is seated on the sit target, returns the avatar&apos;s key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
+            <string>If an avatar is seated on the sit target, returns the avatar's key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
          </map>
          <key>ll.Axes2Rot</key>
          <map>
@@ -15589,7 +15742,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Casts a ray into the physics world from &apos;start&apos; to &apos;end&apos; and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
+            <string>Casts a ray into the physics world from 'start' to 'end' and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
          </map>
          <key>ll.Ceil</key>
          <map>
@@ -15719,6 +15872,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -15742,6 +15897,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -15749,7 +15906,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the cloud density at the object&apos;s position + Offset.</string>
+            <string>Returns the cloud density at the object's position + Offset.</string>
          </map>
          <key>ll.CollisionFilter</key>
          <map>
@@ -15838,6 +15995,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -15923,7 +16082,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a &quot;character&quot;, from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
+            <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a "character", from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
          </map>
          <key>ll.CreateKeyValue</key>
          <map>
@@ -15956,8 +16115,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
-            </string>
+                   Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
+                </string>
          </map>
          <key>ll.CreateLink</key>
          <map>
@@ -15976,7 +16135,7 @@
                   <key>Parent</key>
                   <map>
                      <key>tooltip</key>
-                     <string>If FALSE, then TargetPrim becomes the root. If TRUE, then the script&apos;s object becomes the root.</string>
+                     <string>If FALSE, then TargetPrim becomes the root. If TRUE, then the script's object becomes the root.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16044,8 +16203,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
-            </string>
+                   Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
+                </string>
          </map>
          <key>ll.DeleteCharacter</key>
          <map>
@@ -16082,8 +16241,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-            </string>
+                   Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                </string>
          </map>
          <key>ll.DeleteSubList</key>
          <map>
@@ -16124,7 +16283,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th. list entry.</string>
+            <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th list entry.</string>
          </map>
          <key>ll.DeleteSubString</key>
          <map>
@@ -16165,7 +16324,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th. character.</string>
+            <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th character.</string>
          </map>
          <key>ll.DerezObject</key>
          <map>
@@ -16371,7 +16530,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the key of detected object&apos;s owner.\nReturns invalid key if Number is not a valid index.</string>
+            <string>Returns the key of detected object's owner.\nReturns invalid key if Number is not a valid index.</string>
          </map>
          <key>ll.DetectedPos</key>
          <map>
@@ -16674,18 +16833,16 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>
-               Shows a dialog box on the avatar&apos;s screen with the message.\n
-               Up to 12 strings in the list form buttons.\n
-               If a button is clicked, the name is chatted on Channel.\nOpens a &quot;notify box&quot; in the given avatars screen displaying the message.\n
-               Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
-               Channels work just like llSay(), so channel 0 can be heard by everyone.\n
-               The chat originates at the object&apos;s position, not the avatar&apos;s position, even though it is said as the avatar (uses avatar&apos;s UUID and Name etc.).\n
-               Examples:\n
-               llDialog(who, &quot;Are you a boy or a girl?&quot;, [ &quot;Boy&quot;, &quot;Girl&quot; ], -4913);\n
-               llDialog(who, &quot;This shows only an OK button.&quot;, [], -192);\n
-               llDialog(who, &quot;This chats so you can &apos;hear&apos; it.&quot;, [&quot;Hooray&quot;], 0);
-            </string>
+            <string>Shows a dialog box on the avatar's screen with the message.\n
+                    Up to 12 strings in the list form buttons.\n
+                    If a button is clicked, the name is chatted on Channel.\nOpens a "notify box" in the given avatars screen displaying the message.\n
+                Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
+                Channels work just like llSay(), so channel 0 can be heard by everyone.\n
+                The chat originates at the object's position, not the avatar's position, even though it is said as the avatar (uses avatar's UUID and Name etc.).\n
+                Examples:\n
+                llDialog(who, "Are you a boy or a girl?", [ "Boy", "Girl" ], -4913);\n
+                llDialog(who, "This shows only an OK button.", [], -192);\n
+                llDialog(who, "This chats so you can 'hear' it.", ["Hooray"], 0);</string>
          </map>
          <key>ll.Die</key>
          <map>
@@ -16849,10 +17006,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
-               This function returns the UTF-8 encoded escape codes for selected characters.
-            </string>
+            <string>Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
+                This function returns the UTF-8 encoded escape codes for selected characters.</string>
          </map>
          <key>ll.Euler2Rot</key>
          <map>
@@ -17003,9 +17158,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Searches the text of a cached notecard for lines containing the given pattern and returns the
-               number of matches found through a dataserver event.
+            <string>Searches the text of a cached notecard for lines containing the given pattern and returns the 
+            number of matches found through a dataserver event.
             </string>
          </map>
          <key>ll.FindNotecardTextSync</key>
@@ -17065,12 +17219,10 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Searches the text of a cached notecard for lines containing the given pattern.
-               Returns a list of line numbers and column where a match is found. If the notecard is not in
-               the cache it returns a list containing a single entry of NAK. If no matches are found an
-               empty list is returned.
-            </string>
+            <string>Searches the text of a cached notecard for lines containing the given pattern. 
+            Returns a list of line numbers and column where a match is found. If the notecard is not in
+            the cache it returns a list containing a single entry of NAK. If no matches are found an
+            empty list is returned.</string>
          </map>
          <key>ll.FleeFrom</key>
          <map>
@@ -17206,7 +17358,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the acceleration of the object relative to the region&apos;s axes.\nGets the acceleration of the object.</string>
+            <string>Returns the acceleration of the object relative to the region's axes.\nGets the acceleration of the object.</string>
          </map>
          <key>ll.GetAgentInfo</key>
          <map>
@@ -17229,10 +17381,8 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Returns an integer bit-field containing the agent information about id.\n
-               Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.
-            </string>
+            <string>Returns an integer bit-field containing the agent information about id.\n
+                    Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.</string>
          </map>
          <key>ll.GetAgentLanguage</key>
          <map>
@@ -17333,7 +17483,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the alpha value of Face.\nReturns the &apos;alpha&apos; of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
+            <string>Returns the alpha value of Face.\nReturns the 'alpha' of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
          </map>
          <key>ll.GetAndResetTime</key>
          <map>
@@ -17428,7 +17578,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the object&apos;s attachment point, or 0 if not attached.</string>
+            <string>Returns the object's attachment point, or 0 if not attached.</string>
          </map>
          <key>ll.GetAttachedList</key>
          <map>
@@ -17571,7 +17721,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the prim&apos;s centre of mass (unless called from the root prim, where it returns the object&apos;s centre of mass).</string>
+            <string>Returns the prim's centre of mass (unless called from the root prim, where it returns the object's centre of mass).</string>
          </map>
          <key>ll.GetClosestNavPoint</key>
          <map>
@@ -17639,7 +17789,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a key for the creator of the prim.\nReturns the key of the object&apos;s original creator. Similar to llGetOwner.</string>
+            <string>Returns a key for the creator of the prim.\nReturns the key of the object's original creator. Similar to llGetOwner.</string>
          </map>
          <key>ll.GetDate</key>
          <map>
@@ -17779,7 +17929,7 @@
                   <key>ExperienceID</key>
                   <map>
                      <key>tooltip</key>
-                     <string>May be NULL_KEY to retrieve the details for the script&apos;s Experience</string>
+                     <string>May be NULL_KEY to retrieve the details for the script's Experience</string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -17793,8 +17943,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
-            </string>
+                   Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
+                </string>
          </map>
          <key>ll.GetExperienceErrorMessage</key>
          <map>
@@ -17818,8 +17968,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
-            </string>
+                   Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
+                </string>
          </map>
          <key>ll.GetForce</key>
          <map>
@@ -17962,7 +18112,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the time at which the item was placed into this prim&apos;s inventory as a timestamp.</string>
+            <string>Returns the time at which the item was placed into this prim's inventory as a timestamp.</string>
          </map>
          <key>ll.GetInventoryCreator</key>
          <map>
@@ -17985,7 +18135,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says &quot;No item named &apos;name&apos;&quot;.</string>
+            <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says "No item named 'name'".</string>
          </map>
          <key>ll.GetInventoryDesc</key>
          <map>
@@ -18008,7 +18158,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says &quot;No item named &apos;name&apos;&quot; to the debug channel and returns an empty string.</string>
+            <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says "No item named 'name'" to the debug channel and returns an empty string.</string>
          </map>
          <key>ll.GetInventoryKey</key>
          <map>
@@ -18086,7 +18236,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim&apos;s inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
+            <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim's inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
          <key>ll.GetInventoryPermMask</key>
          <map>
@@ -18118,7 +18268,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object&apos;s inventory, llGetInventoryPermMask returns FALSE and causes the object to say &quot;No item named &apos;&lt;item&gt;&apos;&quot;, where &quot;&lt;item&gt;&quot; is item.</string>
+            <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object's inventory, llGetInventoryPermMask returns FALSE and causes the object to say "No item named '&lt;item&gt;'", where "&lt;item&gt;" is item.</string>
          </map>
          <key>ll.GetInventoryType</key>
          <map>
@@ -18332,7 +18482,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flags attributes.\n* Face flags require the user to also supply a face index parameter.</string>
+            <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flag's attributes.\n* Face flags require the user to also supply a face index parameter.</string>
          </map>
          <key>ll.GetLinkSitFlags</key>
          <map>
@@ -18449,7 +18599,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the mass of object that the script is attached to.\nReturns the scripted object&apos;s mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it&apos;s attached to, not its own.</string>
+            <string>Returns the mass of object that the script is attached to.\nReturns the scripted object's mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it's attached to, not its own.</string>
          </map>
          <key>ll.GetMassMKS</key>
          <map>
@@ -18514,7 +18664,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon&apos;s direction on the simulator in the parcel.</string>
+            <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon's direction on the simulator in the parcel.</string>
          </map>
          <key>ll.GetMoonRotation</key>
          <map>
@@ -18591,7 +18741,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
+            <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero in LSL, one in Lua.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
          </map>
          <key>ll.GetNotecardLineSync</key>
          <map>
@@ -18623,7 +18773,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns LineNumber from NotecardName. The line index starts at zero.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
+            <string>Returns LineNumber from NotecardName. The line index starts at zero in LSL, one in Lua.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
          </map>
          <key>ll.GetNumberOfNotecardLines</key>
          <map>
@@ -18870,7 +19020,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the object owner&apos;s UUID.\nReturns the key for the owner of the object.</string>
+            <string>Returns the object owner's UUID.\nReturns the key for the owner of the object.</string>
          </map>
          <key>ll.GetOwnerKey</key>
          <map>
@@ -18967,7 +19117,7 @@
                   <key>SimWide</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel&apos;s owner.</string>
+                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19021,7 +19171,7 @@
                   <key>SimWide</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel&apos;s owner.</string>
+                     <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19070,7 +19220,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise &quot;and&quot; operation against the PERMISSION_* constants</string>
+            <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise "and" operation against the PERMISSION_* constants</string>
          </map>
          <key>ll.GetPermissionsKey</key>
          <map>
@@ -19255,7 +19405,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon&apos;s direction on the simulator.</string>
+            <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon's direction on the simulator.</string>
          </map>
          <key>ll.GetRegionMoonRotation</key>
          <map>
@@ -19294,7 +19444,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun&apos;s direction on the simulator.</string>
+            <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun's direction on the simulator.</string>
          </map>
          <key>ll.GetRegionSunRotation</key>
          <map>
@@ -19356,7 +19506,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim&apos;s inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
+            <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim's inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
          <key>ll.GetRootPosition</key>
          <map>
@@ -19395,7 +19545,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the rotation relative to the region&apos;s axes.\nReturns the rotation.</string>
+            <string>Returns the rotation relative to the region's axes.\nReturns the rotation.</string>
          </map>
          <key>ll.GetSPMaxMemory</key>
          <map>
@@ -19493,7 +19643,7 @@
             <key>sleep</key>
             <real>10</real>
             <key>tooltip</key>
-            <string>Returns the host-name of the machine which the script is running on.\nFor example, &quot;sim225.agni.lindenlab.com&quot;.</string>
+            <string>Returns the host-name of the machine which the script is running on.\nFor example, "sim225.agni.lindenlab.com".</string>
          </map>
          <key>ll.GetStartParameter</key>
          <map>
@@ -19519,7 +19669,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns an string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
+            <string>Returns a string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
          </map>
          <key>ll.GetStaticPath</key>
          <map>
@@ -19633,7 +19783,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a sub-string from String, in a range specified by the Start and End indicies (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
+            <string>Returns a sub-string from String, in a range specified by the Start and End indices (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
          <key>ll.GetSunDirection</key>
          <map>
@@ -19646,7 +19796,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun&apos;s direction on the simulator in the parcel.</string>
+            <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun's direction on the simulator in the parcel.</string>
          </map>
          <key>ll.GetSunRotation</key>
          <map>
@@ -19682,7 +19832,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim&apos;s inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
+            <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim's inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
          <key>ll.GetTextureOffset</key>
          <map>
@@ -19910,7 +20060,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator&apos;s time-zone midnight (Pacific Time).</string>
+            <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator's time-zone midnight (Pacific Time).</string>
          </map>
          <key>ll.GiveAgentInventory</key>
          <map>
@@ -20122,7 +20272,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object&apos;s position + Offset.</string>
+            <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object's position + Offset.</string>
          </map>
          <key>ll.GroundContour</key>
          <map>
@@ -20145,7 +20295,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object&apos;s position + Offset.</string>
+            <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
          <key>ll.GroundNormal</key>
          <map>
@@ -20168,7 +20318,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object&apos;s position + Offset.</string>
+            <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
          <key>ll.GroundRepel</key>
          <map>
@@ -20209,11 +20359,9 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>
-               Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
-               The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
-               Do not use with vehicles. Only works in physics-enabled objects.
-            </string>
+            <string>Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
+                    The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
+                    Do not use with vehicles. Only works in physics-enabled objects.</string>
          </map>
          <key>ll.GroundSlope</key>
          <map>
@@ -20503,6 +20651,38 @@
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is a friend of the script owner.</string>
          </map>
+         <key>ll.IsLinkGLTFMaterial</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>link</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Link number to check.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>face</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Side to check for a PBR material. Use ALL_SIDES to check for all.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>integer</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Checks the face for a PBR render material.</string>
+         </map>
          <key>ll.Json2List</key>
          <map>
             <key>arguments</key>
@@ -20666,8 +20846,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
-            </string>
+                   Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
+                </string>
          </map>
          <key>ll.KeysKeyValue</key>
          <map>
@@ -20700,8 +20880,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
-            </string>
+                   Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
+                </string>
          </map>
          <key>ll.Linear2sRGB</key>
          <map>
@@ -20921,7 +21101,7 @@
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Position for the sit target, relative to the prim&apos;s position.</string>
+                     <string>Position for the sit target, relative to the prim's position.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20930,7 +21110,7 @@
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Rotation (relative to the prim&apos;s rotation) for the avatar.</string>
+                     <string>Rotation (relative to the prim's rotation) for the avatar.</string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20943,7 +21123,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim&apos;s position and rotation.</string>
+            <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim's position and rotation.</string>
          </map>
          <key>ll.LinkStopSound</key>
          <map>
@@ -20979,7 +21159,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the number of bytes remaining in the linkset&apos;s datastore.</string>
+            <string>Returns the number of bytes remaining in the linkset's datastore.</string>
          </map>
          <key>ll.LinksetDataCountFound</key>
          <map>
@@ -21015,7 +21195,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the number of keys in the linkset&apos;s datastore.</string>
+            <string>Returns the number of keys in the linkset's datastore.</string>
          </map>
          <key>ll.LinksetDataDelete</key>
          <map>
@@ -21025,7 +21205,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to delete from the linkset&apos;s datastore.</string>
+                     <string>Key to delete from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21038,7 +21218,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Deletes a name:value pair from the linkset&apos;s datastore.</string>
+            <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
          <key>ll.LinksetDataDeleteFound</key>
          <map>
@@ -21080,7 +21260,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to delete from the linkset&apos;s datastore.</string>
+                     <string>Key to delete from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21102,7 +21282,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Deletes a name:value pair from the linkset&apos;s datastore.</string>
+            <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
          <key>ll.LinksetDataFindKeys</key>
          <map>
@@ -21143,7 +21323,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns a list of keys from the linkset&apos;s data store matching the search parameter.</string>
+            <string>Returns a list of keys from the linkset's data store matching the search parameter.</string>
          </map>
          <key>ll.LinksetDataListKeys</key>
          <map>
@@ -21185,7 +21365,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to retrieve from the linkset&apos;s datastore.</string>
+                     <string>Key to retrieve from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21208,7 +21388,7 @@
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Key to retrieve from the linkset&apos;s datastore.</string>
+                     <string>Key to retrieve from the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21243,7 +21423,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Resets the linkset&apos;s data store, erasing all key-value pairs.</string>
+            <string>Resets the linkset's data store, erasing all key-value pairs.</string>
          </map>
          <key>ll.LinksetDataWrite</key>
          <map>
@@ -21262,7 +21442,7 @@
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string>value to store in the linkset&apos;s datastore.</string>
+                     <string>value to store in the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21275,7 +21455,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets a name:value pair in the linkset&apos;s datastore</string>
+            <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
          <key>ll.LinksetDataWriteProtected</key>
          <map>
@@ -21294,7 +21474,7 @@
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string>value to store in the linkset&apos;s datastore.</string>
+                     <string>value to store in the linkset's datastore.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21316,7 +21496,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets a name:value pair in the linkset&apos;s datastore</string>
+            <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
          <key>ll.List2CSV</key>
          <map>
@@ -22388,7 +22568,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a &quot;Sync Master&quot;, causing &quot;Slave&quot; sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
+            <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a "Sync Master", causing "Slave" sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
          </map>
          <key>ll.LoopSoundSlave</key>
          <map>
@@ -22420,7 +22600,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a &quot;Sync Master&quot; present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
+            <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a "Sync Master" present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
          </map>
          <key>ll.MD5String</key>
          <map>
@@ -22818,7 +22998,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Adds or removes agents from the estate&apos;s agent access or ban lists, or groups to the estate&apos;s group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
+            <string>Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
          </map>
          <key>ll.MapBeacon</key>
          <map>
@@ -22900,7 +23080,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Opens world map for avatar who touched is is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
+            <string>Opens world map for avatar who touched it or is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
          </map>
          <key>ll.MessageLinked</key>
          <map>
@@ -23308,7 +23488,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object&apos;s simulator since logging into Second Life, regardless of where they may be in-world.</string>
+            <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object's simulator since logging into Second Life, regardless of where they may be in-world.</string>
          </map>
          <key>ll.ParcelMediaCommandList</key>
          <map>
@@ -23601,7 +23781,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a &quot;Sync Master&quot; present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
+            <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a "Sync Master" present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
          </map>
          <key>ll.Pow</key>
          <map>
@@ -23656,7 +23836,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Causes nearby viewers to preload the Sound from the object&apos;s inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
+            <string>Causes nearby viewers to preload the Sound from the object's inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
          </map>
          <key>ll.Pursue</key>
          <map>
@@ -23762,13 +23942,15 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-            </string>
+                   Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                </string>
          </map>
          <key>ll.RefreshPrimURL</key>
          <map>
             <key>arguments</key>
             <array />
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -24128,7 +24310,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Removes the enabled bits in &apos;flags&apos;.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
+            <string>Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
          </map>
          <key>ll.ReplaceAgentEnvironment</key>
          <map>
@@ -24188,10 +24370,8 @@
                   <key>environment</key>
                   <map>
                      <key>tooltip</key>
-                     <string>
-                        Name of inventory item, or UUID of environment resource to apply.
-                        Use NULL_KEY or empty string to remove environment.
-                     </string>
+                     <string>Name of inventory item, or UUID of environment resource to apply.
+                         Use NULL_KEY or empty string to remove environment.</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24268,7 +24448,7 @@
                   <key>Count</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The max number of replacements to make. Zero Count means &quot;replace all&quot;. Positive Count moves left to right. Negative moves right to left.</string>
+                     <string>The max number of replacements to make. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -24281,7 +24461,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means &quot;replace all&quot;. Positive Count moves left to right. Negative moves right to left.</string>
+            <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
          </map>
          <key>ll.RequestAgentData</key>
          <map>
@@ -24355,7 +24535,7 @@
                   <key>unused</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Not used, should be &quot;&quot;</string>
+                     <string>Not used, should be ""</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24369,8 +24549,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
-            </string>
+                   Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
+                </string>
          </map>
          <key>ll.RequestInventoryData</key>
          <map>
@@ -24393,7 +24573,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form &quot;&lt;float, float, float&gt;&quot; which can be cast to a vector. This position is in region local coordinates.</string>
+            <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form "&lt;float, float, float&gt;" which can be cast to a vector. This position is in region local coordinates.</string>
          </map>
          <key>ll.RequestPermissions</key>
          <map>
@@ -24552,7 +24732,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals &quot;ALL&quot;, then all animation states are reset.</string>
+            <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals "ALL", then all animation states are reset.</string>
          </map>
          <key>ll.ResetLandBanList</key>
          <map>
@@ -24660,7 +24840,7 @@
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Object owner&apos;s UUID.</string>
+                     <string>Object owner's UUID.</string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -24741,7 +24921,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owner&apos;s InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object&apos;s location will be set to Position.\nCreates object&apos;s inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
+            <string>Instantiate owner's InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object's location will be set to Position.\nCreates object's inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
          </map>
          <key>ll.RezObject</key>
          <map>
@@ -24800,7 +24980,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object&apos;s inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
+            <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object's inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
          </map>
          <key>ll.RezObjectWithParams</key>
          <map>
@@ -24816,7 +24996,7 @@
                   </map>
                </map>
                <map>
-                  <key>Parms</key>
+                  <key>Params</key>
                   <map>
                      <key>tooltip</key>
                      <string />
@@ -24832,7 +25012,7 @@
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
-            <string>Instantiate owner&apos;s InventoryItem with the given parameters.</string>
+            <string>Instantiate owner's InventoryItem with the given parameters.</string>
          </map>
          <key>ll.Rot2Angle</key>
          <map>
@@ -25341,7 +25521,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns TRUE if Position is over public land, sandbox land, land that doesn&apos;t allow everyone to edit and build, or land that doesn&apos;t allow outside scripts.\nReturns true if the position is over public land, land that doesn&apos;t allow everyone to edit and build, or land that doesn&apos;t allow outside scripts.</string>
+            <string>Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.</string>
          </map>
          <key>ll.ScriptProfiler</key>
          <map>
@@ -25597,7 +25777,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets an agent&apos;s environmental values to the specified values. Must be used as part of an experience.</string>
+            <string>Sets an agent's environmental values to the specified values. Must be used as part of an experience.</string>
          </map>
          <key>ll.SetAgentRot</key>
          <map>
@@ -25693,7 +25873,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets an object&apos;s angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
+            <string>Sets an object's angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
          </map>
          <key>ll.SetAnimationOverride</key>
          <map>
@@ -25771,7 +25951,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar&apos;s camera will be moved to if the avatar sits on the object.</string>
+            <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar's camera will be moved to if the avatar sits on the object.</string>
          </map>
          <key>ll.SetCameraEyeOffset</key>
          <map>
@@ -26106,7 +26286,7 @@
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string>An item in the prim&apos;s inventory</string>
+                     <string>An item in the prim's inventory</string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26231,7 +26411,7 @@
                   <key>EyeOffset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Offset, relative to the object&apos;s centre and expressed in local coordinates, that the camera looks from.</string>
+                     <string>Offset, relative to the object's centre and expressed in local coordinates, that the camera looks from.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26240,7 +26420,7 @@
                   <key>LookOffset</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Offset, relative to the object&apos;s centre and expressed in local coordinates, that the camera looks toward.</string>
+                     <string>Offset, relative to the object's centre and expressed in local coordinates, that the camera looks toward.</string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26294,7 +26474,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child&apos;s side, specified by LinkNumber.</string>
+            <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child's side, specified by LinkNumber.</string>
          </map>
          <key>ll.SetLinkMedia</key>
          <map>
@@ -26360,6 +26540,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -26367,7 +26549,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>Set primitive parameters for LinkNumber based on Parameters.\nSets the parameters (or properties) of any linked prim in one step.</string>
+            <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
          <key>ll.SetLinkPrimitiveParamsFast</key>
          <map>
@@ -26440,7 +26622,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Materail may be a UUID or name of a material in prim inventory.</string>
+            <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Material may be a UUID or name of a material in prim inventory.</string>
          </map>
          <key>ll.SetLinkSitFlags</key>
          <map>
@@ -26472,7 +26654,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the sit flags set on the specified prim in a linkset.</string>
+            <string>Sets the sit flags for the specified prim in a linkset.</string>
          </map>
          <key>ll.SetLinkTexture</key>
          <map>
@@ -26691,7 +26873,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the prim&apos;s name to Name.</string>
+            <string>Sets the prim's name to Name.</string>
          </map>
          <key>ll.SetObjectPermMask</key>
          <map>
@@ -26727,6 +26909,38 @@
             <key>tooltip</key>
             <string>Sets the specified PermissionFlag permission to the value specified by PermissionMask on the object the script is attached to.</string>
          </map>
+         <key>ll.SetParcelForSale</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>ForSale</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>If TRUE, the parcel is put up for sale.</string>
+                     <key>type</key>
+                     <string>integer</string>
+                  </map>
+               </map>
+               <map>
+                  <key>Options</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>A list of options to set for the sale.</string>
+                     <key>type</key>
+                     <string>list</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>integer</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE the parcel is put up for sale. Options is a list of options to set for the sale, such as price, authorized buyer, and whether to include objects on the parcel.\n Setting ForSale to FALSE will remove the parcel from sale and clear any options that were set.</string>
+         </map>
          <key>ll.SetParcelMusicURL</key>
          <map>
             <key>arguments</key>
@@ -26758,7 +26972,7 @@
                   <key>Price</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The default price shown in the textu input field.</string>
+                     <string>The default price shown in the text input field.</string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -26767,7 +26981,7 @@
                   <key>QuickButtons</key>
                   <map>
                      <key>tooltip</key>
-                     <string>Specifies the 4 payment values shown in the payment dialog&apos;s buttons (or PAY_HIDE).</string>
+                     <string>Specifies the 4 payment values shown in the payment dialog's buttons (or PAY_HIDE).</string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -26780,7 +26994,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the textu input field.  QuickButtons specifies the 4 payment values shown in the payment dialog&apos;s buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
+            <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the text input field.  QuickButtons specifies the 4 payment values shown in the payment dialog's buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
          </map>
          <key>ll.SetPhysicsMaterial</key>
          <map>
@@ -26839,7 +27053,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the selected parameters of the object&apos;s physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
+            <string>Sets the selected parameters of the object's physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
          </map>
          <key>ll.SetPos</key>
          <map>
@@ -26935,6 +27149,8 @@
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>1</boolean>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -26942,7 +27158,7 @@
             <key>sleep</key>
             <real>0.2000000000000000111022302</real>
             <key>tooltip</key>
-            <string>This function changes the many properties (or &quot;parameters&quot;) of a prim in one operation. Parameters is a list of changes.</string>
+            <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
          <key>ll.SetRegionPos</key>
          <map>
@@ -27066,7 +27282,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the prim&apos;s scale (size) to Scale.</string>
+            <string>Sets the prim's scale (size) to Scale.</string>
          </map>
          <key>ll.SetScriptState</key>
          <map>
@@ -27121,7 +27337,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Displays Text rather than &apos;Sit&apos; in the viewer&apos;s context menu.</string>
+            <string>Displays Text rather than 'Sit' in the viewer's context menu.</string>
          </map>
          <key>ll.SetSoundQueueing</key>
          <map>
@@ -27404,7 +27620,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Sets the Torque acting on the script&apos;s object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
+            <string>Sets the Torque acting on the script's object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
          <key>ll.SetTouchText</key>
          <map>
@@ -27601,7 +27817,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If the object is physics-enabled, sets the object&apos;s linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
+            <string>If the object is physics-enabled, sets the object's linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
          </map>
          <key>ll.Shout</key>
          <map>
@@ -27729,7 +27945,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link&apos;s sit target.</string>
+            <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link's sit target.</string>
          </map>
          <key>ll.SitTarget</key>
          <map>
@@ -27907,7 +28123,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>This function plays the specified animation from playing on the avatar who received the script&apos;s most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
+            <string>This function plays the specified animation from playing on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
          <key>ll.StartObjectAnimation</key>
          <map>
@@ -27953,7 +28169,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>This function stops the specified animation on the avatar who received the script&apos;s most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
+            <string>This function stops the specified animation on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
          <key>ll.StopHover</key>
          <map>
@@ -28364,7 +28580,7 @@
             <key>sleep</key>
             <real>20</real>
             <key>tooltip</key>
-            <string>Sends an email with Subject and Message to the owner or creator of an object .</string>
+            <string>Sends an email with Subject and Message to the owner or creator of an object.</string>
          </map>
          <key>ll.TeleportAgent</key>
          <map>
@@ -28414,7 +28630,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Requests a teleport of avatar to a landmark stored in the object&apos;s inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
+            <string>Requests a teleport of avatar to a landmark stored in the object's inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
          <key>ll.TeleportAgentGlobalCoords</key>
          <map>
@@ -28487,7 +28703,7 @@
             <key>sleep</key>
             <real>5</real>
             <key>tooltip</key>
-            <string>Teleport agent over the owner&apos;s land to agent&apos;s home location.</string>
+            <string>Teleport agent over the owner's land to agent's home location.</string>
          </map>
          <key>ll.TextBox</key>
          <map>
@@ -28528,7 +28744,7 @@
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
-            <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the &quot;OK&quot; button is clicked.</string>
+            <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the "OK" button is clicked.</string>
          </map>
          <key>ll.ToLower</key>
          <map>
@@ -28752,7 +28968,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the objects owner, the agent is forced to stand up.</string>
+            <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the object's owner, the agent is forced to stand up.</string>
          </map>
          <key>ll.UnescapeURL</key>
          <map>
@@ -28775,7 +28991,7 @@
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
-            <string>Returns the string that is the URL unescaped, replacing &quot;%20&quot; with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
+            <string>Returns the string that is the URL unescaped, replacing "%20" with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
          </map>
          <key>ll.UpdateCharacter</key>
          <map>
@@ -28849,8 +29065,8 @@
             <real>0</real>
             <key>tooltip</key>
             <string>
-               Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
-            </string>
+                   Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
+                </string>
          </map>
          <key>ll.VecDist</key>
          <map>
@@ -29269,7 +29485,7 @@
             <string>Converts a color from the sRGB to the linear colorspace.</string>
          </map>
       </map>
-      <key>ll.sd-lsl-syntax-version</key>
+      <key>llsd-lsl-syntax-version</key>
       <integer>2</integer><!-- increment only when the file format changes, not just the content -->
    </map>
 </llsd>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -9262,12 +9262,6 @@ vector position - position in local coordinates
             <key>value</key>
             <string>&lt;0.0, 0.0, 0.0&gt;</string>
          </map>
-         <key>default</key>
-         <map>
-            <key>tooltip</key>
-            <string>All scripts must have a default state, which is the first state entered when the script starts.
-If another state is defined before the default state, the compiler will report a syntax error.</string>
-         </map>
       </map>
       <key>events</key>
       <map>
@@ -9281,7 +9275,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9316,7 +9310,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9351,7 +9345,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -9368,7 +9362,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9385,7 +9379,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9403,7 +9397,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9421,7 +9415,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9439,7 +9433,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9448,7 +9442,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9457,7 +9451,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9475,7 +9469,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9538,7 +9532,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9556,7 +9550,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>ID of the agent approving permission for the Experience.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -9573,7 +9567,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>ID of the agent denying permission for the Experience.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9582,7 +9576,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>One of the XP_ERROR_... constants describing the reason why the Experience permissions were denied for the agent.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9599,7 +9593,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The number of damage events queued.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9616,7 +9610,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>UUID of avatar supplying input</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9625,7 +9619,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>32-bit mask of buttons pressed</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9651,7 +9645,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9686,7 +9680,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9695,7 +9689,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9781,7 +9775,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9790,7 +9784,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9808,7 +9802,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>string</string>
                   </map>
                </map>
             </array>
@@ -9825,7 +9819,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9860,7 +9854,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -9878,7 +9872,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9905,7 +9899,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -9914,7 +9908,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -9966,7 +9960,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -9983,7 +9977,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The number of damage events queued.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10007,7 +10001,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10024,7 +10018,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -10052,7 +10046,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -10061,7 +10055,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -10070,7 +10064,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -10088,7 +10082,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -10114,7 +10108,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10132,7 +10126,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10171,7 +10165,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10190,7 +10184,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10208,7 +10202,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -10226,7 +10220,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -10235,7 +10229,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -15089,14 +15083,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>An integer value.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15112,14 +15106,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A floating-point value.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15135,7 +15129,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent UUID to add to ban-list.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -15144,7 +15138,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Period, in hours, to ban the avatar for.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15167,7 +15161,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent UUID to add to pass-list.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -15176,7 +15170,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Period, in hours, to allow the avatar for.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15199,7 +15193,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Damage event index to modify.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -15208,7 +15202,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>New damage amount to apply on this event.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15231,7 +15225,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The volume to set.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15254,14 +15248,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15279,7 +15273,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, If TRUE allows anyone to drop inventory on prim, FALSE revokes.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -15318,7 +15312,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15343,7 +15337,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE, force is treated as a local directional vector instead of region directional vector.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -15375,7 +15369,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE, uses local axis, if FALSE, uses region axis.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -15398,14 +15392,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A floating-point value.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15421,7 +15415,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A floating-point value.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -15430,14 +15424,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A floating-point value.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15453,7 +15447,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15476,7 +15470,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Valid attachment point or ATTACH_* constant.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15499,14 +15493,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15519,7 +15513,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15585,7 +15579,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Angle in radians.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15615,7 +15609,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15667,7 +15661,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15697,7 +15691,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{string}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15754,14 +15748,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15777,7 +15771,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Unicode value to convert into a string.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -15813,7 +15807,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -15822,14 +15816,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15845,14 +15839,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Number of side to clear.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
@@ -15868,7 +15862,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -15902,7 +15896,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -15927,7 +15921,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -15936,7 +15930,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If TRUE, only accept collisions with ObjectName name AND ObjectID (either is optional), otherwise with objects not ObjectName AND ObjectID.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -15968,7 +15962,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16048,14 +16042,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16110,7 +16104,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16128,7 +16122,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Object UUID that is in the same region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -16137,7 +16131,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If FALSE, then TargetPrim becomes the root. If TRUE, then the script's object becomes the root.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -16160,7 +16154,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent or task to receive damage.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -16169,7 +16163,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Damage amount to inflict on this target.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -16178,7 +16172,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Damage type to inflict on this target.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16198,7 +16192,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16236,7 +16230,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16246,6 +16240,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.DeleteSubList</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -16254,7 +16252,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -16263,7 +16261,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -16272,14 +16270,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16304,7 +16302,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -16313,7 +16311,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16336,7 +16334,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The ID of an object in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -16345,14 +16343,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Flags for derez behavior.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16381,7 +16379,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16404,7 +16402,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16427,14 +16425,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16450,14 +16448,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16473,14 +16471,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16496,7 +16494,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16519,14 +16517,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16542,7 +16540,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16565,14 +16563,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16588,7 +16586,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16611,7 +16609,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detection information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16634,14 +16632,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detection information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16657,7 +16655,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detection information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16680,7 +16678,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detected information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16703,7 +16701,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detection information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16726,7 +16724,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of detection information</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16749,14 +16747,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16772,7 +16770,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16795,7 +16793,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -16822,7 +16820,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -16915,7 +16913,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -16931,7 +16929,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17042,7 +17040,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent or object to evade.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -17074,7 +17072,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Command to send.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -17106,14 +17104,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17154,7 +17152,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17190,7 +17188,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The number of matches to skip before returning values.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -17199,7 +17197,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The maximum number of matches to return. If 0 this function will return the first 64 matches found.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -17243,7 +17241,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Distance in meters to flee from the source.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -17275,14 +17273,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17298,7 +17296,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE when an avatar sits on the prim, the avatar will be forced into mouse-look mode.\nFALSE is the default setting and will undo a previously set TRUE or do nothing.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -17321,14 +17319,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17341,7 +17339,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17370,14 +17368,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17394,7 +17392,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17417,7 +17415,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The scope (region, parcel, parcel same owner) to return agents for.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -17449,7 +17447,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17472,14 +17470,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17492,7 +17490,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17508,7 +17506,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17531,7 +17529,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17574,7 +17572,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17590,14 +17588,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar to get attachments</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{uuid}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17613,7 +17611,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>An agent in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -17629,7 +17627,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{uuid}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17645,14 +17643,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{vector}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17665,7 +17663,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17678,7 +17676,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17765,7 +17763,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -17785,7 +17783,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17811,7 +17809,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17824,7 +17822,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17840,7 +17838,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar UUID that is in the same region, or is otherwise known to the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17860,7 +17858,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -17931,7 +17929,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>May be NULL_KEY to retrieve the details for the script's Experience</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -17956,7 +17954,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>An Experience error code to translate.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -17991,7 +17989,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18004,7 +18002,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18017,7 +18015,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18046,7 +18044,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A valid HTTP request key</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -18078,14 +18076,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The ID of an agent or object in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18131,7 +18129,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18177,7 +18175,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18193,7 +18191,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Inventory item type</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -18202,7 +18200,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index number of inventory item.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -18225,14 +18223,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Inventory item type</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18257,14 +18255,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE or MASK_NEXT</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18287,7 +18285,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18300,7 +18298,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18323,7 +18321,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18339,14 +18337,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18362,16 +18360,16 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The prim&apos;s side number</string>
+                     <string>The prim's side number</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -18403,7 +18401,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -18423,7 +18421,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18439,14 +18437,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18462,7 +18460,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -18494,14 +18492,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18526,14 +18524,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18556,7 +18554,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18595,7 +18593,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18608,7 +18606,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18621,7 +18619,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18634,7 +18632,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18647,7 +18645,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18730,14 +18728,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
@@ -18762,7 +18760,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -18792,7 +18790,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
@@ -18805,7 +18803,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18818,7 +18816,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18860,7 +18858,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Prim or avatar UUID that is in the same region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -18892,7 +18890,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>UUID of prim</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -18901,14 +18899,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number to retrieve</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18924,14 +18922,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18960,14 +18958,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Category is one of MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE, or MASK_NEXT</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -18983,14 +18981,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19016,7 +19014,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19032,14 +19030,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19094,7 +19092,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19119,14 +19117,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19164,7 +19162,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A PARCEL_COUNT_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -19173,14 +19171,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean. If FALSE then the return is the maximum prims supported by the parcel. If TRUE then it is the combined number of prims on all parcels in the region owned by the specified parcel's owner.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19216,7 +19214,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19229,7 +19227,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19271,7 +19269,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>face number</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -19323,7 +19321,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19349,7 +19347,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19362,7 +19360,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19375,7 +19373,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19388,7 +19386,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19466,7 +19464,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19479,7 +19477,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19495,7 +19493,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -19554,7 +19552,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19603,7 +19601,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19619,14 +19617,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Statistic type.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19652,7 +19650,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19699,7 +19697,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Radius of the character that the path is for, between 0.125m and 5.0m.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -19731,14 +19729,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A STATUS_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19763,7 +19761,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -19772,7 +19770,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -19821,7 +19819,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -19844,7 +19842,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -19867,14 +19865,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19890,7 +19888,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -19910,7 +19908,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19923,7 +19921,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19962,7 +19960,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19975,7 +19973,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -19991,7 +19989,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -20027,7 +20025,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar UUID in the same region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20056,7 +20054,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20072,7 +20070,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>An agent in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20106,7 +20104,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>3</real>
             <key>tooltip</key>
@@ -20122,7 +20120,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20154,7 +20152,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20195,7 +20193,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20204,14 +20202,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20227,7 +20225,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20268,7 +20266,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20330,7 +20328,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Distance above the ground.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20339,7 +20337,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE then hover above water too.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -20348,7 +20346,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Seconds to critically damp in.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -20462,7 +20460,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20478,7 +20476,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A valid HTTP request key.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20487,7 +20485,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>HTTP Status (200, 400, 404, etc.).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20526,7 +20524,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20551,7 +20549,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20583,7 +20581,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -20615,7 +20613,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -20638,14 +20636,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent ID of another agent in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20661,7 +20659,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number to check.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20670,14 +20668,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Side to check for a PBR material. Use ALL_SIDES to check for all.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20821,7 +20819,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar or rezzed prim UUID.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -20841,7 +20839,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20859,7 +20857,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of the first key to return.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20868,14 +20866,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The number of keys to return.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -20916,7 +20914,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20925,7 +20923,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The volume to set.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -20948,7 +20946,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20980,7 +20978,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -20998,7 +20996,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21007,7 +21005,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21030,7 +21028,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21039,7 +21037,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, sound queuing for the linked prim: TRUE enables, FALSE disables (default).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -21062,7 +21060,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21071,7 +21069,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Maximum distance that sounds can be heard.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21094,7 +21092,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag of the prim.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21135,7 +21133,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21155,7 +21153,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21178,7 +21176,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21191,7 +21189,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21214,7 +21212,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21278,7 +21276,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21303,7 +21301,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>First entry to return. 0 for start of list.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21312,7 +21310,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Number of entries to return. Less than 1 for all keys.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21335,7 +21333,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>First entry to return. 0 for start of list.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21344,7 +21342,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Number of entries to return. Less than 1 for all keys.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21451,7 +21449,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21492,7 +21490,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21540,14 +21538,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21572,14 +21570,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21636,14 +21634,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21651,6 +21649,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.List2List</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -21659,7 +21661,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -21668,7 +21670,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21677,14 +21679,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21692,6 +21694,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.List2ListSlice</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -21700,7 +21706,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -21709,7 +21715,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21718,7 +21724,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21727,7 +21733,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21736,14 +21742,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21751,6 +21757,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.List2ListStrided</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -21759,7 +21769,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -21768,7 +21778,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21777,7 +21787,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -21786,14 +21796,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21818,7 +21828,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21850,7 +21860,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21882,7 +21892,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -21921,7 +21931,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21955,14 +21965,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -21996,7 +22006,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22005,7 +22015,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22014,14 +22024,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22029,6 +22039,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.ListInsertList</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -22037,7 +22051,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22046,7 +22060,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22055,14 +22069,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22070,6 +22084,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.ListRandomize</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -22078,7 +22096,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22087,14 +22105,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22102,6 +22120,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.ListReplaceList</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -22110,7 +22132,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22119,7 +22141,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22128,7 +22150,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22137,14 +22159,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22152,6 +22174,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.ListSort</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -22160,7 +22186,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>List to sort.</string>
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22169,7 +22195,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Stride length.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22178,14 +22204,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean. TRUE = result in ascending order, FALSE = result in descending order.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22193,6 +22219,10 @@ If another state is defined before the default state, the compiler will report a
          </map>
          <key>ll.ListSortStrided</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -22201,7 +22231,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>List to sort.</string>
                      <key>type</key>
-                     <string>list</string>
+                     <string>{T}</string>
                   </map>
                </map>
                <map>
@@ -22210,7 +22240,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Stride length.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22219,7 +22249,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The zero based element within the stride to use as the sort key</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22228,14 +22258,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean. TRUE = result in ascending order, FALSE = result in descending order.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{T}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22251,7 +22281,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>One of LIST_STAT_* values</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22267,7 +22297,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22283,7 +22313,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22301,7 +22331,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -22317,7 +22347,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22333,7 +22363,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22342,7 +22372,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -22365,7 +22395,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22388,7 +22418,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -22429,14 +22459,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22452,14 +22482,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -22484,7 +22514,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22493,7 +22523,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22525,7 +22555,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22557,7 +22587,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22589,7 +22619,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22621,7 +22651,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22644,7 +22674,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22653,7 +22683,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22662,7 +22692,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22671,7 +22701,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22680,7 +22710,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22723,7 +22753,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22732,7 +22762,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22741,7 +22771,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22750,7 +22780,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22759,7 +22789,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22802,7 +22832,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22811,7 +22841,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22820,7 +22850,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22829,7 +22859,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22838,7 +22868,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22847,7 +22877,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22874,7 +22904,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -22899,7 +22929,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22908,7 +22938,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22917,7 +22947,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22926,7 +22956,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22935,7 +22965,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22978,7 +23008,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>One of the ESTATE_ACCESS_ALLOWED_* actions.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -22987,14 +23017,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>UUID of the avatar or group to act upon.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23092,7 +23122,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23101,7 +23131,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23110,7 +23140,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>string</string>
+                     <string>string | uuid</string>
                   </map>
                </map>
                <map>
@@ -23119,7 +23149,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>string | uuid</string>
                   </map>
                </map>
             </array>
@@ -23142,7 +23172,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23165,7 +23195,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23174,7 +23204,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23183,14 +23213,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23206,7 +23236,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH, LAND_NOISE or LAND_REVERT</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23215,7 +23245,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>0, 1, 2 (2m x 2m, 4m x 4m, or 8m x 8m)</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23247,7 +23277,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23277,7 +23307,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23325,7 +23355,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23334,7 +23364,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23343,7 +23373,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23391,7 +23421,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23431,14 +23461,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Index of character to convert to unicode.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23454,14 +23484,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23555,7 +23585,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{string}</string>
                   </map>
                </map>
                <map>
@@ -23564,14 +23594,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{string}</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{string}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23596,7 +23626,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{string}</string>
                   </map>
                </map>
                <map>
@@ -23605,14 +23635,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>list</string>
+                     <string>{string}</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>list</string>
+            <string>{string}</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23651,7 +23681,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE, collisions are passed from children on to parents.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -23674,7 +23704,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE, touches are passed from children on to parents.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -23738,7 +23768,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23770,7 +23800,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -23793,7 +23823,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -23802,14 +23832,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23848,7 +23878,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent or object to pursue.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -23880,7 +23910,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -23907,7 +23937,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -23937,7 +23967,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -23970,7 +24000,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Any integer value except zero.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24002,7 +24032,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar or object to say to.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24011,7 +24041,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Output channel, any integer value.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24043,7 +24073,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -24104,7 +24134,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24113,7 +24143,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24131,7 +24161,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Integer data to send</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24171,7 +24201,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Target prim to attempt copying into.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24189,7 +24219,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Integer set on target prim as a Personal Information Number code.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24198,7 +24228,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If the script should be set running in the target prim.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -24207,7 +24237,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Integer. Parameter passed to the script if set to be running.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24230,7 +24260,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -24253,7 +24283,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -24299,7 +24329,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24322,7 +24352,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24331,7 +24361,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24347,7 +24377,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24382,7 +24412,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Elevation zone of where to apply environment. Use -1 for all.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24391,7 +24421,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Length of day cycle for this parcel or region. -1 to leave unchanged.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -24400,14 +24430,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Offset from GMT for the day cycle on this parcel or region. -1 to leave unchanged.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24450,7 +24480,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The max number of replacements to make. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24473,7 +24503,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24482,14 +24512,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
@@ -24505,14 +24535,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Avatar UUID</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24528,7 +24558,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24569,7 +24599,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
@@ -24585,7 +24615,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24594,7 +24624,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24614,7 +24644,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24639,14 +24669,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
@@ -24659,7 +24689,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24682,7 +24712,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24698,14 +24728,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24826,7 +24856,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24842,7 +24872,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Object owner's UUID.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -24851,14 +24881,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -24910,7 +24940,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -24969,7 +24999,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25008,7 +25038,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>200</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0.1000000000000000055511151</real>
             <key>tooltip</key>
@@ -25031,7 +25061,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25203,7 +25233,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25212,7 +25242,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25244,14 +25274,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25267,7 +25297,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25290,7 +25320,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25299,7 +25329,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25322,14 +25352,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25391,14 +25421,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25414,7 +25444,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Channel to use to say text on.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25446,14 +25476,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The multiplier to be used with the prim sizes and their local positions.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25469,7 +25499,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25478,7 +25508,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25487,7 +25517,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25517,7 +25547,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25533,7 +25563,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>PROFILE_NONE or PROFILE_SCRIPT_MEMORY flags to control the state.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25556,7 +25586,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -25574,7 +25604,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25592,7 +25622,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>3</real>
             <key>tooltip</key>
@@ -25617,7 +25647,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Object or avatar UUID.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -25626,7 +25656,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Bit-field mask of AGENT, AGENT_BY_LEGACY_NAME, AGENT_BY_USERNAME, ACTIVE, PASSIVE, and/or SCRIPTED</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25635,7 +25665,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Distance to scan. 0.0 - 96.0m.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25644,7 +25674,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Angle, in radians, from the local x-axis of the prim to scan.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25689,7 +25719,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Object or avatar UUID.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -25698,7 +25728,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Bit-field mask of AGENT, AGENT_BY_LEGACY_NAME, AGENT_BY_USERNAME, ACTIVE, PASSIVE, and/or SCRIPTED</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25707,7 +25737,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Distance to scan. 0.0 - 96.0m.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25716,7 +25746,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Angle, in radians, from the local x-axis of the prim to scan.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25725,7 +25755,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Period, in seconds, between scans.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25748,7 +25778,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Agent to receive new environment settings.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -25757,7 +25787,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Number of seconds over which to apply new settings.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25773,7 +25803,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -25798,7 +25828,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>flags</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25821,7 +25851,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -25830,7 +25860,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -25862,7 +25892,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If TRUE, the AngVel is treated as a local directional vector instead of a regional directional vector.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -25917,7 +25947,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26009,7 +26039,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A CLICK_ACTION_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26041,7 +26071,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26064,7 +26094,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A valid http_request() key</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -26073,7 +26103,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Media type to use with any following llHTTPResponse(HTTPRequestID, ...)</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26096,7 +26126,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26135,7 +26165,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -26160,7 +26190,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE uses local axis, if FALSE uses region axis.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -26201,7 +26231,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE uses local axis, if FALSE uses region axis.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -26231,7 +26261,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -26247,7 +26277,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Distance above the ground.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26256,7 +26286,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE then hover above water too.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -26265,7 +26295,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Seconds to critically damp in.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26297,7 +26327,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>MASK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26306,7 +26336,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Permission bit-field (PERM_* flags)</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26363,7 +26393,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26372,7 +26402,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26381,7 +26411,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26404,7 +26434,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Prim link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26445,7 +26475,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26463,7 +26493,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Side number or ALL_SIDES.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26476,6 +26506,47 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child's side, specified by LinkNumber.</string>
          </map>
+         <key>ll.SetLinkGLTFOverrides</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>link</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Link number to check.</string>
+                     <key>type</key>
+                     <string>number</string>
+                  </map>
+               </map>
+               <map>
+                  <key>face</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>Side to check for a PBR material. Use ALL_SIDES to check for all.</string>
+                     <key>type</key>
+                     <string>number</string>
+                  </map>
+               </map>
+               <map>
+                  <key>options</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string>List of individual overrides to set.</string>
+                     <key>type</key>
+                     <string>list</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>void</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Sets or changes GLTF Overrides set on the selected faces.</string>
+         </map>
          <key>ll.SetLinkMedia</key>
          <map>
             <key>arguments</key>
@@ -26486,7 +26557,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26495,7 +26566,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Face number.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26511,7 +26582,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -26527,7 +26598,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26561,7 +26632,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26593,7 +26664,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26611,7 +26682,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26634,7 +26705,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26643,7 +26714,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The new set of sit flags to apply to the specified prims in this linkset.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26666,7 +26737,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26684,7 +26755,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26707,7 +26778,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Link number (0: unlinked, 1: root prim, &gt;1: child prims) or a LINK_* flag to effect</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26716,7 +26787,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Bitmask of animation options.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26725,7 +26796,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Specifies which object face to animate or ALL_SIDES.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26734,7 +26805,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Horizontal frames (ignored for ROTATE and SCALE).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26743,7 +26814,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Vertical frames (ignored for ROTATE and SCALE).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26752,7 +26823,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Start position/frame number (or radians for ROTATE).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26761,7 +26832,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Specifies the animation duration, in frames (or radians for ROTATE).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26770,7 +26841,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Specifies the animation playback rate, in frames per second (must be greater than zero).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26816,14 +26887,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The amount to reserve, which must be less than the allowed maximum (currently 64KB) and not already have been exceeded.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -26885,7 +26956,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>MASK_* flag</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -26894,7 +26965,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Permission bit-field (PERM_* flags)</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -26919,7 +26990,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If TRUE, the parcel is put up for sale.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -26935,7 +27006,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -26974,7 +27045,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>The default price shown in the text input field.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27006,7 +27077,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>A bitmask specifying which of the parameters in the other arguments should be applied to the object.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27015,7 +27086,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27024,7 +27095,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27033,7 +27104,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27042,7 +27113,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27088,7 +27159,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Face number</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27104,7 +27175,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>1</real>
             <key>tooltip</key>
@@ -27177,7 +27248,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -27193,7 +27264,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27225,7 +27296,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27303,7 +27374,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -27349,7 +27420,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, sound queuing: TRUE enables, FALSE disables (default).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -27372,7 +27443,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Maximum distance that sounds can be heard.</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27395,7 +27466,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27404,7 +27475,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -27445,7 +27516,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27477,7 +27548,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27500,7 +27571,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Mask of Mode flags.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27509,7 +27580,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Face number or ALL_SIDES.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27518,7 +27589,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Horizontal frames (ignored for ROTATE and SCALE).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27527,7 +27598,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Vertical frames (ignored for ROTATE and SCALE).</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27536,7 +27607,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Start position/frame number (or radians for ROTATE).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27545,7 +27616,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>number of frames to display (or radians for ROTATE).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27554,7 +27625,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Frames per second (must not greater than zero).</string>
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27577,7 +27648,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27609,7 +27680,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, if TRUE uses local axis, if FALSE uses region axis.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -27655,7 +27726,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27678,7 +27749,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27687,7 +27758,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27710,7 +27781,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27742,7 +27813,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27765,7 +27836,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27806,7 +27877,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>If TRUE, the Velocity is treated as a local directional vector instead of a regional directional vector.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -27829,7 +27900,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -27902,14 +27973,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -27925,7 +27996,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -27934,14 +28005,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -27989,7 +28060,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28021,7 +28092,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28030,7 +28101,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -28039,7 +28110,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -28089,14 +28160,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28263,7 +28334,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28311,7 +28382,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>STRING_TRIM_HEAD, STRING_TRIM_TAIL, or STRING_TRIM.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28350,7 +28421,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28366,7 +28437,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -28391,7 +28462,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Bit-field of CONTROL_* flags.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28400,7 +28471,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, determines whether control events are generated.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -28409,7 +28480,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Boolean, determines whether controls are disabled.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -28432,14 +28503,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28464,14 +28535,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28496,7 +28567,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28505,7 +28576,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28528,7 +28599,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28551,7 +28622,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28592,7 +28663,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>UUID of avatar.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -28642,7 +28713,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>UUID of avatar.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -28692,7 +28763,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -28715,7 +28786,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -28733,7 +28804,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28802,7 +28873,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -28811,14 +28882,14 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28834,7 +28905,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>An agent in the region.</string>
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
                <map>
@@ -28843,7 +28914,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>Flags to control type of inventory transfer.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28859,7 +28930,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -28884,7 +28955,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
             </array>
@@ -28916,7 +28987,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>float</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>
@@ -28957,7 +29028,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>key</string>
+                     <string>uuid</string>
                   </map>
                </map>
             </array>
@@ -29044,7 +29115,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
                <map>
@@ -29060,7 +29131,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>key</string>
+            <string>uuid</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -29094,7 +29165,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -29117,7 +29188,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -29190,7 +29261,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>integer</string>
+            <string>boolean</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -29206,7 +29277,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string>TRUE enables, FALSE disables.</string>
                      <key>type</key>
-                     <string>integer</string>
+                     <string>boolean | number</string>
                   </map>
                </map>
             </array>
@@ -29277,7 +29348,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10</real>
             <key>return</key>
-            <string>float</string>
+            <string>number</string>
             <key>sleep</key>
             <real>0</real>
             <key>tooltip</key>
@@ -29293,7 +29364,7 @@ If another state is defined before the default state, the compiler will report a
                      <key>tooltip</key>
                      <string />
                      <key>type</key>
-                     <string>integer</string>
+                     <string>number</string>
                   </map>
                </map>
                <map>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -10260,7 +10260,7 @@ vector position - position in local coordinates
       </map>
       <key>functions</key>
       <map>
-         <!-- Global Lua functions -->
+         <!-- Builtin Luau functions -->
          <key>assert</key>
          <map>
             <key>arguments</key>
@@ -10327,6 +10327,8 @@ vector position - position in local coordinates
          </map>
          <key>gcinfo</key>
          <map>
+            <key>arguments</key>
+            <array />
             <key>energy</key>
             <real>10</real>
             <key>return</key>
@@ -10335,29 +10337,6 @@ vector position - position in local coordinates
             <real>0</real>
             <key>tooltip</key>
             <string>Returns the total heap size in kilobytes.</string>
-         </map>
-         <key>getfenv</key>
-         <map>
-            <key>arguments</key>
-            <array>
-               <map>
-                  <key>target</key>
-                  <map>
-                     <key>tooltip</key>
-                     <string>Optional function or stack index to get the environment table for.</string>
-                     <key>type</key>
-                     <string>(function | number)?</string>
-                  </map>
-               </map>
-            </array>
-            <key>energy</key>
-            <real>10</real>
-            <key>return</key>
-            <string>table</string>
-            <key>sleep</key>
-            <real>0</real>
-            <key>tooltip</key>
-            <string>Returns the environment table for the specified function or stack index.</string>
          </map>
          <key>getmetatable</key>
          <map>
@@ -10596,38 +10575,6 @@ vector position - position in local coordinates
             <real>0</real>
             <key>tooltip</key>
             <string>Returns a subset of arguments or the number of arguments.</string>
-         </map>
-         <key>setfenv</key>
-         <map>
-            <key>arguments</key>
-            <array>
-               <map>
-                  <key>target</key>
-                  <map>
-                     <key>tooltip</key>
-                     <string>The function or stack index to set the environment for.</string>
-                     <key>type</key>
-                     <string>function | number</string>
-                  </map>
-               </map>
-               <map>
-                  <key>env</key>
-                  <map>
-                     <key>tooltip</key>
-                     <string>The environment table to set.</string>
-                     <key>type</key>
-                     <string>table</string>
-                  </map>
-               </map>
-            </array>
-            <key>energy</key>
-            <real>10</real>
-            <key>return</key>
-            <string>void</string>
-            <key>sleep</key>
-            <real>0</real>
-            <key>tooltip</key>
-            <string>Changes the environment table for the specified function or stack index.</string>
          </map>
          <key>setmetatable</key>
          <map>
@@ -10921,6 +10868,122 @@ vector position - position in local coordinates
             <real>0</real>
             <key>tooltip</key>
             <string>Returns values from an array in the specified index range.</string>
+         </map>
+         <!-- Global SLua functions -->
+         <key>dangerouslyexecuterequiredmodule</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>f</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string />
+                     <key>type</key>
+                     <string>(...any) -&gt; ...any</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>...any</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Dangerously executes a required module function</string>
+         </map>
+         <key>toquaternion</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>val</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string />
+                     <key>type</key>
+                     <string>any</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>quaternion?</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Converts a value to a quaternion, returns nil if invalid</string>
+         </map>
+         <key>torotation</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>val</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string />
+                     <key>type</key>
+                     <string>any</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>quaternion?</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Converts a value to a rotation (quaternion), returns nil if invalid</string>
+         </map>
+         <key>touuid</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>val</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string />
+                     <key>type</key>
+                     <string>string | buffer | uuid</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>uuid?</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Converts a string, buffer, or uuid to a uuid, returns nil if invalid</string>
+         </map>
+         <key>tovector</key>
+         <map>
+            <key>arguments</key>
+            <array>
+               <map>
+                  <key>val</key>
+                  <map>
+                     <key>tooltip</key>
+                     <string />
+                     <key>type</key>
+                     <string>any</string>
+                  </map>
+               </map>
+            </array>
+            <key>energy</key>
+            <real>10</real>
+            <key>return</key>
+            <string>vector?</string>
+            <key>sleep</key>
+            <real>0</real>
+            <key>tooltip</key>
+            <string>Converts a value to a vector, returns nil if invalid</string>
          </map>
          <!-- math library-->
          <key>math</key>         


### PR DESCRIPTION
Part of a set of PR's improving the keywords files in lsl and slua:
- https://github.com/secondlife/lsl-definitions/pull/38
- https://github.com/secondlife/viewer/pull/5288
- https://github.com/secondlife/sl-vscode-plugin/pull/57
- https://github.com/secondlife/python-llsd/pull/37

---

These files are 99.9% auto-generated by https://github.com/secondlife/lsl-definitions/pull/38 using these 2 commands:
```
python gen_definitions.py lsl_definitions.yaml syntax keywords_lsl_default.xml
python gen_definitions.py lsl_definitions.yaml slua_syntax slua_definitions.yaml keywords_lua_default.xml --pretty
```
The only difference is I manually re-added the XML comments that were already present

---

Yes, the tooltips look way worse in the xml file, but they look way better in-viewer. Also, they match the sim capability now:
| Before | After |
| --- | --- |
| <img width="319" height="254" alt="image" src="https://github.com/user-attachments/assets/edf9a592-c363-4edd-a7b2-6e381a5ac608" /> | <img width="289" height="210" alt="image" src="https://github.com/user-attachments/assets/3bb329ef-e075-4993-86b8-76366b8a5687" /> |

