### PR TITLE
Provide modern screenshot resolution presets

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
+++ b/indra/newview/skins/default/xui/en/panel_snapshot_inventory.xml
@@ -60,9 +60,21 @@
          name="Large(512x512)"
          value="[i512,i512]" />
         <combo_box.item
+         label="Wide (1024x512)"
+         name="Wide(1024x512)"
+         value="[i1024,i512]" />
+        <combo_box.item
          label="Huge (1024x1024)"
          name="Huge(1024x1024)"
          value="[i1024,i1024]" />
+        <combo_box.item
+         label="Full Wide (2048x1024)"
+         name="Full(2048x1024)"
+         value="[i2048,i1024]" />
+        <combo_box.item
+         label="Full (2048x2048)"
+         name="Full(2048x2048)"
+         value="[i2048,i2048]" />
         <combo_box.item
          label="Current Window"
          name="CurrentWindow"

--- a/indra/newview/skins/default/xui/en/panel_snapshot_local.xml
+++ b/indra/newview/skins/default/xui/en/panel_snapshot_local.xml
@@ -75,6 +75,26 @@
          name="1600x1200"
          value="[i1600,i1200]" />
         <combo_box.item
+         label="1920x1080"
+         name="1920x1080"
+         value="[i1920,i1080]" />
+        <combo_box.item
+         label="2560x1440"
+         name="2560x1440"
+         value="[i2560,i1440]" />
+        <combo_box.item
+         label="3840x2160"
+         name="3840x2160"
+         value="[i3840,i2160]" />
+        <combo_box.item
+         label="5120x2880"
+         name="5120x2880"
+         value="[i5120,i2880]" />
+        <combo_box.item
+         label="7680x4320"
+         name="7680x4320"
+         value="[i7680,i4320]" />
+        <combo_box.item
          label="Custom"
          name="Custom"
          value="[i-1,i-1]" />


### PR DESCRIPTION
## Description
The highest screenshot resolution we have as a preset is 1600x1200, which is a mid 2000s screen resolution. Still useful, but not ideal as the highest preset option we have to offer. We can provide up to 8k, which is the limit of OpenGL to my knowledge.
In addition, with support for 2k textures, we should probably offer the ability to take a snapshot to disk as well.

This provides the following **additional** snapshot resolutions:
**Local snapshot**:
* 1920x1080
* 2560x1440
* 3840x2160
* 5120x2880
* 7680x4320

**Inventory snapshot**:
* Wide (1024x512)
* Full Wide (2048x1024)
* Full (2048x2048)

<img width="204" height="236" alt="image" src="https://github.com/user-attachments/assets/f7398d33-b0e8-4e35-83e2-fc62bf6d8ddd" />
<img width="206" height="181" alt="image" src="https://github.com/user-attachments/assets/675c2363-7ebc-461e-b696-f94076f8d5d6" />


## Related Issues

- [x] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link:
* https://feedback.secondlife.com/feature-requests/p/provide-modern-screenshot-resolution-preset (Merged into below)
* https://feedback.secondlife.com/feature-requests/p/save-custom-snapshot-resolutions

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [x] If useful, I have included media such as screenshots and video to show off my changes.
- [x] The PR is linked to a relevant issue with sufficient context.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

I've included a test case below, because this includes high resolution inventory snapshots, and we don't want to unexpectedly charge Residents L$50 without them being aware.

Because this is purely XUI changes, this can be cherry picked / retargeted if needed.

This can also be modified at request to include resolution names (EG: SD, HD, FHD, etc) alongside the resolutions themselves.

## Test case:

1. Log in
2. Open snapshot floater
3. Choose "Save to Disk"
4. Ensure new snapshot resolutions (Above 1600x1200) save properly
5. Ensure that the saved snapshots are of the correct size
6. Click "Cancel" to go back to snapshot destination picker
7. Choose "Save to Inventory"
8. Ensure new snapshot resolutions (1024x512, 2048x1024, 2048x2048) save to inventory properly
9. Ensure that the saved snapshots are of the correct size
10. Ensure that high resolution inventory snapshots (2048x1024, 2048x2048) have the correct upload cost reflected (Should be L$50)