### PR TITLE
#5304 fix UI inconsistencies related to maturity setting in Legacy Se…

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -1735,6 +1735,22 @@ void LLFloaterPreference::onChangeMaturity()
                                                             || sim_access == SIM_ACCESS_ADULT);
 
     getChild<LLIconCtrl>("rating_icon_adult")->setVisible(sim_access == SIM_ACCESS_ADULT);
+
+    // Update Legacy Search maturity settings
+    bool can_access_mature = gAgent.canAccessMature();
+    bool can_access_adult  = gAgent.canAccessAdult();
+    if (!can_access_mature)
+    {
+        gSavedSettings.setBOOL("ShowMatureSims", false);
+        gSavedSettings.setBOOL("ShowMatureLand", false);
+        gSavedSettings.setBOOL("ShowMatureClassifieds", false);
+    }
+    if (!can_access_adult)
+    {
+        gSavedSettings.setBOOL("ShowAdultSims", false);
+        gSavedSettings.setBOOL("ShowAdultLand", false);
+        gSavedSettings.setBOOL("ShowAdultClassifieds", false);
+    }
 }
 
 void LLFloaterPreference::onChangeComplexityMode(const LLSD& newvalue)

--- a/indra/newview/llpaneldirbrowser.cpp
+++ b/indra/newview/llpaneldirbrowser.cpp
@@ -559,9 +559,6 @@ void LLPanelDirBrowser::processDirEventsReply(LLMessageSystem* msg, void**)
     LLUUID owner_id;
     std::string name;
     std::string date;
-    bool show_pg = gSavedSettings.getBOOL("ShowPGEvents");
-    bool show_mature = gSavedSettings.getBOOL("ShowMatureEvents");
-    bool show_adult = gSavedSettings.getBOOL("ShowAdultEvents");
 
     msg->getUUID("AgentData", "AgentID", agent_id);
     msg->getUUID("QueryData", "QueryID", query_id );
@@ -618,27 +615,6 @@ void LLPanelDirBrowser::processDirEventsReply(LLMessageSystem* msg, void**)
             LL_WARNS() << "skipped event due to owner_id null, event_id " << event_id << LL_ENDL;
             continue;
         }
-
-        // skip events that don't match the flags
-        // there's no PG flag, so we make sure neither adult nor mature is set
-        if (((event_flags & (EVENT_FLAG_ADULT | EVENT_FLAG_MATURE)) == EVENT_FLAG_NONE) && !show_pg)
-        {
-            //llwarns << "Skipped pg event because we're not showing pg, event_id " << event_id << llendl;
-            continue;
-        }
-
-        if ((event_flags & EVENT_FLAG_MATURE) && !show_mature)
-        {
-            //llwarns << "Skipped mature event because we're not showing mature, event_id " << event_id << llendl;
-            continue;
-        }
-
-        if ((event_flags & EVENT_FLAG_ADULT) && !show_adult)
-        {
-            //llwarns << "Skipped adult event because we're not showing adult, event_id " << event_id << llendl;
-            continue;
-        }
-
         LLSD content;
 
         content["type"] = EVENT_CODE;

--- a/indra/newview/llpaneldirevents.cpp
+++ b/indra/newview/llpaneldirevents.cpp
@@ -143,17 +143,16 @@ void LLPanelDirEvents::performQueryOrDelete(U32 event_id)
     static LLUICachedControl<bool> incpg("ShowPGEvents", true);
     static LLUICachedControl<bool> incmature("ShowMatureEvents", false);
     static LLUICachedControl<bool> incadult("ShowAdultEvents", false);
+    if (!(incpg || incmature || incadult))
+    {
+        LLNotificationsUtil::add("NoContentToSearch");
+        return;
+    }
 
     U32 scope = DFQ_DATE_EVENTS;
     if (incpg) scope |= DFQ_INC_PG;
     if (incmature && gAgent.canAccessMature()) scope |= DFQ_INC_MATURE;
     if (incadult && gAgent.canAccessAdult()) scope |= DFQ_INC_ADULT;
-
-    if ( !( scope & (DFQ_INC_PG | DFQ_INC_MATURE | DFQ_INC_ADULT )))
-    {
-        LLNotificationsUtil::add("NoContentToSearch");
-        return;
-    }
 
     setupNewSearch();
 

--- a/indra/newview/llpaneldirland.cpp
+++ b/indra/newview/llpaneldirland.cpp
@@ -62,20 +62,6 @@ bool LLPanelDirLand::postBuild()
 
     childSetValue("type", gSavedSettings.getString("FindLandType"));
 
-    bool adult_enabled = gAgent.canAccessAdult();
-    bool mature_enabled = gAgent.canAccessMature();
-    childSetVisible("incpg", true);
-    if (!mature_enabled)
-    {
-        childSetValue("incmature", false);
-        childDisable("incmature");
-    }
-    if (!adult_enabled)
-    {
-        childSetValue("incadult", false);
-        childDisable("incadult");
-    }
-
     childSetCommitCallback("pricecheck", onCommitPrice, this);
     childSetCommitCallback("areacheck", onCommitArea, this);
 

--- a/indra/newview/llpaneldirplaces.cpp
+++ b/indra/newview/llpaneldirplaces.cpp
@@ -121,6 +121,11 @@ void LLPanelDirPlaces::performQuery()
     static LLUICachedControl<bool> inc_pg("ShowPGSims", true);
     static LLUICachedControl<bool> inc_mature("ShowMatureSims", false);
     static LLUICachedControl<bool> inc_adult("ShowAdultSims", false);
+    if (!(inc_pg || inc_mature || inc_adult))
+    {
+        LLNotificationsUtil::add("NoContentToSearch");
+        return;
+    }
 
     if (inc_pg)
     {
@@ -135,12 +140,6 @@ void LLPanelDirPlaces::performQuery()
     if (inc_adult && adult_enabled)
     {
         flags |= DFQ_INC_ADULT;
-    }
-
-    if (0x0 == flags)
-    {
-        LLNotificationsUtil::add("NoContentToSearch");
-        return;
     }
 
     queryCore(query_string, category, flags);


### PR DESCRIPTION
Land sale tab: Fix disabling checkbox once on opening Search floater
Events and Places tabs: ensure search results are shown when agent cannot access higher maturity content.
Update maturity search checkbox if maturity is changed in Preferences (similar to Events tab).

Retargeted https://github.com/secondlife/viewer/pull/5307