### PR TITLE
p#124 Fix wrong max image size for model upload

### DIFF
--- a/indra/newview/llviewertexture.cpp
+++ b/indra/newview/llviewertexture.cpp
@@ -1488,7 +1488,9 @@ bool LLViewerFetchedTexture::preCreateTexture(S32 usename/*= 0*/)
         // from local images, but this might become unsafe in case of changes to fetcher
         if (mBoostLevel == BOOST_PREVIEW)
         {
-            mRawImage->biasedScaleToPowerOfTwo(1024);
+            // A local file with a preview flag likely means mesh's texture upload
+            // which should follow normal upload scaling rules
+            mRawImage->biasedScaleToPowerOfTwo(LLViewerFetchedTexture::MAX_IMAGE_SIZE_DEFAULT);
         }
         else
         { // leave black border, do not scale image content


### PR DESCRIPTION
A very sneaky scaling was going on, resulting in some images being scaled to 1024 instead of staying at 2048 during model upload.