### PR TITLE
#5086 Restore guidebook to use http

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -3476,7 +3476,7 @@
       <key>Type</key>
       <string>String</string>
       <key>Value</key>
-      <string>https://guidebooks.secondlife.io/welcome/index.html</string>
+      <string>http://guidebooks.secondlife.io/welcome/index.html</string>
     </map>
     <key>HighResSnapshot</key>
     <map>


### PR DESCRIPTION
For some reason guidebook only works through http.