### PR TITLE
[#3013] Fix hollowed prims not shading correctly and appearing not smooth

### DIFF
--- a/indra/llmath/llvolume.cpp
+++ b/indra/llmath/llvolume.cpp
@@ -912,7 +912,7 @@ bool LLProfile::generate(const LLProfileParams& params, bool path_open,F32 detai
                 case LL_PCODE_HOLE_CIRCLE:
                 case LL_PCODE_HOLE_SAME:
                 default:
-                    addHole(params, true, circle_detail, 0, hollow, 1.f);
+                    addHole(params, false, circle_detail, 0, hollow, 1.f);
                     break;
                 }
             }


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/3013

This is a long standing bug since the release of viewer version 7.1.9. 
The bug was introduced in this commit when a FALSE fake bool was mistakenly changed to a true bool-
https://github.com/secondlife/viewer/commit/c3e6f7b1643076df35a6960f735024078ddbb353

This PR simply just corrects this function call making sure it is passed false instead of true.

<details>
<Summary>Before and After Screenshots-</Summary>
Before:

<img width="835" height="619" alt="Firestorm_2026-01-19_00-42-50" src="https://github.com/user-attachments/assets/4b829a49-dc75-4636-82e3-b5da355a5b60" />

After:

<img width="818" height="603" alt="Firestorm_2026-01-19_01-44-05" src="https://github.com/user-attachments/assets/33e0fb1b-992b-43f2-af0e-6756cb440654" />

</details>