### PR TITLE
secondlife/viewer#1851 Fix PBR Opaque alpha mask hud shading mismatching in world

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl
@@ -146,6 +146,9 @@ vec3 srgb_to_linear(vec3 c);
 void main()
 {
     vec4 basecolor = texture(diffuseMap, base_color_texcoord.xy).rgba;
+
+    basecolor.a *= vertex_color.a;
+
     if (basecolor.a < minimum_alpha)
     {
         discard;


### PR DESCRIPTION
## Description

Fixes opaque alpha-masked PBR materials mis-matching inworld alpha mask behavior.

## Related Issues

Issue Link: #1851 

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
