### PR TITLE
#5157 fix crash in isHUDGroup

### DIFF
--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -135,9 +135,9 @@ void LLSpatialGroup::clearDrawMap()
     mDrawMap.clear();
 }
 
-bool LLSpatialGroup::isHUDGroup()
+bool LLSpatialGroup::isHUDGroup() const
 {
-    if (isDead())
+    if (hasState(DEAD))
         return false;
 
     LLSpatialPartition* part = (LLSpatialPartition*)mSpatialPartition;

--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -135,8 +135,11 @@ void LLSpatialGroup::clearDrawMap()
     mDrawMap.clear();
 }
 
-bool LLSpatialGroup::isHUDGroup() const
+bool LLSpatialGroup::isHUDGroup()
 {
+    if (isDead())
+        return false;
+
     LLSpatialPartition* part = (LLSpatialPartition*)mSpatialPartition;
     return part && part->isHUDPartition();
 }

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -264,7 +264,7 @@ public:
 
     LLSpatialGroup(OctreeNode* node, LLSpatialPartition* part);
 
-    bool isHUDGroup();
+    bool isHUDGroup() const;
 
     void clearDrawMap();
     void validate();

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -264,7 +264,7 @@ public:
 
     LLSpatialGroup(OctreeNode* node, LLSpatialPartition* part);
 
-    bool isHUDGroup() const;
+    bool isHUDGroup();
 
     void clearDrawMap();
     void validate();

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -2734,6 +2734,10 @@ void LLPipeline::clearRebuildGroups()
     {
         LLSpatialGroup* group = *iter;
 
+        if (!group || group->isDead())
+        {
+            continue;
+        }
         // If the group contains HUD objects, save the group
         if (group->isHUDGroup())
         {


### PR DESCRIPTION
Crash seems to be happening during teleport (when not all objects were removed from deleted region) - so check spatial groups that have been marked but haven't been fully cleaned up yet.