### PR TITLE
#5046 Fix a long freeze when fetching inventory

### DIFF
--- a/indra/llcommon/lleventcoro.cpp
+++ b/indra/llcommon/lleventcoro.cpp
@@ -137,6 +137,18 @@ void llcoro::suspendUntilTimeout(float seconds)
     suspendUntilEventOnWithTimeout(bogus, seconds, timedout);
 }
 
+void llcoro::suspendUntilNextFrame()
+{
+    LLCoros::checkStop();
+    LLCoros::TempStatus st("waiting for next frame");
+
+    // Listen for the next event on the "mainloop" event pump.
+    // Once per frame we get mainloop.post(newFrame);
+    LLEventPumpOrPumpName mainloop_pump("mainloop");
+    // Wait for the next event (the event data is ignored).
+    suspendUntilEventOn(mainloop_pump);
+}
+
 namespace
 {
 

--- a/indra/llcommon/lleventcoro.h
+++ b/indra/llcommon/lleventcoro.h
@@ -85,6 +85,11 @@ void suspend();
 void suspendUntilTimeout(float seconds);
 
 /**
+ * Yield control from a coroutine until the next mainloop's newFrame event.
+ */
+void suspendUntilNextFrame();
+
+/**
  * Post specified LLSD event on the specified LLEventPump, then suspend for a
  * response on specified other LLEventPump. This is more than mere
  * convenience: the difference between this function and the sequence

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1060,7 +1060,12 @@ void AISUpdate::checkTimeout()
 {
     if (mTimer.hasExpired())
     {
-        llcoro::suspend();
+        // If we are taking too long, don't starve other tasks,
+        // yield to mainloop.
+        // If we use normal suspend(), there will be a chance of
+        // waking up from other suspends, before main coro had
+        // a chance, so wait for a frame tick instead.
+        llcoro::suspendUntilNextFrame();
         LLCoros::checkStop();
         mTimer.setTimerExpirySec(AIS_EXPIRY_SECONDS);
     }


### PR DESCRIPTION
Look like there is a feedback loop going on. If two large inventory messages arrive back to back, message A would work foe a short periood then supends, B wakes up, B would work then suspends and A would wake up, loop continues untill work is done 10 secodns later...

P.S. Fix appears to work as intended, but there are odities around this issue that make me think that more might be needed. Sadly corotines do not work with tracy and checking them is a time consuming process, so unless I see a proof of other problems this will have to be enough.