### PR TITLE
[#5305] Fix crash in LLConvexDecompositionVHACD::executeStage accessing nullptr

### DIFF
--- a/indra/llphysicsextensionsos/llconvexdecompositionvhacd.cpp
+++ b/indra/llphysicsextensionsos/llconvexdecompositionvhacd.cpp
@@ -340,6 +340,12 @@ LLCDResult LLConvexDecompositionVHACD::executeStage(int stage)
         out_mesh.setVertices(ch.m_points);
         out_mesh.setIndices(ch.m_triangles);
 
+        if (!mBoundDecomp)
+        {
+            mVHACD->Clean();
+            return LLCD_NULL_PTR;
+        }
+
         mBoundDecomp->mDecomposedHulls.push_back(std::move(out_mesh));
     }
 


### PR DESCRIPTION
Issue: https://github.com/secondlife/viewer/issues/5305

Simply fixes the crash issue above by checking if mBoundDecomp has become nullptr, and if so then cleaning the VHACD data since at this point convex hull data has been internally allocated, and then returning not OK.