### PR TITLE
Add luau-lsp files to the viewer

### DIFF
--- a/indra/newview/app_settings/slua_default.d.luau
+++ b/indra/newview/app_settings/slua_default.d.luau
@@ -1,0 +1,1962 @@
+
+----------------------------------
+---------- LSL LUAU DEFS ---------
+----------------------------------
+
+declare class quaternion
+  x: number
+  y: number
+  z: number
+  s: number
+  function __add(self, other: quaternion): quaternion
+  function __sub(self, other: quaternion): quaternion
+  function __mul(self, other: quaternion): quaternion
+  function __div(self, other: quaternion): quaternion
+  function __unm(self): quaternion
+  function __eq(self, other: quaternion): boolean
+  function __tostring(self): string
+end
+
+declare class uuid
+  istruthy: boolean
+  bytes: string?
+  function __tostring(self): string
+end
+
+declare class vector
+  x: number
+  y: number
+  z: number
+  function __add(self, other: vector): vector
+  function __sub(self, other: vector): vector
+  function __unm(self): vector
+  function __mul(self, other: number | vector | quaternion): vector
+  function __div(self, other: number | vector | quaternion): vector
+  function __mod(self, other: vector): vector
+  function __tostring(self): string
+end
+
+
+type rotation = quaternion
+type numeric = boolean | number
+type list = {string | number | vector | uuid | quaternion | boolean}
+type LLDetectedEventName = "collision" | "collision_end" | "collision_start" | "final_damage" | "on_damage" | "sensor" | "touch" | "touch_end" | "touch_start"
+type LLNonDetectedEventName = "at_rot_target" | "at_target" | "attach" | "changed" | "control" | "dataserver" | "email" | "experience_permissions" | "experience_permissions_denied" | "game_control" | "http_request" | "http_response" | "land_collision" | "land_collision_end" | "land_collision_start" | "link_message" | "linkset_data" | "listen" | "money" | "moving_end" | "moving_start" | "no_sensor" | "not_at_rot_target" | "not_at_target" | "object_rez" | "on_death" | "on_rez" | "path_update" | "remote_data" | "run_time_permissions" | "state_entry" | "state_exit" | "timer" | "transaction_result"
+type LLEventName = LLDetectedEventName | LLNonDetectedEventName
+type LLEventHandler = (...any) -> ()
+type LLDetectedEventHandler = (detected: {LLDetectedEvent}) -> ()
+type LLTimerEveryCallback = (scheduled: number, interval: number) -> ()
+type LLTimerOnceCallback = (scheduled: number) -> ()
+type LLTimerCallback = LLTimerEveryCallback | LLTimerOnceCallback | (...any) -> ...any
+type OsDateTime = {
+  year: number,
+  month: number,
+  day: number,
+  hour: number?,
+  min: number?,
+  sec: number?,
+  wday: number?,
+  yday: number?,
+  isdst: boolean?,
+}
+
+declare class LLDetectedEvent
+  index: number
+  valid: boolean
+  canAdjustDamage: boolean
+  function AdjustDamage(self, Damage: number): nil
+  function getDamage(self): list
+  function getGrab(self): vector
+  function getGroup(self): boolean
+  function getKey(self): uuid
+  function getLinkNumber(self): number
+  function getName(self): string
+  function getOwner(self): uuid
+  function getPos(self): vector
+  function getRezzer(self): uuid
+  function getRot(self): quaternion
+  function getTouchBinormal(self): vector
+  function getTouchFace(self): number
+  function getTouchNormal(self): vector
+  function getTouchPos(self): vector
+  function getTouchST(self): vector
+  function getTouchUV(self): vector
+  function getType(self): number
+  function getVel(self): vector
+end
+
+declare class LLEvents
+  at_rot_target: (TargetNumber: number, TargetRotation: quaternion, CurrentRotation: quaternion) -> () | nil
+  at_target: (TargetNumber: number, TargetPosition: vector, CurrentPosition: vector) -> () | nil
+  attach: (AvatarID: uuid) -> () | nil
+  changed: (Changed: number) -> () | nil
+  collision: (LLDetectedEventHandler)?
+  collision_end: (LLDetectedEventHandler)?
+  collision_start: (LLDetectedEventHandler)?
+  control: (AvatarID: uuid, Levels: number, Edges: number) -> () | nil
+  dataserver: (RequestID: uuid, Data: string) -> () | nil
+  email: (Time: string, Address: string, Subject: string, Body: string, NumberRemaining: number) -> () | nil
+  experience_permissions: (agent_id: uuid) -> () | nil
+  experience_permissions_denied: (agent_id: uuid, Reason: number) -> () | nil
+  final_damage: (LLDetectedEventHandler)?
+  game_control: (id: uuid, buttons: number, axes: list) -> () | nil
+  http_request: (HTTPRequestID: uuid, HTTPMethod: string, Body: string) -> () | nil
+  http_response: (HTTPRequestID: uuid, Status: number, Metadata: list, Body: string) -> () | nil
+  land_collision: (Position: vector) -> () | nil
+  land_collision_end: (Position: vector) -> () | nil
+  land_collision_start: (Position: vector) -> () | nil
+  link_message: (SendersLink: number, Value: number, Text: string, ID: string) -> () | nil
+  linkset_data: (action: number, name: string, value: string) -> () | nil
+  listen: (Channel: number, Name: string, ID: uuid, Text: string) -> () | nil
+  money: (Payer: uuid, Amount: number) -> () | nil
+  moving_end: () -> () | nil
+  moving_start: () -> () | nil
+  no_sensor: () -> () | nil
+  not_at_rot_target: () -> () | nil
+  not_at_target: () -> () | nil
+  object_rez: (RezzedObjectsID: uuid) -> () | nil
+  on_damage: (LLDetectedEventHandler)?
+  on_death: () -> () | nil
+  on_rez: (StartParameter: number) -> () | nil
+  path_update: (Type: number, Reserved: list) -> () | nil
+  remote_data: (EventType: number, ChannelID: uuid, MessageID: uuid, Sender: string, IData: number, SData: string) -> () | nil
+  run_time_permissions: (PermissionFlags: number) -> () | nil
+  sensor: (LLDetectedEventHandler)?
+  state_entry: () -> () | nil
+  state_exit: () -> () | nil
+  timer: () -> () | nil
+  touch: (LLDetectedEventHandler)?
+  touch_end: (LLDetectedEventHandler)?
+  touch_start: (LLDetectedEventHandler)?
+  transaction_result: (RequestID: uuid, Success: number, Message: string) -> () | nil
+  function on(self, event: LLEventName, callback: LLEventHandler): LLEventHandler
+  function off(self, event: LLEventName, callback: LLEventHandler): boolean
+  function once(self, event: LLEventName, callback: LLEventHandler): LLEventHandler
+  function listeners(self, event: LLEventName): {LLEventHandler}
+  function eventNames(self): {string}
+end
+
+declare class LLTimers
+  function every(self, seconds: number, callback: LLTimerEveryCallback): LLTimerCallback
+  function once(self, seconds: number, callback: LLTimerOnceCallback): LLTimerCallback
+  function off(self, callback: LLTimerCallback): boolean
+end
+
+
+declare quaternion: ((x: number, y: number, z: number, s: number) -> quaternion) & {
+  create: (x: number, y: number, z: number, s: number) -> quaternion,
+  identity: quaternion,
+  normalize: (q: quaternion) -> quaternion,
+  magnitude: (q: quaternion) -> number,
+  dot: (a: quaternion, b: quaternion) -> number,
+  slerp: (a: quaternion, b: quaternion, t: number) -> quaternion,
+  conjugate: (q: quaternion) -> quaternion,
+  tofwd: (q: quaternion) -> vector,
+  toleft: (q: quaternion) -> vector,
+  toup: (q: quaternion) -> vector,
+}
+declare rotation: typeof(quaternion)
+declare uuid: ((value: string | buffer | uuid) -> uuid?) & {
+  create: (value: string | buffer | uuid) -> uuid?,
+}
+declare vector: ((x: number, y: number, z: number?) -> vector) & {
+  create: (x: number, y: number, z: number?) -> vector,
+  magnitude: (v: vector) -> number,
+  normalize: (v: vector) -> vector,
+  cross: (a: vector, b: vector) -> vector,
+  dot: (a: vector, b: vector) -> number,
+  angle: (a: vector, b: vector, axis: vector?) -> number,
+  floor: (v: vector) -> vector,
+  ceil: (v: vector) -> vector,
+  abs: (v: vector) -> vector,
+  sign: (v: vector) -> vector,
+  clamp: (v: vector, min: vector, max: vector) -> vector,
+  max: (v: vector, ...vector) -> vector,
+  min: (v: vector, ...vector) -> vector,
+  lerp: (a: vector, b: vector, t: number) -> vector,
+  zero: vector,
+  one: vector,
+}
+declare LLEvents: LLEvents
+declare LLTimers: LLTimers
+declare loadstring: nil
+declare getfenv: nil
+declare setfenv: nil
+declare function dangerouslyexecuterequiredmodule(f: (...any) -> ...any): ...any
+declare function touuid(val: string | buffer | uuid): uuid?
+declare function tovector(val: any): vector?
+declare function toquaternion(val: any): quaternion?
+declare function torotation(val: any): quaternion?
+
+---------------------------
+-- Global Table: bit32
+---------------------------
+
+declare bit32: {
+  arshift: (x: number, disp: number) -> number,
+  band: (...number) -> number,
+  bnot: (x: number) -> number,
+  bor: (...number) -> number,
+  bxor: (...number) -> number,
+  btest: (...number) -> boolean,
+  extract: (n: number, field: number, width: number?) -> number,
+  lrotate: (x: number, disp: number) -> number,
+  lshift: (x: number, disp: number) -> number,
+  replace: (n: number, v: number, field: number, width: number?) -> number,
+  rrotate: (x: number, disp: number) -> number,
+  rshift: (x: number, disp: number) -> number,
+  countlz: (n: number) -> number,
+  countrz: (n: number) -> number,
+  byteswap: (n: number) -> number,
+}
+
+
+---------------------------
+-- Global Table: buffer
+---------------------------
+
+declare buffer: {
+  create: (size: number) -> buffer,
+  fromstring: (str: string) -> buffer,
+  tostring: (b: buffer) -> string,
+  readi8: (b: buffer, offset: number) -> number,
+  readu8: (b: buffer, offset: number) -> number,
+  readi16: (b: buffer, offset: number) -> number,
+  readu16: (b: buffer, offset: number) -> number,
+  readi32: (b: buffer, offset: number) -> number,
+  readu32: (b: buffer, offset: number) -> number,
+  readf32: (b: buffer, offset: number) -> number,
+  readf64: (b: buffer, offset: number) -> number,
+  writei8: (b: buffer, offset: number, value: number) -> (),
+  writeu8: (b: buffer, offset: number, value: number) -> (),
+  writei16: (b: buffer, offset: number, value: number) -> (),
+  writeu16: (b: buffer, offset: number, value: number) -> (),
+  writei32: (b: buffer, offset: number, value: number) -> (),
+  writeu32: (b: buffer, offset: number, value: number) -> (),
+  writef32: (b: buffer, offset: number, value: number) -> (),
+  writef64: (b: buffer, offset: number, value: number) -> (),
+  readstring: (b: buffer, offset: number, count: number) -> string,
+  writestring: (b: buffer, offset: number, value: string, count: number?) -> (),
+  len: (b: buffer) -> number,
+  copy: (target: buffer, targetOffset: number, source: buffer, sourceOffset: number?, count: number?) -> (),
+  fill: (b: buffer, offset: number, value: number, count: number?) -> (),
+  readbits: (b: buffer, bitOffset: number, bitCount: number) -> number,
+  writebits: (b: buffer, bitOffset: number, bitCount: number, value: number) -> (),
+}
+
+
+---------------------------
+-- Global Table: coroutine
+---------------------------
+
+declare coroutine: {
+  create: (f: (...any) -> ...any) -> thread,
+  resume: (co: thread, ...any) -> (boolean, ...any),
+  running: () -> thread?,
+  status: (co: thread) -> "running" | "suspended" | "normal" | "dead",
+  wrap: (f: (...any) -> ...any) -> (...any) -> ...any,
+  yield: (...any) -> ...any,
+  isyieldable: () -> boolean,
+  close: (co: thread) -> (boolean, string?),
+}
+
+
+---------------------------
+-- Global Table: debug
+---------------------------
+
+declare debug: {
+  info: ((thread: thread, level: number, options: string) -> ...any) & ((level: number, options: string) -> ...any) & ((func: (...any) -> ...any, options: string) -> ...any),
+  traceback: ((thread: thread, message: string?, level: number?) -> string) & ((message: string?, level: number?) -> string),
+}
+
+
+---------------------------
+-- Global Table: llbase64
+---------------------------
+
+declare llbase64: {
+  encode: (data: string | buffer) -> string,
+  decode: ((data: string) -> string) & ((data: string, asBuffer: boolean?) -> string | buffer),
+}
+
+
+---------------------------
+-- Global Table: lljson
+---------------------------
+
+declare lljson: {
+  null: any,
+  empty_array_mt: { [any]: any },
+  array_mt: { [any]: any },
+  empty_array: any,
+  _NAME: string,
+  _VERSION: string,
+  encode: (value: any) -> string,
+  decode: (json: string) -> any,
+  slencode: (value: any, tight: boolean?) -> string,
+  sldecode: (json: string) -> any,
+}
+
+
+---------------------------
+-- Global Table: math
+---------------------------
+
+declare math: {
+  pi: number,
+  huge: number,
+  abs: (x: number) -> number,
+  acos: (x: number) -> number,
+  asin: (x: number) -> number,
+  atan: (x: number) -> number,
+  atan2: (y: number, x: number) -> number,
+  ceil: (x: number) -> number,
+  clamp: (n: number, min: number, max: number) -> number,
+  cos: (x: number) -> number,
+  cosh: (x: number) -> number,
+  deg: (x: number) -> number,
+  exp: (x: number) -> number,
+  floor: (x: number) -> number,
+  fmod: (x: number, y: number) -> number,
+  frexp: (x: number) -> (number, number),
+  ldexp: (m: number, e: number) -> number,
+  lerp: (a: number, b: number, t: number) -> number,
+  log: (x: number, base: number?) -> number,
+  log10: (x: number) -> number,
+  map: (x: number, inMin: number, inMax: number, outMin: number, outMax: number) -> number,
+  max: (x: number, ...number) -> number,
+  min: (x: number, ...number) -> number,
+  modf: (x: number) -> (number, number),
+  noise: (x: number, y: number?, z: number?) -> number,
+  pow: (base: number, exponent: number) -> number,
+  rad: (x: number) -> number,
+  random: (m: number?, n: number?) -> number,
+  randomseed: (seed: number) -> (),
+  round: (x: number) -> number,
+  sign: (x: number) -> number,
+  sin: (x: number) -> number,
+  sinh: (x: number) -> number,
+  sqrt: (x: number) -> number,
+  tan: (x: number) -> number,
+  tanh: (x: number) -> number,
+  isnan: (x: number) -> boolean,
+  isinf: (x: number) -> boolean,
+  isfinite: (x: number) -> boolean,
+}
+
+
+---------------------------
+-- Global Table: os
+---------------------------
+
+declare os: {
+  clock: () -> number,
+  date: (format: string?, time: number?) -> string | OsDateTime | nil,
+  difftime: (t2: number, t1: number?) -> number,
+  time: (time: OsDateTime?) -> number?,
+}
+
+
+---------------------------
+-- Global Table: string
+---------------------------
+
+declare string: {
+  byte: (s: string, i: number?, j: number?) -> ...number,
+  char: (...number) -> string,
+  find: (s: string, pattern: string, init: number?, plain: boolean?) -> (number?, number?, ...string),
+  format: (formatstring: string, ...any) -> string,
+  gmatch: (s: string, pattern: string) -> () -> ...string,
+  gsub: (s: string, pattern: string, repl: string | { [string]: string } | (...string) -> string, n: number?) -> (string, number),
+  len: (s: string) -> number,
+  lower: (s: string) -> string,
+  match: (s: string, pattern: string, init: number?) -> ...string,
+  pack: (fmt: string, ...any) -> string,
+  packsize: (fmt: string) -> number,
+  rep: (s: string, n: number) -> string,
+  reverse: (s: string) -> string,
+  split: (s: string, separator: string?) -> {string},
+  sub: (s: string, i: number, j: number?) -> string,
+  unpack: (fmt: string, s: string, pos: number?) -> ...any,
+  upper: (s: string) -> string,
+}
+
+
+---------------------------
+-- Global Table: table
+---------------------------
+
+declare table: {
+  concat: (list: {string}, sep: string?, i: number?, j: number?) -> string,
+  foreach: <T, U>(t: {[T]: U}, f: (key: T, value: T) -> any) -> any?,
+  foreachi: <T>(t: {T}, f: (index: number, value: T) -> any) -> any?,
+  getn: (t: {any}) -> number,
+  maxn: (t: {any}) -> number,
+  insert: (<T>(list: {T}, value: T) -> ()) & (<T>(list: {T}, pos: number, value: T) -> ()),
+  remove: <T>(list: {T}, pos: number?) -> T?,
+  sort: <T>(list: {T}, comp: ((a: T, b: T) -> boolean)?) -> (),
+  pack: <T>(...T) -> { n: number, [number]: T },
+  unpack: <T>(list: {T}, i: number?, j: number?) -> ...T,
+  move: <T>(a1: {T}, f: number, e: number, t: number, a2: {T}?) -> {T},
+  create: <T>(count: number, value: T?) -> {T},
+  find: <T>(t: {T}, value: T, init: number?) -> number?,
+  clear: (t: {[any]: any}) -> (),
+  freeze: <T, U>(t: {[T]: U}) -> {[T]: U},
+  isfrozen: (t: {[any]: any}) -> boolean,
+  clone: <T, U>(t: {[T]: U}) -> {[T]: U},
+}
+
+
+---------------------------
+-- Global Table: utf8
+---------------------------
+
+declare utf8: {
+  charpattern: string,
+  char: (...number) -> string,
+  codes: (s: string) -> ((string, number) -> (number, number), string, number),
+  codepoint: (s: string, i: number?, j: number?) -> ...number,
+  len: (s: string, i: number?, j: number?) -> (number?, number?),
+  offset: (s: string, n: number, i: number?) -> number?,
+}
+
+
+---------------------------
+-- Global Table: ll
+---------------------------
+
+declare ll: {
+  Abs: (Value: number) -> number,
+  Acos: (Value: number) -> number,
+  AddToLandBanList: (ID: uuid, Hours: number) -> nil,
+  AddToLandPassList: (ID: uuid, Hours: number) -> nil,
+  AdjustSoundVolume: (Volume: number) -> nil,
+  AgentInExperience: (AgentID: uuid) -> boolean,
+  AllowInventoryDrop: (Flag: numeric) -> nil,
+  AngleBetween: (Rot1: quaternion, Rot2: quaternion) -> number,
+  ApplyImpulse: (Force: vector, Local: numeric) -> nil,
+  ApplyRotationalImpulse: (Force: vector, Local: numeric) -> nil,
+  Asin: (Value: number) -> number,
+  Atan2: (y: number, x: number) -> number,
+  AttachToAvatar: (AttachmentPoint: number) -> nil,
+  AttachToAvatarTemp: (AttachPoint: number) -> nil,
+  AvatarOnLinkSitTarget: (LinkNumber: number) -> uuid,
+  AvatarOnSitTarget: () -> uuid,
+  Axes2Rot: (Forward: vector, Left: vector, Up: vector) -> quaternion,
+  AxisAngle2Rot: (Axis: vector, Angle: number) -> quaternion,
+  Base64ToInteger: (Text: string) -> number,
+  Base64ToString: (Text: string) -> string,
+  BreakAllLinks: () -> nil,
+  BreakLink: (LinkNumber: number) -> nil,
+  CSV2List: (Text: string) -> {string},
+  CastRay: (Start: vector, End: vector, Options: list) -> list,
+  Ceil: (Value: number) -> number,
+  Char: (value: number) -> string,
+  ClearCameraParams: () -> nil,
+  ClearLinkMedia: (Link: number, Face: number) -> number,
+  ClearPrimMedia: (Face: number) -> number,
+  CloseRemoteDataChannel: (ChannelID: uuid) -> nil,
+  Cloud: (Offset: vector) -> number,
+  CollisionFilter: (ObjectName: string, ObjectID: uuid, Accept: number) -> nil,
+  CollisionSound: (ImpactSound: string, ImpactVolume: number) -> nil,
+  CollisionSprite: (ImpactSprite: string) -> nil,
+  ComputeHash: (Message: string, Algorithm: string) -> string,
+  Cos: (Theta: number) -> number,
+  CreateCharacter: (Options: list) -> nil,
+  CreateKeyValue: (Key: string, Value: string) -> uuid,
+  CreateLink: (TargetPrim: uuid, Parent: number) -> nil,
+  Damage: (target: uuid, damage: number, type: number) -> nil,
+  DataSizeKeyValue: () -> uuid,
+  DeleteCharacter: () -> nil,
+  DeleteKeyValue: (Key: string) -> uuid,
+  DeleteSubList: <T>(Source: {T}, Start: number, End: number) -> {T},
+  DeleteSubString: (Source: string, Start: number, End: number) -> string,
+  DerezObject: (ID: uuid, flags: number) -> boolean,
+  DetachFromAvatar: () -> nil,
+  Dialog: (AvatarID: uuid, Text: string, Buttons: list, Channel: number) -> nil,
+  Die: () -> nil,
+  DumpList2String: (Source: list, Separator: string) -> string,
+  EdgeOfWorld: (Position: vector, Direction: vector) -> boolean,
+  EjectFromLand: (AvatarID: uuid) -> nil,
+  Email: (Address: string, Subject: string, Text: string) -> nil,
+  EscapeURL: (URL: string) -> string,
+  Euler2Rot: (Vector: vector) -> quaternion,
+  Evade: (TargetID: uuid, Options: list) -> nil,
+  ExecCharacterCmd: (Command: number, Options: list) -> nil,
+  Fabs: (Value: number) -> number,
+  FindNotecardTextCount: (NotecardName: string, Pattern: string, Options: list) -> uuid,
+  FindNotecardTextSync: (NotecardName: string, Pattern: string, StartMatch: number, Count: number, Options: list) -> list,
+  FleeFrom: (Source: vector, Distance: number, Options: list) -> nil,
+  Floor: (Value: number) -> number,
+  ForceMouselook: (Enable: numeric) -> nil,
+  Frand: (Magnitude: number) -> number,
+  GenerateKey: () -> uuid,
+  GetAccel: () -> vector,
+  GetAgentInfo: (AvatarID: uuid) -> number,
+  GetAgentLanguage: (AvatarID: uuid) -> string,
+  GetAgentList: (Scope: number, Options: list) -> list,
+  GetAgentSize: (AvatarID: uuid) -> vector,
+  GetAlpha: (Face: number) -> number,
+  GetAndResetTime: () -> number,
+  GetAnimation: (AvatarID: uuid) -> string,
+  GetAnimationList: (AvatarID: uuid) -> list,
+  GetAnimationOverride: (AnimationState: string) -> string,
+  GetAttached: () -> number,
+  GetAttachedList: (ID: uuid) -> {uuid},
+  GetAttachedListFiltered: (AgentID: uuid, Options: list) -> {uuid},
+  GetBoundingBox: (ID: uuid) -> {vector},
+  GetCameraAspect: () -> number,
+  GetCameraFOV: () -> number,
+  GetCameraPos: () -> vector,
+  GetCameraRot: () -> quaternion,
+  GetCenterOfMass: () -> vector,
+  GetClosestNavPoint: (Point: vector, Options: list) -> list,
+  GetColor: (Face: number) -> vector,
+  GetCreator: () -> uuid,
+  GetDate: () -> string,
+  GetDayLength: () -> number,
+  GetDayOffset: () -> number,
+  GetDisplayName: (AvatarID: uuid) -> string,
+  GetEnergy: () -> number,
+  GetEnv: (DataRequest: string) -> string,
+  GetEnvironment: (Position: vector, EnvParams: list) -> list,
+  GetExperienceDetails: (ExperienceID: uuid) -> list,
+  GetExperienceErrorMessage: (Error: number) -> string,
+  GetForce: () -> vector,
+  GetFreeMemory: () -> number,
+  GetFreeURLs: () -> number,
+  GetGMTclock: () -> number,
+  GetGeometricCenter: () -> vector,
+  GetHTTPHeader: (HTTPRequestID: uuid, Header: string) -> string,
+  GetHealth: (ID: uuid) -> number,
+  GetInventoryAcquireTime: (InventoryItem: string) -> string,
+  GetInventoryCreator: (InventoryItem: string) -> uuid,
+  GetInventoryDesc: (InventoryItem: string) -> string,
+  GetInventoryKey: (InventoryItem: string) -> uuid,
+  GetInventoryName: (InventoryType: number, Index: number) -> string,
+  GetInventoryNumber: (InventoryType: number) -> number,
+  GetInventoryPermMask: (InventoryItem: string, BitMask: number) -> number,
+  GetInventoryType: (InventoryItem: string) -> number,
+  GetKey: () -> uuid,
+  GetLandOwnerAt: (Position: vector) -> uuid,
+  GetLinkKey: (LinkNumber: number) -> uuid,
+  GetLinkMedia: (LinkNumber: number, Face: number, Parameters: list) -> list,
+  GetLinkName: (LinkNumber: number) -> string,
+  GetLinkNumber: () -> number,
+  GetLinkNumberOfSides: (LinkNumber: number) -> number,
+  GetLinkPrimitiveParams: (LinkNumber: number, Parameters: list) -> list,
+  GetLinkSitFlags: (LinkNumber: number) -> number,
+  GetListEntryType: (ListVariable: list, Index: number) -> number,
+  GetListLength: (ListVariable: list) -> number,
+  GetLocalPos: () -> vector,
+  GetLocalRot: () -> quaternion,
+  GetMass: () -> number,
+  GetMassMKS: () -> number,
+  GetMaxScaleFactor: () -> number,
+  GetMemoryLimit: () -> number,
+  GetMinScaleFactor: () -> number,
+  GetMoonDirection: () -> vector,
+  GetMoonRotation: () -> quaternion,
+  GetNextEmail: (Address: string, Subject: string) -> nil,
+  GetNotecardLine: (NotecardName: string, LineNumber: number) -> uuid,
+  GetNotecardLineSync: (NotecardName: string, LineNumber: number) -> string,
+  GetNumberOfNotecardLines: (NotecardName: string) -> uuid,
+  GetNumberOfPrims: () -> number,
+  GetNumberOfSides: () -> number,
+  GetObjectAnimationNames: () -> list,
+  GetObjectDesc: () -> string,
+  GetObjectDetails: (ID: uuid, Parameters: list) -> list,
+  GetObjectLinkKey: (id: uuid, link_no: number) -> uuid,
+  GetObjectMass: (ID: uuid) -> number,
+  GetObjectName: () -> string,
+  GetObjectPermMask: (Category: number) -> number,
+  GetObjectPrimCount: (ObjectID: uuid) -> number,
+  GetOmega: () -> vector,
+  GetOwner: () -> uuid,
+  GetOwnerKey: (ObjectID: uuid) -> uuid,
+  GetParcelDetails: (Position: vector, ParcelDetails: list) -> list,
+  GetParcelFlags: (Position: vector) -> number,
+  GetParcelMaxPrims: (Position: vector, SimWide: numeric) -> number,
+  GetParcelMusicURL: () -> string,
+  GetParcelPrimCount: (Position: vector, Category: number, SimWide: numeric) -> number,
+  GetParcelPrimOwners: (Position: vector) -> list,
+  GetPermissions: () -> number,
+  GetPermissionsKey: () -> uuid,
+  GetPhysicsMaterial: () -> list,
+  GetPos: () -> vector,
+  GetPrimMediaParams: (Face: number, Parameters: list) -> list,
+  GetPrimitiveParams: (Parameters: list) -> list,
+  GetRegionAgentCount: () -> number,
+  GetRegionCorner: () -> vector,
+  GetRegionDayLength: () -> number,
+  GetRegionDayOffset: () -> number,
+  GetRegionFPS: () -> number,
+  GetRegionFlags: () -> number,
+  GetRegionMoonDirection: () -> vector,
+  GetRegionMoonRotation: () -> quaternion,
+  GetRegionName: () -> string,
+  GetRegionSunDirection: () -> vector,
+  GetRegionSunRotation: () -> quaternion,
+  GetRegionTimeDilation: () -> number,
+  GetRegionTimeOfDay: () -> number,
+  GetRenderMaterial: (Face: number) -> string,
+  GetRootPosition: () -> vector,
+  GetRootRotation: () -> quaternion,
+  GetRot: () -> quaternion,
+  GetSPMaxMemory: () -> number,
+  GetScale: () -> vector,
+  GetScriptName: () -> string,
+  GetScriptState: (ScriptName: string) -> boolean,
+  GetSimStats: (StatType: number) -> number,
+  GetSimulatorHostname: () -> string,
+  GetStartParameter: () -> number,
+  GetStartString: () -> string,
+  GetStaticPath: (Start: vector, End: vector, Radius: number, Parameters: list) -> list,
+  GetStatus: (StatusFlag: number) -> boolean,
+  GetSubString: (String: string, Start: number, End: number) -> string,
+  GetSunDirection: () -> vector,
+  GetSunRotation: () -> quaternion,
+  GetTexture: (Face: number) -> string,
+  GetTextureOffset: (Face: number) -> vector,
+  GetTextureRot: (Face: number) -> number,
+  GetTextureScale: (Face: number) -> vector,
+  GetTime: () -> number,
+  GetTimeOfDay: () -> number,
+  GetTimestamp: () -> string,
+  GetTorque: () -> vector,
+  GetUnixTime: () -> number,
+  GetUsedMemory: () -> number,
+  GetUsername: (AvatarID: uuid) -> string,
+  GetVel: () -> vector,
+  GetVisualParams: (ID: uuid, Parameters: list) -> list,
+  GetWallclock: () -> number,
+  GiveAgentInventory: (AgentID: uuid, FolderName: string, InventoryItems: list, Options: list) -> number,
+  GiveInventory: (TargetID: uuid, InventoryItem: string) -> nil,
+  GiveInventoryList: (TargetID: uuid, FolderName: string, InventoryItems: list) -> nil,
+  GiveMoney: (AvatarID: uuid, Amount: number) -> number,
+  GodLikeRezObject: (InventoryItemID: uuid, Position: vector) -> nil,
+  Ground: (Offset: vector) -> number,
+  GroundContour: (Offset: vector) -> vector,
+  GroundNormal: (Offset: vector) -> vector,
+  GroundRepel: (Height: number, Water: numeric, Tau: number) -> nil,
+  GroundSlope: (Offset: vector) -> vector,
+  HMAC: (Key: string, Message: string, Algorithm: string) -> string,
+  HTTPRequest: (URL: string, Parameters: list, Body: string) -> uuid,
+  HTTPResponse: (HTTPRequestID: uuid, Status: number, Body: string) -> nil,
+  Hash: (value: string) -> number,
+  InsertString: (TargetVariable: string, Position: number, SourceVariable: string) -> string,
+  InstantMessage: (AvatarID: uuid, Text: string) -> nil,
+  IntegerToBase64: (Value: number) -> string,
+  IsFriend: (agent_id: uuid) -> boolean,
+  IsLinkGLTFMaterial: (link: number, face: number) -> boolean,
+  Json2List: (JSON: string) -> list,
+  JsonGetValue: (JSON: string, Specifiers: list) -> string,
+  JsonSetValue: (JSON: string, Specifiers: list, Value: string) -> string,
+  JsonValueType: (JSON: string, Specifiers: list) -> string,
+  Key2Name: (ID: uuid) -> string,
+  KeyCountKeyValue: () -> uuid,
+  KeysKeyValue: (First: number, Count: number) -> uuid,
+  Linear2sRGB: (color: vector) -> vector,
+  LinkAdjustSoundVolume: (LinkNumber: number, Volume: number) -> nil,
+  LinkParticleSystem: (LinkNumber: number, Rules: list) -> nil,
+  LinkPlaySound: (LinkNumber: number, Sound: string, Volume: number, Flags: number) -> nil,
+  LinkSetSoundQueueing: (LinkNumber: number, QueueEnable: numeric) -> nil,
+  LinkSetSoundRadius: (LinkNumber: number, radius: number) -> nil,
+  LinkSitTarget: (LinkNumber: number, Offset: vector, Rotation: quaternion) -> nil,
+  LinkStopSound: (LinkNumber: number) -> nil,
+  LinksetDataAvailable: () -> number,
+  LinksetDataCountFound: (search: string) -> number,
+  LinksetDataCountKeys: () -> number,
+  LinksetDataDelete: (name: string) -> number,
+  LinksetDataDeleteFound: (search: string, pass: string) -> list,
+  LinksetDataDeleteProtected: (name: string, pass: string) -> number,
+  LinksetDataFindKeys: (search: string, start: number, count: number) -> list,
+  LinksetDataListKeys: (start: number, count: number) -> list,
+  LinksetDataRead: (name: string) -> string,
+  LinksetDataReadProtected: (name: string, pass: string) -> string,
+  LinksetDataReset: () -> nil,
+  LinksetDataWrite: (name: string, value: string) -> number,
+  LinksetDataWriteProtected: (name: string, value: string, pass: string) -> number,
+  List2CSV: (ListVariable: list) -> string,
+  List2Float: (ListVariable: list, Index: number) -> number,
+  List2Integer: (ListVariable: list, Index: number) -> number,
+  List2Json: (JsonType: string, Values: list) -> string,
+  List2Key: (ListVariable: list, Index: number) -> uuid,
+  List2List: <T>(ListVariable: {T}, Start: number, End: number) -> {T},
+  List2ListSlice: <T>(ListVariable: {T}, Start: number, End: number, Stride: number, slice_index: number) -> {T},
+  List2ListStrided: <T>(ListVariable: {T}, Start: number, End: number, Stride: number) -> {T},
+  List2Rot: (ListVariable: list, Index: number) -> quaternion,
+  List2String: (ListVariable: list, Index: number) -> string,
+  List2Vector: (ListVariable: list, Index: number) -> vector,
+  ListFindList: (ListVariable: list, Find: list) -> number,
+  ListFindListNext: (ListVariable: list, Find: list, Instance: number) -> number,
+  ListFindStrided: (ListVariable: list, Find: list, Start: number, End: number, Stride: number) -> number,
+  ListInsertList: <T>(Target: {T}, ListVariable: {T}, Position: number) -> {T},
+  ListRandomize: <T>(ListVariable: {T}, Stride: number) -> {T},
+  ListReplaceList: <T>(Target: {T}, ListVariable: {T}, Start: number, End: number) -> {T},
+  ListSort: <T>(ListVariable: {T}, Stride: number, Ascending: numeric) -> {T},
+  ListSortStrided: <T>(ListVariable: {T}, Stride: number, Sortkey: number, Ascending: numeric) -> {T},
+  ListStatistics: (Operation: number, ListVariable: list) -> number,
+  Listen: (Channel: number, SpeakersName: string, SpeakersID: uuid, Text: string) -> number,
+  ListenControl: (ChannelHandle: number, Active: number) -> nil,
+  ListenRemove: (ChannelHandle: number) -> nil,
+  LoadURL: (AvatarID: uuid, Text: string, URL: string) -> nil,
+  Log: (Value: number) -> number,
+  Log10: (Value: number) -> number,
+  LookAt: (Target: vector, Strength: number, Damping: number) -> nil,
+  LoopSound: (Sound: string, Volume: number) -> nil,
+  LoopSoundMaster: (Sound: string, Volume: number) -> nil,
+  LoopSoundSlave: (Sound: string, Volume: number) -> nil,
+  MD5String: (Text: string, Nonce: number) -> string,
+  MakeExplosion: (Particles: number, Scale: number, Velocity: number, Lifetime: number, Arc: number, Texture: string, Offset: vector) -> nil,
+  MakeFire: (Particles: number, Scale: number, Velocity: number, Lifetime: number, Arc: number, Texture: string, Offset: vector) -> nil,
+  MakeFountain: (Particles: number, Scale: number, Velocity: number, Lifetime: number, Arc: number, Bounce: number, Texture: string, Offset: vector, Bounce_Offset: number) -> nil,
+  MakeSmoke: (Particles: number, Scale: number, Velocity: number, Lifetime: number, Arc: number, Texture: string, Offset: vector) -> nil,
+  ManageEstateAccess: (Action: number, AvatarID: uuid) -> boolean,
+  MapBeacon: (RegionName: string, Position: vector, Options: list) -> nil,
+  MapDestination: (RegionName: string, Position: vector, Direction: vector) -> nil,
+  MessageLinked: (LinkNumber: number, Number: number, Text: string | uuid, ID: string | uuid) -> nil,
+  MinEventDelay: (Delay: number) -> nil,
+  ModPow: (Value: number, Power: number, Modulus: number) -> number,
+  ModifyLand: (Action: number, Area: number) -> nil,
+  MoveToTarget: (Target: vector, Tau: number) -> nil,
+  Name2Key: (Name: string) -> uuid,
+  NavigateTo: (Location: vector, Options: list) -> nil,
+  OffsetTexture: (OffsetS: number, OffsetT: number, Face: number) -> nil,
+  OpenFloater: (floater_name: string, url: string, params: list) -> number,
+  OpenRemoteDataChannel: () -> nil,
+  Ord: (value: string, index: number) -> number,
+  OverMyLand: (ID: uuid) -> boolean,
+  OwnerSay: (Text: string) -> nil,
+  ParcelMediaCommandList: (CommandList: list) -> nil,
+  ParcelMediaQuery: (QueryList: list) -> list,
+  ParseString2List: (Text: string, Separators: {string}, Spacers: {string}) -> {string},
+  ParseStringKeepNulls: (Text: string, Separators: {string}, Spacers: {string}) -> {string},
+  ParticleSystem: (Parameters: list) -> nil,
+  PassCollisions: (Pass: numeric) -> nil,
+  PassTouches: (Pass: numeric) -> nil,
+  PatrolPoints: (Points: list, Options: list) -> nil,
+  PlaySound: (Sound: string, Volume: number) -> nil,
+  PlaySoundSlave: (Sound: string, Volume: number) -> nil,
+  Pow: (Value: number, Exponent: number) -> number,
+  PreloadSound: (Sound: string) -> nil,
+  Pursue: (TargetID: uuid, Options: list) -> nil,
+  PushObject: (ObjectID: uuid, Impulse: vector, AngularImpulse: vector, Local: number) -> nil,
+  ReadKeyValue: (Key: string) -> uuid,
+  RefreshPrimURL: () -> nil,
+  RegionSay: (Channel: number, Text: string) -> nil,
+  RegionSayTo: (TargetID: uuid, Channel: number, Text: string) -> nil,
+  ReleaseCamera: (AvatarID: uuid) -> nil,
+  ReleaseControls: () -> nil,
+  ReleaseURL: (URL: string) -> nil,
+  RemoteDataReply: (ChannelID: uuid, MessageID: uuid, sData: string, iData: number) -> nil,
+  RemoteDataSetRegion: () -> nil,
+  RemoteLoadScriptPin: (ObjectID: uuid, ScriptName: string, PIN: number, Running: numeric, StartParameter: number) -> nil,
+  RemoveFromLandBanList: (AvatarID: uuid) -> nil,
+  RemoveFromLandPassList: (AvatarID: uuid) -> nil,
+  RemoveInventory: (InventoryItem: string) -> nil,
+  RemoveVehicleFlags: (Vehiclelags: number) -> nil,
+  ReplaceAgentEnvironment: (agent_id: uuid, transition: number, environment: string) -> number,
+  ReplaceEnvironment: (position: vector, environment: string, track_no: number, day_length: number, day_offset: number) -> number,
+  ReplaceSubString: (InitialString: string, SubString: string, NewSubString: string, Count: number) -> string,
+  RequestAgentData: (AvatarID: uuid, Data: number) -> uuid,
+  RequestDisplayName: (AvatarID: uuid) -> uuid,
+  RequestExperiencePermissions: (AgentID: uuid, unused: string) -> nil,
+  RequestInventoryData: (InventoryItem: string) -> uuid,
+  RequestPermissions: (AvatarID: uuid, PermissionMask: number) -> nil,
+  RequestSecureURL: () -> uuid,
+  RequestSimulatorData: (RegionName: string, Data: number) -> uuid,
+  RequestURL: () -> uuid,
+  RequestUserKey: (Name: string) -> uuid,
+  RequestUsername: (AvatarID: uuid) -> uuid,
+  ResetAnimationOverride: (AnimationState: string) -> nil,
+  ResetLandBanList: () -> nil,
+  ResetLandPassList: () -> nil,
+  ResetOtherScript: (ScriptName: string) -> nil,
+  ResetScript: () -> nil,
+  ResetTime: () -> nil,
+  ReturnObjectsByID: (ObjectIDs: list) -> number,
+  ReturnObjectsByOwner: (ID: uuid, Scope: number) -> number,
+  RezAtRoot: (InventoryItem: string, Position: vector, Velocity: vector, Rotation: quaternion, StartParameter: number) -> nil,
+  RezObject: (InventoryItem: string, Position: vector, Velocity: vector, Rotation: quaternion, StartParameter: number) -> nil,
+  RezObjectWithParams: (InventoryItem: string, Parms: list) -> uuid,
+  Rot2Angle: (Rotation: quaternion) -> number,
+  Rot2Axis: (Rotation: quaternion) -> vector,
+  Rot2Euler: (Rotation: quaternion) -> vector,
+  Rot2Fwd: (Rotation: quaternion) -> vector,
+  Rot2Left: (Rotation: quaternion) -> vector,
+  Rot2Up: (Rotation: quaternion) -> vector,
+  RotBetween: (Vector1: vector, Vector2: vector) -> quaternion,
+  RotLookAt: (Rotation: quaternion, Strength: number, Damping: number) -> nil,
+  RotTarget: (Rotation: quaternion, LeeWay: number) -> number,
+  RotTargetRemove: (Handle: number) -> nil,
+  RotateTexture: (Radians: number, Face: number) -> nil,
+  Round: (Value: number) -> number,
+  SHA1String: (Text: string) -> string,
+  SHA256String: (text: string) -> string,
+  SameGroup: (ID: uuid) -> boolean,
+  Say: (Channel: number, Text: string) -> nil,
+  ScaleByFactor: (ScalingFactor: number) -> boolean,
+  ScaleTexture: (Horizontal: number, Vertical: number, Face: number) -> nil,
+  ScriptDanger: (Position: vector) -> boolean,
+  ScriptProfiler: (State: number) -> nil,
+  SendRemoteData: (ChannelID: uuid, Destination: string, Value: number, Text: string) -> uuid,
+  Sensor: (Name: string, ID: uuid, Type: number, Range: number, Arc: number) -> nil,
+  SensorRemove: () -> nil,
+  SensorRepeat: (Name: string, ID: uuid, Type: number, Range: number, Arc: number, Rate: number) -> nil,
+  SetAgentEnvironment: (agent_id: uuid, transition: number, Settings: list) -> number,
+  SetAgentRot: (rot: quaternion, flags: number) -> nil,
+  SetAlpha: (Opacity: number, Face: number) -> nil,
+  SetAngularVelocity: (AngVel: vector, Local: number) -> nil,
+  SetAnimationOverride: (AnimationState: string, AnimationName: string) -> nil,
+  SetBuoyancy: (Buoyancy: number) -> nil,
+  SetCameraAtOffset: (Offset: vector) -> nil,
+  SetCameraEyeOffset: (Offset: vector) -> nil,
+  SetCameraParams: (Parameters: list) -> nil,
+  SetClickAction: (Action: number) -> nil,
+  SetColor: (Color: vector, Face: number) -> nil,
+  SetContentType: (HTTPRequestID: uuid, ContentType: number) -> nil,
+  SetDamage: (Damage: number) -> nil,
+  SetEnvironment: (Position: vector, EnvParams: list) -> number,
+  SetForce: (Force: vector, Local: numeric) -> nil,
+  SetForceAndTorque: (Force: vector, Torque: vector, Local: numeric) -> nil,
+  SetGroundTexture: (Changes: list) -> number,
+  SetHoverHeight: (Height: number, Water: numeric, Tau: number) -> nil,
+  SetInventoryPermMask: (InventoryItem: string, PermissionFlag: number, PermissionMask: number) -> nil,
+  SetKeyframedMotion: (Keyframes: list, Options: list) -> nil,
+  SetLinkAlpha: (LinkNumber: number, Opacity: number, Face: number) -> nil,
+  SetLinkCamera: (LinkNumber: number, EyeOffset: vector, LookOffset: vector) -> nil,
+  SetLinkColor: (LinkNumber: number, Color: vector, Face: number) -> nil,
+  SetLinkGLTFOverrides: (link: number, face: number, options: list) -> nil,
+  SetLinkMedia: (Link: number, Face: number, Parameters: list) -> number,
+  SetLinkPrimitiveParams: (LinkNumber: number, Parameters: list) -> nil,
+  SetLinkPrimitiveParamsFast: (LinkNumber: number, Parameters: list) -> nil,
+  SetLinkRenderMaterial: (LinkNumber: number, RenderMaterial: string, Face: number) -> nil,
+  SetLinkSitFlags: (LinkNumber: number, Flags: number) -> nil,
+  SetLinkTexture: (LinkNumber: number, Texture: string, Face: number) -> nil,
+  SetLinkTextureAnim: (LinkNumber: number, Mode: number, Face: number, SizeX: number, SizeY: number, Start: number, Length: number, Rate: number) -> nil,
+  SetLocalRot: (Rotation: quaternion) -> nil,
+  SetMemoryLimit: (Limit: number) -> boolean,
+  SetObjectDesc: (Description: string) -> nil,
+  SetObjectName: (Name: string) -> nil,
+  SetObjectPermMask: (PermissionFlag: number, PermissionMask: number) -> nil,
+  SetParcelForSale: (ForSale: numeric, Options: list) -> boolean,
+  SetParcelMusicURL: (URL: string) -> nil,
+  SetPayPrice: (Price: number, QuickButtons: list) -> nil,
+  SetPhysicsMaterial: (MaterialBits: number, GravityMultiplier: number, Restitution: number, Friction: number, Density: number) -> nil,
+  SetPos: (Position: vector) -> nil,
+  SetPrimMediaParams: (Face: number, MediaParameters: list) -> number,
+  SetPrimURL: (URL: string) -> nil,
+  SetPrimitiveParams: (Parameters: list) -> nil,
+  SetRegionPos: (Position: vector) -> boolean,
+  SetRemoteScriptAccessPin: (PIN: number) -> nil,
+  SetRenderMaterial: (Material: string, Face: number) -> nil,
+  SetRot: (Rotation: quaternion) -> nil,
+  SetScale: (Scale: vector) -> nil,
+  SetScriptState: (ScriptName: string, Running: numeric) -> nil,
+  SetSitText: (Text: string) -> nil,
+  SetSoundQueueing: (QueueEnable: numeric) -> nil,
+  SetSoundRadius: (Radius: number) -> nil,
+  SetStatus: (Status: number, Value: numeric) -> nil,
+  SetText: (Text: string, Color: vector, Opacity: number) -> nil,
+  SetTexture: (Texture: string, Face: number) -> nil,
+  SetTextureAnim: (Mode: number, Face: number, SizeX: number, SizeY: number, Start: number, Length: number, Rate: number) -> nil,
+  SetTimerEvent: (Rate: number) -> nil,
+  SetTorque: (Torque: vector, Local: numeric) -> nil,
+  SetTouchText: (Text: string) -> nil,
+  SetVehicleFlags: (Flags: number) -> nil,
+  SetVehicleFloatParam: (ParameterName: number, ParameterValue: number) -> nil,
+  SetVehicleRotationParam: (ParameterName: number, ParameterValue: quaternion) -> nil,
+  SetVehicleType: (Type: number) -> nil,
+  SetVehicleVectorParam: (ParameterName: number, ParameterValue: vector) -> nil,
+  SetVelocity: (Velocity: vector, Local: number) -> nil,
+  Shout: (Channel: number, Text: string) -> nil,
+  SignRSA: (PrivateKey: string, Message: string, Algorithm: string) -> string,
+  Sin: (Theta: number) -> number,
+  SitOnLink: (AvatarID: uuid, LinkID: number) -> number,
+  SitTarget: (Offset: vector, Rotation: quaternion) -> nil,
+  Sleep: (Time: number) -> nil,
+  Sound: (Sound: string, Volume: number, Queue: number, Loop: number) -> nil,
+  SoundPreload: (Sound: string) -> nil,
+  Sqrt: (Value: number) -> number,
+  StartAnimation: (Animation: string) -> nil,
+  StartObjectAnimation: (Animation: string) -> nil,
+  StopAnimation: (Animation: string) -> nil,
+  StopHover: () -> nil,
+  StopLookAt: () -> nil,
+  StopMoveToTarget: () -> nil,
+  StopObjectAnimation: (Animation: string) -> nil,
+  StopSound: () -> nil,
+  StringLength: (Text: string) -> number,
+  StringToBase64: (Text: string) -> string,
+  StringTrim: (Text: string, TrimType: number) -> string,
+  SubStringIndex: (Text: string, Sequence: string) -> number,
+  TakeCamera: (AvatarID: uuid) -> nil,
+  TakeControls: (Controls: number, Accept: numeric, PassOn: numeric) -> nil,
+  Tan: (Theta: number) -> number,
+  Target: (Position: vector, Range: number) -> number,
+  TargetOmega: (Axis: vector, SpinRate: number, Gain: number) -> nil,
+  TargetRemove: (Target: number) -> nil,
+  TargetedEmail: (Target: number, Subject: string, Text: string) -> nil,
+  TeleportAgent: (AvatarID: uuid, LandmarkName: string, Position: vector, LookAtPoint: vector) -> nil,
+  TeleportAgentGlobalCoords: (AvatarID: uuid, GlobalPosition: vector, RegionPosition: vector, LookAtPoint: vector) -> nil,
+  TeleportAgentHome: (AvatarID: uuid) -> nil,
+  TextBox: (AvatarID: uuid, Text: string, Channel: number) -> nil,
+  ToLower: (Text: string) -> string,
+  ToUpper: (Text: string) -> string,
+  TransferLindenDollars: (AvatarID: uuid, Amount: number) -> uuid,
+  TransferOwnership: (AgentID: uuid, Flags: number, Params: list) -> number,
+  TriggerSound: (Sound: string, Volume: number) -> nil,
+  TriggerSoundLimited: (Sound: string, Volume: number, TNE: vector, BSW: vector) -> nil,
+  UnSit: (AvatarID: uuid) -> nil,
+  UnescapeURL: (URL: string) -> string,
+  UpdateCharacter: (Options: list) -> nil,
+  UpdateKeyValue: (Key: string, Value: string, Checked: number, OriginalValue: string) -> uuid,
+  VecDist: (Location1: vector, Location2: vector) -> number,
+  VecMag: (Vector: vector) -> number,
+  VecNorm: (Vector: vector) -> vector,
+  VerifyRSA: (PublicKey: string, Message: string, Signature: string, Algorithm: string) -> boolean,
+  VolumeDetect: (DetectEnabled: numeric) -> nil,
+  WanderWithin: (Origin: vector, Area: vector, Options: list) -> nil,
+  Water: (Offset: vector) -> number,
+  Whisper: (Channel: number, Text: string) -> nil,
+  Wind: (Offset: vector) -> vector,
+  WorldPosToHUD: (world_pos: vector) -> vector,
+  XorBase64: (Text1: string, Text2: string) -> string,
+  XorBase64Strings: (Text1: string, Text2: string) -> string,
+  XorBase64StringsCorrect: (Text1: string, Text2: string) -> string,
+  sRGB2Linear: (srgb: vector) -> vector,
+}
+
+
+---------------------------
+-- Global Table: llcompat
+---------------------------
+
+declare llcompat: {
+  AdjustDamage: (Number: number, Damage: number) -> nil,
+  DetectedDamage: (Number: number) -> list,
+  DetectedGrab: (Number: number) -> vector,
+  DetectedGroup: (Number: number) -> boolean,
+  DetectedKey: (Number: number) -> uuid,
+  DetectedLinkNumber: (Number: number) -> number,
+  DetectedName: (Number: number) -> string,
+  DetectedOwner: (Number: number) -> uuid,
+  DetectedPos: (Number: number) -> vector,
+  DetectedRezzer: (Number: number) -> uuid,
+  DetectedRot: (Number: number) -> quaternion,
+  DetectedTouchBinormal: (Index: number) -> vector,
+  DetectedTouchFace: (Index: number) -> number,
+  DetectedTouchNormal: (Index: number) -> vector,
+  DetectedTouchPos: (Index: number) -> vector,
+  DetectedTouchST: (Index: number) -> vector,
+  DetectedTouchUV: (Index: number) -> vector,
+  DetectedType: (Number: number) -> number,
+  DetectedVel: (Number: number) -> vector,
+}
+
+declare ACTIVE: number
+declare AGENT: number
+declare AGENT_ALWAYS_RUN: number
+declare AGENT_ATTACHMENTS: number
+declare AGENT_AUTOMATED: number
+declare AGENT_AUTOPILOT: number
+declare AGENT_AWAY: number
+declare AGENT_BUSY: number
+declare AGENT_BY_LEGACY_NAME: number
+declare AGENT_BY_USERNAME: number
+declare AGENT_CROUCHING: number
+declare AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT: number
+declare AGENT_FLYING: number
+declare AGENT_IN_AIR: number
+declare AGENT_LIST_PARCEL: number
+declare AGENT_LIST_PARCEL_OWNER: number
+declare AGENT_LIST_REGION: number
+declare AGENT_MOUSELOOK: number
+declare AGENT_ON_OBJECT: number
+declare AGENT_SCRIPTED: number
+declare AGENT_SITTING: number
+declare AGENT_TYPING: number
+declare AGENT_WALKING: number
+declare ALL_SIDES: number
+declare ANIM_ON: number
+declare ATTACH_ANY_HUD: number
+declare ATTACH_AVATAR_CENTER: number
+declare ATTACH_BACK: number
+declare ATTACH_BELLY: number
+declare ATTACH_CHEST: number
+declare ATTACH_CHIN: number
+declare ATTACH_FACE_JAW: number
+declare ATTACH_FACE_LEAR: number
+declare ATTACH_FACE_LEYE: number
+declare ATTACH_FACE_REAR: number
+declare ATTACH_FACE_REYE: number
+declare ATTACH_FACE_TONGUE: number
+declare ATTACH_GROIN: number
+declare ATTACH_HEAD: number
+declare ATTACH_HIND_LFOOT: number
+declare ATTACH_HIND_RFOOT: number
+declare ATTACH_HUD_BOTTOM: number
+declare ATTACH_HUD_BOTTOM_LEFT: number
+declare ATTACH_HUD_BOTTOM_RIGHT: number
+declare ATTACH_HUD_CENTER_1: number
+declare ATTACH_HUD_CENTER_2: number
+declare ATTACH_HUD_TOP_CENTER: number
+declare ATTACH_HUD_TOP_LEFT: number
+declare ATTACH_HUD_TOP_RIGHT: number
+declare ATTACH_LEAR: number
+declare ATTACH_LEFT_PEC: number
+declare ATTACH_LEYE: number
+declare ATTACH_LFOOT: number
+declare ATTACH_LHAND: number
+declare ATTACH_LHAND_RING1: number
+declare ATTACH_LHIP: number
+declare ATTACH_LLARM: number
+declare ATTACH_LLLEG: number
+declare ATTACH_LPEC: number
+declare ATTACH_LSHOULDER: number
+declare ATTACH_LUARM: number
+declare ATTACH_LULEG: number
+declare ATTACH_LWING: number
+declare ATTACH_MOUTH: number
+declare ATTACH_NECK: number
+declare ATTACH_NOSE: number
+declare ATTACH_PELVIS: number
+declare ATTACH_REAR: number
+declare ATTACH_REYE: number
+declare ATTACH_RFOOT: number
+declare ATTACH_RHAND: number
+declare ATTACH_RHAND_RING1: number
+declare ATTACH_RHIP: number
+declare ATTACH_RIGHT_PEC: number
+declare ATTACH_RLARM: number
+declare ATTACH_RLLEG: number
+declare ATTACH_RPEC: number
+declare ATTACH_RSHOULDER: number
+declare ATTACH_RUARM: number
+declare ATTACH_RULEG: number
+declare ATTACH_RWING: number
+declare ATTACH_TAIL_BASE: number
+declare ATTACH_TAIL_TIP: number
+declare AVOID_CHARACTERS: number
+declare AVOID_DYNAMIC_OBSTACLES: number
+declare AVOID_NONE: number
+declare BEACON_MAP: number
+declare CAMERA_ACTIVE: number
+declare CAMERA_BEHINDNESS_ANGLE: number
+declare CAMERA_BEHINDNESS_LAG: number
+declare CAMERA_DISTANCE: number
+declare CAMERA_FOCUS: number
+declare CAMERA_FOCUS_LAG: number
+declare CAMERA_FOCUS_LOCKED: number
+declare CAMERA_FOCUS_OFFSET: number
+declare CAMERA_FOCUS_THRESHOLD: number
+declare CAMERA_PITCH: number
+declare CAMERA_POSITION: number
+declare CAMERA_POSITION_LAG: number
+declare CAMERA_POSITION_LOCKED: number
+declare CAMERA_POSITION_THRESHOLD: number
+declare CHANGED_ALLOWED_DROP: number
+declare CHANGED_COLOR: number
+declare CHANGED_INVENTORY: number
+declare CHANGED_LINK: number
+declare CHANGED_MEDIA: number
+declare CHANGED_OWNER: number
+declare CHANGED_REGION: number
+declare CHANGED_REGION_START: number
+declare CHANGED_RENDER_MATERIAL: number
+declare CHANGED_SCALE: number
+declare CHANGED_SHAPE: number
+declare CHANGED_TELEPORT: number
+declare CHANGED_TEXTURE: number
+declare CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES: number
+declare CHARACTER_AVOIDANCE_MODE: number
+declare CHARACTER_CMD_JUMP: number
+declare CHARACTER_CMD_SMOOTH_STOP: number
+declare CHARACTER_CMD_STOP: number
+declare CHARACTER_DESIRED_SPEED: number
+declare CHARACTER_DESIRED_TURN_SPEED: number
+declare CHARACTER_LENGTH: number
+declare CHARACTER_MAX_ACCEL: number
+declare CHARACTER_MAX_DECEL: number
+declare CHARACTER_MAX_SPEED: number
+declare CHARACTER_MAX_TURN_RADIUS: number
+declare CHARACTER_ORIENTATION: number
+declare CHARACTER_RADIUS: number
+declare CHARACTER_STAY_WITHIN_PARCEL: number
+declare CHARACTER_TYPE: number
+declare CHARACTER_TYPE_A: number
+declare CHARACTER_TYPE_B: number
+declare CHARACTER_TYPE_C: number
+declare CHARACTER_TYPE_D: number
+declare CHARACTER_TYPE_NONE: number
+declare CLICK_ACTION_BUY: number
+declare CLICK_ACTION_DISABLED: number
+declare CLICK_ACTION_IGNORE: number
+declare CLICK_ACTION_NONE: number
+declare CLICK_ACTION_OPEN: number
+declare CLICK_ACTION_OPEN_MEDIA: number
+declare CLICK_ACTION_PAY: number
+declare CLICK_ACTION_PLAY: number
+declare CLICK_ACTION_SIT: number
+declare CLICK_ACTION_TOUCH: number
+declare CLICK_ACTION_ZOOM: number
+declare COMBAT_CHANNEL: number
+declare COMBAT_LOG_ID: uuid
+declare CONTENT_TYPE_ATOM: number
+declare CONTENT_TYPE_FORM: number
+declare CONTENT_TYPE_HTML: number
+declare CONTENT_TYPE_JSON: number
+declare CONTENT_TYPE_LLSD: number
+declare CONTENT_TYPE_RSS: number
+declare CONTENT_TYPE_TEXT: number
+declare CONTENT_TYPE_XHTML: number
+declare CONTENT_TYPE_XML: number
+declare CONTROL_BACK: number
+declare CONTROL_DOWN: number
+declare CONTROL_FWD: number
+declare CONTROL_LBUTTON: number
+declare CONTROL_LEFT: number
+declare CONTROL_ML_LBUTTON: number
+declare CONTROL_RIGHT: number
+declare CONTROL_ROT_LEFT: number
+declare CONTROL_ROT_RIGHT: number
+declare CONTROL_UP: number
+declare DAMAGEABLE: number
+declare DAMAGE_TYPE_ACID: number
+declare DAMAGE_TYPE_BLUDGEONING: number
+declare DAMAGE_TYPE_COLD: number
+declare DAMAGE_TYPE_ELECTRIC: number
+declare DAMAGE_TYPE_EMOTIONAL: number
+declare DAMAGE_TYPE_FIRE: number
+declare DAMAGE_TYPE_FORCE: number
+declare DAMAGE_TYPE_GENERIC: number
+declare DAMAGE_TYPE_IMPACT: number
+declare DAMAGE_TYPE_NECROTIC: number
+declare DAMAGE_TYPE_PIERCING: number
+declare DAMAGE_TYPE_POISON: number
+declare DAMAGE_TYPE_PSYCHIC: number
+declare DAMAGE_TYPE_RADIANT: number
+declare DAMAGE_TYPE_SLASHING: number
+declare DAMAGE_TYPE_SONIC: number
+declare DATA_BORN: number
+declare DATA_NAME: number
+declare DATA_ONLINE: number
+declare DATA_PAYINFO: number
+declare DATA_RATING: number
+declare DATA_SIM_POS: number
+declare DATA_SIM_RATING: number
+declare DATA_SIM_STATUS: number
+declare DEBUG_CHANNEL: number
+declare DEG_TO_RAD: number
+declare DENSITY: number
+declare DEREZ_DIE: number
+declare DEREZ_MAKE_TEMP: number
+declare DEREZ_TO_INVENTORY: number
+declare ENVIRONMENT_DAYINFO: number
+declare ENV_INVALID_AGENT: number
+declare ENV_INVALID_RULE: number
+declare ENV_NOT_EXPERIENCE: number
+declare ENV_NO_ENVIRONMENT: number
+declare ENV_NO_EXPERIENCE_LAND: number
+declare ENV_NO_EXPERIENCE_PERMISSION: number
+declare ENV_NO_PERMISSIONS: number
+declare ENV_THROTTLE: number
+declare ENV_VALIDATION_FAIL: number
+declare EOF: string
+declare ERR_GENERIC: number
+declare ERR_MALFORMED_PARAMS: number
+declare ERR_PARCEL_PERMISSIONS: number
+declare ERR_RUNTIME_PERMISSIONS: number
+declare ERR_THROTTLED: number
+declare ESTATE_ACCESS_ALLOWED_AGENT_ADD: number
+declare ESTATE_ACCESS_ALLOWED_AGENT_REMOVE: number
+declare ESTATE_ACCESS_ALLOWED_GROUP_ADD: number
+declare ESTATE_ACCESS_ALLOWED_GROUP_REMOVE: number
+declare ESTATE_ACCESS_BANNED_AGENT_ADD: number
+declare ESTATE_ACCESS_BANNED_AGENT_REMOVE: number
+declare FILTER_FLAGS: number
+declare FILTER_FLAG_HUDS: number
+declare FILTER_INCLUDE: number
+declare FORCE_DIRECT_PATH: number
+declare FRICTION: number
+declare GAME_CONTROL_AXIS_LEFTX: number
+declare GAME_CONTROL_AXIS_LEFTY: number
+declare GAME_CONTROL_AXIS_RIGHTX: number
+declare GAME_CONTROL_AXIS_RIGHTY: number
+declare GAME_CONTROL_AXIS_TRIGGERLEFT: number
+declare GAME_CONTROL_AXIS_TRIGGERRIGHT: number
+declare GAME_CONTROL_BUTTON_A: number
+declare GAME_CONTROL_BUTTON_B: number
+declare GAME_CONTROL_BUTTON_BACK: number
+declare GAME_CONTROL_BUTTON_DPAD_DOWN: number
+declare GAME_CONTROL_BUTTON_DPAD_LEFT: number
+declare GAME_CONTROL_BUTTON_DPAD_RIGHT: number
+declare GAME_CONTROL_BUTTON_DPAD_UP: number
+declare GAME_CONTROL_BUTTON_GUIDE: number
+declare GAME_CONTROL_BUTTON_LEFTSHOULDER: number
+declare GAME_CONTROL_BUTTON_LEFTSTICK: number
+declare GAME_CONTROL_BUTTON_MISC1: number
+declare GAME_CONTROL_BUTTON_PADDLE1: number
+declare GAME_CONTROL_BUTTON_PADDLE2: number
+declare GAME_CONTROL_BUTTON_PADDLE3: number
+declare GAME_CONTROL_BUTTON_PADDLE4: number
+declare GAME_CONTROL_BUTTON_RIGHTSHOULDER: number
+declare GAME_CONTROL_BUTTON_RIGHTSTICK: number
+declare GAME_CONTROL_BUTTON_START: number
+declare GAME_CONTROL_BUTTON_TOUCHPAD: number
+declare GAME_CONTROL_BUTTON_X: number
+declare GAME_CONTROL_BUTTON_Y: number
+declare GCNP_RADIUS: number
+declare GCNP_STATIC: number
+declare GRAVITY_MULTIPLIER: number
+declare HORIZONTAL: number
+declare HTTP_ACCEPT: number
+declare HTTP_BODY_MAXLENGTH: number
+declare HTTP_BODY_TRUNCATED: number
+declare HTTP_CUSTOM_HEADER: number
+declare HTTP_EXTENDED_ERROR: number
+declare HTTP_METHOD: number
+declare HTTP_MIMETYPE: number
+declare HTTP_PRAGMA_NO_CACHE: number
+declare HTTP_USER_AGENT: number
+declare HTTP_VERBOSE_THROTTLE: number
+declare HTTP_VERIFY_CERT: number
+declare IMG_USE_BAKED_AUX1: uuid
+declare IMG_USE_BAKED_AUX2: uuid
+declare IMG_USE_BAKED_AUX3: uuid
+declare IMG_USE_BAKED_EYES: uuid
+declare IMG_USE_BAKED_HAIR: uuid
+declare IMG_USE_BAKED_HEAD: uuid
+declare IMG_USE_BAKED_LEFTARM: uuid
+declare IMG_USE_BAKED_LEFTLEG: uuid
+declare IMG_USE_BAKED_LOWER: uuid
+declare IMG_USE_BAKED_SKIRT: uuid
+declare IMG_USE_BAKED_UPPER: uuid
+declare INVENTORY_ALL: number
+declare INVENTORY_ANIMATION: number
+declare INVENTORY_BODYPART: number
+declare INVENTORY_CLOTHING: number
+declare INVENTORY_GESTURE: number
+declare INVENTORY_LANDMARK: number
+declare INVENTORY_MATERIAL: number
+declare INVENTORY_NONE: number
+declare INVENTORY_NOTECARD: number
+declare INVENTORY_OBJECT: number
+declare INVENTORY_SCRIPT: number
+declare INVENTORY_SETTING: number
+declare INVENTORY_SOUND: number
+declare INVENTORY_TEXTURE: number
+declare JSON_APPEND: number
+declare JSON_ARRAY: string
+declare JSON_DELETE: string
+declare JSON_FALSE: string
+declare JSON_INVALID: string
+declare JSON_NULL: string
+declare JSON_NUMBER: string
+declare JSON_OBJECT: string
+declare JSON_STRING: string
+declare JSON_TRUE: string
+declare KFM_CMD_PAUSE: number
+declare KFM_CMD_PLAY: number
+declare KFM_CMD_STOP: number
+declare KFM_COMMAND: number
+declare KFM_DATA: number
+declare KFM_FORWARD: number
+declare KFM_LOOP: number
+declare KFM_MODE: number
+declare KFM_PING_PONG: number
+declare KFM_REVERSE: number
+declare KFM_ROTATION: number
+declare KFM_TRANSLATION: number
+declare LAND_LARGE_BRUSH: number
+declare LAND_LEVEL: number
+declare LAND_LOWER: number
+declare LAND_MEDIUM_BRUSH: number
+declare LAND_NOISE: number
+declare LAND_RAISE: number
+declare LAND_REVERT: number
+declare LAND_SMALL_BRUSH: number
+declare LAND_SMOOTH: number
+declare LINKSETDATA_DELETE: number
+declare LINKSETDATA_EMEMORY: number
+declare LINKSETDATA_ENOKEY: number
+declare LINKSETDATA_EPROTECTED: number
+declare LINKSETDATA_MULTIDELETE: number
+declare LINKSETDATA_NOTFOUND: number
+declare LINKSETDATA_NOUPDATE: number
+declare LINKSETDATA_OK: number
+declare LINKSETDATA_RESET: number
+declare LINKSETDATA_UPDATE: number
+declare LINK_ALL_CHILDREN: number
+declare LINK_ALL_OTHERS: number
+declare LINK_ROOT: number
+declare LINK_SET: number
+declare LINK_THIS: number
+declare LIST_STAT_GEOMETRIC_MEAN: number
+declare LIST_STAT_MAX: number
+declare LIST_STAT_MEAN: number
+declare LIST_STAT_MEDIAN: number
+declare LIST_STAT_MIN: number
+declare LIST_STAT_NUM_COUNT: number
+declare LIST_STAT_RANGE: number
+declare LIST_STAT_STD_DEV: number
+declare LIST_STAT_SUM: number
+declare LIST_STAT_SUM_SQUARES: number
+declare LOOP: number
+declare MASK_BASE: number
+declare MASK_COMBINED: number
+declare MASK_EVERYONE: number
+declare MASK_GROUP: number
+declare MASK_NEXT: number
+declare MASK_OWNER: number
+declare NAK: string
+declare NULL_KEY: uuid
+declare OBJECT_ACCOUNT_LEVEL: number
+declare OBJECT_ANIMATED_COUNT: number
+declare OBJECT_ANIMATED_SLOTS_AVAILABLE: number
+declare OBJECT_ATTACHED_POINT: number
+declare OBJECT_ATTACHED_SLOTS_AVAILABLE: number
+declare OBJECT_BODY_SHAPE_TYPE: number
+declare OBJECT_CHARACTER_TIME: number
+declare OBJECT_CLICK_ACTION: number
+declare OBJECT_CREATION_TIME: number
+declare OBJECT_CREATOR: number
+declare OBJECT_DAMAGE: number
+declare OBJECT_DAMAGE_TYPE: number
+declare OBJECT_DESC: number
+declare OBJECT_GROUP: number
+declare OBJECT_GROUP_TAG: number
+declare OBJECT_HEALTH: number
+declare OBJECT_HOVER_HEIGHT: number
+declare OBJECT_LAST_OWNER_ID: number
+declare OBJECT_LINK_NUMBER: number
+declare OBJECT_MASS: number
+declare OBJECT_MATERIAL: number
+declare OBJECT_NAME: number
+declare OBJECT_OMEGA: number
+declare OBJECT_OWNER: number
+declare OBJECT_PATHFINDING_TYPE: number
+declare OBJECT_PERMS: number
+declare OBJECT_PERMS_COMBINED: number
+declare OBJECT_PHANTOM: number
+declare OBJECT_PHYSICS: number
+declare OBJECT_PHYSICS_COST: number
+declare OBJECT_POS: number
+declare OBJECT_PRIM_COUNT: number
+declare OBJECT_PRIM_EQUIVALENCE: number
+declare OBJECT_RENDER_WEIGHT: number
+declare OBJECT_RETURN_PARCEL: number
+declare OBJECT_RETURN_PARCEL_OWNER: number
+declare OBJECT_RETURN_REGION: number
+declare OBJECT_REZZER_KEY: number
+declare OBJECT_REZ_TIME: number
+declare OBJECT_ROOT: number
+declare OBJECT_ROT: number
+declare OBJECT_RUNNING_SCRIPT_COUNT: number
+declare OBJECT_SCALE: number
+declare OBJECT_SCRIPT_MEMORY: number
+declare OBJECT_SCRIPT_TIME: number
+declare OBJECT_SELECT_COUNT: number
+declare OBJECT_SERVER_COST: number
+declare OBJECT_SIT_COUNT: number
+declare OBJECT_STREAMING_COST: number
+declare OBJECT_TEMP_ATTACHED: number
+declare OBJECT_TEMP_ON_REZ: number
+declare OBJECT_TEXT: number
+declare OBJECT_TEXT_ALPHA: number
+declare OBJECT_TEXT_COLOR: number
+declare OBJECT_TOTAL_INVENTORY_COUNT: number
+declare OBJECT_TOTAL_SCRIPT_COUNT: number
+declare OBJECT_UNKNOWN_DETAIL: number
+declare OBJECT_VELOCITY: number
+declare OPT_AVATAR: number
+declare OPT_CHARACTER: number
+declare OPT_EXCLUSION_VOLUME: number
+declare OPT_LEGACY_LINKSET: number
+declare OPT_MATERIAL_VOLUME: number
+declare OPT_OTHER: number
+declare OPT_STATIC_OBSTACLE: number
+declare OPT_WALKABLE: number
+declare OVERRIDE_GLTF_BASE_ALPHA: number
+declare OVERRIDE_GLTF_BASE_ALPHA_MASK: number
+declare OVERRIDE_GLTF_BASE_ALPHA_MODE: number
+declare OVERRIDE_GLTF_BASE_COLOR_FACTOR: number
+declare OVERRIDE_GLTF_BASE_DOUBLE_SIDED: number
+declare OVERRIDE_GLTF_EMISSIVE_FACTOR: number
+declare OVERRIDE_GLTF_METALLIC_FACTOR: number
+declare OVERRIDE_GLTF_ROUGHNESS_FACTOR: number
+declare PARCEL_COUNT_GROUP: number
+declare PARCEL_COUNT_OTHER: number
+declare PARCEL_COUNT_OWNER: number
+declare PARCEL_COUNT_SELECTED: number
+declare PARCEL_COUNT_TEMP: number
+declare PARCEL_COUNT_TOTAL: number
+declare PARCEL_DETAILS_AREA: number
+declare PARCEL_DETAILS_DESC: number
+declare PARCEL_DETAILS_FLAGS: number
+declare PARCEL_DETAILS_GROUP: number
+declare PARCEL_DETAILS_ID: number
+declare PARCEL_DETAILS_LANDING_LOOKAT: number
+declare PARCEL_DETAILS_LANDING_POINT: number
+declare PARCEL_DETAILS_NAME: number
+declare PARCEL_DETAILS_OWNER: number
+declare PARCEL_DETAILS_PRIM_CAPACITY: number
+declare PARCEL_DETAILS_PRIM_USED: number
+declare PARCEL_DETAILS_SCRIPT_DANGER: number
+declare PARCEL_DETAILS_SEE_AVATARS: number
+declare PARCEL_DETAILS_TP_ROUTING: number
+declare PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY: number
+declare PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS: number
+declare PARCEL_FLAG_ALLOW_CREATE_OBJECTS: number
+declare PARCEL_FLAG_ALLOW_DAMAGE: number
+declare PARCEL_FLAG_ALLOW_FLY: number
+declare PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY: number
+declare PARCEL_FLAG_ALLOW_GROUP_SCRIPTS: number
+declare PARCEL_FLAG_ALLOW_LANDMARK: number
+declare PARCEL_FLAG_ALLOW_SCRIPTS: number
+declare PARCEL_FLAG_ALLOW_TERRAFORM: number
+declare PARCEL_FLAG_LOCAL_SOUND_ONLY: number
+declare PARCEL_FLAG_RESTRICT_PUSHOBJECT: number
+declare PARCEL_FLAG_USE_ACCESS_GROUP: number
+declare PARCEL_FLAG_USE_ACCESS_LIST: number
+declare PARCEL_FLAG_USE_BAN_LIST: number
+declare PARCEL_FLAG_USE_LAND_PASS_LIST: number
+declare PARCEL_MEDIA_COMMAND_AGENT: number
+declare PARCEL_MEDIA_COMMAND_AUTO_ALIGN: number
+declare PARCEL_MEDIA_COMMAND_DESC: number
+declare PARCEL_MEDIA_COMMAND_LOOP: number
+declare PARCEL_MEDIA_COMMAND_LOOP_SET: number
+declare PARCEL_MEDIA_COMMAND_PAUSE: number
+declare PARCEL_MEDIA_COMMAND_PLAY: number
+declare PARCEL_MEDIA_COMMAND_SIZE: number
+declare PARCEL_MEDIA_COMMAND_STOP: number
+declare PARCEL_MEDIA_COMMAND_TEXTURE: number
+declare PARCEL_MEDIA_COMMAND_TIME: number
+declare PARCEL_MEDIA_COMMAND_TYPE: number
+declare PARCEL_MEDIA_COMMAND_UNLOAD: number
+declare PARCEL_MEDIA_COMMAND_URL: number
+declare PARCEL_SALE_AGENT: number
+declare PARCEL_SALE_ERROR_BAD_PARAMS: number
+declare PARCEL_SALE_ERROR_INVALID_PRICE: number
+declare PARCEL_SALE_ERROR_IN_ESCROW: number
+declare PARCEL_SALE_ERROR_NO_PARCEL: number
+declare PARCEL_SALE_ERROR_NO_PERMISSIONS: number
+declare PARCEL_SALE_OBJECTS: number
+declare PARCEL_SALE_OK: number
+declare PARCEL_SALE_PRICE: number
+declare PASSIVE: number
+declare PASS_ALWAYS: number
+declare PASS_IF_NOT_HANDLED: number
+declare PASS_NEVER: number
+declare PATROL_PAUSE_AT_WAYPOINTS: number
+declare PAYMENT_INFO_ON_FILE: number
+declare PAYMENT_INFO_USED: number
+declare PAY_DEFAULT: number
+declare PAY_HIDE: number
+declare PERMISSION_ATTACH: number
+declare PERMISSION_CHANGE_JOINTS: number
+declare PERMISSION_CHANGE_LINKS: number
+declare PERMISSION_CHANGE_PERMISSIONS: number
+declare PERMISSION_CONTROL_CAMERA: number
+declare PERMISSION_DEBIT: number
+declare PERMISSION_OVERRIDE_ANIMATIONS: number
+declare PERMISSION_RELEASE_OWNERSHIP: number
+declare PERMISSION_REMAP_CONTROLS: number
+declare PERMISSION_RETURN_OBJECTS: number
+declare PERMISSION_SILENT_ESTATE_MANAGEMENT: number
+declare PERMISSION_TAKE_CONTROLS: number
+declare PERMISSION_TELEPORT: number
+declare PERMISSION_TRACK_CAMERA: number
+declare PERMISSION_TRIGGER_ANIMATION: number
+declare PERM_ALL: number
+declare PERM_COPY: number
+declare PERM_MODIFY: number
+declare PERM_MOVE: number
+declare PERM_TRANSFER: number
+declare PI: number
+declare PING_PONG: number
+declare PI_BY_TWO: number
+declare PRIM_ALLOW_UNSIT: number
+declare PRIM_ALPHA_MODE: number
+declare PRIM_ALPHA_MODE_BLEND: number
+declare PRIM_ALPHA_MODE_EMISSIVE: number
+declare PRIM_ALPHA_MODE_MASK: number
+declare PRIM_ALPHA_MODE_NONE: number
+declare PRIM_BUMP_BARK: number
+declare PRIM_BUMP_BLOBS: number
+declare PRIM_BUMP_BRICKS: number
+declare PRIM_BUMP_BRIGHT: number
+declare PRIM_BUMP_CHECKER: number
+declare PRIM_BUMP_CONCRETE: number
+declare PRIM_BUMP_DARK: number
+declare PRIM_BUMP_DISKS: number
+declare PRIM_BUMP_GRAVEL: number
+declare PRIM_BUMP_LARGETILE: number
+declare PRIM_BUMP_NONE: number
+declare PRIM_BUMP_SHINY: number
+declare PRIM_BUMP_SIDING: number
+declare PRIM_BUMP_STONE: number
+declare PRIM_BUMP_STUCCO: number
+declare PRIM_BUMP_SUCTION: number
+declare PRIM_BUMP_TILE: number
+declare PRIM_BUMP_WEAVE: number
+declare PRIM_BUMP_WOOD: number
+declare PRIM_CAST_SHADOWS: number
+declare PRIM_CLICK_ACTION: number
+declare PRIM_COLLISION_SOUND: number
+declare PRIM_COLOR: number
+declare PRIM_DAMAGE: number
+declare PRIM_DESC: number
+declare PRIM_FLEXIBLE: number
+declare PRIM_FULLBRIGHT: number
+declare PRIM_GLOW: number
+declare PRIM_GLTF_ALPHA_MODE_BLEND: number
+declare PRIM_GLTF_ALPHA_MODE_MASK: number
+declare PRIM_GLTF_ALPHA_MODE_OPAQUE: number
+declare PRIM_GLTF_BASE_COLOR: number
+declare PRIM_GLTF_EMISSIVE: number
+declare PRIM_GLTF_METALLIC_ROUGHNESS: number
+declare PRIM_GLTF_NORMAL: number
+declare PRIM_HEALTH: number
+declare PRIM_HOLE_CIRCLE: number
+declare PRIM_HOLE_DEFAULT: number
+declare PRIM_HOLE_SQUARE: number
+declare PRIM_HOLE_TRIANGLE: number
+declare PRIM_LINK_TARGET: number
+declare PRIM_MATERIAL: number
+declare PRIM_MATERIAL_FLESH: number
+declare PRIM_MATERIAL_GLASS: number
+declare PRIM_MATERIAL_LIGHT: number
+declare PRIM_MATERIAL_METAL: number
+declare PRIM_MATERIAL_PLASTIC: number
+declare PRIM_MATERIAL_RUBBER: number
+declare PRIM_MATERIAL_STONE: number
+declare PRIM_MATERIAL_WOOD: number
+declare PRIM_MEDIA_ALT_IMAGE_ENABLE: number
+declare PRIM_MEDIA_AUTO_LOOP: number
+declare PRIM_MEDIA_AUTO_PLAY: number
+declare PRIM_MEDIA_AUTO_SCALE: number
+declare PRIM_MEDIA_AUTO_ZOOM: number
+declare PRIM_MEDIA_CONTROLS: number
+declare PRIM_MEDIA_CONTROLS_MINI: number
+declare PRIM_MEDIA_CONTROLS_STANDARD: number
+declare PRIM_MEDIA_CURRENT_URL: number
+declare PRIM_MEDIA_FIRST_CLICK_INTERACT: number
+declare PRIM_MEDIA_HEIGHT_PIXELS: number
+declare PRIM_MEDIA_HOME_URL: number
+declare PRIM_MEDIA_MAX_HEIGHT_PIXELS: number
+declare PRIM_MEDIA_MAX_URL_LENGTH: number
+declare PRIM_MEDIA_MAX_WHITELIST_COUNT: number
+declare PRIM_MEDIA_MAX_WHITELIST_SIZE: number
+declare PRIM_MEDIA_MAX_WIDTH_PIXELS: number
+declare PRIM_MEDIA_PARAM_MAX: number
+declare PRIM_MEDIA_PERMS_CONTROL: number
+declare PRIM_MEDIA_PERMS_INTERACT: number
+declare PRIM_MEDIA_PERM_ANYONE: number
+declare PRIM_MEDIA_PERM_GROUP: number
+declare PRIM_MEDIA_PERM_NONE: number
+declare PRIM_MEDIA_PERM_OWNER: number
+declare PRIM_MEDIA_WHITELIST: number
+declare PRIM_MEDIA_WHITELIST_ENABLE: number
+declare PRIM_MEDIA_WIDTH_PIXELS: number
+declare PRIM_NAME: number
+declare PRIM_NORMAL: number
+declare PRIM_OMEGA: number
+declare PRIM_PHANTOM: number
+declare PRIM_PHYSICS: number
+declare PRIM_PHYSICS_SHAPE_CONVEX: number
+declare PRIM_PHYSICS_SHAPE_NONE: number
+declare PRIM_PHYSICS_SHAPE_PRIM: number
+declare PRIM_PHYSICS_SHAPE_TYPE: number
+declare PRIM_POINT_LIGHT: number
+declare PRIM_POSITION: number
+declare PRIM_POS_LOCAL: number
+declare PRIM_PROJECTOR: number
+declare PRIM_REFLECTION_PROBE: number
+declare PRIM_REFLECTION_PROBE_BOX: number
+declare PRIM_REFLECTION_PROBE_DYNAMIC: number
+declare PRIM_REFLECTION_PROBE_MIRROR: number
+declare PRIM_RENDER_MATERIAL: number
+declare PRIM_ROTATION: number
+declare PRIM_ROT_LOCAL: number
+declare PRIM_SCRIPTED_SIT_ONLY: number
+declare PRIM_SCULPT_FLAG_ANIMESH: number
+declare PRIM_SCULPT_FLAG_INVERT: number
+declare PRIM_SCULPT_FLAG_MIRROR: number
+declare PRIM_SCULPT_TYPE_CYLINDER: number
+declare PRIM_SCULPT_TYPE_MASK: number
+declare PRIM_SCULPT_TYPE_MESH: number
+declare PRIM_SCULPT_TYPE_PLANE: number
+declare PRIM_SCULPT_TYPE_SPHERE: number
+declare PRIM_SCULPT_TYPE_TORUS: number
+declare PRIM_SHINY_HIGH: number
+declare PRIM_SHINY_LOW: number
+declare PRIM_SHINY_MEDIUM: number
+declare PRIM_SHINY_NONE: number
+declare PRIM_SIT_FLAGS: number
+declare PRIM_SIT_TARGET: number
+declare PRIM_SIZE: number
+declare PRIM_SLICE: number
+declare PRIM_SPECULAR: number
+declare PRIM_TEMP_ON_REZ: number
+declare PRIM_TEXGEN: number
+declare PRIM_TEXGEN_DEFAULT: number
+declare PRIM_TEXGEN_PLANAR: number
+declare PRIM_TEXT: number
+declare PRIM_TEXTURE: number
+declare PRIM_TYPE: number
+declare PRIM_TYPE_BOX: number
+declare PRIM_TYPE_CYLINDER: number
+declare PRIM_TYPE_PRISM: number
+declare PRIM_TYPE_RING: number
+declare PRIM_TYPE_SCULPT: number
+declare PRIM_TYPE_SPHERE: number
+declare PRIM_TYPE_TORUS: number
+declare PRIM_TYPE_TUBE: number
+declare PROFILE_NONE: number
+declare PROFILE_SCRIPT_MEMORY: number
+declare PSYS_PART_BF_DEST_COLOR: number
+declare PSYS_PART_BF_ONE: number
+declare PSYS_PART_BF_ONE_MINUS_DEST_COLOR: number
+declare PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA: number
+declare PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR: number
+declare PSYS_PART_BF_SOURCE_ALPHA: number
+declare PSYS_PART_BF_SOURCE_COLOR: number
+declare PSYS_PART_BF_ZERO: number
+declare PSYS_PART_BLEND_FUNC_DEST: number
+declare PSYS_PART_BLEND_FUNC_SOURCE: number
+declare PSYS_PART_BOUNCE_MASK: number
+declare PSYS_PART_EMISSIVE_MASK: number
+declare PSYS_PART_END_ALPHA: number
+declare PSYS_PART_END_COLOR: number
+declare PSYS_PART_END_GLOW: number
+declare PSYS_PART_END_SCALE: number
+declare PSYS_PART_FLAGS: number
+declare PSYS_PART_FOLLOW_SRC_MASK: number
+declare PSYS_PART_FOLLOW_VELOCITY_MASK: number
+declare PSYS_PART_INTERP_COLOR_MASK: number
+declare PSYS_PART_INTERP_SCALE_MASK: number
+declare PSYS_PART_MAX_AGE: number
+declare PSYS_PART_RIBBON_MASK: number
+declare PSYS_PART_START_ALPHA: number
+declare PSYS_PART_START_COLOR: number
+declare PSYS_PART_START_GLOW: number
+declare PSYS_PART_START_SCALE: number
+declare PSYS_PART_TARGET_LINEAR_MASK: number
+declare PSYS_PART_TARGET_POS_MASK: number
+declare PSYS_PART_WIND_MASK: number
+declare PSYS_SRC_ACCEL: number
+declare PSYS_SRC_ANGLE_BEGIN: number
+declare PSYS_SRC_ANGLE_END: number
+declare PSYS_SRC_BURST_PART_COUNT: number
+declare PSYS_SRC_BURST_RADIUS: number
+declare PSYS_SRC_BURST_RATE: number
+declare PSYS_SRC_BURST_SPEED_MAX: number
+declare PSYS_SRC_BURST_SPEED_MIN: number
+declare PSYS_SRC_INNERANGLE: number
+declare PSYS_SRC_MAX_AGE: number
+declare PSYS_SRC_OMEGA: number
+declare PSYS_SRC_OUTERANGLE: number
+declare PSYS_SRC_PATTERN: number
+declare PSYS_SRC_PATTERN_ANGLE: number
+declare PSYS_SRC_PATTERN_ANGLE_CONE: number
+declare PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY: number
+declare PSYS_SRC_PATTERN_DROP: number
+declare PSYS_SRC_PATTERN_EXPLODE: number
+declare PSYS_SRC_TARGET_KEY: number
+declare PSYS_SRC_TEXTURE: number
+declare PUBLIC_CHANNEL: number
+declare PURSUIT_FUZZ_FACTOR: number
+declare PURSUIT_GOAL_TOLERANCE: number
+declare PURSUIT_INTERCEPT: number
+declare PURSUIT_OFFSET: number
+declare PU_EVADE_HIDDEN: number
+declare PU_EVADE_SPOTTED: number
+declare PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED: number
+declare PU_FAILURE_INVALID_GOAL: number
+declare PU_FAILURE_INVALID_START: number
+declare PU_FAILURE_NO_NAVMESH: number
+declare PU_FAILURE_NO_VALID_DESTINATION: number
+declare PU_FAILURE_OTHER: number
+declare PU_FAILURE_PARCEL_UNREACHABLE: number
+declare PU_FAILURE_TARGET_GONE: number
+declare PU_FAILURE_UNREACHABLE: number
+declare PU_GOAL_REACHED: number
+declare PU_SLOWDOWN_DISTANCE_REACHED: number
+declare RAD_TO_DEG: number
+declare RCERR_CAST_TIME_EXCEEDED: number
+declare RCERR_SIM_PERF_LOW: number
+declare RCERR_UNKNOWN: number
+declare RC_DATA_FLAGS: number
+declare RC_DETECT_PHANTOM: number
+declare RC_GET_LINK_NUM: number
+declare RC_GET_NORMAL: number
+declare RC_GET_ROOT_KEY: number
+declare RC_MAX_HITS: number
+declare RC_REJECT_AGENTS: number
+declare RC_REJECT_LAND: number
+declare RC_REJECT_NONPHYSICAL: number
+declare RC_REJECT_PHYSICAL: number
+declare RC_REJECT_TYPES: number
+declare REGION_FLAG_ALLOW_DAMAGE: number
+declare REGION_FLAG_ALLOW_DIRECT_TELEPORT: number
+declare REGION_FLAG_BLOCK_FLY: number
+declare REGION_FLAG_BLOCK_FLYOVER: number
+declare REGION_FLAG_BLOCK_TERRAFORM: number
+declare REGION_FLAG_DISABLE_COLLISIONS: number
+declare REGION_FLAG_DISABLE_PHYSICS: number
+declare REGION_FLAG_FIXED_SUN: number
+declare REGION_FLAG_RESTRICT_PUSHOBJECT: number
+declare REGION_FLAG_SANDBOX: number
+declare REMOTE_DATA_CHANNEL: number
+declare REMOTE_DATA_REPLY: number
+declare REMOTE_DATA_REQUEST: number
+declare REQUIRE_LINE_OF_SIGHT: number
+declare RESTITUTION: number
+declare REVERSE: number
+declare REZ_ACCEL: number
+declare REZ_DAMAGE: number
+declare REZ_DAMAGE_TYPE: number
+declare REZ_FLAGS: number
+declare REZ_FLAG_BLOCK_GRAB_OBJECT: number
+declare REZ_FLAG_DIE_ON_COLLIDE: number
+declare REZ_FLAG_DIE_ON_NOENTRY: number
+declare REZ_FLAG_NO_COLLIDE_FAMILY: number
+declare REZ_FLAG_NO_COLLIDE_OWNER: number
+declare REZ_FLAG_PHANTOM: number
+declare REZ_FLAG_PHYSICAL: number
+declare REZ_FLAG_TEMP: number
+declare REZ_LOCK_AXES: number
+declare REZ_OMEGA: number
+declare REZ_PARAM: number
+declare REZ_PARAM_STRING: number
+declare REZ_POS: number
+declare REZ_ROT: number
+declare REZ_SOUND: number
+declare REZ_SOUND_COLLIDE: number
+declare REZ_VEL: number
+declare ROTATE: number
+declare SCALE: number
+declare SCRIPTED: number
+declare SIM_STAT_ACTIVE_SCRIPT_COUNT: number
+declare SIM_STAT_AGENT_COUNT: number
+declare SIM_STAT_AGENT_MS: number
+declare SIM_STAT_AGENT_UPDATES: number
+declare SIM_STAT_AI_MS: number
+declare SIM_STAT_ASSET_DOWNLOADS: number
+declare SIM_STAT_ASSET_UPLOADS: number
+declare SIM_STAT_CHILD_AGENT_COUNT: number
+declare SIM_STAT_FRAME_MS: number
+declare SIM_STAT_IMAGE_MS: number
+declare SIM_STAT_IO_PUMP_MS: number
+declare SIM_STAT_NET_MS: number
+declare SIM_STAT_OTHER_MS: number
+declare SIM_STAT_PACKETS_IN: number
+declare SIM_STAT_PACKETS_OUT: number
+declare SIM_STAT_PCT_CHARS_STEPPED: number
+declare SIM_STAT_PHYSICS_FPS: number
+declare SIM_STAT_PHYSICS_MS: number
+declare SIM_STAT_PHYSICS_OTHER_MS: number
+declare SIM_STAT_PHYSICS_SHAPE_MS: number
+declare SIM_STAT_PHYSICS_STEP_MS: number
+declare SIM_STAT_SCRIPT_EPS: number
+declare SIM_STAT_SCRIPT_MS: number
+declare SIM_STAT_SCRIPT_RUN_PCT: number
+declare SIM_STAT_SLEEP_MS: number
+declare SIM_STAT_SPARE_MS: number
+declare SIM_STAT_UNACKED_BYTES: number
+declare SIT_FLAG_ALLOW_UNSIT: number
+declare SIT_FLAG_NO_COLLIDE: number
+declare SIT_FLAG_NO_DAMAGE: number
+declare SIT_FLAG_SCRIPTED_ONLY: number
+declare SIT_FLAG_SIT_TARGET: number
+declare SIT_INVALID_AGENT: number
+declare SIT_INVALID_LINK: number
+declare SIT_INVALID_OBJECT: number
+declare SIT_NOT_EXPERIENCE: number
+declare SIT_NO_ACCESS: number
+declare SIT_NO_EXPERIENCE_PERMISSION: number
+declare SIT_NO_SIT_TARGET: number
+declare SKY_AMBIENT: number
+declare SKY_BLUE: number
+declare SKY_CLOUDS: number
+declare SKY_CLOUD_TEXTURE: number
+declare SKY_DOME: number
+declare SKY_GAMMA: number
+declare SKY_GLOW: number
+declare SKY_HAZE: number
+declare SKY_LIGHT: number
+declare SKY_MOON: number
+declare SKY_MOON_TEXTURE: number
+declare SKY_PLANET: number
+declare SKY_REFLECTION_PROBE_AMBIANCE: number
+declare SKY_REFRACTION: number
+declare SKY_STAR_BRIGHTNESS: number
+declare SKY_SUN: number
+declare SKY_SUN_TEXTURE: number
+declare SKY_TEXTURE_DEFAULTS: number
+declare SKY_TRACKS: number
+declare SMOOTH: number
+declare SOUND_LOOP: number
+declare SOUND_PLAY: number
+declare SOUND_SYNC: number
+declare SOUND_TRIGGER: number
+declare SQRT2: number
+declare STATUS_BLOCK_GRAB: number
+declare STATUS_BLOCK_GRAB_OBJECT: number
+declare STATUS_BOUNDS_ERROR: number
+declare STATUS_CAST_SHADOWS: number
+declare STATUS_DIE_AT_EDGE: number
+declare STATUS_DIE_AT_NO_ENTRY: number
+declare STATUS_INTERNAL_ERROR: number
+declare STATUS_MALFORMED_PARAMS: number
+declare STATUS_NOT_FOUND: number
+declare STATUS_NOT_SUPPORTED: number
+declare STATUS_OK: number
+declare STATUS_PHANTOM: number
+declare STATUS_PHYSICS: number
+declare STATUS_RETURN_AT_EDGE: number
+declare STATUS_ROTATE_X: number
+declare STATUS_ROTATE_Y: number
+declare STATUS_ROTATE_Z: number
+declare STATUS_SANDBOX: number
+declare STATUS_TYPE_MISMATCH: number
+declare STATUS_WHITELIST_FAILED: number
+declare STRING_TRIM: number
+declare STRING_TRIM_HEAD: number
+declare STRING_TRIM_TAIL: number
+declare TARGETED_EMAIL_OBJECT_OWNER: number
+declare TARGETED_EMAIL_ROOT_CREATOR: number
+declare TERRAIN_DETAIL_1: number
+declare TERRAIN_DETAIL_2: number
+declare TERRAIN_DETAIL_3: number
+declare TERRAIN_DETAIL_4: number
+declare TERRAIN_HEIGHT_RANGE_NE: number
+declare TERRAIN_HEIGHT_RANGE_NW: number
+declare TERRAIN_HEIGHT_RANGE_SE: number
+declare TERRAIN_HEIGHT_RANGE_SW: number
+declare TERRAIN_PBR_OFFSET_1: number
+declare TERRAIN_PBR_OFFSET_2: number
+declare TERRAIN_PBR_OFFSET_3: number
+declare TERRAIN_PBR_OFFSET_4: number
+declare TERRAIN_PBR_ROTATION_1: number
+declare TERRAIN_PBR_ROTATION_2: number
+declare TERRAIN_PBR_ROTATION_3: number
+declare TERRAIN_PBR_ROTATION_4: number
+declare TERRAIN_PBR_SCALE_1: number
+declare TERRAIN_PBR_SCALE_2: number
+declare TERRAIN_PBR_SCALE_3: number
+declare TERRAIN_PBR_SCALE_4: number
+declare TEXTURE_BLANK: uuid
+declare TEXTURE_DEFAULT: uuid
+declare TEXTURE_MEDIA: uuid
+declare TEXTURE_PLYWOOD: uuid
+declare TEXTURE_TRANSPARENT: uuid
+declare TOUCH_INVALID_FACE: number
+declare TOUCH_INVALID_TEXCOORD: vector
+declare TOUCH_INVALID_VECTOR: vector
+declare TP_ROUTING_BLOCKED: number
+declare TP_ROUTING_FREE: number
+declare TP_ROUTING_LANDINGP: number
+declare TRANSFER_BAD_OPTS: number
+declare TRANSFER_BAD_ROOT: number
+declare TRANSFER_DEST: number
+declare TRANSFER_FLAGS: number
+declare TRANSFER_FLAG_COPY: number
+declare TRANSFER_FLAG_RESERVED: number
+declare TRANSFER_FLAG_TAKE: number
+declare TRANSFER_NO_ATTACHMENT: number
+declare TRANSFER_NO_ITEMS: number
+declare TRANSFER_NO_PERMS: number
+declare TRANSFER_NO_TARGET: number
+declare TRANSFER_OK: number
+declare TRANSFER_THROTTLE: number
+declare TRAVERSAL_TYPE: number
+declare TRAVERSAL_TYPE_FAST: number
+declare TRAVERSAL_TYPE_NONE: number
+declare TRAVERSAL_TYPE_SLOW: number
+declare TWO_PI: number
+declare TYPE_FLOAT: number
+declare TYPE_INTEGER: number
+declare TYPE_INVALID: number
+declare TYPE_KEY: number
+declare TYPE_ROTATION: number
+declare TYPE_STRING: number
+declare TYPE_VECTOR: number
+declare URL_REQUEST_DENIED: string
+declare URL_REQUEST_GRANTED: string
+declare VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY: number
+declare VEHICLE_ANGULAR_DEFLECTION_TIMESCALE: number
+declare VEHICLE_ANGULAR_FRICTION_TIMESCALE: number
+declare VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE: number
+declare VEHICLE_ANGULAR_MOTOR_DIRECTION: number
+declare VEHICLE_ANGULAR_MOTOR_TIMESCALE: number
+declare VEHICLE_BANKING_EFFICIENCY: number
+declare VEHICLE_BANKING_MIX: number
+declare VEHICLE_BANKING_TIMESCALE: number
+declare VEHICLE_BUOYANCY: number
+declare VEHICLE_FLAG_BLOCK_INTERFERENCE: number
+declare VEHICLE_FLAG_CAMERA_DECOUPLED: number
+declare VEHICLE_FLAG_HOVER_GLOBAL_HEIGHT: number
+declare VEHICLE_FLAG_HOVER_TERRAIN_ONLY: number
+declare VEHICLE_FLAG_HOVER_UP_ONLY: number
+declare VEHICLE_FLAG_HOVER_WATER_ONLY: number
+declare VEHICLE_FLAG_LIMIT_MOTOR_UP: number
+declare VEHICLE_FLAG_LIMIT_ROLL_ONLY: number
+declare VEHICLE_FLAG_MOUSELOOK_BANK: number
+declare VEHICLE_FLAG_MOUSELOOK_STEER: number
+declare VEHICLE_FLAG_NO_DEFLECTION_UP: number
+declare VEHICLE_FLAG_NO_FLY_UP: number
+declare VEHICLE_HOVER_EFFICIENCY: number
+declare VEHICLE_HOVER_HEIGHT: number
+declare VEHICLE_HOVER_TIMESCALE: number
+declare VEHICLE_LINEAR_DEFLECTION_EFFICIENCY: number
+declare VEHICLE_LINEAR_DEFLECTION_TIMESCALE: number
+declare VEHICLE_LINEAR_FRICTION_TIMESCALE: number
+declare VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE: number
+declare VEHICLE_LINEAR_MOTOR_DIRECTION: number
+declare VEHICLE_LINEAR_MOTOR_OFFSET: number
+declare VEHICLE_LINEAR_MOTOR_TIMESCALE: number
+declare VEHICLE_REFERENCE_FRAME: number
+declare VEHICLE_TYPE_AIRPLANE: number
+declare VEHICLE_TYPE_BALLOON: number
+declare VEHICLE_TYPE_BOAT: number
+declare VEHICLE_TYPE_CAR: number
+declare VEHICLE_TYPE_NONE: number
+declare VEHICLE_TYPE_SLED: number
+declare VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY: number
+declare VEHICLE_VERTICAL_ATTRACTION_TIMESCALE: number
+declare VERTICAL: number
+declare WANDER_PAUSE_AT_WAYPOINTS: number
+declare WATER_BLUR_MULTIPLIER: number
+declare WATER_FOG: number
+declare WATER_FRESNEL: number
+declare WATER_NORMAL_SCALE: number
+declare WATER_NORMAL_TEXTURE: number
+declare WATER_REFRACTION: number
+declare WATER_TEXTURE_DEFAULTS: number
+declare WATER_WAVE_DIRECTION: number
+declare XP_ERROR_EXPERIENCES_DISABLED: number
+declare XP_ERROR_EXPERIENCE_DISABLED: number
+declare XP_ERROR_EXPERIENCE_SUSPENDED: number
+declare XP_ERROR_INVALID_EXPERIENCE: number
+declare XP_ERROR_INVALID_PARAMETERS: number
+declare XP_ERROR_KEY_NOT_FOUND: number
+declare XP_ERROR_MATURITY_EXCEEDED: number
+declare XP_ERROR_NONE: number
+declare XP_ERROR_NOT_FOUND: number
+declare XP_ERROR_NOT_PERMITTED: number
+declare XP_ERROR_NOT_PERMITTED_LAND: number
+declare XP_ERROR_NO_EXPERIENCE: number
+declare XP_ERROR_QUOTA_EXCEEDED: number
+declare XP_ERROR_REQUEST_PERM_TIMEOUT: number
+declare XP_ERROR_RETRY_UPDATE: number
+declare XP_ERROR_STORAGE_EXCEPTION: number
+declare XP_ERROR_STORE_DISABLED: number
+declare XP_ERROR_THROTTLED: number
+declare XP_ERROR_UNKNOWN_ERROR: number
+declare ZERO_ROTATION: quaternion
+declare ZERO_VECTOR: vector
+declare default: any

--- a/indra/newview/app_settings/slua_default.docs.json
+++ b/indra/newview/app_settings/slua_default.docs.json
@@ -1,0 +1,5581 @@
+{
+    "@sl-slua/global/dangerouslyexecuterequiredmodule": {
+        "documentation": "Dangerously executes a required module function"
+    },
+    "@sl-slua/global/touuid": {
+        "documentation": "Converts a string, buffer, or uuid to a uuid, returns nil if invalid"
+    },
+    "@sl-slua/global/tovector": {
+        "documentation": "Converts a value to a vector, returns nil if invalid",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/tovector/"
+    },
+    "@sl-slua/global/toquaternion": {
+        "documentation": "Converts a value to a quaternion, returns nil if invalid",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/toquaternion/"
+    },
+    "@sl-slua/global/torotation": {
+        "documentation": "Converts a value to a rotation (quaternion), returns nil if invalid"
+    },
+    "@sl-slua/global/bit32": {
+        "documentation": "Bitwise operations library",
+        "summary": "Bitwise operations library",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/bit32/"
+    },
+    "@sl-slua/global/bit32.arshift": {
+        "documentation": "Arithmetic right shift"
+    },
+    "@sl-slua/global/bit32.band": {
+        "documentation": "Bitwise AND of all arguments"
+    },
+    "@sl-slua/global/bit32.bnot": {
+        "documentation": "Bitwise NOT"
+    },
+    "@sl-slua/global/bit32.bor": {
+        "documentation": "Bitwise OR of all arguments"
+    },
+    "@sl-slua/global/bit32.bxor": {
+        "documentation": "Bitwise XOR of all arguments"
+    },
+    "@sl-slua/global/bit32.btest": {
+        "documentation": "Returns true if bitwise AND of all arguments is not zero"
+    },
+    "@sl-slua/global/bit32.extract": {
+        "documentation": "Extracts bits from n at position field with width"
+    },
+    "@sl-slua/global/bit32.lrotate": {
+        "documentation": "Left rotate"
+    },
+    "@sl-slua/global/bit32.lshift": {
+        "documentation": "Left shift"
+    },
+    "@sl-slua/global/bit32.replace": {
+        "documentation": "Replaces bits in n at position field with width using value v"
+    },
+    "@sl-slua/global/bit32.rrotate": {
+        "documentation": "Right rotate"
+    },
+    "@sl-slua/global/bit32.rshift": {
+        "documentation": "Right shift"
+    },
+    "@sl-slua/global/bit32.countlz": {
+        "documentation": "Count leading zeros"
+    },
+    "@sl-slua/global/bit32.countrz": {
+        "documentation": "Count trailing zeros"
+    },
+    "@sl-slua/global/bit32.byteswap": {
+        "documentation": "Swap byte order"
+    },
+    "@sl-slua/global/buffer": {
+        "documentation": "Buffer manipulation library for binary data",
+        "summary": "Buffer manipulation library for binary data"
+    },
+    "@sl-slua/global/buffer.create": {
+        "documentation": "Creates a new buffer of the specified size"
+    },
+    "@sl-slua/global/buffer.fromstring": {
+        "documentation": "Creates a buffer from a string"
+    },
+    "@sl-slua/global/buffer.tostring": {
+        "documentation": "Converts buffer to string"
+    },
+    "@sl-slua/global/buffer.readi8": {
+        "documentation": "Read signed 8-bit integer"
+    },
+    "@sl-slua/global/buffer.readu8": {
+        "documentation": "Read unsigned 8-bit integer"
+    },
+    "@sl-slua/global/buffer.readi16": {
+        "documentation": "Read signed 16-bit integer"
+    },
+    "@sl-slua/global/buffer.readu16": {
+        "documentation": "Read unsigned 16-bit integer"
+    },
+    "@sl-slua/global/buffer.readi32": {
+        "documentation": "Read signed 32-bit integer"
+    },
+    "@sl-slua/global/buffer.readu32": {
+        "documentation": "Read unsigned 32-bit integer"
+    },
+    "@sl-slua/global/buffer.readf32": {
+        "documentation": "Read 32-bit float"
+    },
+    "@sl-slua/global/buffer.readf64": {
+        "documentation": "Read 64-bit float"
+    },
+    "@sl-slua/global/buffer.writei8": {
+        "documentation": "Write signed 8-bit integer"
+    },
+    "@sl-slua/global/buffer.writeu8": {
+        "documentation": "Write unsigned 8-bit integer"
+    },
+    "@sl-slua/global/buffer.writei16": {
+        "documentation": "Write signed 16-bit integer"
+    },
+    "@sl-slua/global/buffer.writeu16": {
+        "documentation": "Write unsigned 16-bit integer"
+    },
+    "@sl-slua/global/buffer.writei32": {
+        "documentation": "Write signed 32-bit integer"
+    },
+    "@sl-slua/global/buffer.writeu32": {
+        "documentation": "Write unsigned 32-bit integer"
+    },
+    "@sl-slua/global/buffer.writef32": {
+        "documentation": "Write 32-bit float"
+    },
+    "@sl-slua/global/buffer.writef64": {
+        "documentation": "Write 64-bit float"
+    },
+    "@sl-slua/global/buffer.readstring": {
+        "documentation": "Read string from buffer"
+    },
+    "@sl-slua/global/buffer.writestring": {
+        "documentation": "Write string to buffer"
+    },
+    "@sl-slua/global/buffer.len": {
+        "documentation": "Returns the length of the buffer"
+    },
+    "@sl-slua/global/buffer.copy": {
+        "documentation": "Copy data from source buffer to target buffer"
+    },
+    "@sl-slua/global/buffer.fill": {
+        "documentation": "Fill buffer with a value"
+    },
+    "@sl-slua/global/buffer.readbits": {
+        "documentation": "Read bits from buffer"
+    },
+    "@sl-slua/global/buffer.writebits": {
+        "documentation": "Write bits to buffer"
+    },
+    "@sl-slua/global/coroutine": {
+        "documentation": "Coroutine manipulation library",
+        "summary": "Coroutine manipulation library"
+    },
+    "@sl-slua/global/coroutine.create": {
+        "documentation": "Creates a new coroutine from a function"
+    },
+    "@sl-slua/global/coroutine.resume": {
+        "documentation": "Resumes a coroutine, returns success and results"
+    },
+    "@sl-slua/global/coroutine.running": {
+        "documentation": "Returns the running coroutine, or nil if called from main thread"
+    },
+    "@sl-slua/global/coroutine.status": {
+        "documentation": "Returns the status of a coroutine"
+    },
+    "@sl-slua/global/coroutine.wrap": {
+        "documentation": "Creates a coroutine and returns a function that resumes it"
+    },
+    "@sl-slua/global/coroutine.yield": {
+        "documentation": "Suspends the coroutine and returns values to resume"
+    },
+    "@sl-slua/global/coroutine.isyieldable": {
+        "documentation": "Returns true if the coroutine can yield"
+    },
+    "@sl-slua/global/coroutine.close": {
+        "documentation": "Closes a coroutine, returns success and optional error message"
+    },
+    "@sl-slua/global/debug": {
+        "documentation": "Debug library for introspection",
+        "summary": "Debug library for introspection"
+    },
+    "@sl-slua/global/debug.info": {
+        "documentation": "Returns information about a function or stack level"
+    },
+    "@sl-slua/global/debug.traceback": {
+        "documentation": "Returns a string with a traceback of the call stack"
+    },
+    "@sl-slua/global/llbase64": {
+        "documentation": "Base64 encoding/decoding library",
+        "summary": "Base64 encoding/decoding library",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/llbase64/"
+    },
+    "@sl-slua/global/llbase64.encode": {
+        "documentation": "Encodes a string or buffer to base64"
+    },
+    "@sl-slua/global/llbase64.decode": {
+        "documentation": "Decodes a base64 string to a string"
+    },
+    "@sl-slua/global/lljson": {
+        "documentation": "JSON encoding/decoding library for Second Life",
+        "summary": "JSON encoding/decoding library for Second Life",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/lljson/"
+    },
+    "@sl-slua/global/lljson.null": {
+        "documentation": "A constant to pass for null to json encode"
+    },
+    "@sl-slua/global/lljson.empty_array_mt": {
+        "documentation": "Metatable for declaring table as an empty array for json encode"
+    },
+    "@sl-slua/global/lljson.array_mt": {
+        "documentation": "Metatable for declaring table as an array for json encode"
+    },
+    "@sl-slua/global/lljson.empty_array": {
+        "documentation": "A constant to pass for an empty array to json encode"
+    },
+    "@sl-slua/global/lljson._NAME": {
+        "documentation": "Name of the lljson library"
+    },
+    "@sl-slua/global/lljson._VERSION": {
+        "documentation": "Version of the lljson library"
+    },
+    "@sl-slua/global/lljson.encode": {
+        "documentation": "Encodes a Lua value as JSON"
+    },
+    "@sl-slua/global/lljson.decode": {
+        "documentation": "Decodes a JSON string to a Lua value"
+    },
+    "@sl-slua/global/lljson.slencode": {
+        "documentation": "Encodes a Lua value as JSON preserving SL types. Use tight to encode more compactly."
+    },
+    "@sl-slua/global/lljson.sldecode": {
+        "documentation": "Decodes a JSON string to a Lua value preserving SL types"
+    },
+    "@sl-slua/global/math": {
+        "documentation": "Mathematical functions library",
+        "summary": "Mathematical functions library"
+    },
+    "@sl-slua/global/math.pi": {
+        "documentation": "The value of pi"
+    },
+    "@sl-slua/global/math.huge": {
+        "documentation": "A value larger than any other numeric value (infinity)"
+    },
+    "@sl-slua/global/math.abs": {
+        "documentation": "Returns the absolute value of x"
+    },
+    "@sl-slua/global/math.acos": {
+        "documentation": "Returns the arc cosine of x (in radians)"
+    },
+    "@sl-slua/global/math.asin": {
+        "documentation": "Returns the arc sine of x (in radians)"
+    },
+    "@sl-slua/global/math.atan": {
+        "documentation": "Returns the arc tangent of x (in radians)"
+    },
+    "@sl-slua/global/math.atan2": {
+        "documentation": "Returns the arc tangent of y/x (in radians), using the signs to determine the quadrant"
+    },
+    "@sl-slua/global/math.ceil": {
+        "documentation": "Returns the smallest integer larger than or equal to x"
+    },
+    "@sl-slua/global/math.clamp": {
+        "documentation": "Returns n clamped between min and max"
+    },
+    "@sl-slua/global/math.cos": {
+        "documentation": "Returns the cosine of x (x in radians)"
+    },
+    "@sl-slua/global/math.cosh": {
+        "documentation": "Returns the hyperbolic cosine of x"
+    },
+    "@sl-slua/global/math.deg": {
+        "documentation": "Converts x from radians to degrees"
+    },
+    "@sl-slua/global/math.exp": {
+        "documentation": "Returns e^x"
+    },
+    "@sl-slua/global/math.floor": {
+        "documentation": "Returns the largest integer smaller than or equal to x"
+    },
+    "@sl-slua/global/math.fmod": {
+        "documentation": "Returns the remainder of x/y that rounds towards zero"
+    },
+    "@sl-slua/global/math.frexp": {
+        "documentation": "Returns m and e such that x = m * 2^e"
+    },
+    "@sl-slua/global/math.ldexp": {
+        "documentation": "Returns m * 2^e"
+    },
+    "@sl-slua/global/math.lerp": {
+        "documentation": "Linear interpolation between a and b by t"
+    },
+    "@sl-slua/global/math.log": {
+        "documentation": "Returns the logarithm of x in the given base (default e)"
+    },
+    "@sl-slua/global/math.log10": {
+        "documentation": "Returns the base-10 logarithm of x"
+    },
+    "@sl-slua/global/math.map": {
+        "documentation": "Maps x from input range to output range"
+    },
+    "@sl-slua/global/math.max": {
+        "documentation": "Returns the maximum value among the arguments"
+    },
+    "@sl-slua/global/math.min": {
+        "documentation": "Returns the minimum value among the arguments"
+    },
+    "@sl-slua/global/math.modf": {
+        "documentation": "Returns the integer and fractional parts of x"
+    },
+    "@sl-slua/global/math.noise": {
+        "documentation": "Returns Perlin noise value for the given coordinates"
+    },
+    "@sl-slua/global/math.pow": {
+        "documentation": "Returns base^exponent"
+    },
+    "@sl-slua/global/math.rad": {
+        "documentation": "Converts x from degrees to radians"
+    },
+    "@sl-slua/global/math.random": {
+        "documentation": "Returns a pseudo-random number"
+    },
+    "@sl-slua/global/math.randomseed": {
+        "documentation": "Sets the seed for the pseudo-random generator"
+    },
+    "@sl-slua/global/math.round": {
+        "documentation": "Returns x rounded to the nearest integer"
+    },
+    "@sl-slua/global/math.sign": {
+        "documentation": "Returns -1, 0, or 1 depending on the sign of x"
+    },
+    "@sl-slua/global/math.sin": {
+        "documentation": "Returns the sine of x (x in radians)"
+    },
+    "@sl-slua/global/math.sinh": {
+        "documentation": "Returns the hyperbolic sine of x"
+    },
+    "@sl-slua/global/math.sqrt": {
+        "documentation": "Returns the square root of x"
+    },
+    "@sl-slua/global/math.tan": {
+        "documentation": "Returns the tangent of x (x in radians)"
+    },
+    "@sl-slua/global/math.tanh": {
+        "documentation": "Returns the hyperbolic tangent of x"
+    },
+    "@sl-slua/global/math.isnan": {
+        "documentation": "Returns true if x is NaN"
+    },
+    "@sl-slua/global/math.isinf": {
+        "documentation": "Returns true if x is infinite"
+    },
+    "@sl-slua/global/math.isfinite": {
+        "documentation": "Returns true if x is finite"
+    },
+    "@sl-slua/global/os": {
+        "documentation": "Operating system facilities library",
+        "summary": "Operating system facilities library"
+    },
+    "@sl-slua/global/os.clock": {
+        "documentation": "Returns CPU time used by the program in seconds"
+    },
+    "@sl-slua/global/os.date": {
+        "documentation": "Returns a string or table containing date and time"
+    },
+    "@sl-slua/global/os.difftime": {
+        "documentation": "Returns the difference in seconds between two times"
+    },
+    "@sl-slua/global/os.time": {
+        "documentation": "Returns the current time or converts a table to time"
+    },
+    "@sl-slua/global/string": {
+        "documentation": "String manipulation library",
+        "summary": "String manipulation library"
+    },
+    "@sl-slua/global/string.byte": {
+        "documentation": "Returns the internal numeric codes of the characters"
+    },
+    "@sl-slua/global/string.char": {
+        "documentation": "Returns a string from character codes"
+    },
+    "@sl-slua/global/string.find": {
+        "documentation": "Finds first match of pattern in string"
+    },
+    "@sl-slua/global/string.format": {
+        "documentation": "Returns a formatted string"
+    },
+    "@sl-slua/global/string.gmatch": {
+        "documentation": "Returns an iterator function for pattern matches"
+    },
+    "@sl-slua/global/string.gsub": {
+        "documentation": "Global substitution of pattern matches"
+    },
+    "@sl-slua/global/string.len": {
+        "documentation": "Returns the length of the string"
+    },
+    "@sl-slua/global/string.lower": {
+        "documentation": "Converts string to lowercase"
+    },
+    "@sl-slua/global/string.match": {
+        "documentation": "Returns captures from pattern match"
+    },
+    "@sl-slua/global/string.pack": {
+        "documentation": "Packs values into a binary string"
+    },
+    "@sl-slua/global/string.packsize": {
+        "documentation": "Returns the size of a packed string for the given format"
+    },
+    "@sl-slua/global/string.rep": {
+        "documentation": "Returns a string repeated n times"
+    },
+    "@sl-slua/global/string.reverse": {
+        "documentation": "Reverses a string"
+    },
+    "@sl-slua/global/string.split": {
+        "documentation": "Splits a string by separator"
+    },
+    "@sl-slua/global/string.sub": {
+        "documentation": "Returns a substring"
+    },
+    "@sl-slua/global/string.unpack": {
+        "documentation": "Unpacks values from a binary string"
+    },
+    "@sl-slua/global/string.upper": {
+        "documentation": "Converts string to uppercase"
+    },
+    "@sl-slua/global/table": {
+        "documentation": "Table manipulation library",
+        "summary": "Table manipulation library"
+    },
+    "@sl-slua/global/table.concat": {
+        "documentation": "Concatenates table elements into a string"
+    },
+    "@sl-slua/global/table.foreach": {
+        "documentation": "Iterates over table key-value pairs (deprecated)"
+    },
+    "@sl-slua/global/table.foreachi": {
+        "documentation": "Iterates over array indices (deprecated)"
+    },
+    "@sl-slua/global/table.getn": {
+        "documentation": "Returns the length of a table (deprecated, use # operator)"
+    },
+    "@sl-slua/global/table.maxn": {
+        "documentation": "Returns the largest positive numeric index"
+    },
+    "@sl-slua/global/table.insert": {
+        "documentation": "Inserts an element at the end of a list"
+    },
+    "@sl-slua/global/table.remove": {
+        "documentation": "Removes and returns an element from a list"
+    },
+    "@sl-slua/global/table.sort": {
+        "documentation": "Sorts list elements in place"
+    },
+    "@sl-slua/global/table.pack": {
+        "documentation": "Packs arguments into a table with length field n"
+    },
+    "@sl-slua/global/table.unpack": {
+        "documentation": "Unpacks table elements as multiple return values"
+    },
+    "@sl-slua/global/table.move": {
+        "documentation": "Moves elements from one table to another"
+    },
+    "@sl-slua/global/table.create": {
+        "documentation": "Creates a new table with pre-allocated array slots"
+    },
+    "@sl-slua/global/table.find": {
+        "documentation": "Finds the index of a value in an array"
+    },
+    "@sl-slua/global/table.clear": {
+        "documentation": "Removes all elements from a table"
+    },
+    "@sl-slua/global/table.freeze": {
+        "documentation": "Makes a table read-only"
+    },
+    "@sl-slua/global/table.isfrozen": {
+        "documentation": "Returns true if a table is frozen"
+    },
+    "@sl-slua/global/table.clone": {
+        "documentation": "Creates a shallow copy of a table"
+    },
+    "@sl-slua/global/utf8": {
+        "documentation": "UTF-8 support library",
+        "summary": "UTF-8 support library"
+    },
+    "@sl-slua/global/utf8.charpattern": {
+        "documentation": "Pattern that matches exactly one UTF-8 byte sequence"
+    },
+    "@sl-slua/global/utf8.char": {
+        "documentation": "Returns a string from UTF-8 codepoints"
+    },
+    "@sl-slua/global/utf8.codes": {
+        "documentation": "Returns an iterator for UTF-8 codepoints in a string"
+    },
+    "@sl-slua/global/utf8.codepoint": {
+        "documentation": "Returns the codepoints of characters in a string"
+    },
+    "@sl-slua/global/utf8.len": {
+        "documentation": "Returns the number of UTF-8 characters in a string, or nil and error position"
+    },
+    "@sl-slua/global/utf8.offset": {
+        "documentation": "Returns the byte position of the n-th character"
+    },
+    "@sl-slua/global/ll": {
+        "documentation": "LSL built-in functions",
+        "summary": "LSL built-in functions"
+    },
+    "@sl-slua/global/ll.Abs": {
+        "documentation": "Returns the absolute (positive) version of Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llabs/"
+    },
+    "@sl-slua/global/ll.Acos": {
+        "documentation": "Returns the arc-cosine of Value, in radians.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llacos/"
+    },
+    "@sl-slua/global/ll.AddToLandBanList": {
+        "documentation": "Add avatar ID to the parcel ban list for the specified number of Hours.\\nA value of 0 for Hours will add the agent indefinitely.\\nThe smallest value that Hours will accept is 0.01; anything smaller will be seen as 0.\\nWhen values that small are used, it seems the function bans in approximately 30 second increments (Probably 36 second increments, as 0.01 of an hour is 36 seconds).\\nResidents teleporting to a parcel where they are banned will be redirected to a neighbouring parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lladdtolandbanlist/"
+    },
+    "@sl-slua/global/ll.AddToLandPassList": {
+        "documentation": "Add avatar ID to the land pass list, for a duration of Hours.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lladdtolandpasslist/"
+    },
+    "@sl-slua/global/ll.AdjustSoundVolume": {
+        "documentation": "Adjusts the volume (0.0 - 1.0) of the currently playing attached sound.\\nThis function has no effect on sounds started with llTriggerSound.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lladjustsoundvolume/"
+    },
+    "@sl-slua/global/ll.AgentInExperience": {
+        "documentation": "\\n                   Returns TRUE if the agent is in the Experience and the Experience can run in the current location.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llagentinexperience/"
+    },
+    "@sl-slua/global/ll.AllowInventoryDrop": {
+        "documentation": "If Flag == TRUE, users without object modify permissions can still drop inventory items into the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llallowinventorydrop/"
+    },
+    "@sl-slua/global/ll.AngleBetween": {
+        "documentation": "Returns the angle, in radians, between rotations Rot1 and Rot2.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llanglebetween/"
+    },
+    "@sl-slua/global/ll.ApplyImpulse": {
+        "documentation": "Applies impulse to the object.\\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\\nThis function only works on physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llapplyimpulse/"
+    },
+    "@sl-slua/global/ll.ApplyRotationalImpulse": {
+        "documentation": "Applies rotational impulse to the object.\\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\\nThis function only works on physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llapplyrotationalimpulse/"
+    },
+    "@sl-slua/global/ll.Asin": {
+        "documentation": "Returns the arc-sine, in radians, of Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llasin/"
+    },
+    "@sl-slua/global/ll.Atan2": {
+        "documentation": "Returns the arc-tangent2 of y, x.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llatan2/"
+    },
+    "@sl-slua/global/ll.AttachToAvatar": {
+        "documentation": "Attach to avatar at point AttachmentPoint.\\nRequires the PERMISSION_ATTACH runtime permission.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llattachtoavatar/"
+    },
+    "@sl-slua/global/ll.AttachToAvatarTemp": {
+        "documentation": "Follows the same convention as llAttachToAvatar, with the exception that the object will not create new inventory for the user, and will disappear on detach or disconnect.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llattachtoavatartemp/"
+    },
+    "@sl-slua/global/ll.AvatarOnLinkSitTarget": {
+        "documentation": "If an avatar is sitting on the link's sit target, return the avatar's key, NULL_KEY otherwise.\\nReturns a key that is the UUID of the user seated on the specified link's prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llavataronlinksittarget/"
+    },
+    "@sl-slua/global/ll.AvatarOnSitTarget": {
+        "documentation": "If an avatar is seated on the sit target, returns the avatar's key, otherwise NULL_KEY.\\nThis only will detect avatars sitting on sit targets defined with llSitTarget.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llavataronsittarget/"
+    },
+    "@sl-slua/global/ll.Axes2Rot": {
+        "documentation": "Returns the rotation represented by coordinate axes Forward, Left, and Up.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llaxes2rot/"
+    },
+    "@sl-slua/global/ll.AxisAngle2Rot": {
+        "documentation": "Returns the rotation that is a generated Angle about Axis.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llaxisangle2rot/"
+    },
+    "@sl-slua/global/ll.Base64ToInteger": {
+        "documentation": "Returns an integer that is the Text, Base64 decoded as a big endian integer.\\nReturns zero if Text is longer then 8 characters. If Text contains fewer then 6 characters, the return value is unpredictable.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llbase64tointeger/"
+    },
+    "@sl-slua/global/ll.Base64ToString": {
+        "documentation": "Converts a Base64 string to a conventional string.\\nIf the conversion creates any unprintable characters, they are converted to question marks.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llbase64tostring/"
+    },
+    "@sl-slua/global/ll.BreakAllLinks": {
+        "documentation": "De-links all prims in the link set (requires permission PERMISSION_CHANGE_LINKS be set).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llbreakalllinks/"
+    },
+    "@sl-slua/global/ll.BreakLink": {
+        "documentation": "De-links the prim with the given link number (requires permission PERMISSION_CHANGE_LINKS be set).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llbreaklink/"
+    },
+    "@sl-slua/global/ll.CSV2List": {
+        "documentation": "Create a list from a string of comma separated values specified in Text.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcsv2list/"
+    },
+    "@sl-slua/global/ll.CastRay": {
+        "documentation": "Casts a ray into the physics world from 'start' to 'end' and returns data according to details in Options.\\nReports collision data for intersections with objects.\\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcastray/"
+    },
+    "@sl-slua/global/ll.Ceil": {
+        "documentation": "Returns smallest integer value >= Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llceil/"
+    },
+    "@sl-slua/global/ll.Char": {
+        "documentation": "Returns a single character string that is the representation of the unicode value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llchar/"
+    },
+    "@sl-slua/global/ll.ClearCameraParams": {
+        "documentation": "Resets all camera parameters to default values and turns off scripted camera control.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llclearcameraparams/"
+    },
+    "@sl-slua/global/ll.ClearLinkMedia": {
+        "documentation": "Clears (deletes) the media and all parameters from the given Face on the linked prim.\\nReturns an integer that is a STATUS_* flag, which details the success/failure of the operation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llclearlinkmedia/"
+    },
+    "@sl-slua/global/ll.ClearPrimMedia": {
+        "documentation": "Clears (deletes) the media and all parameters from the given Face.\\nReturns an integer that is a STATUS_* flag which details the success/failure of the operation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llclearprimmedia/"
+    },
+    "@sl-slua/global/ll.CloseRemoteDataChannel": {
+        "documentation": "This function is deprecated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcloseremotedatachannel/"
+    },
+    "@sl-slua/global/ll.Cloud": {
+        "documentation": "Returns the cloud density at the object's position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcloud/"
+    },
+    "@sl-slua/global/ll.CollisionFilter": {
+        "documentation": "Specify an empty string or NULL_KEY for Accept, to not filter on the corresponding parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcollisionfilter/"
+    },
+    "@sl-slua/global/ll.CollisionSound": {
+        "documentation": "Suppress default collision sounds, replace default impact sounds with ImpactSound.\\nThe ImpactSound must be in the object inventory.\\nSupply an empty string to suppress collision sounds.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcollisionsound/"
+    },
+    "@sl-slua/global/ll.CollisionSprite": {
+        "documentation": "Suppress default collision sprites, replace default impact sprite with ImpactSprite; found in the object inventory (empty string to just suppress).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcollisionsprite/"
+    },
+    "@sl-slua/global/ll.ComputeHash": {
+        "documentation": "Returns hex-encoded Hash string of Message using digest Algorithm.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcomputehash/"
+    },
+    "@sl-slua/global/ll.Cos": {
+        "documentation": "Returns the cosine of Theta (Theta in radians).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcos/"
+    },
+    "@sl-slua/global/ll.CreateCharacter": {
+        "documentation": "Convert link-set to AI/Physics character.\\nCreates a path-finding entity, known as a \"character\", from the object containing the script. Required to activate use of path-finding functions.\\nOptions is a list of key/value pairs.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcreatecharacter/"
+    },
+    "@sl-slua/global/ll.CreateKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcreatekeyvalue/"
+    },
+    "@sl-slua/global/ll.CreateLink": {
+        "documentation": "Attempt to link the object the script is in, to target (requires permission PERMISSION_CHANGE_LINKS be set).\\nRequires permission PERMISSION_CHANGE_LINKS be set.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llcreatelink/"
+    },
+    "@sl-slua/global/ll.Damage": {
+        "documentation": "Generates a damage event on the targeted agent or task.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldamage/"
+    },
+    "@sl-slua/global/ll.DataSizeKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldatasizekeyvalue/"
+    },
+    "@sl-slua/global/ll.DeleteCharacter": {
+        "documentation": "Convert link-set from AI/Physics character to Physics object.\\nConvert the current link-set back to a standard object, removing all path-finding properties.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldeletecharacter/"
+    },
+    "@sl-slua/global/ll.DeleteKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldeletekeyvalue/"
+    },
+    "@sl-slua/global/ll.DeleteSubList": {
+        "documentation": "Removes the slice from start to end and returns the remainder of the list.\\nRemove a slice from the list and return the remainder, start and end are inclusive.\\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th list entry.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldeletesublist/"
+    },
+    "@sl-slua/global/ll.DeleteSubString": {
+        "documentation": "Removes the indicated sub-string and returns the result.\\nStart and End are inclusive.\\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th character.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldeletesubstring/"
+    },
+    "@sl-slua/global/ll.DerezObject": {
+        "documentation": "Derezzes an object previously rezzed by a script in this region. Returns TRUE on success or FALSE if the object could not be derezzed.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llderezobject/"
+    },
+    "@sl-slua/global/ll.DetachFromAvatar": {
+        "documentation": "Remove the object containing the script from the avatar.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldetachfromavatar/"
+    },
+    "@sl-slua/global/ll.Dialog": {
+        "documentation": "Shows a dialog box on the avatar's screen with the message.\\n\\n                    Up to 12 strings in the list form buttons.\\n\\n                    If a button is clicked, the name is chatted on Channel.\\nOpens a \"notify box\" in the given avatars screen displaying the message.\\n\\n                Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\\n\\n                Channels work just like llSay(), so channel 0 can be heard by everyone.\\n\\n                The chat originates at the object's position, not the avatar's position, even though it is said as the avatar (uses avatar's UUID and Name etc.).\\n\\n                Examples:\\n\\n                llDialog(who, \"Are you a boy or a girl?\", [ \"Boy\", \"Girl\" ], -4913);\\n\\n                llDialog(who, \"This shows only an OK button.\", [], -192);\\n\\n                llDialog(who, \"This chats so you can 'hear' it.\", [\"Hooray\"], 0);",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldialog/"
+    },
+    "@sl-slua/global/ll.Die": {
+        "documentation": "Delete the object which holds the script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldie/"
+    },
+    "@sl-slua/global/ll.DumpList2String": {
+        "documentation": "Returns the list as a single string, using Separator between the entries.\\nWrite the list out as a single string, using Separator between values.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lldumplist2string/"
+    },
+    "@sl-slua/global/ll.EdgeOfWorld": {
+        "documentation": "Checks to see whether the border hit by Direction from Position is the edge of the world (has no neighboring region).\\nReturns TRUE if the line along Direction from Position hits the edge of the world in the current simulator, returns FALSE if that edge crosses into another simulator.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lledgeofworld/"
+    },
+    "@sl-slua/global/ll.EjectFromLand": {
+        "documentation": "Ejects AvatarID from land that you own.\\nEjects AvatarID from land that the object owner (group or resident) owns.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llejectfromland/"
+    },
+    "@sl-slua/global/ll.Email": {
+        "documentation": "Sends email to Address with Subject and Message.\\nSends an email to Address with Subject and Message.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llemail/"
+    },
+    "@sl-slua/global/ll.EscapeURL": {
+        "documentation": "Returns an escaped/encoded version of url, replacing spaces with %20 etc.\\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\\n\\n                This function returns the UTF-8 encoded escape codes for selected characters.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llescapeurl/"
+    },
+    "@sl-slua/global/ll.Euler2Rot": {
+        "documentation": "Returns the rotation representation of the Euler angles.\\nReturns the rotation represented by the Euler Angle.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lleuler2rot/"
+    },
+    "@sl-slua/global/ll.Evade": {
+        "documentation": "Evade a specified target.\\nCharacters will (roughly) try to hide from their pursuers if there is a good hiding spot along their fleeing path. Hiding means no direct line of sight from the head of the character (centre of the top of its physics bounding box) to the head of its pursuer and no direct path between the two on the navigation-mesh.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llevade/"
+    },
+    "@sl-slua/global/ll.ExecCharacterCmd": {
+        "documentation": "Execute a character command.\\nSend a command to the path system.\\nCurrently only supports stopping the current path-finding operation or causing the character to jump.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llexeccharactercmd/"
+    },
+    "@sl-slua/global/ll.Fabs": {
+        "documentation": "Returns the positive version of Value.\\nReturns the absolute value of Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfabs/"
+    },
+    "@sl-slua/global/ll.FindNotecardTextCount": {
+        "documentation": "Searches the text of a cached notecard for lines containing the given pattern and returns the \\n            number of matches found through a dataserver event.\\n            ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfindnotecardtextcount/"
+    },
+    "@sl-slua/global/ll.FindNotecardTextSync": {
+        "documentation": "Searches the text of a cached notecard for lines containing the given pattern. \\n            Returns a list of line numbers and column where a match is found. If the notecard is not in\\n            the cache it returns a list containing a single entry of NAK. If no matches are found an\\n            empty list is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfindnotecardtextsync/"
+    },
+    "@sl-slua/global/ll.FleeFrom": {
+        "documentation": "Flee from a point.\\nDirects a character (llCreateCharacter) to keep away from a defined position in the region or adjacent regions.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfleefrom/"
+    },
+    "@sl-slua/global/ll.Floor": {
+        "documentation": "Returns largest integer value <= Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfloor/"
+    },
+    "@sl-slua/global/ll.ForceMouselook": {
+        "documentation": "If Enable is TRUE any avatar that sits on this object is forced into mouse-look mode.\\nAfter calling this function with Enable set to TRUE, any agent sitting down on the prim will be forced into mouse-look.\\nJust like llSitTarget, this changes a permanent property of the prim (not the object) and needs to be reset by calling this function with Enable set to FALSE in order to disable it.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llforcemouselook/"
+    },
+    "@sl-slua/global/ll.Frand": {
+        "documentation": "Returns a pseudo random number in the range [0, Magnitude] or [Magnitude, 0].\\nReturns a pseudo-random number between [0, Magnitude].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llfrand/"
+    },
+    "@sl-slua/global/ll.GenerateKey": {
+        "documentation": "Generates a key (SHA-1 hash) using UUID generation to create a unique key.\\nAs the UUID produced is versioned, it should never return a value of NULL_KEY.\\nThe specific UUID version is an implementation detail that has changed in the past and may change again in the future. Do not depend upon the UUID that is returned to be version 5 SHA-1 hash.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgeneratekey/"
+    },
+    "@sl-slua/global/ll.GetAccel": {
+        "documentation": "Returns the acceleration of the object relative to the region's axes.\\nGets the acceleration of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetaccel/"
+    },
+    "@sl-slua/global/ll.GetAgentInfo": {
+        "documentation": "Returns an integer bit-field containing the agent information about id.\\n\\n                    Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\\nReturns information about the given agent ID as a bit-field of agent info constants.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetagentinfo/"
+    },
+    "@sl-slua/global/ll.GetAgentLanguage": {
+        "documentation": "Returns the language code of the preferred interface language of the avatar.\\nReturns a string that is the language code of the preferred interface language of the resident.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetagentlanguage/"
+    },
+    "@sl-slua/global/ll.GetAgentList": {
+        "documentation": "Requests a list of agents currently in the region, limited by the scope parameter.\\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or [string error_msg] - returns avatar keys for all agents in the region limited to the area(s) specified by scope",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetagentlist/"
+    },
+    "@sl-slua/global/ll.GetAgentSize": {
+        "documentation": "If the avatar is in the same region, returns the size of the bounding box of the requested avatar by id, otherwise returns ZERO_VECTOR.\\nIf the agent is in the same region as the object, returns the size of the avatar.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetagentsize/"
+    },
+    "@sl-slua/global/ll.GetAlpha": {
+        "documentation": "Returns the alpha value of Face.\\nReturns the 'alpha' of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetalpha/"
+    },
+    "@sl-slua/global/ll.GetAndResetTime": {
+        "documentation": "Returns the script time in seconds and then resets the script timer to zero.\\nGets the time in seconds since starting and resets the time to zero.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetandresettime/"
+    },
+    "@sl-slua/global/ll.GetAnimation": {
+        "documentation": "Returns the name of the currently playing locomotion animation for the avatar id.\\nReturns the currently playing animation for the specified avatar ID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetanimation/"
+    },
+    "@sl-slua/global/ll.GetAnimationList": {
+        "documentation": "Returns a list of keys of playing animations for an avatar.\\nReturns a list of keys of all playing animations for the specified avatar ID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetanimationlist/"
+    },
+    "@sl-slua/global/ll.GetAnimationOverride": {
+        "documentation": "Returns a string that is the name of the animation that is used for the specified animation state\\nTo use this function the script must obtain either the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION permission (automatically granted to attached objects).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetanimationoverride/"
+    },
+    "@sl-slua/global/ll.GetAttached": {
+        "documentation": "Returns the object's attachment point, or 0 if not attached.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetattached/"
+    },
+    "@sl-slua/global/ll.GetAttachedList": {
+        "documentation": "Returns a list of keys of all visible (not HUD) attachments on the avatar identified by the ID argument",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetattachedlist/"
+    },
+    "@sl-slua/global/ll.GetAttachedListFiltered": {
+        "documentation": "Retrieves a list of attachments on an avatar.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetattachedlistfiltered/"
+    },
+    "@sl-slua/global/ll.GetBoundingBox": {
+        "documentation": "Returns the bounding box around the object (including any linked prims) relative to its root prim, as a list in the format [ (vector) min_corner, (vector) max_corner ].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetboundingbox/"
+    },
+    "@sl-slua/global/ll.GetCameraAspect": {
+        "documentation": "Returns the current camera aspect ratio (width / height) of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcameraaspect/"
+    },
+    "@sl-slua/global/ll.GetCameraFOV": {
+        "documentation": "Returns the current camera field of view of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcamerafov/"
+    },
+    "@sl-slua/global/ll.GetCameraPos": {
+        "documentation": "Returns the current camera position for the agent the task has permissions for.\\nReturns the position of the camera, of the user that granted the script PERMISSION_TRACK_CAMERA. If no user has granted the permission, it returns ZERO_VECTOR.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcamerapos/"
+    },
+    "@sl-slua/global/ll.GetCameraRot": {
+        "documentation": "Returns the current camera orientation for the agent the task has permissions for. If no user has granted the PERMISSION_TRACK_CAMERA permission, returns ZERO_ROTATION.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcamerarot/"
+    },
+    "@sl-slua/global/ll.GetCenterOfMass": {
+        "documentation": "Returns the prim's centre of mass (unless called from the root prim, where it returns the object's centre of mass).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcenterofmass/"
+    },
+    "@sl-slua/global/ll.GetClosestNavPoint": {
+        "documentation": "Get the closest navigable point to the point provided.\\nThe function accepts a point in region-local space (like all the other path-finding methods) and returns either an empty list or a list containing a single vector which is the closest point on the navigation-mesh to the point provided.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetclosestnavpoint/"
+    },
+    "@sl-slua/global/ll.GetColor": {
+        "documentation": "Returns the color on Face.\\nReturns the color of Face as a vector of red, green, and blue values between 0 and 1. If face is ALL_SIDES the color returned is the mean average of each channel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcolor/"
+    },
+    "@sl-slua/global/ll.GetCreator": {
+        "documentation": "Returns a key for the creator of the prim.\\nReturns the key of the object's original creator. Similar to llGetOwner.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetcreator/"
+    },
+    "@sl-slua/global/ll.GetDate": {
+        "documentation": "Returns the current date in the UTC time zone in the format YYYY-MM-DD.\\nReturns the current UTC date as YYYY-MM-DD.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetdate/"
+    },
+    "@sl-slua/global/ll.GetDayLength": {
+        "documentation": "Returns the number of seconds in a day on this parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetdaylength/"
+    },
+    "@sl-slua/global/ll.GetDayOffset": {
+        "documentation": "Returns the number of seconds in a day is offset from midnight in this parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetdayoffset/"
+    },
+    "@sl-slua/global/ll.GetDisplayName": {
+        "documentation": "Returns the display name of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestDisplayName if the avatar may be absent from the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetdisplayname/"
+    },
+    "@sl-slua/global/ll.GetEnergy": {
+        "documentation": "Returns how much energy is in the object as a percentage of maximum.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetenergy/"
+    },
+    "@sl-slua/global/ll.GetEnv": {
+        "documentation": "Returns a string with the requested data about the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetenv/"
+    },
+    "@sl-slua/global/ll.GetEnvironment": {
+        "documentation": "Returns a string with the requested data about the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetenvironment/"
+    },
+    "@sl-slua/global/ll.GetExperienceDetails": {
+        "documentation": "\\n                   Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetexperiencedetails/"
+    },
+    "@sl-slua/global/ll.GetExperienceErrorMessage": {
+        "documentation": "\\n                   Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetexperienceerrormessage/"
+    },
+    "@sl-slua/global/ll.GetForce": {
+        "documentation": "Returns the force (if the script is physical).\\nReturns the current force if the script is physical.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetforce/"
+    },
+    "@sl-slua/global/ll.GetFreeMemory": {
+        "documentation": "Returns the number of free bytes of memory the script can use.\\nReturns the available free space for the current script. This is inaccurate with LSO.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetfreememory/"
+    },
+    "@sl-slua/global/ll.GetFreeURLs": {
+        "documentation": "Returns the number of available URLs for the current script.\\nReturns an integer that is the number of available URLs.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetfreeurls/"
+    },
+    "@sl-slua/global/ll.GetGMTclock": {
+        "documentation": "Returns the time in seconds since midnight GMT.\\nGets the time in seconds since midnight in GMT/UTC.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetgmtclock/"
+    },
+    "@sl-slua/global/ll.GetGeometricCenter": {
+        "documentation": "Returns the vector that is the geometric center of the object relative to the root prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetgeometriccenter/"
+    },
+    "@sl-slua/global/ll.GetHTTPHeader": {
+        "documentation": "Returns the value for header for request_id.\\nReturns a string that is the value of the Header for HTTPRequestID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgethttpheader/"
+    },
+    "@sl-slua/global/ll.GetHealth": {
+        "documentation": "Returns the current health of an avatar or object in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgethealth/"
+    },
+    "@sl-slua/global/ll.GetInventoryAcquireTime": {
+        "documentation": "Returns the time at which the item was placed into this prim's inventory as a timestamp.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventoryacquiretime/"
+    },
+    "@sl-slua/global/ll.GetInventoryCreator": {
+        "documentation": "Returns a key for the creator of the inventory item.\\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says \"No item named 'name'\".",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorycreator/"
+    },
+    "@sl-slua/global/ll.GetInventoryDesc": {
+        "documentation": "Returns the item description of the item in inventory. If item is not found in inventory, the object says \"No item named 'name'\" to the debug channel and returns an empty string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorydesc/"
+    },
+    "@sl-slua/global/ll.GetInventoryKey": {
+        "documentation": "Returns the key that is the UUID of the inventory named.\\nReturns the key of the inventory named.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorykey/"
+    },
+    "@sl-slua/global/ll.GetInventoryName": {
+        "documentation": "Returns the name of the inventory item of a given type, specified by index number.\\nUse the inventory constants INVENTORY_* to specify the type.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventoryname/"
+    },
+    "@sl-slua/global/ll.GetInventoryNumber": {
+        "documentation": "Returns the quantity of items of a given type (INVENTORY_* flag) in the prim's inventory.\\nUse the inventory constants INVENTORY_* to specify the type.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorynumber/"
+    },
+    "@sl-slua/global/ll.GetInventoryPermMask": {
+        "documentation": "Returns the requested permission mask for the inventory item.\\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object's inventory, llGetInventoryPermMask returns FALSE and causes the object to say \"No item named '<item>'\", where \"<item>\" is item.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorypermmask/"
+    },
+    "@sl-slua/global/ll.GetInventoryType": {
+        "documentation": "Returns the type of the named inventory item.\\nLike all inventory functions, llGetInventoryType is case-sensitive.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetinventorytype/"
+    },
+    "@sl-slua/global/ll.GetKey": {
+        "documentation": "Returns the key of the prim the script is attached to.\\nGet the key for the object which has this script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetkey/"
+    },
+    "@sl-slua/global/ll.GetLandOwnerAt": {
+        "documentation": "Returns the key of the land owner, returns NULL_KEY if public.\\nReturns the key of the land owner at Position, or NULL_KEY if public.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlandownerat/"
+    },
+    "@sl-slua/global/ll.GetLinkKey": {
+        "documentation": "Returns the key of the linked prim LinkNumber.\\nReturns the key of LinkNumber in the link set.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinkkey/"
+    },
+    "@sl-slua/global/ll.GetLinkMedia": {
+        "documentation": "Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.\tReturns an empty list if no media exists on the face.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinkmedia/"
+    },
+    "@sl-slua/global/ll.GetLinkName": {
+        "documentation": "Returns the name of LinkNumber in a link set.\\nReturns the name of LinkNumber the link set.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinkname/"
+    },
+    "@sl-slua/global/ll.GetLinkNumber": {
+        "documentation": "Returns the link number of the prim containing the script (0 means not linked, 1 the prim is the root, 2 the prim is the first child, etc.).\\nReturns the link number of the prim containing the script. 0 means no link, 1 the root, 2 for first child, etc.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinknumber/"
+    },
+    "@sl-slua/global/ll.GetLinkNumberOfSides": {
+        "documentation": "Returns the number of sides of the specified linked prim.\\nReturns an integer that is the number of faces (or sides) of the prim link.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinknumberofsides/"
+    },
+    "@sl-slua/global/ll.GetLinkPrimitiveParams": {
+        "documentation": "Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\\n* Supplying a prim or object flag will return that flag's attributes.\\n* Face flags require the user to also supply a face index parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinkprimitiveparams/"
+    },
+    "@sl-slua/global/ll.GetLinkSitFlags": {
+        "documentation": "Returns the sit flags set on the specified prim in a linkset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlinksitflags/"
+    },
+    "@sl-slua/global/ll.GetListEntryType": {
+        "documentation": "Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT, TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if index is off list).\\nReturns the type of the variable at Index in ListVariable.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlistentrytype/"
+    },
+    "@sl-slua/global/ll.GetListLength": {
+        "documentation": "Returns the number of elements in the list.\\nReturns the number of elements in ListVariable.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlistlength/"
+    },
+    "@sl-slua/global/ll.GetLocalPos": {
+        "documentation": "Returns the position relative to the root.\\nReturns the local position of a child object relative to the root.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlocalpos/"
+    },
+    "@sl-slua/global/ll.GetLocalRot": {
+        "documentation": "Returns the rotation local to the root.\\nReturns the local rotation of a child object relative to the root.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetlocalrot/"
+    },
+    "@sl-slua/global/ll.GetMass": {
+        "documentation": "Returns the mass of object that the script is attached to.\\nReturns the scripted object's mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it's attached to, not its own.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmass/"
+    },
+    "@sl-slua/global/ll.GetMassMKS": {
+        "documentation": "Acts as llGetMass(), except that the units of the value returned are Kg.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmassmks/"
+    },
+    "@sl-slua/global/ll.GetMaxScaleFactor": {
+        "documentation": "Returns the largest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmaxscalefactor/"
+    },
+    "@sl-slua/global/ll.GetMemoryLimit": {
+        "documentation": "Get the maximum memory a script can use, in bytes.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmemorylimit/"
+    },
+    "@sl-slua/global/ll.GetMinScaleFactor": {
+        "documentation": "Returns the smallest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetminscalefactor/"
+    },
+    "@sl-slua/global/ll.GetMoonDirection": {
+        "documentation": "Returns a normalized vector of the direction of the moon in the parcel.\\nReturns the moon's direction on the simulator in the parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmoondirection/"
+    },
+    "@sl-slua/global/ll.GetMoonRotation": {
+        "documentation": "Returns the rotation applied to the moon in the parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetmoonrotation/"
+    },
+    "@sl-slua/global/ll.GetNextEmail": {
+        "documentation": "Fetch the next queued email with that matches the given address and/or subject, via the email event.\\nIf the parameters are blank, they are not used for filtering.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnextemail/"
+    },
+    "@sl-slua/global/ll.GetNotecardLine": {
+        "documentation": "Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero in LSL, one in Lua.\\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnotecardline/"
+    },
+    "@sl-slua/global/ll.GetNotecardLineSync": {
+        "documentation": "Returns LineNumber from NotecardName. The line index starts at zero in LSL, one in Lua.\\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\\nIf the note-card is not cached on the simulator the return value is the NAK string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnotecardlinesync/"
+    },
+    "@sl-slua/global/ll.GetNumberOfNotecardLines": {
+        "documentation": "Returns the number of lines contained within a notecard via the dataserver event.\\nThe key returned by this function is a query ID for identifying the dataserver reply.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnumberofnotecardlines/"
+    },
+    "@sl-slua/global/ll.GetNumberOfPrims": {
+        "documentation": "Returns the number of prims in a link set the script is attached to.\\nReturns the number of prims in (and avatars seated on) the object the script is in.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnumberofprims/"
+    },
+    "@sl-slua/global/ll.GetNumberOfSides": {
+        "documentation": "Returns the number of faces (or sides) of the prim.\\nReturns the number of sides of the prim which has the script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetnumberofsides/"
+    },
+    "@sl-slua/global/ll.GetObjectAnimationNames": {
+        "documentation": "Returns a list of names of playing animations for an object.\\nReturns a list of names of all playing animations for the current object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectanimationnames/"
+    },
+    "@sl-slua/global/ll.GetObjectDesc": {
+        "documentation": "Returns the description of the prim the script is attached to.\\nReturns the description of the scripted object/prim. You can set the description using llSetObjectDesc.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectdesc/"
+    },
+    "@sl-slua/global/ll.GetObjectDetails": {
+        "documentation": "Returns a list of object details specified in the Parameters list for the object or avatar in the region with key ID.\\nParameters are specified by the OBJECT_* constants.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectdetails/"
+    },
+    "@sl-slua/global/ll.GetObjectLinkKey": {
+        "documentation": "Returns the key of the linked prim link_no in a linkset.\\nReturns the key of link_no in the link set specified by id.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectlinkkey/"
+    },
+    "@sl-slua/global/ll.GetObjectMass": {
+        "documentation": "Returns the mass of the avatar or object in the region.\\nGets the mass of the object or avatar corresponding to ID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectmass/"
+    },
+    "@sl-slua/global/ll.GetObjectName": {
+        "documentation": "Returns the name of the prim which the script is attached to.\\nReturns the name of the prim (not object) which contains the script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectname/"
+    },
+    "@sl-slua/global/ll.GetObjectPermMask": {
+        "documentation": "Returns the permission mask of the requested category for the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectpermmask/"
+    },
+    "@sl-slua/global/ll.GetObjectPrimCount": {
+        "documentation": "Returns the total number of prims for an object in the region.\\nReturns the prim count for any object id in the same region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetobjectprimcount/"
+    },
+    "@sl-slua/global/ll.GetOmega": {
+        "documentation": "Returns the rotation velocity in radians per second.\\nReturns a vector that is the rotation velocity of the object in radians per second.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetomega/"
+    },
+    "@sl-slua/global/ll.GetOwner": {
+        "documentation": "Returns the object owner's UUID.\\nReturns the key for the owner of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetowner/"
+    },
+    "@sl-slua/global/ll.GetOwnerKey": {
+        "documentation": "Returns the owner of ObjectID.\\nReturns the key for the owner of object ObjectID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetownerkey/"
+    },
+    "@sl-slua/global/ll.GetParcelDetails": {
+        "documentation": "Returns a list of parcel details specified in the ParcelDetails list for the parcel at Position.\\nParameters is one or more of: PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\\nReturns a list that is the parcel details specified in ParcelDetails (in the same order) for the parcel at Position.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparceldetails/"
+    },
+    "@sl-slua/global/ll.GetParcelFlags": {
+        "documentation": "Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that includes the point Position.\\nReturns a bit-field specifying the parcel flags (PARCEL_FLAG_*) for the parcel at Position.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparcelflags/"
+    },
+    "@sl-slua/global/ll.GetParcelMaxPrims": {
+        "documentation": "Returns the maximum number of prims allowed on the parcel at Position for a given scope.\\nThe scope may be set to an individual parcel or the combined resources of all parcels with the same ownership in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparcelmaxprims/"
+    },
+    "@sl-slua/global/ll.GetParcelMusicURL": {
+        "documentation": "Gets the streaming audio URL for the parcel object is on.\\nThe object owner, avatar or group, must also be the land owner.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparcelmusicurl/"
+    },
+    "@sl-slua/global/ll.GetParcelPrimCount": {
+        "documentation": "Returns the number of prims on the parcel at Position of the given category.\\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER, _SELECTED, _TEMP.\\nReturns the number of prims used on the parcel at Position which are in Category.\\nIf SimWide is TRUE, it returns the total number of objects for all parcels with matching ownership in the category specified.\\nIf SimWide is FALSE, it returns the number of objects on this specific parcel in the category specified",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparcelprimcount/"
+    },
+    "@sl-slua/global/ll.GetParcelPrimOwners": {
+        "documentation": "Returns a list of up to 100 residents who own objects on the parcel at Position, with per-owner land impact totals.\\nRequires owner-like permissions for the parcel, and for the script owner to be present in the region.\\nThe list is formatted as [ key agentKey1, integer agentLI1, key agentKey2, integer agentLI2, ... ], sorted by agent key.\\nThe integers are the combined land impacts of the objects owned by the corresponding agents.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetparcelprimowners/"
+    },
+    "@sl-slua/global/ll.GetPermissions": {
+        "documentation": "Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise \"and\" operation against the PERMISSION_* constants",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetpermissions/"
+    },
+    "@sl-slua/global/ll.GetPermissionsKey": {
+        "documentation": "Returns the key of the avatar that last granted or declined permissions to the script.\\nReturns NULL_KEY if permissions were never granted or declined.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetpermissionskey/"
+    },
+    "@sl-slua/global/ll.GetPhysicsMaterial": {
+        "documentation": "Returns a list of the form [float gravity_multiplier, float restitution, float friction, float density].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetphysicsmaterial/"
+    },
+    "@sl-slua/global/ll.GetPos": {
+        "documentation": "Returns the position of the task in region coordinates.\\nReturns the vector position of the task in region coordinates.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetpos/"
+    },
+    "@sl-slua/global/ll.GetPrimMediaParams": {
+        "documentation": "Returns the media parameters for a particular face on an object, given the desired list of parameter names, in the order requested. Returns an empty list if no media exists on the face.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetprimmediaparams/"
+    },
+    "@sl-slua/global/ll.GetPrimitiveParams": {
+        "documentation": "Returns the primitive parameters specified in the parameters list.\\nReturns primitive parameters specified in the Parameters list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetprimitiveparams/"
+    },
+    "@sl-slua/global/ll.GetRegionAgentCount": {
+        "documentation": "Returns the number of avatars in the region.\\nReturns an integer that is the number of avatars in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionagentcount/"
+    },
+    "@sl-slua/global/ll.GetRegionCorner": {
+        "documentation": "Returns a vector, in meters, that is the global location of the south-west corner of the region which the object is in.\\nReturns the Region-Corner of the simulator containing the task. The region-corner is a vector (values in meters) representing distance from the first region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregioncorner/"
+    },
+    "@sl-slua/global/ll.GetRegionDayLength": {
+        "documentation": "Returns the number of seconds in a day in this region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregiondaylength/"
+    },
+    "@sl-slua/global/ll.GetRegionDayOffset": {
+        "documentation": "Returns the number of seconds in a day is offset from midnight in this parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregiondayoffset/"
+    },
+    "@sl-slua/global/ll.GetRegionFPS": {
+        "documentation": "Returns the mean region frames per second.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionfps/"
+    },
+    "@sl-slua/global/ll.GetRegionFlags": {
+        "documentation": "Returns the region flags (REGION_FLAG_*) for the region the object is in.\\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for the region the object is in.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionflags/"
+    },
+    "@sl-slua/global/ll.GetRegionMoonDirection": {
+        "documentation": "Returns a normalized vector of the direction of the moon in the region.\\nReturns the moon's direction on the simulator.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionmoondirection/"
+    },
+    "@sl-slua/global/ll.GetRegionMoonRotation": {
+        "documentation": "Returns the rotation applied to the moon in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionmoonrotation/"
+    },
+    "@sl-slua/global/ll.GetRegionName": {
+        "documentation": "Returns the current region name.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionname/"
+    },
+    "@sl-slua/global/ll.GetRegionSunDirection": {
+        "documentation": "Returns a normalized vector of the direction of the sun in the region.\\nReturns the sun's direction on the simulator.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionsundirection/"
+    },
+    "@sl-slua/global/ll.GetRegionSunRotation": {
+        "documentation": "Returns the rotation applied to the sun in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregionsunrotation/"
+    },
+    "@sl-slua/global/ll.GetRegionTimeDilation": {
+        "documentation": "Returns the current time dilation as a float between 0.0 (full dilation) and 1.0 (no dilation).\\nReturns the current time dilation as a float between 0.0 and 1.0.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregiontimedilation/"
+    },
+    "@sl-slua/global/ll.GetRegionTimeOfDay": {
+        "documentation": "Returns the time in seconds since environmental midnight for the entire region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetregiontimeofday/"
+    },
+    "@sl-slua/global/ll.GetRenderMaterial": {
+        "documentation": "Returns a string that is the render material on face (the inventory name if it is a material in the prim's inventory, otherwise the key).\\nReturns the render material of a face, if it is found in object inventory, its key otherwise.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetrendermaterial/"
+    },
+    "@sl-slua/global/ll.GetRootPosition": {
+        "documentation": "Returns the position (in region coordinates) of the root prim of the object which the script is attached to.\\nThis is used to allow a child prim to determine where the root is.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetrootposition/"
+    },
+    "@sl-slua/global/ll.GetRootRotation": {
+        "documentation": "Returns the rotation (relative to the region) of the root prim of the object which the script is attached to.\\nGets the global rotation of the root object of the object script is attached to.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetrootrotation/"
+    },
+    "@sl-slua/global/ll.GetRot": {
+        "documentation": "Returns the rotation relative to the region's axes.\\nReturns the rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetrot/"
+    },
+    "@sl-slua/global/ll.GetSPMaxMemory": {
+        "documentation": "Returns the maximum used memory for the current script. Only valid after using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\\nReturns the integer of the most bytes used while llScriptProfiler was last active.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetspmaxmemory/"
+    },
+    "@sl-slua/global/ll.GetScale": {
+        "documentation": "Returns the scale of the prim.\\nReturns a vector that is the scale (dimensions) of the prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetscale/"
+    },
+    "@sl-slua/global/ll.GetScriptName": {
+        "documentation": "Returns the name of the script that this function is used in.\\nReturns the name of this script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetscriptname/"
+    },
+    "@sl-slua/global/ll.GetScriptState": {
+        "documentation": "Returns TRUE if the script named is running.\\nReturns TRUE if ScriptName is running.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetscriptstate/"
+    },
+    "@sl-slua/global/ll.GetSimStats": {
+        "documentation": "Returns a float that is the requested statistic.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetsimstats/"
+    },
+    "@sl-slua/global/ll.GetSimulatorHostname": {
+        "documentation": "Returns the host-name of the machine which the script is running on.\\nFor example, \"sim225.agni.lindenlab.com\".",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetsimulatorhostname/"
+    },
+    "@sl-slua/global/ll.GetStartParameter": {
+        "documentation": "Returns an integer that is the script rez parameter.\\nIf the object was rezzed by an agent, this function returns 0.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetstartparameter/"
+    },
+    "@sl-slua/global/ll.GetStartString": {
+        "documentation": "Returns a string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\\nIf the object was rezzed by an agent, this function returns an empty string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetstartstring/"
+    },
+    "@sl-slua/global/ll.GetStaticPath": {
+        "documentation": "ll.GetStaticPath function",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetstaticpath/"
+    },
+    "@sl-slua/global/ll.GetStatus": {
+        "documentation": "Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the object the script is attached to.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetstatus/"
+    },
+    "@sl-slua/global/ll.GetSubString": {
+        "documentation": "Returns a sub-string from String, in a range specified by the Start and End indices (inclusive).\\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\\nIf Start is greater than End, the sub string is the exclusion of the entries.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetsubstring/"
+    },
+    "@sl-slua/global/ll.GetSunDirection": {
+        "documentation": "Returns a normalized vector of the direction of the sun in the parcel.\\nReturns the sun's direction on the simulator in the parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetsundirection/"
+    },
+    "@sl-slua/global/ll.GetSunRotation": {
+        "documentation": "Returns the rotation applied to the sun in the parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetsunrotation/"
+    },
+    "@sl-slua/global/ll.GetTexture": {
+        "documentation": "Returns a string that is the texture on face (the inventory name if it is a texture in the prim's inventory, otherwise the key).\\nReturns the texture of a face, if it is found in object inventory, its key otherwise.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettexture/"
+    },
+    "@sl-slua/global/ll.GetTextureOffset": {
+        "documentation": "Returns the texture offset of face in the x and y components of a vector.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettextureoffset/"
+    },
+    "@sl-slua/global/ll.GetTextureRot": {
+        "documentation": "Returns the texture rotation of side.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettexturerot/"
+    },
+    "@sl-slua/global/ll.GetTextureScale": {
+        "documentation": "Returns the texture scale of side in the x and y components of a vector.\\nReturns the texture scale of a side in the x and y components of a vector.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettexturescale/"
+    },
+    "@sl-slua/global/ll.GetTime": {
+        "documentation": "Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettime/"
+    },
+    "@sl-slua/global/ll.GetTimeOfDay": {
+        "documentation": "Returns the time in seconds since environmental midnight on the parcel.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettimeofday/"
+    },
+    "@sl-slua/global/ll.GetTimestamp": {
+        "documentation": "Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettimestamp/"
+    },
+    "@sl-slua/global/ll.GetTorque": {
+        "documentation": "Returns the torque (if the script is physical).\\nReturns a vector that is the torque (if the script is physical).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgettorque/"
+    },
+    "@sl-slua/global/ll.GetUnixTime": {
+        "documentation": "Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC from the system clock.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetunixtime/"
+    },
+    "@sl-slua/global/ll.GetUsedMemory": {
+        "documentation": "Returns the current used memory for the current script. Non-mono scripts always use 16K.\\nReturns the integer of the number of bytes of memory currently in use by the script. Non-mono scripts always use 16K.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetusedmemory/"
+    },
+    "@sl-slua/global/ll.GetUsername": {
+        "documentation": "Returns the username of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestUsername if the avatar may be absent from the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetusername/"
+    },
+    "@sl-slua/global/ll.GetVel": {
+        "documentation": "Returns the velocity of the object.\\nReturns a vector that is the velocity of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetvel/"
+    },
+    "@sl-slua/global/ll.GetVisualParams": {
+        "documentation": "Returns a list of the current value for each requested visual parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetvisualparams/"
+    },
+    "@sl-slua/global/ll.GetWallclock": {
+        "documentation": "Returns the time in seconds since midnight California Pacific time (PST/PDT).\\nReturns the time in seconds since simulator's time-zone midnight (Pacific Time).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgetwallclock/"
+    },
+    "@sl-slua/global/ll.GiveAgentInventory": {
+        "documentation": "Give InventoryItems to the specified agent as a new folder of items, as permitted by the permissions system. The target must be an agent.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgiveagentinventory/"
+    },
+    "@sl-slua/global/ll.GiveInventory": {
+        "documentation": "Give InventoryItem to destination represented by TargetID, as permitted by the permissions system.\\nTargetID may be any agent or an object in the same region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgiveinventory/"
+    },
+    "@sl-slua/global/ll.GiveInventoryList": {
+        "documentation": "Give InventoryItems to destination (represented by TargetID) as a new folder of items, as permitted by the permissions system.\\nTargetID may be any agent or an object in the same region. If TargetID is an object, the items are passed directly to the object inventory (no folder is created).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgiveinventorylist/"
+    },
+    "@sl-slua/global/ll.GiveMoney": {
+        "documentation": "Transfers Amount of L$ from script owner to AvatarID.\\nThis call will silently fail if PERMISSION_DEBIT has not been granted.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgivemoney/"
+    },
+    "@sl-slua/global/ll.GodLikeRezObject": {
+        "documentation": "Rez directly off of a UUID if owner has god-bit set.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgodlikerezobject/"
+    },
+    "@sl-slua/global/ll.Ground": {
+        "documentation": "Returns the ground height at the object position + offset.\\nReturns the ground height at the object's position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llground/"
+    },
+    "@sl-slua/global/ll.GroundContour": {
+        "documentation": "Returns the ground contour direction below the object position + Offset.\\nReturns the ground contour at the object's position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgroundcontour/"
+    },
+    "@sl-slua/global/ll.GroundNormal": {
+        "documentation": "Returns the ground normal below the object position + offset.\\nReturns the ground contour at the object's position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgroundnormal/"
+    },
+    "@sl-slua/global/ll.GroundRepel": {
+        "documentation": "Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\\n\\n                    The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\\n\\n                    Do not use with vehicles. Only works in physics-enabled objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgroundrepel/"
+    },
+    "@sl-slua/global/ll.GroundSlope": {
+        "documentation": "Returns the ground slope below the object position + Offset.\\nReturns the ground slope at the object position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llgroundslope/"
+    },
+    "@sl-slua/global/ll.HMAC": {
+        "documentation": "Returns the base64-encoded hashed message authentication code (HMAC), of Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224, sha256, sha384, sha512).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llhmac/"
+    },
+    "@sl-slua/global/ll.HTTPRequest": {
+        "documentation": "Sends an HTTP request to the specified URL with the Body of the request and Parameters.\\nReturns a key that is a handle identifying the HTTP request made.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llhttprequest/"
+    },
+    "@sl-slua/global/ll.HTTPResponse": {
+        "documentation": "Responds to an incoming HTTP request which was triggerd by an http_request event within the script. HTTPRequestID specifies the request to respond to (this ID is supplied in the http_request event handler).  Status and Body specify the status code and message to respond with.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llhttpresponse/"
+    },
+    "@sl-slua/global/ll.Hash": {
+        "documentation": "Calculates the 32bit hash value for the provided string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llhash/"
+    },
+    "@sl-slua/global/ll.InsertString": {
+        "documentation": "Inserts SourceVariable into TargetVariable at Position, and returns the result.\\nInserts SourceVariable into TargetVariable at Position and returns the result. Note this does not alter TargetVariable.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llinsertstring/"
+    },
+    "@sl-slua/global/ll.InstantMessage": {
+        "documentation": "IMs Text to the user identified.\\nSend Text to the user as an instant message.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llinstantmessage/"
+    },
+    "@sl-slua/global/ll.IntegerToBase64": {
+        "documentation": "Returns a string that is a Base64 big endian encode of Value.\\nEncodes the Value as an 8-character Base64 string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llintegertobase64/"
+    },
+    "@sl-slua/global/ll.IsFriend": {
+        "documentation": "Returns TRUE if avatar ID is a friend of the script owner.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llisfriend/"
+    },
+    "@sl-slua/global/ll.IsLinkGLTFMaterial": {
+        "documentation": "Checks the face for a PBR render material.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llislinkgltfmaterial/"
+    },
+    "@sl-slua/global/ll.Json2List": {
+        "documentation": "Converts the top level of the JSON string to a list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lljson2list/"
+    },
+    "@sl-slua/global/ll.JsonGetValue": {
+        "documentation": "Gets the value indicated by Specifiers from the JSON string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lljsongetvalue/"
+    },
+    "@sl-slua/global/ll.JsonSetValue": {
+        "documentation": "Returns a new JSON string that is the JSON given with the Value indicated by Specifiers set to Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lljsonsetvalue/"
+    },
+    "@sl-slua/global/ll.JsonValueType": {
+        "documentation": "Returns the type constant (JSON_*) for the value in JSON indicated by Specifiers.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lljsonvaluetype/"
+    },
+    "@sl-slua/global/ll.Key2Name": {
+        "documentation": "Returns the name of the prim or avatar specified by ID. The ID must be a valid rezzed prim or avatar key in the current simulator, otherwise an empty string is returned.\\nFor avatars, the returned name is the legacy name",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llkey2name/"
+    },
+    "@sl-slua/global/ll.KeyCountKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llkeycountkeyvalue/"
+    },
+    "@sl-slua/global/ll.KeysKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llkeyskeyvalue/"
+    },
+    "@sl-slua/global/ll.Linear2sRGB": {
+        "documentation": "Converts a color from the linear colorspace to sRGB.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinear2srgb/"
+    },
+    "@sl-slua/global/ll.LinkAdjustSoundVolume": {
+        "documentation": "Adjusts the volume (0.0 - 1.0) of the currently playing sound attached to the link.\\nThis function has no effect on sounds started with llTriggerSound.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinkadjustsoundvolume/"
+    },
+    "@sl-slua/global/ll.LinkParticleSystem": {
+        "documentation": "Creates a particle system in prim LinkNumber based on Rules. An empty list removes a particle system from object.\\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].\\nThis is identical to llParticleSystem except that it applies to a specified linked prim and not just the prim the script is in.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinkparticlesystem/"
+    },
+    "@sl-slua/global/ll.LinkPlaySound": {
+        "documentation": "Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be attached to the link or triggered at its location.\\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinkplaysound/"
+    },
+    "@sl-slua/global/ll.LinkSetSoundQueueing": {
+        "documentation": "Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetsoundqueueing/"
+    },
+    "@sl-slua/global/ll.LinkSetSoundRadius": {
+        "documentation": "Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetsoundradius/"
+    },
+    "@sl-slua/global/ll.LinkSitTarget": {
+        "documentation": "Set the sit location for the linked prim(s). If Offset == <0,0,0> clear it.\\nSet the sit location for the linked prim(s). The sit location is relative to the prim's position and rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksittarget/"
+    },
+    "@sl-slua/global/ll.LinkStopSound": {
+        "documentation": "Stops playback of the currently attached sound on a link.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinkstopsound/"
+    },
+    "@sl-slua/global/ll.LinksetDataAvailable": {
+        "documentation": "Returns the number of bytes remaining in the linkset's datastore.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdataavailable/"
+    },
+    "@sl-slua/global/ll.LinksetDataCountFound": {
+        "documentation": "Returns the number of keys matching the regular expression passed in the search parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatacountfound/"
+    },
+    "@sl-slua/global/ll.LinksetDataCountKeys": {
+        "documentation": "Returns the number of keys in the linkset's datastore.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatacountkeys/"
+    },
+    "@sl-slua/global/ll.LinksetDataDelete": {
+        "documentation": "Deletes a name:value pair from the linkset's datastore.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatadelete/"
+    },
+    "@sl-slua/global/ll.LinksetDataDeleteFound": {
+        "documentation": "Deletes all key value pairs in the linkset data where the key matches the regular expression in search. Returns a list consisting of [ #deleted, #not deleted ].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatadeletefound/"
+    },
+    "@sl-slua/global/ll.LinksetDataDeleteProtected": {
+        "documentation": "Deletes a name:value pair from the linkset's datastore.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatadeleteprotected/"
+    },
+    "@sl-slua/global/ll.LinksetDataFindKeys": {
+        "documentation": "Returns a list of keys from the linkset's data store matching the search parameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatafindkeys/"
+    },
+    "@sl-slua/global/ll.LinksetDataListKeys": {
+        "documentation": "Returns a list of all keys in the linkset datastore.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatalistkeys/"
+    },
+    "@sl-slua/global/ll.LinksetDataRead": {
+        "documentation": "Returns the value stored for a key in the linkset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdataread/"
+    },
+    "@sl-slua/global/ll.LinksetDataReadProtected": {
+        "documentation": "Returns the value stored for a key in the linkset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatareadprotected/"
+    },
+    "@sl-slua/global/ll.LinksetDataReset": {
+        "documentation": "Resets the linkset's data store, erasing all key-value pairs.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatareset/"
+    },
+    "@sl-slua/global/ll.LinksetDataWrite": {
+        "documentation": "Sets a name:value pair in the linkset's datastore",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatawrite/"
+    },
+    "@sl-slua/global/ll.LinksetDataWriteProtected": {
+        "documentation": "Sets a name:value pair in the linkset's datastore",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllinksetdatawriteprotected/"
+    },
+    "@sl-slua/global/ll.List2CSV": {
+        "documentation": "Creates a string of comma separated values from the list.\\nCreate a string of comma separated values from the specified list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2csv/"
+    },
+    "@sl-slua/global/ll.List2Float": {
+        "documentation": "Copies the float at Index in the list.\\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a float, then zero is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2float/"
+    },
+    "@sl-slua/global/ll.List2Integer": {
+        "documentation": "Copies the integer at Index in the list.\\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to an integer, then zero is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2integer/"
+    },
+    "@sl-slua/global/ll.List2Json": {
+        "documentation": "Converts either a strided list of key:value pairs to a JSON_OBJECT, or a list of values to a JSON_ARRAY.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2json/"
+    },
+    "@sl-slua/global/ll.List2Key": {
+        "documentation": "Copies the key at Index in the list.\\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a key, then null string is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2key/"
+    },
+    "@sl-slua/global/ll.List2List": {
+        "documentation": "Returns a subset of entries from ListVariable, in a range specified by the Start and End indicies (inclusive).\\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\\nIf Start is greater than End, the sub string is the exclusion of the entries.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2list/"
+    },
+    "@sl-slua/global/ll.List2ListSlice": {
+        "documentation": "Returns a subset of entries from ListVariable, in a range specified by Start and End indices (inclusive) return the slice_index element of each stride.\\n Using negative numbers for Start and/or End causes the index to count backwards from the length of the list. (e.g. 0, -1 captures entire list)\\nIf slice_index is less than 0, it is counted backwards from the end of the stride.\\n Stride must be a positive integer > 0 or an empy list is returned.  If slice_index falls outside range of stride, an empty list is returned. slice_index is zero-based. (e.g. A stride of 2 has valid indices 0,1)",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2listslice/"
+    },
+    "@sl-slua/global/ll.List2ListStrided": {
+        "documentation": "Copies the strided slice of the list from Start to End.\\nReturns a copy of the strided slice of the specified list from Start to End.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2liststrided/"
+    },
+    "@sl-slua/global/ll.List2Rot": {
+        "documentation": "Copies the rotation at Index in the list.\\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to rotation, thenZERO_ROTATION is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2rot/"
+    },
+    "@sl-slua/global/ll.List2String": {
+        "documentation": "Copies the string at Index in the list.\\nReturns the value at Index in the specified list as a string. If Index describes a location not in the list then null string is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2string/"
+    },
+    "@sl-slua/global/ll.List2Vector": {
+        "documentation": "Copies the vector at Index in the list.\\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a vector, then ZERO_VECTOR is returned.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllist2vector/"
+    },
+    "@sl-slua/global/ll.ListFindList": {
+        "documentation": "Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\\nReturns the position of the first instance of the Find list in the ListVariable. Returns -1 if not found.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistfindlist/"
+    },
+    "@sl-slua/global/ll.ListFindListNext": {
+        "documentation": "Returns the index of the nth instance of Find in ListVariable. Returns -1 if not found.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistfindlistnext/"
+    },
+    "@sl-slua/global/ll.ListFindStrided": {
+        "documentation": "Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\\nReturns the position of the first instance of the Find list in the ListVariable after the start index and before the end index. Steps through ListVariable by stride.  Returns -1 if not found.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistfindstrided/"
+    },
+    "@sl-slua/global/ll.ListInsertList": {
+        "documentation": "Returns a list that contains all the elements from Target but with the elements from ListVariable inserted at Position start.\\nReturns a new list, created by inserting ListVariable into the Target list at Position. Note this does not alter the Target.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistinsertlist/"
+    },
+    "@sl-slua/global/ll.ListRandomize": {
+        "documentation": "Returns a version of the input ListVariable which has been randomized by blocks of size Stride.\\nIf the remainder from the length of the list, divided by the stride is non-zero, this function does not randomize the list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistrandomize/"
+    },
+    "@sl-slua/global/ll.ListReplaceList": {
+        "documentation": "Returns a list that is Target with Start through End removed and ListVariable inserted at Start.\\nReturns a list replacing the slice of the Target list from Start to End with the specified ListVariable. Start and End are inclusive, so 0, 1 would replace the first two entries and 0, 0 would replace only the first list entry.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistreplacelist/"
+    },
+    "@sl-slua/global/ll.ListSort": {
+        "documentation": "Returns the specified list, sorted into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistsort/"
+    },
+    "@sl-slua/global/ll.ListSortStrided": {
+        "documentation": "Returns the specified list, sorted by the specified element into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistsortstrided/"
+    },
+    "@sl-slua/global/ll.ListStatistics": {
+        "documentation": "Performs a statistical aggregate function, specified by a LIST_STAT_* constant, on ListVariables.\\nThis function allows a script to perform a statistical operation as defined by operation on a list composed of integers and floats.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llliststatistics/"
+    },
+    "@sl-slua/global/ll.Listen": {
+        "documentation": "Creates a listen callback for Text on Channel from SpeakersName and SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and returns an identifier that can be used to deactivate or remove the listen.\\nNon-empty values for SpeakersName, SpeakersID, and Text will filter the results accordingly, while empty strings and NULL_KEY will not filter the results, for string and key parameters respectively.\\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllisten/"
+    },
+    "@sl-slua/global/ll.ListenControl": {
+        "documentation": "Makes a listen event callback active or inactive. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener you are controlling.\\nUse boolean values to specify Active",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistencontrol/"
+    },
+    "@sl-slua/global/ll.ListenRemove": {
+        "documentation": "Removes a listen event callback. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener to remove.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllistenremove/"
+    },
+    "@sl-slua/global/ll.LoadURL": {
+        "documentation": "Shows dialog to avatar AvatarID offering to load web page at URL.\tIf user clicks yes, launches their web browser.\\nllLoadURL displays a dialogue box to the user, offering to load the specified web page using the default web browser.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llloadurl/"
+    },
+    "@sl-slua/global/ll.Log": {
+        "documentation": "Returns the natural logarithm of Value. Returns zero if Value <= 0.\\nReturns the base e (natural) logarithm of the specified Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllog/"
+    },
+    "@sl-slua/global/ll.Log10": {
+        "documentation": "Returns the base 10 logarithm of Value. Returns zero if Value <= 0.\\nReturns the base 10 (common) logarithm of the specified Value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllog10/"
+    },
+    "@sl-slua/global/ll.LookAt": {
+        "documentation": "Cause object name to point its forward axis towards Target, at a force controlled by Strength and Damping.\\nGood Strength values are around half the mass of the object and good Damping values are less than 1/10th of the Strength.\\nAsymmetrical shapes require smaller Damping. A Strength of 0.0 cancels the look at.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lllookat/"
+    },
+    "@sl-slua/global/ll.LoopSound": {
+        "documentation": "Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\\nOnly one sound may be attached to an object at a time.\\nA second call to llLoopSound with the same key will not restart the sound, but the new volume will be used. This allows control over the volume of already playing sounds.\\nSetting the volume to 0 is not the same as calling llStopSound; a sound with 0 volume will continue to loop.\\nTo restart the sound from the beginning, call llStopSound before calling llLoopSound again.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llloopsound/"
+    },
+    "@sl-slua/global/ll.LoopSoundMaster": {
+        "documentation": "Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\\nBehaviour is identical to llLoopSound, with the addition of marking the source as a \"Sync Master\", causing \"Slave\" sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\\nThe use of multiple masters within a small area is unlikely to produce the desired effect.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llloopsoundmaster/"
+    },
+    "@sl-slua/global/ll.LoopSoundSlave": {
+        "documentation": "Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\\nBehaviour is identical to llLoopSound, unless there is a \"Sync Master\" present.\\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llloopsoundslave/"
+    },
+    "@sl-slua/global/ll.MD5String": {
+        "documentation": "Returns a string of 32 hex characters that is an RSA Data Security Inc., MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\\nReturns a 32-character hex string. (128-bit in binary.)",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmd5string/"
+    },
+    "@sl-slua/global/ll.MakeExplosion": {
+        "documentation": "Make a round explosion of particles. Deprecated: Use llParticleSystem instead.\\nMake a round explosion of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmakeexplosion/"
+    },
+    "@sl-slua/global/ll.MakeFire": {
+        "documentation": "Make fire like particles. Deprecated: Use llParticleSystem instead.\\nMake fire particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmakefire/"
+    },
+    "@sl-slua/global/ll.MakeFountain": {
+        "documentation": "Make a fountain of particles. Deprecated: Use llParticleSystem instead.\\nMake a fountain of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmakefountain/"
+    },
+    "@sl-slua/global/ll.MakeSmoke": {
+        "documentation": "Make smoke like particles. Deprecated: Use llParticleSystem instead.\\nMake smoky particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmakesmoke/"
+    },
+    "@sl-slua/global/ll.ManageEstateAccess": {
+        "documentation": "Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmanageestateaccess/"
+    },
+    "@sl-slua/global/ll.MapBeacon": {
+        "documentation": "Displays an in world beacon and optionally opens world map for avatar who touched the object or is wearing the script, centered on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmapbeacon/"
+    },
+    "@sl-slua/global/ll.MapDestination": {
+        "documentation": "Opens world map for avatar who touched it or is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\\nDirection currently has no effect.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmapdestination/"
+    },
+    "@sl-slua/global/ll.MessageLinked": {
+        "documentation": "Sends Number, Text, and ID to members of the link set identified by LinkNumber.\\nLinkNumber is either a linked number (available through llGetLinkNumber) or a LINK_* constant.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmessagelinked/"
+    },
+    "@sl-slua/global/ll.MinEventDelay": {
+        "documentation": "Set the minimum time between events being handled.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmineventdelay/"
+    },
+    "@sl-slua/global/ll.ModPow": {
+        "documentation": "Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped at 0xFFFF (16 bits).\\nReturns (Value ^ Power) % Modulus. (Value raised to the Power, Modulus). Value is capped at 0xFFFF (16 bits).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmodpow/"
+    },
+    "@sl-slua/global/ll.ModifyLand": {
+        "documentation": "Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH, LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x 4m, 8m x 8m).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmodifyland/"
+    },
+    "@sl-slua/global/ll.MoveToTarget": {
+        "documentation": "Critically damp to Target in Tau seconds (if the script is physical).\\nCritically damp to position target in tau-seconds if the script is physical. Good tau-values are greater than 0.2. A tau of 0.0 stops the critical damping.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llmovetotarget/"
+    },
+    "@sl-slua/global/ll.Name2Key": {
+        "documentation": "Look up Agent ID for the named agent in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llname2key/"
+    },
+    "@sl-slua/global/ll.NavigateTo": {
+        "documentation": "Navigate to destination.\\nDirects an object to travel to a defined position in the region or adjacent regions.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llnavigateto/"
+    },
+    "@sl-slua/global/ll.OffsetTexture": {
+        "documentation": "Sets the texture S and T offsets for the chosen Face.\\nIf Face is ALL_SIDES this function sets the texture offsets for all faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lloffsettexture/"
+    },
+    "@sl-slua/global/ll.OpenFloater": {
+        "documentation": "Returns the value for header for request_id.\\nReturns a string that is the value of the Header for HTTPRequestID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llopenfloater/"
+    },
+    "@sl-slua/global/ll.OpenRemoteDataChannel": {
+        "documentation": "This function is deprecated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llopenremotedatachannel/"
+    },
+    "@sl-slua/global/ll.Ord": {
+        "documentation": "Returns the unicode value of the indicated character in the string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llord/"
+    },
+    "@sl-slua/global/ll.OverMyLand": {
+        "documentation": "Returns TRUE if id ID over land owned by the script owner, otherwise FALSE.\\nReturns TRUE if key ID is over land owned by the object owner, FALSE otherwise.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llovermyland/"
+    },
+    "@sl-slua/global/ll.OwnerSay": {
+        "documentation": "says Text to owner only (if owner is in region).\\nSays Text to the owner of the object running the script, if the owner has been within the object's simulator since logging into Second Life, regardless of where they may be in-world.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llownersay/"
+    },
+    "@sl-slua/global/ll.ParcelMediaCommandList": {
+        "documentation": "Controls the playback of multimedia resources on a parcel or for an agent, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llparcelmediacommandlist/"
+    },
+    "@sl-slua/global/ll.ParcelMediaQuery": {
+        "documentation": "Queries the media properties of the parcel containing the script, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\\nThis function will only work if the script is contained within an object owned by the land-owner (or if the land is owned by a group, only if the object has been deeded to the group).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llparcelmediaquery/"
+    },
+    "@sl-slua/global/ll.ParseString2List": {
+        "documentation": "Converts Text into a list, discarding Separators, keeping Spacers (Separators and Spacers must be lists of strings, maximum of 8 each).\\nSeparators and Spacers are lists of strings with a maximum of 8 entries each.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llparsestring2list/"
+    },
+    "@sl-slua/global/ll.ParseStringKeepNulls": {
+        "documentation": "Breaks Text into a list, discarding separators, keeping spacers, keeping any null values generated. (separators and spacers must be lists of strings, maximum of 8 each).\\nllParseStringKeepNulls works almost exactly like llParseString2List, except that if a null is found it will add a null-string instead of discarding it like llParseString2List does.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llparsestringkeepnulls/"
+    },
+    "@sl-slua/global/ll.ParticleSystem": {
+        "documentation": "Creates a particle system in the prim the script is attached to, based on Parameters. An empty list removes a particle system from object.\\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llparticlesystem/"
+    },
+    "@sl-slua/global/ll.PassCollisions": {
+        "documentation": "Configures how collision events are passed to scripts in the linkset.\\nIf Pass == TRUE, collisions involving collision-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such collisions will only trigger events in the affected child prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpasscollisions/"
+    },
+    "@sl-slua/global/ll.PassTouches": {
+        "documentation": "Configures how touch events are passed to scripts in the linkset.\\nIf Pass == TRUE, touches involving touch-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such touches will only trigger events in the affected child prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpasstouches/"
+    },
+    "@sl-slua/global/ll.PatrolPoints": {
+        "documentation": "Patrol a list of points.\\nSets the points for a character (llCreateCharacter) to patrol along.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpatrolpoints/"
+    },
+    "@sl-slua/global/ll.PlaySound": {
+        "documentation": "Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.\\nA second call to llPlaySound with the same sound will not restart the sound, but the new volume will be used, which allows control over the volume of already playing sounds.\\nTo restart the sound from the beginning, call llStopSound before calling llPlaySound again.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llplaysound/"
+    },
+    "@sl-slua/global/ll.PlaySoundSlave": {
+        "documentation": "Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\\nBehaviour is identical to llPlaySound, unless there is a \"Sync Master\" present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llplaysoundslave/"
+    },
+    "@sl-slua/global/ll.Pow": {
+        "documentation": "Returns the Value raised to the power Exponent, or returns 0 and triggers Math Error for imaginary results.\\nReturns the Value raised to the Exponent.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpow/"
+    },
+    "@sl-slua/global/ll.PreloadSound": {
+        "documentation": "Causes nearby viewers to preload the Sound from the object's inventory.\\nThis is intended to prevent delays in starting new sounds when called upon.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpreloadsound/"
+    },
+    "@sl-slua/global/ll.Pursue": {
+        "documentation": "Chase after a target.\\nCauses the character (llCharacter) to pursue the target defined by TargetID.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpursue/"
+    },
+    "@sl-slua/global/ll.PushObject": {
+        "documentation": "Applies Impulse and AngularImpulse to ObjectID.\\nApplies the supplied impulse and angular impulse to the object specified.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llpushobject/"
+    },
+    "@sl-slua/global/ll.ReadKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreadkeyvalue/"
+    },
+    "@sl-slua/global/ll.RefreshPrimURL": {
+        "documentation": "Reloads the web page shown on the sides of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrefreshprimurl/"
+    },
+    "@sl-slua/global/ll.RegionSay": {
+        "documentation": "Broadcasts Text to entire region on Channel (except for channel 0).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llregionsay/"
+    },
+    "@sl-slua/global/ll.RegionSayTo": {
+        "documentation": "Says Text, on Channel, to avatar or object indicated by TargetID (if within region).\\nIf TargetID is an avatar and Channel is nonzero, Text can be heard by any attachment on the avatar.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llregionsayto/"
+    },
+    "@sl-slua/global/ll.ReleaseCamera": {
+        "documentation": "Return camera to agent.\\nDeprecated: Use llClearCameraParams instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreleasecamera/"
+    },
+    "@sl-slua/global/ll.ReleaseControls": {
+        "documentation": "Stop taking inputs.\\nStop taking inputs from the avatar.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreleasecontrols/"
+    },
+    "@sl-slua/global/ll.ReleaseURL": {
+        "documentation": "Releases the specified URL, which was previously obtained using llRequestURL.  Once released, the URL will no longer be usable.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreleaseurl/"
+    },
+    "@sl-slua/global/ll.RemoteDataReply": {
+        "documentation": "This function is deprecated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremotedatareply/"
+    },
+    "@sl-slua/global/ll.RemoteDataSetRegion": {
+        "documentation": "This function is deprecated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremotedatasetregion/"
+    },
+    "@sl-slua/global/ll.RemoteLoadScriptPin": {
+        "documentation": "If the owner of the object containing this script can modify the object identified by the specified object key, and if the PIN matches the PIN previously set using llSetRemoteScriptAccessPin (on the target prim), then the script will be copied into target. Running is a boolean specifying whether the script should be enabled once copied into the target object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremoteloadscriptpin/"
+    },
+    "@sl-slua/global/ll.RemoveFromLandBanList": {
+        "documentation": "Remove avatar from the land ban list.\\nRemove specified avatar from the land parcel ban list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremovefromlandbanlist/"
+    },
+    "@sl-slua/global/ll.RemoveFromLandPassList": {
+        "documentation": "Remove avatar from the land pass list.\\nRemove specified avatar from the land parcel pass list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremovefromlandpasslist/"
+    },
+    "@sl-slua/global/ll.RemoveInventory": {
+        "documentation": "Remove the named inventory item.\\nRemove the named inventory item from the object inventory.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremoveinventory/"
+    },
+    "@sl-slua/global/ll.RemoveVehicleFlags": {
+        "documentation": "Removes the enabled bits in 'flags'.\\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llremovevehicleflags/"
+    },
+    "@sl-slua/global/ll.ReplaceAgentEnvironment": {
+        "documentation": "Replaces the entire environment for an agent. Must be used as part of an experience.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreplaceagentenvironment/"
+    },
+    "@sl-slua/global/ll.ReplaceEnvironment": {
+        "documentation": "Replaces the environment for a parcel or region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreplaceenvironment/"
+    },
+    "@sl-slua/global/ll.ReplaceSubString": {
+        "documentation": "Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means \"replace all\". Positive Count moves left to right. Negative moves right to left.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreplacesubstring/"
+    },
+    "@sl-slua/global/ll.RequestAgentData": {
+        "documentation": "Requests data about AvatarID. When data is available the dataserver event will be raised.\\nThis function requests data about an avatar. If and when the information is collected, the dataserver event is triggered with the key returned from this function passed in the requested parameter. See the agent data constants (DATA_*) for details about valid values of data and what each will return in the dataserver event.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestagentdata/"
+    },
+    "@sl-slua/global/ll.RequestDisplayName": {
+        "documentation": "Requests the display name of the agent. When the display name is available the dataserver event will be raised.\\nThe avatar identified does not need to be in the same region or online at the time of the request.\\nReturns a key that is used to identify the dataserver event when it is raised.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestdisplayname/"
+    },
+    "@sl-slua/global/ll.RequestExperiencePermissions": {
+        "documentation": "\\n                   Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestexperiencepermissions/"
+    },
+    "@sl-slua/global/ll.RequestInventoryData": {
+        "documentation": "Requests data for the named InventoryItem.\\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form \"<float, float, float>\" which can be cast to a vector. This position is in region local coordinates.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestinventorydata/"
+    },
+    "@sl-slua/global/ll.RequestPermissions": {
+        "documentation": "Ask AvatarID to allow the script to perform certain actions, specified in the PermissionMask bitmask. PermissionMask should be one or more PERMISSION_* constants. Multiple permissions can be requested simultaneously by ORing the constants together. Many of the permissions requests can only go to object owner.\\nThis call will not stop script execution. If the avatar grants the requested permissions, the run_time_permissions event will be called.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestpermissions/"
+    },
+    "@sl-slua/global/ll.RequestSecureURL": {
+        "documentation": "Requests one HTTPS:// (SSL) URL for use by this object. The http_request event is triggered with results.\\nReturns a key that is the handle used for identifying the request in the http_request event.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestsecureurl/"
+    },
+    "@sl-slua/global/ll.RequestSimulatorData": {
+        "documentation": "Requests the specified Data about RegionName. When the specified data is available, the dataserver event is raised.\\nData should use one of the DATA_SIM_* constants.\\nReturns a dataserver query ID and triggers the dataserver event when data is found.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestsimulatordata/"
+    },
+    "@sl-slua/global/ll.RequestURL": {
+        "documentation": "Requests one HTTP:// URL for use by this script. The http_request event is triggered with the result of the request.\\nReturns a key that is the handle used for identifying the result in the http_request event.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequesturl/"
+    },
+    "@sl-slua/global/ll.RequestUserKey": {
+        "documentation": "Look up Agent ID for the named agent using a historical name.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestuserkey/"
+    },
+    "@sl-slua/global/ll.RequestUsername": {
+        "documentation": "Requests single-word user-name of an avatar. When data is available the dataserver event will be raised.\\nRequests the user-name of the identified agent. When the user-name is available the dataserver event is raised.\\nThe agent identified does not need to be in the same region or online at the time of the request.\\nReturns a key that is used to identify the dataserver event when it is raised.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrequestusername/"
+    },
+    "@sl-slua/global/ll.ResetAnimationOverride": {
+        "documentation": "Resets the animation of the specified animation state to the default value.\\nIf animation state equals \"ALL\", then all animation states are reset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresetanimationoverride/"
+    },
+    "@sl-slua/global/ll.ResetLandBanList": {
+        "documentation": "Removes all residents from the land ban list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresetlandbanlist/"
+    },
+    "@sl-slua/global/ll.ResetLandPassList": {
+        "documentation": "Removes all residents from the land access/pass list.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresetlandpasslist/"
+    },
+    "@sl-slua/global/ll.ResetOtherScript": {
+        "documentation": "Resets the named script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresetotherscript/"
+    },
+    "@sl-slua/global/ll.ResetScript": {
+        "documentation": "Resets the script.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresetscript/"
+    },
+    "@sl-slua/global/ll.ResetTime": {
+        "documentation": "Sets the time to zero.\\nSets the internal timer to zero.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llresettime/"
+    },
+    "@sl-slua/global/ll.ReturnObjectsByID": {
+        "documentation": "Return objects using their UUIDs.\\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreturnobjectsbyid/"
+    },
+    "@sl-slua/global/ll.ReturnObjectsByOwner": {
+        "documentation": "Return objects based upon their owner and a scope of parcel, parcel owner, or region.\\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llreturnobjectsbyowner/"
+    },
+    "@sl-slua/global/ll.RezAtRoot": {
+        "documentation": "Instantiate owner's InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object's location will be set to Position.\\nCreates object's inventory item at the given Position, with Velocity, Rotation, and StartParameter.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrezatroot/"
+    },
+    "@sl-slua/global/ll.RezObject": {
+        "documentation": "Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\\nCreates object's inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\\nThe Velocity parameter is ignored if the rezzed object is not physical.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrezobject/"
+    },
+    "@sl-slua/global/ll.RezObjectWithParams": {
+        "documentation": "Instantiate owner's InventoryItem with the given parameters.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrezobjectwithparams/"
+    },
+    "@sl-slua/global/ll.Rot2Angle": {
+        "documentation": "Returns the rotation angle represented by Rotation.\\nReturns the angle represented by the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2angle/"
+    },
+    "@sl-slua/global/ll.Rot2Axis": {
+        "documentation": "Returns the rotation axis represented by Rotation.\\nReturns the axis represented by the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2axis/"
+    },
+    "@sl-slua/global/ll.Rot2Euler": {
+        "documentation": "Returns the Euler representation (roll, pitch, yaw) of Rotation.\\nReturns the Euler Angle representation of the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2euler/"
+    },
+    "@sl-slua/global/ll.Rot2Fwd": {
+        "documentation": "Returns the forward vector defined by Rotation.\\nReturns the forward axis represented by the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2fwd/"
+    },
+    "@sl-slua/global/ll.Rot2Left": {
+        "documentation": "Returns the left vector defined by Rotation.\\nReturns the left axis represented by the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2left/"
+    },
+    "@sl-slua/global/ll.Rot2Up": {
+        "documentation": "Returns the up vector defined by Rotation.\\nReturns the up axis represented by the Rotation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrot2up/"
+    },
+    "@sl-slua/global/ll.RotBetween": {
+        "documentation": "Returns the rotation to rotate Vector1 to Vector2.\\nReturns the rotation needed to rotate Vector1 to Vector2.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrotbetween/"
+    },
+    "@sl-slua/global/ll.RotLookAt": {
+        "documentation": "Cause object to rotate to Rotation, with a force function defined by Strength and Damping parameters. Good strength values are around half the mass of the object and good damping values are less than 1/10th of the strength.\\nAsymmetrical shapes require smaller damping.\\nA strength of 0.0 cancels the look at.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrotlookat/"
+    },
+    "@sl-slua/global/ll.RotTarget": {
+        "documentation": "Set rotations with error of LeeWay radians as a rotational target, and return an ID for the rotational target.\\nThe returned number is a handle that can be used in at_rot_target and llRotTargetRemove.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrottarget/"
+    },
+    "@sl-slua/global/ll.RotTargetRemove": {
+        "documentation": "Removes rotational target number.\\nRemove rotational target indicated by the handle.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrottargetremove/"
+    },
+    "@sl-slua/global/ll.RotateTexture": {
+        "documentation": "Sets the texture rotation for the specified Face to angle Radians.\\nIf Face is ALL_SIDES, rotates the texture of all sides.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llrotatetexture/"
+    },
+    "@sl-slua/global/ll.Round": {
+        "documentation": "Returns Value rounded to the nearest integer.\\nReturns the Value rounded to the nearest integer.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llround/"
+    },
+    "@sl-slua/global/ll.SHA1String": {
+        "documentation": "Returns a string of 40 hex characters that is the SHA1 security hash of text.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsha1string/"
+    },
+    "@sl-slua/global/ll.SHA256String": {
+        "documentation": "Returns a string of 64 hex characters that is the SHA256 security hash of text.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsha256string/"
+    },
+    "@sl-slua/global/ll.SameGroup": {
+        "documentation": "Returns TRUE if avatar ID is in the same region and has the same active group, otherwise FALSE.\\nReturns TRUE if the object or agent identified is in the same simulator and has the same active group as this object. Otherwise, returns FALSE.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsamegroup/"
+    },
+    "@sl-slua/global/ll.Say": {
+        "documentation": "Says Text on Channel.\\nThis chat method has a range of 20m radius.\\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsay/"
+    },
+    "@sl-slua/global/ll.ScaleByFactor": {
+        "documentation": "Attempts to resize the entire object by ScalingFactor, maintaining the size-position ratios of the prims.\\n\\nResizing is subject to prim scale limits and linkability limits. This function can not resize the object if the linkset is physical, a pathfinding character, in a keyframed motion, or if resizing would cause the parcel to overflow.\\nReturns a boolean (an integer) TRUE if it succeeds, FALSE if it fails.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llscalebyfactor/"
+    },
+    "@sl-slua/global/ll.ScaleTexture": {
+        "documentation": "Sets the diffuse texture Horizontal and Vertical repeats on Face of the prim the script is attached to.\\nIf Face == ALL_SIDES, all sides are set in one call.\\nNegative values for horizontal and vertical will flip the texture.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llscaletexture/"
+    },
+    "@sl-slua/global/ll.ScriptDanger": {
+        "documentation": "Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llscriptdanger/"
+    },
+    "@sl-slua/global/ll.ScriptProfiler": {
+        "documentation": "Enables or disables script profiling options. Currently only supports PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\\nMay significantly reduce script performance.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llscriptprofiler/"
+    },
+    "@sl-slua/global/ll.SendRemoteData": {
+        "documentation": "This function is deprecated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsendremotedata/"
+    },
+    "@sl-slua/global/ll.Sensor": {
+        "documentation": "Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\\nResults are returned in the sensor and no_sensor events.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsensor/"
+    },
+    "@sl-slua/global/ll.SensorRemove": {
+        "documentation": "removes sensor.\\nRemoves the sensor set by llSensorRepeat.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsensorremove/"
+    },
+    "@sl-slua/global/ll.SensorRepeat": {
+        "documentation": "Initiates a periodic scan every Rate seconds, for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\\nResults are returned in the sensor and no_sensor events.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsensorrepeat/"
+    },
+    "@sl-slua/global/ll.SetAgentEnvironment": {
+        "documentation": "Sets an agent's environmental values to the specified values. Must be used as part of an experience.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetagentenvironment/"
+    },
+    "@sl-slua/global/ll.SetAgentRot": {
+        "documentation": "Sets the avatar rotation to the given value.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetagentrot/"
+    },
+    "@sl-slua/global/ll.SetAlpha": {
+        "documentation": "Sets the alpha (opacity) of Face.\\nSets the alpha (opacity) value for Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is mostly transparent). This function will clamp alpha values less than 0.1 to 0.1 and greater than 1.0 to 1.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetalpha/"
+    },
+    "@sl-slua/global/ll.SetAngularVelocity": {
+        "documentation": "Sets an object's angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\\nHas no effect on non-physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetangularvelocity/"
+    },
+    "@sl-slua/global/ll.SetAnimationOverride": {
+        "documentation": "Sets the animation (in object inventory) that will play for the given animation state.\\nTo use this function the script must obtain the PERMISSION_OVERRIDE_ANIMATIONS permission.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetanimationoverride/"
+    },
+    "@sl-slua/global/ll.SetBuoyancy": {
+        "documentation": "Set the tasks buoyancy (0 is none, < 1.0 sinks, 1.0 floats, > 1.0 rises).\\nSet the object buoyancy. A value of 0 is none, less than 1.0 sinks, 1.0 floats, and greater than 1.0 rises.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetbuoyancy/"
+    },
+    "@sl-slua/global/ll.SetCameraAtOffset": {
+        "documentation": "Sets the camera used in this object, at offset, if an avatar sits on it.\\nSets the offset that an avatar's camera will be moved to if the avatar sits on the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetcameraatoffset/"
+    },
+    "@sl-slua/global/ll.SetCameraEyeOffset": {
+        "documentation": "Sets the camera eye offset used in this object if an avatar sits on it.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetcameraeyeoffset/"
+    },
+    "@sl-slua/global/ll.SetCameraParams": {
+        "documentation": "Sets multiple camera parameters at once. List format is [ rule-1, data-1, rule-2, data-2 . . . rule-n, data-n ].",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetcameraparams/"
+    },
+    "@sl-slua/global/ll.SetClickAction": {
+        "documentation": "Sets the action performed when a prim is clicked upon.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetclickaction/"
+    },
+    "@sl-slua/global/ll.SetColor": {
+        "documentation": "Sets the color, for the face.\\nSets the color of the side specified. If Face is ALL_SIDES, sets the color on all faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetcolor/"
+    },
+    "@sl-slua/global/ll.SetContentType": {
+        "documentation": "Set the media type of an LSL HTTP server response to ContentType.\\nHTTPRequestID must be a valid http_request ID. ContentType must be one of the CONTENT_TYPE_* constants.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetcontenttype/"
+    },
+    "@sl-slua/global/ll.SetDamage": {
+        "documentation": "Sets the amount of damage that will be done to an avatar that this task hits.\tTask will be killed.\\nSets the amount of damage that will be done to an avatar that this object hits. This object will be destroyed on damaging an avatar, and no collision event is triggered.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetdamage/"
+    },
+    "@sl-slua/global/ll.SetEnvironment": {
+        "documentation": "Returns a string with the requested data about the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetenvironment/"
+    },
+    "@sl-slua/global/ll.SetForce": {
+        "documentation": "Sets Force on object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\\nOnly works on physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetforce/"
+    },
+    "@sl-slua/global/ll.SetForceAndTorque": {
+        "documentation": "Sets the Force and Torque of object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\\nOnly works on physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetforceandtorque/"
+    },
+    "@sl-slua/global/ll.SetGroundTexture": {
+        "documentation": "Changes terrain texture properties in the region.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetgroundtexture/"
+    },
+    "@sl-slua/global/ll.SetHoverHeight": {
+        "documentation": "Critically damps a physical object to a Height (either above ground level or above the higher of land and water if water == TRUE).\\nDo not use with vehicles. Use llStopHover to stop hovering.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsethoverheight/"
+    },
+    "@sl-slua/global/ll.SetInventoryPermMask": {
+        "documentation": "Sets the given permission mask to the new value on the inventory item.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetinventorypermmask/"
+    },
+    "@sl-slua/global/ll.SetKeyframedMotion": {
+        "documentation": "Requests that a non-physical object be key-framed according to key-frame list.\\nSpecify a list of times, positions, and orientations to be followed by an object. The object will be smoothly moved between key-frames by the simulator. Collisions with other non-physical or key-framed objects will be ignored (no script events will fire and collision processing will not occur). Collisions with physical objects will be computed and reported, but the key-framed object will be unaffected by those collisions.\\nKeyframes is a strided list containing positional, rotational, and time data for each step in the motion.  Options is a list containing optional arguments and parameters (specified by KFM_* constants).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetkeyframedmotion/"
+    },
+    "@sl-slua/global/ll.SetLinkAlpha": {
+        "documentation": "If a prim exists in the link chain at LinkNumber, set Face to Opacity.\\nSets the Face, on the linked prim specified, to the Opacity.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkalpha/"
+    },
+    "@sl-slua/global/ll.SetLinkCamera": {
+        "documentation": "Sets the camera eye offset, and the offset that camera is looking at, for avatars that sit on the linked prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkcamera/"
+    },
+    "@sl-slua/global/ll.SetLinkColor": {
+        "documentation": "If a task exists in the link chain at LinkNumber, set the Face to color.\\nSets the color of the linked child's side, specified by LinkNumber.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkcolor/"
+    },
+    "@sl-slua/global/ll.SetLinkGLTFOverrides": {
+        "documentation": "Sets or changes GLTF Overrides set on the selected faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkgltfoverrides/"
+    },
+    "@sl-slua/global/ll.SetLinkMedia": {
+        "documentation": "Set the media parameters for a particular face on linked prim, specified by Link. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkmedia/"
+    },
+    "@sl-slua/global/ll.SetLinkPrimitiveParams": {
+        "documentation": "Deprecated: Use llSetLinkPrimitiveParamsFast instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkprimitiveparams/"
+    },
+    "@sl-slua/global/ll.SetLinkPrimitiveParamsFast": {
+        "documentation": "Set primitive parameters for LinkNumber based on Parameters, without a delay.\\nSet parameters for link number, from the list of Parameters, with no built-in script sleep. This function is identical to llSetLinkPrimitiveParams, except without the delay.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkprimitiveparamsfast/"
+    },
+    "@sl-slua/global/ll.SetLinkRenderMaterial": {
+        "documentation": "Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Material may be a UUID or name of a material in prim inventory.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinkrendermaterial/"
+    },
+    "@sl-slua/global/ll.SetLinkSitFlags": {
+        "documentation": "Sets the sit flags for the specified prim in a linkset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinksitflags/"
+    },
+    "@sl-slua/global/ll.SetLinkTexture": {
+        "documentation": "Sets the Texture of Face on a linked prim, specified by LinkNumber. Texture may be a UUID or name of a texture in prim inventory.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinktexture/"
+    },
+    "@sl-slua/global/ll.SetLinkTextureAnim": {
+        "documentation": "Animates a texture on the prim specified by LinkNumber, by setting the texture scale and offset.\\nMode is a bitmask of animation options.\\nFace specifies which object face to animate.\\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\\nLength specifies the animation duration.\\nRate specifies the animation playback rate.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlinktextureanim/"
+    },
+    "@sl-slua/global/ll.SetLocalRot": {
+        "documentation": "Sets the rotation of a child prim relative to the root prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetlocalrot/"
+    },
+    "@sl-slua/global/ll.SetMemoryLimit": {
+        "documentation": "Requests Limit bytes to be reserved for this script.\\nReturns TRUE or FALSE indicating whether the limit was set successfully.\\nThis function has no effect if the script is running in the LSO VM.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetmemorylimit/"
+    },
+    "@sl-slua/global/ll.SetObjectDesc": {
+        "documentation": "Sets the description of the prim to Description.\\nThe description field is limited to 127 characters.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetobjectdesc/"
+    },
+    "@sl-slua/global/ll.SetObjectName": {
+        "documentation": "Sets the prim's name to Name.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetobjectname/"
+    },
+    "@sl-slua/global/ll.SetObjectPermMask": {
+        "documentation": "Sets the specified PermissionFlag permission to the value specified by PermissionMask on the object the script is attached to.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetobjectpermmask/"
+    },
+    "@sl-slua/global/ll.SetParcelForSale": {
+        "documentation": "Sets the parcel the object is on for sale.\\nForSale is a boolean, if TRUE the parcel is put up for sale. Options is a list of options to set for the sale, such as price, authorized buyer, and whether to include objects on the parcel.\\n Setting ForSale to FALSE will remove the parcel from sale and clear any options that were set.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetparcelforsale/"
+    },
+    "@sl-slua/global/ll.SetParcelMusicURL": {
+        "documentation": "Sets the streaming audio URL for the parcel the object is on.\\nThe object must be owned by the owner of the parcel; if the parcel is group owned the object must be owned by that group.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetparcelmusicurl/"
+    },
+    "@sl-slua/global/ll.SetPayPrice": {
+        "documentation": "Sets the default amount when someone chooses to pay this object.\\nPrice is the default price shown in the text input field.  QuickButtons specifies the 4 payment values shown in the payment dialog's buttons.\\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetpayprice/"
+    },
+    "@sl-slua/global/ll.SetPhysicsMaterial": {
+        "documentation": "Sets the selected parameters of the object's physics behavior.\\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetphysicsmaterial/"
+    },
+    "@sl-slua/global/ll.SetPos": {
+        "documentation": "If the object is not physical, this function sets the position of the prim.\\nIf the script is in a child prim, Position is treated as root relative and the link-set is adjusted.\\nIf the prim is the root prim, the entire object is moved (up to 10m) to Position in region coordinates.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetpos/"
+    },
+    "@sl-slua/global/ll.SetPrimMediaParams": {
+        "documentation": "Sets the MediaParameters for a particular Face on the prim. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetprimmediaparams/"
+    },
+    "@sl-slua/global/ll.SetPrimURL": {
+        "documentation": "Deprecated: Use llSetPrimMediaParams instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetprimurl/"
+    },
+    "@sl-slua/global/ll.SetPrimitiveParams": {
+        "documentation": "Deprecated: Use llSetLinkPrimitiveParamsFast instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetprimitiveparams/"
+    },
+    "@sl-slua/global/ll.SetRegionPos": {
+        "documentation": "Attempts to move the object so that the root prim is within 0.1m of Position.\\nReturns an integer boolean, TRUE if the object is successfully placed within 0.1 m of Position, FALSE otherwise.\\nPosition may be any location within the region or up to 10m across a region border.\\nIf the position is below ground, it will be set to the ground level at that x,y location.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetregionpos/"
+    },
+    "@sl-slua/global/ll.SetRemoteScriptAccessPin": {
+        "documentation": "If PIN is set to a non-zero number, the task will accept remote script loads via llRemoteLoadScriptPin() if it passes in the correct PIN. Othersise, llRemoteLoadScriptPin() is ignored.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetremotescriptaccesspin/"
+    },
+    "@sl-slua/global/ll.SetRenderMaterial": {
+        "documentation": "Applies Render Material to Face of prim.\\nRender Material may be a UUID or name of a material in prim inventory.\\nIf Face is ALL_SIDES, set the render material on all faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetrendermaterial/"
+    },
+    "@sl-slua/global/ll.SetRot": {
+        "documentation": "If the object is not physical, this function sets the rotation of the prim.\\nIf the script is in a child prim, Rotation is treated as root relative and the link-set is adjusted.\\nIf the prim is the root prim, the entire object is rotated to Rotation in the global reference frame.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetrot/"
+    },
+    "@sl-slua/global/ll.SetScale": {
+        "documentation": "Sets the prim's scale (size) to Scale.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetscale/"
+    },
+    "@sl-slua/global/ll.SetScriptState": {
+        "documentation": "Enable or disable the script Running state of Script in the prim.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetscriptstate/"
+    },
+    "@sl-slua/global/ll.SetSitText": {
+        "documentation": "Displays Text rather than 'Sit' in the viewer's context menu.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetsittext/"
+    },
+    "@sl-slua/global/ll.SetSoundQueueing": {
+        "documentation": "Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached sounds) interrupt the currently playing sound.\\nThe default for objects is FALSE. Setting this value to TRUE will make the sound wait until the current playing sound reaches its end. The queue is one level deep.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetsoundqueueing/"
+    },
+    "@sl-slua/global/ll.SetSoundRadius": {
+        "documentation": "Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetsoundradius/"
+    },
+    "@sl-slua/global/ll.SetStatus": {
+        "documentation": "Sets object status specified in Status bitmask (e.g. STATUS_PHYSICS|STATUS_PHANTOM) to boolean Value.\\nFor a full list of STATUS_* constants, see wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetstatus/"
+    },
+    "@sl-slua/global/ll.SetText": {
+        "documentation": "Causes Text to float above the prim, using the specified Color and Opacity.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettext/"
+    },
+    "@sl-slua/global/ll.SetTexture": {
+        "documentation": "Applies Texture to Face of prim.\\nTexture may be a UUID or name of a texture in prim inventory.\\nIf Face is ALL_SIDES, set the texture on all faces.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettexture/"
+    },
+    "@sl-slua/global/ll.SetTextureAnim": {
+        "documentation": "Animates a texture by setting the texture scale and offset.\\nMode is a bitmask of animation options.\\nFace specifies which object face to animate.\\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\\nLength specifies the animation duration.\\nRate specifies the animation playback rate.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettextureanim/"
+    },
+    "@sl-slua/global/ll.SetTimerEvent": {
+        "documentation": "Causes the timer event to be triggered every Rate seconds.\\n Passing in 0.0 stops further timer events.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettimerevent/"
+    },
+    "@sl-slua/global/ll.SetTorque": {
+        "documentation": "Sets the Torque acting on the script's object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\\nOnly works on physical objects.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettorque/"
+    },
+    "@sl-slua/global/ll.SetTouchText": {
+        "documentation": "Displays Text in the viewer context menu that acts on a touch.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsettouchtext/"
+    },
+    "@sl-slua/global/ll.SetVehicleFlags": {
+        "documentation": "Enables the vehicle flags specified in the Flags bitmask.\\nValid parameters can be found in the wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvehicleflags/"
+    },
+    "@sl-slua/global/ll.SetVehicleFloatParam": {
+        "documentation": "Sets a vehicle float parameter.\\nValid parameters can be found in the wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvehiclefloatparam/"
+    },
+    "@sl-slua/global/ll.SetVehicleRotationParam": {
+        "documentation": "Sets a vehicle rotation parameter.\\nValid parameters can be found in the wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvehiclerotationparam/"
+    },
+    "@sl-slua/global/ll.SetVehicleType": {
+        "documentation": "Activates the vehicle action on the object with vehicle preset Type.\\nValid Types and an explanation of their characteristics can be found in wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvehicletype/"
+    },
+    "@sl-slua/global/ll.SetVehicleVectorParam": {
+        "documentation": "Sets a vehicle vector parameter.\\nValid parameters can be found in the wiki documentation.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvehiclevectorparam/"
+    },
+    "@sl-slua/global/ll.SetVelocity": {
+        "documentation": "If the object is physics-enabled, sets the object's linear velocity to Velocity.\\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsetvelocity/"
+    },
+    "@sl-slua/global/ll.Shout": {
+        "documentation": "Shouts Text on Channel.\\nThis chat method has a range of 100m radius.\\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llshout/"
+    },
+    "@sl-slua/global/ll.SignRSA": {
+        "documentation": "Returns the base64-encoded RSA signature of Message using PEM-formatted PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsignrsa/"
+    },
+    "@sl-slua/global/ll.Sin": {
+        "documentation": "Returns the sine of Theta (Theta in radians).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsin/"
+    },
+    "@sl-slua/global/ll.SitOnLink": {
+        "documentation": "If agent identified by AvatarID is participating in the experience, sit them on the specified link's sit target.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsitonlink/"
+    },
+    "@sl-slua/global/ll.SitTarget": {
+        "documentation": "Set the sit location for this object. If offset == ZERO_VECTOR, clears the sit target.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsittarget/"
+    },
+    "@sl-slua/global/ll.Sleep": {
+        "documentation": "Put script to sleep for Time seconds.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsleep/"
+    },
+    "@sl-slua/global/ll.Sound": {
+        "documentation": "Deprecated: Use llPlaySound instead.\\nPlays Sound at Volume and specifies whether the sound should loop and/or be enqueued.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsound/"
+    },
+    "@sl-slua/global/ll.SoundPreload": {
+        "documentation": "Deprecated: Use llPreloadSound instead.\\nPreloads a sound on viewers within range.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsoundpreload/"
+    },
+    "@sl-slua/global/ll.Sqrt": {
+        "documentation": "Returns the square root of Value.\\nTriggers a math runtime error for imaginary results (if Value < 0.0).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsqrt/"
+    },
+    "@sl-slua/global/ll.StartAnimation": {
+        "documentation": "This function plays the specified animation from playing on the avatar who received the script's most recent permissions request.\\nAnimation may be an animation in task inventory or a built-in animation.\\nRequires PERMISSION_TRIGGER_ANIMATION.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstartanimation/"
+    },
+    "@sl-slua/global/ll.StartObjectAnimation": {
+        "documentation": "This function plays the specified animation on the rigged mesh object associated with the current script.\\nAnimation may be an animation in task inventory or a built-in animation.\\n",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstartobjectanimation/"
+    },
+    "@sl-slua/global/ll.StopAnimation": {
+        "documentation": "This function stops the specified animation on the avatar who received the script's most recent permissions request.\\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\\nRequires PERMISSION_TRIGGER_ANIMATION.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstopanimation/"
+    },
+    "@sl-slua/global/ll.StopHover": {
+        "documentation": "Stop hovering to a height (due to llSetHoverHeight()).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstophover/"
+    },
+    "@sl-slua/global/ll.StopLookAt": {
+        "documentation": "Stop causing object to point at a target (due to llLookAt() or llRotLookAt()).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstoplookat/"
+    },
+    "@sl-slua/global/ll.StopMoveToTarget": {
+        "documentation": "Stops critically damped motion (due to llMoveToTarget()).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstopmovetotarget/"
+    },
+    "@sl-slua/global/ll.StopObjectAnimation": {
+        "documentation": "This function stops the specified animation on the rigged mesh object associated with the current script.\\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\\n",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstopobjectanimation/"
+    },
+    "@sl-slua/global/ll.StopSound": {
+        "documentation": "Stops playback of the currently attached sound.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstopsound/"
+    },
+    "@sl-slua/global/ll.StringLength": {
+        "documentation": "Returns an integer that is the number of characters in Text (not counting the null).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstringlength/"
+    },
+    "@sl-slua/global/ll.StringToBase64": {
+        "documentation": "Returns the string Base64 representation of the input string.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstringtobase64/"
+    },
+    "@sl-slua/global/ll.StringTrim": {
+        "documentation": "Outputs a string, eliminating white-space from the start and/or end of the input string Text.\\nValid options for TrimType:\\nSTRING_TRIM_HEAD: trim all leading spaces in Text\\nSTRING_TRIM_TAIL: trim all trailing spaces in Text\\nSTRING_TRIM: trim all leading and trailing spaces in Text.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llstringtrim/"
+    },
+    "@sl-slua/global/ll.SubStringIndex": {
+        "documentation": "Returns an integer that is the index in Text where string pattern Sequence first appears. Returns -1 if not found.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsubstringindex/"
+    },
+    "@sl-slua/global/ll.TakeCamera": {
+        "documentation": "Deprecated: Use llSetCameraParams instead.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltakecamera/"
+    },
+    "@sl-slua/global/ll.TakeControls": {
+        "documentation": "Take controls from the agent the script has permissions for.\\nIf (Accept == (Controls & input)), send input to the script.  PassOn determines whether Controls also perform their normal functions.\\nRequires the PERMISSION_TAKE_CONTROLS permission to run.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltakecontrols/"
+    },
+    "@sl-slua/global/ll.Tan": {
+        "documentation": "Returns the tangent of Theta (Theta in radians).",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltan/"
+    },
+    "@sl-slua/global/ll.Target": {
+        "documentation": "This function is to have the script know when it has reached a position.\\nIt registers a Position with a Range that triggers at_target and not_at_target events continuously until unregistered.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltarget/"
+    },
+    "@sl-slua/global/ll.TargetOmega": {
+        "documentation": "Attempt to spin at SpinRate with strength Gain on Axis.\\nA spin rate of 0.0 cancels the spin. This function always works in object-local coordinates.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltargetomega/"
+    },
+    "@sl-slua/global/ll.TargetRemove": {
+        "documentation": "Removes positional target Handle registered with llTarget.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltargetremove/"
+    },
+    "@sl-slua/global/ll.TargetedEmail": {
+        "documentation": "Sends an email with Subject and Message to the owner or creator of an object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltargetedemail/"
+    },
+    "@sl-slua/global/ll.TeleportAgent": {
+        "documentation": "Requests a teleport of avatar to a landmark stored in the object's inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llteleportagent/"
+    },
+    "@sl-slua/global/ll.TeleportAgentGlobalCoords": {
+        "documentation": "Teleports an agent to the RegionPosition local coordinates within a region which is specified by the GlobalPosition global coordinates. The agent lands facing the position defined by LookAtPoint local coordinates.\\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llteleportagentglobalcoords/"
+    },
+    "@sl-slua/global/ll.TeleportAgentHome": {
+        "documentation": "Teleport agent over the owner's land to agent's home location.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llteleportagenthome/"
+    },
+    "@sl-slua/global/ll.TextBox": {
+        "documentation": "Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the \"OK\" button is clicked.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltextbox/"
+    },
+    "@sl-slua/global/ll.ToLower": {
+        "documentation": "Returns a string that is Text with all lower-case characters.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltolower/"
+    },
+    "@sl-slua/global/ll.ToUpper": {
+        "documentation": "Returns a string that is Text with all upper-case characters.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltoupper/"
+    },
+    "@sl-slua/global/ll.TransferLindenDollars": {
+        "documentation": "Transfer Amount of linden dollars (L$) from script owner to AvatarID. Returns a key to a corresponding transaction_result event for the success of the transfer.\\nAttempts to send the amount of money to the specified avatar, and trigger a transaction_result event identified by the returned key.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltransferlindendollars/"
+    },
+    "@sl-slua/global/ll.TransferOwnership": {
+        "documentation": "Transfers ownership of an object, or a copy of the object to a new agent.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltransferownership/"
+    },
+    "@sl-slua/global/ll.TriggerSound": {
+        "documentation": "Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object.\\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltriggersound/"
+    },
+    "@sl-slua/global/ll.TriggerSoundLimited": {
+        "documentation": "Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object, limited to axis-aligned bounding box defined by vectors top-north-east (TNE) and bottom-south-west (BSW).\\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/lltriggersoundlimited/"
+    },
+    "@sl-slua/global/ll.UnSit": {
+        "documentation": "If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the object's owner, the agent is forced to stand up.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llunsit/"
+    },
+    "@sl-slua/global/ll.UnescapeURL": {
+        "documentation": "Returns the string that is the URL unescaped, replacing \"%20\" with spaces, etc., version of URL.\\nThis function can output raw UTF-8 strings.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llunescapeurl/"
+    },
+    "@sl-slua/global/ll.UpdateCharacter": {
+        "documentation": "Updates settings for a pathfinding character.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llupdatecharacter/"
+    },
+    "@sl-slua/global/ll.UpdateKeyValue": {
+        "documentation": "\\n                   Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.\\n                ",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llupdatekeyvalue/"
+    },
+    "@sl-slua/global/ll.VecDist": {
+        "documentation": "Returns the distance between Location1 and Location2.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llvecdist/"
+    },
+    "@sl-slua/global/ll.VecMag": {
+        "documentation": "Returns the magnitude of the vector.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llvecmag/"
+    },
+    "@sl-slua/global/ll.VecNorm": {
+        "documentation": "Returns normalized vector.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llvecnorm/"
+    },
+    "@sl-slua/global/ll.VerifyRSA": {
+        "documentation": "Returns TRUE if PublicKey, Message, and Algorithm produce the same base64-formatted Signature.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llverifyrsa/"
+    },
+    "@sl-slua/global/ll.VolumeDetect": {
+        "documentation": "If DetectEnabled = TRUE, object becomes phantom but triggers collision_start and collision_end events when other objects start and stop interpenetrating.\\nIf another object (including avatars) interpenetrates it, it will get a collision_start event.\\nWhen an object stops interpenetrating, a collision_end event is generated. While the other is inter-penetrating, collision events are NOT generated.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llvolumedetect/"
+    },
+    "@sl-slua/global/ll.WanderWithin": {
+        "documentation": "Wander within a specified volume.\\nSets a character to wander about a central spot within a specified area.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llwanderwithin/"
+    },
+    "@sl-slua/global/ll.Water": {
+        "documentation": "Returns the water height below the object position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llwater/"
+    },
+    "@sl-slua/global/ll.Whisper": {
+        "documentation": "Whispers Text on Channel.\\nThis chat method has a range of 10m radius.\\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llwhisper/"
+    },
+    "@sl-slua/global/ll.Wind": {
+        "documentation": "Returns the wind velocity at the object position + Offset.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llwind/"
+    },
+    "@sl-slua/global/ll.WorldPosToHUD": {
+        "documentation": "Returns the local position that would put the origin of a HUD object directly over world_pos as viewed by the current camera.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llworldpostohud/"
+    },
+    "@sl-slua/global/ll.XorBase64": {
+        "documentation": "Performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llxorbase64/"
+    },
+    "@sl-slua/global/ll.XorBase64Strings": {
+        "documentation": "Deprecated: Please use llXorBase64 instead.\\nIncorrectly performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.\\nRetained for backwards compatibility.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llxorbase64strings/"
+    },
+    "@sl-slua/global/ll.XorBase64StringsCorrect": {
+        "documentation": "Deprecated: Please use llXorBase64 instead.\\nCorrectly (unless nulls are present) performs an exclusive OR on two Base64 strings and returns a Base64 string.\\nText2 repeats if it is shorter than Text1.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llxorbase64stringscorrect/"
+    },
+    "@sl-slua/global/ll.sRGB2Linear": {
+        "documentation": "Converts a color from the sRGB to the linear colorspace.",
+        "learn_more_link": "https://create.secondlife.com/script/slua-reference/functions/llsrgb2linear/"
+    },
+    "@sl-slua/global/llcompat": {
+        "documentation": "LSL compatibility functions",
+        "summary": "LSL compatibility functions"
+    },
+    "@sl-slua/global/llcompat.AdjustDamage": {
+        "documentation": "(Index semantics) Changes the amount of damage to be delivered by this damage event."
+    },
+    "@sl-slua/global/llcompat.DetectedDamage": {
+        "documentation": "(Index semantics) Returns a list containing the current damage for the event, the damage type and the original damage delivered."
+    },
+    "@sl-slua/global/llcompat.DetectedGrab": {
+        "documentation": "(Index semantics) Returns the grab offset of a user touching the object.\\nReturns <0.0, 0.0, 0.0> if Number is not a valid object."
+    },
+    "@sl-slua/global/llcompat.DetectedGroup": {
+        "documentation": "(Index semantics) Returns TRUE if detected object or agent Number has the same user group active as this object.\\nIt will return FALSE if the object or agent is in the group, but the group is not active."
+    },
+    "@sl-slua/global/llcompat.DetectedKey": {
+        "documentation": "(Index semantics) Returns the key of detected object or avatar number.\\nReturns NULL_KEY if Number is not a valid index."
+    },
+    "@sl-slua/global/llcompat.DetectedLinkNumber": {
+        "documentation": "(Index semantics) Returns the link position of the triggered event for touches and collisions only.\\n0 for a non-linked object, 1 for the root of a linked object, 2 for the first child, etc."
+    },
+    "@sl-slua/global/llcompat.DetectedName": {
+        "documentation": "(Index semantics) Returns the name of detected object or avatar number.\\nReturns the name of detected object number.\\nReturns empty string if Number is not a valid index."
+    },
+    "@sl-slua/global/llcompat.DetectedOwner": {
+        "documentation": "(Index semantics) Returns the key of detected object's owner.\\nReturns invalid key if Number is not a valid index."
+    },
+    "@sl-slua/global/llcompat.DetectedPos": {
+        "documentation": "(Index semantics) Returns the position of detected object or avatar number.\\nReturns <0.0, 0.0, 0.0> if Number is not a valid index."
+    },
+    "@sl-slua/global/llcompat.DetectedRezzer": {
+        "documentation": "(Index semantics) Returns the key for the rezzer of the detected object."
+    },
+    "@sl-slua/global/llcompat.DetectedRot": {
+        "documentation": "(Index semantics) Returns the rotation of detected object or avatar number.\\nReturns <0.0, 0.0, 0.0, 1.0> if Number is not a valid offset."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchBinormal": {
+        "documentation": "(Index semantics) Returns the surface bi-normal for a triggered touch event.\\nReturns a vector that is the surface bi-normal (tangent to the surface) where the touch event was triggered."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchFace": {
+        "documentation": "(Index semantics) Returns the index of the face where the avatar clicked in a triggered touch event."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchNormal": {
+        "documentation": "(Index semantics) Returns the surface normal for a triggered touch event.\\nReturns a vector that is the surface normal (perpendicular to the surface) where the touch event was triggered."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchPos": {
+        "documentation": "(Index semantics) Returns the position, in region coordinates, where the object was touched in a triggered touch event.\\nUnless it is a HUD, in which case it returns the position relative to the attach point."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchST": {
+        "documentation": "(Index semantics) Returns a vector that is the surface coordinates where the prim was touched.\\nThe X and Y vector positions contain the horizontal (S) and vertical (T) face coordinates respectively.\\nEach component is in the interval [0.0, 1.0].\\nTOUCH_INVALID_TEXCOORD is returned if the surface coordinates cannot be determined (e.g. when the viewer does not support this function)."
+    },
+    "@sl-slua/global/llcompat.DetectedTouchUV": {
+        "documentation": "(Index semantics) Returns a vector that is the texture coordinates for where the prim was touched.\\nThe X and Y vector positions contain the U and V face coordinates respectively.\\nTOUCH_INVALID_TEXCOORD is returned if the touch UV coordinates cannot be determined (e.g. when the viewer does not support this function)."
+    },
+    "@sl-slua/global/llcompat.DetectedType": {
+        "documentation": "(Index semantics) Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\\nReturns 0 if number is not a valid index.\\nNote that number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\\ninteger iType = llDetectedType(0);\\n{\\n\t// ...do stuff with the agent\\n}"
+    },
+    "@sl-slua/global/llcompat.DetectedVel": {
+        "documentation": "(Index semantics) Returns the velocity of the detected object Number.\\nReturns<0.0, 0.0, 0.0> if Number is not a valid offset."
+    },
+    "@sl-slua/global/ACTIVE": {
+        "documentation": "Objects in world that are running a script or currently physically moving."
+    },
+    "@sl-slua/global/AGENT": {
+        "documentation": "Objects in world that are agents."
+    },
+    "@sl-slua/global/AGENT_ALWAYS_RUN": {
+        "documentation": "AGENT_ALWAYS_RUN constant"
+    },
+    "@sl-slua/global/AGENT_ATTACHMENTS": {
+        "documentation": "The agent has attachments."
+    },
+    "@sl-slua/global/AGENT_AUTOMATED": {
+        "documentation": "The agent has been identified as a scripted agent"
+    },
+    "@sl-slua/global/AGENT_AUTOPILOT": {
+        "documentation": "AGENT_AUTOPILOT constant"
+    },
+    "@sl-slua/global/AGENT_AWAY": {
+        "documentation": "AGENT_AWAY constant"
+    },
+    "@sl-slua/global/AGENT_BUSY": {
+        "documentation": "AGENT_BUSY constant"
+    },
+    "@sl-slua/global/AGENT_BY_LEGACY_NAME": {
+        "documentation": "AGENT_BY_LEGACY_NAME constant"
+    },
+    "@sl-slua/global/AGENT_BY_USERNAME": {
+        "documentation": "AGENT_BY_USERNAME constant"
+    },
+    "@sl-slua/global/AGENT_CROUCHING": {
+        "documentation": "AGENT_CROUCHING constant"
+    },
+    "@sl-slua/global/AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT": {
+        "documentation": "The agent is floating via scripted attachment."
+    },
+    "@sl-slua/global/AGENT_FLYING": {
+        "documentation": "The agent is flying."
+    },
+    "@sl-slua/global/AGENT_IN_AIR": {
+        "documentation": "AGENT_IN_AIR constant"
+    },
+    "@sl-slua/global/AGENT_LIST_PARCEL": {
+        "documentation": "Agents on the same parcel where the script is running."
+    },
+    "@sl-slua/global/AGENT_LIST_PARCEL_OWNER": {
+        "documentation": "Agents on any parcel in the region where the parcel owner is the same as the owner of the parcel under the scripted object."
+    },
+    "@sl-slua/global/AGENT_LIST_REGION": {
+        "documentation": "All agents in the region."
+    },
+    "@sl-slua/global/AGENT_MOUSELOOK": {
+        "documentation": "AGENT_MOUSELOOK constant"
+    },
+    "@sl-slua/global/AGENT_ON_OBJECT": {
+        "documentation": "AGENT_ON_OBJECT constant"
+    },
+    "@sl-slua/global/AGENT_SCRIPTED": {
+        "documentation": "The agent has scripted attachments."
+    },
+    "@sl-slua/global/AGENT_SITTING": {
+        "documentation": "AGENT_SITTING constant"
+    },
+    "@sl-slua/global/AGENT_TYPING": {
+        "documentation": "AGENT_TYPING constant"
+    },
+    "@sl-slua/global/AGENT_WALKING": {
+        "documentation": "AGENT_WALKING constant"
+    },
+    "@sl-slua/global/ALL_SIDES": {
+        "documentation": "ALL_SIDES constant"
+    },
+    "@sl-slua/global/ANIM_ON": {
+        "documentation": "Texture animation is on."
+    },
+    "@sl-slua/global/ATTACH_ANY_HUD": {
+        "documentation": "Filtering for any HUD attachment."
+    },
+    "@sl-slua/global/ATTACH_AVATAR_CENTER": {
+        "documentation": "Attach to the avatar's geometric centre."
+    },
+    "@sl-slua/global/ATTACH_BACK": {
+        "documentation": "Attach to the avatar's back."
+    },
+    "@sl-slua/global/ATTACH_BELLY": {
+        "documentation": "Attach to the avatar's belly."
+    },
+    "@sl-slua/global/ATTACH_CHEST": {
+        "documentation": "Attach to the avatar's chest."
+    },
+    "@sl-slua/global/ATTACH_CHIN": {
+        "documentation": "Attach to the avatar's chin."
+    },
+    "@sl-slua/global/ATTACH_FACE_JAW": {
+        "documentation": "Attach to the avatar's jaw."
+    },
+    "@sl-slua/global/ATTACH_FACE_LEAR": {
+        "documentation": "Attach to the avatar's left ear (extended)."
+    },
+    "@sl-slua/global/ATTACH_FACE_LEYE": {
+        "documentation": "Attach to the avatar's left eye (extended)."
+    },
+    "@sl-slua/global/ATTACH_FACE_REAR": {
+        "documentation": "Attach to the avatar's right ear (extended)."
+    },
+    "@sl-slua/global/ATTACH_FACE_REYE": {
+        "documentation": "Attach to the avatar's right eye (extended)."
+    },
+    "@sl-slua/global/ATTACH_FACE_TONGUE": {
+        "documentation": "Attach to the avatar's tongue."
+    },
+    "@sl-slua/global/ATTACH_GROIN": {
+        "documentation": "Attach to the avatar's groin."
+    },
+    "@sl-slua/global/ATTACH_HEAD": {
+        "documentation": "Attach to the avatar's head."
+    },
+    "@sl-slua/global/ATTACH_HIND_LFOOT": {
+        "documentation": "Attach to the avatar's left hind foot."
+    },
+    "@sl-slua/global/ATTACH_HIND_RFOOT": {
+        "documentation": "Attach to the avatar's right hind foot."
+    },
+    "@sl-slua/global/ATTACH_HUD_BOTTOM": {
+        "documentation": "ATTACH_HUD_BOTTOM constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_BOTTOM_LEFT": {
+        "documentation": "ATTACH_HUD_BOTTOM_LEFT constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_BOTTOM_RIGHT": {
+        "documentation": "ATTACH_HUD_BOTTOM_RIGHT constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_CENTER_1": {
+        "documentation": "ATTACH_HUD_CENTER_1 constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_CENTER_2": {
+        "documentation": "ATTACH_HUD_CENTER_2 constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_TOP_CENTER": {
+        "documentation": "ATTACH_HUD_TOP_CENTER constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_TOP_LEFT": {
+        "documentation": "ATTACH_HUD_TOP_LEFT constant"
+    },
+    "@sl-slua/global/ATTACH_HUD_TOP_RIGHT": {
+        "documentation": "ATTACH_HUD_TOP_RIGHT constant"
+    },
+    "@sl-slua/global/ATTACH_LEAR": {
+        "documentation": "Attach to the avatar's left ear."
+    },
+    "@sl-slua/global/ATTACH_LEFT_PEC": {
+        "documentation": "Attach to the avatar's left pectoral."
+    },
+    "@sl-slua/global/ATTACH_LEYE": {
+        "documentation": "Attach to the avatar's left eye."
+    },
+    "@sl-slua/global/ATTACH_LFOOT": {
+        "documentation": "Attach to the avatar's left foot."
+    },
+    "@sl-slua/global/ATTACH_LHAND": {
+        "documentation": "Attach to the avatar's left hand."
+    },
+    "@sl-slua/global/ATTACH_LHAND_RING1": {
+        "documentation": "Attach to the avatar's left ring finger."
+    },
+    "@sl-slua/global/ATTACH_LHIP": {
+        "documentation": "Attach to the avatar's left hip."
+    },
+    "@sl-slua/global/ATTACH_LLARM": {
+        "documentation": "Attach to the avatar's left lower arm."
+    },
+    "@sl-slua/global/ATTACH_LLLEG": {
+        "documentation": "Attach to the avatar's lower left leg."
+    },
+    "@sl-slua/global/ATTACH_LPEC": {
+        "documentation": "Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)"
+    },
+    "@sl-slua/global/ATTACH_LSHOULDER": {
+        "documentation": "Attach to the avatar's left shoulder."
+    },
+    "@sl-slua/global/ATTACH_LUARM": {
+        "documentation": "Attach to the avatar's left upper arm."
+    },
+    "@sl-slua/global/ATTACH_LULEG": {
+        "documentation": "Attach to the avatar's lower upper leg."
+    },
+    "@sl-slua/global/ATTACH_LWING": {
+        "documentation": "Attach to the avatar's left wing."
+    },
+    "@sl-slua/global/ATTACH_MOUTH": {
+        "documentation": "Attach to the avatar's mouth."
+    },
+    "@sl-slua/global/ATTACH_NECK": {
+        "documentation": "Attach to the avatar's neck."
+    },
+    "@sl-slua/global/ATTACH_NOSE": {
+        "documentation": "Attach to the avatar's nose."
+    },
+    "@sl-slua/global/ATTACH_PELVIS": {
+        "documentation": "Attach to the avatar's pelvis."
+    },
+    "@sl-slua/global/ATTACH_REAR": {
+        "documentation": "Attach to the avatar's right ear."
+    },
+    "@sl-slua/global/ATTACH_REYE": {
+        "documentation": "Attach to the avatar's right eye."
+    },
+    "@sl-slua/global/ATTACH_RFOOT": {
+        "documentation": "Attach to the avatar's right foot."
+    },
+    "@sl-slua/global/ATTACH_RHAND": {
+        "documentation": "Attach to the avatar's right hand."
+    },
+    "@sl-slua/global/ATTACH_RHAND_RING1": {
+        "documentation": "Attach to the avatar's right ring finger."
+    },
+    "@sl-slua/global/ATTACH_RHIP": {
+        "documentation": "Attach to the avatar's right hip."
+    },
+    "@sl-slua/global/ATTACH_RIGHT_PEC": {
+        "documentation": "Attach to the avatar's right pectoral."
+    },
+    "@sl-slua/global/ATTACH_RLARM": {
+        "documentation": "Attach to the avatar's right lower arm."
+    },
+    "@sl-slua/global/ATTACH_RLLEG": {
+        "documentation": "Attach to the avatar's right lower leg."
+    },
+    "@sl-slua/global/ATTACH_RPEC": {
+        "documentation": "Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)"
+    },
+    "@sl-slua/global/ATTACH_RSHOULDER": {
+        "documentation": "Attach to the avatar's right shoulder."
+    },
+    "@sl-slua/global/ATTACH_RUARM": {
+        "documentation": "Attach to the avatar's right upper arm."
+    },
+    "@sl-slua/global/ATTACH_RULEG": {
+        "documentation": "Attach to the avatar's right upper leg."
+    },
+    "@sl-slua/global/ATTACH_RWING": {
+        "documentation": "Attach to the avatar's right wing."
+    },
+    "@sl-slua/global/ATTACH_TAIL_BASE": {
+        "documentation": "Attach to the avatar's tail base."
+    },
+    "@sl-slua/global/ATTACH_TAIL_TIP": {
+        "documentation": "Attach to the avatar's tail tip."
+    },
+    "@sl-slua/global/AVOID_CHARACTERS": {
+        "documentation": "AVOID_CHARACTERS constant"
+    },
+    "@sl-slua/global/AVOID_DYNAMIC_OBSTACLES": {
+        "documentation": "AVOID_DYNAMIC_OBSTACLES constant"
+    },
+    "@sl-slua/global/AVOID_NONE": {
+        "documentation": "AVOID_NONE constant"
+    },
+    "@sl-slua/global/BEACON_MAP": {
+        "documentation": "Cause llMapBeacon to optionally display and focus the world map on the avatar's viewer."
+    },
+    "@sl-slua/global/CAMERA_ACTIVE": {
+        "documentation": "CAMERA_ACTIVE constant"
+    },
+    "@sl-slua/global/CAMERA_BEHINDNESS_ANGLE": {
+        "documentation": "CAMERA_BEHINDNESS_ANGLE constant"
+    },
+    "@sl-slua/global/CAMERA_BEHINDNESS_LAG": {
+        "documentation": "CAMERA_BEHINDNESS_LAG constant"
+    },
+    "@sl-slua/global/CAMERA_DISTANCE": {
+        "documentation": "CAMERA_DISTANCE constant"
+    },
+    "@sl-slua/global/CAMERA_FOCUS": {
+        "documentation": "CAMERA_FOCUS constant"
+    },
+    "@sl-slua/global/CAMERA_FOCUS_LAG": {
+        "documentation": "CAMERA_FOCUS_LAG constant"
+    },
+    "@sl-slua/global/CAMERA_FOCUS_LOCKED": {
+        "documentation": "CAMERA_FOCUS_LOCKED constant"
+    },
+    "@sl-slua/global/CAMERA_FOCUS_OFFSET": {
+        "documentation": "CAMERA_FOCUS_OFFSET constant"
+    },
+    "@sl-slua/global/CAMERA_FOCUS_THRESHOLD": {
+        "documentation": "CAMERA_FOCUS_THRESHOLD constant"
+    },
+    "@sl-slua/global/CAMERA_PITCH": {
+        "documentation": "CAMERA_PITCH constant"
+    },
+    "@sl-slua/global/CAMERA_POSITION": {
+        "documentation": "CAMERA_POSITION constant"
+    },
+    "@sl-slua/global/CAMERA_POSITION_LAG": {
+        "documentation": "CAMERA_POSITION_LAG constant"
+    },
+    "@sl-slua/global/CAMERA_POSITION_LOCKED": {
+        "documentation": "CAMERA_POSITION_LOCKED constant"
+    },
+    "@sl-slua/global/CAMERA_POSITION_THRESHOLD": {
+        "documentation": "CAMERA_POSITION_THRESHOLD constant"
+    },
+    "@sl-slua/global/CHANGED_ALLOWED_DROP": {
+        "documentation": "The object inventory has changed because an item was added through the llAllowInventoryDrop interface."
+    },
+    "@sl-slua/global/CHANGED_COLOR": {
+        "documentation": "The object color has changed."
+    },
+    "@sl-slua/global/CHANGED_INVENTORY": {
+        "documentation": "The object inventory has changed."
+    },
+    "@sl-slua/global/CHANGED_LINK": {
+        "documentation": "The object has linked or its links were broken."
+    },
+    "@sl-slua/global/CHANGED_MEDIA": {
+        "documentation": "CHANGED_MEDIA constant"
+    },
+    "@sl-slua/global/CHANGED_OWNER": {
+        "documentation": "The object has changed ownership."
+    },
+    "@sl-slua/global/CHANGED_REGION": {
+        "documentation": "The object has changed region."
+    },
+    "@sl-slua/global/CHANGED_REGION_START": {
+        "documentation": "The region this object is in has just come online."
+    },
+    "@sl-slua/global/CHANGED_RENDER_MATERIAL": {
+        "documentation": "The render material has changed."
+    },
+    "@sl-slua/global/CHANGED_SCALE": {
+        "documentation": "The object scale (size) has changed."
+    },
+    "@sl-slua/global/CHANGED_SHAPE": {
+        "documentation": "The object base shape has changed, e.g., a box to a cylinder."
+    },
+    "@sl-slua/global/CHANGED_TELEPORT": {
+        "documentation": "The avatar to whom this object is attached has teleported."
+    },
+    "@sl-slua/global/CHANGED_TEXTURE": {
+        "documentation": "The texture offset, scale rotation, or simply the object texture has changed."
+    },
+    "@sl-slua/global/CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES": {
+        "documentation": "If set to false, character will not attempt to catch up on lost time when pathfinding performance is low, potentially providing more reliable movement (albeit while potentially appearing to be more stuttery). Default is true to match pre-existing behavior."
+    },
+    "@sl-slua/global/CHARACTER_AVOIDANCE_MODE": {
+        "documentation": "Allows you to specify that a character should not try to avoid other characters, should not try to avoid dynamic obstacles (relatively fast moving objects and avatars), or both."
+    },
+    "@sl-slua/global/CHARACTER_CMD_JUMP": {
+        "documentation": "Makes the character jump. Requires an additional parameter, the height to jump, between 0.1m and 2.0m. This must be provided as the first element of the llExecCharacterCmd option list."
+    },
+    "@sl-slua/global/CHARACTER_CMD_SMOOTH_STOP": {
+        "documentation": "CHARACTER_CMD_SMOOTH_STOP constant"
+    },
+    "@sl-slua/global/CHARACTER_CMD_STOP": {
+        "documentation": "Stops any current pathfinding operation."
+    },
+    "@sl-slua/global/CHARACTER_DESIRED_SPEED": {
+        "documentation": "Speed of pursuit in meters per second."
+    },
+    "@sl-slua/global/CHARACTER_DESIRED_TURN_SPEED": {
+        "documentation": "The character's maximum speed while turning about the Z axis. - Note that this is only loosely enforced."
+    },
+    "@sl-slua/global/CHARACTER_LENGTH": {
+        "documentation": "Set collision capsule length - cannot be less than two times the radius."
+    },
+    "@sl-slua/global/CHARACTER_MAX_ACCEL": {
+        "documentation": "The character's maximum acceleration rate."
+    },
+    "@sl-slua/global/CHARACTER_MAX_DECEL": {
+        "documentation": "The character's maximum deceleration rate."
+    },
+    "@sl-slua/global/CHARACTER_MAX_SPEED": {
+        "documentation": "The character's maximum speed."
+    },
+    "@sl-slua/global/CHARACTER_MAX_TURN_RADIUS": {
+        "documentation": "The character's turn radius when travelling at CHARACTER_MAX_TURN_SPEED."
+    },
+    "@sl-slua/global/CHARACTER_ORIENTATION": {
+        "documentation": "Valid options are: VERTICAL, HORIZONTAL."
+    },
+    "@sl-slua/global/CHARACTER_RADIUS": {
+        "documentation": "Set collision capsule radius."
+    },
+    "@sl-slua/global/CHARACTER_STAY_WITHIN_PARCEL": {
+        "documentation": "Determines whether a character can leave its starting parcel.\\nTakes a boolean parameter. If TRUE, the character cannot voluntarilly leave the parcel, but can return to it."
+    },
+    "@sl-slua/global/CHARACTER_TYPE": {
+        "documentation": "Specifies which walk-ability coefficient will be used by this character."
+    },
+    "@sl-slua/global/CHARACTER_TYPE_A": {
+        "documentation": "CHARACTER_TYPE_A constant"
+    },
+    "@sl-slua/global/CHARACTER_TYPE_B": {
+        "documentation": "CHARACTER_TYPE_B constant"
+    },
+    "@sl-slua/global/CHARACTER_TYPE_C": {
+        "documentation": "CHARACTER_TYPE_C constant"
+    },
+    "@sl-slua/global/CHARACTER_TYPE_D": {
+        "documentation": "CHARACTER_TYPE_D constant"
+    },
+    "@sl-slua/global/CHARACTER_TYPE_NONE": {
+        "documentation": "CHARACTER_TYPE_NONE constant"
+    },
+    "@sl-slua/global/CLICK_ACTION_BUY": {
+        "documentation": "When the prim is clicked, the buy dialog is opened."
+    },
+    "@sl-slua/global/CLICK_ACTION_DISABLED": {
+        "documentation": "No click action. No touches detected or passed."
+    },
+    "@sl-slua/global/CLICK_ACTION_IGNORE": {
+        "documentation": "No click action. Object is invisible to the mouse."
+    },
+    "@sl-slua/global/CLICK_ACTION_NONE": {
+        "documentation": "Performs the default action: when the prim is clicked, touch events are triggered."
+    },
+    "@sl-slua/global/CLICK_ACTION_OPEN": {
+        "documentation": "When the prim is clicked, the object inventory dialog is opened."
+    },
+    "@sl-slua/global/CLICK_ACTION_OPEN_MEDIA": {
+        "documentation": "When the prim is touched, the web media dialog is opened."
+    },
+    "@sl-slua/global/CLICK_ACTION_PAY": {
+        "documentation": "When the prim is clicked, the pay dialog is opened."
+    },
+    "@sl-slua/global/CLICK_ACTION_PLAY": {
+        "documentation": "When the prim is clicked, html-on-a-prim is enabled?"
+    },
+    "@sl-slua/global/CLICK_ACTION_SIT": {
+        "documentation": "When the prim is clicked, the avatar sits upon it."
+    },
+    "@sl-slua/global/CLICK_ACTION_TOUCH": {
+        "documentation": "When the prim is clicked, touch events are triggered."
+    },
+    "@sl-slua/global/CLICK_ACTION_ZOOM": {
+        "documentation": "Zoom in on object when clicked."
+    },
+    "@sl-slua/global/COMBAT_CHANNEL": {
+        "documentation": "COMBAT_CHANNEL is an integer constant that, when passed to llRegionSay will add the message to the combat log. A script with a chat listen active on COMBAT_CHANNEL may also monitor the combat log."
+    },
+    "@sl-slua/global/COMBAT_LOG_ID": {
+        "documentation": "Messages from the region to the COMBAT_CHANNEL will all be from this ID.\\n Scripts may filter llListen calls on this ID to receive only system generated combat log messages."
+    },
+    "@sl-slua/global/CONTENT_TYPE_ATOM": {
+        "documentation": "\"application/atom+xml\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_FORM": {
+        "documentation": "\"application/x-www-form-urlencoded\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_HTML": {
+        "documentation": "\"text/html\", only valid for embedded browsers on content owned by the person viewing. Falls back to \"text/plain\" otherwise."
+    },
+    "@sl-slua/global/CONTENT_TYPE_JSON": {
+        "documentation": "\"application/json\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_LLSD": {
+        "documentation": "\"application/llsd+xml\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_RSS": {
+        "documentation": "\"application/rss+xml\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_TEXT": {
+        "documentation": "\"text/plain\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_XHTML": {
+        "documentation": "\"application/xhtml+xml\""
+    },
+    "@sl-slua/global/CONTENT_TYPE_XML": {
+        "documentation": "\"application/xml\""
+    },
+    "@sl-slua/global/CONTROL_BACK": {
+        "documentation": "Test for the avatar move back control."
+    },
+    "@sl-slua/global/CONTROL_DOWN": {
+        "documentation": "Test for the avatar move down control."
+    },
+    "@sl-slua/global/CONTROL_FWD": {
+        "documentation": "Test for the avatar move forward control."
+    },
+    "@sl-slua/global/CONTROL_LBUTTON": {
+        "documentation": "Test for the avatar left button control."
+    },
+    "@sl-slua/global/CONTROL_LEFT": {
+        "documentation": "Test for the avatar move left control."
+    },
+    "@sl-slua/global/CONTROL_ML_LBUTTON": {
+        "documentation": "Test for the avatar left button control while in mouse look."
+    },
+    "@sl-slua/global/CONTROL_RIGHT": {
+        "documentation": "Test for the avatar move right control."
+    },
+    "@sl-slua/global/CONTROL_ROT_LEFT": {
+        "documentation": "Test for the avatar rotate left control."
+    },
+    "@sl-slua/global/CONTROL_ROT_RIGHT": {
+        "documentation": "Test for the avatar rotate right control."
+    },
+    "@sl-slua/global/CONTROL_UP": {
+        "documentation": "Test for the avatar move up control."
+    },
+    "@sl-slua/global/DAMAGEABLE": {
+        "documentation": "Objects in world that are able to process damage."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_ACID": {
+        "documentation": "Damage caused by a caustic substance, such as acid"
+    },
+    "@sl-slua/global/DAMAGE_TYPE_BLUDGEONING": {
+        "documentation": "Damage caused by a blunt object, such as a club."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_COLD": {
+        "documentation": "Damage inflicted by exposure to extreme cold"
+    },
+    "@sl-slua/global/DAMAGE_TYPE_ELECTRIC": {
+        "documentation": "Damage caused by electricity."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_EMOTIONAL": {
+        "documentation": "DAMAGE_TYPE_EMOTIONAL constant"
+    },
+    "@sl-slua/global/DAMAGE_TYPE_FIRE": {
+        "documentation": "Damage inflicted by exposure to heat or flames."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_FORCE": {
+        "documentation": "Damage inflicted by a great force or impact."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_GENERIC": {
+        "documentation": "Generic or legacy damage."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_IMPACT": {
+        "documentation": "System damage generated by impact with land or a prim."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_NECROTIC": {
+        "documentation": "Damage caused by a direct assault on life-force"
+    },
+    "@sl-slua/global/DAMAGE_TYPE_PIERCING": {
+        "documentation": "Damage caused by a piercing object such as a bullet, spear, or arrow."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_POISON": {
+        "documentation": "Damage caused by poison."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_PSYCHIC": {
+        "documentation": "Damage caused by a direct assault on the mind."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_RADIANT": {
+        "documentation": "Damage caused by radiation or extreme light."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_SLASHING": {
+        "documentation": "Damage caused by a slashing object such as a sword or axe."
+    },
+    "@sl-slua/global/DAMAGE_TYPE_SONIC": {
+        "documentation": "Damage caused by loud noises, like a Crash Worship concert."
+    },
+    "@sl-slua/global/DATA_BORN": {
+        "documentation": "The date the agent was born, returned in ISO 8601 format of YYYY-MM-DD."
+    },
+    "@sl-slua/global/DATA_NAME": {
+        "documentation": "The name of the agent."
+    },
+    "@sl-slua/global/DATA_ONLINE": {
+        "documentation": "TRUE for online, FALSE for offline."
+    },
+    "@sl-slua/global/DATA_PAYINFO": {
+        "documentation": "DATA_PAYINFO constant"
+    },
+    "@sl-slua/global/DATA_RATING": {
+        "documentation": "Returns the agent ratings as a comma separated string of six integers. They are:\\n\t\t\t1) Positive rated behaviour\\n\t\t\t2) Negative rated behaviour\\n\t\t\t3) Positive rated appearance\\n\t\t\t4) Negative rated appearance\\n\t\t\t5) Positive rated building\\n\t\t\t6) Negative rated building"
+    },
+    "@sl-slua/global/DATA_SIM_POS": {
+        "documentation": "DATA_SIM_POS constant"
+    },
+    "@sl-slua/global/DATA_SIM_RATING": {
+        "documentation": "DATA_SIM_RATING constant"
+    },
+    "@sl-slua/global/DATA_SIM_STATUS": {
+        "documentation": "DATA_SIM_STATUS constant"
+    },
+    "@sl-slua/global/DEBUG_CHANNEL": {
+        "documentation": "DEBUG_CHANNEL is an integer constant that, when passed to llSay, llWhisper, or llShout as a channel parameter, will print text to the Script Warning/Error Window."
+    },
+    "@sl-slua/global/DEG_TO_RAD": {
+        "documentation": "0.017453293 - Number of radians per degree.\\n\t\t\tYou can use this to convert degrees to radians by multiplying the degrees by this number."
+    },
+    "@sl-slua/global/DENSITY": {
+        "documentation": "Used with llSetPhysicsMaterial to enable the density value. Must be between 1.0 and 22587.0 (in Kg/m^3 -- see if you can figure out what 22587 represents)"
+    },
+    "@sl-slua/global/DEREZ_DIE": {
+        "documentation": "Causes the object to immediately die."
+    },
+    "@sl-slua/global/DEREZ_MAKE_TEMP": {
+        "documentation": "The object is made temporary and will be cleaned up at some later timer."
+    },
+    "@sl-slua/global/DEREZ_TO_INVENTORY": {
+        "documentation": "The object is returned to the inventory of the rezzer."
+    },
+    "@sl-slua/global/ENVIRONMENT_DAYINFO": {
+        "documentation": "Day length, offset and progression."
+    },
+    "@sl-slua/global/ENV_INVALID_AGENT": {
+        "documentation": "Could not find agent with the specified ID"
+    },
+    "@sl-slua/global/ENV_INVALID_RULE": {
+        "documentation": "Attempted to change an unknown property."
+    },
+    "@sl-slua/global/ENV_NOT_EXPERIENCE": {
+        "documentation": "Attempt to change environments outside an experience."
+    },
+    "@sl-slua/global/ENV_NO_ENVIRONMENT": {
+        "documentation": "Could not find environmental settings in object inventory."
+    },
+    "@sl-slua/global/ENV_NO_EXPERIENCE_LAND": {
+        "documentation": "The experience has not been enabled on this land."
+    },
+    "@sl-slua/global/ENV_NO_EXPERIENCE_PERMISSION": {
+        "documentation": "Agent has not granted permission to change environments."
+    },
+    "@sl-slua/global/ENV_NO_PERMISSIONS": {
+        "documentation": "Script does not have permission to modify environment."
+    },
+    "@sl-slua/global/ENV_THROTTLE": {
+        "documentation": "Could not validate values for environment."
+    },
+    "@sl-slua/global/ENV_VALIDATION_FAIL": {
+        "documentation": "Could not validate values for environment."
+    },
+    "@sl-slua/global/EOF": {
+        "documentation": "Indicates the last line of a notecard was read."
+    },
+    "@sl-slua/global/ERR_GENERIC": {
+        "documentation": "ERR_GENERIC constant"
+    },
+    "@sl-slua/global/ERR_MALFORMED_PARAMS": {
+        "documentation": "ERR_MALFORMED_PARAMS constant"
+    },
+    "@sl-slua/global/ERR_PARCEL_PERMISSIONS": {
+        "documentation": "ERR_PARCEL_PERMISSIONS constant"
+    },
+    "@sl-slua/global/ERR_RUNTIME_PERMISSIONS": {
+        "documentation": "ERR_RUNTIME_PERMISSIONS constant"
+    },
+    "@sl-slua/global/ERR_THROTTLED": {
+        "documentation": "ERR_THROTTLED constant"
+    },
+    "@sl-slua/global/ESTATE_ACCESS_ALLOWED_AGENT_ADD": {
+        "documentation": "Add the agent to this estate's Allowed Residents list."
+    },
+    "@sl-slua/global/ESTATE_ACCESS_ALLOWED_AGENT_REMOVE": {
+        "documentation": "Remove the agent from this estate's Allowed Residents list."
+    },
+    "@sl-slua/global/ESTATE_ACCESS_ALLOWED_GROUP_ADD": {
+        "documentation": "Add the group to this estate's Allowed groups list."
+    },
+    "@sl-slua/global/ESTATE_ACCESS_ALLOWED_GROUP_REMOVE": {
+        "documentation": "Remove the group from this estate's Allowed groups list."
+    },
+    "@sl-slua/global/ESTATE_ACCESS_BANNED_AGENT_ADD": {
+        "documentation": "Add the agent to this estate's Banned residents list."
+    },
+    "@sl-slua/global/ESTATE_ACCESS_BANNED_AGENT_REMOVE": {
+        "documentation": "Remove the agent from this estate's Banned residents list."
+    },
+    "@sl-slua/global/FILTER_FLAGS": {
+        "documentation": "Flags to control returned attachments."
+    },
+    "@sl-slua/global/FILTER_FLAG_HUDS": {
+        "documentation": "Include HUDs with matching experience."
+    },
+    "@sl-slua/global/FILTER_INCLUDE": {
+        "documentation": "Include attachment point."
+    },
+    "@sl-slua/global/FORCE_DIRECT_PATH": {
+        "documentation": "Makes character navigate in a straight line toward position. May be set to TRUE or FALSE."
+    },
+    "@sl-slua/global/FRICTION": {
+        "documentation": "Used with llSetPhysicsMaterial to enable the friction value. Must be between 0.0 and 255.0"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_LEFTX": {
+        "documentation": "GAME_CONTROL_AXIS_LEFTX constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_LEFTY": {
+        "documentation": "GAME_CONTROL_AXIS_LEFTY constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_RIGHTX": {
+        "documentation": "GAME_CONTROL_AXIS_RIGHTX constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_RIGHTY": {
+        "documentation": "GAME_CONTROL_AXIS_RIGHTY constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_TRIGGERLEFT": {
+        "documentation": "GAME_CONTROL_AXIS_TRIGGERLEFT constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_AXIS_TRIGGERRIGHT": {
+        "documentation": "GAME_CONTROL_AXIS_TRIGGERRIGHT constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_A": {
+        "documentation": "GAME_CONTROL_BUTTON_A constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_B": {
+        "documentation": "GAME_CONTROL_BUTTON_B constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_BACK": {
+        "documentation": "GAME_CONTROL_BUTTON_BACK constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_DPAD_DOWN": {
+        "documentation": "GAME_CONTROL_BUTTON_DPAD_DOWN constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_DPAD_LEFT": {
+        "documentation": "GAME_CONTROL_BUTTON_DPAD_LEFT constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_DPAD_RIGHT": {
+        "documentation": "GAME_CONTROL_BUTTON_DPAD_RIGHT constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_DPAD_UP": {
+        "documentation": "GAME_CONTROL_BUTTON_DPAD_UP constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_GUIDE": {
+        "documentation": "GAME_CONTROL_BUTTON_GUIDE constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_LEFTSHOULDER": {
+        "documentation": "GAME_CONTROL_BUTTON_LEFTSHOULDER constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_LEFTSTICK": {
+        "documentation": "GAME_CONTROL_BUTTON_LEFTSTICK constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_MISC1": {
+        "documentation": "GAME_CONTROL_BUTTON_MISC1 constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_PADDLE1": {
+        "documentation": "GAME_CONTROL_BUTTON_PADDLE1 constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_PADDLE2": {
+        "documentation": "GAME_CONTROL_BUTTON_PADDLE2 constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_PADDLE3": {
+        "documentation": "GAME_CONTROL_BUTTON_PADDLE3 constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_PADDLE4": {
+        "documentation": "GAME_CONTROL_BUTTON_PADDLE4 constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_RIGHTSHOULDER": {
+        "documentation": "GAME_CONTROL_BUTTON_RIGHTSHOULDER constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_RIGHTSTICK": {
+        "documentation": "GAME_CONTROL_BUTTON_RIGHTSTICK constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_START": {
+        "documentation": "GAME_CONTROL_BUTTON_START constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_TOUCHPAD": {
+        "documentation": "GAME_CONTROL_BUTTON_TOUCHPAD constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_X": {
+        "documentation": "GAME_CONTROL_BUTTON_X constant"
+    },
+    "@sl-slua/global/GAME_CONTROL_BUTTON_Y": {
+        "documentation": "GAME_CONTROL_BUTTON_Y constant"
+    },
+    "@sl-slua/global/GCNP_RADIUS": {
+        "documentation": "GCNP_RADIUS constant"
+    },
+    "@sl-slua/global/GCNP_STATIC": {
+        "documentation": "GCNP_STATIC constant"
+    },
+    "@sl-slua/global/GRAVITY_MULTIPLIER": {
+        "documentation": "Used with llSetPhysicsMaterial to enable the gravity multiplier value. Must be between -1.0 and +28.0"
+    },
+    "@sl-slua/global/HORIZONTAL": {
+        "documentation": "HORIZONTAL constant"
+    },
+    "@sl-slua/global/HTTP_ACCEPT": {
+        "documentation": "Provide a string value to be included in the HTTP\\n            accepts header value. This replaces the default Second Life HTTP accepts header."
+    },
+    "@sl-slua/global/HTTP_BODY_MAXLENGTH": {
+        "documentation": "HTTP_BODY_MAXLENGTH constant"
+    },
+    "@sl-slua/global/HTTP_BODY_TRUNCATED": {
+        "documentation": "HTTP_BODY_TRUNCATED constant"
+    },
+    "@sl-slua/global/HTTP_CUSTOM_HEADER": {
+        "documentation": "Add an extra custom HTTP header to the request. The first string is the name of the parameter to change, e.g. \"Pragma\", and the second string is the value, e.g. \"no-cache\". Up to 8 custom headers may be configured per request. Note that certain headers, such as the default headers, are blocked for security reasons."
+    },
+    "@sl-slua/global/HTTP_EXTENDED_ERROR": {
+        "documentation": "Report extended error information through http_response event."
+    },
+    "@sl-slua/global/HTTP_METHOD": {
+        "documentation": "HTTP_METHOD constant"
+    },
+    "@sl-slua/global/HTTP_MIMETYPE": {
+        "documentation": "HTTP_MIMETYPE constant"
+    },
+    "@sl-slua/global/HTTP_PRAGMA_NO_CACHE": {
+        "documentation": "Allows enabling/disabling of the \"Pragma: no-cache\" header.\\nUsage: [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the \"Pragma: no-cache\" header is sent by the script. This matches the default behavior. When SendHeader is FALSE, no \"Pragma\" header is sent by the script."
+    },
+    "@sl-slua/global/HTTP_USER_AGENT": {
+        "documentation": "Provide a string value to be included in the HTTP\\n            User-Agent header value. This is appended to the default value."
+    },
+    "@sl-slua/global/HTTP_VERBOSE_THROTTLE": {
+        "documentation": "HTTP_VERBOSE_THROTTLE constant"
+    },
+    "@sl-slua/global/HTTP_VERIFY_CERT": {
+        "documentation": "HTTP_VERIFY_CERT constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_AUX1": {
+        "documentation": "IMG_USE_BAKED_AUX1 constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_AUX2": {
+        "documentation": "IMG_USE_BAKED_AUX2 constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_AUX3": {
+        "documentation": "IMG_USE_BAKED_AUX3 constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_EYES": {
+        "documentation": "IMG_USE_BAKED_EYES constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_HAIR": {
+        "documentation": "IMG_USE_BAKED_HAIR constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_HEAD": {
+        "documentation": "IMG_USE_BAKED_HEAD constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_LEFTARM": {
+        "documentation": "IMG_USE_BAKED_LEFTARM constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_LEFTLEG": {
+        "documentation": "IMG_USE_BAKED_LEFTLEG constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_LOWER": {
+        "documentation": "IMG_USE_BAKED_LOWER constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_SKIRT": {
+        "documentation": "IMG_USE_BAKED_SKIRT constant"
+    },
+    "@sl-slua/global/IMG_USE_BAKED_UPPER": {
+        "documentation": "IMG_USE_BAKED_UPPER constant"
+    },
+    "@sl-slua/global/INVENTORY_ALL": {
+        "documentation": "INVENTORY_ALL constant"
+    },
+    "@sl-slua/global/INVENTORY_ANIMATION": {
+        "documentation": "INVENTORY_ANIMATION constant"
+    },
+    "@sl-slua/global/INVENTORY_BODYPART": {
+        "documentation": "INVENTORY_BODYPART constant"
+    },
+    "@sl-slua/global/INVENTORY_CLOTHING": {
+        "documentation": "INVENTORY_CLOTHING constant"
+    },
+    "@sl-slua/global/INVENTORY_GESTURE": {
+        "documentation": "INVENTORY_GESTURE constant"
+    },
+    "@sl-slua/global/INVENTORY_LANDMARK": {
+        "documentation": "INVENTORY_LANDMARK constant"
+    },
+    "@sl-slua/global/INVENTORY_MATERIAL": {
+        "documentation": "INVENTORY_MATERIAL constant"
+    },
+    "@sl-slua/global/INVENTORY_NONE": {
+        "documentation": "INVENTORY_NONE constant"
+    },
+    "@sl-slua/global/INVENTORY_NOTECARD": {
+        "documentation": "INVENTORY_NOTECARD constant"
+    },
+    "@sl-slua/global/INVENTORY_OBJECT": {
+        "documentation": "INVENTORY_OBJECT constant"
+    },
+    "@sl-slua/global/INVENTORY_SCRIPT": {
+        "documentation": "INVENTORY_SCRIPT constant"
+    },
+    "@sl-slua/global/INVENTORY_SETTING": {
+        "documentation": "INVENTORY_SETTING constant"
+    },
+    "@sl-slua/global/INVENTORY_SOUND": {
+        "documentation": "INVENTORY_SOUND constant"
+    },
+    "@sl-slua/global/INVENTORY_TEXTURE": {
+        "documentation": "INVENTORY_TEXTURE constant"
+    },
+    "@sl-slua/global/JSON_APPEND": {
+        "documentation": "JSON_APPEND constant"
+    },
+    "@sl-slua/global/JSON_ARRAY": {
+        "documentation": "JSON_ARRAY constant"
+    },
+    "@sl-slua/global/JSON_DELETE": {
+        "documentation": "JSON_DELETE constant"
+    },
+    "@sl-slua/global/JSON_FALSE": {
+        "documentation": "JSON_FALSE constant"
+    },
+    "@sl-slua/global/JSON_INVALID": {
+        "documentation": "JSON_INVALID constant"
+    },
+    "@sl-slua/global/JSON_NULL": {
+        "documentation": "JSON_NULL constant"
+    },
+    "@sl-slua/global/JSON_NUMBER": {
+        "documentation": "JSON_NUMBER constant"
+    },
+    "@sl-slua/global/JSON_OBJECT": {
+        "documentation": "JSON_OBJECT constant"
+    },
+    "@sl-slua/global/JSON_STRING": {
+        "documentation": "JSON_STRING constant"
+    },
+    "@sl-slua/global/JSON_TRUE": {
+        "documentation": "JSON_TRUE constant"
+    },
+    "@sl-slua/global/KFM_CMD_PAUSE": {
+        "documentation": "For use with KFM_COMMAND."
+    },
+    "@sl-slua/global/KFM_CMD_PLAY": {
+        "documentation": "For use with KFM_COMMAND."
+    },
+    "@sl-slua/global/KFM_CMD_STOP": {
+        "documentation": "For use with KFM_COMMAND."
+    },
+    "@sl-slua/global/KFM_COMMAND": {
+        "documentation": "KFM_COMMAND constant"
+    },
+    "@sl-slua/global/KFM_DATA": {
+        "documentation": "KFM_DATA constant"
+    },
+    "@sl-slua/global/KFM_FORWARD": {
+        "documentation": "For use with KFM_MODE."
+    },
+    "@sl-slua/global/KFM_LOOP": {
+        "documentation": "For use with KFM_MODE."
+    },
+    "@sl-slua/global/KFM_MODE": {
+        "documentation": "KFM_MODE constant"
+    },
+    "@sl-slua/global/KFM_PING_PONG": {
+        "documentation": "For use with KFM_MODE."
+    },
+    "@sl-slua/global/KFM_REVERSE": {
+        "documentation": "For use with KFM_MODE."
+    },
+    "@sl-slua/global/KFM_ROTATION": {
+        "documentation": "For use with KFM_DATA."
+    },
+    "@sl-slua/global/KFM_TRANSLATION": {
+        "documentation": "For use with KFM_DATA."
+    },
+    "@sl-slua/global/LAND_LARGE_BRUSH": {
+        "documentation": "Use a large brush size.\\nNOTE: This value is incorrect, a large brush should be 2."
+    },
+    "@sl-slua/global/LAND_LEVEL": {
+        "documentation": "Action to level the land."
+    },
+    "@sl-slua/global/LAND_LOWER": {
+        "documentation": "Action to lower the land."
+    },
+    "@sl-slua/global/LAND_MEDIUM_BRUSH": {
+        "documentation": "Use a medium brush size.\\nNOTE: This value is incorrect, a medium brush should be 1."
+    },
+    "@sl-slua/global/LAND_NOISE": {
+        "documentation": "LAND_NOISE constant"
+    },
+    "@sl-slua/global/LAND_RAISE": {
+        "documentation": "Action to raise the land."
+    },
+    "@sl-slua/global/LAND_REVERT": {
+        "documentation": "LAND_REVERT constant"
+    },
+    "@sl-slua/global/LAND_SMALL_BRUSH": {
+        "documentation": "Use a small brush size.\\nNOTE: This value is incorrect, a small brush should be 0."
+    },
+    "@sl-slua/global/LAND_SMOOTH": {
+        "documentation": "LAND_SMOOTH constant"
+    },
+    "@sl-slua/global/LINKSETDATA_DELETE": {
+        "documentation": "A name:value pair has been removed from the linkset datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_EMEMORY": {
+        "documentation": "A name:value pair was too large to write to the linkset datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_ENOKEY": {
+        "documentation": "The key supplied was empty."
+    },
+    "@sl-slua/global/LINKSETDATA_EPROTECTED": {
+        "documentation": "The name:value pair has been protected from overwrite in the linkset datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_MULTIDELETE": {
+        "documentation": "A CSV list of names removed from the linkset datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_NOTFOUND": {
+        "documentation": "The named key was not found in the datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_NOUPDATE": {
+        "documentation": "The value written to a name in the keystore is the same as the value already there."
+    },
+    "@sl-slua/global/LINKSETDATA_OK": {
+        "documentation": "The name:value pair was written to the datastore."
+    },
+    "@sl-slua/global/LINKSETDATA_RESET": {
+        "documentation": "The linkset datastore has been reset."
+    },
+    "@sl-slua/global/LINKSETDATA_UPDATE": {
+        "documentation": "A name:value pair in the linkset datastore has been changed or created."
+    },
+    "@sl-slua/global/LINK_ALL_CHILDREN": {
+        "documentation": "This targets every object except the root in the linked set."
+    },
+    "@sl-slua/global/LINK_ALL_OTHERS": {
+        "documentation": "This targets every object in the linked set except the object with the script."
+    },
+    "@sl-slua/global/LINK_ROOT": {
+        "documentation": "This targets the root of the linked set."
+    },
+    "@sl-slua/global/LINK_SET": {
+        "documentation": "This targets every object in the linked set."
+    },
+    "@sl-slua/global/LINK_THIS": {
+        "documentation": "The link number of the prim containing the script."
+    },
+    "@sl-slua/global/LIST_STAT_GEOMETRIC_MEAN": {
+        "documentation": "LIST_STAT_GEOMETRIC_MEAN constant"
+    },
+    "@sl-slua/global/LIST_STAT_MAX": {
+        "documentation": "LIST_STAT_MAX constant"
+    },
+    "@sl-slua/global/LIST_STAT_MEAN": {
+        "documentation": "LIST_STAT_MEAN constant"
+    },
+    "@sl-slua/global/LIST_STAT_MEDIAN": {
+        "documentation": "LIST_STAT_MEDIAN constant"
+    },
+    "@sl-slua/global/LIST_STAT_MIN": {
+        "documentation": "LIST_STAT_MIN constant"
+    },
+    "@sl-slua/global/LIST_STAT_NUM_COUNT": {
+        "documentation": "LIST_STAT_NUM_COUNT constant"
+    },
+    "@sl-slua/global/LIST_STAT_RANGE": {
+        "documentation": "LIST_STAT_RANGE constant"
+    },
+    "@sl-slua/global/LIST_STAT_STD_DEV": {
+        "documentation": "LIST_STAT_STD_DEV constant"
+    },
+    "@sl-slua/global/LIST_STAT_SUM": {
+        "documentation": "LIST_STAT_SUM constant"
+    },
+    "@sl-slua/global/LIST_STAT_SUM_SQUARES": {
+        "documentation": "LIST_STAT_SUM_SQUARES constant"
+    },
+    "@sl-slua/global/LOOP": {
+        "documentation": "Loop the texture animation."
+    },
+    "@sl-slua/global/MASK_BASE": {
+        "documentation": "MASK_BASE constant"
+    },
+    "@sl-slua/global/MASK_COMBINED": {
+        "documentation": "Fold permissions for object inventory into results."
+    },
+    "@sl-slua/global/MASK_EVERYONE": {
+        "documentation": "MASK_EVERYONE constant"
+    },
+    "@sl-slua/global/MASK_GROUP": {
+        "documentation": "MASK_GROUP constant"
+    },
+    "@sl-slua/global/MASK_NEXT": {
+        "documentation": "MASK_NEXT constant"
+    },
+    "@sl-slua/global/MASK_OWNER": {
+        "documentation": "MASK_OWNER constant"
+    },
+    "@sl-slua/global/NAK": {
+        "documentation": "Indicates a notecard read was attempted and the notecard was not yet cached on the server."
+    },
+    "@sl-slua/global/NULL_KEY": {
+        "documentation": "NULL_KEY constant"
+    },
+    "@sl-slua/global/OBJECT_ACCOUNT_LEVEL": {
+        "documentation": "Retrieves the account level of an avatar.\\nReturns 0 when the avatar has a basic account,\\n 1 when the avatar has a premium account,\\n 10 when the avatar has a premium plus account,\\n or -1 if the object is not an avatar."
+    },
+    "@sl-slua/global/OBJECT_ANIMATED_COUNT": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the number of associated animated objects"
+    },
+    "@sl-slua/global/OBJECT_ANIMATED_SLOTS_AVAILABLE": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the number of additional animated object attachments allowed."
+    },
+    "@sl-slua/global/OBJECT_ATTACHED_POINT": {
+        "documentation": "Gets the attachment point to which the object is attached.\\nReturns 0 if the object is not an attachment (or is an avatar, etc)."
+    },
+    "@sl-slua/global/OBJECT_ATTACHED_SLOTS_AVAILABLE": {
+        "documentation": "Returns the number of attachment slots available.\\nReturns 0 if the object is not an avatar or none are available."
+    },
+    "@sl-slua/global/OBJECT_BODY_SHAPE_TYPE": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the body type of the avatar, based on shape data.\\nIf no data is available, -1.0 is returned.\\nThis is normally between 0 and 1.0, with 0.5 and larger considered 'male'"
+    },
+    "@sl-slua/global/OBJECT_CHARACTER_TIME": {
+        "documentation": "Units in seconds"
+    },
+    "@sl-slua/global/OBJECT_CLICK_ACTION": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the click action.\\nThe default is 0"
+    },
+    "@sl-slua/global/OBJECT_CREATION_TIME": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the time this object was created"
+    },
+    "@sl-slua/global/OBJECT_CREATOR": {
+        "documentation": "Gets the object's creator key. If id is an avatar, a NULL_KEY is returned."
+    },
+    "@sl-slua/global/OBJECT_DAMAGE": {
+        "documentation": "Gets the damage value assigned to this object."
+    },
+    "@sl-slua/global/OBJECT_DAMAGE_TYPE": {
+        "documentation": "Gets the damage type, if any, assigned to this object."
+    },
+    "@sl-slua/global/OBJECT_DESC": {
+        "documentation": "Gets the object's description. If id is an avatar, an empty string is returned."
+    },
+    "@sl-slua/global/OBJECT_GROUP": {
+        "documentation": "Gets the prims's group key. If id is an avatar, a NULL_KEY is returned."
+    },
+    "@sl-slua/global/OBJECT_GROUP_TAG": {
+        "documentation": "Gets the agent's current group role tag. If id is an object, an empty is returned."
+    },
+    "@sl-slua/global/OBJECT_HEALTH": {
+        "documentation": "Gets current health value for the object."
+    },
+    "@sl-slua/global/OBJECT_HOVER_HEIGHT": {
+        "documentation": "This is a flag used with llGetObjectDetails to get hover height of the avatar\\nIf no data is available, 0.0 is returned."
+    },
+    "@sl-slua/global/OBJECT_LAST_OWNER_ID": {
+        "documentation": "Gets the object's last owner ID."
+    },
+    "@sl-slua/global/OBJECT_LINK_NUMBER": {
+        "documentation": "Gets the object's link number or 0 if unlinked."
+    },
+    "@sl-slua/global/OBJECT_MASS": {
+        "documentation": "Get the object's mass"
+    },
+    "@sl-slua/global/OBJECT_MATERIAL": {
+        "documentation": "Get an object's material setting."
+    },
+    "@sl-slua/global/OBJECT_NAME": {
+        "documentation": "Gets the object's name."
+    },
+    "@sl-slua/global/OBJECT_OMEGA": {
+        "documentation": "Gets an object's angular velocity."
+    },
+    "@sl-slua/global/OBJECT_OWNER": {
+        "documentation": "Gets an object's owner's key. If id is group owned, a NULL_KEY is returned."
+    },
+    "@sl-slua/global/OBJECT_PATHFINDING_TYPE": {
+        "documentation": "Returns the pathfinding setting of any object in the region. It returns an integer matching one of the OPT_* constants."
+    },
+    "@sl-slua/global/OBJECT_PERMS": {
+        "documentation": "Gets the objects permissions"
+    },
+    "@sl-slua/global/OBJECT_PERMS_COMBINED": {
+        "documentation": "Gets the object's permissions including any inventory."
+    },
+    "@sl-slua/global/OBJECT_PHANTOM": {
+        "documentation": "Returns boolean, detailing if phantom is enabled or disabled on the object.\\nIf id is an avatar or attachment, 0 is returned."
+    },
+    "@sl-slua/global/OBJECT_PHYSICS": {
+        "documentation": "Returns boolean, detailing if physics is enabled or disabled on the object.\\nIf id is an avatar or attachment, 0 is returned."
+    },
+    "@sl-slua/global/OBJECT_PHYSICS_COST": {
+        "documentation": "OBJECT_PHYSICS_COST constant"
+    },
+    "@sl-slua/global/OBJECT_POS": {
+        "documentation": "Gets the object's position in region coordinates."
+    },
+    "@sl-slua/global/OBJECT_PRIM_COUNT": {
+        "documentation": "Gets the prim count of the object.  The script and target object  must be owned by the same owner"
+    },
+    "@sl-slua/global/OBJECT_PRIM_EQUIVALENCE": {
+        "documentation": "OBJECT_PRIM_EQUIVALENCE constant"
+    },
+    "@sl-slua/global/OBJECT_RENDER_WEIGHT": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the Avatar_Rendering_Cost of an avatar, based on values reported by nearby viewers.\\nIf no data is available, -1 is returned.\\nThe maximum render weight stored by the simulator is 500000. When called against an object, 0 is returned."
+    },
+    "@sl-slua/global/OBJECT_RETURN_PARCEL": {
+        "documentation": "OBJECT_RETURN_PARCEL constant"
+    },
+    "@sl-slua/global/OBJECT_RETURN_PARCEL_OWNER": {
+        "documentation": "OBJECT_RETURN_PARCEL_OWNER constant"
+    },
+    "@sl-slua/global/OBJECT_RETURN_REGION": {
+        "documentation": "OBJECT_RETURN_REGION constant"
+    },
+    "@sl-slua/global/OBJECT_REZZER_KEY": {
+        "documentation": "OBJECT_REZZER_KEY constant"
+    },
+    "@sl-slua/global/OBJECT_REZ_TIME": {
+        "documentation": "Get the time when an object was rezzed."
+    },
+    "@sl-slua/global/OBJECT_ROOT": {
+        "documentation": "Gets the id of the root prim of the object requested.\\nIf id is an avatar, return the id of the root prim of the linkset the avatar is sitting on (or the avatar's own id if the avatar is not sitting on an object within the region)."
+    },
+    "@sl-slua/global/OBJECT_ROT": {
+        "documentation": "Gets the object's rotation."
+    },
+    "@sl-slua/global/OBJECT_RUNNING_SCRIPT_COUNT": {
+        "documentation": "OBJECT_RUNNING_SCRIPT_COUNT constant"
+    },
+    "@sl-slua/global/OBJECT_SCALE": {
+        "documentation": "Gets the object's size."
+    },
+    "@sl-slua/global/OBJECT_SCRIPT_MEMORY": {
+        "documentation": "OBJECT_SCRIPT_MEMORY constant"
+    },
+    "@sl-slua/global/OBJECT_SCRIPT_TIME": {
+        "documentation": "OBJECT_SCRIPT_TIME constant"
+    },
+    "@sl-slua/global/OBJECT_SELECT_COUNT": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the number of avatars selecting any part of the object"
+    },
+    "@sl-slua/global/OBJECT_SERVER_COST": {
+        "documentation": "OBJECT_SERVER_COST constant"
+    },
+    "@sl-slua/global/OBJECT_SIT_COUNT": {
+        "documentation": "This is a flag used with llGetObjectDetails to get the number of avatars sitting on the object"
+    },
+    "@sl-slua/global/OBJECT_STREAMING_COST": {
+        "documentation": "OBJECT_STREAMING_COST constant"
+    },
+    "@sl-slua/global/OBJECT_TEMP_ATTACHED": {
+        "documentation": "Returns boolean, indicating if object is a temp attachment."
+    },
+    "@sl-slua/global/OBJECT_TEMP_ON_REZ": {
+        "documentation": "Returns boolean, detailing if temporary is enabled or disabled on the object."
+    },
+    "@sl-slua/global/OBJECT_TEXT": {
+        "documentation": "Gets an objects hover text."
+    },
+    "@sl-slua/global/OBJECT_TEXT_ALPHA": {
+        "documentation": "Gets the alpha of an objects hover text."
+    },
+    "@sl-slua/global/OBJECT_TEXT_COLOR": {
+        "documentation": "Gets the color of an objects hover text."
+    },
+    "@sl-slua/global/OBJECT_TOTAL_INVENTORY_COUNT": {
+        "documentation": "Gets the total inventory count of the object.  The script and target object must be owned by the same owner"
+    },
+    "@sl-slua/global/OBJECT_TOTAL_SCRIPT_COUNT": {
+        "documentation": "OBJECT_TOTAL_SCRIPT_COUNT constant"
+    },
+    "@sl-slua/global/OBJECT_UNKNOWN_DETAIL": {
+        "documentation": "OBJECT_UNKNOWN_DETAIL constant"
+    },
+    "@sl-slua/global/OBJECT_VELOCITY": {
+        "documentation": "Gets the object's velocity."
+    },
+    "@sl-slua/global/OPT_AVATAR": {
+        "documentation": "Returned for avatars."
+    },
+    "@sl-slua/global/OPT_CHARACTER": {
+        "documentation": "Returned for pathfinding characters."
+    },
+    "@sl-slua/global/OPT_EXCLUSION_VOLUME": {
+        "documentation": "Returned for exclusion volumes."
+    },
+    "@sl-slua/global/OPT_LEGACY_LINKSET": {
+        "documentation": "Returned for movable obstacles, movable phantoms, physical, and volumedetect objects."
+    },
+    "@sl-slua/global/OPT_MATERIAL_VOLUME": {
+        "documentation": "Returned for material volumes."
+    },
+    "@sl-slua/global/OPT_OTHER": {
+        "documentation": "Returned for attachments, Linden trees, and grass."
+    },
+    "@sl-slua/global/OPT_STATIC_OBSTACLE": {
+        "documentation": "Returned for static obstacles."
+    },
+    "@sl-slua/global/OPT_WALKABLE": {
+        "documentation": "Returned for walkable objects."
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_BASE_ALPHA": {
+        "documentation": "OVERRIDE_GLTF_BASE_ALPHA constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_BASE_ALPHA_MASK": {
+        "documentation": "OVERRIDE_GLTF_BASE_ALPHA_MASK constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_BASE_ALPHA_MODE": {
+        "documentation": "OVERRIDE_GLTF_BASE_ALPHA_MODE constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_BASE_COLOR_FACTOR": {
+        "documentation": "OVERRIDE_GLTF_BASE_COLOR_FACTOR constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_BASE_DOUBLE_SIDED": {
+        "documentation": "OVERRIDE_GLTF_BASE_DOUBLE_SIDED constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_EMISSIVE_FACTOR": {
+        "documentation": "OVERRIDE_GLTF_EMISSIVE_FACTOR constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_METALLIC_FACTOR": {
+        "documentation": "OVERRIDE_GLTF_METALLIC_FACTOR constant"
+    },
+    "@sl-slua/global/OVERRIDE_GLTF_ROUGHNESS_FACTOR": {
+        "documentation": "OVERRIDE_GLTF_ROUGHNESS_FACTOR constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_GROUP": {
+        "documentation": "PARCEL_COUNT_GROUP constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_OTHER": {
+        "documentation": "PARCEL_COUNT_OTHER constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_OWNER": {
+        "documentation": "PARCEL_COUNT_OWNER constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_SELECTED": {
+        "documentation": "PARCEL_COUNT_SELECTED constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_TEMP": {
+        "documentation": "PARCEL_COUNT_TEMP constant"
+    },
+    "@sl-slua/global/PARCEL_COUNT_TOTAL": {
+        "documentation": "PARCEL_COUNT_TOTAL constant"
+    },
+    "@sl-slua/global/PARCEL_DETAILS_AREA": {
+        "documentation": "The parcel's area, in square meters. (5 chars.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_DESC": {
+        "documentation": "The description of the parcel. (127 chars)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_FLAGS": {
+        "documentation": "Flags set on the parcel"
+    },
+    "@sl-slua/global/PARCEL_DETAILS_GROUP": {
+        "documentation": "The parcel group's key. (36 chars.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_ID": {
+        "documentation": "The parcel's key. (36 chars.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_LANDING_LOOKAT": {
+        "documentation": "Lookat vector set for teleport routing."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_LANDING_POINT": {
+        "documentation": "The parcel's landing point, if any."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_NAME": {
+        "documentation": "The name of the parcel. (63 chars.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_OWNER": {
+        "documentation": "The parcel owner's key. (36 chars.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_PRIM_CAPACITY": {
+        "documentation": "The parcel's prim capacity."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_PRIM_USED": {
+        "documentation": "The number of prims used on this parcel."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_SCRIPT_DANGER": {
+        "documentation": "There are restrictions on this parcel that may impact script execution."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_SEE_AVATARS": {
+        "documentation": "The parcel's avatar visibility setting. (1 char.)."
+    },
+    "@sl-slua/global/PARCEL_DETAILS_TP_ROUTING": {
+        "documentation": "Parcel's teleport routing setting."
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY": {
+        "documentation": "PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS": {
+        "documentation": "PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_CREATE_OBJECTS": {
+        "documentation": "PARCEL_FLAG_ALLOW_CREATE_OBJECTS constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_DAMAGE": {
+        "documentation": "PARCEL_FLAG_ALLOW_DAMAGE constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_FLY": {
+        "documentation": "PARCEL_FLAG_ALLOW_FLY constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY": {
+        "documentation": "PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_GROUP_SCRIPTS": {
+        "documentation": "PARCEL_FLAG_ALLOW_GROUP_SCRIPTS constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_LANDMARK": {
+        "documentation": "PARCEL_FLAG_ALLOW_LANDMARK constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_SCRIPTS": {
+        "documentation": "PARCEL_FLAG_ALLOW_SCRIPTS constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_ALLOW_TERRAFORM": {
+        "documentation": "PARCEL_FLAG_ALLOW_TERRAFORM constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_LOCAL_SOUND_ONLY": {
+        "documentation": "PARCEL_FLAG_LOCAL_SOUND_ONLY constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_RESTRICT_PUSHOBJECT": {
+        "documentation": "PARCEL_FLAG_RESTRICT_PUSHOBJECT constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_USE_ACCESS_GROUP": {
+        "documentation": "PARCEL_FLAG_USE_ACCESS_GROUP constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_USE_ACCESS_LIST": {
+        "documentation": "PARCEL_FLAG_USE_ACCESS_LIST constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_USE_BAN_LIST": {
+        "documentation": "PARCEL_FLAG_USE_BAN_LIST constant"
+    },
+    "@sl-slua/global/PARCEL_FLAG_USE_LAND_PASS_LIST": {
+        "documentation": "PARCEL_FLAG_USE_LAND_PASS_LIST constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_AGENT": {
+        "documentation": "PARCEL_MEDIA_COMMAND_AGENT constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_AUTO_ALIGN": {
+        "documentation": "PARCEL_MEDIA_COMMAND_AUTO_ALIGN constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_DESC": {
+        "documentation": "Use this to get or set the parcel media description."
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_LOOP": {
+        "documentation": "PARCEL_MEDIA_COMMAND_LOOP constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_LOOP_SET": {
+        "documentation": "Used to get or set the parcel's media looping variable."
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_PAUSE": {
+        "documentation": "PARCEL_MEDIA_COMMAND_PAUSE constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_PLAY": {
+        "documentation": "PARCEL_MEDIA_COMMAND_PLAY constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_SIZE": {
+        "documentation": "Use this to get or set the parcel media pixel resolution."
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_STOP": {
+        "documentation": "PARCEL_MEDIA_COMMAND_STOP constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_TEXTURE": {
+        "documentation": "PARCEL_MEDIA_COMMAND_TEXTURE constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_TIME": {
+        "documentation": "PARCEL_MEDIA_COMMAND_TIME constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_TYPE": {
+        "documentation": "Use this to get or set the parcel media MIME type (e.g. \"text/html\")."
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_UNLOAD": {
+        "documentation": "PARCEL_MEDIA_COMMAND_UNLOAD constant"
+    },
+    "@sl-slua/global/PARCEL_MEDIA_COMMAND_URL": {
+        "documentation": "PARCEL_MEDIA_COMMAND_URL constant"
+    },
+    "@sl-slua/global/PARCEL_SALE_AGENT": {
+        "documentation": "The agent authorized to purchase the parcel."
+    },
+    "@sl-slua/global/PARCEL_SALE_ERROR_BAD_PARAMS": {
+        "documentation": "The parameters provided to set the sale information are invalid."
+    },
+    "@sl-slua/global/PARCEL_SALE_ERROR_INVALID_PRICE": {
+        "documentation": "The price set for the parcel is invalid (e.g., less than or equal to 0)."
+    },
+    "@sl-slua/global/PARCEL_SALE_ERROR_IN_ESCROW": {
+        "documentation": "The parcel is currently in escrow and cannot be set for sale."
+    },
+    "@sl-slua/global/PARCEL_SALE_ERROR_NO_PARCEL": {
+        "documentation": "The parcel could not be found."
+    },
+    "@sl-slua/global/PARCEL_SALE_ERROR_NO_PERMISSIONS": {
+        "documentation": "The script does not have the required permissions to set the sale information."
+    },
+    "@sl-slua/global/PARCEL_SALE_OBJECTS": {
+        "documentation": "Are the objects on the parcel included in the sale?"
+    },
+    "@sl-slua/global/PARCEL_SALE_OK": {
+        "documentation": "The sale information was successfully set."
+    },
+    "@sl-slua/global/PARCEL_SALE_PRICE": {
+        "documentation": "The price of the parcel. If no authorized agent is set, must be greater than 0."
+    },
+    "@sl-slua/global/PASSIVE": {
+        "documentation": "Static in-world objects."
+    },
+    "@sl-slua/global/PASS_ALWAYS": {
+        "documentation": "Always pass the event."
+    },
+    "@sl-slua/global/PASS_IF_NOT_HANDLED": {
+        "documentation": "Pass the event if there is no script handling the event in the prim."
+    },
+    "@sl-slua/global/PASS_NEVER": {
+        "documentation": "Always pass the event."
+    },
+    "@sl-slua/global/PATROL_PAUSE_AT_WAYPOINTS": {
+        "documentation": "PATROL_PAUSE_AT_WAYPOINTS constant"
+    },
+    "@sl-slua/global/PAYMENT_INFO_ON_FILE": {
+        "documentation": "PAYMENT_INFO_ON_FILE constant"
+    },
+    "@sl-slua/global/PAYMENT_INFO_USED": {
+        "documentation": "PAYMENT_INFO_USED constant"
+    },
+    "@sl-slua/global/PAY_DEFAULT": {
+        "documentation": "PAY_DEFAULT constant"
+    },
+    "@sl-slua/global/PAY_HIDE": {
+        "documentation": "PAY_HIDE constant"
+    },
+    "@sl-slua/global/PERMISSION_ATTACH": {
+        "documentation": "If this permission is enabled, the object can successfully call llAttachToAvatar to attach to the given avatar."
+    },
+    "@sl-slua/global/PERMISSION_CHANGE_JOINTS": {
+        "documentation": "(not yet implemented)"
+    },
+    "@sl-slua/global/PERMISSION_CHANGE_LINKS": {
+        "documentation": "If this permission is enabled, the object can successfully call llCreateLink, llBreakLink, and llBreakAllLinks to change links to other objects."
+    },
+    "@sl-slua/global/PERMISSION_CHANGE_PERMISSIONS": {
+        "documentation": "(not yet implemented)"
+    },
+    "@sl-slua/global/PERMISSION_CONTROL_CAMERA": {
+        "documentation": "PERMISSION_CONTROL_CAMERA constant"
+    },
+    "@sl-slua/global/PERMISSION_DEBIT": {
+        "documentation": "If this permission is enabled, the object can successfully call llGiveMoney or llTransferLindenDollars to debit the owners account."
+    },
+    "@sl-slua/global/PERMISSION_OVERRIDE_ANIMATIONS": {
+        "documentation": "Permission to override default animations."
+    },
+    "@sl-slua/global/PERMISSION_RELEASE_OWNERSHIP": {
+        "documentation": "(not yet implemented)"
+    },
+    "@sl-slua/global/PERMISSION_REMAP_CONTROLS": {
+        "documentation": "(not yet implemented)"
+    },
+    "@sl-slua/global/PERMISSION_RETURN_OBJECTS": {
+        "documentation": "PERMISSION_RETURN_OBJECTS constant"
+    },
+    "@sl-slua/global/PERMISSION_SILENT_ESTATE_MANAGEMENT": {
+        "documentation": "A script with this permission does not notify the object owner when it modifies estate access rules via llManageEstateAccess."
+    },
+    "@sl-slua/global/PERMISSION_TAKE_CONTROLS": {
+        "documentation": "If this permission enabled, the object can successfully call the llTakeControls libray call."
+    },
+    "@sl-slua/global/PERMISSION_TELEPORT": {
+        "documentation": "PERMISSION_TELEPORT constant"
+    },
+    "@sl-slua/global/PERMISSION_TRACK_CAMERA": {
+        "documentation": "PERMISSION_TRACK_CAMERA constant"
+    },
+    "@sl-slua/global/PERMISSION_TRIGGER_ANIMATION": {
+        "documentation": "If this permission is enabled, the object can successfully call llStartAnimation for the avatar that owns this."
+    },
+    "@sl-slua/global/PERM_ALL": {
+        "documentation": "PERM_ALL constant"
+    },
+    "@sl-slua/global/PERM_COPY": {
+        "documentation": "PERM_COPY constant"
+    },
+    "@sl-slua/global/PERM_MODIFY": {
+        "documentation": "PERM_MODIFY constant"
+    },
+    "@sl-slua/global/PERM_MOVE": {
+        "documentation": "PERM_MOVE constant"
+    },
+    "@sl-slua/global/PERM_TRANSFER": {
+        "documentation": "PERM_TRANSFER constant"
+    },
+    "@sl-slua/global/PI": {
+        "documentation": "3.14159265 - The number of radians in a semi-circle."
+    },
+    "@sl-slua/global/PING_PONG": {
+        "documentation": "Play animation going forwards, then backwards."
+    },
+    "@sl-slua/global/PI_BY_TWO": {
+        "documentation": "1.57079633 - The number of radians in a quarter circle."
+    },
+    "@sl-slua/global/PRIM_ALLOW_UNSIT": {
+        "documentation": "Prim parameter for restricting manual standing for seated avatars in an experience.\\nIgnored if the avatar was not seated via a call to llSitOnLink."
+    },
+    "@sl-slua/global/PRIM_ALPHA_MODE": {
+        "documentation": "Prim parameter for materials using integer face, integer alpha_mode, integer alpha_cutoff.\\nDefines how the alpha channel of the diffuse texture should be rendered.\\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, _MASK, and _EMISSIVE.\\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK."
+    },
+    "@sl-slua/global/PRIM_ALPHA_MODE_BLEND": {
+        "documentation": "Prim parameter setting for PRIM_ALPHA_MODE.\\nIndicates that the diffuse texture's alpha channel should be rendered as alpha-blended."
+    },
+    "@sl-slua/global/PRIM_ALPHA_MODE_EMISSIVE": {
+        "documentation": "Prim parameter setting for PRIM_ALPHA_MODE.\\nIndicates that the diffuse texture's alpha channel should be rendered as an emissivity mask."
+    },
+    "@sl-slua/global/PRIM_ALPHA_MODE_MASK": {
+        "documentation": "Prim parameter setting for PRIM_ALPHA_MODE.\\nIndicates that the diffuse texture's alpha channel should be rendered as fully opaque for alpha values above alpha_cutoff and fully transparent otherwise."
+    },
+    "@sl-slua/global/PRIM_ALPHA_MODE_NONE": {
+        "documentation": "Prim parameter setting for PRIM_ALPHA_MODE.\\nIndicates that the diffuse texture's alpha channel should be ignored."
+    },
+    "@sl-slua/global/PRIM_BUMP_BARK": {
+        "documentation": "PRIM_BUMP_BARK constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_BLOBS": {
+        "documentation": "PRIM_BUMP_BLOBS constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_BRICKS": {
+        "documentation": "PRIM_BUMP_BRICKS constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_BRIGHT": {
+        "documentation": "PRIM_BUMP_BRIGHT constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_CHECKER": {
+        "documentation": "PRIM_BUMP_CHECKER constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_CONCRETE": {
+        "documentation": "PRIM_BUMP_CONCRETE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_DARK": {
+        "documentation": "PRIM_BUMP_DARK constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_DISKS": {
+        "documentation": "PRIM_BUMP_DISKS constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_GRAVEL": {
+        "documentation": "PRIM_BUMP_GRAVEL constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_LARGETILE": {
+        "documentation": "PRIM_BUMP_LARGETILE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_NONE": {
+        "documentation": "PRIM_BUMP_NONE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_SHINY": {
+        "documentation": "PRIM_BUMP_SHINY constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_SIDING": {
+        "documentation": "PRIM_BUMP_SIDING constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_STONE": {
+        "documentation": "PRIM_BUMP_STONE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_STUCCO": {
+        "documentation": "PRIM_BUMP_STUCCO constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_SUCTION": {
+        "documentation": "PRIM_BUMP_SUCTION constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_TILE": {
+        "documentation": "PRIM_BUMP_TILE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_WEAVE": {
+        "documentation": "PRIM_BUMP_WEAVE constant"
+    },
+    "@sl-slua/global/PRIM_BUMP_WOOD": {
+        "documentation": "PRIM_BUMP_WOOD constant"
+    },
+    "@sl-slua/global/PRIM_CAST_SHADOWS": {
+        "documentation": "PRIM_CAST_SHADOWS constant"
+    },
+    "@sl-slua/global/PRIM_CLICK_ACTION": {
+        "documentation": "[PRIM_CLICK_ACTION, integer CLICK_ACTION_*]"
+    },
+    "@sl-slua/global/PRIM_COLLISION_SOUND": {
+        "documentation": "Collision sound uuid and volume for this prim"
+    },
+    "@sl-slua/global/PRIM_COLOR": {
+        "documentation": "[PRIM_COLOR, integer face, vector color, float alpha]\\ninteger face – face number or ALL_SIDES vector color – color in RGB <R, G, B> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float alpha – from 0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)"
+    },
+    "@sl-slua/global/PRIM_DAMAGE": {
+        "documentation": "Damage and damage type assigned to this prim."
+    },
+    "@sl-slua/global/PRIM_DESC": {
+        "documentation": "[PRIM_DESC, string description]"
+    },
+    "@sl-slua/global/PRIM_FLEXIBLE": {
+        "documentation": "[ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float friction, float wind, float tension, vector force ] + +integer boolean – TRUE enables, FALSE disables +integer softness – ranges from 0 to 3 +float gravity – ranges from -10.0 to 10.0 +float friction – ranges from 0.0 to 10.0 +float wind – ranges from 0.0 to 10.0 +float tension – ranges from 0.0 to 10.0 +vector force"
+    },
+    "@sl-slua/global/PRIM_FULLBRIGHT": {
+        "documentation": "[ PRIM_FULLBRIGHT, integer face, integer boolean ]"
+    },
+    "@sl-slua/global/PRIM_GLOW": {
+        "documentation": "PRIM_GLOW is used to get or set the glow status of the face.\\n[ PRIM_GLOW, integer face, float intensity ]"
+    },
+    "@sl-slua/global/PRIM_GLTF_ALPHA_MODE_BLEND": {
+        "documentation": "Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode \"BLEND\"."
+    },
+    "@sl-slua/global/PRIM_GLTF_ALPHA_MODE_MASK": {
+        "documentation": "Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode \"MASK\"."
+    },
+    "@sl-slua/global/PRIM_GLTF_ALPHA_MODE_OPAQUE": {
+        "documentation": "Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode \"OPAQUE\"."
+    },
+    "@sl-slua/global/PRIM_GLTF_BASE_COLOR": {
+        "documentation": "Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode, float alpha_cutoff, boolean double_sided.\\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK."
+    },
+    "@sl-slua/global/PRIM_GLTF_EMISSIVE": {
+        "documentation": "Prim parameter for GLTF materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color"
+    },
+    "@sl-slua/global/PRIM_GLTF_METALLIC_ROUGHNESS": {
+        "documentation": "Prim parameter for GLTF materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, float metallic_factor, float roughness_factor"
+    },
+    "@sl-slua/global/PRIM_GLTF_NORMAL": {
+        "documentation": "Prim parameter for GLTF materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians"
+    },
+    "@sl-slua/global/PRIM_HEALTH": {
+        "documentation": "Health value for this prim"
+    },
+    "@sl-slua/global/PRIM_HOLE_CIRCLE": {
+        "documentation": "PRIM_HOLE_CIRCLE constant"
+    },
+    "@sl-slua/global/PRIM_HOLE_DEFAULT": {
+        "documentation": "PRIM_HOLE_DEFAULT constant"
+    },
+    "@sl-slua/global/PRIM_HOLE_SQUARE": {
+        "documentation": "PRIM_HOLE_SQUARE constant"
+    },
+    "@sl-slua/global/PRIM_HOLE_TRIANGLE": {
+        "documentation": "PRIM_HOLE_TRIANGLE constant"
+    },
+    "@sl-slua/global/PRIM_LINK_TARGET": {
+        "documentation": "[ PRIM_LINK_TARGET, integer link_target ]\\nUsed to get or set multiple links with a single PrimParameters call."
+    },
+    "@sl-slua/global/PRIM_MATERIAL": {
+        "documentation": "[ PRIM_MATERIAL, integer PRIM_MATERIAL_* ]"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_FLESH": {
+        "documentation": "PRIM_MATERIAL_FLESH constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_GLASS": {
+        "documentation": "PRIM_MATERIAL_GLASS constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_LIGHT": {
+        "documentation": "PRIM_MATERIAL_LIGHT constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_METAL": {
+        "documentation": "PRIM_MATERIAL_METAL constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_PLASTIC": {
+        "documentation": "PRIM_MATERIAL_PLASTIC constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_RUBBER": {
+        "documentation": "PRIM_MATERIAL_RUBBER constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_STONE": {
+        "documentation": "PRIM_MATERIAL_STONE constant"
+    },
+    "@sl-slua/global/PRIM_MATERIAL_WOOD": {
+        "documentation": "PRIM_MATERIAL_WOOD constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_ALT_IMAGE_ENABLE": {
+        "documentation": "Boolean. Gets/Sets the default image state (the image that the user sees before a piece of media is active) for the chosen face. The default image is specified by Second Life's server for that media type."
+    },
+    "@sl-slua/global/PRIM_MEDIA_AUTO_LOOP": {
+        "documentation": "Boolean. Gets/Sets whether auto-looping is enabled."
+    },
+    "@sl-slua/global/PRIM_MEDIA_AUTO_PLAY": {
+        "documentation": "Boolean. Gets/Sets whether the media auto-plays when a Resident can view it."
+    },
+    "@sl-slua/global/PRIM_MEDIA_AUTO_SCALE": {
+        "documentation": "Boolean. Gets/Sets whether auto-scaling is enabled. Auto-scaling forces the media to the full size of the texture."
+    },
+    "@sl-slua/global/PRIM_MEDIA_AUTO_ZOOM": {
+        "documentation": "Boolean. Gets/Sets whether clicking the media triggers auto-zoom and auto-focus on the media."
+    },
+    "@sl-slua/global/PRIM_MEDIA_CONTROLS": {
+        "documentation": "Integer. Gets/Sets the style of controls. Can be either PRIM_MEDIA_CONTROLS_STANDARD or PRIM_MEDIA_CONTROLS_MINI."
+    },
+    "@sl-slua/global/PRIM_MEDIA_CONTROLS_MINI": {
+        "documentation": "Mini web navigation controls; does not include an address bar."
+    },
+    "@sl-slua/global/PRIM_MEDIA_CONTROLS_STANDARD": {
+        "documentation": "Standard web navigation controls."
+    },
+    "@sl-slua/global/PRIM_MEDIA_CURRENT_URL": {
+        "documentation": "String. Gets/Sets the current url displayed on the chosen face. Changing this URL causes navigation. 1024 characters Maximum."
+    },
+    "@sl-slua/global/PRIM_MEDIA_FIRST_CLICK_INTERACT": {
+        "documentation": "Boolean. Gets/Sets whether the first click interaction is enabled."
+    },
+    "@sl-slua/global/PRIM_MEDIA_HEIGHT_PIXELS": {
+        "documentation": "Integer. Gets/Sets the height of the media in pixels."
+    },
+    "@sl-slua/global/PRIM_MEDIA_HOME_URL": {
+        "documentation": "String. Gets/Sets the home URL for the chosen face. 1024 characters maximum."
+    },
+    "@sl-slua/global/PRIM_MEDIA_MAX_HEIGHT_PIXELS": {
+        "documentation": "PRIM_MEDIA_MAX_HEIGHT_PIXELS constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_MAX_URL_LENGTH": {
+        "documentation": "PRIM_MEDIA_MAX_URL_LENGTH constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_MAX_WHITELIST_COUNT": {
+        "documentation": "PRIM_MEDIA_MAX_WHITELIST_COUNT constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_MAX_WHITELIST_SIZE": {
+        "documentation": "PRIM_MEDIA_MAX_WHITELIST_SIZE constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_MAX_WIDTH_PIXELS": {
+        "documentation": "PRIM_MEDIA_MAX_WIDTH_PIXELS constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PARAM_MAX": {
+        "documentation": "PRIM_MEDIA_PARAM_MAX constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERMS_CONTROL": {
+        "documentation": "Integer. Gets/Sets the permissions mask that control who can see the media control bar above the object:: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERMS_INTERACT": {
+        "documentation": "Integer. Gets/Sets the permissions mask that control who can interact with the object: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERM_ANYONE": {
+        "documentation": "PRIM_MEDIA_PERM_ANYONE constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERM_GROUP": {
+        "documentation": "PRIM_MEDIA_PERM_GROUP constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERM_NONE": {
+        "documentation": "PRIM_MEDIA_PERM_NONE constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_PERM_OWNER": {
+        "documentation": "PRIM_MEDIA_PERM_OWNER constant"
+    },
+    "@sl-slua/global/PRIM_MEDIA_WHITELIST": {
+        "documentation": "String. Gets/Sets the white-list as a string of escaped, comma-separated URLs. This string can hold up to 64 URLs or 1024 characters, whichever comes first."
+    },
+    "@sl-slua/global/PRIM_MEDIA_WHITELIST_ENABLE": {
+        "documentation": "Boolean. Gets/Sets whether navigation is restricted to URLs in PRIM_MEDIA_WHITELIST."
+    },
+    "@sl-slua/global/PRIM_MEDIA_WIDTH_PIXELS": {
+        "documentation": "Integer. Gets/Sets the width of the media in pixels."
+    },
+    "@sl-slua/global/PRIM_NAME": {
+        "documentation": "[ PRIM_NAME, string name ]"
+    },
+    "@sl-slua/global/PRIM_NORMAL": {
+        "documentation": "Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians"
+    },
+    "@sl-slua/global/PRIM_OMEGA": {
+        "documentation": "[ PRIM_OMEGA, vector axis, float spinrate, float gain ]\\nvector axis – arbitrary axis to rotate the object around float spinrate – rate of rotation in radians per second float gain – also modulates the final spinrate and disables the rotation behavior if zero"
+    },
+    "@sl-slua/global/PRIM_PHANTOM": {
+        "documentation": "[ PRIM_PHANTOM, integer boolean ]"
+    },
+    "@sl-slua/global/PRIM_PHYSICS": {
+        "documentation": "[ PRIM_PHYSICS, integer boolean ]"
+    },
+    "@sl-slua/global/PRIM_PHYSICS_SHAPE_CONVEX": {
+        "documentation": "Use the convex hull of the prim shape for physics (this is the default for mesh objects)."
+    },
+    "@sl-slua/global/PRIM_PHYSICS_SHAPE_NONE": {
+        "documentation": "Ignore this prim in the physics shape. NB: This cannot be applied to the root prim."
+    },
+    "@sl-slua/global/PRIM_PHYSICS_SHAPE_PRIM": {
+        "documentation": "Use the normal prim shape for physics (this is the default for all non-mesh objects)."
+    },
+    "@sl-slua/global/PRIM_PHYSICS_SHAPE_TYPE": {
+        "documentation": "Allows you to set the physics shape type of a prim via lsl. Permitted values are:\\n\t\t\tPRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX"
+    },
+    "@sl-slua/global/PRIM_POINT_LIGHT": {
+        "documentation": "[ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity, float radius, float falloff ]\\ninteger boolean – TRUE enables, FALSE disables vector linear_color – linear color in RGB <R, G, B&> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float intensity – ranges from 0.0 to 1.0 float radius – ranges from 0.1 to 20.0 float falloff – ranges from 0.01 to 2.0"
+    },
+    "@sl-slua/global/PRIM_POSITION": {
+        "documentation": "[ PRIM_POSITION, vector position ]\\nvector position – position in region or local coordinates depending upon the situation"
+    },
+    "@sl-slua/global/PRIM_POS_LOCAL": {
+        "documentation": "PRIM_POS_LOCAL, vector position ]\\nvector position - position in local coordinates"
+    },
+    "@sl-slua/global/PRIM_PROJECTOR": {
+        "documentation": "[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]"
+    },
+    "@sl-slua/global/PRIM_REFLECTION_PROBE": {
+        "documentation": "Allows you to configure the object as a custom-placed reflection probe, for image-based lighting (IBL). Only objects in the influence volume of the reflection probe object are affected."
+    },
+    "@sl-slua/global/PRIM_REFLECTION_PROBE_BOX": {
+        "documentation": "This is a flag option used with llGetPrimitiveParams and related functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe is a box. When unset, the reflection probe is a sphere."
+    },
+    "@sl-slua/global/PRIM_REFLECTION_PROBE_DYNAMIC": {
+        "documentation": "This is a flag option used with llGetPrimitiveParams and related functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe includes avatars in IBL effects. When unset, the reflection probe excludes avatars."
+    },
+    "@sl-slua/global/PRIM_REFLECTION_PROBE_MIRROR": {
+        "documentation": "This is a flag option used with llGetPrimitiveParams and related functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe acts as a mirror."
+    },
+    "@sl-slua/global/PRIM_RENDER_MATERIAL": {
+        "documentation": "[ PRIM_RENDER_MATERIAL, integer face, string material ]"
+    },
+    "@sl-slua/global/PRIM_ROTATION": {
+        "documentation": "[ PRIM_ROT_LOCAL, rotation global_rot ]"
+    },
+    "@sl-slua/global/PRIM_ROT_LOCAL": {
+        "documentation": "[ PRIM_ROT_LOCAL, rotation local_rot ]"
+    },
+    "@sl-slua/global/PRIM_SCRIPTED_SIT_ONLY": {
+        "documentation": "Prim parameter for restricting manual sitting on this prim.\\nSitting must be initiated via call to llSitOnLink."
+    },
+    "@sl-slua/global/PRIM_SCULPT_FLAG_ANIMESH": {
+        "documentation": "Mesh is animated."
+    },
+    "@sl-slua/global/PRIM_SCULPT_FLAG_INVERT": {
+        "documentation": "Render inside out (inverts the normals)."
+    },
+    "@sl-slua/global/PRIM_SCULPT_FLAG_MIRROR": {
+        "documentation": "Render an X axis mirror of the sculpty."
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_CYLINDER": {
+        "documentation": "PRIM_SCULPT_TYPE_CYLINDER constant"
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_MASK": {
+        "documentation": "PRIM_SCULPT_TYPE_MASK constant"
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_MESH": {
+        "documentation": "PRIM_SCULPT_TYPE_MESH constant"
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_PLANE": {
+        "documentation": "PRIM_SCULPT_TYPE_PLANE constant"
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_SPHERE": {
+        "documentation": "PRIM_SCULPT_TYPE_SPHERE constant"
+    },
+    "@sl-slua/global/PRIM_SCULPT_TYPE_TORUS": {
+        "documentation": "PRIM_SCULPT_TYPE_TORUS constant"
+    },
+    "@sl-slua/global/PRIM_SHINY_HIGH": {
+        "documentation": "PRIM_SHINY_HIGH constant"
+    },
+    "@sl-slua/global/PRIM_SHINY_LOW": {
+        "documentation": "PRIM_SHINY_LOW constant"
+    },
+    "@sl-slua/global/PRIM_SHINY_MEDIUM": {
+        "documentation": "PRIM_SHINY_MEDIUM constant"
+    },
+    "@sl-slua/global/PRIM_SHINY_NONE": {
+        "documentation": "PRIM_SHINY_NONE constant"
+    },
+    "@sl-slua/global/PRIM_SIT_FLAGS": {
+        "documentation": "PRIM_SIT_FLAGS constant"
+    },
+    "@sl-slua/global/PRIM_SIT_TARGET": {
+        "documentation": "[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]"
+    },
+    "@sl-slua/global/PRIM_SIZE": {
+        "documentation": "[ PRIM_SIZE, vector size ]"
+    },
+    "@sl-slua/global/PRIM_SLICE": {
+        "documentation": "[ PRIM_SLICE, vector slice ]"
+    },
+    "@sl-slua/global/PRIM_SPECULAR": {
+        "documentation": "Prim parameter for materials using integer face, string texture, vector repeats, vector offsets, float rotation_in_radians, vector color, integer glossy, integer environment"
+    },
+    "@sl-slua/global/PRIM_TEMP_ON_REZ": {
+        "documentation": "PRIM_TEMP_ON_REZ constant"
+    },
+    "@sl-slua/global/PRIM_TEXGEN": {
+        "documentation": "[ PRIM_TEXGEN, integer face, PRIM_TEXGEN_* ]"
+    },
+    "@sl-slua/global/PRIM_TEXGEN_DEFAULT": {
+        "documentation": "PRIM_TEXGEN_DEFAULT constant"
+    },
+    "@sl-slua/global/PRIM_TEXGEN_PLANAR": {
+        "documentation": "PRIM_TEXGEN_PLANAR constant"
+    },
+    "@sl-slua/global/PRIM_TEXT": {
+        "documentation": "[ PRIM_TEXT, string text, vector color, float alpha ]"
+    },
+    "@sl-slua/global/PRIM_TEXTURE": {
+        "documentation": "[ PRIM_TEXTURE, integer face, string texture, vector repeats, vector offsets, float rotation_in_radians ]"
+    },
+    "@sl-slua/global/PRIM_TYPE": {
+        "documentation": "PRIM_TYPE constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_BOX": {
+        "documentation": "PRIM_TYPE_BOX constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_CYLINDER": {
+        "documentation": "PRIM_TYPE_CYLINDER constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_PRISM": {
+        "documentation": "PRIM_TYPE_PRISM constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_RING": {
+        "documentation": "PRIM_TYPE_RING constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_SCULPT": {
+        "documentation": "PRIM_TYPE_SCULPT constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_SPHERE": {
+        "documentation": "PRIM_TYPE_SPHERE constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_TORUS": {
+        "documentation": "PRIM_TYPE_TORUS constant"
+    },
+    "@sl-slua/global/PRIM_TYPE_TUBE": {
+        "documentation": "PRIM_TYPE_TUBE constant"
+    },
+    "@sl-slua/global/PROFILE_NONE": {
+        "documentation": "Disables profiling"
+    },
+    "@sl-slua/global/PROFILE_SCRIPT_MEMORY": {
+        "documentation": "Enables memory profiling"
+    },
+    "@sl-slua/global/PSYS_PART_BF_DEST_COLOR": {
+        "documentation": "PSYS_PART_BF_DEST_COLOR constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_ONE": {
+        "documentation": "PSYS_PART_BF_ONE constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_ONE_MINUS_DEST_COLOR": {
+        "documentation": "PSYS_PART_BF_ONE_MINUS_DEST_COLOR constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA": {
+        "documentation": "PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR": {
+        "documentation": "PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_SOURCE_ALPHA": {
+        "documentation": "PSYS_PART_BF_SOURCE_ALPHA constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_SOURCE_COLOR": {
+        "documentation": "PSYS_PART_BF_SOURCE_COLOR constant"
+    },
+    "@sl-slua/global/PSYS_PART_BF_ZERO": {
+        "documentation": "PSYS_PART_BF_ZERO constant"
+    },
+    "@sl-slua/global/PSYS_PART_BLEND_FUNC_DEST": {
+        "documentation": "PSYS_PART_BLEND_FUNC_DEST constant"
+    },
+    "@sl-slua/global/PSYS_PART_BLEND_FUNC_SOURCE": {
+        "documentation": "PSYS_PART_BLEND_FUNC_SOURCE constant"
+    },
+    "@sl-slua/global/PSYS_PART_BOUNCE_MASK": {
+        "documentation": "Particles bounce off of a plane at the objects Z height."
+    },
+    "@sl-slua/global/PSYS_PART_EMISSIVE_MASK": {
+        "documentation": "The particle glows."
+    },
+    "@sl-slua/global/PSYS_PART_END_ALPHA": {
+        "documentation": "A float which determines the ending alpha of the object."
+    },
+    "@sl-slua/global/PSYS_PART_END_COLOR": {
+        "documentation": "A vector <r, g, b> which determines the ending color of the object."
+    },
+    "@sl-slua/global/PSYS_PART_END_GLOW": {
+        "documentation": "PSYS_PART_END_GLOW constant"
+    },
+    "@sl-slua/global/PSYS_PART_END_SCALE": {
+        "documentation": "A vector <sx, sy, z>, which is the ending size of the particle billboard in meters (z is ignored)."
+    },
+    "@sl-slua/global/PSYS_PART_FLAGS": {
+        "documentation": "Each particle that is emitted by the particle system is simulated based on the following flags. To use multiple flags, bitwise or (|) them together."
+    },
+    "@sl-slua/global/PSYS_PART_FOLLOW_SRC_MASK": {
+        "documentation": "The particle position is relative to the source objects position."
+    },
+    "@sl-slua/global/PSYS_PART_FOLLOW_VELOCITY_MASK": {
+        "documentation": "The particle orientation is rotated so the vertical axis faces towards the particle velocity."
+    },
+    "@sl-slua/global/PSYS_PART_INTERP_COLOR_MASK": {
+        "documentation": "Interpolate both the color and alpha from the start value to the end value."
+    },
+    "@sl-slua/global/PSYS_PART_INTERP_SCALE_MASK": {
+        "documentation": "Interpolate the particle scale from the start value to the end value."
+    },
+    "@sl-slua/global/PSYS_PART_MAX_AGE": {
+        "documentation": "Age in seconds of a particle at which it dies."
+    },
+    "@sl-slua/global/PSYS_PART_RIBBON_MASK": {
+        "documentation": "PSYS_PART_RIBBON_MASK constant"
+    },
+    "@sl-slua/global/PSYS_PART_START_ALPHA": {
+        "documentation": "A float which determines the starting alpha of the object."
+    },
+    "@sl-slua/global/PSYS_PART_START_COLOR": {
+        "documentation": "A vector <r, g, b> which determines the starting color of the object."
+    },
+    "@sl-slua/global/PSYS_PART_START_GLOW": {
+        "documentation": "PSYS_PART_START_GLOW constant"
+    },
+    "@sl-slua/global/PSYS_PART_START_SCALE": {
+        "documentation": "A vector <sx, sy, z>, which is the starting size of the particle billboard in meters (z is ignored)."
+    },
+    "@sl-slua/global/PSYS_PART_TARGET_LINEAR_MASK": {
+        "documentation": "PSYS_PART_TARGET_LINEAR_MASK constant"
+    },
+    "@sl-slua/global/PSYS_PART_TARGET_POS_MASK": {
+        "documentation": "The particle heads towards the location of the target object as defined by PSYS_SRC_TARGET_KEY."
+    },
+    "@sl-slua/global/PSYS_PART_WIND_MASK": {
+        "documentation": "Particles have their velocity damped towards the wind velocity."
+    },
+    "@sl-slua/global/PSYS_SRC_ACCEL": {
+        "documentation": "A vector <x, y, z> which is the acceleration to apply on particles."
+    },
+    "@sl-slua/global/PSYS_SRC_ANGLE_BEGIN": {
+        "documentation": "Area in radians specifying where particles will NOT be created (for ANGLE patterns)"
+    },
+    "@sl-slua/global/PSYS_SRC_ANGLE_END": {
+        "documentation": "Area in radians filled with particles (for ANGLE patterns) (if lower than PSYS_SRC_ANGLE_BEGIN, acts as PSYS_SRC_ANGLE_BEGIN itself, and PSYS_SRC_ANGLE_BEGIN acts as PSYS_SRC_ANGLE_END)."
+    },
+    "@sl-slua/global/PSYS_SRC_BURST_PART_COUNT": {
+        "documentation": "How many particles to release in a burst."
+    },
+    "@sl-slua/global/PSYS_SRC_BURST_RADIUS": {
+        "documentation": "What distance from the center of the object to create the particles."
+    },
+    "@sl-slua/global/PSYS_SRC_BURST_RATE": {
+        "documentation": "How often to release a particle burst (float seconds)."
+    },
+    "@sl-slua/global/PSYS_SRC_BURST_SPEED_MAX": {
+        "documentation": "Maximum speed that a particle should be moving."
+    },
+    "@sl-slua/global/PSYS_SRC_BURST_SPEED_MIN": {
+        "documentation": "Minimum speed that a particle should be moving."
+    },
+    "@sl-slua/global/PSYS_SRC_INNERANGLE": {
+        "documentation": "Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\\n\t\t\tThe area specified will NOT have particles in it."
+    },
+    "@sl-slua/global/PSYS_SRC_MAX_AGE": {
+        "documentation": "How long this particle system should last, 0.0 means forever."
+    },
+    "@sl-slua/global/PSYS_SRC_OMEGA": {
+        "documentation": "Sets the angular velocity to rotate the axis that SRC_PATTERN_ANGLE and SRC_PATTERN_ANGLE_CONE use."
+    },
+    "@sl-slua/global/PSYS_SRC_OUTERANGLE": {
+        "documentation": "Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\\n\t\t\tThe area between the outer and inner angle will be filled with particles."
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN": {
+        "documentation": "The pattern which is used to generate particles.\\n\t\t\tUse one of the following values: PSYS_SRC_PATTERN Values."
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN_ANGLE": {
+        "documentation": "Shoot particles across a 2 dimensional area defined by the arc created from PSYS_SRC_OUTERANGLE. There will be an open area defined by PSYS_SRC_INNERANGLE within the larger arc."
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN_ANGLE_CONE": {
+        "documentation": "Shoot particles out in a 3 dimensional cone with an outer arc of PSYS_SRC_OUTERANGLE and an inner open area defined by PSYS_SRC_INNERANGLE."
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY": {
+        "documentation": "PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY constant"
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN_DROP": {
+        "documentation": "Drop particles at the source position."
+    },
+    "@sl-slua/global/PSYS_SRC_PATTERN_EXPLODE": {
+        "documentation": "Shoot particles out in all directions, using the burst parameters."
+    },
+    "@sl-slua/global/PSYS_SRC_TARGET_KEY": {
+        "documentation": "The key of a target object to move towards if PSYS_PART_TARGET_POS_MASK is enabled."
+    },
+    "@sl-slua/global/PSYS_SRC_TEXTURE": {
+        "documentation": "An asset name for the texture to use for the particles."
+    },
+    "@sl-slua/global/PUBLIC_CHANNEL": {
+        "documentation": "PUBLIC_CHANNEL is an integer constant that, when passed to llSay, llWhisper, or llShout as a channel parameter, will print text to the publicly heard chat channel."
+    },
+    "@sl-slua/global/PURSUIT_FUZZ_FACTOR": {
+        "documentation": "Selects a random destination near the offset."
+    },
+    "@sl-slua/global/PURSUIT_GOAL_TOLERANCE": {
+        "documentation": "PURSUIT_GOAL_TOLERANCE constant"
+    },
+    "@sl-slua/global/PURSUIT_INTERCEPT": {
+        "documentation": "Define whether the character attempts to predict the target's location."
+    },
+    "@sl-slua/global/PURSUIT_OFFSET": {
+        "documentation": "Go to a position offset from the target."
+    },
+    "@sl-slua/global/PU_EVADE_HIDDEN": {
+        "documentation": "Triggered when an llEvade character thinks it has hidden from its pursuer."
+    },
+    "@sl-slua/global/PU_EVADE_SPOTTED": {
+        "documentation": "Triggered when an llEvade character switches from hiding to running"
+    },
+    "@sl-slua/global/PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED": {
+        "documentation": "PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED constant"
+    },
+    "@sl-slua/global/PU_FAILURE_INVALID_GOAL": {
+        "documentation": "Goal is not on the navigation-mesh and cannot be reached."
+    },
+    "@sl-slua/global/PU_FAILURE_INVALID_START": {
+        "documentation": "Character cannot navigate from the current location - e.g., the character is off the navmesh or too high above it."
+    },
+    "@sl-slua/global/PU_FAILURE_NO_NAVMESH": {
+        "documentation": "This is a fatal error reported to a character when there is no navmesh for the region. This usually indicates a server failure and users should file a bug report and include the time and region in which they received this message."
+    },
+    "@sl-slua/global/PU_FAILURE_NO_VALID_DESTINATION": {
+        "documentation": "There is no good place for the character to go - e.g., it is patrolling and all the patrol points are now unreachable."
+    },
+    "@sl-slua/global/PU_FAILURE_OTHER": {
+        "documentation": "PU_FAILURE_OTHER constant"
+    },
+    "@sl-slua/global/PU_FAILURE_PARCEL_UNREACHABLE": {
+        "documentation": "PU_FAILURE_PARCEL_UNREACHABLE constant"
+    },
+    "@sl-slua/global/PU_FAILURE_TARGET_GONE": {
+        "documentation": "Target (for llPursue or llEvade) can no longer be tracked - e.g., it left the region or is an avatar that is now more than about 30m outside the region."
+    },
+    "@sl-slua/global/PU_FAILURE_UNREACHABLE": {
+        "documentation": "Goal is no longer reachable for some reason - e.g., an obstacle blocks the path."
+    },
+    "@sl-slua/global/PU_GOAL_REACHED": {
+        "documentation": "Character has reached the goal and will stop or choose a new goal (if wandering)."
+    },
+    "@sl-slua/global/PU_SLOWDOWN_DISTANCE_REACHED": {
+        "documentation": "Character is near current goal."
+    },
+    "@sl-slua/global/RAD_TO_DEG": {
+        "documentation": "57.2957795 - Number of degrees per radian. You can use this number to convert radians to degrees by multiplying the radians by this number."
+    },
+    "@sl-slua/global/RCERR_CAST_TIME_EXCEEDED": {
+        "documentation": "RCERR_CAST_TIME_EXCEEDED constant"
+    },
+    "@sl-slua/global/RCERR_SIM_PERF_LOW": {
+        "documentation": "RCERR_SIM_PERF_LOW constant"
+    },
+    "@sl-slua/global/RCERR_UNKNOWN": {
+        "documentation": "RCERR_UNKNOWN constant"
+    },
+    "@sl-slua/global/RC_DATA_FLAGS": {
+        "documentation": "RC_DATA_FLAGS constant"
+    },
+    "@sl-slua/global/RC_DETECT_PHANTOM": {
+        "documentation": "RC_DETECT_PHANTOM constant"
+    },
+    "@sl-slua/global/RC_GET_LINK_NUM": {
+        "documentation": "RC_GET_LINK_NUM constant"
+    },
+    "@sl-slua/global/RC_GET_NORMAL": {
+        "documentation": "RC_GET_NORMAL constant"
+    },
+    "@sl-slua/global/RC_GET_ROOT_KEY": {
+        "documentation": "RC_GET_ROOT_KEY constant"
+    },
+    "@sl-slua/global/RC_MAX_HITS": {
+        "documentation": "RC_MAX_HITS constant"
+    },
+    "@sl-slua/global/RC_REJECT_AGENTS": {
+        "documentation": "RC_REJECT_AGENTS constant"
+    },
+    "@sl-slua/global/RC_REJECT_LAND": {
+        "documentation": "RC_REJECT_LAND constant"
+    },
+    "@sl-slua/global/RC_REJECT_NONPHYSICAL": {
+        "documentation": "RC_REJECT_NONPHYSICAL constant"
+    },
+    "@sl-slua/global/RC_REJECT_PHYSICAL": {
+        "documentation": "RC_REJECT_PHYSICAL constant"
+    },
+    "@sl-slua/global/RC_REJECT_TYPES": {
+        "documentation": "RC_REJECT_TYPES constant"
+    },
+    "@sl-slua/global/REGION_FLAG_ALLOW_DAMAGE": {
+        "documentation": "REGION_FLAG_ALLOW_DAMAGE constant"
+    },
+    "@sl-slua/global/REGION_FLAG_ALLOW_DIRECT_TELEPORT": {
+        "documentation": "REGION_FLAG_ALLOW_DIRECT_TELEPORT constant"
+    },
+    "@sl-slua/global/REGION_FLAG_BLOCK_FLY": {
+        "documentation": "REGION_FLAG_BLOCK_FLY constant"
+    },
+    "@sl-slua/global/REGION_FLAG_BLOCK_FLYOVER": {
+        "documentation": "REGION_FLAG_BLOCK_FLYOVER constant"
+    },
+    "@sl-slua/global/REGION_FLAG_BLOCK_TERRAFORM": {
+        "documentation": "REGION_FLAG_BLOCK_TERRAFORM constant"
+    },
+    "@sl-slua/global/REGION_FLAG_DISABLE_COLLISIONS": {
+        "documentation": "REGION_FLAG_DISABLE_COLLISIONS constant"
+    },
+    "@sl-slua/global/REGION_FLAG_DISABLE_PHYSICS": {
+        "documentation": "REGION_FLAG_DISABLE_PHYSICS constant"
+    },
+    "@sl-slua/global/REGION_FLAG_FIXED_SUN": {
+        "documentation": "REGION_FLAG_FIXED_SUN constant"
+    },
+    "@sl-slua/global/REGION_FLAG_RESTRICT_PUSHOBJECT": {
+        "documentation": "REGION_FLAG_RESTRICT_PUSHOBJECT constant"
+    },
+    "@sl-slua/global/REGION_FLAG_SANDBOX": {
+        "documentation": "REGION_FLAG_SANDBOX constant"
+    },
+    "@sl-slua/global/REMOTE_DATA_CHANNEL": {
+        "documentation": "REMOTE_DATA_CHANNEL constant"
+    },
+    "@sl-slua/global/REMOTE_DATA_REPLY": {
+        "documentation": "REMOTE_DATA_REPLY constant"
+    },
+    "@sl-slua/global/REMOTE_DATA_REQUEST": {
+        "documentation": "REMOTE_DATA_REQUEST constant"
+    },
+    "@sl-slua/global/REQUIRE_LINE_OF_SIGHT": {
+        "documentation": "Define whether the character needs a line-of-sight to give chase."
+    },
+    "@sl-slua/global/RESTITUTION": {
+        "documentation": "Used with llSetPhysicsMaterial to enable the density value. Must be between 0.0 and 1.0"
+    },
+    "@sl-slua/global/REVERSE": {
+        "documentation": "Play animation in reverse direction."
+    },
+    "@sl-slua/global/REZ_ACCEL": {
+        "documentation": "Acceleration forced applied to the rezzed object. [vector force, integer rel]"
+    },
+    "@sl-slua/global/REZ_DAMAGE": {
+        "documentation": "Damage applied by the object when it collides with an agent. [float damage]"
+    },
+    "@sl-slua/global/REZ_DAMAGE_TYPE": {
+        "documentation": "Set the damage type applied when this object collides. [integer damage_type]"
+    },
+    "@sl-slua/global/REZ_FLAGS": {
+        "documentation": "Rez flags to set on the newly rezzed object. [integer flags]"
+    },
+    "@sl-slua/global/REZ_FLAG_BLOCK_GRAB_OBJECT": {
+        "documentation": "Prevent grabbing the object."
+    },
+    "@sl-slua/global/REZ_FLAG_DIE_ON_COLLIDE": {
+        "documentation": "Object will die after its first collision."
+    },
+    "@sl-slua/global/REZ_FLAG_DIE_ON_NOENTRY": {
+        "documentation": "Object will die if it attempts to enter a parcel that it can not."
+    },
+    "@sl-slua/global/REZ_FLAG_NO_COLLIDE_FAMILY": {
+        "documentation": "Object will not trigger collision events with other objects created by the same rezzer."
+    },
+    "@sl-slua/global/REZ_FLAG_NO_COLLIDE_OWNER": {
+        "documentation": "Object will not trigger collision events with its owner."
+    },
+    "@sl-slua/global/REZ_FLAG_PHANTOM": {
+        "documentation": "Make the object phantom on rez."
+    },
+    "@sl-slua/global/REZ_FLAG_PHYSICAL": {
+        "documentation": "Make the object physical on rez."
+    },
+    "@sl-slua/global/REZ_FLAG_TEMP": {
+        "documentation": "Flag the object as temp on rez."
+    },
+    "@sl-slua/global/REZ_LOCK_AXES": {
+        "documentation": "Prevent the object from rotating around some axes. [vector locks]"
+    },
+    "@sl-slua/global/REZ_OMEGA": {
+        "documentation": "Omega applied to the rezzed object. [vector axis, integer rel, float spin, float gain]"
+    },
+    "@sl-slua/global/REZ_PARAM": {
+        "documentation": "Integer value to pass to the object as its rez parameter. [integer param]"
+    },
+    "@sl-slua/global/REZ_PARAM_STRING": {
+        "documentation": "A string value to pass to the object as its rez parameter. [string param]"
+    },
+    "@sl-slua/global/REZ_POS": {
+        "documentation": "Position at which to rez the new object. [vector position, integer rel, integer atroot]"
+    },
+    "@sl-slua/global/REZ_ROT": {
+        "documentation": "Rotation applied to newly rezzed object. [rotation rot, integer rel]"
+    },
+    "@sl-slua/global/REZ_SOUND": {
+        "documentation": "Sound attached to the rezzed object. [string name, float volume, integer loop]"
+    },
+    "@sl-slua/global/REZ_SOUND_COLLIDE": {
+        "documentation": "Sound played by the object on a collision. [string name, float volume]"
+    },
+    "@sl-slua/global/REZ_VEL": {
+        "documentation": "Initial velocity of rezzed object. [vector vel, integer rel, integer inherit]"
+    },
+    "@sl-slua/global/ROTATE": {
+        "documentation": "Animate texture rotation."
+    },
+    "@sl-slua/global/SCALE": {
+        "documentation": "Animate the texture scale."
+    },
+    "@sl-slua/global/SCRIPTED": {
+        "documentation": "Scripted in-world objects."
+    },
+    "@sl-slua/global/SIM_STAT_ACTIVE_SCRIPT_COUNT": {
+        "documentation": "Number of active scripts."
+    },
+    "@sl-slua/global/SIM_STAT_AGENT_COUNT": {
+        "documentation": "Number of agents in region."
+    },
+    "@sl-slua/global/SIM_STAT_AGENT_MS": {
+        "documentation": "Time spent in 'agent' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_AGENT_UPDATES": {
+        "documentation": "Agent updates per second."
+    },
+    "@sl-slua/global/SIM_STAT_AI_MS": {
+        "documentation": "Time spent on AI step."
+    },
+    "@sl-slua/global/SIM_STAT_ASSET_DOWNLOADS": {
+        "documentation": "Pending asset download count."
+    },
+    "@sl-slua/global/SIM_STAT_ASSET_UPLOADS": {
+        "documentation": "Pending asset upload count."
+    },
+    "@sl-slua/global/SIM_STAT_CHILD_AGENT_COUNT": {
+        "documentation": "Number of child agents in region."
+    },
+    "@sl-slua/global/SIM_STAT_FRAME_MS": {
+        "documentation": "Total frame time."
+    },
+    "@sl-slua/global/SIM_STAT_IMAGE_MS": {
+        "documentation": "Time spent in 'image' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_IO_PUMP_MS": {
+        "documentation": "Pump IO time."
+    },
+    "@sl-slua/global/SIM_STAT_NET_MS": {
+        "documentation": "Time spent in 'network' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_OTHER_MS": {
+        "documentation": "Time spent in 'other' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_PACKETS_IN": {
+        "documentation": "Packets in per second."
+    },
+    "@sl-slua/global/SIM_STAT_PACKETS_OUT": {
+        "documentation": "Packets out per second."
+    },
+    "@sl-slua/global/SIM_STAT_PCT_CHARS_STEPPED": {
+        "documentation": "Returns the % of pathfinding characters skipped each frame, averaged over the last minute.\\nThe returned value corresponds to the \"Characters Updated\" stat in the viewer's Statistics Bar."
+    },
+    "@sl-slua/global/SIM_STAT_PHYSICS_FPS": {
+        "documentation": "Physics simulation FPS."
+    },
+    "@sl-slua/global/SIM_STAT_PHYSICS_MS": {
+        "documentation": "Time spent in 'physics' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_PHYSICS_OTHER_MS": {
+        "documentation": "Physics other time."
+    },
+    "@sl-slua/global/SIM_STAT_PHYSICS_SHAPE_MS": {
+        "documentation": "Physics shape update time."
+    },
+    "@sl-slua/global/SIM_STAT_PHYSICS_STEP_MS": {
+        "documentation": "Physics step time."
+    },
+    "@sl-slua/global/SIM_STAT_SCRIPT_EPS": {
+        "documentation": "Script events per second."
+    },
+    "@sl-slua/global/SIM_STAT_SCRIPT_MS": {
+        "documentation": "Time spent in 'script' segment of simulation frame."
+    },
+    "@sl-slua/global/SIM_STAT_SCRIPT_RUN_PCT": {
+        "documentation": "Percent of scripts run during frame."
+    },
+    "@sl-slua/global/SIM_STAT_SLEEP_MS": {
+        "documentation": "Time spent sleeping."
+    },
+    "@sl-slua/global/SIM_STAT_SPARE_MS": {
+        "documentation": "Spare time left after frame."
+    },
+    "@sl-slua/global/SIM_STAT_UNACKED_BYTES": {
+        "documentation": "Total unacknowledged bytes."
+    },
+    "@sl-slua/global/SIT_FLAG_ALLOW_UNSIT": {
+        "documentation": "The prim allows a seated avatar to stand up."
+    },
+    "@sl-slua/global/SIT_FLAG_NO_COLLIDE": {
+        "documentation": "The seated avatar's hit box is disabled when seated on this prim."
+    },
+    "@sl-slua/global/SIT_FLAG_NO_DAMAGE": {
+        "documentation": "Damage will not be forwarded to an avatar seated on this prim."
+    },
+    "@sl-slua/global/SIT_FLAG_SCRIPTED_ONLY": {
+        "documentation": "An avatar may not manually sit on this prim."
+    },
+    "@sl-slua/global/SIT_FLAG_SIT_TARGET": {
+        "documentation": "The prim has an explicitly set sit target."
+    },
+    "@sl-slua/global/SIT_INVALID_AGENT": {
+        "documentation": "Avatar ID did not specify a valid avatar."
+    },
+    "@sl-slua/global/SIT_INVALID_LINK": {
+        "documentation": "Link ID did not specify a valid prim in the linkset or resolved to multiple prims."
+    },
+    "@sl-slua/global/SIT_INVALID_OBJECT": {
+        "documentation": "Attempt to force an avatar to sit on an attachment or other invalid target."
+    },
+    "@sl-slua/global/SIT_NOT_EXPERIENCE": {
+        "documentation": "Attempt to force an avatar to sit outside an experience."
+    },
+    "@sl-slua/global/SIT_NO_ACCESS": {
+        "documentation": "Avatar does not have access to the parcel containing the target linkset of the forced sit."
+    },
+    "@sl-slua/global/SIT_NO_EXPERIENCE_PERMISSION": {
+        "documentation": "Avatar has not granted permission to force sits."
+    },
+    "@sl-slua/global/SIT_NO_SIT_TARGET": {
+        "documentation": "No available sit target in linkset for forced sit."
+    },
+    "@sl-slua/global/SKY_AMBIENT": {
+        "documentation": "The ambient color of the environment"
+    },
+    "@sl-slua/global/SKY_BLUE": {
+        "documentation": "Blue settings for environment"
+    },
+    "@sl-slua/global/SKY_CLOUDS": {
+        "documentation": "Settings controlling cloud density and configuration"
+    },
+    "@sl-slua/global/SKY_CLOUD_TEXTURE": {
+        "documentation": "Texture ID used by clouds"
+    },
+    "@sl-slua/global/SKY_DOME": {
+        "documentation": "Sky dome information."
+    },
+    "@sl-slua/global/SKY_GAMMA": {
+        "documentation": "The gamma value applied to the scene."
+    },
+    "@sl-slua/global/SKY_GLOW": {
+        "documentation": "Glow color applied to the sun and moon."
+    },
+    "@sl-slua/global/SKY_HAZE": {
+        "documentation": "Haze settings for environment"
+    },
+    "@sl-slua/global/SKY_LIGHT": {
+        "documentation": "Miscellaneous lighting values."
+    },
+    "@sl-slua/global/SKY_MOON": {
+        "documentation": "Environmental moon details."
+    },
+    "@sl-slua/global/SKY_MOON_TEXTURE": {
+        "documentation": "Environmental moon texture."
+    },
+    "@sl-slua/global/SKY_PLANET": {
+        "documentation": "Planet information used in rendering the sky."
+    },
+    "@sl-slua/global/SKY_REFLECTION_PROBE_AMBIANCE": {
+        "documentation": "Settings the ambience of the reflection probe."
+    },
+    "@sl-slua/global/SKY_REFRACTION": {
+        "documentation": "Sky refraction parameters for rainbows and optical effects."
+    },
+    "@sl-slua/global/SKY_STAR_BRIGHTNESS": {
+        "documentation": "Brightness value for the stars."
+    },
+    "@sl-slua/global/SKY_SUN": {
+        "documentation": "Detailed sun information"
+    },
+    "@sl-slua/global/SKY_SUN_TEXTURE": {
+        "documentation": "Environmental sun texture"
+    },
+    "@sl-slua/global/SKY_TEXTURE_DEFAULTS": {
+        "documentation": "Is the environment using the default textures."
+    },
+    "@sl-slua/global/SKY_TRACKS": {
+        "documentation": "Track elevations for this region."
+    },
+    "@sl-slua/global/SMOOTH": {
+        "documentation": "Slide in the X direction, instead of playing separate frames."
+    },
+    "@sl-slua/global/SOUND_LOOP": {
+        "documentation": "Sound will loop until stopped."
+    },
+    "@sl-slua/global/SOUND_PLAY": {
+        "documentation": "Sound will play normally."
+    },
+    "@sl-slua/global/SOUND_SYNC": {
+        "documentation": "Sound will be synchronized with the nearest master."
+    },
+    "@sl-slua/global/SOUND_TRIGGER": {
+        "documentation": "Sound will be triggered at the prim's location and not attached."
+    },
+    "@sl-slua/global/SQRT2": {
+        "documentation": "1.41421356 - The square root of 2."
+    },
+    "@sl-slua/global/STATUS_BLOCK_GRAB": {
+        "documentation": "Controls whether the object can be grabbed.\\nA grab is the default action when in third person, and is available as the hand tool in build mode. This is useful for physical objects that you don't want other people to be able to trivially disturb. The default is FALSE"
+    },
+    "@sl-slua/global/STATUS_BLOCK_GRAB_OBJECT": {
+        "documentation": "Prevent click-and-drag movement on all prims in the object."
+    },
+    "@sl-slua/global/STATUS_BOUNDS_ERROR": {
+        "documentation": "Argument(s) passed to function had a bounds error."
+    },
+    "@sl-slua/global/STATUS_CAST_SHADOWS": {
+        "documentation": "STATUS_CAST_SHADOWS constant"
+    },
+    "@sl-slua/global/STATUS_DIE_AT_EDGE": {
+        "documentation": "Controls whether the object is returned to the owner's inventory if it wanders off the edge of the world.\\nIt is useful to set this status TRUE for things like bullets or rockets. The default is TRUE"
+    },
+    "@sl-slua/global/STATUS_DIE_AT_NO_ENTRY": {
+        "documentation": "Controls whether the object dies if it attempts to enter a parcel that does not allow object entry or does not have enough capacity.\\nIt is useful to set this status TRUE for things like bullets or rockets. The default is FALSE"
+    },
+    "@sl-slua/global/STATUS_INTERNAL_ERROR": {
+        "documentation": "An internal error occurred."
+    },
+    "@sl-slua/global/STATUS_MALFORMED_PARAMS": {
+        "documentation": "Function was called with malformed parameters."
+    },
+    "@sl-slua/global/STATUS_NOT_FOUND": {
+        "documentation": "Object or other item was not found."
+    },
+    "@sl-slua/global/STATUS_NOT_SUPPORTED": {
+        "documentation": "Feature not supported."
+    },
+    "@sl-slua/global/STATUS_OK": {
+        "documentation": "Result of function call was a success."
+    },
+    "@sl-slua/global/STATUS_PHANTOM": {
+        "documentation": "Controls/indicates whether the object collides or not.\\nSetting the value to TRUE makes the object non-colliding with all objects. It is a good idea to use this for most objects that move or rotate, but are non-physical. It is also useful for simulating volumetric lighting. The default is FALSE."
+    },
+    "@sl-slua/global/STATUS_PHYSICS": {
+        "documentation": "Controls/indicates whether the object moves physically.\\nThis controls the same flag that the UI check-box for Physical controls. The default is FALSE."
+    },
+    "@sl-slua/global/STATUS_RETURN_AT_EDGE": {
+        "documentation": "STATUS_RETURN_AT_EDGE constant"
+    },
+    "@sl-slua/global/STATUS_ROTATE_X": {
+        "documentation": "STATUS_ROTATE_X constant"
+    },
+    "@sl-slua/global/STATUS_ROTATE_Y": {
+        "documentation": "STATUS_ROTATE_Y constant"
+    },
+    "@sl-slua/global/STATUS_ROTATE_Z": {
+        "documentation": "Controls/indicates whether the object can physically rotate around\\n\t\t\tthe specific axis or not. This flag has no meaning\\n\t\t\tfor non-physical objects. Set the value to FALSE\\n\t\t\tif you want to disable rotation around that axis. The\\n\t\t\tdefault is TRUE for a physical object.\\n\t\t\tA useful example to think about when visualizing\\n\t\t\tthe effect is a sit-and-spin device. They spin around the\\n\t\t\tZ axis (up) but not around the X or Y axis."
+    },
+    "@sl-slua/global/STATUS_SANDBOX": {
+        "documentation": "Controls/indicates whether the object can cross region boundaries\\n\t\t\tand move more than 20 meters from its creation\\n\t\t\tpoint. The default if FALSE."
+    },
+    "@sl-slua/global/STATUS_TYPE_MISMATCH": {
+        "documentation": "Argument(s) passed to function had a type mismatch."
+    },
+    "@sl-slua/global/STATUS_WHITELIST_FAILED": {
+        "documentation": "Whitelist Failed."
+    },
+    "@sl-slua/global/STRING_TRIM": {
+        "documentation": "STRING_TRIM constant"
+    },
+    "@sl-slua/global/STRING_TRIM_HEAD": {
+        "documentation": "STRING_TRIM_HEAD constant"
+    },
+    "@sl-slua/global/STRING_TRIM_TAIL": {
+        "documentation": "STRING_TRIM_TAIL constant"
+    },
+    "@sl-slua/global/TARGETED_EMAIL_OBJECT_OWNER": {
+        "documentation": "Send email to the owner of the object"
+    },
+    "@sl-slua/global/TARGETED_EMAIL_ROOT_CREATOR": {
+        "documentation": "Send email to the creator of the root object"
+    },
+    "@sl-slua/global/TERRAIN_DETAIL_1": {
+        "documentation": "TERRAIN_DETAIL_1 constant"
+    },
+    "@sl-slua/global/TERRAIN_DETAIL_2": {
+        "documentation": "TERRAIN_DETAIL_2 constant"
+    },
+    "@sl-slua/global/TERRAIN_DETAIL_3": {
+        "documentation": "TERRAIN_DETAIL_3 constant"
+    },
+    "@sl-slua/global/TERRAIN_DETAIL_4": {
+        "documentation": "TERRAIN_DETAIL_4 constant"
+    },
+    "@sl-slua/global/TERRAIN_HEIGHT_RANGE_NE": {
+        "documentation": "TERRAIN_HEIGHT_RANGE_NE constant"
+    },
+    "@sl-slua/global/TERRAIN_HEIGHT_RANGE_NW": {
+        "documentation": "TERRAIN_HEIGHT_RANGE_NW constant"
+    },
+    "@sl-slua/global/TERRAIN_HEIGHT_RANGE_SE": {
+        "documentation": "TERRAIN_HEIGHT_RANGE_SE constant"
+    },
+    "@sl-slua/global/TERRAIN_HEIGHT_RANGE_SW": {
+        "documentation": "TERRAIN_HEIGHT_RANGE_SW constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_OFFSET_1": {
+        "documentation": "TERRAIN_PBR_OFFSET_1 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_OFFSET_2": {
+        "documentation": "TERRAIN_PBR_OFFSET_2 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_OFFSET_3": {
+        "documentation": "TERRAIN_PBR_OFFSET_3 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_OFFSET_4": {
+        "documentation": "TERRAIN_PBR_OFFSET_4 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_ROTATION_1": {
+        "documentation": "TERRAIN_PBR_ROTATION_1 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_ROTATION_2": {
+        "documentation": "TERRAIN_PBR_ROTATION_2 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_ROTATION_3": {
+        "documentation": "TERRAIN_PBR_ROTATION_3 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_ROTATION_4": {
+        "documentation": "TERRAIN_PBR_ROTATION_4 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_SCALE_1": {
+        "documentation": "TERRAIN_PBR_SCALE_1 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_SCALE_2": {
+        "documentation": "TERRAIN_PBR_SCALE_2 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_SCALE_3": {
+        "documentation": "TERRAIN_PBR_SCALE_3 constant"
+    },
+    "@sl-slua/global/TERRAIN_PBR_SCALE_4": {
+        "documentation": "TERRAIN_PBR_SCALE_4 constant"
+    },
+    "@sl-slua/global/TEXTURE_BLANK": {
+        "documentation": "TEXTURE_BLANK constant"
+    },
+    "@sl-slua/global/TEXTURE_DEFAULT": {
+        "documentation": "TEXTURE_DEFAULT constant"
+    },
+    "@sl-slua/global/TEXTURE_MEDIA": {
+        "documentation": "TEXTURE_MEDIA constant"
+    },
+    "@sl-slua/global/TEXTURE_PLYWOOD": {
+        "documentation": "TEXTURE_PLYWOOD constant"
+    },
+    "@sl-slua/global/TEXTURE_TRANSPARENT": {
+        "documentation": "TEXTURE_TRANSPARENT constant"
+    },
+    "@sl-slua/global/TOUCH_INVALID_FACE": {
+        "documentation": "TOUCH_INVALID_FACE constant"
+    },
+    "@sl-slua/global/TOUCH_INVALID_TEXCOORD": {
+        "documentation": "TOUCH_INVALID_TEXCOORD constant"
+    },
+    "@sl-slua/global/TOUCH_INVALID_VECTOR": {
+        "documentation": "TOUCH_INVALID_VECTOR constant"
+    },
+    "@sl-slua/global/TP_ROUTING_BLOCKED": {
+        "documentation": "Direct teleporting is blocked on this parcel."
+    },
+    "@sl-slua/global/TP_ROUTING_FREE": {
+        "documentation": "Teleports are unrestricted on this parcel."
+    },
+    "@sl-slua/global/TP_ROUTING_LANDINGP": {
+        "documentation": "Teleports are routed to a landing point if set on this parcel."
+    },
+    "@sl-slua/global/TRANSFER_BAD_OPTS": {
+        "documentation": "Invalid inventory options."
+    },
+    "@sl-slua/global/TRANSFER_BAD_ROOT": {
+        "documentation": "The root path specified in TRANSFER_DEST contained an invalid directory or was reduced to nothing."
+    },
+    "@sl-slua/global/TRANSFER_DEST": {
+        "documentation": "The root folder to transfer inventory into."
+    },
+    "@sl-slua/global/TRANSFER_FLAGS": {
+        "documentation": "Flags to control the behavior of inventory transfer."
+    },
+    "@sl-slua/global/TRANSFER_FLAG_COPY": {
+        "documentation": "Gives a copy of the object being transfered. Implies TRANSFER_FLAG_TAKE."
+    },
+    "@sl-slua/global/TRANSFER_FLAG_RESERVED": {
+        "documentation": "Reserved for future expansion."
+    },
+    "@sl-slua/global/TRANSFER_FLAG_TAKE": {
+        "documentation": "On a successful transfer, automatically takes the object into inventory."
+    },
+    "@sl-slua/global/TRANSFER_NO_ATTACHMENT": {
+        "documentation": "Can not transfer ownership of an attached object."
+    },
+    "@sl-slua/global/TRANSFER_NO_ITEMS": {
+        "documentation": "No items in the inventory list are eligible for transfer."
+    },
+    "@sl-slua/global/TRANSFER_NO_PERMS": {
+        "documentation": "The object does not have transfer permissions."
+    },
+    "@sl-slua/global/TRANSFER_NO_TARGET": {
+        "documentation": "Could not find the receiver in the current region."
+    },
+    "@sl-slua/global/TRANSFER_OK": {
+        "documentation": "Inventory transfer offer was successfully made."
+    },
+    "@sl-slua/global/TRANSFER_THROTTLE": {
+        "documentation": "Inventory throttle hit."
+    },
+    "@sl-slua/global/TRAVERSAL_TYPE": {
+        "documentation": "One of TRAVERSAL_TYPE_FAST, TRAVERSAL_TYPE_SLOW, and TRAVERSAL_TYPE_NONE."
+    },
+    "@sl-slua/global/TRAVERSAL_TYPE_FAST": {
+        "documentation": "TRAVERSAL_TYPE_FAST constant"
+    },
+    "@sl-slua/global/TRAVERSAL_TYPE_NONE": {
+        "documentation": "TRAVERSAL_TYPE_NONE constant"
+    },
+    "@sl-slua/global/TRAVERSAL_TYPE_SLOW": {
+        "documentation": "TRAVERSAL_TYPE_SLOW constant"
+    },
+    "@sl-slua/global/TWO_PI": {
+        "documentation": "6.28318530 - The radians of a circle."
+    },
+    "@sl-slua/global/TYPE_FLOAT": {
+        "documentation": "The list entry is a float."
+    },
+    "@sl-slua/global/TYPE_INTEGER": {
+        "documentation": "The list entry is an integer."
+    },
+    "@sl-slua/global/TYPE_INVALID": {
+        "documentation": "The list entry is invalid."
+    },
+    "@sl-slua/global/TYPE_KEY": {
+        "documentation": "The list entry is a key."
+    },
+    "@sl-slua/global/TYPE_ROTATION": {
+        "documentation": "The list entry is a rotation."
+    },
+    "@sl-slua/global/TYPE_STRING": {
+        "documentation": "The list entry is a string."
+    },
+    "@sl-slua/global/TYPE_VECTOR": {
+        "documentation": "The list entry is a vector."
+    },
+    "@sl-slua/global/URL_REQUEST_DENIED": {
+        "documentation": "URL_REQUEST_DENIED constant"
+    },
+    "@sl-slua/global/URL_REQUEST_GRANTED": {
+        "documentation": "URL_REQUEST_GRANTED constant"
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY": {
+        "documentation": "A slider between minimum (0.0) and maximum (1.0) deflection of angular orientation. That is, its a simple scalar for modulating the strength of angular deflection such that the vehicles preferred axis of motion points toward its real velocity."
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_DEFLECTION_TIMESCALE": {
+        "documentation": "The time-scale for exponential success of linear deflection deflection. Its another way to specify the strength of the vehicles tendency to reorient itself so that its preferred axis of motion agrees with its true velocity."
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_FRICTION_TIMESCALE": {
+        "documentation": "A vector of timescales for exponential decay of the vehicle's angular velocity about its preferred axes of motion (at, left, up).\\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE": {
+        "documentation": "The timescale for exponential decay of the angular motors magnitude."
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_MOTOR_DIRECTION": {
+        "documentation": "The direction and magnitude (in preferred frame) of the vehicle's angular motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor."
+    },
+    "@sl-slua/global/VEHICLE_ANGULAR_MOTOR_TIMESCALE": {
+        "documentation": "The timescale for exponential approach to full angular motor velocity."
+    },
+    "@sl-slua/global/VEHICLE_BANKING_EFFICIENCY": {
+        "documentation": "A slider between anti (-1.0), none (0.0), and maxmum (1.0) banking strength."
+    },
+    "@sl-slua/global/VEHICLE_BANKING_MIX": {
+        "documentation": "A slider between static (0.0) and dynamic (1.0) banking. \"Static\" means the banking scales only with the angle of roll, whereas \"dynamic\" is a term that also scales with the vehicles linear speed."
+    },
+    "@sl-slua/global/VEHICLE_BANKING_TIMESCALE": {
+        "documentation": "The timescale for banking to exponentially approach its maximum effect. This is another way to scale the strength of the banking effect, however it affects the term that is proportional to the difference between what the banking behavior is trying to do, and what the vehicle is actually doing."
+    },
+    "@sl-slua/global/VEHICLE_BUOYANCY": {
+        "documentation": "A slider between minimum (0.0) and maximum anti-gravity (1.0)."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_BLOCK_INTERFERENCE": {
+        "documentation": "Prevent other scripts from pushing vehicle."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_CAMERA_DECOUPLED": {
+        "documentation": "VEHICLE_FLAG_CAMERA_DECOUPLED constant"
+    },
+    "@sl-slua/global/VEHICLE_FLAG_HOVER_GLOBAL_HEIGHT": {
+        "documentation": "Hover at global height."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_HOVER_TERRAIN_ONLY": {
+        "documentation": "Ignore water height when hovering."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_HOVER_UP_ONLY": {
+        "documentation": "Hover does not push down. Use this flag for hovering vehicles that should be able to jump above their hover height."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_HOVER_WATER_ONLY": {
+        "documentation": "Ignore terrain height when hovering."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_LIMIT_MOTOR_UP": {
+        "documentation": "Prevents ground vehicles from motoring into the sky."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_LIMIT_ROLL_ONLY": {
+        "documentation": "For vehicles with vertical attractor that want to be able to climb/dive, for instance, aeroplanes that want to use the banking feature."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_MOUSELOOK_BANK": {
+        "documentation": "VEHICLE_FLAG_MOUSELOOK_BANK constant"
+    },
+    "@sl-slua/global/VEHICLE_FLAG_MOUSELOOK_STEER": {
+        "documentation": "VEHICLE_FLAG_MOUSELOOK_STEER constant"
+    },
+    "@sl-slua/global/VEHICLE_FLAG_NO_DEFLECTION_UP": {
+        "documentation": "This flag prevents linear deflection parallel to world z-axis. This is useful for preventing ground vehicles with large linear deflection, like bumper cars, from climbing their linear deflection into the sky."
+    },
+    "@sl-slua/global/VEHICLE_FLAG_NO_FLY_UP": {
+        "documentation": "Old, changed to VEHICLE_FLAG_NO_DEFLECTION_UP"
+    },
+    "@sl-slua/global/VEHICLE_HOVER_EFFICIENCY": {
+        "documentation": "A slider between minimum (0.0 = bouncy) and maximum (1.0 = fast as possible) damped motion of the hover behavior. "
+    },
+    "@sl-slua/global/VEHICLE_HOVER_HEIGHT": {
+        "documentation": "The height (above the terrain or water, or global) at which the vehicle will try to hover."
+    },
+    "@sl-slua/global/VEHICLE_HOVER_TIMESCALE": {
+        "documentation": "Period of time (in seconds) for the vehicle to achieve its hover height."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_DEFLECTION_EFFICIENCY": {
+        "documentation": "A slider between minimum (0.0) and maximum (1.0) deflection of linear velocity. That is, its a simple scalar for modulating the strength of linear deflection."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_DEFLECTION_TIMESCALE": {
+        "documentation": "The timescale for exponential success of linear deflection deflection. It is another way to specify how much time it takes for the vehicle's linear velocity to be redirected to its preferred axis of motion."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_FRICTION_TIMESCALE": {
+        "documentation": "A vector of timescales for exponential decay of the vehicle's linear velocity along its preferred axes of motion (at, left, up).\\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE": {
+        "documentation": "The timescale for exponential decay of the linear motors magnitude."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_MOTOR_DIRECTION": {
+        "documentation": "The direction and magnitude (in preferred frame) of the vehicle's linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.\\n\t\t\tRange of magnitude = [0, 30] meters/second."
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_MOTOR_OFFSET": {
+        "documentation": "VEHICLE_LINEAR_MOTOR_OFFSET constant"
+    },
+    "@sl-slua/global/VEHICLE_LINEAR_MOTOR_TIMESCALE": {
+        "documentation": "The timescale for exponential approach to full linear motor velocity."
+    },
+    "@sl-slua/global/VEHICLE_REFERENCE_FRAME": {
+        "documentation": "A rotation of the vehicle's preferred axes of motion and orientation (at, left, up) with respect to the vehicle's local frame (x, y, z)."
+    },
+    "@sl-slua/global/VEHICLE_TYPE_AIRPLANE": {
+        "documentation": "Uses linear deflection for lift, no hover, and banking to turn.\\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_AIRPLANE"
+    },
+    "@sl-slua/global/VEHICLE_TYPE_BALLOON": {
+        "documentation": "Hover, and friction, but no deflection.\\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BALLOON"
+    },
+    "@sl-slua/global/VEHICLE_TYPE_BOAT": {
+        "documentation": "Hovers over water with lots of friction and some anglar deflection.\\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BOAT"
+    },
+    "@sl-slua/global/VEHICLE_TYPE_CAR": {
+        "documentation": "Another vehicle that bounces along the ground but needs the motors to be driven from external controls or timer events.\\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_CAR"
+    },
+    "@sl-slua/global/VEHICLE_TYPE_NONE": {
+        "documentation": "VEHICLE_TYPE_NONE constant"
+    },
+    "@sl-slua/global/VEHICLE_TYPE_SLED": {
+        "documentation": "Simple vehicle that bumps along the ground, and likes to move along its local x-axis.\\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_SLED"
+    },
+    "@sl-slua/global/VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY": {
+        "documentation": "A slider between minimum (0.0 = wobbly) and maximum (1.0 = firm as possible) stability of the vehicle to keep itself upright."
+    },
+    "@sl-slua/global/VEHICLE_VERTICAL_ATTRACTION_TIMESCALE": {
+        "documentation": "The period of wobble, or timescale for exponential approach, of the vehicle to rotate such that its preferred \"up\" axis is oriented along the world's \"up\" axis."
+    },
+    "@sl-slua/global/VERTICAL": {
+        "documentation": "VERTICAL constant"
+    },
+    "@sl-slua/global/WANDER_PAUSE_AT_WAYPOINTS": {
+        "documentation": "WANDER_PAUSE_AT_WAYPOINTS constant"
+    },
+    "@sl-slua/global/WATER_BLUR_MULTIPLIER": {
+        "documentation": "Blur factor."
+    },
+    "@sl-slua/global/WATER_FOG": {
+        "documentation": "Fog properties when underwater."
+    },
+    "@sl-slua/global/WATER_FRESNEL": {
+        "documentation": "Fresnel scattering applied to the surface of the water."
+    },
+    "@sl-slua/global/WATER_NORMAL_SCALE": {
+        "documentation": "Scaling applied to the water normal map."
+    },
+    "@sl-slua/global/WATER_NORMAL_TEXTURE": {
+        "documentation": "Normal map used for environmental waves."
+    },
+    "@sl-slua/global/WATER_REFRACTION": {
+        "documentation": "Refraction factors when looking through the surface of the water."
+    },
+    "@sl-slua/global/WATER_TEXTURE_DEFAULTS": {
+        "documentation": "Is the environment using the default wave map."
+    },
+    "@sl-slua/global/WATER_WAVE_DIRECTION": {
+        "documentation": "Vectors for the directions of the waves."
+    },
+    "@sl-slua/global/XP_ERROR_EXPERIENCES_DISABLED": {
+        "documentation": "The region currently has experiences disabled."
+    },
+    "@sl-slua/global/XP_ERROR_EXPERIENCE_DISABLED": {
+        "documentation": "The experience owner has temporarily disabled the experience."
+    },
+    "@sl-slua/global/XP_ERROR_EXPERIENCE_SUSPENDED": {
+        "documentation": "The experience has been suspended by Linden Customer Support."
+    },
+    "@sl-slua/global/XP_ERROR_INVALID_EXPERIENCE": {
+        "documentation": "The script is associated with an experience that no longer exists."
+    },
+    "@sl-slua/global/XP_ERROR_INVALID_PARAMETERS": {
+        "documentation": "One of the string arguments was too big to fit in the key-value store."
+    },
+    "@sl-slua/global/XP_ERROR_KEY_NOT_FOUND": {
+        "documentation": "The requested key does not exist."
+    },
+    "@sl-slua/global/XP_ERROR_MATURITY_EXCEEDED": {
+        "documentation": "The content rating of the experience exceeds that of the region."
+    },
+    "@sl-slua/global/XP_ERROR_NONE": {
+        "documentation": "No error was detected."
+    },
+    "@sl-slua/global/XP_ERROR_NOT_FOUND": {
+        "documentation": "The sim was unable to verify the validity of the experience. Retrying after a short wait is advised."
+    },
+    "@sl-slua/global/XP_ERROR_NOT_PERMITTED": {
+        "documentation": "This experience is not allowed to run by the requested agent."
+    },
+    "@sl-slua/global/XP_ERROR_NOT_PERMITTED_LAND": {
+        "documentation": "This experience is not allowed to run on the current region."
+    },
+    "@sl-slua/global/XP_ERROR_NO_EXPERIENCE": {
+        "documentation": "This script is not associated with an experience."
+    },
+    "@sl-slua/global/XP_ERROR_QUOTA_EXCEEDED": {
+        "documentation": "An attempted write data to the key-value store failed due to the data quota being met."
+    },
+    "@sl-slua/global/XP_ERROR_REQUEST_PERM_TIMEOUT": {
+        "documentation": "Request timed out; permissions not modified."
+    },
+    "@sl-slua/global/XP_ERROR_RETRY_UPDATE": {
+        "documentation": "A checked update failed due to an out of date request."
+    },
+    "@sl-slua/global/XP_ERROR_STORAGE_EXCEPTION": {
+        "documentation": "Unable to communicate with the key-value store."
+    },
+    "@sl-slua/global/XP_ERROR_STORE_DISABLED": {
+        "documentation": "The key-value store is currently disabled on this region."
+    },
+    "@sl-slua/global/XP_ERROR_THROTTLED": {
+        "documentation": "The call failed due to too many recent calls."
+    },
+    "@sl-slua/global/XP_ERROR_UNKNOWN_ERROR": {
+        "documentation": "Other unknown error."
+    },
+    "@sl-slua/global/ZERO_ROTATION": {
+        "documentation": "ZERO_ROTATION constant"
+    },
+    "@sl-slua/global/ZERO_VECTOR": {
+        "documentation": "ZERO_VECTOR constant"
+    },
+    "@sl-slua/global/default": {
+        "documentation": "All scripts must have a default state, which is the first state entered when the script starts.\\nIf another state is defined before the default state, the compiler will report a syntax error."
+    }
+}

--- a/indra/newview/app_settings/slua_default.yml
+++ b/indra/newview/app_settings/slua_default.yml
@@ -1,8 +1,8 @@
 base: luau
 name: SLua LSL language support
 lua_versions:
-  - luau
-  - lua51
+- luau
+- lua51
 last_updated: 1763572449
 globals:
   getfenv:
@@ -17,7 +17,8 @@ globals:
   ACTIVE:
     property: read-only
     type: number
-    description: Objects in world that are running a script or currently physically moving.
+    description: Objects in world that are running a script or currently physically
+      moving.
   AGENT:
     property: read-only
     type: number
@@ -69,9 +70,8 @@ globals:
   AGENT_LIST_PARCEL_OWNER:
     property: read-only
     type: number
-    description: >-
-      Agents on any parcel in the region where the parcel owner is the same as
-      the owner of the parcel under the scripted object.
+    description: Agents on any parcel in the region where the parcel owner is the
+      same as the owner of the parcel under the scripted object.
   AGENT_LIST_REGION:
     property: read-only
     type: number
@@ -338,9 +338,8 @@ globals:
   BEACON_MAP:
     property: read-only
     type: number
-    description: >-
-      Cause llMapBeacon to optionally display and focus the world map on the
-      avatar's viewer.
+    description: Cause llMapBeacon to optionally display and focus the world map on
+      the avatar's viewer.
   CAMERA_ACTIVE:
     property: read-only
     type: number
@@ -386,9 +385,8 @@ globals:
   CHANGED_ALLOWED_DROP:
     property: read-only
     type: number
-    description: >-
-      The object inventory has changed because an item was added through the
-      llAllowInventoryDrop interface.
+    description: The object inventory has changed because an item was added through
+      the llAllowInventoryDrop interface.
   CHANGED_COLOR:
     property: read-only
     type: number
@@ -435,30 +433,26 @@ globals:
   CHANGED_TEXTURE:
     property: read-only
     type: number
-    description: >-
-      The texture offset, scale rotation, or simply the object texture has
-      changed.
+    description: The texture offset, scale rotation, or simply the object texture
+      has changed.
   CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES:
     property: read-only
     type: number
-    description: >-
-      If set to false, character will not attempt to catch up on lost time when
-      pathfinding performance is low, potentially providing more reliable
-      movement (albeit while potentially appearing to be more stuttery). Default
-      is true to match pre-existing behavior.
+    description: If set to false, character will not attempt to catch up on lost time
+      when pathfinding performance is low, potentially providing more reliable movement
+      (albeit while potentially appearing to be more stuttery). Default is true to
+      match pre-existing behavior.
   CHARACTER_AVOIDANCE_MODE:
     property: read-only
     type: number
-    description: >-
-      Allows you to specify that a character should not try to avoid other
-      characters, should not try to avoid dynamic obstacles (relatively fast
-      moving objects and avatars), or both.
+    description: Allows you to specify that a character should not try to avoid other
+      characters, should not try to avoid dynamic obstacles (relatively fast moving
+      objects and avatars), or both.
   CHARACTER_CMD_JUMP:
     property: read-only
     type: number
-    description: >-
-      Makes the character jump. Requires an additional parameter, the height to
-      jump, between 0.1m and 2.0m. This must be provided as the first element of
+    description: Makes the character jump. Requires an additional parameter, the height
+      to jump, between 0.1m and 2.0m. This must be provided as the first element of
       the llExecCharacterCmd option list.
   CHARACTER_CMD_SMOOTH_STOP:
     property: read-only
@@ -474,13 +468,13 @@ globals:
   CHARACTER_DESIRED_TURN_SPEED:
     property: read-only
     type: number
-    description: >-
-      The character's maximum speed while turning about the Z axis. - Note that
-      this is only loosely enforced.
+    description: The character's maximum speed while turning about the Z axis. - Note
+      that this is only loosely enforced.
   CHARACTER_LENGTH:
     property: read-only
     type: number
-    description: Set collision capsule length - cannot be less than two times the radius.
+    description: Set collision capsule length - cannot be less than two times the
+      radius.
   CHARACTER_MAX_ACCEL:
     property: read-only
     type: number
@@ -508,10 +502,9 @@ globals:
   CHARACTER_STAY_WITHIN_PARCEL:
     property: read-only
     type: number
-    description: >-
-      Determines whether a character can leave its starting parcel.\nTakes a
-      boolean parameter. If TRUE, the character cannot voluntarilly leave the
-      parcel, but can return to it.
+    description: Determines whether a character can leave its starting parcel.\nTakes
+      a boolean parameter. If TRUE, the character cannot voluntarilly leave the parcel,
+      but can return to it.
   CHARACTER_TYPE:
     property: read-only
     type: number
@@ -546,9 +539,8 @@ globals:
   CLICK_ACTION_NONE:
     property: read-only
     type: number
-    description: >-
-      Performs the default action: when the prim is clicked, touch events are
-      triggered.
+    description: 'Performs the default action: when the prim is clicked, touch events
+      are triggered.'
   CLICK_ACTION_OPEN:
     property: read-only
     type: number
@@ -580,18 +572,16 @@ globals:
   COMBAT_CHANNEL:
     property: read-only
     type: number
-    description: >-
-      COMBAT_CHANNEL is an integer constant that, when passed to llRegionSay
-      will add the message to the combat log. A script with a chat listen active
-      on COMBAT_CHANNEL may also monitor the combat log.
+    description: COMBAT_CHANNEL is an integer constant that, when passed to llRegionSay
+      will add the message to the combat log. A script with a chat listen active on
+      COMBAT_CHANNEL may also monitor the combat log.
   COMBAT_LOG_ID:
     property: read-only
     type:
       display: uuid
-    description: >-
-      Messages from the region to the COMBAT_CHANNEL will all be from this ID.\n
-      Scripts may filter llListen calls on this ID to receive only system
-      generated combat log messages.
+    description: Messages from the region to the COMBAT_CHANNEL will all be from this
+      ID.\n Scripts may filter llListen calls on this ID to receive only system generated
+      combat log messages.
   CONTENT_TYPE_ATOM:
     property: read-only
     type: number
@@ -603,9 +593,8 @@ globals:
   CONTENT_TYPE_HTML:
     property: read-only
     type: number
-    description: >-
-      "text/html", only valid for embedded browsers on content owned by the
-      person viewing. Falls back to "text/plain" otherwise.
+    description: '"text/html", only valid for embedded browsers on content owned by
+      the person viewing. Falls back to "text/plain" otherwise.'
   CONTENT_TYPE_JSON:
     property: read-only
     type: number
@@ -755,7 +744,10 @@ globals:
   DATA_RATING:
     property: read-only
     type: number
-    description: "Returns the agent ratings as a comma separated string of six integers. They are:\n\t\t\t1) Positive rated behaviour\n\t\t\t2) Negative rated behaviour\n\t\t\t3) Positive rated appearance\n\t\t\t4) Negative rated appearance\n\t\t\t5) Positive rated building\n\t\t\t6) Negative rated building"
+    description: "Returns the agent ratings as a comma separated string of six integers.\
+      \ They are:\n\t\t\t1) Positive rated behaviour\n\t\t\t2) Negative rated behaviour\n\
+      \t\t\t3) Positive rated appearance\n\t\t\t4) Negative rated appearance\n\t\t\
+      \t5) Positive rated building\n\t\t\t6) Negative rated building"
   DATA_SIM_POS:
     property: read-only
     type: number
@@ -768,20 +760,19 @@ globals:
   DEBUG_CHANNEL:
     property: read-only
     type: number
-    description: >-
-      DEBUG_CHANNEL is an integer constant that, when passed to llSay,
-      llWhisper, or llShout as a channel parameter, will print text to the
-      Script Warning/Error Window.
+    description: DEBUG_CHANNEL is an integer constant that, when passed to llSay,
+      llWhisper, or llShout as a channel parameter, will print text to the Script
+      Warning/Error Window.
   DEG_TO_RAD:
     property: read-only
     type: number
-    description: "0.017453293 - Number of radians per degree.\n\t\t\tYou can use this to convert degrees to radians by multiplying the degrees by this number."
+    description: "0.017453293 - Number of radians per degree.\n\t\t\tYou can use this\
+      \ to convert degrees to radians by multiplying the degrees by this number."
   DENSITY:
     property: read-only
     type: number
-    description: >-
-      Used with llSetPhysicsMaterial to enable the density value. Must be
-      between 1.0 and 22587.0 (in Kg/m^3 -- see if you can figure out what 22587
+    description: Used with llSetPhysicsMaterial to enable the density value. Must
+      be between 1.0 and 22587.0 (in Kg/m^3 -- see if you can figure out what 22587
       represents)
   DEREZ_DIE:
     property: read-only
@@ -790,7 +781,8 @@ globals:
   DEREZ_MAKE_TEMP:
     property: read-only
     type: number
-    description: The object is made temporary and will be cleaned up at some later timer.
+    description: The object is made temporary and will be cleaned up at some later
+      timer.
   DEREZ_TO_INVENTORY:
     property: read-only
     type: number
@@ -893,15 +885,13 @@ globals:
   FORCE_DIRECT_PATH:
     property: read-only
     type: number
-    description: >-
-      Makes character navigate in a straight line toward position. May be set to
-      TRUE or FALSE.
+    description: Makes character navigate in a straight line toward position. May
+      be set to TRUE or FALSE.
   FRICTION:
     property: read-only
     type: number
-    description: >-
-      Used with llSetPhysicsMaterial to enable the friction value. Must be
-      between 0.0 and 255.0
+    description: Used with llSetPhysicsMaterial to enable the friction value. Must
+      be between 0.0 and 255.0
   GAME_CONTROL_AXIS_LEFTX:
     property: read-only
     type: number
@@ -992,8 +982,7 @@ globals:
   GRAVITY_MULTIPLIER:
     property: read-only
     type: number
-    description: >-
-      Used with llSetPhysicsMaterial to enable the gravity multiplier value.
+    description: Used with llSetPhysicsMaterial to enable the gravity multiplier value.
       Must be between -1.0 and +28.0
   HORIZONTAL:
     property: read-only
@@ -1001,9 +990,8 @@ globals:
   HTTP_ACCEPT:
     property: read-only
     type: number
-    description: |-
-      Provide a string value to be included in the HTTP
-                  accepts header value. This replaces the default Second Life HTTP accepts header.
+    description: "Provide a string value to be included in the HTTP\n            accepts\
+      \ header value. This replaces the default Second Life HTTP accepts header."
   HTTP_BODY_MAXLENGTH:
     property: read-only
     type: number
@@ -1013,12 +1001,11 @@ globals:
   HTTP_CUSTOM_HEADER:
     property: read-only
     type: number
-    description: >-
-      Add an extra custom HTTP header to the request. The first string is the
-      name of the parameter to change, e.g. "Pragma", and the second string is
-      the value, e.g. "no-cache". Up to 8 custom headers may be configured per
-      request. Note that certain headers, such as the default headers, are
-      blocked for security reasons.
+    description: Add an extra custom HTTP header to the request. The first string
+      is the name of the parameter to change, e.g. "Pragma", and the second string
+      is the value, e.g. "no-cache". Up to 8 custom headers may be configured per
+      request. Note that certain headers, such as the default headers, are blocked
+      for security reasons.
   HTTP_EXTENDED_ERROR:
     property: read-only
     type: number
@@ -1032,18 +1019,15 @@ globals:
   HTTP_PRAGMA_NO_CACHE:
     property: read-only
     type: number
-    description: >-
-      Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage:
-      [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the
-      "Pragma: no-cache" header is sent by the script. This matches the default
-      behavior. When SendHeader is FALSE, no "Pragma" header is sent by the
-      script.
+    description: 'Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage:
+      [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the "Pragma:
+      no-cache" header is sent by the script. This matches the default behavior. When
+      SendHeader is FALSE, no "Pragma" header is sent by the script.'
   HTTP_USER_AGENT:
     property: read-only
     type: number
-    description: |-
-      Provide a string value to be included in the HTTP
-                  User-Agent header value. This is appended to the default value.
+    description: "Provide a string value to be included in the HTTP\n            User-Agent\
+      \ header value. This is appended to the default value."
   HTTP_VERBOSE_THROTTLE:
     property: read-only
     type: number
@@ -1214,9 +1198,8 @@ globals:
   LAND_LARGE_BRUSH:
     property: read-only
     type: number
-    description: >-
-      Use a large brush size.\nNOTE: This value is incorrect, a large brush
-      should be 2.
+    description: 'Use a large brush size.\nNOTE: This value is incorrect, a large
+      brush should be 2.'
   LAND_LEVEL:
     property: read-only
     type: number
@@ -1228,9 +1211,8 @@ globals:
   LAND_MEDIUM_BRUSH:
     property: read-only
     type: number
-    description: >-
-      Use a medium brush size.\nNOTE: This value is incorrect, a medium brush
-      should be 1.
+    description: 'Use a medium brush size.\nNOTE: This value is incorrect, a medium
+      brush should be 1.'
   LAND_NOISE:
     property: read-only
     type: number
@@ -1244,9 +1226,8 @@ globals:
   LAND_SMALL_BRUSH:
     property: read-only
     type: number
-    description: >-
-      Use a small brush size.\nNOTE: This value is incorrect, a small brush
-      should be 0.
+    description: 'Use a small brush size.\nNOTE: This value is incorrect, a small
+      brush should be 0.'
   LAND_SMOOTH:
     property: read-only
     type: number
@@ -1265,8 +1246,7 @@ globals:
   LINKSETDATA_EPROTECTED:
     property: read-only
     type: number
-    description: >-
-      The name:value pair has been protected from overwrite in the linkset
+    description: The name:value pair has been protected from overwrite in the linkset
       datastore.
   LINKSETDATA_MULTIDELETE:
     property: read-only
@@ -1279,8 +1259,7 @@ globals:
   LINKSETDATA_NOUPDATE:
     property: read-only
     type: number
-    description: >-
-      The value written to a name in the keystore is the same as the value
+    description: The value written to a name in the keystore is the same as the value
       already there.
   LINKSETDATA_OK:
     property: read-only
@@ -1301,9 +1280,8 @@ globals:
   LINK_ALL_OTHERS:
     property: read-only
     type: number
-    description: >-
-      This targets every object in the linked set except the object with the
-      script.
+    description: This targets every object in the linked set except the object with
+      the script.
   LINK_ROOT:
     property: read-only
     type: number
@@ -1372,9 +1350,8 @@ globals:
   NAK:
     property: read-only
     type: string
-    description: >-
-      Indicates a notecard read was attempted and the notecard was not yet
-      cached on the server.
+    description: Indicates a notecard read was attempted and the notecard was not
+      yet cached on the server.
   NULL_KEY:
     property: read-only
     type:
@@ -1382,42 +1359,35 @@ globals:
   OBJECT_ACCOUNT_LEVEL:
     property: read-only
     type: number
-    description: >-
-      Retrieves the account level of an avatar.\nReturns 0 when the avatar has a
-      basic account,\n 1 when the avatar has a premium account,\n 10 when the
+    description: Retrieves the account level of an avatar.\nReturns 0 when the avatar
+      has a basic account,\n 1 when the avatar has a premium account,\n 10 when the
       avatar has a premium plus account,\n or -1 if the object is not an avatar.
   OBJECT_ANIMATED_COUNT:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the number of
+    description: This is a flag used with llGetObjectDetails to get the number of
       associated animated objects
   OBJECT_ANIMATED_SLOTS_AVAILABLE:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the number of
+    description: This is a flag used with llGetObjectDetails to get the number of
       additional animated object attachments allowed.
   OBJECT_ATTACHED_POINT:
     property: read-only
     type: number
-    description: >-
-      Gets the attachment point to which the object is attached.\nReturns 0 if
-      the object is not an attachment (or is an avatar, etc).
+    description: Gets the attachment point to which the object is attached.\nReturns
+      0 if the object is not an attachment (or is an avatar, etc).
   OBJECT_ATTACHED_SLOTS_AVAILABLE:
     property: read-only
     type: number
-    description: >-
-      Returns the number of attachment slots available.\nReturns 0 if the object
-      is not an avatar or none are available.
+    description: Returns the number of attachment slots available.\nReturns 0 if the
+      object is not an avatar or none are available.
   OBJECT_BODY_SHAPE_TYPE:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the body type of the
-      avatar, based on shape data.\nIf no data is available, -1.0 is
-      returned.\nThis is normally between 0 and 1.0, with 0.5 and larger
-      considered 'male'
+    description: This is a flag used with llGetObjectDetails to get the body type
+      of the avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis
+      is normally between 0 and 1.0, with 0.5 and larger considered 'male'
   OBJECT_CHARACTER_TIME:
     property: read-only
     type: number
@@ -1425,19 +1395,18 @@ globals:
   OBJECT_CLICK_ACTION:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the click action.\nThe
+    description: This is a flag used with llGetObjectDetails to get the click action.\nThe
       default is 0
   OBJECT_CREATION_TIME:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the time this object
-      was created
+    description: This is a flag used with llGetObjectDetails to get the time this
+      object was created
   OBJECT_CREATOR:
     property: read-only
     type: number
-    description: Gets the object's creator key. If id is an avatar, a NULL_KEY is returned.
+    description: Gets the object's creator key. If id is an avatar, a NULL_KEY is
+      returned.
   OBJECT_DAMAGE:
     property: read-only
     type: number
@@ -1449,9 +1418,8 @@ globals:
   OBJECT_DESC:
     property: read-only
     type: number
-    description: >-
-      Gets the object's description. If id is an avatar, an empty string is
-      returned.
+    description: Gets the object's description. If id is an avatar, an empty string
+      is returned.
   OBJECT_GROUP:
     property: read-only
     type: number
@@ -1459,9 +1427,8 @@ globals:
   OBJECT_GROUP_TAG:
     property: read-only
     type: number
-    description: >-
-      Gets the agent's current group role tag. If id is an object, an empty is
-      returned.
+    description: Gets the agent's current group role tag. If id is an object, an empty
+      is returned.
   OBJECT_HEALTH:
     property: read-only
     type: number
@@ -1469,9 +1436,8 @@ globals:
   OBJECT_HOVER_HEIGHT:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get hover height of the
-      avatar\nIf no data is available, 0.0 is returned.
+    description: This is a flag used with llGetObjectDetails to get hover height of
+      the avatar\nIf no data is available, 0.0 is returned.
   OBJECT_LAST_OWNER_ID:
     property: read-only
     type: number
@@ -1499,15 +1465,13 @@ globals:
   OBJECT_OWNER:
     property: read-only
     type: number
-    description: >-
-      Gets an object's owner's key. If id is group owned, a NULL_KEY is
+    description: Gets an object's owner's key. If id is group owned, a NULL_KEY is
       returned.
   OBJECT_PATHFINDING_TYPE:
     property: read-only
     type: number
-    description: >-
-      Returns the pathfinding setting of any object in the region. It returns an
-      integer matching one of the OPT_* constants.
+    description: Returns the pathfinding setting of any object in the region. It returns
+      an integer matching one of the OPT_* constants.
   OBJECT_PERMS:
     property: read-only
     type: number
@@ -1519,14 +1483,12 @@ globals:
   OBJECT_PHANTOM:
     property: read-only
     type: number
-    description: >-
-      Returns boolean, detailing if phantom is enabled or disabled on the
+    description: Returns boolean, detailing if phantom is enabled or disabled on the
       object.\nIf id is an avatar or attachment, 0 is returned.
   OBJECT_PHYSICS:
     property: read-only
     type: number
-    description: >-
-      Returns boolean, detailing if physics is enabled or disabled on the
+    description: Returns boolean, detailing if physics is enabled or disabled on the
       object.\nIf id is an avatar or attachment, 0 is returned.
   OBJECT_PHYSICS_COST:
     property: read-only
@@ -1538,21 +1500,18 @@ globals:
   OBJECT_PRIM_COUNT:
     property: read-only
     type: number
-    description: >-
-      Gets the prim count of the object.  The script and target object  must be
-      owned by the same owner
+    description: Gets the prim count of the object.  The script and target object  must
+      be owned by the same owner
   OBJECT_PRIM_EQUIVALENCE:
     property: read-only
     type: number
   OBJECT_RENDER_WEIGHT:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the
-      Avatar_Rendering_Cost of an avatar, based on values reported by nearby
-      viewers.\nIf no data is available, -1 is returned.\nThe maximum render
-      weight stored by the simulator is 500000. When called against an object, 0
-      is returned.
+    description: This is a flag used with llGetObjectDetails to get the Avatar_Rendering_Cost
+      of an avatar, based on values reported by nearby viewers.\nIf no data is available,
+      -1 is returned.\nThe maximum render weight stored by the simulator is 500000.
+      When called against an object, 0 is returned.
   OBJECT_RETURN_PARCEL:
     property: read-only
     type: number
@@ -1572,11 +1531,10 @@ globals:
   OBJECT_ROOT:
     property: read-only
     type: number
-    description: >-
-      Gets the id of the root prim of the object requested.\nIf id is an avatar,
-      return the id of the root prim of the linkset the avatar is sitting on (or
-      the avatar's own id if the avatar is not sitting on an object within the
-      region).
+    description: Gets the id of the root prim of the object requested.\nIf id is an
+      avatar, return the id of the root prim of the linkset the avatar is sitting
+      on (or the avatar's own id if the avatar is not sitting on an object within
+      the region).
   OBJECT_ROT:
     property: read-only
     type: number
@@ -1597,18 +1555,16 @@ globals:
   OBJECT_SELECT_COUNT:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the number of avatars
-      selecting any part of the object
+    description: This is a flag used with llGetObjectDetails to get the number of
+      avatars selecting any part of the object
   OBJECT_SERVER_COST:
     property: read-only
     type: number
   OBJECT_SIT_COUNT:
     property: read-only
     type: number
-    description: >-
-      This is a flag used with llGetObjectDetails to get the number of avatars
-      sitting on the object
+    description: This is a flag used with llGetObjectDetails to get the number of
+      avatars sitting on the object
   OBJECT_STREAMING_COST:
     property: read-only
     type: number
@@ -1619,9 +1575,8 @@ globals:
   OBJECT_TEMP_ON_REZ:
     property: read-only
     type: number
-    description: >-
-      Returns boolean, detailing if temporary is enabled or disabled on the
-      object.
+    description: Returns boolean, detailing if temporary is enabled or disabled on
+      the object.
   OBJECT_TEXT:
     property: read-only
     type: number
@@ -1637,8 +1592,7 @@ globals:
   OBJECT_TOTAL_INVENTORY_COUNT:
     property: read-only
     type: number
-    description: >-
-      Gets the total inventory count of the object.  The script and target
+    description: Gets the total inventory count of the object.  The script and target
       object must be owned by the same owner
   OBJECT_TOTAL_SCRIPT_COUNT:
     property: read-only
@@ -1665,9 +1619,8 @@ globals:
   OPT_LEGACY_LINKSET:
     property: read-only
     type: number
-    description: >-
-      Returned for movable obstacles, movable phantoms, physical, and
-      volumedetect objects.
+    description: Returned for movable obstacles, movable phantoms, physical, and volumedetect
+      objects.
   OPT_MATERIAL_VOLUME:
     property: read-only
     type: number
@@ -1887,7 +1840,8 @@ globals:
   PARCEL_SALE_ERROR_INVALID_PRICE:
     property: read-only
     type: number
-    description: The price set for the parcel is invalid (e.g., less than or equal to 0).
+    description: The price set for the parcel is invalid (e.g., less than or equal
+      to 0).
   PARCEL_SALE_ERROR_IN_ESCROW:
     property: read-only
     type: number
@@ -1899,8 +1853,7 @@ globals:
   PARCEL_SALE_ERROR_NO_PERMISSIONS:
     property: read-only
     type: number
-    description: >-
-      The script does not have the required permissions to set the sale
+    description: The script does not have the required permissions to set the sale
       information.
   PARCEL_SALE_OBJECTS:
     property: read-only
@@ -1913,8 +1866,7 @@ globals:
   PARCEL_SALE_PRICE:
     property: read-only
     type: number
-    description: >-
-      The price of the parcel. If no authorized agent is set, must be greater
+    description: The price of the parcel. If no authorized agent is set, must be greater
       than 0.
   PASSIVE:
     property: read-only
@@ -1950,9 +1902,8 @@ globals:
   PERMISSION_ATTACH:
     property: read-only
     type: number
-    description: >-
-      If this permission is enabled, the object can successfully call
-      llAttachToAvatar to attach to the given avatar.
+    description: If this permission is enabled, the object can successfully call llAttachToAvatar
+      to attach to the given avatar.
   PERMISSION_CHANGE_JOINTS:
     property: read-only
     type: number
@@ -1960,10 +1911,8 @@ globals:
   PERMISSION_CHANGE_LINKS:
     property: read-only
     type: number
-    description: >-
-      If this permission is enabled, the object can successfully call
-      llCreateLink, llBreakLink, and llBreakAllLinks to change links to other
-      objects.
+    description: If this permission is enabled, the object can successfully call llCreateLink,
+      llBreakLink, and llBreakAllLinks to change links to other objects.
   PERMISSION_CHANGE_PERMISSIONS:
     property: read-only
     type: number
@@ -1974,9 +1923,8 @@ globals:
   PERMISSION_DEBIT:
     property: read-only
     type: number
-    description: >-
-      If this permission is enabled, the object can successfully call
-      llGiveMoney or llTransferLindenDollars to debit the owners account.
+    description: If this permission is enabled, the object can successfully call llGiveMoney
+      or llTransferLindenDollars to debit the owners account.
   PERMISSION_OVERRIDE_ANIMATIONS:
     property: read-only
     type: number
@@ -1995,14 +1943,12 @@ globals:
   PERMISSION_SILENT_ESTATE_MANAGEMENT:
     property: read-only
     type: number
-    description: >-
-      A script with this permission does not notify the object owner when it
-      modifies estate access rules via llManageEstateAccess.
+    description: A script with this permission does not notify the object owner when
+      it modifies estate access rules via llManageEstateAccess.
   PERMISSION_TAKE_CONTROLS:
     property: read-only
     type: number
-    description: >-
-      If this permission enabled, the object can successfully call the
+    description: If this permission enabled, the object can successfully call the
       llTakeControls libray call.
   PERMISSION_TELEPORT:
     property: read-only
@@ -2013,9 +1959,8 @@ globals:
   PERMISSION_TRIGGER_ANIMATION:
     property: read-only
     type: number
-    description: >-
-      If this permission is enabled, the object can successfully call
-      llStartAnimation for the avatar that owns this.
+    description: If this permission is enabled, the object can successfully call llStartAnimation
+      for the avatar that owns this.
   PERM_ALL:
     property: read-only
     type: number
@@ -2046,43 +1991,35 @@ globals:
   PRIM_ALLOW_UNSIT:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for restricting manual standing for seated avatars in an
-      experience.\nIgnored if the avatar was not seated via a call to
-      llSitOnLink.
+    description: Prim parameter for restricting manual standing for seated avatars
+      in an experience.\nIgnored if the avatar was not seated via a call to llSitOnLink.
   PRIM_ALPHA_MODE:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for materials using integer face, integer alpha_mode,
-      integer alpha_cutoff.\nDefines how the alpha channel of the diffuse
-      texture should be rendered.\nValid options for alpha_mode are
-      PRIM_ALPHA_MODE_BLEND, _NONE, _MASK, and _EMISSIVE.\nalpha_cutoff is used
-      only for PRIM_ALPHA_MODE_MASK.
+    description: Prim parameter for materials using integer face, integer alpha_mode,
+      integer alpha_cutoff.\nDefines how the alpha channel of the diffuse texture
+      should be rendered.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND,
+      _NONE, _MASK, and _EMISSIVE.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.
   PRIM_ALPHA_MODE_BLEND:
     property: read-only
     type: number
-    description: >-
-      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+    description: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
       texture's alpha channel should be rendered as alpha-blended.
   PRIM_ALPHA_MODE_EMISSIVE:
     property: read-only
     type: number
-    description: >-
-      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+    description: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
       texture's alpha channel should be rendered as an emissivity mask.
   PRIM_ALPHA_MODE_MASK:
     property: read-only
     type: number
-    description: >-
-      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
-      texture's alpha channel should be rendered as fully opaque for alpha
-      values above alpha_cutoff and fully transparent otherwise.
+    description: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+      texture's alpha channel should be rendered as fully opaque for alpha values
+      above alpha_cutoff and fully transparent otherwise.
   PRIM_ALPHA_MODE_NONE:
     property: read-only
     type: number
-    description: >-
-      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+    description: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
       texture's alpha channel should be ignored.
   PRIM_BUMP_BARK:
     property: read-only
@@ -2155,12 +2092,10 @@ globals:
   PRIM_COLOR:
     property: read-only
     type: number
-    description: >-
-      [PRIM_COLOR, integer face, vector color, float alpha]
-
-      integer face – face number or ALL_SIDES vector color – color in RGB <R, G,
-      B> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float alpha – from
-      0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)
+    description: "[PRIM_COLOR, integer face, vector color, float alpha]\ninteger face\
+      \ \u2013 face number or ALL_SIDES vector color \u2013 color in RGB <R, G, B>\
+      \ (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float alpha \u2013 from\
+      \ 0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)"
   PRIM_DAMAGE:
     property: read-only
     type: number
@@ -2172,13 +2107,12 @@ globals:
   PRIM_FLEXIBLE:
     property: read-only
     type: number
-    description: >-
-      [ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float
-      friction, float wind, float tension, vector force ] + +integer boolean –
-      TRUE enables, FALSE disables +integer softness – ranges from 0 to 3 +float
-      gravity – ranges from -10.0 to 10.0 +float friction – ranges from 0.0 to
-      10.0 +float wind – ranges from 0.0 to 10.0 +float tension – ranges from
-      0.0 to 10.0 +vector force
+    description: "[ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity,\
+      \ float friction, float wind, float tension, vector force ] + +integer boolean\
+      \ \u2013 TRUE enables, FALSE disables +integer softness \u2013 ranges from 0\
+      \ to 3 +float gravity \u2013 ranges from -10.0 to 10.0 +float friction \u2013\
+      \ ranges from 0.0 to 10.0 +float wind \u2013 ranges from 0.0 to 10.0 +float\
+      \ tension \u2013 ranges from 0.0 to 10.0 +vector force"
   PRIM_FULLBRIGHT:
     property: read-only
     type: number
@@ -2186,8 +2120,7 @@ globals:
   PRIM_GLOW:
     property: read-only
     type: number
-    description: >-
-      PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW,
+    description: PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW,
       integer face, float intensity ]
   PRIM_GLTF_ALPHA_MODE_BLEND:
     property: read-only
@@ -2204,30 +2137,26 @@ globals:
   PRIM_GLTF_BASE_COLOR:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians, vector color, integer
-      alpha_mode, float alpha_cutoff, boolean double_sided.\nValid options for
-      alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is
-      used only for PRIM_ALPHA_MODE_MASK.
+    description: Prim parameter for materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians, vector color, integer
+      alpha_mode, float alpha_cutoff, boolean double_sided.\nValid options for alpha_mode
+      are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for
+      PRIM_ALPHA_MODE_MASK.
   PRIM_GLTF_EMISSIVE:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for GLTF materials using integer face, string texture,
+    description: Prim parameter for GLTF materials using integer face, string texture,
       vector repeats, vector offsets, float rotation_in_radians, vector color
   PRIM_GLTF_METALLIC_ROUGHNESS:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for GLTF materials using integer face, string texture,
-      vector repeats, vector offsets, float rotation_in_radians, float
-      metallic_factor, float roughness_factor
+    description: Prim parameter for GLTF materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians, float metallic_factor,
+      float roughness_factor
   PRIM_GLTF_NORMAL:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for GLTF materials using integer face, string texture,
+    description: Prim parameter for GLTF materials using integer face, string texture,
       vector repeats, vector offsets, float rotation_in_radians
   PRIM_HEALTH:
     property: read-only
@@ -2248,9 +2177,9 @@ globals:
   PRIM_LINK_TARGET:
     property: read-only
     type: number
-    description: |-
-      [ PRIM_LINK_TARGET, integer link_target ]
-      Used to get or set multiple links with a single PrimParameters call.
+    description: '[ PRIM_LINK_TARGET, integer link_target ]
+
+      Used to get or set multiple links with a single PrimParameters call.'
   PRIM_MATERIAL:
     property: read-only
     type: number
@@ -2282,9 +2211,8 @@ globals:
   PRIM_MEDIA_ALT_IMAGE_ENABLE:
     property: read-only
     type: number
-    description: >-
-      Boolean. Gets/Sets the default image state (the image that the user sees
-      before a piece of media is active) for the chosen face. The default image
+    description: Boolean. Gets/Sets the default image state (the image that the user
+      sees before a piece of media is active) for the chosen face. The default image
       is specified by Second Life's server for that media type.
   PRIM_MEDIA_AUTO_LOOP:
     property: read-only
@@ -2293,27 +2221,23 @@ globals:
   PRIM_MEDIA_AUTO_PLAY:
     property: read-only
     type: number
-    description: >-
-      Boolean. Gets/Sets whether the media auto-plays when a Resident can view
-      it.
+    description: Boolean. Gets/Sets whether the media auto-plays when a Resident can
+      view it.
   PRIM_MEDIA_AUTO_SCALE:
     property: read-only
     type: number
-    description: >-
-      Boolean. Gets/Sets whether auto-scaling is enabled. Auto-scaling forces
-      the media to the full size of the texture.
+    description: Boolean. Gets/Sets whether auto-scaling is enabled. Auto-scaling
+      forces the media to the full size of the texture.
   PRIM_MEDIA_AUTO_ZOOM:
     property: read-only
     type: number
-    description: >-
-      Boolean. Gets/Sets whether clicking the media triggers auto-zoom and
-      auto-focus on the media.
+    description: Boolean. Gets/Sets whether clicking the media triggers auto-zoom
+      and auto-focus on the media.
   PRIM_MEDIA_CONTROLS:
     property: read-only
     type: number
-    description: >-
-      Integer. Gets/Sets the style of controls. Can be either
-      PRIM_MEDIA_CONTROLS_STANDARD or PRIM_MEDIA_CONTROLS_MINI.
+    description: Integer. Gets/Sets the style of controls. Can be either PRIM_MEDIA_CONTROLS_STANDARD
+      or PRIM_MEDIA_CONTROLS_MINI.
   PRIM_MEDIA_CONTROLS_MINI:
     property: read-only
     type: number
@@ -2325,8 +2249,7 @@ globals:
   PRIM_MEDIA_CURRENT_URL:
     property: read-only
     type: number
-    description: >-
-      String. Gets/Sets the current url displayed on the chosen face. Changing
+    description: String. Gets/Sets the current url displayed on the chosen face. Changing
       this URL causes navigation. 1024 characters Maximum.
   PRIM_MEDIA_FIRST_CLICK_INTERACT:
     property: read-only
@@ -2339,8 +2262,7 @@ globals:
   PRIM_MEDIA_HOME_URL:
     property: read-only
     type: number
-    description: >-
-      String. Gets/Sets the home URL for the chosen face. 1024 characters
+    description: String. Gets/Sets the home URL for the chosen face. 1024 characters
       maximum.
   PRIM_MEDIA_MAX_HEIGHT_PIXELS:
     property: read-only
@@ -2363,17 +2285,15 @@ globals:
   PRIM_MEDIA_PERMS_CONTROL:
     property: read-only
     type: number
-    description: >-
-      Integer. Gets/Sets the permissions mask that control who can see the media
-      control bar above the object:: PRIM_MEDIA_PERM_ANYONE,
-      PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER
+    description: 'Integer. Gets/Sets the permissions mask that control who can see
+      the media control bar above the object:: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP,
+      PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER'
   PRIM_MEDIA_PERMS_INTERACT:
     property: read-only
     type: number
-    description: >-
-      Integer. Gets/Sets the permissions mask that control who can interact with
-      the object: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP,
-      PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER
+    description: 'Integer. Gets/Sets the permissions mask that control who can interact
+      with the object: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE,
+      PRIM_MEDIA_PERM_OWNER'
   PRIM_MEDIA_PERM_ANYONE:
     property: read-only
     type: number
@@ -2389,16 +2309,13 @@ globals:
   PRIM_MEDIA_WHITELIST:
     property: read-only
     type: number
-    description: >-
-      String. Gets/Sets the white-list as a string of escaped, comma-separated
-      URLs. This string can hold up to 64 URLs or 1024 characters, whichever
-      comes first.
+    description: String. Gets/Sets the white-list as a string of escaped, comma-separated
+      URLs. This string can hold up to 64 URLs or 1024 characters, whichever comes
+      first.
   PRIM_MEDIA_WHITELIST_ENABLE:
     property: read-only
     type: number
-    description: >-
-      Boolean. Gets/Sets whether navigation is restricted to URLs in
-      PRIM_MEDIA_WHITELIST.
+    description: Boolean. Gets/Sets whether navigation is restricted to URLs in PRIM_MEDIA_WHITELIST.
   PRIM_MEDIA_WIDTH_PIXELS:
     property: read-only
     type: number
@@ -2410,18 +2327,15 @@ globals:
   PRIM_NORMAL:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians
+    description: Prim parameter for materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians
   PRIM_OMEGA:
     property: read-only
     type: number
-    description: >-
-      [ PRIM_OMEGA, vector axis, float spinrate, float gain ]
-
-      vector axis – arbitrary axis to rotate the object around float spinrate –
-      rate of rotation in radians per second float gain – also modulates the
-      final spinrate and disables the rotation behavior if zero
+    description: "[ PRIM_OMEGA, vector axis, float spinrate, float gain ]\nvector\
+      \ axis \u2013 arbitrary axis to rotate the object around float spinrate \u2013\
+      \ rate of rotation in radians per second float gain \u2013 also modulates the\
+      \ final spinrate and disables the rotation behavior if zero"
   PRIM_PHANTOM:
     property: read-only
     type: number
@@ -2433,82 +2347,72 @@ globals:
   PRIM_PHYSICS_SHAPE_CONVEX:
     property: read-only
     type: number
-    description: >-
-      Use the convex hull of the prim shape for physics (this is the default for
-      mesh objects).
+    description: Use the convex hull of the prim shape for physics (this is the default
+      for mesh objects).
   PRIM_PHYSICS_SHAPE_NONE:
     property: read-only
     type: number
-    description: >-
-      Ignore this prim in the physics shape. NB: This cannot be applied to the
-      root prim.
+    description: 'Ignore this prim in the physics shape. NB: This cannot be applied
+      to the root prim.'
   PRIM_PHYSICS_SHAPE_PRIM:
     property: read-only
     type: number
-    description: >-
-      Use the normal prim shape for physics (this is the default for all
+    description: Use the normal prim shape for physics (this is the default for all
       non-mesh objects).
   PRIM_PHYSICS_SHAPE_TYPE:
     property: read-only
     type: number
-    description: "Allows you to set the physics shape type of a prim via lsl. Permitted values are:\n\t\t\tPRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX"
+    description: "Allows you to set the physics shape type of a prim via lsl. Permitted\
+      \ values are:\n\t\t\tPRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX"
   PRIM_POINT_LIGHT:
     property: read-only
     type: number
-    description: >-
-      [ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity,
-      float radius, float falloff ]
-
-      integer boolean – TRUE enables, FALSE disables vector linear_color –
-      linear color in RGB <R, G, B&> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> =
-      white) float intensity – ranges from 0.0 to 1.0 float radius – ranges from
-      0.1 to 20.0 float falloff – ranges from 0.01 to 2.0
+    description: "[ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float\
+      \ intensity, float radius, float falloff ]\ninteger boolean \u2013 TRUE enables,\
+      \ FALSE disables vector linear_color \u2013 linear color in RGB <R, G, B&> (<0.0,\
+      \ 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float intensity \u2013 ranges\
+      \ from 0.0 to 1.0 float radius \u2013 ranges from 0.1 to 20.0 float falloff\
+      \ \u2013 ranges from 0.01 to 2.0"
   PRIM_POSITION:
     property: read-only
     type: number
-    description: >-
-      [ PRIM_POSITION, vector position ]
-
-      vector position – position in region or local coordinates depending upon
-      the situation
+    description: "[ PRIM_POSITION, vector position ]\nvector position \u2013 position\
+      \ in region or local coordinates depending upon the situation"
   PRIM_POS_LOCAL:
     property: read-only
     type: number
-    description: |-
-      PRIM_POS_LOCAL, vector position ]
-      vector position - position in local coordinates
+    description: 'PRIM_POS_LOCAL, vector position ]
+
+      vector position - position in local coordinates'
   PRIM_PROJECTOR:
     property: read-only
     type: number
-    description: '[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]'
+    description: '[ PRIM_PROJECTOR, string texture, float fov, float focus, float
+      ambiance ]'
   PRIM_REFLECTION_PROBE:
     property: read-only
     type: number
-    description: >-
-      Allows you to configure the object as a custom-placed reflection probe,
-      for image-based lighting (IBL). Only objects in the influence volume of
-      the reflection probe object are affected.
+    description: Allows you to configure the object as a custom-placed reflection
+      probe, for image-based lighting (IBL). Only objects in the influence volume
+      of the reflection probe object are affected.
   PRIM_REFLECTION_PROBE_BOX:
     property: read-only
     type: number
-    description: >-
-      This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+    description: This is a flag option used with llGetPrimitiveParams and related
+      functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
       probe is a box. When unset, the reflection probe is a sphere.
   PRIM_REFLECTION_PROBE_DYNAMIC:
     property: read-only
     type: number
-    description: >-
-      This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
-      probe includes avatars in IBL effects. When unset, the reflection probe
-      excludes avatars.
+    description: This is a flag option used with llGetPrimitiveParams and related
+      functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+      probe includes avatars in IBL effects. When unset, the reflection probe excludes
+      avatars.
   PRIM_REFLECTION_PROBE_MIRROR:
     property: read-only
     type: number
-    description: >-
-      This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+    description: This is a flag option used with llGetPrimitiveParams and related
+      functions when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
       probe acts as a mirror.
   PRIM_RENDER_MATERIAL:
     property: read-only
@@ -2525,9 +2429,8 @@ globals:
   PRIM_SCRIPTED_SIT_ONLY:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for restricting manual sitting on this prim.\nSitting must
-      be initiated via call to llSitOnLink.
+    description: Prim parameter for restricting manual sitting on this prim.\nSitting
+      must be initiated via call to llSitOnLink.
   PRIM_SCULPT_FLAG_ANIMESH:
     property: read-only
     type: number
@@ -2576,7 +2479,8 @@ globals:
   PRIM_SIT_TARGET:
     property: read-only
     type: number
-    description: '[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]'
+    description: '[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot
+      ]'
   PRIM_SIZE:
     property: read-only
     type: number
@@ -2588,9 +2492,8 @@ globals:
   PRIM_SPECULAR:
     property: read-only
     type: number
-    description: >-
-      Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians, vector color, integer
+    description: Prim parameter for materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians, vector color, integer
       glossy, integer environment
   PRIM_TEMP_ON_REZ:
     property: read-only
@@ -2612,9 +2515,8 @@ globals:
   PRIM_TEXTURE:
     property: read-only
     type: number
-    description: >-
-      [ PRIM_TEXTURE, integer face, string texture, vector repeats, vector
-      offsets, float rotation_in_radians ]
+    description: '[ PRIM_TEXTURE, integer face, string texture, vector repeats, vector
+      offsets, float rotation_in_radians ]'
   PRIM_TYPE:
     property: read-only
     type: number
@@ -2702,15 +2604,13 @@ globals:
   PSYS_PART_END_SCALE:
     property: read-only
     type: number
-    description: >-
-      A vector <sx, sy, z>, which is the ending size of the particle billboard
+    description: A vector <sx, sy, z>, which is the ending size of the particle billboard
       in meters (z is ignored).
   PSYS_PART_FLAGS:
     property: read-only
     type: number
-    description: >-
-      Each particle that is emitted by the particle system is simulated based on
-      the following flags. To use multiple flags, bitwise or (|) them together.
+    description: Each particle that is emitted by the particle system is simulated
+      based on the following flags. To use multiple flags, bitwise or (|) them together.
   PSYS_PART_FOLLOW_SRC_MASK:
     property: read-only
     type: number
@@ -2718,15 +2618,13 @@ globals:
   PSYS_PART_FOLLOW_VELOCITY_MASK:
     property: read-only
     type: number
-    description: >-
-      The particle orientation is rotated so the vertical axis faces towards the
-      particle velocity.
+    description: The particle orientation is rotated so the vertical axis faces towards
+      the particle velocity.
   PSYS_PART_INTERP_COLOR_MASK:
     property: read-only
     type: number
-    description: >-
-      Interpolate both the color and alpha from the start value to the end
-      value.
+    description: Interpolate both the color and alpha from the start value to the
+      end value.
   PSYS_PART_INTERP_SCALE_MASK:
     property: read-only
     type: number
@@ -2752,18 +2650,16 @@ globals:
   PSYS_PART_START_SCALE:
     property: read-only
     type: number
-    description: >-
-      A vector <sx, sy, z>, which is the starting size of the particle billboard
-      in meters (z is ignored).
+    description: A vector <sx, sy, z>, which is the starting size of the particle
+      billboard in meters (z is ignored).
   PSYS_PART_TARGET_LINEAR_MASK:
     property: read-only
     type: number
   PSYS_PART_TARGET_POS_MASK:
     property: read-only
     type: number
-    description: >-
-      The particle heads towards the location of the target object as defined by
-      PSYS_SRC_TARGET_KEY.
+    description: The particle heads towards the location of the target object as defined
+      by PSYS_SRC_TARGET_KEY.
   PSYS_PART_WIND_MASK:
     property: read-only
     type: number
@@ -2775,16 +2671,14 @@ globals:
   PSYS_SRC_ANGLE_BEGIN:
     property: read-only
     type: number
-    description: >-
-      Area in radians specifying where particles will NOT be created (for ANGLE
-      patterns)
+    description: Area in radians specifying where particles will NOT be created (for
+      ANGLE patterns)
   PSYS_SRC_ANGLE_END:
     property: read-only
     type: number
-    description: >-
-      Area in radians filled with particles (for ANGLE patterns) (if lower than
-      PSYS_SRC_ANGLE_BEGIN, acts as PSYS_SRC_ANGLE_BEGIN itself, and
-      PSYS_SRC_ANGLE_BEGIN acts as PSYS_SRC_ANGLE_END).
+    description: Area in radians filled with particles (for ANGLE patterns) (if lower
+      than PSYS_SRC_ANGLE_BEGIN, acts as PSYS_SRC_ANGLE_BEGIN itself, and PSYS_SRC_ANGLE_BEGIN
+      acts as PSYS_SRC_ANGLE_END).
   PSYS_SRC_BURST_PART_COUNT:
     property: read-only
     type: number
@@ -2808,7 +2702,9 @@ globals:
   PSYS_SRC_INNERANGLE:
     property: read-only
     type: number
-    description: "Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area specified will NOT have particles in it."
+    description: "Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE\
+      \ or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area specified will\
+      \ NOT have particles in it."
   PSYS_SRC_MAX_AGE:
     property: read-only
     type: number
@@ -2816,29 +2712,29 @@ globals:
   PSYS_SRC_OMEGA:
     property: read-only
     type: number
-    description: >-
-      Sets the angular velocity to rotate the axis that SRC_PATTERN_ANGLE and
-      SRC_PATTERN_ANGLE_CONE use.
+    description: Sets the angular velocity to rotate the axis that SRC_PATTERN_ANGLE
+      and SRC_PATTERN_ANGLE_CONE use.
   PSYS_SRC_OUTERANGLE:
     property: read-only
     type: number
-    description: "Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area between the outer and inner angle will be filled with particles."
+    description: "Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE\
+      \ or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area between the\
+      \ outer and inner angle will be filled with particles."
   PSYS_SRC_PATTERN:
     property: read-only
     type: number
-    description: "The pattern which is used to generate particles.\n\t\t\tUse one of the following values: PSYS_SRC_PATTERN Values."
+    description: "The pattern which is used to generate particles.\n\t\t\tUse one\
+      \ of the following values: PSYS_SRC_PATTERN Values."
   PSYS_SRC_PATTERN_ANGLE:
     property: read-only
     type: number
-    description: >-
-      Shoot particles across a 2 dimensional area defined by the arc created
-      from PSYS_SRC_OUTERANGLE. There will be an open area defined by
-      PSYS_SRC_INNERANGLE within the larger arc.
+    description: Shoot particles across a 2 dimensional area defined by the arc created
+      from PSYS_SRC_OUTERANGLE. There will be an open area defined by PSYS_SRC_INNERANGLE
+      within the larger arc.
   PSYS_SRC_PATTERN_ANGLE_CONE:
     property: read-only
     type: number
-    description: >-
-      Shoot particles out in a 3 dimensional cone with an outer arc of
+    description: Shoot particles out in a 3 dimensional cone with an outer arc of
       PSYS_SRC_OUTERANGLE and an inner open area defined by PSYS_SRC_INNERANGLE.
   PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY:
     property: read-only
@@ -2854,9 +2750,8 @@ globals:
   PSYS_SRC_TARGET_KEY:
     property: read-only
     type: number
-    description: >-
-      The key of a target object to move towards if PSYS_PART_TARGET_POS_MASK is
-      enabled.
+    description: The key of a target object to move towards if PSYS_PART_TARGET_POS_MASK
+      is enabled.
   PSYS_SRC_TEXTURE:
     property: read-only
     type: number
@@ -2864,10 +2759,9 @@ globals:
   PUBLIC_CHANNEL:
     property: read-only
     type: number
-    description: >-
-      PUBLIC_CHANNEL is an integer constant that, when passed to llSay,
-      llWhisper, or llShout as a channel parameter, will print text to the
-      publicly heard chat channel.
+    description: PUBLIC_CHANNEL is an integer constant that, when passed to llSay,
+      llWhisper, or llShout as a channel parameter, will print text to the publicly
+      heard chat channel.
   PURSUIT_FUZZ_FACTOR:
     property: read-only
     type: number
@@ -2886,7 +2780,8 @@ globals:
   PU_EVADE_HIDDEN:
     property: read-only
     type: number
-    description: Triggered when an llEvade character thinks it has hidden from its pursuer.
+    description: Triggered when an llEvade character thinks it has hidden from its
+      pursuer.
   PU_EVADE_SPOTTED:
     property: read-only
     type: number
@@ -2901,22 +2796,18 @@ globals:
   PU_FAILURE_INVALID_START:
     property: read-only
     type: number
-    description: >-
-      Character cannot navigate from the current location - e.g., the character
+    description: Character cannot navigate from the current location - e.g., the character
       is off the navmesh or too high above it.
   PU_FAILURE_NO_NAVMESH:
     property: read-only
     type: number
-    description: >-
-      This is a fatal error reported to a character when there is no navmesh for
-      the region. This usually indicates a server failure and users should file
-      a bug report and include the time and region in which they received this
-      message.
+    description: This is a fatal error reported to a character when there is no navmesh
+      for the region. This usually indicates a server failure and users should file
+      a bug report and include the time and region in which they received this message.
   PU_FAILURE_NO_VALID_DESTINATION:
     property: read-only
     type: number
-    description: >-
-      There is no good place for the character to go - e.g., it is patrolling
+    description: There is no good place for the character to go - e.g., it is patrolling
       and all the patrol points are now unreachable.
   PU_FAILURE_OTHER:
     property: read-only
@@ -2927,22 +2818,19 @@ globals:
   PU_FAILURE_TARGET_GONE:
     property: read-only
     type: number
-    description: >-
-      Target (for llPursue or llEvade) can no longer be tracked - e.g., it left
-      the region or is an avatar that is now more than about 30m outside the
+    description: Target (for llPursue or llEvade) can no longer be tracked - e.g.,
+      it left the region or is an avatar that is now more than about 30m outside the
       region.
   PU_FAILURE_UNREACHABLE:
     property: read-only
     type: number
-    description: >-
-      Goal is no longer reachable for some reason - e.g., an obstacle blocks the
-      path.
+    description: Goal is no longer reachable for some reason - e.g., an obstacle blocks
+      the path.
   PU_GOAL_REACHED:
     property: read-only
     type: number
-    description: >-
-      Character has reached the goal and will stop or choose a new goal (if
-      wandering).
+    description: Character has reached the goal and will stop or choose a new goal
+      (if wandering).
   PU_SLOWDOWN_DISTANCE_REACHED:
     property: read-only
     type: number
@@ -2950,9 +2838,8 @@ globals:
   RAD_TO_DEG:
     property: read-only
     type: number
-    description: >-
-      57.2957795 - Number of degrees per radian. You can use this number to
-      convert radians to degrees by multiplying the radians by this number.
+    description: 57.2957795 - Number of degrees per radian. You can use this number
+      to convert radians to degrees by multiplying the radians by this number.
   RCERR_CAST_TIME_EXCEEDED:
     property: read-only
     type: number
@@ -3041,9 +2928,8 @@ globals:
   RESTITUTION:
     property: read-only
     type: number
-    description: >-
-      Used with llSetPhysicsMaterial to enable the density value. Must be
-      between 0.0 and 1.0
+    description: Used with llSetPhysicsMaterial to enable the density value. Must
+      be between 0.0 and 1.0
   REVERSE:
     property: read-only
     type: number
@@ -3051,21 +2937,17 @@ globals:
   REZ_ACCEL:
     property: read-only
     type: number
-    description: >-
-      Acceleration forced applied to the rezzed object. [vector force, integer
-      rel]
+    description: Acceleration forced applied to the rezzed object. [vector force,
+      integer rel]
   REZ_DAMAGE:
     property: read-only
     type: number
-    description: >-
-      Damage applied by the object when it collides with an agent. [float
+    description: Damage applied by the object when it collides with an agent. [float
       damage]
   REZ_DAMAGE_TYPE:
     property: read-only
     type: number
-    description: >-
-      Set the damage type applied when this object collides. [integer
-      damage_type]
+    description: Set the damage type applied when this object collides. [integer damage_type]
   REZ_FLAGS:
     property: read-only
     type: number
@@ -3085,9 +2967,8 @@ globals:
   REZ_FLAG_NO_COLLIDE_FAMILY:
     property: read-only
     type: number
-    description: >-
-      Object will not trigger collision events with other objects created by the
-      same rezzer.
+    description: Object will not trigger collision events with other objects created
+      by the same rezzer.
   REZ_FLAG_NO_COLLIDE_OWNER:
     property: read-only
     type: number
@@ -3111,23 +2992,23 @@ globals:
   REZ_OMEGA:
     property: read-only
     type: number
-    description: >-
-      Omega applied to the rezzed object. [vector axis, integer rel, float spin,
-      float gain]
+    description: Omega applied to the rezzed object. [vector axis, integer rel, float
+      spin, float gain]
   REZ_PARAM:
     property: read-only
     type: number
-    description: Integer value to pass to the object as its rez parameter. [integer param]
+    description: Integer value to pass to the object as its rez parameter. [integer
+      param]
   REZ_PARAM_STRING:
     property: read-only
     type: number
-    description: A string value to pass to the object as its rez parameter. [string param]
+    description: A string value to pass to the object as its rez parameter. [string
+      param]
   REZ_POS:
     property: read-only
     type: number
-    description: >-
-      Position at which to rez the new object. [vector position, integer rel,
-      integer atroot]
+    description: Position at which to rez the new object. [vector position, integer
+      rel, integer atroot]
   REZ_ROT:
     property: read-only
     type: number
@@ -3135,9 +3016,8 @@ globals:
   REZ_SOUND:
     property: read-only
     type: number
-    description: >-
-      Sound attached to the rezzed object. [string name, float volume, integer
-      loop]
+    description: Sound attached to the rezzed object. [string name, float volume,
+      integer loop]
   REZ_SOUND_COLLIDE:
     property: read-only
     type: number
@@ -3145,8 +3025,7 @@ globals:
   REZ_VEL:
     property: read-only
     type: number
-    description: >-
-      Initial velocity of rezzed object. [vector vel, integer rel, integer
+    description: Initial velocity of rezzed object. [vector vel, integer rel, integer
       inherit]
   ROTATE:
     property: read-only
@@ -3223,10 +3102,9 @@ globals:
   SIM_STAT_PCT_CHARS_STEPPED:
     property: read-only
     type: number
-    description: >-
-      Returns the % of pathfinding characters skipped each frame, averaged over
-      the last minute.\nThe returned value corresponds to the "Characters
-      Updated" stat in the viewer's Statistics Bar.
+    description: Returns the % of pathfinding characters skipped each frame, averaged
+      over the last minute.\nThe returned value corresponds to the "Characters Updated"
+      stat in the viewer's Statistics Bar.
   SIM_STAT_PHYSICS_FPS:
     property: read-only
     type: number
@@ -3298,14 +3176,12 @@ globals:
   SIT_INVALID_LINK:
     property: read-only
     type: number
-    description: >-
-      Link ID did not specify a valid prim in the linkset or resolved to
+    description: Link ID did not specify a valid prim in the linkset or resolved to
       multiple prims.
   SIT_INVALID_OBJECT:
     property: read-only
     type: number
-    description: >-
-      Attempt to force an avatar to sit on an attachment or other invalid
+    description: Attempt to force an avatar to sit on an attachment or other invalid
       target.
   SIT_NOT_EXPERIENCE:
     property: read-only
@@ -3314,9 +3190,8 @@ globals:
   SIT_NO_ACCESS:
     property: read-only
     type: number
-    description: >-
-      Avatar does not have access to the parcel containing the target linkset of
-      the forced sit.
+    description: Avatar does not have access to the parcel containing the target linkset
+      of the forced sit.
   SIT_NO_EXPERIENCE_PERMISSION:
     property: read-only
     type: number
@@ -3428,11 +3303,10 @@ globals:
   STATUS_BLOCK_GRAB:
     property: read-only
     type: number
-    description: >-
-      Controls whether the object can be grabbed.\nA grab is the default action
-      when in third person, and is available as the hand tool in build mode.
-      This is useful for physical objects that you don't want other people to be
-      able to trivially disturb. The default is FALSE
+    description: Controls whether the object can be grabbed.\nA grab is the default
+      action when in third person, and is available as the hand tool in build mode.
+      This is useful for physical objects that you don't want other people to be able
+      to trivially disturb. The default is FALSE
   STATUS_BLOCK_GRAB_OBJECT:
     property: read-only
     type: number
@@ -3447,18 +3321,15 @@ globals:
   STATUS_DIE_AT_EDGE:
     property: read-only
     type: number
-    description: >-
-      Controls whether the object is returned to the owner's inventory if it
-      wanders off the edge of the world.\nIt is useful to set this status TRUE
+    description: Controls whether the object is returned to the owner's inventory
+      if it wanders off the edge of the world.\nIt is useful to set this status TRUE
       for things like bullets or rockets. The default is TRUE
   STATUS_DIE_AT_NO_ENTRY:
     property: read-only
     type: number
-    description: >-
-      Controls whether the object dies if it attempts to enter a parcel that
-      does not allow object entry or does not have enough capacity.\nIt is
-      useful to set this status TRUE for things like bullets or rockets. The
-      default is FALSE
+    description: Controls whether the object dies if it attempts to enter a parcel
+      that does not allow object entry or does not have enough capacity.\nIt is useful
+      to set this status TRUE for things like bullets or rockets. The default is FALSE
   STATUS_INTERNAL_ERROR:
     property: read-only
     type: number
@@ -3482,18 +3353,15 @@ globals:
   STATUS_PHANTOM:
     property: read-only
     type: number
-    description: >-
-      Controls/indicates whether the object collides or not.\nSetting the value
-      to TRUE makes the object non-colliding with all objects. It is a good idea
-      to use this for most objects that move or rotate, but are non-physical. It
-      is also useful for simulating volumetric lighting. The default is FALSE.
+    description: Controls/indicates whether the object collides or not.\nSetting the
+      value to TRUE makes the object non-colliding with all objects. It is a good
+      idea to use this for most objects that move or rotate, but are non-physical.
+      It is also useful for simulating volumetric lighting. The default is FALSE.
   STATUS_PHYSICS:
     property: read-only
     type: number
-    description: >-
-      Controls/indicates whether the object moves physically.\nThis controls the
-      same flag that the UI check-box for Physical controls. The default is
-      FALSE.
+    description: Controls/indicates whether the object moves physically.\nThis controls
+      the same flag that the UI check-box for Physical controls. The default is FALSE.
   STATUS_RETURN_AT_EDGE:
     property: read-only
     type: number
@@ -3506,11 +3374,19 @@ globals:
   STATUS_ROTATE_Z:
     property: read-only
     type: number
-    description: "Controls/indicates whether the object can physically rotate around\n\t\t\tthe specific axis or not. This flag has no meaning\n\t\t\tfor non-physical objects. Set the value to FALSE\n\t\t\tif you want to disable rotation around that axis. The\n\t\t\tdefault is TRUE for a physical object.\n\t\t\tA useful example to think about when visualizing\n\t\t\tthe effect is a sit-and-spin device. They spin around the\n\t\t\tZ axis (up) but not around the X or Y axis."
+    description: "Controls/indicates whether the object can physically rotate around\n\
+      \t\t\tthe specific axis or not. This flag has no meaning\n\t\t\tfor non-physical\
+      \ objects. Set the value to FALSE\n\t\t\tif you want to disable rotation around\
+      \ that axis. The\n\t\t\tdefault is TRUE for a physical object.\n\t\t\tA useful\
+      \ example to think about when visualizing\n\t\t\tthe effect is a sit-and-spin\
+      \ device. They spin around the\n\t\t\tZ axis (up) but not around the X or Y\
+      \ axis."
   STATUS_SANDBOX:
     property: read-only
     type: number
-    description: "Controls/indicates whether the object can cross region boundaries\n\t\t\tand move more than 20 meters from its creation\n\t\t\tpoint. The default if FALSE."
+    description: "Controls/indicates whether the object can cross region boundaries\n\
+      \t\t\tand move more than 20 meters from its creation\n\t\t\tpoint. The default\
+      \ if FALSE."
   STATUS_TYPE_MISMATCH:
     property: read-only
     type: number
@@ -3646,9 +3522,8 @@ globals:
   TRANSFER_BAD_ROOT:
     property: read-only
     type: number
-    description: >-
-      The root path specified in TRANSFER_DEST contained an invalid directory or
-      was reduced to nothing.
+    description: The root path specified in TRANSFER_DEST contained an invalid directory
+      or was reduced to nothing.
   TRANSFER_DEST:
     property: read-only
     type: number
@@ -3747,23 +3622,22 @@ globals:
   VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY:
     property: read-only
     type: number
-    description: >-
-      A slider between minimum (0.0) and maximum (1.0) deflection of angular
-      orientation. That is, its a simple scalar for modulating the strength of
-      angular deflection such that the vehicles preferred axis of motion points
-      toward its real velocity.
+    description: A slider between minimum (0.0) and maximum (1.0) deflection of angular
+      orientation. That is, its a simple scalar for modulating the strength of angular
+      deflection such that the vehicles preferred axis of motion points toward its
+      real velocity.
   VEHICLE_ANGULAR_DEFLECTION_TIMESCALE:
     property: read-only
     type: number
-    description: >-
-      The time-scale for exponential success of linear deflection deflection.
-      Its another way to specify the strength of the vehicles tendency to
-      reorient itself so that its preferred axis of motion agrees with its true
-      velocity.
+    description: The time-scale for exponential success of linear deflection deflection.
+      Its another way to specify the strength of the vehicles tendency to reorient
+      itself so that its preferred axis of motion agrees with its true velocity.
   VEHICLE_ANGULAR_FRICTION_TIMESCALE:
     property: read-only
     type: number
-    description: "A vector of timescales for exponential decay of the vehicle's angular velocity about its preferred axes of motion (at, left, up).\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+    description: "A vector of timescales for exponential decay of the vehicle's angular\
+      \ velocity about its preferred axes of motion (at, left, up).\n\t\t\tRange =\
+      \ [0.07, inf) seconds for each element of the vector."
   VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE:
     property: read-only
     type: number
@@ -3771,9 +3645,8 @@ globals:
   VEHICLE_ANGULAR_MOTOR_DIRECTION:
     property: read-only
     type: number
-    description: >-
-      The direction and magnitude (in preferred frame) of the vehicle's angular
-      motor. The vehicle will accelerate (or decelerate if necessary) to match
+    description: The direction and magnitude (in preferred frame) of the vehicle's
+      angular motor. The vehicle will accelerate (or decelerate if necessary) to match
       its velocity to its motor.
   VEHICLE_ANGULAR_MOTOR_TIMESCALE:
     property: read-only
@@ -3782,25 +3655,21 @@ globals:
   VEHICLE_BANKING_EFFICIENCY:
     property: read-only
     type: number
-    description: >-
-      A slider between anti (-1.0), none (0.0), and maxmum (1.0) banking
+    description: A slider between anti (-1.0), none (0.0), and maxmum (1.0) banking
       strength.
   VEHICLE_BANKING_MIX:
     property: read-only
     type: number
-    description: >-
-      A slider between static (0.0) and dynamic (1.0) banking. "Static" means
-      the banking scales only with the angle of roll, whereas "dynamic" is a
+    description: A slider between static (0.0) and dynamic (1.0) banking. "Static"
+      means the banking scales only with the angle of roll, whereas "dynamic" is a
       term that also scales with the vehicles linear speed.
   VEHICLE_BANKING_TIMESCALE:
     property: read-only
     type: number
-    description: >-
-      The timescale for banking to exponentially approach its maximum effect.
-      This is another way to scale the strength of the banking effect, however
-      it affects the term that is proportional to the difference between what
-      the banking behavior is trying to do, and what the vehicle is actually
-      doing.
+    description: The timescale for banking to exponentially approach its maximum effect.
+      This is another way to scale the strength of the banking effect, however it
+      affects the term that is proportional to the difference between what the banking
+      behavior is trying to do, and what the vehicle is actually doing.
   VEHICLE_BUOYANCY:
     property: read-only
     type: number
@@ -3823,9 +3692,8 @@ globals:
   VEHICLE_FLAG_HOVER_UP_ONLY:
     property: read-only
     type: number
-    description: >-
-      Hover does not push down. Use this flag for hovering vehicles that should
-      be able to jump above their hover height.
+    description: Hover does not push down. Use this flag for hovering vehicles that
+      should be able to jump above their hover height.
   VEHICLE_FLAG_HOVER_WATER_ONLY:
     property: read-only
     type: number
@@ -3837,8 +3705,7 @@ globals:
   VEHICLE_FLAG_LIMIT_ROLL_ONLY:
     property: read-only
     type: number
-    description: >-
-      For vehicles with vertical attractor that want to be able to climb/dive,
+    description: For vehicles with vertical attractor that want to be able to climb/dive,
       for instance, aeroplanes that want to use the banking feature.
   VEHICLE_FLAG_MOUSELOOK_BANK:
     property: read-only
@@ -3849,9 +3716,8 @@ globals:
   VEHICLE_FLAG_NO_DEFLECTION_UP:
     property: read-only
     type: number
-    description: >-
-      This flag prevents linear deflection parallel to world z-axis. This is
-      useful for preventing ground vehicles with large linear deflection, like
+    description: This flag prevents linear deflection parallel to world z-axis. This
+      is useful for preventing ground vehicles with large linear deflection, like
       bumper cars, from climbing their linear deflection into the sky.
   VEHICLE_FLAG_NO_FLY_UP:
     property: read-only
@@ -3860,37 +3726,36 @@ globals:
   VEHICLE_HOVER_EFFICIENCY:
     property: read-only
     type: number
-    description: >-
-      A slider between minimum (0.0 = bouncy) and maximum (1.0 = fast as
-      possible) damped motion of the hover behavior. 
+    description: 'A slider between minimum (0.0 = bouncy) and maximum (1.0 = fast
+      as possible) damped motion of the hover behavior. '
   VEHICLE_HOVER_HEIGHT:
     property: read-only
     type: number
-    description: >-
-      The height (above the terrain or water, or global) at which the vehicle
+    description: The height (above the terrain or water, or global) at which the vehicle
       will try to hover.
   VEHICLE_HOVER_TIMESCALE:
     property: read-only
     type: number
-    description: Period of time (in seconds) for the vehicle to achieve its hover height.
+    description: Period of time (in seconds) for the vehicle to achieve its hover
+      height.
   VEHICLE_LINEAR_DEFLECTION_EFFICIENCY:
     property: read-only
     type: number
-    description: >-
-      A slider between minimum (0.0) and maximum (1.0) deflection of linear
-      velocity. That is, its a simple scalar for modulating the strength of
-      linear deflection.
+    description: A slider between minimum (0.0) and maximum (1.0) deflection of linear
+      velocity. That is, its a simple scalar for modulating the strength of linear
+      deflection.
   VEHICLE_LINEAR_DEFLECTION_TIMESCALE:
     property: read-only
     type: number
-    description: >-
-      The timescale for exponential success of linear deflection deflection. It
-      is another way to specify how much time it takes for the vehicle's linear
+    description: The timescale for exponential success of linear deflection deflection.
+      It is another way to specify how much time it takes for the vehicle's linear
       velocity to be redirected to its preferred axis of motion.
   VEHICLE_LINEAR_FRICTION_TIMESCALE:
     property: read-only
     type: number
-    description: "A vector of timescales for exponential decay of the vehicle's linear velocity along its preferred axes of motion (at, left, up).\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+    description: "A vector of timescales for exponential decay of the vehicle's linear\
+      \ velocity along its preferred axes of motion (at, left, up).\n\t\t\tRange =\
+      \ [0.07, inf) seconds for each element of the vector."
   VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE:
     property: read-only
     type: number
@@ -3898,7 +3763,9 @@ globals:
   VEHICLE_LINEAR_MOTOR_DIRECTION:
     property: read-only
     type: number
-    description: "The direction and magnitude (in preferred frame) of the vehicle's linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.\n\t\t\tRange of magnitude = [0, 30] meters/second."
+    description: "The direction and magnitude (in preferred frame) of the vehicle's\
+      \ linear motor. The vehicle will accelerate (or decelerate if necessary) to\
+      \ match its velocity to its motor.\n\t\t\tRange of magnitude = [0, 30] meters/second."
   VEHICLE_LINEAR_MOTOR_OFFSET:
     property: read-only
     type: number
@@ -3909,56 +3776,46 @@ globals:
   VEHICLE_REFERENCE_FRAME:
     property: read-only
     type: number
-    description: >-
-      A rotation of the vehicle's preferred axes of motion and orientation (at,
-      left, up) with respect to the vehicle's local frame (x, y, z).
+    description: A rotation of the vehicle's preferred axes of motion and orientation
+      (at, left, up) with respect to the vehicle's local frame (x, y, z).
   VEHICLE_TYPE_AIRPLANE:
     property: read-only
     type: number
-    description: >-
-      Uses linear deflection for lift, no hover, and banking to turn.\nSee
+    description: Uses linear deflection for lift, no hover, and banking to turn.\nSee
       http://wiki.secondlife.com/wiki/VEHICLE_TYPE_AIRPLANE
   VEHICLE_TYPE_BALLOON:
     property: read-only
     type: number
-    description: >-
-      Hover, and friction, but no deflection.\nSee
-      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BALLOON
+    description: Hover, and friction, but no deflection.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BALLOON
   VEHICLE_TYPE_BOAT:
     property: read-only
     type: number
-    description: >-
-      Hovers over water with lots of friction and some anglar deflection.\nSee
+    description: Hovers over water with lots of friction and some anglar deflection.\nSee
       http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BOAT
   VEHICLE_TYPE_CAR:
     property: read-only
     type: number
-    description: >-
-      Another vehicle that bounces along the ground but needs the motors to be
-      driven from external controls or timer events.\nSee
-      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_CAR
+    description: Another vehicle that bounces along the ground but needs the motors
+      to be driven from external controls or timer events.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_CAR
   VEHICLE_TYPE_NONE:
     property: read-only
     type: number
   VEHICLE_TYPE_SLED:
     property: read-only
     type: number
-    description: >-
-      Simple vehicle that bumps along the ground, and likes to move along its
-      local x-axis.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_SLED
+    description: Simple vehicle that bumps along the ground, and likes to move along
+      its local x-axis.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_SLED
   VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY:
     property: read-only
     type: number
-    description: >-
-      A slider between minimum (0.0 = wobbly) and maximum (1.0 = firm as
+    description: A slider between minimum (0.0 = wobbly) and maximum (1.0 = firm as
       possible) stability of the vehicle to keep itself upright.
   VEHICLE_VERTICAL_ATTRACTION_TIMESCALE:
     property: read-only
     type: number
-    description: >-
-      The period of wobble, or timescale for exponential approach, of the
-      vehicle to rotate such that its preferred "up" axis is oriented along the
-      world's "up" axis.
+    description: The period of wobble, or timescale for exponential approach, of the
+      vehicle to rotate such that its preferred "up" axis is oriented along the world's
+      "up" axis.
   VERTICAL:
     property: read-only
     type: number
@@ -4032,8 +3889,7 @@ globals:
   XP_ERROR_NOT_FOUND:
     property: read-only
     type: number
-    description: >-
-      The sim was unable to verify the validity of the experience. Retrying
+    description: The sim was unable to verify the validity of the experience. Retrying
       after a short wait is advised.
   XP_ERROR_NOT_PERMITTED:
     property: read-only
@@ -4050,9 +3906,8 @@ globals:
   XP_ERROR_QUOTA_EXCEEDED:
     property: read-only
     type: number
-    description: >-
-      An attempted write data to the key-value store failed due to the data
-      quota being met.
+    description: An attempted write data to the key-value store failed due to the
+      data quota being met.
   XP_ERROR_REQUEST_PERM_TIMEOUT:
     property: read-only
     type: number
@@ -4088,12 +3943,11 @@ globals:
   default:
     property: read-only
     type: any
-    description: >-
-      All scripts must have a default state, which is the first state entered
-      when the script starts.
+    description: 'All scripts must have a default state, which is the first state
+      entered when the script starts.
 
-      If another state is defined before the default state, the compiler will
-      report a syntax error.
+      If another state is defined before the default state, the compiler will report
+      a syntax error.'
   quaternion:
     type: any
     description: Global 'quaternion' library table with callable metatable
@@ -4114,1885 +3968,1761 @@ globals:
     description: Second Life timer management and scheduling
   dangerouslyexecuterequiredmodule:
     args:
-      - type: any
+    - type: any
     description: Dangerously executes a required module function
   touuid:
     args:
-      - type: any
+    - type: any
     description: Converts a string, buffer, or uuid to a uuid, returns nil if invalid
   tovector:
     args:
-      - type: any
+    - type: any
     description: Converts a value to a vector, returns nil if invalid
   toquaternion:
     args:
-      - type: any
+    - type: any
     description: Converts a value to a quaternion, returns nil if invalid
   torotation:
     args:
-      - type: any
+    - type: any
     description: Converts a value to a rotation (quaternion), returns nil if invalid
   LLDetectedEvent:
     any: true
-    description: >-
-      Event detection class providing access to detected object/avatar
+    description: Event detection class providing access to detected object/avatar
       information
   bit32.arshift:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Arithmetic right shift
   bit32.band:
     args:
-      - type: ...
+    - type: '...'
     description: Bitwise AND of all arguments
   bit32.bnot:
     args:
-      - type: number
+    - type: number
     description: Bitwise NOT
   bit32.bor:
     args:
-      - type: ...
+    - type: '...'
     description: Bitwise OR of all arguments
   bit32.bxor:
     args:
-      - type: ...
+    - type: '...'
     description: Bitwise XOR of all arguments
   bit32.btest:
     args:
-      - type: ...
+    - type: '...'
     description: Returns true if bitwise AND of all arguments is not zero
   bit32.extract:
     args:
-      - type: number
-      - type: number
-      - type: number
-        required: false
+    - type: number
+    - type: number
+    - type: number
+      required: false
     description: Extracts bits from n at position field with width
   bit32.lrotate:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Left rotate
   bit32.lshift:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Left shift
   bit32.replace:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-        required: false
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+      required: false
     description: Replaces bits in n at position field with width using value v
   bit32.rrotate:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Right rotate
   bit32.rshift:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Right shift
   bit32.countlz:
     args:
-      - type: number
+    - type: number
     description: Count leading zeros
   bit32.countrz:
     args:
-      - type: number
+    - type: number
     description: Count trailing zeros
   bit32.byteswap:
     args:
-      - type: number
+    - type: number
     description: Swap byte order
   buffer.create:
     args:
-      - type: number
+    - type: number
     description: Creates a new buffer of the specified size
   buffer.fromstring:
     args:
-      - type: string
+    - type: string
     description: Creates a buffer from a string
   buffer.tostring:
     args:
-      - type: any
+    - type: any
     description: Converts buffer to string
   buffer.readi8:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read signed 8-bit integer
   buffer.readu8:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read unsigned 8-bit integer
   buffer.readi16:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read signed 16-bit integer
   buffer.readu16:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read unsigned 16-bit integer
   buffer.readi32:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read signed 32-bit integer
   buffer.readu32:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read unsigned 32-bit integer
   buffer.readf32:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read 32-bit float
   buffer.readf64:
     args:
-      - type: any
-      - type: number
+    - type: any
+    - type: number
     description: Read 64-bit float
   buffer.writei8:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write signed 8-bit integer
   buffer.writeu8:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write unsigned 8-bit integer
   buffer.writei16:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write signed 16-bit integer
   buffer.writeu16:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write unsigned 16-bit integer
   buffer.writei32:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write signed 32-bit integer
   buffer.writeu32:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write unsigned 32-bit integer
   buffer.writef32:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write 32-bit float
   buffer.writef64:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Write 64-bit float
   buffer.readstring:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Read string from buffer
   buffer.writestring:
     args:
-      - type: any
-      - type: number
-      - type: string
-      - type: number
-        required: false
+    - type: any
+    - type: number
+    - type: string
+    - type: number
+      required: false
     description: Write string to buffer
   buffer.len:
     args:
-      - type: any
+    - type: any
     description: Returns the length of the buffer
   buffer.copy:
     args:
-      - type: any
-      - type: number
-      - type: any
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: any
+    - type: number
+    - type: any
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Copy data from source buffer to target buffer
   buffer.fill:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type: number
-        required: false
+    - type: any
+    - type: number
+    - type: number
+    - type: number
+      required: false
     description: Fill buffer with a value
   buffer.readbits:
     args:
-      - type: any
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
     description: Read bits from buffer
   buffer.writebits:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type: number
+    - type: any
+    - type: number
+    - type: number
+    - type: number
     description: Write bits to buffer
   coroutine.create:
     args:
-      - type: any
+    - type: any
     description: Creates a new coroutine from a function
   coroutine.resume:
     args:
-      - type: any
-      - type: ...
+    - type: any
+    - type: '...'
     description: Resumes a coroutine, returns success and results
   coroutine.running:
     args: []
     description: Returns the running coroutine, or nil if called from main thread
   coroutine.status:
     args:
-      - type: any
+    - type: any
     description: Returns the status of a coroutine
   coroutine.wrap:
     args:
-      - type: any
+    - type: any
     description: Creates a coroutine and returns a function that resumes it
   coroutine.yield:
     args:
-      - type: ...
+    - type: '...'
     description: Suspends the coroutine and returns values to resume
   coroutine.isyieldable:
     args: []
     description: Returns true if the coroutine can yield
   coroutine.close:
     args:
-      - type: any
+    - type: any
     description: Closes a coroutine, returns success and optional error message
   debug.info:
     args:
-      - type: any
-      - type: any
-      - type: string
-        required: false
+    - type: any
+    - type: any
+    - type: string
+      required: false
     description: 'OVERLOAD: Returns information about a function or stack level'
   debug.traceback:
     args:
-      - type: any
-        required: false
-      - type: any
-        required: false
-      - type: number
-        required: false
+    - type: any
+      required: false
+    - type: any
+      required: false
+    - type: number
+      required: false
     description: 'OVERLOAD: Returns a string with a traceback of the call stack'
   llbase64.encode:
     args:
-      - type: any
+    - type: any
     description: Encodes a string or buffer to base64
   llbase64.decode:
     args:
-      - type: string
-      - type: bool
-        required: false
+    - type: string
+    - type: bool
+      required: false
     description: 'OVERLOAD: Decodes a base64 string to a string'
   lljson.encode:
     args:
-      - type: any
+    - type: any
     description: Encodes a Lua value as JSON
   lljson.decode:
     args:
-      - type: string
+    - type: string
     description: Decodes a JSON string to a Lua value
   lljson.slencode:
     args:
-      - type: any
-      - type: bool
-        required: false
-    description: >-
-      Encodes a Lua value as JSON preserving SL types. Use tight to encode more
-      compactly.
+    - type: any
+    - type: bool
+      required: false
+    description: Encodes a Lua value as JSON preserving SL types. Use tight to encode
+      more compactly.
   lljson.sldecode:
     args:
-      - type: string
+    - type: string
     description: Decodes a JSON string to a Lua value preserving SL types
   math.abs:
     args:
-      - type: number
+    - type: number
     description: Returns the absolute value of x
   math.acos:
     args:
-      - type: number
+    - type: number
     description: Returns the arc cosine of x (in radians)
   math.asin:
     args:
-      - type: number
+    - type: number
     description: Returns the arc sine of x (in radians)
   math.atan:
     args:
-      - type: number
+    - type: number
     description: Returns the arc tangent of x (in radians)
   math.atan2:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Returns the arc tangent of y/x (in radians), using the signs to determine
+    - type: number
+    - type: number
+    description: Returns the arc tangent of y/x (in radians), using the signs to determine
       the quadrant
   math.ceil:
     args:
-      - type: number
+    - type: number
     description: Returns the smallest integer larger than or equal to x
   math.clamp:
     args:
-      - type: number
-      - type: number
-      - type: number
+    - type: number
+    - type: number
+    - type: number
     description: Returns n clamped between min and max
   math.cos:
     args:
-      - type: number
+    - type: number
     description: Returns the cosine of x (x in radians)
   math.cosh:
     args:
-      - type: number
+    - type: number
     description: Returns the hyperbolic cosine of x
   math.deg:
     args:
-      - type: number
+    - type: number
     description: Converts x from radians to degrees
   math.exp:
     args:
-      - type: number
+    - type: number
     description: Returns e^x
   math.floor:
     args:
-      - type: number
+    - type: number
     description: Returns the largest integer smaller than or equal to x
   math.fmod:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Returns the remainder of x/y that rounds towards zero
   math.frexp:
     args:
-      - type: number
+    - type: number
     description: Returns m and e such that x = m * 2^e
   math.ldexp:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Returns m * 2^e
   math.lerp:
     args:
-      - type: number
-      - type: number
-      - type: number
+    - type: number
+    - type: number
+    - type: number
     description: Linear interpolation between a and b by t
   math.log:
     args:
-      - type: number
-      - type: number
-        required: false
+    - type: number
+    - type: number
+      required: false
     description: Returns the logarithm of x in the given base (default e)
   math.log10:
     args:
-      - type: number
+    - type: number
     description: Returns the base-10 logarithm of x
   math.map:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
     description: Maps x from input range to output range
   math.max:
     args:
-      - type: number
-      - type: ...
+    - type: number
+    - type: '...'
     description: Returns the maximum value among the arguments
   math.min:
     args:
-      - type: number
-      - type: ...
+    - type: number
+    - type: '...'
     description: Returns the minimum value among the arguments
   math.modf:
     args:
-      - type: number
+    - type: number
     description: Returns the integer and fractional parts of x
   math.noise:
     args:
-      - type: number
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: number
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Returns Perlin noise value for the given coordinates
   math.pow:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Returns base^exponent
   math.rad:
     args:
-      - type: number
+    - type: number
     description: Converts x from degrees to radians
   math.random:
     args:
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Returns a pseudo-random number
   math.randomseed:
     args:
-      - type: number
+    - type: number
     description: Sets the seed for the pseudo-random generator
   math.round:
     args:
-      - type: number
+    - type: number
     description: Returns x rounded to the nearest integer
   math.sign:
     args:
-      - type: number
+    - type: number
     description: Returns -1, 0, or 1 depending on the sign of x
   math.sin:
     args:
-      - type: number
+    - type: number
     description: Returns the sine of x (x in radians)
   math.sinh:
     args:
-      - type: number
+    - type: number
     description: Returns the hyperbolic sine of x
   math.sqrt:
     args:
-      - type: number
+    - type: number
     description: Returns the square root of x
   math.tan:
     args:
-      - type: number
+    - type: number
     description: Returns the tangent of x (x in radians)
   math.tanh:
     args:
-      - type: number
+    - type: number
     description: Returns the hyperbolic tangent of x
   math.isnan:
     args:
-      - type: number
+    - type: number
     description: Returns true if x is NaN
   math.isinf:
     args:
-      - type: number
+    - type: number
     description: Returns true if x is infinite
   math.isfinite:
     args:
-      - type: number
+    - type: number
     description: Returns true if x is finite
   os.clock:
     args: []
     description: Returns CPU time used by the program in seconds
   os.date:
     args:
-      - type: string
-        required: false
-      - type: number
-        required: false
+    - type: string
+      required: false
+    - type: number
+      required: false
     description: Returns a string or table containing date and time
   os.difftime:
     args:
-      - type: number
-      - type: number
-        required: false
+    - type: number
+    - type: number
+      required: false
     description: Returns the difference in seconds between two times
   os.time:
     args:
-      - type:
-          display: OsDateTime
-        required: false
+    - type:
+        display: OsDateTime
+      required: false
     description: Returns the current time or converts a table to time
   string.byte:
     args:
-      - type: string
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: string
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Returns the internal numeric codes of the characters
   string.char:
     args:
-      - type: ...
+    - type: '...'
     description: Returns a string from character codes
   string.find:
     args:
-      - type: string
-      - type: string
-      - type: number
-        required: false
-      - type: bool
-        required: false
+    - type: string
+    - type: string
+    - type: number
+      required: false
+    - type: bool
+      required: false
     description: Finds first match of pattern in string
   string.format:
     args:
-      - type: string
-      - type: ...
+    - type: string
+    - type: '...'
     description: Returns a formatted string
   string.gmatch:
     args:
-      - type: string
-      - type: string
+    - type: string
+    - type: string
     description: Returns an iterator function for pattern matches
   string.gsub:
     args:
-      - type: string
-      - type: string
-      - type: any
-      - type: number
-        required: false
+    - type: string
+    - type: string
+    - type: any
+    - type: number
+      required: false
     description: Global substitution of pattern matches
   string.len:
     args:
-      - type: string
+    - type: string
     description: Returns the length of the string
   string.lower:
     args:
-      - type: string
+    - type: string
     description: Converts string to lowercase
   string.match:
     args:
-      - type: string
-      - type: string
-      - type: number
-        required: false
+    - type: string
+    - type: string
+    - type: number
+      required: false
     description: Returns captures from pattern match
   string.pack:
     args:
-      - type: string
-      - type: ...
+    - type: string
+    - type: '...'
     description: Packs values into a binary string
   string.packsize:
     args:
-      - type: string
+    - type: string
     description: Returns the size of a packed string for the given format
   string.rep:
     args:
-      - type: string
-      - type: number
+    - type: string
+    - type: number
     description: Returns a string repeated n times
   string.reverse:
     args:
-      - type: string
+    - type: string
     description: Reverses a string
   string.split:
     args:
-      - type: string
-      - type: string
-        required: false
+    - type: string
+    - type: string
+      required: false
     description: Splits a string by separator
   string.sub:
     args:
-      - type: string
-      - type: number
-      - type: number
-        required: false
+    - type: string
+    - type: number
+    - type: number
+      required: false
     description: Returns a substring
   string.unpack:
     args:
-      - type: string
-      - type: string
-      - type: number
-        required: false
+    - type: string
+    - type: string
+    - type: number
+      required: false
     description: Unpacks values from a binary string
   string.upper:
     args:
-      - type: string
+    - type: string
     description: Converts string to uppercase
   table.concat:
     args:
-      - type: any
-      - type: string
-        required: false
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: any
+    - type: string
+      required: false
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Concatenates table elements into a string
   table.foreach:
     args:
-      - type: any
-      - type: any
+    - type: any
+    - type: any
     description: Iterates over table key-value pairs (deprecated)
   table.foreachi:
     args:
-      - type: any
-      - type: any
+    - type: any
+    - type: any
     description: Iterates over array indices (deprecated)
   table.getn:
     args:
-      - type: any
+    - type: any
     description: 'Returns the length of a table (deprecated, use # operator)'
   table.maxn:
     args:
-      - type: any
+    - type: any
     description: Returns the largest positive numeric index
   table.insert:
     args:
-      - type: any
-      - type: any
-      - type: any
-        required: false
+    - type: any
+    - type: any
+    - type: any
+      required: false
     description: 'OVERLOAD: Inserts an element at the end of a list'
   table.remove:
     args:
-      - type: any
-      - type: number
-        required: false
+    - type: any
+    - type: number
+      required: false
     description: Removes and returns an element from a list
   table.sort:
     args:
-      - type: any
-      - type: any
-        required: false
+    - type: any
+    - type: any
+      required: false
     description: Sorts list elements in place
   table.pack:
     args:
-      - type: ...
+    - type: '...'
     description: Packs arguments into a table with length field n
   table.unpack:
     args:
-      - type: any
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: any
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Unpacks table elements as multiple return values
   table.move:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type: number
-      - type: any
-        required: false
+    - type: any
+    - type: number
+    - type: number
+    - type: number
+    - type: any
+      required: false
     description: Moves elements from one table to another
   table.create:
     args:
-      - type: number
-      - type: any
-        required: false
+    - type: number
+    - type: any
+      required: false
     description: Creates a new table with pre-allocated array slots
   table.find:
     args:
-      - type: any
-      - type: any
-      - type: number
-        required: false
+    - type: any
+    - type: any
+    - type: number
+      required: false
     description: Finds the index of a value in an array
   table.clear:
     args:
-      - type: any
+    - type: any
     description: Removes all elements from a table
   table.freeze:
     args:
-      - type: any
+    - type: any
     description: Makes a table read-only
   table.isfrozen:
     args:
-      - type: any
+    - type: any
     description: Returns true if a table is frozen
   table.clone:
     args:
-      - type: any
+    - type: any
     description: Creates a shallow copy of a table
   utf8.char:
     args:
-      - type: ...
+    - type: '...'
     description: Returns a string from UTF-8 codepoints
   utf8.codes:
     args:
-      - type: string
+    - type: string
     description: Returns an iterator for UTF-8 codepoints in a string
   utf8.codepoint:
     args:
-      - type: string
-      - type: number
-        required: false
-      - type: number
-        required: false
+    - type: string
+    - type: number
+      required: false
+    - type: number
+      required: false
     description: Returns the codepoints of characters in a string
   utf8.len:
     args:
-      - type: string
-      - type: number
-        required: false
-      - type: number
-        required: false
-    description: >-
-      Returns the number of UTF-8 characters in a string, or nil and error
+    - type: string
+    - type: number
+      required: false
+    - type: number
+      required: false
+    description: Returns the number of UTF-8 characters in a string, or nil and error
       position
   utf8.offset:
     args:
-      - type: string
-      - type: number
-      - type: number
-        required: false
+    - type: string
+    - type: number
+    - type: number
+      required: false
     description: Returns the byte position of the n-th character
   ll.Abs:
     args:
-      - type: number
+    - type: number
     description: Returns the absolute (positive) version of Value.
   ll.Acos:
     args:
-      - type: number
+    - type: number
     description: Returns the arc-cosine of Value, in radians.
   ll.AddToLandBanList:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Add avatar ID to the parcel ban list for the specified number of Hours.\nA
-      value of 0 for Hours will add the agent indefinitely.\nThe smallest value
-      that Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen
-      values that small are used, it seems the function bans in approximately 30
-      second increments (Probably 36 second increments, as 0.01 of an hour is 36
-      seconds).\nResidents teleporting to a parcel where they are banned will be
-      redirected to a neighbouring parcel.
+    - type:
+        display: uuid
+    - type: number
+    description: Add avatar ID to the parcel ban list for the specified number of
+      Hours.\nA value of 0 for Hours will add the agent indefinitely.\nThe smallest
+      value that Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen
+      values that small are used, it seems the function bans in approximately 30 second
+      increments (Probably 36 second increments, as 0.01 of an hour is 36 seconds).\nResidents
+      teleporting to a parcel where they are banned will be redirected to a neighbouring
+      parcel.
   ll.AddToLandPassList:
     args:
-      - type:
-          display: uuid
-      - type: number
+    - type:
+        display: uuid
+    - type: number
     description: Add avatar ID to the land pass list, for a duration of Hours.
   ll.AdjustSoundVolume:
     args:
-      - type: number
-    description: >-
-      Adjusts the volume (0.0 - 1.0) of the currently playing attached
+    - type: number
+    description: Adjusts the volume (0.0 - 1.0) of the currently playing attached
       sound.\nThis function has no effect on sounds started with llTriggerSound.
   ll.AgentInExperience:
     args:
-      - type:
-          display: uuid
-    description: |2-
-
-                         Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
-                      
+    - type:
+        display: uuid
+    description: "\n                   Returns TRUE if the agent is in the Experience\
+      \ and the Experience can run in the current location.\n                "
   ll.AllowInventoryDrop:
     args:
-      - type:
-          display: numeric
-    description: >-
-      If Flag == TRUE, users without object modify permissions can still drop
-      inventory items into the object.
+    - type:
+        display: numeric
+    description: If Flag == TRUE, users without object modify permissions can still
+      drop inventory items into the object.
   ll.AngleBetween:
     args:
-      - type:
-          display: quaternion
-      - type:
-          display: quaternion
+    - type:
+        display: quaternion
+    - type:
+        display: quaternion
     description: Returns the angle, in radians, between rotations Rot1 and Rot2.
   ll.ApplyImpulse:
     args:
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Applies impulse to the object.\nIf Local == TRUE, apply the Force in local
-      coordinates; otherwise, apply the Force in global coordinates.\nThis
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Applies impulse to the object.\nIf Local == TRUE, apply the Force
+      in local coordinates; otherwise, apply the Force in global coordinates.\nThis
       function only works on physical objects.
   ll.ApplyRotationalImpulse:
     args:
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Applies rotational impulse to the object.\nIf Local == TRUE, apply the
-      Force in local coordinates; otherwise, apply the Force in global
-      coordinates.\nThis function only works on physical objects.
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Applies rotational impulse to the object.\nIf Local == TRUE, apply
+      the Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis
+      function only works on physical objects.
   ll.Asin:
     args:
-      - type: number
+    - type: number
     description: Returns the arc-sine, in radians, of Value.
   ll.Atan2:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Returns the arc-tangent2 of y, x.
   ll.AttachToAvatar:
     args:
-      - type: number
-    description: >-
-      Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH
+    - type: number
+    description: Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH
       runtime permission.
   ll.AttachToAvatarTemp:
     args:
-      - type: number
-    description: >-
-      Follows the same convention as llAttachToAvatar, with the exception that
-      the object will not create new inventory for the user, and will disappear
+    - type: number
+    description: Follows the same convention as llAttachToAvatar, with the exception
+      that the object will not create new inventory for the user, and will disappear
       on detach or disconnect.
   ll.AvatarOnLinkSitTarget:
     args:
-      - type: number
-    description: >-
-      If an avatar is sitting on the link's sit target, return the avatar's key,
-      NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on
-      the specified link's prim.
+    - type: number
+    description: If an avatar is sitting on the link's sit target, return the avatar's
+      key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated
+      on the specified link's prim.
   ll.AvatarOnSitTarget:
     args: []
-    description: >-
-      If an avatar is seated on the sit target, returns the avatar's key,
-      otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets
-      defined with llSitTarget.
+    description: If an avatar is seated on the sit target, returns the avatar's key,
+      otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined
+      with llSitTarget.
   ll.Axes2Rot:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: Returns the rotation represented by coordinate axes Forward, Left, and Up.
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Returns the rotation represented by coordinate axes Forward, Left,
+      and Up.
   ll.AxisAngle2Rot:
     args:
-      - type:
-          display: vector
-      - type: number
+    - type:
+        display: vector
+    - type: number
     description: Returns the rotation that is a generated Angle about Axis.
   ll.Base64ToInteger:
     args:
-      - type: string
-    description: >-
-      Returns an integer that is the Text, Base64 decoded as a big endian
-      integer.\nReturns zero if Text is longer then 8 characters. If Text
-      contains fewer then 6 characters, the return value is unpredictable.
+    - type: string
+    description: Returns an integer that is the Text, Base64 decoded as a big endian
+      integer.\nReturns zero if Text is longer then 8 characters. If Text contains
+      fewer then 6 characters, the return value is unpredictable.
   ll.Base64ToString:
     args:
-      - type: string
-    description: >-
-      Converts a Base64 string to a conventional string.\nIf the conversion
+    - type: string
+    description: Converts a Base64 string to a conventional string.\nIf the conversion
       creates any unprintable characters, they are converted to question marks.
   ll.BreakAllLinks:
     args: []
-    description: >-
-      De-links all prims in the link set (requires permission
-      PERMISSION_CHANGE_LINKS be set).
+    description: De-links all prims in the link set (requires permission PERMISSION_CHANGE_LINKS
+      be set).
   ll.BreakLink:
     args:
-      - type: number
-    description: >-
-      De-links the prim with the given link number (requires permission
+    - type: number
+    description: De-links the prim with the given link number (requires permission
       PERMISSION_CHANGE_LINKS be set).
   ll.CSV2List:
     args:
-      - type: string
-    description: Create a list from a string of comma separated values specified in Text.
+    - type: string
+    description: Create a list from a string of comma separated values specified in
+      Text.
   ll.CastRay:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Casts a ray into the physics world from 'start' to 'end' and returns data
-      according to details in Options.\nReports collision data for intersections
-      with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1,
-      {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2},
-      ... , status_code] where {} indicates optional data.
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type: table
+    description: 'Casts a ray into the physics world from ''start'' to ''end'' and
+      returns data according to details in Options.\nReports collision data for intersections
+      with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1},
+      UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code]
+      where {} indicates optional data.'
   ll.Ceil:
     args:
-      - type: number
+    - type: number
     description: Returns smallest integer value >= Value.
   ll.Char:
     args:
-      - type: number
-    description: >-
-      Returns a single character string that is the representation of the
+    - type: number
+    description: Returns a single character string that is the representation of the
       unicode value.
   ll.ClearCameraParams:
     args: []
-    description: >-
-      Resets all camera parameters to default values and turns off scripted
+    description: Resets all camera parameters to default values and turns off scripted
       camera control.
   ll.ClearLinkMedia:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Clears (deletes) the media and all parameters from the given Face on the
-      linked prim.\nReturns an integer that is a STATUS_* flag, which details
+    - type: number
+    - type: number
+    description: Clears (deletes) the media and all parameters from the given Face
+      on the linked prim.\nReturns an integer that is a STATUS_* flag, which details
       the success/failure of the operation.
   ll.ClearPrimMedia:
     args:
-      - type: number
-    description: >-
-      Clears (deletes) the media and all parameters from the given
-      Face.\nReturns an integer that is a STATUS_* flag which details the
-      success/failure of the operation.
+    - type: number
+    description: Clears (deletes) the media and all parameters from the given Face.\nReturns
+      an integer that is a STATUS_* flag which details the success/failure of the
+      operation.
   ll.CloseRemoteDataChannel:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: This function is deprecated.
   ll.Cloud:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Returns the cloud density at the object's position + Offset.
   ll.CollisionFilter:
     args:
-      - type: string
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Specify an empty string or NULL_KEY for Accept, to not filter on the
-      corresponding parameter.
+    - type: string
+    - type:
+        display: uuid
+    - type: number
+    description: Specify an empty string or NULL_KEY for Accept, to not filter on
+      the corresponding parameter.
   ll.CollisionSound:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Suppress default collision sounds, replace default impact sounds with
-      ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply an
-      empty string to suppress collision sounds.
+    - type: string
+    - type: number
+    description: Suppress default collision sounds, replace default impact sounds
+      with ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply
+      an empty string to suppress collision sounds.
   ll.CollisionSprite:
     args:
-      - type: string
-    description: >-
-      Suppress default collision sprites, replace default impact sprite with
-      ImpactSprite; found in the object inventory (empty string to just
-      suppress).
+    - type: string
+    description: Suppress default collision sprites, replace default impact sprite
+      with ImpactSprite; found in the object inventory (empty string to just suppress).
   ll.ComputeHash:
     args:
-      - type: string
-      - type: string
+    - type: string
+    - type: string
     description: Returns hex-encoded Hash string of Message using digest Algorithm.
   ll.Cos:
     args:
-      - type: number
+    - type: number
     description: Returns the cosine of Theta (Theta in radians).
   ll.CreateCharacter:
     args:
-      - type: table
-    description: >-
-      Convert link-set to AI/Physics character.\nCreates a path-finding entity,
-      known as a "character", from the object containing the script. Required to
-      activate use of path-finding functions.\nOptions is a list of key/value
-      pairs.
+    - type: table
+    description: Convert link-set to AI/Physics character.\nCreates a path-finding
+      entity, known as a "character", from the object containing the script. Required
+      to activate use of path-finding functions.\nOptions is a list of key/value pairs.
   ll.CreateKeyValue:
     args:
-      - type: string
-      - type: string
-    description: |2-
-
-                         Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
-                      
+    - type: string
+    - type: string
+    description: "\n                   Starts an asychronous transaction to create\
+      \ a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already\
+      \ exists. The dataserver callback will be executed with the key returned from\
+      \ this call and a string describing the result. The result is a two element\
+      \ commma-delimited list. The first item is an integer specifying if the transaction\
+      \ succeeded (1) or not (0). In the failure case, the second item will be an\
+      \ integer corresponding to one of the XP_ERROR_... constants. In the success\
+      \ case the second item will be the value passed to the function.\n         \
+      \       "
   ll.CreateLink:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Attempt to link the object the script is in, to target (requires
-      permission PERMISSION_CHANGE_LINKS be set).\nRequires permission
-      PERMISSION_CHANGE_LINKS be set.
+    - type:
+        display: uuid
+    - type: number
+    description: Attempt to link the object the script is in, to target (requires
+      permission PERMISSION_CHANGE_LINKS be set).\nRequires permission PERMISSION_CHANGE_LINKS
+      be set.
   ll.Damage:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: number
+    - type:
+        display: uuid
+    - type: number
+    - type: number
     description: Generates a damage event on the targeted agent or task.
   ll.DataSizeKeyValue:
     args: []
-    description: |2-
-
-                         Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
-                      
+    description: "\n                   Starts an asychronous transaction the request\
+      \ the used and total amount of data allocated for the Experience. The dataserver\
+      \ callback will be executed with the key returned from this call and a string\
+      \ describing the result. The result is commma-delimited list. The first item\
+      \ is an integer specifying if the transaction succeeded (1) or not (0). In the\
+      \ failure case, the second item will be an integer corresponding to one of the\
+      \ XP_ERROR_... constants. In the success case the second item will be the the\
+      \ amount in use and the third item will be the total available.\n          \
+      \      "
   ll.DeleteCharacter:
     args: []
-    description: >-
-      Convert link-set from AI/Physics character to Physics object.\nConvert the
-      current link-set back to a standard object, removing all path-finding
-      properties.
+    description: Convert link-set from AI/Physics character to Physics object.\nConvert
+      the current link-set back to a standard object, removing all path-finding properties.
   ll.DeleteKeyValue:
     args:
-      - type: string
-    description: |2-
-
-                         Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-                      
+    - type: string
+    description: "\n                   Starts an asychronous transaction to delete\
+      \ a key-value pair. The dataserver callback will be executed with the key returned\
+      \ from this call and a string describing the result. The result is a two element\
+      \ commma-delimited list. The first item is an integer specifying if the transaction\
+      \ succeeded (1) or not (0). In the failure case, the second item will be an\
+      \ integer corresponding to one of the XP_ERROR_... constants. In the success\
+      \ case the second item will be the value associated with the key.\n        \
+      \        "
   ll.DeleteSubList:
     args:
-      - type: any
-      - type: number
-      - type: number
-    description: >-
-      Removes the slice from start to end and returns the remainder of the
-      list.\nRemove a slice from the list and return the remainder, start and
-      end are inclusive.\nUsing negative numbers for start and/or end causes the
-      index to count backwards from the length of the list, so 0, -1 would
-      delete the entire list.\nIf Start is larger than End the list deleted is
-      the exclusion of the entries; so 6, 4 would delete the entire list except
-      for the 5th list entry.
+    - type: any
+    - type: number
+    - type: number
+    description: Removes the slice from start to end and returns the remainder of
+      the list.\nRemove a slice from the list and return the remainder, start and
+      end are inclusive.\nUsing negative numbers for start and/or end causes the index
+      to count backwards from the length of the list, so 0, -1 would delete the entire
+      list.\nIf Start is larger than End the list deleted is the exclusion of the
+      entries; so 6, 4 would delete the entire list except for the 5th list entry.
   ll.DeleteSubString:
     args:
-      - type: string
-      - type: number
-      - type: number
-    description: >-
-      Removes the indicated sub-string and returns the result.\nStart and End
-      are inclusive.\nUsing negative numbers for Start and/or End causes the
-      index to count backwards from the length of the string, so 0, -1 would
-      delete the entire string.\nIf Start is larger than End, the sub-string is
-      the exclusion of the entries; so 6, 4 would delete the entire string
-      except for the 5th character.
+    - type: string
+    - type: number
+    - type: number
+    description: Removes the indicated sub-string and returns the result.\nStart and
+      End are inclusive.\nUsing negative numbers for Start and/or End causes the index
+      to count backwards from the length of the string, so 0, -1 would delete the
+      entire string.\nIf Start is larger than End, the sub-string is the exclusion
+      of the entries; so 6, 4 would delete the entire string except for the 5th character.
   ll.DerezObject:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Derezzes an object previously rezzed by a script in this region. Returns
-      TRUE on success or FALSE if the object could not be derezzed.
+    - type:
+        display: uuid
+    - type: number
+    description: Derezzes an object previously rezzed by a script in this region.
+      Returns TRUE on success or FALSE if the object could not be derezzed.
   ll.DetachFromAvatar:
     args: []
     description: Remove the object containing the script from the avatar.
   ll.Dialog:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: table
-      - type: number
-    description: |-
-      Shows a dialog box on the avatar's screen with the message.\n
-                          Up to 12 strings in the list form buttons.\n
-                          If a button is clicked, the name is chatted on Channel.\nOpens a "notify box" in the given avatars screen displaying the message.\n
-                      Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
-                      Channels work just like llSay(), so channel 0 can be heard by everyone.\n
-                      The chat originates at the object's position, not the avatar's position, even though it is said as the avatar (uses avatar's UUID and Name etc.).\n
-                      Examples:\n
-                      llDialog(who, "Are you a boy or a girl?", [ "Boy", "Girl" ], -4913);\n
-                      llDialog(who, "This shows only an OK button.", [], -192);\n
-                      llDialog(who, "This chats so you can 'hear' it.", ["Hooray"], 0);
+    - type:
+        display: uuid
+    - type: string
+    - type: table
+    - type: number
+    description: "Shows a dialog box on the avatar's screen with the message.\\n\n\
+      \                    Up to 12 strings in the list form buttons.\\n\n       \
+      \             If a button is clicked, the name is chatted on Channel.\\nOpens\
+      \ a \"notify box\" in the given avatars screen displaying the message.\\n\n\
+      \                Up to twelve buttons can be specified in a list of strings.\
+      \ When the user clicks a button, the name of the button is said on the specified\
+      \ channel.\\n\n                Channels work just like llSay(), so channel 0\
+      \ can be heard by everyone.\\n\n                The chat originates at the object's\
+      \ position, not the avatar's position, even though it is said as the avatar\
+      \ (uses avatar's UUID and Name etc.).\\n\n                Examples:\\n\n   \
+      \             llDialog(who, \"Are you a boy or a girl?\", [ \"Boy\", \"Girl\"\
+      \ ], -4913);\\n\n                llDialog(who, \"This shows only an OK button.\"\
+      , [], -192);\\n\n                llDialog(who, \"This chats so you can 'hear'\
+      \ it.\", [\"Hooray\"], 0);"
   ll.Die:
     args: []
     description: Delete the object which holds the script.
   ll.DumpList2String:
     args:
-      - type: table
-      - type: string
-    description: >-
-      Returns the list as a single string, using Separator between the
-      entries.\nWrite the list out as a single string, using Separator between
-      values.
+    - type: table
+    - type: string
+    description: Returns the list as a single string, using Separator between the
+      entries.\nWrite the list out as a single string, using Separator between values.
   ll.EdgeOfWorld:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Checks to see whether the border hit by Direction from Position is the
-      edge of the world (has no neighboring region).\nReturns TRUE if the line
-      along Direction from Position hits the edge of the world in the current
-      simulator, returns FALSE if that edge crosses into another simulator.
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Checks to see whether the border hit by Direction from Position is
+      the edge of the world (has no neighboring region).\nReturns TRUE if the line
+      along Direction from Position hits the edge of the world in the current simulator,
+      returns FALSE if that edge crosses into another simulator.
   ll.EjectFromLand:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Ejects AvatarID from land that you own.\nEjects AvatarID from land that
-      the object owner (group or resident) owns.
+    - type:
+        display: uuid
+    description: Ejects AvatarID from land that you own.\nEjects AvatarID from land
+      that the object owner (group or resident) owns.
   ll.Email:
     args:
-      - type: string
-      - type: string
-      - type: string
-    description: >-
-      Sends email to Address with Subject and Message.\nSends an email to
-      Address with Subject and Message.
+    - type: string
+    - type: string
+    - type: string
+    description: Sends email to Address with Subject and Message.\nSends an email
+      to Address with Subject and Message.
   ll.EscapeURL:
     args:
-      - type: string
-    description: >-
-      Returns an escaped/encoded version of url, replacing spaces with %20
-      etc.\nReturns the string that is the URL-escaped version of URL (replacing
-      spaces with %20, etc.).\n
-                      This function returns the UTF-8 encoded escape codes for selected characters.
+    - type: string
+    description: "Returns an escaped/encoded version of url, replacing spaces with\
+      \ %20 etc.\\nReturns the string that is the URL-escaped version of URL (replacing\
+      \ spaces with %20, etc.).\\n\n                This function returns the UTF-8\
+      \ encoded escape codes for selected characters."
   ll.Euler2Rot:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the rotation representation of the Euler angles.\nReturns the
-      rotation represented by the Euler Angle.
+    - type:
+        display: vector
+    description: Returns the rotation representation of the Euler angles.\nReturns
+      the rotation represented by the Euler Angle.
   ll.Evade:
     args:
-      - type:
-          display: uuid
-      - type: table
-    description: >-
-      Evade a specified target.\nCharacters will (roughly) try to hide from
-      their pursuers if there is a good hiding spot along their fleeing path.
-      Hiding means no direct line of sight from the head of the character
-      (centre of the top of its physics bounding box) to the head of its pursuer
-      and no direct path between the two on the navigation-mesh.
+    - type:
+        display: uuid
+    - type: table
+    description: Evade a specified target.\nCharacters will (roughly) try to hide
+      from their pursuers if there is a good hiding spot along their fleeing path.
+      Hiding means no direct line of sight from the head of the character (centre
+      of the top of its physics bounding box) to the head of its pursuer and no direct
+      path between the two on the navigation-mesh.
   ll.ExecCharacterCmd:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Execute a character command.\nSend a command to the path
-      system.\nCurrently only supports stopping the current path-finding
-      operation or causing the character to jump.
+    - type: number
+    - type: table
+    description: Execute a character command.\nSend a command to the path system.\nCurrently
+      only supports stopping the current path-finding operation or causing the character
+      to jump.
   ll.Fabs:
     args:
-      - type: number
-    description: >-
-      Returns the positive version of Value.\nReturns the absolute value of
-      Value.
+    - type: number
+    description: Returns the positive version of Value.\nReturns the absolute value
+      of Value.
   ll.FindNotecardTextCount:
     args:
-      - type: string
-      - type: string
-      - type: table
-    description: >-
-      Searches the text of a cached notecard for lines containing the given
-      pattern and returns the 
-                  number of matches found through a dataserver event.
-                  
+    - type: string
+    - type: string
+    - type: table
+    description: "Searches the text of a cached notecard for lines containing the\
+      \ given pattern and returns the \n            number of matches found through\
+      \ a dataserver event.\n            "
   ll.FindNotecardTextSync:
     args:
-      - type: string
-      - type: string
-      - type: number
-      - type: number
-      - type: table
-    description: >-
-      Searches the text of a cached notecard for lines containing the given
-      pattern. 
-                  Returns a list of line numbers and column where a match is found. If the notecard is not in
-                  the cache it returns a list containing a single entry of NAK. If no matches are found an
-                  empty list is returned.
+    - type: string
+    - type: string
+    - type: number
+    - type: number
+    - type: table
+    description: "Searches the text of a cached notecard for lines containing the\
+      \ given pattern. \n            Returns a list of line numbers and column where\
+      \ a match is found. If the notecard is not in\n            the cache it returns\
+      \ a list containing a single entry of NAK. If no matches are found an\n    \
+      \        empty list is returned."
   ll.FleeFrom:
     args:
-      - type:
-          display: vector
-      - type: number
-      - type: table
-    description: >-
-      Flee from a point.\nDirects a character (llCreateCharacter) to keep away
-      from a defined position in the region or adjacent regions.
+    - type:
+        display: vector
+    - type: number
+    - type: table
+    description: Flee from a point.\nDirects a character (llCreateCharacter) to keep
+      away from a defined position in the region or adjacent regions.
   ll.Floor:
     args:
-      - type: number
+    - type: number
     description: Returns largest integer value <= Value.
   ll.ForceMouselook:
     args:
-      - type:
-          display: numeric
-    description: >-
-      If Enable is TRUE any avatar that sits on this object is forced into
-      mouse-look mode.\nAfter calling this function with Enable set to TRUE, any
-      agent sitting down on the prim will be forced into mouse-look.\nJust like
-      llSitTarget, this changes a permanent property of the prim (not the
-      object) and needs to be reset by calling this function with Enable set to
-      FALSE in order to disable it.
+    - type:
+        display: numeric
+    description: If Enable is TRUE any avatar that sits on this object is forced into
+      mouse-look mode.\nAfter calling this function with Enable set to TRUE, any agent
+      sitting down on the prim will be forced into mouse-look.\nJust like llSitTarget,
+      this changes a permanent property of the prim (not the object) and needs to
+      be reset by calling this function with Enable set to FALSE in order to disable
+      it.
   ll.Frand:
     args:
-      - type: number
-    description: >-
-      Returns a pseudo random number in the range [0, Magnitude] or [Magnitude,
+    - type: number
+    description: Returns a pseudo random number in the range [0, Magnitude] or [Magnitude,
       0].\nReturns a pseudo-random number between [0, Magnitude].
   ll.GenerateKey:
     args: []
-    description: >-
-      Generates a key (SHA-1 hash) using UUID generation to create a unique
-      key.\nAs the UUID produced is versioned, it should never return a value of
-      NULL_KEY.\nThe specific UUID version is an implementation detail that has
-      changed in the past and may change again in the future. Do not depend upon
-      the UUID that is returned to be version 5 SHA-1 hash.
+    description: Generates a key (SHA-1 hash) using UUID generation to create a unique
+      key.\nAs the UUID produced is versioned, it should never return a value of NULL_KEY.\nThe
+      specific UUID version is an implementation detail that has changed in the past
+      and may change again in the future. Do not depend upon the UUID that is returned
+      to be version 5 SHA-1 hash.
   ll.GetAccel:
     args: []
-    description: >-
-      Returns the acceleration of the object relative to the region's
-      axes.\nGets the acceleration of the object.
+    description: Returns the acceleration of the object relative to the region's axes.\nGets
+      the acceleration of the object.
   ll.GetAgentInfo:
     args:
-      - type:
-          display: uuid
-    description: |-
-      Returns an integer bit-field containing the agent information about id.\n
-                          Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.
+    - type:
+        display: uuid
+    description: "Returns an integer bit-field containing the agent information about\
+      \ id.\\n\n                    Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED,\
+      \ AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING,\
+      \ AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\\\
+      nReturns information about the given agent ID as a bit-field of agent info constants."
   ll.GetAgentLanguage:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the language code of the preferred interface language of the
-      avatar.\nReturns a string that is the language code of the preferred
-      interface language of the resident.
+    - type:
+        display: uuid
+    description: Returns the language code of the preferred interface language of
+      the avatar.\nReturns a string that is the language code of the preferred interface
+      language of the resident.
   ll.GetAgentList:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Requests a list of agents currently in the region, limited by the scope
-      parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or
-      [string error_msg] - returns avatar keys for all agents in the region
-      limited to the area(s) specified by scope
+    - type: number
+    - type: table
+    description: Requests a list of agents currently in the region, limited by the
+      scope parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or
+      [string error_msg] - returns avatar keys for all agents in the region limited
+      to the area(s) specified by scope
   ll.GetAgentSize:
     args:
-      - type:
-          display: uuid
-    description: >-
-      If the avatar is in the same region, returns the size of the bounding box
-      of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the
-      agent is in the same region as the object, returns the size of the avatar.
+    - type:
+        display: uuid
+    description: If the avatar is in the same region, returns the size of the bounding
+      box of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the agent
+      is in the same region as the object, returns the size of the avatar.
   ll.GetAlpha:
     args:
-      - type: number
-    description: >-
-      Returns the alpha value of Face.\nReturns the 'alpha' of the given face.
-      If face is ALL_SIDES the value returned is the mean average of all faces.
+    - type: number
+    description: Returns the alpha value of Face.\nReturns the 'alpha' of the given
+      face. If face is ALL_SIDES the value returned is the mean average of all faces.
   ll.GetAndResetTime:
     args: []
-    description: >-
-      Returns the script time in seconds and then resets the script timer to
-      zero.\nGets the time in seconds since starting and resets the time to
-      zero.
+    description: Returns the script time in seconds and then resets the script timer
+      to zero.\nGets the time in seconds since starting and resets the time to zero.
   ll.GetAnimation:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the name of the currently playing locomotion animation for the
-      avatar id.\nReturns the currently playing animation for the specified
-      avatar ID.
+    - type:
+        display: uuid
+    description: Returns the name of the currently playing locomotion animation for
+      the avatar id.\nReturns the currently playing animation for the specified avatar
+      ID.
   ll.GetAnimationList:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns a list of keys of playing animations for an avatar.\nReturns a
-      list of keys of all playing animations for the specified avatar ID.
+    - type:
+        display: uuid
+    description: Returns a list of keys of playing animations for an avatar.\nReturns
+      a list of keys of all playing animations for the specified avatar ID.
   ll.GetAnimationOverride:
     args:
-      - type: string
-    description: >-
-      Returns a string that is the name of the animation that is used for the
-      specified animation state\nTo use this function the script must obtain
-      either the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION
-      permission (automatically granted to attached objects).
+    - type: string
+    description: Returns a string that is the name of the animation that is used for
+      the specified animation state\nTo use this function the script must obtain either
+      the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION permission
+      (automatically granted to attached objects).
   ll.GetAttached:
     args: []
     description: Returns the object's attachment point, or 0 if not attached.
   ll.GetAttachedList:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns a list of keys of all visible (not HUD) attachments on the avatar
-      identified by the ID argument
+    - type:
+        display: uuid
+    description: Returns a list of keys of all visible (not HUD) attachments on the
+      avatar identified by the ID argument
   ll.GetAttachedListFiltered:
     args:
-      - type:
-          display: uuid
-      - type: table
+    - type:
+        display: uuid
+    - type: table
     description: Retrieves a list of attachments on an avatar.
   ll.GetBoundingBox:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the bounding box around the object (including any linked prims)
-      relative to its root prim, as a list in the format [ (vector) min_corner,
+    - type:
+        display: uuid
+    description: Returns the bounding box around the object (including any linked
+      prims) relative to its root prim, as a list in the format [ (vector) min_corner,
       (vector) max_corner ].
   ll.GetCameraAspect:
     args: []
-    description: >-
-      Returns the current camera aspect ratio (width / height) of the agent who
-      has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no
-      permissions have been granted: it returns zero.
+    description: 'Returns the current camera aspect ratio (width / height) of the
+      agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions.
+      If no permissions have been granted: it returns zero.'
   ll.GetCameraFOV:
     args: []
-    description: >-
-      Returns the current camera field of view of the agent who has granted the
-      scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions
-      have been granted: it returns zero.
+    description: 'Returns the current camera field of view of the agent who has granted
+      the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have
+      been granted: it returns zero.'
   ll.GetCameraPos:
     args: []
-    description: >-
-      Returns the current camera position for the agent the task has permissions
-      for.\nReturns the position of the camera, of the user that granted the
-      script PERMISSION_TRACK_CAMERA. If no user has granted the permission, it
-      returns ZERO_VECTOR.
+    description: Returns the current camera position for the agent the task has permissions
+      for.\nReturns the position of the camera, of the user that granted the script
+      PERMISSION_TRACK_CAMERA. If no user has granted the permission, it returns ZERO_VECTOR.
   ll.GetCameraRot:
     args: []
-    description: >-
-      Returns the current camera orientation for the agent the task has
-      permissions for. If no user has granted the PERMISSION_TRACK_CAMERA
-      permission, returns ZERO_ROTATION.
+    description: Returns the current camera orientation for the agent the task has
+      permissions for. If no user has granted the PERMISSION_TRACK_CAMERA permission,
+      returns ZERO_ROTATION.
   ll.GetCenterOfMass:
     args: []
-    description: >-
-      Returns the prim's centre of mass (unless called from the root prim, where
-      it returns the object's centre of mass).
+    description: Returns the prim's centre of mass (unless called from the root prim,
+      where it returns the object's centre of mass).
   ll.GetClosestNavPoint:
     args:
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Get the closest navigable point to the point provided.\nThe function
-      accepts a point in region-local space (like all the other path-finding
-      methods) and returns either an empty list or a list containing a single
-      vector which is the closest point on the navigation-mesh to the point
-      provided.
+    - type:
+        display: vector
+    - type: table
+    description: Get the closest navigable point to the point provided.\nThe function
+      accepts a point in region-local space (like all the other path-finding methods)
+      and returns either an empty list or a list containing a single vector which
+      is the closest point on the navigation-mesh to the point provided.
   ll.GetColor:
     args:
-      - type: number
-    description: >-
-      Returns the color on Face.\nReturns the color of Face as a vector of red,
-      green, and blue values between 0 and 1. If face is ALL_SIDES the color
+    - type: number
+    description: Returns the color on Face.\nReturns the color of Face as a vector
+      of red, green, and blue values between 0 and 1. If face is ALL_SIDES the color
       returned is the mean average of each channel.
   ll.GetCreator:
     args: []
-    description: >-
-      Returns a key for the creator of the prim.\nReturns the key of the
+    description: Returns a key for the creator of the prim.\nReturns the key of the
       object's original creator. Similar to llGetOwner.
   ll.GetDate:
     args: []
-    description: >-
-      Returns the current date in the UTC time zone in the format
-      YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.
+    description: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
+      the current UTC date as YYYY-MM-DD.
   ll.GetDayLength:
     args: []
     description: Returns the number of seconds in a day on this parcel.
   ll.GetDayOffset:
     args: []
-    description: >-
-      Returns the number of seconds in a day is offset from midnight in this
-      parcel.
+    description: Returns the number of seconds in a day is offset from midnight in
+      this parcel.
   ll.GetDisplayName:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the display name of an avatar, if the avatar is connected to the
-      current region, or if the name has been cached.  Otherwise, returns an
-      empty string. Use llRequestDisplayName if the avatar may be absent from
-      the region.
+    - type:
+        display: uuid
+    description: Returns the display name of an avatar, if the avatar is connected
+      to the current region, or if the name has been cached.  Otherwise, returns an
+      empty string. Use llRequestDisplayName if the avatar may be absent from the
+      region.
   ll.GetEnergy:
     args: []
     description: Returns how much energy is in the object as a percentage of maximum.
   ll.GetEnv:
     args:
-      - type: string
+    - type: string
     description: Returns a string with the requested data about the region.
   ll.GetEnvironment:
     args:
-      - type:
-          display: vector
-      - type: table
+    - type:
+        display: vector
+    - type: table
     description: Returns a string with the requested data about the region.
   ll.GetExperienceDetails:
     args:
-      - type:
-          display: uuid
-    description: |2-
-
-                         Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
-                      
+    - type:
+        display: uuid
+    description: "\n                   Returns a list with the following Experience\
+      \ properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State\
+      \ Message]. State is an integer corresponding to one of the constants XP_ERROR_...\
+      \ and State Message is the string returned by llGetExperienceErrorMessage for\
+      \ that integer.\n                "
   ll.GetExperienceErrorMessage:
     args:
-      - type: number
-    description: |2-
-
-                         Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
-                      
+    - type: number
+    description: "\n                   Returns a string describing the error code\
+      \ passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value\
+      \ is not a valid Experience error code.\n                "
   ll.GetForce:
     args: []
-    description: >-
-      Returns the force (if the script is physical).\nReturns the current force
-      if the script is physical.
+    description: Returns the force (if the script is physical).\nReturns the current
+      force if the script is physical.
   ll.GetFreeMemory:
     args: []
-    description: >-
-      Returns the number of free bytes of memory the script can use.\nReturns
-      the available free space for the current script. This is inaccurate with
-      LSO.
+    description: Returns the number of free bytes of memory the script can use.\nReturns
+      the available free space for the current script. This is inaccurate with LSO.
   ll.GetFreeURLs:
     args: []
-    description: >-
-      Returns the number of available URLs for the current script.\nReturns an
-      integer that is the number of available URLs.
+    description: Returns the number of available URLs for the current script.\nReturns
+      an integer that is the number of available URLs.
   ll.GetGMTclock:
     args: []
-    description: >-
-      Returns the time in seconds since midnight GMT.\nGets the time in seconds
-      since midnight in GMT/UTC.
+    description: Returns the time in seconds since midnight GMT.\nGets the time in
+      seconds since midnight in GMT/UTC.
   ll.GetGeometricCenter:
     args: []
-    description: >-
-      Returns the vector that is the geometric center of the object relative to
-      the root prim.
+    description: Returns the vector that is the geometric center of the object relative
+      to the root prim.
   ll.GetHTTPHeader:
     args:
-      - type:
-          display: uuid
-      - type: string
-    description: >-
-      Returns the value for header for request_id.\nReturns a string that is the
-      value of the Header for HTTPRequestID.
+    - type:
+        display: uuid
+    - type: string
+    description: Returns the value for header for request_id.\nReturns a string that
+      is the value of the Header for HTTPRequestID.
   ll.GetHealth:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: Returns the current health of an avatar or object in the region.
   ll.GetInventoryAcquireTime:
     args:
-      - type: string
-    description: >-
-      Returns the time at which the item was placed into this prim's inventory
+    - type: string
+    description: Returns the time at which the item was placed into this prim's inventory
       as a timestamp.
   ll.GetInventoryCreator:
     args:
-      - type: string
-    description: >-
-      Returns a key for the creator of the inventory item.\nThis function
-      returns the UUID of the creator of item. If item is not found in
-      inventory, the object says "No item named 'name'".
+    - type: string
+    description: Returns a key for the creator of the inventory item.\nThis function
+      returns the UUID of the creator of item. If item is not found in inventory,
+      the object says "No item named 'name'".
   ll.GetInventoryDesc:
     args:
-      - type: string
-    description: >-
-      Returns the item description of the item in inventory. If item is not
-      found in inventory, the object says "No item named 'name'" to the debug
+    - type: string
+    description: Returns the item description of the item in inventory. If item is
+      not found in inventory, the object says "No item named 'name'" to the debug
       channel and returns an empty string.
   ll.GetInventoryKey:
     args:
-      - type: string
-    description: >-
-      Returns the key that is the UUID of the inventory named.\nReturns the key
-      of the inventory named.
+    - type: string
+    description: Returns the key that is the UUID of the inventory named.\nReturns
+      the key of the inventory named.
   ll.GetInventoryName:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Returns the name of the inventory item of a given type, specified by index
-      number.\nUse the inventory constants INVENTORY_* to specify the type.
+    - type: number
+    - type: number
+    description: Returns the name of the inventory item of a given type, specified
+      by index number.\nUse the inventory constants INVENTORY_* to specify the type.
   ll.GetInventoryNumber:
     args:
-      - type: number
-    description: >-
-      Returns the quantity of items of a given type (INVENTORY_* flag) in the
-      prim's inventory.\nUse the inventory constants INVENTORY_* to specify the
-      type.
+    - type: number
+    description: Returns the quantity of items of a given type (INVENTORY_* flag)
+      in the prim's inventory.\nUse the inventory constants INVENTORY_* to specify
+      the type.
   ll.GetInventoryPermMask:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Returns the requested permission mask for the inventory item.\nReturns the
-      requested permission mask for the inventory item defined by InventoryItem.
-      If item is not in the object's inventory, llGetInventoryPermMask returns
-      FALSE and causes the object to say "No item named '<item>'", where
-      "<item>" is item.
+    - type: string
+    - type: number
+    description: Returns the requested permission mask for the inventory item.\nReturns
+      the requested permission mask for the inventory item defined by InventoryItem.
+      If item is not in the object's inventory, llGetInventoryPermMask returns FALSE
+      and causes the object to say "No item named '<item>'", where "<item>" is item.
   ll.GetInventoryType:
     args:
-      - type: string
-    description: >-
-      Returns the type of the named inventory item.\nLike all inventory
+    - type: string
+    description: Returns the type of the named inventory item.\nLike all inventory
       functions, llGetInventoryType is case-sensitive.
   ll.GetKey:
     args: []
-    description: >-
-      Returns the key of the prim the script is attached to.\nGet the key for
-      the object which has this script.
+    description: Returns the key of the prim the script is attached to.\nGet the key
+      for the object which has this script.
   ll.GetLandOwnerAt:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the key of the land owner, returns NULL_KEY if public.\nReturns
+    - type:
+        display: vector
+    description: Returns the key of the land owner, returns NULL_KEY if public.\nReturns
       the key of the land owner at Position, or NULL_KEY if public.
   ll.GetLinkKey:
     args:
-      - type: number
-    description: >-
-      Returns the key of the linked prim LinkNumber.\nReturns the key of
+    - type: number
+    description: Returns the key of the linked prim LinkNumber.\nReturns the key of
       LinkNumber in the link set.
   ll.GetLinkMedia:
     args:
-      - type: number
-      - type: number
-      - type: table
-    description: "Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.\tReturns an empty list if no media exists on the face."
+    - type: number
+    - type: number
+    - type: table
+    description: "Get the media parameters for a particular face on linked prim, given\
+      \ the desired list of parameter names. Returns a list of values in the order\
+      \ requested.\tReturns an empty list if no media exists on the face."
   ll.GetLinkName:
     args:
-      - type: number
-    description: >-
-      Returns the name of LinkNumber in a link set.\nReturns the name of
+    - type: number
+    description: Returns the name of LinkNumber in a link set.\nReturns the name of
       LinkNumber the link set.
   ll.GetLinkNumber:
     args: []
-    description: >-
-      Returns the link number of the prim containing the script (0 means not
-      linked, 1 the prim is the root, 2 the prim is the first child,
-      etc.).\nReturns the link number of the prim containing the script. 0 means
-      no link, 1 the root, 2 for first child, etc.
+    description: Returns the link number of the prim containing the script (0 means
+      not linked, 1 the prim is the root, 2 the prim is the first child, etc.).\nReturns
+      the link number of the prim containing the script. 0 means no link, 1 the root,
+      2 for first child, etc.
   ll.GetLinkNumberOfSides:
     args:
-      - type: number
-    description: >-
-      Returns the number of sides of the specified linked prim.\nReturns an
-      integer that is the number of faces (or sides) of the prim link.
+    - type: number
+    description: Returns the number of sides of the specified linked prim.\nReturns
+      an integer that is the number of faces (or sides) of the prim link.
   ll.GetLinkPrimitiveParams:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Returns the list of primitive attributes requested in the Parameters list
-      for LinkNumber.\nPRIM_* flags can be broken into three categories, face
-      flags, prim flags, and object flags.\n* Supplying a prim or object flag
-      will return that flag's attributes.\n* Face flags require the user to also
-      supply a face index parameter.
+    - type: number
+    - type: table
+    description: Returns the list of primitive attributes requested in the Parameters
+      list for LinkNumber.\nPRIM_* flags can be broken into three categories, face
+      flags, prim flags, and object flags.\n* Supplying a prim or object flag will
+      return that flag's attributes.\n* Face flags require the user to also supply
+      a face index parameter.
   ll.GetLinkSitFlags:
     args:
-      - type: number
+    - type: number
     description: Returns the sit flags set on the specified prim in a linkset.
   ll.GetListEntryType:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT,
-      TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if
-      index is off list).\nReturns the type of the variable at Index in
-      ListVariable.
+    - type: table
+    - type: number
+    description: Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT,
+      TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if index
+      is off list).\nReturns the type of the variable at Index in ListVariable.
   ll.GetListLength:
     args:
-      - type: table
-    description: >-
-      Returns the number of elements in the list.\nReturns the number of
+    - type: table
+    description: Returns the number of elements in the list.\nReturns the number of
       elements in ListVariable.
   ll.GetLocalPos:
     args: []
-    description: >-
-      Returns the position relative to the root.\nReturns the local position of
-      a child object relative to the root.
+    description: Returns the position relative to the root.\nReturns the local position
+      of a child object relative to the root.
   ll.GetLocalRot:
     args: []
-    description: >-
-      Returns the rotation local to the root.\nReturns the local rotation of a
-      child object relative to the root.
+    description: Returns the rotation local to the root.\nReturns the local rotation
+      of a child object relative to the root.
   ll.GetMass:
     args: []
-    description: >-
-      Returns the mass of object that the script is attached to.\nReturns the
-      scripted object's mass. When called from a script in a link-set, the
-      parent will return the sum of the link-set weights, while a child will
-      return just its own mass. When called from a script inside an attachment,
-      this function will return the mass of the avatar it's attached to, not its
-      own.
+    description: Returns the mass of object that the script is attached to.\nReturns
+      the scripted object's mass. When called from a script in a link-set, the parent
+      will return the sum of the link-set weights, while a child will return just
+      its own mass. When called from a script inside an attachment, this function
+      will return the mass of the avatar it's attached to, not its own.
   ll.GetMassMKS:
     args: []
-    description: Acts as llGetMass(), except that the units of the value returned are Kg.
+    description: Acts as llGetMass(), except that the units of the value returned
+      are Kg.
   ll.GetMaxScaleFactor:
     args: []
-    description: >-
-      Returns the largest multiplicative uniform scale factor that can be
-      successfully applied (via llScaleByFactor()) to the object without
-      violating prim size or linkability rules.
+    description: Returns the largest multiplicative uniform scale factor that can
+      be successfully applied (via llScaleByFactor()) to the object without violating
+      prim size or linkability rules.
   ll.GetMemoryLimit:
     args: []
     description: Get the maximum memory a script can use, in bytes.
   ll.GetMinScaleFactor:
     args: []
-    description: >-
-      Returns the smallest multiplicative uniform scale factor that can be
-      successfully applied (via llScaleByFactor()) to the object without
-      violating prim size or linkability rules.
+    description: Returns the smallest multiplicative uniform scale factor that can
+      be successfully applied (via llScaleByFactor()) to the object without violating
+      prim size or linkability rules.
   ll.GetMoonDirection:
     args: []
-    description: >-
-      Returns a normalized vector of the direction of the moon in the
-      parcel.\nReturns the moon's direction on the simulator in the parcel.
+    description: Returns a normalized vector of the direction of the moon in the parcel.\nReturns
+      the moon's direction on the simulator in the parcel.
   ll.GetMoonRotation:
     args: []
     description: Returns the rotation applied to the moon in the parcel.
   ll.GetNextEmail:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Fetch the next queued email with that matches the given address and/or
-      subject, via the email event.\nIf the parameters are blank, they are not
-      used for filtering.
+    - type: string
+    - type: string
+    description: Fetch the next queued email with that matches the given address and/or
+      subject, via the email event.\nIf the parameters are blank, they are not used
+      for filtering.
   ll.GetNotecardLine:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Returns LineNumber from NotecardName via the dataserver event. The line
-      index starts at zero in LSL, one in Lua.\nIf the requested line is passed
-      the end of the note-card the dataserver event will return the constant EOF
-      string.\nThe key returned by this function is a unique identifier which
-      will be supplied to the dataserver event in the requested parameter.
+    - type: string
+    - type: number
+    description: Returns LineNumber from NotecardName via the dataserver event. The
+      line index starts at zero in LSL, one in Lua.\nIf the requested line is passed
+      the end of the note-card the dataserver event will return the constant EOF string.\nThe
+      key returned by this function is a unique identifier which will be supplied
+      to the dataserver event in the requested parameter.
   ll.GetNotecardLineSync:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Returns LineNumber from NotecardName. The line index starts at zero in
-      LSL, one in Lua.\nIf the requested line is past the end of the note-card
-      the return value will be set to the constant EOF string.\nIf the note-card
-      is not cached on the simulator the return value is the NAK string.
+    - type: string
+    - type: number
+    description: Returns LineNumber from NotecardName. The line index starts at zero
+      in LSL, one in Lua.\nIf the requested line is past the end of the note-card
+      the return value will be set to the constant EOF string.\nIf the note-card is
+      not cached on the simulator the return value is the NAK string.
   ll.GetNumberOfNotecardLines:
     args:
-      - type: string
-    description: >-
-      Returns the number of lines contained within a notecard via the dataserver
-      event.\nThe key returned by this function is a query ID for identifying
-      the dataserver reply.
+    - type: string
+    description: Returns the number of lines contained within a notecard via the dataserver
+      event.\nThe key returned by this function is a query ID for identifying the
+      dataserver reply.
   ll.GetNumberOfPrims:
     args: []
-    description: >-
-      Returns the number of prims in a link set the script is attached
-      to.\nReturns the number of prims in (and avatars seated on) the object the
-      script is in.
+    description: Returns the number of prims in a link set the script is attached
+      to.\nReturns the number of prims in (and avatars seated on) the object the script
+      is in.
   ll.GetNumberOfSides:
     args: []
-    description: >-
-      Returns the number of faces (or sides) of the prim.\nReturns the number of
-      sides of the prim which has the script.
+    description: Returns the number of faces (or sides) of the prim.\nReturns the
+      number of sides of the prim which has the script.
   ll.GetObjectAnimationNames:
     args: []
-    description: >-
-      Returns a list of names of playing animations for an object.\nReturns a
-      list of names of all playing animations for the current object.
+    description: Returns a list of names of playing animations for an object.\nReturns
+      a list of names of all playing animations for the current object.
   ll.GetObjectDesc:
     args: []
-    description: >-
-      Returns the description of the prim the script is attached to.\nReturns
-      the description of the scripted object/prim. You can set the description
-      using llSetObjectDesc.
+    description: Returns the description of the prim the script is attached to.\nReturns
+      the description of the scripted object/prim. You can set the description using
+      llSetObjectDesc.
   ll.GetObjectDetails:
     args:
-      - type:
-          display: uuid
-      - type: table
-    description: >-
-      Returns a list of object details specified in the Parameters list for the
-      object or avatar in the region with key ID.\nParameters are specified by
-      the OBJECT_* constants.
+    - type:
+        display: uuid
+    - type: table
+    description: Returns a list of object details specified in the Parameters list
+      for the object or avatar in the region with key ID.\nParameters are specified
+      by the OBJECT_* constants.
   ll.GetObjectLinkKey:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Returns the key of the linked prim link_no in a linkset.\nReturns the key
-      of link_no in the link set specified by id.
+    - type:
+        display: uuid
+    - type: number
+    description: Returns the key of the linked prim link_no in a linkset.\nReturns
+      the key of link_no in the link set specified by id.
   ll.GetObjectMass:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the mass of the avatar or object in the region.\nGets the mass of
-      the object or avatar corresponding to ID.
+    - type:
+        display: uuid
+    description: Returns the mass of the avatar or object in the region.\nGets the
+      mass of the object or avatar corresponding to ID.
   ll.GetObjectName:
     args: []
-    description: >-
-      Returns the name of the prim which the script is attached to.\nReturns the
-      name of the prim (not object) which contains the script.
+    description: Returns the name of the prim which the script is attached to.\nReturns
+      the name of the prim (not object) which contains the script.
   ll.GetObjectPermMask:
     args:
-      - type: number
+    - type: number
     description: Returns the permission mask of the requested category for the object.
   ll.GetObjectPrimCount:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the total number of prims for an object in the region.\nReturns
+    - type:
+        display: uuid
+    description: Returns the total number of prims for an object in the region.\nReturns
       the prim count for any object id in the same region.
   ll.GetOmega:
     args: []
-    description: >-
-      Returns the rotation velocity in radians per second.\nReturns a vector
+    description: Returns the rotation velocity in radians per second.\nReturns a vector
       that is the rotation velocity of the object in radians per second.
   ll.GetOwner:
     args: []
-    description: >-
-      Returns the object owner's UUID.\nReturns the key for the owner of the
-      object.
+    description: Returns the object owner's UUID.\nReturns the key for the owner of
+      the object.
   ll.GetOwnerKey:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the owner of ObjectID.\nReturns the key for the owner of object
-      ObjectID.
+    - type:
+        display: uuid
+    description: Returns the owner of ObjectID.\nReturns the key for the owner of
+      object ObjectID.
   ll.GetParcelDetails:
     args:
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Returns a list of parcel details specified in the ParcelDetails list for
-      the parcel at Position.\nParameters is one or more of:
-      PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID,
-      _SEE_AVATARS.\nReturns a list that is the parcel details specified in
-      ParcelDetails (in the same order) for the parcel at Position.
+    - type:
+        display: vector
+    - type: table
+    description: 'Returns a list of parcel details specified in the ParcelDetails
+      list for the parcel at Position.\nParameters is one or more of: PARCEL_DETAILS_NAME,
+      _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\nReturns a list that is the
+      parcel details specified in ParcelDetails (in the same order) for the parcel
+      at Position.'
   ll.GetParcelFlags:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that
-      includes the point Position.\nReturns a bit-field specifying the parcel
+    - type:
+        display: vector
+    description: Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel
+      that includes the point Position.\nReturns a bit-field specifying the parcel
       flags (PARCEL_FLAG_*) for the parcel at Position.
   ll.GetParcelMaxPrims:
     args:
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Returns the maximum number of prims allowed on the parcel at Position for
-      a given scope.\nThe scope may be set to an individual parcel or the
-      combined resources of all parcels with the same ownership in the region.
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Returns the maximum number of prims allowed on the parcel at Position
+      for a given scope.\nThe scope may be set to an individual parcel or the combined
+      resources of all parcels with the same ownership in the region.
   ll.GetParcelMusicURL:
     args: []
-    description: >-
-      Gets the streaming audio URL for the parcel object is on.\nThe object
+    description: Gets the streaming audio URL for the parcel object is on.\nThe object
       owner, avatar or group, must also be the land owner.
   ll.GetParcelPrimCount:
     args:
-      - type:
-          display: vector
-      - type: number
-      - type:
-          display: numeric
-    description: >-
-      Returns the number of prims on the parcel at Position of the given
-      category.\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER,
-      _SELECTED, _TEMP.\nReturns the number of prims used on the parcel at
-      Position which are in Category.\nIf SimWide is TRUE, it returns the total
-      number of objects for all parcels with matching ownership in the category
-      specified.\nIf SimWide is FALSE, it returns the number of objects on this
-      specific parcel in the category specified
+    - type:
+        display: vector
+    - type: number
+    - type:
+        display: numeric
+    description: 'Returns the number of prims on the parcel at Position of the given
+      category.\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER, _SELECTED,
+      _TEMP.\nReturns the number of prims used on the parcel at Position which are
+      in Category.\nIf SimWide is TRUE, it returns the total number of objects for
+      all parcels with matching ownership in the category specified.\nIf SimWide is
+      FALSE, it returns the number of objects on this specific parcel in the category
+      specified'
   ll.GetParcelPrimOwners:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns a list of up to 100 residents who own objects on the parcel at
-      Position, with per-owner land impact totals.\nRequires owner-like
-      permissions for the parcel, and for the script owner to be present in the
-      region.\nThe list is formatted as [ key agentKey1, integer agentLI1, key
-      agentKey2, integer agentLI2, ... ], sorted by agent key.\nThe integers are
-      the combined land impacts of the objects owned by the corresponding
-      agents.
+    - type:
+        display: vector
+    description: Returns a list of up to 100 residents who own objects on the parcel
+      at Position, with per-owner land impact totals.\nRequires owner-like permissions
+      for the parcel, and for the script owner to be present in the region.\nThe list
+      is formatted as [ key agentKey1, integer agentLI1, key agentKey2, integer agentLI2,
+      ... ], sorted by agent key.\nThe integers are the combined land impacts of the
+      objects owned by the corresponding agents.
   ll.GetPermissions:
     args: []
-    description: >-
-      Returns an integer bitmask of the permissions that have been granted to
-      the script.  Individual permissions can be determined using a bit-wise
-      "and" operation against the PERMISSION_* constants
+    description: Returns an integer bitmask of the permissions that have been granted
+      to the script.  Individual permissions can be determined using a bit-wise "and"
+      operation against the PERMISSION_* constants
   ll.GetPermissionsKey:
     args: []
-    description: >-
-      Returns the key of the avatar that last granted or declined permissions to
-      the script.\nReturns NULL_KEY if permissions were never granted or
-      declined.
+    description: Returns the key of the avatar that last granted or declined permissions
+      to the script.\nReturns NULL_KEY if permissions were never granted or declined.
   ll.GetPhysicsMaterial:
     args: []
-    description: >-
-      Returns a list of the form [float gravity_multiplier, float restitution,
+    description: Returns a list of the form [float gravity_multiplier, float restitution,
       float friction, float density].
   ll.GetPos:
     args: []
-    description: >-
-      Returns the position of the task in region coordinates.\nReturns the
-      vector position of the task in region coordinates.
+    description: Returns the position of the task in region coordinates.\nReturns
+      the vector position of the task in region coordinates.
   ll.GetPrimMediaParams:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Returns the media parameters for a particular face on an object, given the
-      desired list of parameter names, in the order requested. Returns an empty
-      list if no media exists on the face.
+    - type: number
+    - type: table
+    description: Returns the media parameters for a particular face on an object,
+      given the desired list of parameter names, in the order requested. Returns an
+      empty list if no media exists on the face.
   ll.GetPrimitiveParams:
     args:
-      - type: table
-    description: >-
-      Returns the primitive parameters specified in the parameters
-      list.\nReturns primitive parameters specified in the Parameters list.
+    - type: table
+    description: Returns the primitive parameters specified in the parameters list.\nReturns
+      primitive parameters specified in the Parameters list.
   ll.GetRegionAgentCount:
     args: []
-    description: >-
-      Returns the number of avatars in the region.\nReturns an integer that is
-      the number of avatars in the region.
+    description: Returns the number of avatars in the region.\nReturns an integer
+      that is the number of avatars in the region.
   ll.GetRegionCorner:
     args: []
-    description: >-
-      Returns a vector, in meters, that is the global location of the south-west
-      corner of the region which the object is in.\nReturns the Region-Corner of
-      the simulator containing the task. The region-corner is a vector (values
-      in meters) representing distance from the first region.
+    description: Returns a vector, in meters, that is the global location of the south-west
+      corner of the region which the object is in.\nReturns the Region-Corner of the
+      simulator containing the task. The region-corner is a vector (values in meters)
+      representing distance from the first region.
   ll.GetRegionDayLength:
     args: []
     description: Returns the number of seconds in a day in this region.
   ll.GetRegionDayOffset:
     args: []
-    description: >-
-      Returns the number of seconds in a day is offset from midnight in this
-      parcel.
+    description: Returns the number of seconds in a day is offset from midnight in
+      this parcel.
   ll.GetRegionFPS:
     args: []
     description: Returns the mean region frames per second.
   ll.GetRegionFlags:
     args: []
-    description: >-
-      Returns the region flags (REGION_FLAG_*) for the region the object is
-      in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for
+    description: Returns the region flags (REGION_FLAG_*) for the region the object
+      is in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for
       the region the object is in.
   ll.GetRegionMoonDirection:
     args: []
-    description: >-
-      Returns a normalized vector of the direction of the moon in the
-      region.\nReturns the moon's direction on the simulator.
+    description: Returns a normalized vector of the direction of the moon in the region.\nReturns
+      the moon's direction on the simulator.
   ll.GetRegionMoonRotation:
     args: []
     description: Returns the rotation applied to the moon in the region.
@@ -6001,1355 +5731,1234 @@ globals:
     description: Returns the current region name.
   ll.GetRegionSunDirection:
     args: []
-    description: >-
-      Returns a normalized vector of the direction of the sun in the
-      region.\nReturns the sun's direction on the simulator.
+    description: Returns a normalized vector of the direction of the sun in the region.\nReturns
+      the sun's direction on the simulator.
   ll.GetRegionSunRotation:
     args: []
     description: Returns the rotation applied to the sun in the region.
   ll.GetRegionTimeDilation:
     args: []
-    description: >-
-      Returns the current time dilation as a float between 0.0 (full dilation)
-      and 1.0 (no dilation).\nReturns the current time dilation as a float
-      between 0.0 and 1.0.
+    description: Returns the current time dilation as a float between 0.0 (full dilation)
+      and 1.0 (no dilation).\nReturns the current time dilation as a float between
+      0.0 and 1.0.
   ll.GetRegionTimeOfDay:
     args: []
-    description: >-
-      Returns the time in seconds since environmental midnight for the entire
-      region.
+    description: Returns the time in seconds since environmental midnight for the
+      entire region.
   ll.GetRenderMaterial:
     args:
-      - type: number
-    description: >-
-      Returns a string that is the render material on face (the inventory name
-      if it is a material in the prim's inventory, otherwise the key).\nReturns
-      the render material of a face, if it is found in object inventory, its key
-      otherwise.
+    - type: number
+    description: Returns a string that is the render material on face (the inventory
+      name if it is a material in the prim's inventory, otherwise the key).\nReturns
+      the render material of a face, if it is found in object inventory, its key otherwise.
   ll.GetRootPosition:
     args: []
-    description: >-
-      Returns the position (in region coordinates) of the root prim of the
-      object which the script is attached to.\nThis is used to allow a child
-      prim to determine where the root is.
+    description: Returns the position (in region coordinates) of the root prim of
+      the object which the script is attached to.\nThis is used to allow a child prim
+      to determine where the root is.
   ll.GetRootRotation:
     args: []
-    description: >-
-      Returns the rotation (relative to the region) of the root prim of the
-      object which the script is attached to.\nGets the global rotation of the
+    description: Returns the rotation (relative to the region) of the root prim of
+      the object which the script is attached to.\nGets the global rotation of the
       root object of the object script is attached to.
   ll.GetRot:
     args: []
-    description: Returns the rotation relative to the region's axes.\nReturns the rotation.
+    description: Returns the rotation relative to the region's axes.\nReturns the
+      rotation.
   ll.GetSPMaxMemory:
     args: []
-    description: >-
-      Returns the maximum used memory for the current script. Only valid after
-      using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns the
-      integer of the most bytes used while llScriptProfiler was last active.
+    description: Returns the maximum used memory for the current script. Only valid
+      after using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns
+      the integer of the most bytes used while llScriptProfiler was last active.
   ll.GetScale:
     args: []
-    description: >-
-      Returns the scale of the prim.\nReturns a vector that is the scale
+    description: Returns the scale of the prim.\nReturns a vector that is the scale
       (dimensions) of the prim.
   ll.GetScriptName:
     args: []
-    description: >-
-      Returns the name of the script that this function is used in.\nReturns the
-      name of this script.
+    description: Returns the name of the script that this function is used in.\nReturns
+      the name of this script.
   ll.GetScriptState:
     args:
-      - type: string
-    description: >-
-      Returns TRUE if the script named is running.\nReturns TRUE if ScriptName
+    - type: string
+    description: Returns TRUE if the script named is running.\nReturns TRUE if ScriptName
       is running.
   ll.GetSimStats:
     args:
-      - type: number
+    - type: number
     description: Returns a float that is the requested statistic.
   ll.GetSimulatorHostname:
     args: []
-    description: >-
-      Returns the host-name of the machine which the script is running on.\nFor
-      example, "sim225.agni.lindenlab.com".
+    description: Returns the host-name of the machine which the script is running
+      on.\nFor example, "sim225.agni.lindenlab.com".
   ll.GetStartParameter:
     args: []
-    description: >-
-      Returns an integer that is the script rez parameter.\nIf the object was
-      rezzed by an agent, this function returns 0.
+    description: Returns an integer that is the script rez parameter.\nIf the object
+      was rezzed by an agent, this function returns 0.
   ll.GetStartString:
     args: []
-    description: >-
-      Returns a string that is the value passed to llRezObjectWithParams with
-      REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function
+    description: Returns a string that is the value passed to llRezObjectWithParams
+      with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function
       returns an empty string.
   ll.GetStaticPath:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type: number
-      - type: table
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type: number
+    - type: table
   ll.GetStatus:
     args:
-      - type: number
-    description: >-
-      Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the
-      object the script is attached to.
+    - type: number
+    description: Returns boolean value of the specified status (e.g. STATUS_PHANTOM)
+      of the object the script is attached to.
   ll.GetSubString:
     args:
-      - type: string
-      - type: number
-      - type: number
-    description: >-
-      Returns a sub-string from String, in a range specified by the Start and
-      End indices (inclusive).\nUsing negative numbers for Start and/or End
-      causes the index to count backwards from the length of the string, so 0,
-      -1 would capture the entire string.\nIf Start is greater than End, the sub
-      string is the exclusion of the entries.
+    - type: string
+    - type: number
+    - type: number
+    description: Returns a sub-string from String, in a range specified by the Start
+      and End indices (inclusive).\nUsing negative numbers for Start and/or End causes
+      the index to count backwards from the length of the string, so 0, -1 would capture
+      the entire string.\nIf Start is greater than End, the sub string is the exclusion
+      of the entries.
   ll.GetSunDirection:
     args: []
-    description: >-
-      Returns a normalized vector of the direction of the sun in the
-      parcel.\nReturns the sun's direction on the simulator in the parcel.
+    description: Returns a normalized vector of the direction of the sun in the parcel.\nReturns
+      the sun's direction on the simulator in the parcel.
   ll.GetSunRotation:
     args: []
     description: Returns the rotation applied to the sun in the parcel.
   ll.GetTexture:
     args:
-      - type: number
-    description: >-
-      Returns a string that is the texture on face (the inventory name if it is
-      a texture in the prim's inventory, otherwise the key).\nReturns the
+    - type: number
+    description: Returns a string that is the texture on face (the inventory name
+      if it is a texture in the prim's inventory, otherwise the key).\nReturns the
       texture of a face, if it is found in object inventory, its key otherwise.
   ll.GetTextureOffset:
     args:
-      - type: number
-    description: Returns the texture offset of face in the x and y components of a vector.
+    - type: number
+    description: Returns the texture offset of face in the x and y components of a
+      vector.
   ll.GetTextureRot:
     args:
-      - type: number
+    - type: number
     description: Returns the texture rotation of side.
   ll.GetTextureScale:
     args:
-      - type: number
-    description: >-
-      Returns the texture scale of side in the x and y components of a
-      vector.\nReturns the texture scale of a side in the x and y components of
-      a vector.
+    - type: number
+    description: Returns the texture scale of side in the x and y components of a
+      vector.\nReturns the texture scale of a side in the x and y components of a
+      vector.
   ll.GetTime:
     args: []
-    description: >-
-      Returns the time in seconds since the last region reset, script reset, or
-      call to either llResetTime or llGetAndResetTime.
+    description: Returns the time in seconds since the last region reset, script reset,
+      or call to either llResetTime or llGetAndResetTime.
   ll.GetTimeOfDay:
     args: []
     description: Returns the time in seconds since environmental midnight on the parcel.
   ll.GetTimestamp:
     args: []
-    description: >-
-      Returns a time-stamp (UTC time zone) in the format:
-      YYYY-MM-DDThh:mm:ss.ff..fZ.
+    description: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.'
   ll.GetTorque:
     args: []
-    description: >-
-      Returns the torque (if the script is physical).\nReturns a vector that is
-      the torque (if the script is physical).
+    description: Returns the torque (if the script is physical).\nReturns a vector
+      that is the torque (if the script is physical).
   ll.GetUnixTime:
     args: []
-    description: >-
-      Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC
-      from the system clock.
+    description: Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970
+      UTC from the system clock.
   ll.GetUsedMemory:
     args: []
-    description: >-
-      Returns the current used memory for the current script. Non-mono scripts
-      always use 16K.\nReturns the integer of the number of bytes of memory
+    description: Returns the current used memory for the current script. Non-mono
+      scripts always use 16K.\nReturns the integer of the number of bytes of memory
       currently in use by the script. Non-mono scripts always use 16K.
   ll.GetUsername:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the username of an avatar, if the avatar is connected to the
-      current region, or if the name has been cached.  Otherwise, returns an
-      empty string. Use llRequestUsername if the avatar may be absent from the
-      region.
+    - type:
+        display: uuid
+    description: Returns the username of an avatar, if the avatar is connected to
+      the current region, or if the name has been cached.  Otherwise, returns an empty
+      string. Use llRequestUsername if the avatar may be absent from the region.
   ll.GetVel:
     args: []
-    description: >-
-      Returns the velocity of the object.\nReturns a vector that is the velocity
-      of the object.
+    description: Returns the velocity of the object.\nReturns a vector that is the
+      velocity of the object.
   ll.GetVisualParams:
     args:
-      - type:
-          display: uuid
-      - type: table
+    - type:
+        display: uuid
+    - type: table
     description: Returns a list of the current value for each requested visual parameter.
   ll.GetWallclock:
     args: []
-    description: >-
-      Returns the time in seconds since midnight California Pacific time
-      (PST/PDT).\nReturns the time in seconds since simulator's time-zone
-      midnight (Pacific Time).
+    description: Returns the time in seconds since midnight California Pacific time
+      (PST/PDT).\nReturns the time in seconds since simulator's time-zone midnight
+      (Pacific Time).
   ll.GiveAgentInventory:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: table
-      - type: table
-    description: >-
-      Give InventoryItems to the specified agent as a new folder of items, as
-      permitted by the permissions system. The target must be an agent.
+    - type:
+        display: uuid
+    - type: string
+    - type: table
+    - type: table
+    description: Give InventoryItems to the specified agent as a new folder of items,
+      as permitted by the permissions system. The target must be an agent.
   ll.GiveInventory:
     args:
-      - type:
-          display: uuid
-      - type: string
-    description: >-
-      Give InventoryItem to destination represented by TargetID, as permitted by
-      the permissions system.\nTargetID may be any agent or an object in the
-      same region.
+    - type:
+        display: uuid
+    - type: string
+    description: Give InventoryItem to destination represented by TargetID, as permitted
+      by the permissions system.\nTargetID may be any agent or an object in the same
+      region.
   ll.GiveInventoryList:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: table
-    description: >-
-      Give InventoryItems to destination (represented by TargetID) as a new
-      folder of items, as permitted by the permissions system.\nTargetID may be
-      any agent or an object in the same region. If TargetID is an object, the
-      items are passed directly to the object inventory (no folder is created).
+    - type:
+        display: uuid
+    - type: string
+    - type: table
+    description: Give InventoryItems to destination (represented by TargetID) as a
+      new folder of items, as permitted by the permissions system.\nTargetID may be
+      any agent or an object in the same region. If TargetID is an object, the items
+      are passed directly to the object inventory (no folder is created).
   ll.GiveMoney:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Transfers Amount of L$ from script owner to AvatarID.\nThis call will
-      silently fail if PERMISSION_DEBIT has not been granted.
+    - type:
+        display: uuid
+    - type: number
+    description: Transfers Amount of L$ from script owner to AvatarID.\nThis call
+      will silently fail if PERMISSION_DEBIT has not been granted.
   ll.GodLikeRezObject:
     args:
-      - type:
-          display: uuid
-      - type:
-          display: vector
+    - type:
+        display: uuid
+    - type:
+        display: vector
     description: Rez directly off of a UUID if owner has god-bit set.
   ll.Ground:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the ground height at the object position + offset.\nReturns the
-      ground height at the object's position + Offset.
+    - type:
+        display: vector
+    description: Returns the ground height at the object position + offset.\nReturns
+      the ground height at the object's position + Offset.
   ll.GroundContour:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the ground contour direction below the object position +
+    - type:
+        display: vector
+    description: Returns the ground contour direction below the object position +
       Offset.\nReturns the ground contour at the object's position + Offset.
   ll.GroundNormal:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the ground normal below the object position + offset.\nReturns the
-      ground contour at the object's position + Offset.
+    - type:
+        display: vector
+    description: Returns the ground normal below the object position + offset.\nReturns
+      the ground contour at the object's position + Offset.
   ll.GroundRepel:
     args:
-      - type: number
-      - type:
-          display: numeric
-      - type: number
-    description: >-
-      Critically damps to height if within height * 0.5 of level (either above
-      ground level or above the higher of land and water if water ==
-      TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or
-      water level.\n
-                          The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
-                          Do not use with vehicles. Only works in physics-enabled objects.
+    - type: number
+    - type:
+        display: numeric
+    - type: number
+    description: "Critically damps to height if within height * 0.5 of level (either\
+      \ above ground level or above the higher of land and water if water == TRUE).\\\
+      nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\\\
+      n\n                    The height is above ground level if iWater is FALSE or\
+      \ above the higher of land and water if iWater is TRUE.\\n\n               \
+      \     Do not use with vehicles. Only works in physics-enabled objects."
   ll.GroundSlope:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the ground slope below the object position + Offset.\nReturns the
-      ground slope at the object position + Offset.
+    - type:
+        display: vector
+    description: Returns the ground slope below the object position + Offset.\nReturns
+      the ground slope at the object position + Offset.
   ll.HMAC:
     args:
-      - type: string
-      - type: string
-      - type: string
-    description: >-
-      Returns the base64-encoded hashed message authentication code (HMAC), of
-      Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224,
+    - type: string
+    - type: string
+    - type: string
+    description: Returns the base64-encoded hashed message authentication code (HMAC),
+      of Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224,
       sha256, sha384, sha512).
   ll.HTTPRequest:
     args:
-      - type: string
-      - type: table
-      - type: string
-    description: >-
-      Sends an HTTP request to the specified URL with the Body of the request
-      and Parameters.\nReturns a key that is a handle identifying the HTTP
-      request made.
+    - type: string
+    - type: table
+    - type: string
+    description: Sends an HTTP request to the specified URL with the Body of the request
+      and Parameters.\nReturns a key that is a handle identifying the HTTP request
+      made.
   ll.HTTPResponse:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: string
-    description: >-
-      Responds to an incoming HTTP request which was triggerd by an http_request
-      event within the script. HTTPRequestID specifies the request to respond to
-      (this ID is supplied in the http_request event handler).  Status and Body
-      specify the status code and message to respond with.
+    - type:
+        display: uuid
+    - type: number
+    - type: string
+    description: Responds to an incoming HTTP request which was triggerd by an http_request
+      event within the script. HTTPRequestID specifies the request to respond to (this
+      ID is supplied in the http_request event handler).  Status and Body specify
+      the status code and message to respond with.
   ll.Hash:
     args:
-      - type: string
+    - type: string
     description: Calculates the 32bit hash value for the provided string.
   ll.InsertString:
     args:
-      - type: string
-      - type: number
-      - type: string
-    description: >-
-      Inserts SourceVariable into TargetVariable at Position, and returns the
-      result.\nInserts SourceVariable into TargetVariable at Position and
-      returns the result. Note this does not alter TargetVariable.
+    - type: string
+    - type: number
+    - type: string
+    description: Inserts SourceVariable into TargetVariable at Position, and returns
+      the result.\nInserts SourceVariable into TargetVariable at Position and returns
+      the result. Note this does not alter TargetVariable.
   ll.InstantMessage:
     args:
-      - type:
-          display: uuid
-      - type: string
-    description: >-
-      IMs Text to the user identified.\nSend Text to the user as an instant
+    - type:
+        display: uuid
+    - type: string
+    description: IMs Text to the user identified.\nSend Text to the user as an instant
       message.
   ll.IntegerToBase64:
     args:
-      - type: number
-    description: >-
-      Returns a string that is a Base64 big endian encode of Value.\nEncodes the
-      Value as an 8-character Base64 string.
+    - type: number
+    description: Returns a string that is a Base64 big endian encode of Value.\nEncodes
+      the Value as an 8-character Base64 string.
   ll.IsFriend:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: Returns TRUE if avatar ID is a friend of the script owner.
   ll.IsLinkGLTFMaterial:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Checks the face for a PBR render material.
   ll.Json2List:
     args:
-      - type: string
+    - type: string
     description: Converts the top level of the JSON string to a list.
   ll.JsonGetValue:
     args:
-      - type: string
-      - type: table
+    - type: string
+    - type: table
     description: Gets the value indicated by Specifiers from the JSON string.
   ll.JsonSetValue:
     args:
-      - type: string
-      - type: table
-      - type: string
-    description: >-
-      Returns a new JSON string that is the JSON given with the Value indicated
+    - type: string
+    - type: table
+    - type: string
+    description: Returns a new JSON string that is the JSON given with the Value indicated
       by Specifiers set to Value.
   ll.JsonValueType:
     args:
-      - type: string
-      - type: table
-    description: >-
-      Returns the type constant (JSON_*) for the value in JSON indicated by
-      Specifiers.
+    - type: string
+    - type: table
+    description: Returns the type constant (JSON_*) for the value in JSON indicated
+      by Specifiers.
   ll.Key2Name:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns the name of the prim or avatar specified by ID. The ID must be a
-      valid rezzed prim or avatar key in the current simulator, otherwise an
-      empty string is returned.\nFor avatars, the returned name is the legacy
-      name
+    - type:
+        display: uuid
+    description: Returns the name of the prim or avatar specified by ID. The ID must
+      be a valid rezzed prim or avatar key in the current simulator, otherwise an
+      empty string is returned.\nFor avatars, the returned name is the legacy name
   ll.KeyCountKeyValue:
     args: []
-    description: |2-
-
-                         Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
-                      
+    description: "\n                   Starts an asychronous transaction the request\
+      \ the number of keys in the data store. The dataserver callback will be executed\
+      \ with the key returned from this call and a string describing the result. The\
+      \ result is commma-delimited list. The first item is an integer specifying if\
+      \ the transaction succeeded (1) or not (0). In the failure case, the second\
+      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
+      \ In the success case the second item will the the number of keys in the system.\n\
+      \                "
   ll.KeysKeyValue:
     args:
-      - type: number
-      - type: number
-    description: |2-
-
-                         Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
-                      
+    - type: number
+    - type: number
+    description: "\n                   Starts an asychronous transaction the request\
+      \ a number of keys from the data store. The dataserver callback will be executed\
+      \ with the key returned from this call and a string describing the result. The\
+      \ result is commma-delimited list. The first item is an integer specifying if\
+      \ the transaction succeeded (1) or not (0). In the failure case, the second\
+      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
+      \ The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal\
+      \ to the number of keys in the data store. In the success case the subsequent\
+      \ items will be the keys requested. The number of keys returned may be less\
+      \ than requested if the return value is too large or if there is not enough\
+      \ keys remaining. The order keys are returned is not guaranteed but is stable\
+      \ between subsequent calls as long as no keys are added or removed. Because\
+      \ the keys are returned in a comma-delimited list it is not recommended to use\
+      \ commas in key names if this function is used.\n                "
   ll.Linear2sRGB:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Converts a color from the linear colorspace to sRGB.
   ll.LinkAdjustSoundVolume:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Adjusts the volume (0.0 - 1.0) of the currently playing sound attached to
-      the link.\nThis function has no effect on sounds started with
-      llTriggerSound.
+    - type: number
+    - type: number
+    description: Adjusts the volume (0.0 - 1.0) of the currently playing sound attached
+      to the link.\nThis function has no effect on sounds started with llTriggerSound.
   ll.LinkParticleSystem:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Creates a particle system in prim LinkNumber based on Rules. An empty list
-      removes a particle system from object.\nList format is [ rule-1, data-1,
-      rule-2, data-2 ... rule-n, data-n ].\nThis is identical to
-      llParticleSystem except that it applies to a specified linked prim and not
-      just the prim the script is in.
+    - type: number
+    - type: table
+    description: Creates a particle system in prim LinkNumber based on Rules. An empty
+      list removes a particle system from object.\nList format is [ rule-1, data-1,
+      rule-2, data-2 ... rule-n, data-n ].\nThis is identical to llParticleSystem
+      except that it applies to a specified linked prim and not just the prim the
+      script is in.
   ll.LinkPlaySound:
     args:
-      - type: number
-      - type: string
-      - type: number
-      - type: number
-    description: >-
-      Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be
-      attached to the link or triggered at its location.\nOnly one sound may be
-      attached to an object at a time, and attaching a new sound or calling
-      llStopSound will stop the previously attached sound.
+    - type: number
+    - type: string
+    - type: number
+    - type: number
+    description: Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may
+      be attached to the link or triggered at its location.\nOnly one sound may be
+      attached to an object at a time, and attaching a new sound or calling llStopSound
+      will stop the previously attached sound.
   ll.LinkSetSoundQueueing:
     args:
-      - type: number
-      - type:
-          display: numeric
-    description: >-
-      Limits radius for audibility of scripted sounds (both attached and
+    - type: number
+    - type:
+        display: numeric
+    description: Limits radius for audibility of scripted sounds (both attached and
       triggered) to distance Radius around the link.
   ll.LinkSetSoundRadius:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Limits radius for audibility of scripted sounds (both attached and
+    - type: number
+    - type: number
+    description: Limits radius for audibility of scripted sounds (both attached and
       triggered) to distance Radius around the link.
   ll.LinkSitTarget:
     args:
-      - type: number
-      - type:
-          display: vector
-      - type:
-          display: quaternion
-    description: >-
-      Set the sit location for the linked prim(s). If Offset == <0,0,0> clear
-      it.\nSet the sit location for the linked prim(s). The sit location is
+    - type: number
+    - type:
+        display: vector
+    - type:
+        display: quaternion
+    description: Set the sit location for the linked prim(s). If Offset == <0,0,0>
+      clear it.\nSet the sit location for the linked prim(s). The sit location is
       relative to the prim's position and rotation.
   ll.LinkStopSound:
     args:
-      - type: number
+    - type: number
     description: Stops playback of the currently attached sound on a link.
   ll.LinksetDataAvailable:
     args: []
     description: Returns the number of bytes remaining in the linkset's datastore.
   ll.LinksetDataCountFound:
     args:
-      - type: string
-    description: >-
-      Returns the number of keys matching the regular expression passed in the
-      search parameter.
+    - type: string
+    description: Returns the number of keys matching the regular expression passed
+      in the search parameter.
   ll.LinksetDataCountKeys:
     args: []
     description: Returns the number of keys in the linkset's datastore.
   ll.LinksetDataDelete:
     args:
-      - type: string
+    - type: string
     description: Deletes a name:value pair from the linkset's datastore.
   ll.LinksetDataDeleteFound:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Deletes all key value pairs in the linkset data where the key matches the
-      regular expression in search. Returns a list consisting of [ #deleted,
-      #not deleted ].
+    - type: string
+    - type: string
+    description: 'Deletes all key value pairs in the linkset data where the key matches
+      the regular expression in search. Returns a list consisting of [ #deleted, #not
+      deleted ].'
   ll.LinksetDataDeleteProtected:
     args:
-      - type: string
-      - type: string
+    - type: string
+    - type: string
     description: Deletes a name:value pair from the linkset's datastore.
   ll.LinksetDataFindKeys:
     args:
-      - type: string
-      - type: number
-      - type: number
-    description: >-
-      Returns a list of keys from the linkset's data store matching the search
-      parameter.
+    - type: string
+    - type: number
+    - type: number
+    description: Returns a list of keys from the linkset's data store matching the
+      search parameter.
   ll.LinksetDataListKeys:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Returns a list of all keys in the linkset datastore.
   ll.LinksetDataRead:
     args:
-      - type: string
+    - type: string
     description: Returns the value stored for a key in the linkset.
   ll.LinksetDataReadProtected:
     args:
-      - type: string
-      - type: string
+    - type: string
+    - type: string
     description: Returns the value stored for a key in the linkset.
   ll.LinksetDataReset:
     args: []
     description: Resets the linkset's data store, erasing all key-value pairs.
   ll.LinksetDataWrite:
     args:
-      - type: string
-      - type: string
+    - type: string
+    - type: string
     description: Sets a name:value pair in the linkset's datastore
   ll.LinksetDataWriteProtected:
     args:
-      - type: string
-      - type: string
-      - type: string
+    - type: string
+    - type: string
+    - type: string
     description: Sets a name:value pair in the linkset's datastore
   ll.List2CSV:
     args:
-      - type: table
-    description: >-
-      Creates a string of comma separated values from the list.\nCreate a string
-      of comma separated values from the specified list.
+    - type: table
+    description: Creates a string of comma separated values from the list.\nCreate
+      a string of comma separated values from the specified list.
   ll.List2Float:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the float at Index in the list.\nReturns the value at Index in the
-      specified list. If Index describes a location not in the list, or the
+    - type: table
+    - type: number
+    description: Copies the float at Index in the list.\nReturns the value at Index
+      in the specified list. If Index describes a location not in the list, or the
       value cannot be type-cast to a float, then zero is returned.
   ll.List2Integer:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the integer at Index in the list.\nReturns the value at Index in
-      the specified list. If Index describes a location not in the list, or the
+    - type: table
+    - type: number
+    description: Copies the integer at Index in the list.\nReturns the value at Index
+      in the specified list. If Index describes a location not in the list, or the
       value cannot be type-cast to an integer, then zero is returned.
   ll.List2Json:
     args:
-      - type: string
-      - type: table
-    description: >-
-      Converts either a strided list of key:value pairs to a JSON_OBJECT, or a
-      list of values to a JSON_ARRAY.
+    - type: string
+    - type: table
+    description: Converts either a strided list of key:value pairs to a JSON_OBJECT,
+      or a list of values to a JSON_ARRAY.
   ll.List2Key:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the key at Index in the list.\nReturns the value at Index in the
-      specified list. If Index describes a location not in the list, or the
+    - type: table
+    - type: number
+    description: Copies the key at Index in the list.\nReturns the value at Index
+      in the specified list. If Index describes a location not in the list, or the
       value cannot be type-cast to a key, then null string is returned.
   ll.List2List:
     args:
-      - type: any
-      - type: number
-      - type: number
-    description: >-
-      Returns a subset of entries from ListVariable, in a range specified by the
-      Start and End indicies (inclusive).\nUsing negative numbers for Start
-      and/or End causes the index to count backwards from the length of the
-      string, so 0, -1 would capture the entire string.\nIf Start is greater
-      than End, the sub string is the exclusion of the entries.
+    - type: any
+    - type: number
+    - type: number
+    description: Returns a subset of entries from ListVariable, in a range specified
+      by the Start and End indicies (inclusive).\nUsing negative numbers for Start
+      and/or End causes the index to count backwards from the length of the string,
+      so 0, -1 would capture the entire string.\nIf Start is greater than End, the
+      sub string is the exclusion of the entries.
   ll.List2ListSlice:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Returns a subset of entries from ListVariable, in a range specified by
-      Start and End indices (inclusive) return the slice_index element of each
-      stride.\n Using negative numbers for Start and/or End causes the index to
-      count backwards from the length of the list. (e.g. 0, -1 captures entire
-      list)\nIf slice_index is less than 0, it is counted backwards from the end
-      of the stride.\n Stride must be a positive integer > 0 or an empy list is
-      returned.  If slice_index falls outside range of stride, an empty list is
-      returned. slice_index is zero-based. (e.g. A stride of 2 has valid indices
-      0,1)
+    - type: any
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    description: Returns a subset of entries from ListVariable, in a range specified
+      by Start and End indices (inclusive) return the slice_index element of each
+      stride.\n Using negative numbers for Start and/or End causes the index to count
+      backwards from the length of the list. (e.g. 0, -1 captures entire list)\nIf
+      slice_index is less than 0, it is counted backwards from the end of the stride.\n
+      Stride must be a positive integer > 0 or an empy list is returned.  If slice_index
+      falls outside range of stride, an empty list is returned. slice_index is zero-based.
+      (e.g. A stride of 2 has valid indices 0,1)
   ll.List2ListStrided:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Copies the strided slice of the list from Start to End.\nReturns a copy of
-      the strided slice of the specified list from Start to End.
+    - type: any
+    - type: number
+    - type: number
+    - type: number
+    description: Copies the strided slice of the list from Start to End.\nReturns
+      a copy of the strided slice of the specified list from Start to End.
   ll.List2Rot:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the rotation at Index in the list.\nReturns the value at Index in
-      the specified list. If Index describes a location not in the list, or the
+    - type: table
+    - type: number
+    description: Copies the rotation at Index in the list.\nReturns the value at Index
+      in the specified list. If Index describes a location not in the list, or the
       value cannot be type-cast to rotation, thenZERO_ROTATION is returned.
   ll.List2String:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the string at Index in the list.\nReturns the value at Index in the
-      specified list as a string. If Index describes a location not in the list
-      then null string is returned.
+    - type: table
+    - type: number
+    description: Copies the string at Index in the list.\nReturns the value at Index
+      in the specified list as a string. If Index describes a location not in the
+      list then null string is returned.
   ll.List2Vector:
     args:
-      - type: table
-      - type: number
-    description: >-
-      Copies the vector at Index in the list.\nReturns the value at Index in the
-      specified list. If Index describes a location not in the list, or the
+    - type: table
+    - type: number
+    description: Copies the vector at Index in the list.\nReturns the value at Index
+      in the specified list. If Index describes a location not in the list, or the
       value cannot be type-cast to a vector, then ZERO_VECTOR is returned.
   ll.ListFindList:
     args:
-      - type: table
-      - type: table
-    description: >-
-      Returns the index of the first instance of Find in ListVariable. Returns
-      -1 if not found.\nReturns the position of the first instance of the Find
-      list in the ListVariable. Returns -1 if not found.
+    - type: table
+    - type: table
+    description: Returns the index of the first instance of Find in ListVariable.
+      Returns -1 if not found.\nReturns the position of the first instance of the
+      Find list in the ListVariable. Returns -1 if not found.
   ll.ListFindListNext:
     args:
-      - type: table
-      - type: table
-      - type: number
-    description: >-
-      Returns the index of the nth instance of Find in ListVariable. Returns -1
-      if not found.
+    - type: table
+    - type: table
+    - type: number
+    description: Returns the index of the nth instance of Find in ListVariable. Returns
+      -1 if not found.
   ll.ListFindStrided:
     args:
-      - type: table
-      - type: table
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Returns the index of the first instance of Find in ListVariable. Returns
-      -1 if not found.\nReturns the position of the first instance of the Find
-      list in the ListVariable after the start index and before the end index.
+    - type: table
+    - type: table
+    - type: number
+    - type: number
+    - type: number
+    description: Returns the index of the first instance of Find in ListVariable.
+      Returns -1 if not found.\nReturns the position of the first instance of the
+      Find list in the ListVariable after the start index and before the end index.
       Steps through ListVariable by stride.  Returns -1 if not found.
   ll.ListInsertList:
     args:
-      - type: any
-      - type: any
-      - type: number
-    description: >-
-      Returns a list that contains all the elements from Target but with the
-      elements from ListVariable inserted at Position start.\nReturns a new
-      list, created by inserting ListVariable into the Target list at Position.
-      Note this does not alter the Target.
+    - type: any
+    - type: any
+    - type: number
+    description: Returns a list that contains all the elements from Target but with
+      the elements from ListVariable inserted at Position start.\nReturns a new list,
+      created by inserting ListVariable into the Target list at Position. Note this
+      does not alter the Target.
   ll.ListRandomize:
     args:
-      - type: any
-      - type: number
-    description: >-
-      Returns a version of the input ListVariable which has been randomized by
-      blocks of size Stride.\nIf the remainder from the length of the list,
-      divided by the stride is non-zero, this function does not randomize the
-      list.
+    - type: any
+    - type: number
+    description: Returns a version of the input ListVariable which has been randomized
+      by blocks of size Stride.\nIf the remainder from the length of the list, divided
+      by the stride is non-zero, this function does not randomize the list.
   ll.ListReplaceList:
     args:
-      - type: any
-      - type: any
-      - type: number
-      - type: number
-    description: >-
-      Returns a list that is Target with Start through End removed and
-      ListVariable inserted at Start.\nReturns a list replacing the slice of the
-      Target list from Start to End with the specified ListVariable. Start and
-      End are inclusive, so 0, 1 would replace the first two entries and 0, 0
-      would replace only the first list entry.
+    - type: any
+    - type: any
+    - type: number
+    - type: number
+    description: Returns a list that is Target with Start through End removed and
+      ListVariable inserted at Start.\nReturns a list replacing the slice of the Target
+      list from Start to End with the specified ListVariable. Start and End are inclusive,
+      so 0, 1 would replace the first two entries and 0, 0 would replace only the
+      first list entry.
   ll.ListSort:
     args:
-      - type: any
-      - type: number
-      - type:
-          display: numeric
-    description: >-
-      Returns the specified list, sorted into blocks of stride in ascending
-      order (if Ascending is TRUE, otherwise descending). Note that sort only
-      works if the first entry of each block is the same datatype.
+    - type: any
+    - type: number
+    - type:
+        display: numeric
+    description: Returns the specified list, sorted into blocks of stride in ascending
+      order (if Ascending is TRUE, otherwise descending). Note that sort only works
+      if the first entry of each block is the same datatype.
   ll.ListSortStrided:
     args:
-      - type: any
-      - type: number
-      - type: number
-      - type:
-          display: numeric
-    description: >-
-      Returns the specified list, sorted by the specified element into blocks of
-      stride in ascending order (if Ascending is TRUE, otherwise descending).
-      Note that sort only works if the first entry of each block is the same
-      datatype.
+    - type: any
+    - type: number
+    - type: number
+    - type:
+        display: numeric
+    description: Returns the specified list, sorted by the specified element into
+      blocks of stride in ascending order (if Ascending is TRUE, otherwise descending).
+      Note that sort only works if the first entry of each block is the same datatype.
   ll.ListStatistics:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Performs a statistical aggregate function, specified by a LIST_STAT_*
-      constant, on ListVariables.\nThis function allows a script to perform a
-      statistical operation as defined by operation on a list composed of
-      integers and floats.
+    - type: number
+    - type: table
+    description: Performs a statistical aggregate function, specified by a LIST_STAT_*
+      constant, on ListVariables.\nThis function allows a script to perform a statistical
+      operation as defined by operation on a list composed of integers and floats.
   ll.Listen:
     args:
-      - type: number
-      - type: string
-      - type:
-          display: uuid
-      - type: string
-    description: >-
-      Creates a listen callback for Text on Channel from SpeakersName and
-      SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and
-      returns an identifier that can be used to deactivate or remove the
-      listen.\nNon-empty values for SpeakersName, SpeakersID, and Text will
-      filter the results accordingly, while empty strings and NULL_KEY will not
-      filter the results, for string and key parameters
-      respectively.\nPUBLIC_CHANNEL is the public chat channel that all avatars
-      see as chat text. DEBUG_CHANNEL is the script debug channel, and is also
-      visible to nearby avatars. All other channels are are not sent to avatars,
+    - type: number
+    - type: string
+    - type:
+        display: uuid
+    - type: string
+    description: Creates a listen callback for Text on Channel from SpeakersName and
+      SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and returns
+      an identifier that can be used to deactivate or remove the listen.\nNon-empty
+      values for SpeakersName, SpeakersID, and Text will filter the results accordingly,
+      while empty strings and NULL_KEY will not filter the results, for string and
+      key parameters respectively.\nPUBLIC_CHANNEL is the public chat channel that
+      all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and
+      is also visible to nearby avatars. All other channels are are not sent to avatars,
       but may be used to communicate with scripts.
   ll.ListenControl:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Makes a listen event callback active or inactive. Pass in the value
-      returned from llListen to the iChannelHandle parameter to specify which
-      listener you are controlling.\nUse boolean values to specify Active
+    - type: number
+    - type: number
+    description: Makes a listen event callback active or inactive. Pass in the value
+      returned from llListen to the iChannelHandle parameter to specify which listener
+      you are controlling.\nUse boolean values to specify Active
   ll.ListenRemove:
     args:
-      - type: number
-    description: >-
-      Removes a listen event callback. Pass in the value returned from llListen
-      to the iChannelHandle parameter to specify which listener to remove.
+    - type: number
+    description: Removes a listen event callback. Pass in the value returned from
+      llListen to the iChannelHandle parameter to specify which listener to remove.
   ll.LoadURL:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: string
-    description: "Shows dialog to avatar AvatarID offering to load web page at URL.\tIf user clicks yes, launches their web browser.\\nllLoadURL displays a dialogue box to the user, offering to load the specified web page using the default web browser."
+    - type:
+        display: uuid
+    - type: string
+    - type: string
+    description: "Shows dialog to avatar AvatarID offering to load web page at URL.\t\
+      If user clicks yes, launches their web browser.\\nllLoadURL displays a dialogue\
+      \ box to the user, offering to load the specified web page using the default\
+      \ web browser."
   ll.Log:
     args:
-      - type: number
-    description: >-
-      Returns the natural logarithm of Value. Returns zero if Value <=
+    - type: number
+    description: Returns the natural logarithm of Value. Returns zero if Value <=
       0.\nReturns the base e (natural) logarithm of the specified Value.
   ll.Log10:
     args:
-      - type: number
-    description: >-
-      Returns the base 10 logarithm of Value. Returns zero if Value <=
+    - type: number
+    description: Returns the base 10 logarithm of Value. Returns zero if Value <=
       0.\nReturns the base 10 (common) logarithm of the specified Value.
   ll.LookAt:
     args:
-      - type:
-          display: vector
-      - type: number
-      - type: number
-    description: >-
-      Cause object name to point its forward axis towards Target, at a force
-      controlled by Strength and Damping.\nGood Strength values are around half
-      the mass of the object and good Damping values are less than 1/10th of the
-      Strength.\nAsymmetrical shapes require smaller Damping. A Strength of 0.0
-      cancels the look at.
+    - type:
+        display: vector
+    - type: number
+    - type: number
+    description: Cause object name to point its forward axis towards Target, at a
+      force controlled by Strength and Damping.\nGood Strength values are around half
+      the mass of the object and good Damping values are less than 1/10th of the Strength.\nAsymmetrical
+      shapes require smaller Damping. A Strength of 0.0 cancels the look at.
   ll.LoopSound:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly
-      one sound may be attached to an object at a time.\nA second call to
-      llLoopSound with the same key will not restart the sound, but the new
-      volume will be used. This allows control over the volume of already
-      playing sounds.\nSetting the volume to 0 is not the same as calling
-      llStopSound; a sound with 0 volume will continue to loop.\nTo restart the
-      sound from the beginning, call llStopSound before calling llLoopSound
-      again.
+    - type: string
+    - type: number
+    description: Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly
+      one sound may be attached to an object at a time.\nA second call to llLoopSound
+      with the same key will not restart the sound, but the new volume will be used.
+      This allows control over the volume of already playing sounds.\nSetting the
+      volume to 0 is not the same as calling llStopSound; a sound with 0 volume will
+      continue to loop.\nTo restart the sound from the beginning, call llStopSound
+      before calling llLoopSound again.
   ll.LoopSoundMaster:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a
-      sync master.\nBehaviour is identical to llLoopSound, with the addition of
-      marking the source as a "Sync Master", causing "Slave" sounds to sync to
-      it. If there are multiple masters within a viewers interest area, the most
-      audible one (a function of both distance and volume) will win out as the
-      master.\nThe use of multiple masters within a small area is unlikely to
-      produce the desired effect.
+    - type: string
+    - type: number
+    description: Plays attached Sound, looping at volume (0.0 - 1.0), and declares
+      it a sync master.\nBehaviour is identical to llLoopSound, with the addition
+      of marking the source as a "Sync Master", causing "Slave" sounds to sync to
+      it. If there are multiple masters within a viewers interest area, the most audible
+      one (a function of both distance and volume) will win out as the master.\nThe
+      use of multiple masters within a small area is unlikely to produce the desired
+      effect.
   ll.LoopSoundSlave:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays attached sound looping at volume (0.0 - 1.0), synced to most audible
-      sync master.\nBehaviour is identical to llLoopSound, unless there is a
-      "Sync Master" present.\nIf a Sync Master is already playing the Slave
-      sound will begin playing from the same point the master is in its loop
-      synchronizing the loop points of both sounds.\nIf a Sync Master is started
-      when the Slave is already playing, the Slave will skip to the correct
-      position to sync with the Master.
+    - type: string
+    - type: number
+    description: Plays attached sound looping at volume (0.0 - 1.0), synced to most
+      audible sync master.\nBehaviour is identical to llLoopSound, unless there is
+      a "Sync Master" present.\nIf a Sync Master is already playing the Slave sound
+      will begin playing from the same point the master is in its loop synchronizing
+      the loop points of both sounds.\nIf a Sync Master is started when the Slave
+      is already playing, the Slave will skip to the correct position to sync with
+      the Master.
   ll.MD5String:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Returns a string of 32 hex characters that is an RSA Data Security Inc.,
-      MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns
+    - type: string
+    - type: number
+    description: Returns a string of 32 hex characters that is an RSA Data Security
+      Inc., MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns
       a 32-character hex string. (128-bit in binary.)
   ll.MakeExplosion:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: string
-      - type:
-          display: vector
-    description: >-
-      Make a round explosion of particles. Deprecated: Use llParticleSystem
-      instead.\nMake a round explosion of particles using texture from the
-      objects inventory. Deprecated: Use llParticleSystem instead.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: string
+    - type:
+        display: vector
+    description: 'Make a round explosion of particles. Deprecated: Use llParticleSystem
+      instead.\nMake a round explosion of particles using texture from the objects
+      inventory. Deprecated: Use llParticleSystem instead.'
   ll.MakeFire:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: string
-      - type:
-          display: vector
-    description: >-
-      Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake
-      fire particles using texture from the objects inventory. Deprecated: Use
-      llParticleSystem instead.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: string
+    - type:
+        display: vector
+    description: 'Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake
+      fire particles using texture from the objects inventory. Deprecated: Use llParticleSystem
+      instead.'
   ll.MakeFountain:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: string
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Make a fountain of particles. Deprecated: Use llParticleSystem
-      instead.\nMake a fountain of particles using texture from the objects
-      inventory. Deprecated: Use llParticleSystem instead.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: string
+    - type:
+        display: vector
+    - type: number
+    description: 'Make a fountain of particles. Deprecated: Use llParticleSystem instead.\nMake
+      a fountain of particles using texture from the objects inventory. Deprecated:
+      Use llParticleSystem instead.'
   ll.MakeSmoke:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: string
-      - type:
-          display: vector
-    description: >-
-      Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake
-      smoky particles using texture from the objects inventory. Deprecated: Use
-      llParticleSystem instead.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: string
+    - type:
+        display: vector
+    description: 'Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake
+      smoky particles using texture from the objects inventory. Deprecated: Use llParticleSystem
+      instead.'
   ll.ManageEstateAccess:
     args:
-      - type: number
-      - type:
-          display: uuid
-    description: >-
-      Adds or removes agents from the estate's agent access or ban lists, or
-      groups to the estate's group access list. Action is one of the
-      ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer
-      representing a boolean, TRUE if the call was successful; FALSE if
-      throttled, invalid action, invalid or null id or object owner is not
-      allowed to manage the estate.\nThe object owner is notified of any
-      changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to
-      the script.
+    - type: number
+    - type:
+        display: uuid
+    description: Adds or removes agents from the estate's agent access or ban lists,
+      or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_*
+      operations to perform.\nReturns an integer representing a boolean, TRUE if the
+      call was successful; FALSE if throttled, invalid action, invalid or null id
+      or object owner is not allowed to manage the estate.\nThe object owner is notified
+      of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted
+      to the script.
   ll.MapBeacon:
     args:
-      - type: string
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Displays an in world beacon and optionally opens world map for avatar who
-      touched the object or is wearing the script, centered on RegionName with
-      Position highlighted. Only works for scripts attached to avatar, or during
-      touch events.
+    - type: string
+    - type:
+        display: vector
+    - type: table
+    description: Displays an in world beacon and optionally opens world map for avatar
+      who touched the object or is wearing the script, centered on RegionName with
+      Position highlighted. Only works for scripts attached to avatar, or during touch
+      events.
   ll.MapDestination:
     args:
-      - type: string
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Opens world map for avatar who touched it or is wearing the script,
-      centred on RegionName with Position highlighted. Only works for scripts
-      attached to avatar, or during touch events.\nDirection currently has no
-      effect.
+    - type: string
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Opens world map for avatar who touched it or is wearing the script,
+      centred on RegionName with Position highlighted. Only works for scripts attached
+      to avatar, or during touch events.\nDirection currently has no effect.
   ll.MessageLinked:
     args:
-      - type: number
-      - type: number
-      - type: any
-      - type: any
-    description: >-
-      Sends Number, Text, and ID to members of the link set identified by
-      LinkNumber.\nLinkNumber is either a linked number (available through
-      llGetLinkNumber) or a LINK_* constant.
+    - type: number
+    - type: number
+    - type: any
+    - type: any
+    description: Sends Number, Text, and ID to members of the link set identified
+      by LinkNumber.\nLinkNumber is either a linked number (available through llGetLinkNumber)
+      or a LINK_* constant.
   ll.MinEventDelay:
     args:
-      - type: number
+    - type: number
     description: Set the minimum time between events being handled.
   ll.ModPow:
     args:
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped
-      at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised to
-      the Power, Modulus). Value is capped at 0xFFFF (16 bits).
+    - type: number
+    - type: number
+    - type: number
+    description: Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is
+      capped at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised
+      to the Power, Modulus). Value is capped at 0xFFFF (16 bits).
   ll.ModifyLand:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH,
-      LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x
-      4m, 8m x 8m).
+    - type: number
+    - type: number
+    description: Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH,
+      LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x 4m,
+      8m x 8m).
   ll.MoveToTarget:
     args:
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Critically damp to Target in Tau seconds (if the script is
-      physical).\nCritically damp to position target in tau-seconds if the
-      script is physical. Good tau-values are greater than 0.2. A tau of 0.0
-      stops the critical damping.
+    - type:
+        display: vector
+    - type: number
+    description: Critically damp to Target in Tau seconds (if the script is physical).\nCritically
+      damp to position target in tau-seconds if the script is physical. Good tau-values
+      are greater than 0.2. A tau of 0.0 stops the critical damping.
   ll.Name2Key:
     args:
-      - type: string
+    - type: string
     description: Look up Agent ID for the named agent in the region.
   ll.NavigateTo:
     args:
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Navigate to destination.\nDirects an object to travel to a defined
+    - type:
+        display: vector
+    - type: table
+    description: Navigate to destination.\nDirects an object to travel to a defined
       position in the region or adjacent regions.
   ll.OffsetTexture:
     args:
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Sets the texture S and T offsets for the chosen Face.\nIf Face is
+    - type: number
+    - type: number
+    - type: number
+    description: Sets the texture S and T offsets for the chosen Face.\nIf Face is
       ALL_SIDES this function sets the texture offsets for all faces.
   ll.OpenFloater:
     args:
-      - type: string
-      - type: string
-      - type: table
-    description: >-
-      Returns the value for header for request_id.\nReturns a string that is the
-      value of the Header for HTTPRequestID.
+    - type: string
+    - type: string
+    - type: table
+    description: Returns the value for header for request_id.\nReturns a string that
+      is the value of the Header for HTTPRequestID.
   ll.OpenRemoteDataChannel:
     args: []
     description: This function is deprecated.
   ll.Ord:
     args:
-      - type: string
-      - type: number
+    - type: string
+    - type: number
     description: Returns the unicode value of the indicated character in the string.
   ll.OverMyLand:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns TRUE if id ID over land owned by the script owner, otherwise
-      FALSE.\nReturns TRUE if key ID is over land owned by the object owner,
-      FALSE otherwise.
+    - type:
+        display: uuid
+    description: Returns TRUE if id ID over land owned by the script owner, otherwise
+      FALSE.\nReturns TRUE if key ID is over land owned by the object owner, FALSE
+      otherwise.
   ll.OwnerSay:
     args:
-      - type: string
-    description: >-
-      says Text to owner only (if owner is in region).\nSays Text to the owner
-      of the object running the script, if the owner has been within the
-      object's simulator since logging into Second Life, regardless of where
-      they may be in-world.
+    - type: string
+    description: says Text to owner only (if owner is in region).\nSays Text to the
+      owner of the object running the script, if the owner has been within the object's
+      simulator since logging into Second Life, regardless of where they may be in-world.
   ll.ParcelMediaCommandList:
     args:
-      - type: table
-    description: >-
-      Controls the playback of multimedia resources on a parcel or for an agent,
-      via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.
+    - type: table
+    description: Controls the playback of multimedia resources on a parcel or for
+      an agent, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.
   ll.ParcelMediaQuery:
     args:
-      - type: table
-    description: >-
-      Queries the media properties of the parcel containing the script, via one
-      or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis
-      function will only work if the script is contained within an object owned
-      by the land-owner (or if the land is owned by a group, only if the object
-      has been deeded to the group).
+    - type: table
+    description: Queries the media properties of the parcel containing the script,
+      via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis
+      function will only work if the script is contained within an object owned by
+      the land-owner (or if the land is owned by a group, only if the object has been
+      deeded to the group).
   ll.ParseString2List:
     args:
-      - type: string
-      - type: any
-      - type: any
-    description: >-
-      Converts Text into a list, discarding Separators, keeping Spacers
-      (Separators and Spacers must be lists of strings, maximum of 8
-      each).\nSeparators and Spacers are lists of strings with a maximum of 8
-      entries each.
+    - type: string
+    - type: any
+    - type: any
+    description: Converts Text into a list, discarding Separators, keeping Spacers
+      (Separators and Spacers must be lists of strings, maximum of 8 each).\nSeparators
+      and Spacers are lists of strings with a maximum of 8 entries each.
   ll.ParseStringKeepNulls:
     args:
-      - type: string
-      - type: any
-      - type: any
-    description: >-
-      Breaks Text into a list, discarding separators, keeping spacers, keeping
-      any null values generated. (separators and spacers must be lists of
-      strings, maximum of 8 each).\nllParseStringKeepNulls works almost exactly
-      like llParseString2List, except that if a null is found it will add a
-      null-string instead of discarding it like llParseString2List does.
+    - type: string
+    - type: any
+    - type: any
+    description: Breaks Text into a list, discarding separators, keeping spacers,
+      keeping any null values generated. (separators and spacers must be lists of
+      strings, maximum of 8 each).\nllParseStringKeepNulls works almost exactly like
+      llParseString2List, except that if a null is found it will add a null-string
+      instead of discarding it like llParseString2List does.
   ll.ParticleSystem:
     args:
-      - type: table
-    description: >-
-      Creates a particle system in the prim the script is attached to, based on
-      Parameters. An empty list removes a particle system from object.\nList
+    - type: table
+    description: Creates a particle system in the prim the script is attached to,
+      based on Parameters. An empty list removes a particle system from object.\nList
       format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].
   ll.PassCollisions:
     args:
-      - type:
-          display: numeric
-    description: >-
-      Configures how collision events are passed to scripts in the linkset.\nIf
-      Pass == TRUE, collisions involving collision-handling scripted child prims
-      are also passed on to the root prim. If Pass == FALSE (default behavior),
-      such collisions will only trigger events in the affected child prim.
+    - type:
+        display: numeric
+    description: Configures how collision events are passed to scripts in the linkset.\nIf
+      Pass == TRUE, collisions involving collision-handling scripted child prims are
+      also passed on to the root prim. If Pass == FALSE (default behavior), such collisions
+      will only trigger events in the affected child prim.
   ll.PassTouches:
     args:
-      - type:
-          display: numeric
-    description: >-
-      Configures how touch events are passed to scripts in the linkset.\nIf Pass
-      == TRUE, touches involving touch-handling scripted child prims are also
-      passed on to the root prim. If Pass == FALSE (default behavior), such
-      touches will only trigger events in the affected child prim.
+    - type:
+        display: numeric
+    description: Configures how touch events are passed to scripts in the linkset.\nIf
+      Pass == TRUE, touches involving touch-handling scripted child prims are also
+      passed on to the root prim. If Pass == FALSE (default behavior), such touches
+      will only trigger events in the affected child prim.
   ll.PatrolPoints:
     args:
-      - type: table
-      - type: table
-    description: >-
-      Patrol a list of points.\nSets the points for a character
-      (llCreateCharacter) to patrol along.
+    - type: table
+    - type: table
+    description: Patrol a list of points.\nSets the points for a character (llCreateCharacter)
+      to patrol along.
   ll.PlaySound:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly
-      one sound may be attached to an object at a time, and attaching a new
-      sound or calling llStopSound will stop the previously attached sound.\nA
-      second call to llPlaySound with the same sound will not restart the sound,
-      but the new volume will be used, which allows control over the volume of
-      already playing sounds.\nTo restart the sound from the beginning, call
-      llStopSound before calling llPlaySound again.
+    - type: string
+    - type: number
+    description: Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly
+      one sound may be attached to an object at a time, and attaching a new sound
+      or calling llStopSound will stop the previously attached sound.\nA second call
+      to llPlaySound with the same sound will not restart the sound, but the new volume
+      will be used, which allows control over the volume of already playing sounds.\nTo
+      restart the sound from the beginning, call llStopSound before calling llPlaySound
+      again.
   ll.PlaySoundSlave:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of
-      most audible sync master.\nBehaviour is identical to llPlaySound, unless
-      there is a "Sync Master" present. If a Sync Master is already playing, the
-      Slave sound will not be played until the Master hits its loop point and
-      returns to the beginning.\nllPlaySoundSlave will play the sound exactly
-      once; if it is desired to have the sound play every time the Master loops,
-      either use llLoopSoundSlave with extra silence padded on the end of the
-      sound or ensure that llPlaySoundSlave is called at least once per loop of
-      the Master.
+    - type: string
+    - type: number
+    description: Plays attached Sound once, at Volume (0.0 - 1.0), synced to next
+      loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless
+      there is a "Sync Master" present. If a Sync Master is already playing, the Slave
+      sound will not be played until the Master hits its loop point and returns to
+      the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is
+      desired to have the sound play every time the Master loops, either use llLoopSoundSlave
+      with extra silence padded on the end of the sound or ensure that llPlaySoundSlave
+      is called at least once per loop of the Master.
   ll.Pow:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Returns the Value raised to the power Exponent, or returns 0 and triggers
-      Math Error for imaginary results.\nReturns the Value raised to the
+    - type: number
+    - type: number
+    description: Returns the Value raised to the power Exponent, or returns 0 and
+      triggers Math Error for imaginary results.\nReturns the Value raised to the
       Exponent.
   ll.PreloadSound:
     args:
-      - type: string
-    description: >-
-      Causes nearby viewers to preload the Sound from the object's
-      inventory.\nThis is intended to prevent delays in starting new sounds when
-      called upon.
+    - type: string
+    description: Causes nearby viewers to preload the Sound from the object's inventory.\nThis
+      is intended to prevent delays in starting new sounds when called upon.
   ll.Pursue:
     args:
-      - type:
-          display: uuid
-      - type: table
-    description: >-
-      Chase after a target.\nCauses the character (llCharacter) to pursue the
-      target defined by TargetID.
+    - type:
+        display: uuid
+    - type: table
+    description: Chase after a target.\nCauses the character (llCharacter) to pursue
+      the target defined by TargetID.
   ll.PushObject:
     args:
-      - type:
-          display: uuid
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied
+    - type:
+        display: uuid
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type: number
+    description: Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied
       impulse and angular impulse to the object specified.
   ll.ReadKeyValue:
     args:
-      - type: string
-    description: |2-
-
-                         Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
-                      
+    - type: string
+    description: "\n                   Starts an asychronous transaction to retrieve\
+      \ the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND\
+      \ if the key does not exist. The dataserver callback will be executed with the\
+      \ key returned from this call and a string describing the result. The result\
+      \ is a two element commma-delimited list. The first item is an integer specifying\
+      \ if the transaction succeeded (1) or not (0). In the failure case, the second\
+      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
+      \ In the success case the second item will be the value associated with the\
+      \ key.\n                "
   ll.RefreshPrimURL:
     args: []
     description: Reloads the web page shown on the sides of the object.
   ll.RegionSay:
     args:
-      - type: number
-      - type: string
+    - type: number
+    - type: string
     description: Broadcasts Text to entire region on Channel (except for channel 0).
   ll.RegionSayTo:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: string
-    description: >-
-      Says Text, on Channel, to avatar or object indicated by TargetID (if
-      within region).\nIf TargetID is an avatar and Channel is nonzero, Text can
+    - type:
+        display: uuid
+    - type: number
+    - type: string
+    description: Says Text, on Channel, to avatar or object indicated by TargetID
+      (if within region).\nIf TargetID is an avatar and Channel is nonzero, Text can
       be heard by any attachment on the avatar.
   ll.ReleaseCamera:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: 'Return camera to agent.\nDeprecated: Use llClearCameraParams instead.'
   ll.ReleaseControls:
     args: []
     description: Stop taking inputs.\nStop taking inputs from the avatar.
   ll.ReleaseURL:
     args:
-      - type: string
-    description: >-
-      Releases the specified URL, which was previously obtained using
-      llRequestURL.  Once released, the URL will no longer be usable.
+    - type: string
+    description: Releases the specified URL, which was previously obtained using llRequestURL.  Once
+      released, the URL will no longer be usable.
   ll.RemoteDataReply:
     args:
-      - type:
-          display: uuid
-      - type:
-          display: uuid
-      - type: string
-      - type: number
+    - type:
+        display: uuid
+    - type:
+        display: uuid
+    - type: string
+    - type: number
     description: This function is deprecated.
   ll.RemoteDataSetRegion:
     args: []
     description: This function is deprecated.
   ll.RemoteLoadScriptPin:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: number
-      - type:
-          display: numeric
-      - type: number
-    description: >-
-      If the owner of the object containing this script can modify the object
-      identified by the specified object key, and if the PIN matches the PIN
-      previously set using llSetRemoteScriptAccessPin (on the target prim), then
-      the script will be copied into target. Running is a boolean specifying
-      whether the script should be enabled once copied into the target object.
+    - type:
+        display: uuid
+    - type: string
+    - type: number
+    - type:
+        display: numeric
+    - type: number
+    description: If the owner of the object containing this script can modify the
+      object identified by the specified object key, and if the PIN matches the PIN
+      previously set using llSetRemoteScriptAccessPin (on the target prim), then the
+      script will be copied into target. Running is a boolean specifying whether the
+      script should be enabled once copied into the target object.
   ll.RemoveFromLandBanList:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Remove avatar from the land ban list.\nRemove specified avatar from the
-      land parcel ban list.
+    - type:
+        display: uuid
+    description: Remove avatar from the land ban list.\nRemove specified avatar from
+      the land parcel ban list.
   ll.RemoveFromLandPassList:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Remove avatar from the land pass list.\nRemove specified avatar from the
-      land parcel pass list.
+    - type:
+        display: uuid
+    description: Remove avatar from the land pass list.\nRemove specified avatar from
+      the land parcel pass list.
   ll.RemoveInventory:
     args:
-      - type: string
-    description: >-
-      Remove the named inventory item.\nRemove the named inventory item from the
-      object inventory.
+    - type: string
+    description: Remove the named inventory item.\nRemove the named inventory item
+      from the object inventory.
   ll.RemoveVehicleFlags:
     args:
-      - type: number
-    description: >-
-      Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE.
+    - type: number
+    description: Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE.
       Valid parameters can be found in the vehicle flags constants section.
   ll.ReplaceAgentEnvironment:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: string
-    description: >-
-      Replaces the entire environment for an agent. Must be used as part of an
-      experience.
+    - type:
+        display: uuid
+    - type: number
+    - type: string
+    description: Replaces the entire environment for an agent. Must be used as part
+      of an experience.
   ll.ReplaceEnvironment:
     args:
-      - type:
-          display: vector
-      - type: string
-      - type: number
-      - type: number
-      - type: number
+    - type:
+        display: vector
+    - type: string
+    - type: number
+    - type: number
+    - type: number
     description: Replaces the environment for a parcel or region.
   ll.ReplaceSubString:
     args:
-      - type: string
-      - type: string
-      - type: string
-      - type: number
-    description: >-
-      Searches InitialString and replaces instances of SubString with
-      NewSubString. Zero Count means "replace all". Positive Count moves left to
-      right. Negative moves right to left.
+    - type: string
+    - type: string
+    - type: string
+    - type: number
+    description: Searches InitialString and replaces instances of SubString with NewSubString.
+      Zero Count means "replace all". Positive Count moves left to right. Negative
+      moves right to left.
   ll.RequestAgentData:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Requests data about AvatarID. When data is available the dataserver event
-      will be raised.\nThis function requests data about an avatar. If and when
-      the information is collected, the dataserver event is triggered with the
-      key returned from this function passed in the requested parameter. See the
-      agent data constants (DATA_*) for details about valid values of data and
-      what each will return in the dataserver event.
+    - type:
+        display: uuid
+    - type: number
+    description: Requests data about AvatarID. When data is available the dataserver
+      event will be raised.\nThis function requests data about an avatar. If and when
+      the information is collected, the dataserver event is triggered with the key
+      returned from this function passed in the requested parameter. See the agent
+      data constants (DATA_*) for details about valid values of data and what each
+      will return in the dataserver event.
   ll.RequestDisplayName:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Requests the display name of the agent. When the display name is available
-      the dataserver event will be raised.\nThe avatar identified does not need
-      to be in the same region or online at the time of the request.\nReturns a
-      key that is used to identify the dataserver event when it is raised.
+    - type:
+        display: uuid
+    description: Requests the display name of the agent. When the display name is
+      available the dataserver event will be raised.\nThe avatar identified does not
+      need to be in the same region or online at the time of the request.\nReturns
+      a key that is used to identify the dataserver event when it is raised.
   ll.RequestExperiencePermissions:
     args:
-      - type:
-          display: uuid
-      - type: string
-    description: |2-
-
-                         Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
-                      
+    - type:
+        display: uuid
+    - type: string
+    description: "\n                   Ask the agent for permission to participate\
+      \ in an experience. This request is similar to llRequestPermissions with the\
+      \ following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION,\
+      \ PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and\
+      \ PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to\
+      \ allow or block the request is persistent and applies to all scripts using\
+      \ the experience grid wide. Subsequent calls to llRequestExperiencePermissions\
+      \ from scripts in the experience will receive the same response automatically\
+      \ with no user interaction. One of experience_permissions or experience_permissions_denied\
+      \ will be generated in response to this call. Outstanding permission requests\
+      \ will be lost if the script is derezzed, moved to another region or reset.\n\
+      \                "
   ll.RequestInventoryData:
     args:
-      - type: string
-    description: >-
-      Requests data for the named InventoryItem.\nWhen data is available, the
-      dataserver event will be raised with the key returned from this function
-      in the requested parameter.\nThe only request currently implemented is to
-      request data from landmarks, where the data returned is in the form
-      "<float, float, float>" which can be cast to a vector. This position is in
-      region local coordinates.
+    - type: string
+    description: Requests data for the named InventoryItem.\nWhen data is available,
+      the dataserver event will be raised with the key returned from this function
+      in the requested parameter.\nThe only request currently implemented is to request
+      data from landmarks, where the data returned is in the form "<float, float,
+      float>" which can be cast to a vector. This position is in region local coordinates.
   ll.RequestPermissions:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Ask AvatarID to allow the script to perform certain actions, specified in
-      the PermissionMask bitmask. PermissionMask should be one or more
-      PERMISSION_* constants. Multiple permissions can be requested
-      simultaneously by ORing the constants together. Many of the permissions
-      requests can only go to object owner.\nThis call will not stop script
-      execution. If the avatar grants the requested permissions, the
-      run_time_permissions event will be called.
+    - type:
+        display: uuid
+    - type: number
+    description: Ask AvatarID to allow the script to perform certain actions, specified
+      in the PermissionMask bitmask. PermissionMask should be one or more PERMISSION_*
+      constants. Multiple permissions can be requested simultaneously by ORing the
+      constants together. Many of the permissions requests can only go to object owner.\nThis
+      call will not stop script execution. If the avatar grants the requested permissions,
+      the run_time_permissions event will be called.
   ll.RequestSecureURL:
     args: []
-    description: >-
-      Requests one HTTPS:// (SSL) URL for use by this object. The http_request
-      event is triggered with results.\nReturns a key that is the handle used
-      for identifying the request in the http_request event.
+    description: Requests one HTTPS:// (SSL) URL for use by this object. The http_request
+      event is triggered with results.\nReturns a key that is the handle used for
+      identifying the request in the http_request event.
   ll.RequestSimulatorData:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Requests the specified Data about RegionName. When the specified data is
-      available, the dataserver event is raised.\nData should use one of the
-      DATA_SIM_* constants.\nReturns a dataserver query ID and triggers the
-      dataserver event when data is found.
+    - type: string
+    - type: number
+    description: Requests the specified Data about RegionName. When the specified
+      data is available, the dataserver event is raised.\nData should use one of the
+      DATA_SIM_* constants.\nReturns a dataserver query ID and triggers the dataserver
+      event when data is found.
   ll.RequestURL:
     args: []
-    description: >-
-      Requests one HTTP:// URL for use by this script. The http_request event is
-      triggered with the result of the request.\nReturns a key that is the
+    description: Requests one HTTP:// URL for use by this script. The http_request
+      event is triggered with the result of the request.\nReturns a key that is the
       handle used for identifying the result in the http_request event.
   ll.RequestUserKey:
     args:
-      - type: string
+    - type: string
     description: Look up Agent ID for the named agent using a historical name.
   ll.RequestUsername:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Requests single-word user-name of an avatar. When data is available the
-      dataserver event will be raised.\nRequests the user-name of the identified
-      agent. When the user-name is available the dataserver event is
-      raised.\nThe agent identified does not need to be in the same region or
-      online at the time of the request.\nReturns a key that is used to identify
-      the dataserver event when it is raised.
+    - type:
+        display: uuid
+    description: Requests single-word user-name of an avatar. When data is available
+      the dataserver event will be raised.\nRequests the user-name of the identified
+      agent. When the user-name is available the dataserver event is raised.\nThe
+      agent identified does not need to be in the same region or online at the time
+      of the request.\nReturns a key that is used to identify the dataserver event
+      when it is raised.
   ll.ResetAnimationOverride:
     args:
-      - type: string
-    description: >-
-      Resets the animation of the specified animation state to the default
-      value.\nIf animation state equals "ALL", then all animation states are
-      reset.
+    - type: string
+    description: Resets the animation of the specified animation state to the default
+      value.\nIf animation state equals "ALL", then all animation states are reset.
   ll.ResetLandBanList:
     args: []
     description: Removes all residents from the land ban list.
@@ -7358,7 +6967,7 @@ globals:
     description: Removes all residents from the land access/pass list.
   ll.ResetOtherScript:
     args:
-      - type: string
+    - type: string
     description: Resets the named script.
   ll.ResetScript:
     args: []
@@ -7368,1519 +6977,1384 @@ globals:
     description: Sets the time to zero.\nSets the internal timer to zero.
   ll.ReturnObjectsByID:
     args:
-      - type: table
-    description: >-
-      Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS
-      permission and that the script owner owns the parcel the returned objects
-      are in, or is an estate manager or region owner.
+    - type: table
+    description: Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS
+      permission and that the script owner owns the parcel the returned objects are
+      in, or is an estate manager or region owner.
   ll.ReturnObjectsByOwner:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Return objects based upon their owner and a scope of parcel, parcel owner,
-      or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the
-      script owner owns the parcel the returned objects are in, or is an estate
+    - type:
+        display: uuid
+    - type: number
+    description: Return objects based upon their owner and a scope of parcel, parcel
+      owner, or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that
+      the script owner owns the parcel the returned objects are in, or is an estate
       manager or region owner.
   ll.RezAtRoot:
     args:
-      - type: string
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type:
-          display: quaternion
-      - type: number
-    description: >-
-      Instantiate owner's InventoryItem at Position with Velocity, Rotation and
-      with StartParameter. The last selected root object's location will be set
-      to Position.\nCreates object's inventory item at the given Position, with
-      Velocity, Rotation, and StartParameter.
+    - type: string
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type:
+        display: quaternion
+    - type: number
+    description: Instantiate owner's InventoryItem at Position with Velocity, Rotation
+      and with StartParameter. The last selected root object's location will be set
+      to Position.\nCreates object's inventory item at the given Position, with Velocity,
+      Rotation, and StartParameter.
   ll.RezObject:
     args:
-      - type: string
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type:
-          display: quaternion
-      - type: number
-    description: >-
-      Instantiate owners InventoryItem at Position with Velocity, Rotation and
-      with start StartParameter.\nCreates object's inventory item at Position
-      with Velocity and Rotation supplied. The StartParameter value will be
-      available to the newly created object in the on_rez event or through the
-      llGetStartParameter function.\nThe Velocity parameter is ignored if the
-      rezzed object is not physical.
+    - type: string
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type:
+        display: quaternion
+    - type: number
+    description: Instantiate owners InventoryItem at Position with Velocity, Rotation
+      and with start StartParameter.\nCreates object's inventory item at Position
+      with Velocity and Rotation supplied. The StartParameter value will be available
+      to the newly created object in the on_rez event or through the llGetStartParameter
+      function.\nThe Velocity parameter is ignored if the rezzed object is not physical.
   ll.RezObjectWithParams:
     args:
-      - type: string
-      - type: table
+    - type: string
+    - type: table
     description: Instantiate owner's InventoryItem with the given parameters.
   ll.Rot2Angle:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the rotation angle represented by Rotation.\nReturns the angle
-      represented by the Rotation.
+    - type:
+        display: quaternion
+    description: Returns the rotation angle represented by Rotation.\nReturns the
+      angle represented by the Rotation.
   ll.Rot2Axis:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the rotation axis represented by Rotation.\nReturns the axis
+    - type:
+        display: quaternion
+    description: Returns the rotation axis represented by Rotation.\nReturns the axis
       represented by the Rotation.
   ll.Rot2Euler:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns
+    - type:
+        display: quaternion
+    description: Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns
       the Euler Angle representation of the Rotation.
   ll.Rot2Fwd:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the forward vector defined by Rotation.\nReturns the forward axis
-      represented by the Rotation.
+    - type:
+        display: quaternion
+    description: Returns the forward vector defined by Rotation.\nReturns the forward
+      axis represented by the Rotation.
   ll.Rot2Left:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the left vector defined by Rotation.\nReturns the left axis
+    - type:
+        display: quaternion
+    description: Returns the left vector defined by Rotation.\nReturns the left axis
       represented by the Rotation.
   ll.Rot2Up:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      Returns the up vector defined by Rotation.\nReturns the up axis
-      represented by the Rotation.
+    - type:
+        display: quaternion
+    description: Returns the up vector defined by Rotation.\nReturns the up axis represented
+      by the Rotation.
   ll.RotBetween:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation
       needed to rotate Vector1 to Vector2.
   ll.RotLookAt:
     args:
-      - type:
-          display: quaternion
-      - type: number
-      - type: number
-    description: >-
-      Cause object to rotate to Rotation, with a force function defined by
-      Strength and Damping parameters. Good strength values are around half the
-      mass of the object and good damping values are less than 1/10th of the
-      strength.\nAsymmetrical shapes require smaller damping.\nA strength of 0.0
-      cancels the look at.
+    - type:
+        display: quaternion
+    - type: number
+    - type: number
+    description: Cause object to rotate to Rotation, with a force function defined
+      by Strength and Damping parameters. Good strength values are around half the
+      mass of the object and good damping values are less than 1/10th of the strength.\nAsymmetrical
+      shapes require smaller damping.\nA strength of 0.0 cancels the look at.
   ll.RotTarget:
     args:
-      - type:
-          display: quaternion
-      - type: number
-    description: >-
-      Set rotations with error of LeeWay radians as a rotational target, and
-      return an ID for the rotational target.\nThe returned number is a handle
+    - type:
+        display: quaternion
+    - type: number
+    description: Set rotations with error of LeeWay radians as a rotational target,
+      and return an ID for the rotational target.\nThe returned number is a handle
       that can be used in at_rot_target and llRotTargetRemove.
   ll.RotTargetRemove:
     args:
-      - type: number
-    description: >-
-      Removes rotational target number.\nRemove rotational target indicated by
-      the handle.
+    - type: number
+    description: Removes rotational target number.\nRemove rotational target indicated
+      by the handle.
   ll.RotateTexture:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Sets the texture rotation for the specified Face to angle Radians.\nIf
+    - type: number
+    - type: number
+    description: Sets the texture rotation for the specified Face to angle Radians.\nIf
       Face is ALL_SIDES, rotates the texture of all sides.
   ll.Round:
     args:
-      - type: number
-    description: >-
-      Returns Value rounded to the nearest integer.\nReturns the Value rounded
-      to the nearest integer.
+    - type: number
+    description: Returns Value rounded to the nearest integer.\nReturns the Value
+      rounded to the nearest integer.
   ll.SHA1String:
     args:
-      - type: string
-    description: >-
-      Returns a string of 40 hex characters that is the SHA1 security hash of
-      text.
+    - type: string
+    description: Returns a string of 40 hex characters that is the SHA1 security hash
+      of text.
   ll.SHA256String:
     args:
-      - type: string
-    description: >-
-      Returns a string of 64 hex characters that is the SHA256 security hash of
-      text.
+    - type: string
+    description: Returns a string of 64 hex characters that is the SHA256 security
+      hash of text.
   ll.SameGroup:
     args:
-      - type:
-          display: uuid
-    description: >-
-      Returns TRUE if avatar ID is in the same region and has the same active
-      group, otherwise FALSE.\nReturns TRUE if the object or agent identified is
-      in the same simulator and has the same active group as this object.
-      Otherwise, returns FALSE.
+    - type:
+        display: uuid
+    description: Returns TRUE if avatar ID is in the same region and has the same
+      active group, otherwise FALSE.\nReturns TRUE if the object or agent identified
+      is in the same simulator and has the same active group as this object. Otherwise,
+      returns FALSE.
   ll.Say:
     args:
-      - type: number
-      - type: string
-    description: >-
-      Says Text on Channel.\nThis chat method has a range of 20m
-      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
-      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
-      to nearby avatars. All other channels are are not sent to avatars, but may
-      be used to communicate with scripts.
+    - type: number
+    - type: string
+    description: Says Text on Channel.\nThis chat method has a range of 20m radius.\nPUBLIC_CHANNEL
+      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
+      is the script debug channel, and is also visible to nearby avatars. All other
+      channels are are not sent to avatars, but may be used to communicate with scripts.
   ll.ScaleByFactor:
     args:
-      - type: number
-    description: >-
-      Attempts to resize the entire object by ScalingFactor, maintaining the
-      size-position ratios of the prims.\n\nResizing is subject to prim scale
-      limits and linkability limits. This function can not resize the object if
-      the linkset is physical, a pathfinding character, in a keyframed motion,
-      or if resizing would cause the parcel to overflow.\nReturns a boolean (an
-      integer) TRUE if it succeeds, FALSE if it fails.
+    - type: number
+    description: Attempts to resize the entire object by ScalingFactor, maintaining
+      the size-position ratios of the prims.\n\nResizing is subject to prim scale
+      limits and linkability limits. This function can not resize the object if the
+      linkset is physical, a pathfinding character, in a keyframed motion, or if resizing
+      would cause the parcel to overflow.\nReturns a boolean (an integer) TRUE if
+      it succeeds, FALSE if it fails.
   ll.ScaleTexture:
     args:
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Sets the diffuse texture Horizontal and Vertical repeats on Face of the
-      prim the script is attached to.\nIf Face == ALL_SIDES, all sides are set
-      in one call.\nNegative values for horizontal and vertical will flip the
+    - type: number
+    - type: number
+    - type: number
+    description: Sets the diffuse texture Horizontal and Vertical repeats on Face
+      of the prim the script is attached to.\nIf Face == ALL_SIDES, all sides are
+      set in one call.\nNegative values for horizontal and vertical will flip the
       texture.
   ll.ScriptDanger:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns TRUE if Position is over public land, sandbox land, land that
-      doesn't allow everyone to edit and build, or land that doesn't allow
-      outside scripts.\nReturns true if the position is over public land, land
-      that doesn't allow everyone to edit and build, or land that doesn't allow
-      outside scripts.
+    - type:
+        display: vector
+    description: Returns TRUE if Position is over public land, sandbox land, land
+      that doesn't allow everyone to edit and build, or land that doesn't allow outside
+      scripts.\nReturns true if the position is over public land, land that doesn't
+      allow everyone to edit and build, or land that doesn't allow outside scripts.
   ll.ScriptProfiler:
     args:
-      - type: number
-    description: >-
-      Enables or disables script profiling options. Currently only supports
-      PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly
-      reduce script performance.
+    - type: number
+    description: Enables or disables script profiling options. Currently only supports
+      PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly reduce
+      script performance.
   ll.SendRemoteData:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: number
-      - type: string
+    - type:
+        display: uuid
+    - type: string
+    - type: number
+    - type: string
     description: This function is deprecated.
   ll.Sensor:
     args:
-      - type: string
-      - type:
-          display: uuid
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE,
-      and/or SCRIPTED) within Range meters and Arc radians of forward
-      vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent
-      filtering results based on that parameter. A range of 0.0 does not perform
-      a scan.\nResults are returned in the sensor and no_sensor events.
+    - type: string
+    - type:
+        display: uuid
+    - type: number
+    - type: number
+    - type: number
+    description: Performs a single scan for Name and ID with Type (AGENT, ACTIVE,
+      PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying
+      a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on
+      that parameter. A range of 0.0 does not perform a scan.\nResults are returned
+      in the sensor and no_sensor events.
   ll.SensorRemove:
     args: []
     description: removes sensor.\nRemoves the sensor set by llSensorRepeat.
   ll.SensorRepeat:
     args:
-      - type: string
-      - type:
-          display: uuid
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Initiates a periodic scan every Rate seconds, for Name and ID with Type
-      (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc
-      radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY
-      ID will prevent filtering results based on that parameter. A range of 0.0
-      does not perform a scan.\nResults are returned in the sensor and no_sensor
-      events.
+    - type: string
+    - type:
+        display: uuid
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    description: Initiates a periodic scan every Rate seconds, for Name and ID with
+      Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians
+      of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent
+      filtering results based on that parameter. A range of 0.0 does not perform a
+      scan.\nResults are returned in the sensor and no_sensor events.
   ll.SetAgentEnvironment:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: table
-    description: >-
-      Sets an agent's environmental values to the specified values. Must be used
-      as part of an experience.
+    - type:
+        display: uuid
+    - type: number
+    - type: table
+    description: Sets an agent's environmental values to the specified values. Must
+      be used as part of an experience.
   ll.SetAgentRot:
     args:
-      - type:
-          display: quaternion
-      - type: number
+    - type:
+        display: quaternion
+    - type: number
     description: Sets the avatar rotation to the given value.
   ll.SetAlpha:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value for
-      Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value
-      is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is
-      mostly transparent). This function will clamp alpha values less than 0.1
-      to 0.1 and greater than 1.0 to 1.
+    - type: number
+    - type: number
+    description: Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value
+      for Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value
+      is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is mostly
+      transparent). This function will clamp alpha values less than 0.1 to 0.1 and
+      greater than 1.0 to 1.
   ll.SetAngularVelocity:
     args:
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Sets an object's angular velocity to AngVel, in local coordinates if Local
-      == TRUE (if the script is physical).\nHas no effect on non-physical
+    - type:
+        display: vector
+    - type: number
+    description: Sets an object's angular velocity to AngVel, in local coordinates
+      if Local == TRUE (if the script is physical).\nHas no effect on non-physical
       objects.
   ll.SetAnimationOverride:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Sets the animation (in object inventory) that will play for the given
-      animation state.\nTo use this function the script must obtain the
-      PERMISSION_OVERRIDE_ANIMATIONS permission.
+    - type: string
+    - type: string
+    description: Sets the animation (in object inventory) that will play for the given
+      animation state.\nTo use this function the script must obtain the PERMISSION_OVERRIDE_ANIMATIONS
+      permission.
   ll.SetBuoyancy:
     args:
-      - type: number
-    description: >-
-      Set the tasks buoyancy (0 is none, < 1.0 sinks, 1.0 floats, > 1.0
-      rises).\nSet the object buoyancy. A value of 0 is none, less than 1.0
-      sinks, 1.0 floats, and greater than 1.0 rises.
+    - type: number
+    description: Set the tasks buoyancy (0 is none, < 1.0 sinks, 1.0 floats, > 1.0
+      rises).\nSet the object buoyancy. A value of 0 is none, less than 1.0 sinks,
+      1.0 floats, and greater than 1.0 rises.
   ll.SetCameraAtOffset:
     args:
-      - type:
-          display: vector
-    description: >-
-      Sets the camera used in this object, at offset, if an avatar sits on
-      it.\nSets the offset that an avatar's camera will be moved to if the
-      avatar sits on the object.
+    - type:
+        display: vector
+    description: Sets the camera used in this object, at offset, if an avatar sits
+      on it.\nSets the offset that an avatar's camera will be moved to if the avatar
+      sits on the object.
   ll.SetCameraEyeOffset:
     args:
-      - type:
-          display: vector
-    description: Sets the camera eye offset used in this object if an avatar sits on it.
+    - type:
+        display: vector
+    description: Sets the camera eye offset used in this object if an avatar sits
+      on it.
   ll.SetCameraParams:
     args:
-      - type: table
-    description: >-
-      Sets multiple camera parameters at once. List format is [ rule-1, data-1,
-      rule-2, data-2 . . . rule-n, data-n ].
+    - type: table
+    description: Sets multiple camera parameters at once. List format is [ rule-1,
+      data-1, rule-2, data-2 . . . rule-n, data-n ].
   ll.SetClickAction:
     args:
-      - type: number
+    - type: number
     description: Sets the action performed when a prim is clicked upon.
   ll.SetColor:
     args:
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Sets the color, for the face.\nSets the color of the side specified. If
-      Face is ALL_SIDES, sets the color on all faces.
+    - type:
+        display: vector
+    - type: number
+    description: Sets the color, for the face.\nSets the color of the side specified.
+      If Face is ALL_SIDES, sets the color on all faces.
   ll.SetContentType:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Set the media type of an LSL HTTP server response to
-      ContentType.\nHTTPRequestID must be a valid http_request ID. ContentType
-      must be one of the CONTENT_TYPE_* constants.
+    - type:
+        display: uuid
+    - type: number
+    description: Set the media type of an LSL HTTP server response to ContentType.\nHTTPRequestID
+      must be a valid http_request ID. ContentType must be one of the CONTENT_TYPE_*
+      constants.
   ll.SetDamage:
     args:
-      - type: number
-    description: "Sets the amount of damage that will be done to an avatar that this task hits.\tTask will be killed.\\nSets the amount of damage that will be done to an avatar that this object hits. This object will be destroyed on damaging an avatar, and no collision event is triggered."
+    - type: number
+    description: "Sets the amount of damage that will be done to an avatar that this\
+      \ task hits.\tTask will be killed.\\nSets the amount of damage that will be\
+      \ done to an avatar that this object hits. This object will be destroyed on\
+      \ damaging an avatar, and no collision event is triggered."
   ll.SetEnvironment:
     args:
-      - type:
-          display: vector
-      - type: table
+    - type:
+        display: vector
+    - type: table
     description: Returns a string with the requested data about the region.
   ll.SetForce:
     args:
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Sets Force on object, in object-local coordinates if Local == TRUE
-      (otherwise, the region reference frame is used).\nOnly works on physical
-      objects.
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Sets Force on object, in object-local coordinates if Local == TRUE
+      (otherwise, the region reference frame is used).\nOnly works on physical objects.
   ll.SetForceAndTorque:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Sets the Force and Torque of object, in object-local coordinates if Local
-      == TRUE (otherwise, the region reference frame is used).\nOnly works on
-      physical objects.
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Sets the Force and Torque of object, in object-local coordinates
+      if Local == TRUE (otherwise, the region reference frame is used).\nOnly works
+      on physical objects.
   ll.SetGroundTexture:
     args:
-      - type: table
+    - type: table
     description: Changes terrain texture properties in the region.
   ll.SetHoverHeight:
     args:
-      - type: number
-      - type:
-          display: numeric
-      - type: number
-    description: >-
-      Critically damps a physical object to a Height (either above ground level
-      or above the higher of land and water if water == TRUE).\nDo not use with
+    - type: number
+    - type:
+        display: numeric
+    - type: number
+    description: Critically damps a physical object to a Height (either above ground
+      level or above the higher of land and water if water == TRUE).\nDo not use with
       vehicles. Use llStopHover to stop hovering.
   ll.SetInventoryPermMask:
     args:
-      - type: string
-      - type: number
-      - type: number
-    description: Sets the given permission mask to the new value on the inventory item.
+    - type: string
+    - type: number
+    - type: number
+    description: Sets the given permission mask to the new value on the inventory
+      item.
   ll.SetKeyframedMotion:
     args:
-      - type: table
-      - type: table
-    description: >-
-      Requests that a non-physical object be key-framed according to key-frame
-      list.\nSpecify a list of times, positions, and orientations to be followed
-      by an object. The object will be smoothly moved between key-frames by the
-      simulator. Collisions with other non-physical or key-framed objects will
-      be ignored (no script events will fire and collision processing will not
-      occur). Collisions with physical objects will be computed and reported,
-      but the key-framed object will be unaffected by those
-      collisions.\nKeyframes is a strided list containing positional,
-      rotational, and time data for each step in the motion.  Options is a list
-      containing optional arguments and parameters (specified by KFM_*
-      constants).
+    - type: table
+    - type: table
+    description: Requests that a non-physical object be key-framed according to key-frame
+      list.\nSpecify a list of times, positions, and orientations to be followed by
+      an object. The object will be smoothly moved between key-frames by the simulator.
+      Collisions with other non-physical or key-framed objects will be ignored (no
+      script events will fire and collision processing will not occur). Collisions
+      with physical objects will be computed and reported, but the key-framed object
+      will be unaffected by those collisions.\nKeyframes is a strided list containing
+      positional, rotational, and time data for each step in the motion.  Options
+      is a list containing optional arguments and parameters (specified by KFM_* constants).
   ll.SetLinkAlpha:
     args:
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      If a prim exists in the link chain at LinkNumber, set Face to
-      Opacity.\nSets the Face, on the linked prim specified, to the Opacity.
+    - type: number
+    - type: number
+    - type: number
+    description: If a prim exists in the link chain at LinkNumber, set Face to Opacity.\nSets
+      the Face, on the linked prim specified, to the Opacity.
   ll.SetLinkCamera:
     args:
-      - type: number
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Sets the camera eye offset, and the offset that camera is looking at, for
-      avatars that sit on the linked prim.
+    - type: number
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Sets the camera eye offset, and the offset that camera is looking
+      at, for avatars that sit on the linked prim.
   ll.SetLinkColor:
     args:
-      - type: number
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      If a task exists in the link chain at LinkNumber, set the Face to
-      color.\nSets the color of the linked child's side, specified by
-      LinkNumber.
+    - type: number
+    - type:
+        display: vector
+    - type: number
+    description: If a task exists in the link chain at LinkNumber, set the Face to
+      color.\nSets the color of the linked child's side, specified by LinkNumber.
   ll.SetLinkGLTFOverrides:
     args:
-      - type: number
-      - type: number
-      - type: table
+    - type: number
+    - type: number
+    - type: table
     description: Sets or changes GLTF Overrides set on the selected faces.
   ll.SetLinkMedia:
     args:
-      - type: number
-      - type: number
-      - type: table
-    description: >-
-      Set the media parameters for a particular face on linked prim, specified
-      by Link. Returns an integer that is a STATUS_* flag which details the
-      success/failure of the operation(s).\nMediaParameters is a set of
-      name/value pairs in no particular order. Parameters not specified are
-      unchanged, or if new media is added then set to the default specified.
+    - type: number
+    - type: number
+    - type: table
+    description: Set the media parameters for a particular face on linked prim, specified
+      by Link. Returns an integer that is a STATUS_* flag which details the success/failure
+      of the operation(s).\nMediaParameters is a set of name/value pairs in no particular
+      order. Parameters not specified are unchanged, or if new media is added then
+      set to the default specified.
   ll.SetLinkPrimitiveParams:
     args:
-      - type: number
-      - type: table
+    - type: number
+    - type: table
     description: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
   ll.SetLinkPrimitiveParamsFast:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Set primitive parameters for LinkNumber based on Parameters, without a
-      delay.\nSet parameters for link number, from the list of Parameters, with
-      no built-in script sleep. This function is identical to
-      llSetLinkPrimitiveParams, except without the delay.
+    - type: number
+    - type: table
+    description: Set primitive parameters for LinkNumber based on Parameters, without
+      a delay.\nSet parameters for link number, from the list of Parameters, with
+      no built-in script sleep. This function is identical to llSetLinkPrimitiveParams,
+      except without the delay.
   ll.SetLinkRenderMaterial:
     args:
-      - type: number
-      - type: string
-      - type: number
-    description: >-
-      Sets the Render Material of Face on a linked prim, specified by
-      LinkNumber. Render Material may be a UUID or name of a material in prim
-      inventory.
+    - type: number
+    - type: string
+    - type: number
+    description: Sets the Render Material of Face on a linked prim, specified by LinkNumber.
+      Render Material may be a UUID or name of a material in prim inventory.
   ll.SetLinkSitFlags:
     args:
-      - type: number
-      - type: number
+    - type: number
+    - type: number
     description: Sets the sit flags for the specified prim in a linkset.
   ll.SetLinkTexture:
     args:
-      - type: number
-      - type: string
-      - type: number
-    description: >-
-      Sets the Texture of Face on a linked prim, specified by LinkNumber.
+    - type: number
+    - type: string
+    - type: number
+    description: Sets the Texture of Face on a linked prim, specified by LinkNumber.
       Texture may be a UUID or name of a texture in prim inventory.
   ll.SetLinkTextureAnim:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Animates a texture on the prim specified by LinkNumber, by setting the
-      texture scale and offset.\nMode is a bitmask of animation options.\nFace
-      specifies which object face to animate.\nSizeX and SizeY specify the
-      number of horizontal and vertical frames.Start specifes the animation
-      start point.\nLength specifies the animation duration.\nRate specifies the
-      animation playback rate.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    description: Animates a texture on the prim specified by LinkNumber, by setting
+      the texture scale and offset.\nMode is a bitmask of animation options.\nFace
+      specifies which object face to animate.\nSizeX and SizeY specify the number
+      of horizontal and vertical frames.Start specifes the animation start point.\nLength
+      specifies the animation duration.\nRate specifies the animation playback rate.
   ll.SetLocalRot:
     args:
-      - type:
-          display: quaternion
+    - type:
+        display: quaternion
     description: Sets the rotation of a child prim relative to the root prim.
   ll.SetMemoryLimit:
     args:
-      - type: number
-    description: >-
-      Requests Limit bytes to be reserved for this script.\nReturns TRUE or
-      FALSE indicating whether the limit was set successfully.\nThis function
-      has no effect if the script is running in the LSO VM.
+    - type: number
+    description: Requests Limit bytes to be reserved for this script.\nReturns TRUE
+      or FALSE indicating whether the limit was set successfully.\nThis function has
+      no effect if the script is running in the LSO VM.
   ll.SetObjectDesc:
     args:
-      - type: string
-    description: >-
-      Sets the description of the prim to Description.\nThe description field is
-      limited to 127 characters.
+    - type: string
+    description: Sets the description of the prim to Description.\nThe description
+      field is limited to 127 characters.
   ll.SetObjectName:
     args:
-      - type: string
+    - type: string
     description: Sets the prim's name to Name.
   ll.SetObjectPermMask:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Sets the specified PermissionFlag permission to the value specified by
-      PermissionMask on the object the script is attached to.
+    - type: number
+    - type: number
+    description: Sets the specified PermissionFlag permission to the value specified
+      by PermissionMask on the object the script is attached to.
   ll.SetParcelForSale:
     args:
-      - type:
-          display: numeric
-      - type: table
-    description: >-
-      Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE
-      the parcel is put up for sale. Options is a list of options to set for the
-      sale, such as price, authorized buyer, and whether to include objects on
-      the parcel.\n Setting ForSale to FALSE will remove the parcel from sale
-      and clear any options that were set.
+    - type:
+        display: numeric
+    - type: table
+    description: Sets the parcel the object is on for sale.\nForSale is a boolean,
+      if TRUE the parcel is put up for sale. Options is a list of options to set for
+      the sale, such as price, authorized buyer, and whether to include objects on
+      the parcel.\n Setting ForSale to FALSE will remove the parcel from sale and
+      clear any options that were set.
   ll.SetParcelMusicURL:
     args:
-      - type: string
-    description: >-
-      Sets the streaming audio URL for the parcel the object is on.\nThe object
-      must be owned by the owner of the parcel; if the parcel is group owned the
-      object must be owned by that group.
+    - type: string
+    description: Sets the streaming audio URL for the parcel the object is on.\nThe
+      object must be owned by the owner of the parcel; if the parcel is group owned
+      the object must be owned by that group.
   ll.SetPayPrice:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Sets the default amount when someone chooses to pay this object.\nPrice is
-      the default price shown in the text input field.  QuickButtons specifies
-      the 4 payment values shown in the payment dialog's buttons.\nInput field
-      and buttons may be hidden with PAY_HIDE constant, and may be set to their
-      default values using PAY_DEFAULT.
+    - type: number
+    - type: table
+    description: Sets the default amount when someone chooses to pay this object.\nPrice
+      is the default price shown in the text input field.  QuickButtons specifies
+      the 4 payment values shown in the payment dialog's buttons.\nInput field and
+      buttons may be hidden with PAY_HIDE constant, and may be set to their default
+      values using PAY_DEFAULT.
   ll.SetPhysicsMaterial:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Sets the selected parameters of the object's physics
-      behavior.\nMaterialBits is a bitmask specifying which of the parameters in
-      the other arguments should be applied to the object. GravityMultiplier,
-      Restitution, Friction, and Density are the possible parameters to
-      manipulate.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    description: Sets the selected parameters of the object's physics behavior.\nMaterialBits
+      is a bitmask specifying which of the parameters in the other arguments should
+      be applied to the object. GravityMultiplier, Restitution, Friction, and Density
+      are the possible parameters to manipulate.
   ll.SetPos:
     args:
-      - type:
-          display: vector
-    description: >-
-      If the object is not physical, this function sets the position of the
-      prim.\nIf the script is in a child prim, Position is treated as root
-      relative and the link-set is adjusted.\nIf the prim is the root prim, the
-      entire object is moved (up to 10m) to Position in region coordinates.
+    - type:
+        display: vector
+    description: If the object is not physical, this function sets the position of
+      the prim.\nIf the script is in a child prim, Position is treated as root relative
+      and the link-set is adjusted.\nIf the prim is the root prim, the entire object
+      is moved (up to 10m) to Position in region coordinates.
   ll.SetPrimMediaParams:
     args:
-      - type: number
-      - type: table
-    description: >-
-      Sets the MediaParameters for a particular Face on the prim. Returns an
-      integer that is a STATUS_* flag which details the success/failure of the
-      operation(s).\nMediaParameters is a set of name/value pairs in no
-      particular order. Parameters not specified are unchanged, or if new media
-      is added then set to the default specified.
+    - type: number
+    - type: table
+    description: Sets the MediaParameters for a particular Face on the prim. Returns
+      an integer that is a STATUS_* flag which details the success/failure of the
+      operation(s).\nMediaParameters is a set of name/value pairs in no particular
+      order. Parameters not specified are unchanged, or if new media is added then
+      set to the default specified.
   ll.SetPrimURL:
     args:
-      - type: string
+    - type: string
     description: 'Deprecated: Use llSetPrimMediaParams instead.'
   ll.SetPrimitiveParams:
     args:
-      - type: table
+    - type: table
     description: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
   ll.SetRegionPos:
     args:
-      - type:
-          display: vector
-    description: >-
-      Attempts to move the object so that the root prim is within 0.1m of
-      Position.\nReturns an integer boolean, TRUE if the object is successfully
-      placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any
-      location within the region or up to 10m across a region border.\nIf the
-      position is below ground, it will be set to the ground level at that x,y
-      location.
+    - type:
+        display: vector
+    description: Attempts to move the object so that the root prim is within 0.1m
+      of Position.\nReturns an integer boolean, TRUE if the object is successfully
+      placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any location
+      within the region or up to 10m across a region border.\nIf the position is below
+      ground, it will be set to the ground level at that x,y location.
   ll.SetRemoteScriptAccessPin:
     args:
-      - type: number
-    description: >-
-      If PIN is set to a non-zero number, the task will accept remote script
-      loads via llRemoteLoadScriptPin() if it passes in the correct PIN.
-      Othersise, llRemoteLoadScriptPin() is ignored.
+    - type: number
+    description: If PIN is set to a non-zero number, the task will accept remote script
+      loads via llRemoteLoadScriptPin() if it passes in the correct PIN. Othersise,
+      llRemoteLoadScriptPin() is ignored.
   ll.SetRenderMaterial:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Applies Render Material to Face of prim.\nRender Material may be a UUID or
-      name of a material in prim inventory.\nIf Face is ALL_SIDES, set the
+    - type: string
+    - type: number
+    description: Applies Render Material to Face of prim.\nRender Material may be
+      a UUID or name of a material in prim inventory.\nIf Face is ALL_SIDES, set the
       render material on all faces.
   ll.SetRot:
     args:
-      - type:
-          display: quaternion
-    description: >-
-      If the object is not physical, this function sets the rotation of the
-      prim.\nIf the script is in a child prim, Rotation is treated as root
-      relative and the link-set is adjusted.\nIf the prim is the root prim, the
-      entire object is rotated to Rotation in the global reference frame.
+    - type:
+        display: quaternion
+    description: If the object is not physical, this function sets the rotation of
+      the prim.\nIf the script is in a child prim, Rotation is treated as root relative
+      and the link-set is adjusted.\nIf the prim is the root prim, the entire object
+      is rotated to Rotation in the global reference frame.
   ll.SetScale:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Sets the prim's scale (size) to Scale.
   ll.SetScriptState:
     args:
-      - type: string
-      - type:
-          display: numeric
+    - type: string
+    - type:
+        display: numeric
     description: Enable or disable the script Running state of Script in the prim.
   ll.SetSitText:
     args:
-      - type: string
+    - type: string
     description: Displays Text rather than 'Sit' in the viewer's context menu.
   ll.SetSoundQueueing:
     args:
-      - type:
-          display: numeric
-    description: >-
-      Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached
-      sounds) interrupt the currently playing sound.\nThe default for objects is
-      FALSE. Setting this value to TRUE will make the sound wait until the
-      current playing sound reaches its end. The queue is one level deep.
+    - type:
+        display: numeric
+    description: Sets whether successive calls to llPlaySound, llLoopSound, etc.,
+      (attached sounds) interrupt the currently playing sound.\nThe default for objects
+      is FALSE. Setting this value to TRUE will make the sound wait until the current
+      playing sound reaches its end. The queue is one level deep.
   ll.SetSoundRadius:
     args:
-      - type: number
-    description: >-
-      Limits radius for audibility of scripted sounds (both attached and
+    - type: number
+    description: Limits radius for audibility of scripted sounds (both attached and
       triggered) to distance Radius.
   ll.SetStatus:
     args:
-      - type: number
-      - type:
-          display: numeric
-    description: >-
-      Sets object status specified in Status bitmask (e.g.
-      STATUS_PHYSICS|STATUS_PHANTOM) to boolean Value.\nFor a full list of
-      STATUS_* constants, see wiki documentation.
+    - type: number
+    - type:
+        display: numeric
+    description: Sets object status specified in Status bitmask (e.g. STATUS_PHYSICS|STATUS_PHANTOM)
+      to boolean Value.\nFor a full list of STATUS_* constants, see wiki documentation.
   ll.SetText:
     args:
-      - type: string
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      Causes Text to float above the prim, using the specified Color and
+    - type: string
+    - type:
+        display: vector
+    - type: number
+    description: Causes Text to float above the prim, using the specified Color and
       Opacity.
   ll.SetTexture:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Applies Texture to Face of prim.\nTexture may be a UUID or name of a
-      texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all
-      faces.
+    - type: string
+    - type: number
+    description: Applies Texture to Face of prim.\nTexture may be a UUID or name of
+      a texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all faces.
   ll.SetTextureAnim:
     args:
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Animates a texture by setting the texture scale and offset.\nMode is a
-      bitmask of animation options.\nFace specifies which object face to
-      animate.\nSizeX and SizeY specify the number of horizontal and vertical
-      frames.Start specifes the animation start point.\nLength specifies the
-      animation duration.\nRate specifies the animation playback rate.
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    - type: number
+    description: Animates a texture by setting the texture scale and offset.\nMode
+      is a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX
+      and SizeY specify the number of horizontal and vertical frames.Start specifes
+      the animation start point.\nLength specifies the animation duration.\nRate specifies
+      the animation playback rate.
   ll.SetTimerEvent:
     args:
-      - type: number
-    description: >-
-      Causes the timer event to be triggered every Rate seconds.\n Passing in
-      0.0 stops further timer events.
+    - type: number
+    description: Causes the timer event to be triggered every Rate seconds.\n Passing
+      in 0.0 stops further timer events.
   ll.SetTorque:
     args:
-      - type:
-          display: vector
-      - type:
-          display: numeric
-    description: >-
-      Sets the Torque acting on the script's object, in object-local coordinates
-      if Local == TRUE (otherwise, the region reference frame is used).\nOnly
-      works on physical objects.
+    - type:
+        display: vector
+    - type:
+        display: numeric
+    description: Sets the Torque acting on the script's object, in object-local coordinates
+      if Local == TRUE (otherwise, the region reference frame is used).\nOnly works
+      on physical objects.
   ll.SetTouchText:
     args:
-      - type: string
+    - type: string
     description: Displays Text in the viewer context menu that acts on a touch.
   ll.SetVehicleFlags:
     args:
-      - type: number
-    description: >-
-      Enables the vehicle flags specified in the Flags bitmask.\nValid
+    - type: number
+    description: Enables the vehicle flags specified in the Flags bitmask.\nValid
       parameters can be found in the wiki documentation.
   ll.SetVehicleFloatParam:
     args:
-      - type: number
-      - type: number
-    description: >-
-      Sets a vehicle float parameter.\nValid parameters can be found in the wiki
-      documentation.
+    - type: number
+    - type: number
+    description: Sets a vehicle float parameter.\nValid parameters can be found in
+      the wiki documentation.
   ll.SetVehicleRotationParam:
     args:
-      - type: number
-      - type:
-          display: quaternion
-    description: >-
-      Sets a vehicle rotation parameter.\nValid parameters can be found in the
-      wiki documentation.
+    - type: number
+    - type:
+        display: quaternion
+    description: Sets a vehicle rotation parameter.\nValid parameters can be found
+      in the wiki documentation.
   ll.SetVehicleType:
     args:
-      - type: number
-    description: >-
-      Activates the vehicle action on the object with vehicle preset
-      Type.\nValid Types and an explanation of their characteristics can be
-      found in wiki documentation.
+    - type: number
+    description: Activates the vehicle action on the object with vehicle preset Type.\nValid
+      Types and an explanation of their characteristics can be found in wiki documentation.
   ll.SetVehicleVectorParam:
     args:
-      - type: number
-      - type:
-          display: vector
-    description: >-
-      Sets a vehicle vector parameter.\nValid parameters can be found in the
-      wiki documentation.
+    - type: number
+    - type:
+        display: vector
+    description: Sets a vehicle vector parameter.\nValid parameters can be found in
+      the wiki documentation.
   ll.SetVelocity:
     args:
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      If the object is physics-enabled, sets the object's linear velocity to
-      Velocity.\nIf Local==TRUE, Velocity is treated as a local directional
-      vector; otherwise, Velocity is treated as a global directional vector.
+    - type:
+        display: vector
+    - type: number
+    description: If the object is physics-enabled, sets the object's linear velocity
+      to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector;
+      otherwise, Velocity is treated as a global directional vector.
   ll.Shout:
     args:
-      - type: number
-      - type: string
-    description: >-
-      Shouts Text on Channel.\nThis chat method has a range of 100m
-      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
-      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
-      to nearby avatars. All other channels are are not sent to avatars, but may
-      be used to communicate with scripts.
+    - type: number
+    - type: string
+    description: Shouts Text on Channel.\nThis chat method has a range of 100m radius.\nPUBLIC_CHANNEL
+      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
+      is the script debug channel, and is also visible to nearby avatars. All other
+      channels are are not sent to avatars, but may be used to communicate with scripts.
   ll.SignRSA:
     args:
-      - type: string
-      - type: string
-      - type: string
-    description: >-
-      Returns the base64-encoded RSA signature of Message using PEM-formatted
+    - type: string
+    - type: string
+    - type: string
+    description: Returns the base64-encoded RSA signature of Message using PEM-formatted
       PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).
   ll.Sin:
     args:
-      - type: number
+    - type: number
     description: Returns the sine of Theta (Theta in radians).
   ll.SitOnLink:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      If agent identified by AvatarID is participating in the experience, sit
-      them on the specified link's sit target.
+    - type:
+        display: uuid
+    - type: number
+    description: If agent identified by AvatarID is participating in the experience,
+      sit them on the specified link's sit target.
   ll.SitTarget:
     args:
-      - type:
-          display: vector
-      - type:
-          display: quaternion
-    description: >-
-      Set the sit location for this object. If offset == ZERO_VECTOR, clears the
-      sit target.
+    - type:
+        display: vector
+    - type:
+        display: quaternion
+    description: Set the sit location for this object. If offset == ZERO_VECTOR, clears
+      the sit target.
   ll.Sleep:
     args:
-      - type: number
+    - type: number
     description: Put script to sleep for Time seconds.
   ll.Sound:
     args:
-      - type: string
-      - type: number
-      - type: number
-      - type: number
-    description: >-
-      Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and specifies
-      whether the sound should loop and/or be enqueued.
+    - type: string
+    - type: number
+    - type: number
+    - type: number
+    description: 'Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and
+      specifies whether the sound should loop and/or be enqueued.'
   ll.SoundPreload:
     args:
-      - type: string
-    description: >-
-      Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers
-      within range.
+    - type: string
+    description: 'Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers
+      within range.'
   ll.Sqrt:
     args:
-      - type: number
-    description: >-
-      Returns the square root of Value.\nTriggers a math runtime error for
-      imaginary results (if Value < 0.0).
+    - type: number
+    description: Returns the square root of Value.\nTriggers a math runtime error
+      for imaginary results (if Value < 0.0).
   ll.StartAnimation:
     args:
-      - type: string
-    description: >-
-      This function plays the specified animation from playing on the avatar who
-      received the script's most recent permissions request.\nAnimation may be
-      an animation in task inventory or a built-in animation.\nRequires
-      PERMISSION_TRIGGER_ANIMATION.
+    - type: string
+    description: This function plays the specified animation from playing on the avatar
+      who received the script's most recent permissions request.\nAnimation may be
+      an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.
   ll.StartObjectAnimation:
     args:
-      - type: string
-    description: >-
-      This function plays the specified animation on the rigged mesh object
-      associated with the current script.\nAnimation may be an animation in task
-      inventory or a built-in animation.\n
+    - type: string
+    description: This function plays the specified animation on the rigged mesh object
+      associated with the current script.\nAnimation may be an animation in task inventory
+      or a built-in animation.\n
   ll.StopAnimation:
     args:
-      - type: string
-    description: >-
-      This function stops the specified animation on the avatar who received the
-      script's most recent permissions request.\nAnimation may be an animation
-      in task inventory, a built-in animation, or the uuid of an
-      animation.\nRequires PERMISSION_TRIGGER_ANIMATION.
+    - type: string
+    description: This function stops the specified animation on the avatar who received
+      the script's most recent permissions request.\nAnimation may be an animation
+      in task inventory, a built-in animation, or the uuid of an animation.\nRequires
+      PERMISSION_TRIGGER_ANIMATION.
   ll.StopHover:
     args: []
     description: Stop hovering to a height (due to llSetHoverHeight()).
   ll.StopLookAt:
     args: []
-    description: >-
-      Stop causing object to point at a target (due to llLookAt() or
-      llRotLookAt()).
+    description: Stop causing object to point at a target (due to llLookAt() or llRotLookAt()).
   ll.StopMoveToTarget:
     args: []
     description: Stops critically damped motion (due to llMoveToTarget()).
   ll.StopObjectAnimation:
     args:
-      - type: string
-    description: >-
-      This function stops the specified animation on the rigged mesh object
-      associated with the current script.\nAnimation may be an animation in task
-      inventory, a built-in animation, or the uuid of an animation.\n
+    - type: string
+    description: This function stops the specified animation on the rigged mesh object
+      associated with the current script.\nAnimation may be an animation in task inventory,
+      a built-in animation, or the uuid of an animation.\n
   ll.StopSound:
     args: []
     description: Stops playback of the currently attached sound.
   ll.StringLength:
     args:
-      - type: string
-    description: >-
-      Returns an integer that is the number of characters in Text (not counting
-      the null).
+    - type: string
+    description: Returns an integer that is the number of characters in Text (not
+      counting the null).
   ll.StringToBase64:
     args:
-      - type: string
+    - type: string
     description: Returns the string Base64 representation of the input string.
   ll.StringTrim:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Outputs a string, eliminating white-space from the start and/or end of the
-      input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD: trim
-      all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces in
-      Text\nSTRING_TRIM: trim all leading and trailing spaces in Text.
+    - type: string
+    - type: number
+    description: 'Outputs a string, eliminating white-space from the start and/or
+      end of the input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD:
+      trim all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces
+      in Text\nSTRING_TRIM: trim all leading and trailing spaces in Text.'
   ll.SubStringIndex:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Returns an integer that is the index in Text where string pattern Sequence
-      first appears. Returns -1 if not found.
+    - type: string
+    - type: string
+    description: Returns an integer that is the index in Text where string pattern
+      Sequence first appears. Returns -1 if not found.
   ll.TakeCamera:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: 'Deprecated: Use llSetCameraParams instead.'
   ll.TakeControls:
     args:
-      - type: number
-      - type:
-          display: numeric
-      - type:
-          display: numeric
-    description: >-
-      Take controls from the agent the script has permissions for.\nIf (Accept
-      == (Controls & input)), send input to the script.  PassOn determines
-      whether Controls also perform their normal functions.\nRequires the
-      PERMISSION_TAKE_CONTROLS permission to run.
+    - type: number
+    - type:
+        display: numeric
+    - type:
+        display: numeric
+    description: Take controls from the agent the script has permissions for.\nIf
+      (Accept == (Controls & input)), send input to the script.  PassOn determines
+      whether Controls also perform their normal functions.\nRequires the PERMISSION_TAKE_CONTROLS
+      permission to run.
   ll.Tan:
     args:
-      - type: number
+    - type: number
     description: Returns the tangent of Theta (Theta in radians).
   ll.Target:
     args:
-      - type:
-          display: vector
-      - type: number
-    description: >-
-      This function is to have the script know when it has reached a
-      position.\nIt registers a Position with a Range that triggers at_target
-      and not_at_target events continuously until unregistered.
+    - type:
+        display: vector
+    - type: number
+    description: This function is to have the script know when it has reached a position.\nIt
+      registers a Position with a Range that triggers at_target and not_at_target
+      events continuously until unregistered.
   ll.TargetOmega:
     args:
-      - type:
-          display: vector
-      - type: number
-      - type: number
-    description: >-
-      Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate of
-      0.0 cancels the spin. This function always works in object-local
-      coordinates.
+    - type:
+        display: vector
+    - type: number
+    - type: number
+    description: Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate
+      of 0.0 cancels the spin. This function always works in object-local coordinates.
   ll.TargetRemove:
     args:
-      - type: number
+    - type: number
     description: Removes positional target Handle registered with llTarget.
   ll.TargetedEmail:
     args:
-      - type: number
-      - type: string
-      - type: string
-    description: >-
-      Sends an email with Subject and Message to the owner or creator of an
-      object.
+    - type: number
+    - type: string
+    - type: string
+    description: Sends an email with Subject and Message to the owner or creator of
+      an object.
   ll.TeleportAgent:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Requests a teleport of avatar to a landmark stored in the object's
-      inventory. If no landmark is provided (an empty string), the avatar is
-      teleported to the location position in the current region. In either case,
-      the avatar is turned to face the position given by look_at in local
-      coordinates.\nRequires the PERMISSION_TELEPORT permission. This function
-      can only teleport the owner of the object.
+    - type:
+        display: uuid
+    - type: string
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Requests a teleport of avatar to a landmark stored in the object's
+      inventory. If no landmark is provided (an empty string), the avatar is teleported
+      to the location position in the current region. In either case, the avatar is
+      turned to face the position given by look_at in local coordinates.\nRequires
+      the PERMISSION_TELEPORT permission. This function can only teleport the owner
+      of the object.
   ll.TeleportAgentGlobalCoords:
     args:
-      - type:
-          display: uuid
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Teleports an agent to the RegionPosition local coordinates within a region
-      which is specified by the GlobalPosition global coordinates. The agent
-      lands facing the position defined by LookAtPoint local
-      coordinates.\nRequires the PERMISSION_TELEPORT permission. This function
-      can only teleport the owner of the object.
+    - type:
+        display: uuid
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Teleports an agent to the RegionPosition local coordinates within
+      a region which is specified by the GlobalPosition global coordinates. The agent
+      lands facing the position defined by LookAtPoint local coordinates.\nRequires
+      the PERMISSION_TELEPORT permission. This function can only teleport the owner
+      of the object.
   ll.TeleportAgentHome:
     args:
-      - type:
-          display: uuid
+    - type:
+        display: uuid
     description: Teleport agent over the owner's land to agent's home location.
   ll.TextBox:
     args:
-      - type:
-          display: uuid
-      - type: string
-      - type: number
-    description: >-
-      Opens a dialog for the specified avatar with message Text, which contains
-      a text box for input. Any text that is entered is said on the specified
+    - type:
+        display: uuid
+    - type: string
+    - type: number
+    description: Opens a dialog for the specified avatar with message Text, which
+      contains a text box for input. Any text that is entered is said on the specified
       Channel (as if by the avatar) when the "OK" button is clicked.
   ll.ToLower:
     args:
-      - type: string
+    - type: string
     description: Returns a string that is Text with all lower-case characters.
   ll.ToUpper:
     args:
-      - type: string
+    - type: string
     description: Returns a string that is Text with all upper-case characters.
   ll.TransferLindenDollars:
     args:
-      - type:
-          display: uuid
-      - type: number
-    description: >-
-      Transfer Amount of linden dollars (L$) from script owner to AvatarID.
-      Returns a key to a corresponding transaction_result event for the success
-      of the transfer.\nAttempts to send the amount of money to the specified
-      avatar, and trigger a transaction_result event identified by the returned
-      key.
+    - type:
+        display: uuid
+    - type: number
+    description: Transfer Amount of linden dollars (L$) from script owner to AvatarID.
+      Returns a key to a corresponding transaction_result event for the success of
+      the transfer.\nAttempts to send the amount of money to the specified avatar,
+      and trigger a transaction_result event identified by the returned key.
   ll.TransferOwnership:
     args:
-      - type:
-          display: uuid
-      - type: number
-      - type: table
-    description: Transfers ownership of an object, or a copy of the object to a new agent.
+    - type:
+        display: uuid
+    - type: number
+    - type: table
+    description: Transfers ownership of an object, or a copy of the object to a new
+      agent.
   ll.TriggerSound:
     args:
-      - type: string
-      - type: number
-    description: >-
-      Plays Sound at Volume (0.0 - 1.0), centered at but not attached to
-      object.\nThere is no limit to the number of triggered sounds which can be
-      generated by an object, and calling llTriggerSound does not affect the
-      attached sounds created by llPlaySound and llLoopSound. This is very
-      useful for things like collision noises, explosions, etc. There is no way
-      to stop or alter the volume of a sound triggered by this function.
+    - type: string
+    - type: number
+    description: Plays Sound at Volume (0.0 - 1.0), centered at but not attached to
+      object.\nThere is no limit to the number of triggered sounds which can be generated
+      by an object, and calling llTriggerSound does not affect the attached sounds
+      created by llPlaySound and llLoopSound. This is very useful for things like
+      collision noises, explosions, etc. There is no way to stop or alter the volume
+      of a sound triggered by this function.
   ll.TriggerSoundLimited:
     args:
-      - type: string
-      - type: number
-      - type:
-          display: vector
-      - type:
-          display: vector
-    description: >-
-      Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object,
-      limited to axis-aligned bounding box defined by vectors top-north-east
-      (TNE) and bottom-south-west (BSW).\nThere is no limit to the number of
-      triggered sounds which can be generated by an object, and calling
-      llTriggerSound does not affect the attached sounds created by llPlaySound
-      and llLoopSound. This is very useful for things like collision noises,
-      explosions, etc. There is no way to stop or alter the volume of a sound
-      triggered by this function.
+    - type: string
+    - type: number
+    - type:
+        display: vector
+    - type:
+        display: vector
+    description: Plays Sound at Volume (0.0 - 1.0), centered at but not attached to
+      object, limited to axis-aligned bounding box defined by vectors top-north-east
+      (TNE) and bottom-south-west (BSW).\nThere is no limit to the number of triggered
+      sounds which can be generated by an object, and calling llTriggerSound does
+      not affect the attached sounds created by llPlaySound and llLoopSound. This
+      is very useful for things like collision noises, explosions, etc. There is no
+      way to stop or alter the volume of a sound triggered by this function.
   ll.UnSit:
     args:
-      - type:
-          display: uuid
-    description: >-
-      If agent identified by AvatarID is sitting on the object the script is
-      attached to or is over land owned by the object's owner, the agent is
-      forced to stand up.
+    - type:
+        display: uuid
+    description: If agent identified by AvatarID is sitting on the object the script
+      is attached to or is over land owned by the object's owner, the agent is forced
+      to stand up.
   ll.UnescapeURL:
     args:
-      - type: string
-    description: >-
-      Returns the string that is the URL unescaped, replacing "%20" with spaces,
-      etc., version of URL.\nThis function can output raw UTF-8 strings.
+    - type: string
+    description: Returns the string that is the URL unescaped, replacing "%20" with
+      spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.
   ll.UpdateCharacter:
     args:
-      - type: table
+    - type: table
     description: Updates settings for a pathfinding character.
   ll.UpdateKeyValue:
     args:
-      - type: string
-      - type: string
-      - type: number
-      - type: string
-    description: |2-
-
-                         Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
-                      
+    - type: string
+    - type: string
+    - type: number
+    - type: string
+    description: "\n                   Starts an asychronous transaction to update\
+      \ the value associated with the key given. The dataserver callback will be executed\
+      \ with the key returned from this call and a string describing the result. The\
+      \ result is a two element commma-delimited list. The first item is an integer\
+      \ specifying if the transaction succeeded (1) or not (0). In the failure case,\
+      \ the second item will be an integer corresponding to one of the XP_ERROR_...\
+      \ constants. In the success case the second item will be the value associated\
+      \ with the key. If Checked is 1 the existing value in the data store must match\
+      \ the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked\
+      \ is 0 the key will be created if necessary.\n                "
   ll.VecDist:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
+    - type:
+        display: vector
+    - type:
+        display: vector
     description: Returns the distance between Location1 and Location2.
   ll.VecMag:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Returns the magnitude of the vector.
   ll.VecNorm:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Returns normalized vector.
   ll.VerifyRSA:
     args:
-      - type: string
-      - type: string
-      - type: string
-      - type: string
-    description: >-
-      Returns TRUE if PublicKey, Message, and Algorithm produce the same
+    - type: string
+    - type: string
+    - type: string
+    - type: string
+    description: Returns TRUE if PublicKey, Message, and Algorithm produce the same
       base64-formatted Signature.
   ll.VolumeDetect:
     args:
-      - type:
-          display: numeric
-    description: >-
-      If DetectEnabled = TRUE, object becomes phantom but triggers
-      collision_start and collision_end events when other objects start and stop
-      interpenetrating.\nIf another object (including avatars) interpenetrates
-      it, it will get a collision_start event.\nWhen an object stops
-      interpenetrating, a collision_end event is generated. While the other is
-      inter-penetrating, collision events are NOT generated.
+    - type:
+        display: numeric
+    description: If DetectEnabled = TRUE, object becomes phantom but triggers collision_start
+      and collision_end events when other objects start and stop interpenetrating.\nIf
+      another object (including avatars) interpenetrates it, it will get a collision_start
+      event.\nWhen an object stops interpenetrating, a collision_end event is generated.
+      While the other is inter-penetrating, collision events are NOT generated.
   ll.WanderWithin:
     args:
-      - type:
-          display: vector
-      - type:
-          display: vector
-      - type: table
-    description: >-
-      Wander within a specified volume.\nSets a character to wander about a
-      central spot within a specified area.
+    - type:
+        display: vector
+    - type:
+        display: vector
+    - type: table
+    description: Wander within a specified volume.\nSets a character to wander about
+      a central spot within a specified area.
   ll.Water:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Returns the water height below the object position + Offset.
   ll.Whisper:
     args:
-      - type: number
-      - type: string
-    description: >-
-      Whispers Text on Channel.\nThis chat method has a range of 10m
-      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
-      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
-      to nearby avatars. All other channels are are not sent to avatars, but may
-      be used to communicate with scripts.
+    - type: number
+    - type: string
+    description: Whispers Text on Channel.\nThis chat method has a range of 10m radius.\nPUBLIC_CHANNEL
+      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
+      is the script debug channel, and is also visible to nearby avatars. All other
+      channels are are not sent to avatars, but may be used to communicate with scripts.
   ll.Wind:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Returns the wind velocity at the object position + Offset.
   ll.WorldPosToHUD:
     args:
-      - type:
-          display: vector
-    description: >-
-      Returns the local position that would put the origin of a HUD object
+    - type:
+        display: vector
+    description: Returns the local position that would put the origin of a HUD object
       directly over world_pos as viewed by the current camera.
   ll.XorBase64:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Performs an exclusive OR on two Base64 strings and returns a Base64
+    - type: string
+    - type: string
+    description: Performs an exclusive OR on two Base64 strings and returns a Base64
       string. Text2 repeats if it is shorter than Text1.
   ll.XorBase64Strings:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Deprecated: Please use llXorBase64 instead.\nIncorrectly performs an
-      exclusive OR on two Base64 strings and returns a Base64 string. Text2
-      repeats if it is shorter than Text1.\nRetained for backwards
-      compatibility.
+    - type: string
+    - type: string
+    description: 'Deprecated: Please use llXorBase64 instead.\nIncorrectly performs
+      an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats
+      if it is shorter than Text1.\nRetained for backwards compatibility.'
   ll.XorBase64StringsCorrect:
     args:
-      - type: string
-      - type: string
-    description: >-
-      Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls are
-      present) performs an exclusive OR on two Base64 strings and returns a
-      Base64 string.\nText2 repeats if it is shorter than Text1.
+    - type: string
+    - type: string
+    description: 'Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls
+      are present) performs an exclusive OR on two Base64 strings and returns a Base64
+      string.\nText2 repeats if it is shorter than Text1.'
   ll.sRGB2Linear:
     args:
-      - type:
-          display: vector
+    - type:
+        display: vector
     description: Converts a color from the sRGB to the linear colorspace.
   llcompat.AdjustDamage:
     args:
-      - type: number
-      - type: number
-    description: >-
-      (Index semantics) Changes the amount of damage to be delivered by this
-      damage event.
+    - type: number
+    - type: number
+    description: (Index semantics) Changes the amount of damage to be delivered by
+      this damage event.
   llcompat.DetectedDamage:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns a list containing the current damage for the
-      event, the damage type and the original damage delivered.
+    - type: number
+    description: (Index semantics) Returns a list containing the current damage for
+      the event, the damage type and the original damage delivered.
   llcompat.DetectedGrab:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the grab offset of a user touching the
+    - type: number
+    description: (Index semantics) Returns the grab offset of a user touching the
       object.\nReturns <0.0, 0.0, 0.0> if Number is not a valid object.
   llcompat.DetectedGroup:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns TRUE if detected object or agent Number has the
-      same user group active as this object.\nIt will return FALSE if the object
-      or agent is in the group, but the group is not active.
+    - type: number
+    description: (Index semantics) Returns TRUE if detected object or agent Number
+      has the same user group active as this object.\nIt will return FALSE if the
+      object or agent is in the group, but the group is not active.
   llcompat.DetectedKey:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the key of detected object or avatar
-      number.\nReturns NULL_KEY if Number is not a valid index.
+    - type: number
+    description: (Index semantics) Returns the key of detected object or avatar number.\nReturns
+      NULL_KEY if Number is not a valid index.
   llcompat.DetectedLinkNumber:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the link position of the triggered event for
-      touches and collisions only.\n0 for a non-linked object, 1 for the root of
-      a linked object, 2 for the first child, etc.
+    - type: number
+    description: (Index semantics) Returns the link position of the triggered event
+      for touches and collisions only.\n0 for a non-linked object, 1 for the root
+      of a linked object, 2 for the first child, etc.
   llcompat.DetectedName:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the name of detected object or avatar
-      number.\nReturns the name of detected object number.\nReturns empty string
-      if Number is not a valid index.
+    - type: number
+    description: (Index semantics) Returns the name of detected object or avatar number.\nReturns
+      the name of detected object number.\nReturns empty string if Number is not a
+      valid index.
   llcompat.DetectedOwner:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the key of detected object's owner.\nReturns
+    - type: number
+    description: (Index semantics) Returns the key of detected object's owner.\nReturns
       invalid key if Number is not a valid index.
   llcompat.DetectedPos:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the position of detected object or avatar
+    - type: number
+    description: (Index semantics) Returns the position of detected object or avatar
       number.\nReturns <0.0, 0.0, 0.0> if Number is not a valid index.
   llcompat.DetectedRezzer:
     args:
-      - type: number
-    description: (Index semantics) Returns the key for the rezzer of the detected object.
+    - type: number
+    description: (Index semantics) Returns the key for the rezzer of the detected
+      object.
   llcompat.DetectedRot:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the rotation of detected object or avatar
+    - type: number
+    description: (Index semantics) Returns the rotation of detected object or avatar
       number.\nReturns <0.0, 0.0, 0.0, 1.0> if Number is not a valid offset.
   llcompat.DetectedTouchBinormal:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the surface bi-normal for a triggered touch
-      event.\nReturns a vector that is the surface bi-normal (tangent to the
-      surface) where the touch event was triggered.
+    - type: number
+    description: (Index semantics) Returns the surface bi-normal for a triggered touch
+      event.\nReturns a vector that is the surface bi-normal (tangent to the surface)
+      where the touch event was triggered.
   llcompat.DetectedTouchFace:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the index of the face where the avatar clicked
-      in a triggered touch event.
+    - type: number
+    description: (Index semantics) Returns the index of the face where the avatar
+      clicked in a triggered touch event.
   llcompat.DetectedTouchNormal:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the surface normal for a triggered touch
-      event.\nReturns a vector that is the surface normal (perpendicular to the
-      surface) where the touch event was triggered.
+    - type: number
+    description: (Index semantics) Returns the surface normal for a triggered touch
+      event.\nReturns a vector that is the surface normal (perpendicular to the surface)
+      where the touch event was triggered.
   llcompat.DetectedTouchPos:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the position, in region coordinates, where the
-      object was touched in a triggered touch event.\nUnless it is a HUD, in
-      which case it returns the position relative to the attach point.
+    - type: number
+    description: (Index semantics) Returns the position, in region coordinates, where
+      the object was touched in a triggered touch event.\nUnless it is a HUD, in which
+      case it returns the position relative to the attach point.
   llcompat.DetectedTouchST:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns a vector that is the surface coordinates where
-      the prim was touched.\nThe X and Y vector positions contain the horizontal
-      (S) and vertical (T) face coordinates respectively.\nEach component is in
-      the interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD is returned if the
-      surface coordinates cannot be determined (e.g. when the viewer does not
-      support this function).
+    - type: number
+    description: (Index semantics) Returns a vector that is the surface coordinates
+      where the prim was touched.\nThe X and Y vector positions contain the horizontal
+      (S) and vertical (T) face coordinates respectively.\nEach component is in the
+      interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD is returned if the surface coordinates
+      cannot be determined (e.g. when the viewer does not support this function).
   llcompat.DetectedTouchUV:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns a vector that is the texture coordinates for
-      where the prim was touched.\nThe X and Y vector positions contain the U
-      and V face coordinates respectively.\nTOUCH_INVALID_TEXCOORD is returned
-      if the touch UV coordinates cannot be determined (e.g. when the viewer
-      does not support this function).
+    - type: number
+    description: (Index semantics) Returns a vector that is the texture coordinates
+      for where the prim was touched.\nThe X and Y vector positions contain the U
+      and V face coordinates respectively.\nTOUCH_INVALID_TEXCOORD is returned if
+      the touch UV coordinates cannot be determined (e.g. when the viewer does not
+      support this function).
   llcompat.DetectedType:
     args:
-      - type: number
-    description: "(Index semantics) Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\\nReturns 0 if number is not a valid index.\\nNote that number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\\ninteger iType = llDetectedType(0);\\n{\\n\t// ...do stuff with the agent\\n}"
+    - type: number
+    description: "(Index semantics) Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED)\
+      \ of detected object.\\nReturns 0 if number is not a valid index.\\nNote that\
+      \ number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\\\
+      ninteger iType = llDetectedType(0);\\n{\\n\t// ...do stuff with the agent\\\
+      n}"
   llcompat.DetectedVel:
     args:
-      - type: number
-    description: >-
-      (Index semantics) Returns the velocity of the detected object
-      Number.\nReturns<0.0, 0.0, 0.0> if Number is not a valid offset.
+    - type: number
+    description: (Index semantics) Returns the velocity of the detected object Number.\nReturns<0.0,
+      0.0, 0.0> if Number is not a valid offset.
 structs:
   LLEvents:
     'on':
       method: true
       args:
-        - type:
-            - collision
-            - collision_end
-            - collision_start
-            - final_damage
-            - on_damage
-            - sensor
-            - touch
-            - touch_end
-            - touch_start
-            - at_rot_target
-            - at_target
-            - attach
-            - changed
-            - control
-            - dataserver
-            - email
-            - experience_permissions
-            - experience_permissions_denied
-            - game_control
-            - http_request
-            - http_response
-            - land_collision
-            - land_collision_end
-            - land_collision_start
-            - link_message
-            - linkset_data
-            - listen
-            - money
-            - moving_end
-            - moving_start
-            - no_sensor
-            - not_at_rot_target
-            - not_at_target
-            - object_rez
-            - on_death
-            - on_rez
-            - path_update
-            - remote_data
-            - run_time_permissions
-            - state_entry
-            - state_exit
-            - timer
-            - transaction_result
-        - type: function
+      - type:
+        - collision
+        - collision_end
+        - collision_start
+        - final_damage
+        - on_damage
+        - sensor
+        - touch
+        - touch_end
+        - touch_start
+        - at_rot_target
+        - at_target
+        - attach
+        - changed
+        - control
+        - dataserver
+        - email
+        - experience_permissions
+        - experience_permissions_denied
+        - game_control
+        - http_request
+        - http_response
+        - land_collision
+        - land_collision_end
+        - land_collision_start
+        - link_message
+        - linkset_data
+        - listen
+        - money
+        - moving_end
+        - moving_start
+        - no_sensor
+        - not_at_rot_target
+        - not_at_target
+        - object_rez
+        - on_death
+        - on_rez
+        - path_update
+        - remote_data
+        - run_time_permissions
+        - state_entry
+        - state_exit
+        - timer
+        - transaction_result
+      - type: function
       description: Registers a callback for an event. Returns the callback.
     'off':
       method: true
       args:
-        - type:
-            - collision
-            - collision_end
-            - collision_start
-            - final_damage
-            - on_damage
-            - sensor
-            - touch
-            - touch_end
-            - touch_start
-            - at_rot_target
-            - at_target
-            - attach
-            - changed
-            - control
-            - dataserver
-            - email
-            - experience_permissions
-            - experience_permissions_denied
-            - game_control
-            - http_request
-            - http_response
-            - land_collision
-            - land_collision_end
-            - land_collision_start
-            - link_message
-            - linkset_data
-            - listen
-            - money
-            - moving_end
-            - moving_start
-            - no_sensor
-            - not_at_rot_target
-            - not_at_target
-            - object_rez
-            - on_death
-            - on_rez
-            - path_update
-            - remote_data
-            - run_time_permissions
-            - state_entry
-            - state_exit
-            - timer
-            - transaction_result
-        - type: function
+      - type:
+        - collision
+        - collision_end
+        - collision_start
+        - final_damage
+        - on_damage
+        - sensor
+        - touch
+        - touch_end
+        - touch_start
+        - at_rot_target
+        - at_target
+        - attach
+        - changed
+        - control
+        - dataserver
+        - email
+        - experience_permissions
+        - experience_permissions_denied
+        - game_control
+        - http_request
+        - http_response
+        - land_collision
+        - land_collision_end
+        - land_collision_start
+        - link_message
+        - linkset_data
+        - listen
+        - money
+        - moving_end
+        - moving_start
+        - no_sensor
+        - not_at_rot_target
+        - not_at_target
+        - object_rez
+        - on_death
+        - on_rez
+        - path_update
+        - remote_data
+        - run_time_permissions
+        - state_entry
+        - state_exit
+        - timer
+        - transaction_result
+      - type: function
       description: Unregisters a callback. Returns true if found and removed.
     once:
       method: true
       args:
-        - type:
-            - collision
-            - collision_end
-            - collision_start
-            - final_damage
-            - on_damage
-            - sensor
-            - touch
-            - touch_end
-            - touch_start
-            - at_rot_target
-            - at_target
-            - attach
-            - changed
-            - control
-            - dataserver
-            - email
-            - experience_permissions
-            - experience_permissions_denied
-            - game_control
-            - http_request
-            - http_response
-            - land_collision
-            - land_collision_end
-            - land_collision_start
-            - link_message
-            - linkset_data
-            - listen
-            - money
-            - moving_end
-            - moving_start
-            - no_sensor
-            - not_at_rot_target
-            - not_at_target
-            - object_rez
-            - on_death
-            - on_rez
-            - path_update
-            - remote_data
-            - run_time_permissions
-            - state_entry
-            - state_exit
-            - timer
-            - transaction_result
-        - type: function
+      - type:
+        - collision
+        - collision_end
+        - collision_start
+        - final_damage
+        - on_damage
+        - sensor
+        - touch
+        - touch_end
+        - touch_start
+        - at_rot_target
+        - at_target
+        - attach
+        - changed
+        - control
+        - dataserver
+        - email
+        - experience_permissions
+        - experience_permissions_denied
+        - game_control
+        - http_request
+        - http_response
+        - land_collision
+        - land_collision_end
+        - land_collision_start
+        - link_message
+        - linkset_data
+        - listen
+        - money
+        - moving_end
+        - moving_start
+        - no_sensor
+        - not_at_rot_target
+        - not_at_target
+        - object_rez
+        - on_death
+        - on_rez
+        - path_update
+        - remote_data
+        - run_time_permissions
+        - state_entry
+        - state_exit
+        - timer
+        - transaction_result
+      - type: function
       description: Registers a one-time callback. Returns the wrapper function.
     listeners:
       method: true
       args:
-        - type:
-            - collision
-            - collision_end
-            - collision_start
-            - final_damage
-            - on_damage
-            - sensor
-            - touch
-            - touch_end
-            - touch_start
-            - at_rot_target
-            - at_target
-            - attach
-            - changed
-            - control
-            - dataserver
-            - email
-            - experience_permissions
-            - experience_permissions_denied
-            - game_control
-            - http_request
-            - http_response
-            - land_collision
-            - land_collision_end
-            - land_collision_start
-            - link_message
-            - linkset_data
-            - listen
-            - money
-            - moving_end
-            - moving_start
-            - no_sensor
-            - not_at_rot_target
-            - not_at_target
-            - object_rez
-            - on_death
-            - on_rez
-            - path_update
-            - remote_data
-            - run_time_permissions
-            - state_entry
-            - state_exit
-            - timer
-            - transaction_result
+      - type:
+        - collision
+        - collision_end
+        - collision_start
+        - final_damage
+        - on_damage
+        - sensor
+        - touch
+        - touch_end
+        - touch_start
+        - at_rot_target
+        - at_target
+        - attach
+        - changed
+        - control
+        - dataserver
+        - email
+        - experience_permissions
+        - experience_permissions_denied
+        - game_control
+        - http_request
+        - http_response
+        - land_collision
+        - land_collision_end
+        - land_collision_start
+        - link_message
+        - linkset_data
+        - listen
+        - money
+        - moving_end
+        - moving_start
+        - no_sensor
+        - not_at_rot_target
+        - not_at_target
+        - object_rez
+        - on_death
+        - on_rez
+        - path_update
+        - remote_data
+        - run_time_permissions
+        - state_entry
+        - state_exit
+        - timer
+        - transaction_result
       description: Returns a list of all listeners for a specific event.
     eventNames:
       method: true
@@ -9019,19 +8493,19 @@ structs:
     every:
       method: true
       args:
-        - type: number
-        - type: function
-      description: Registers a callback to be called every N seconds. Returns the callback.
+      - type: number
+      - type: function
+      description: Registers a callback to be called every N seconds. Returns the
+        callback.
     once:
       method: true
       args:
-        - type: number
-        - type: function
-      description: >-
-        Registers a callback to be called once after N seconds. Returns the
-        callback.
+      - type: number
+      - type: function
+      description: Registers a callback to be called once after N seconds. Returns
+        the callback.
     'off':
       method: true
       args:
-        - type: any
+      - type: any
       description: Unregisters a timer callback. Returns true if found and removed.

--- a/indra/newview/app_settings/slua_default.yml
+++ b/indra/newview/app_settings/slua_default.yml
@@ -1,0 +1,9037 @@
+base: luau
+name: SLua LSL language support
+lua_versions:
+  - luau
+  - lua51
+last_updated: 1763572449
+globals:
+  getfenv:
+    type: any
+    description: getfenv is removed in SLua
+  setfenv:
+    type: any
+    description: setfenv is removed in SLua
+  loadstring:
+    type: any
+    description: loadstring is removed in SLua
+  ACTIVE:
+    property: read-only
+    type: number
+    description: Objects in world that are running a script or currently physically moving.
+  AGENT:
+    property: read-only
+    type: number
+    description: Objects in world that are agents.
+  AGENT_ALWAYS_RUN:
+    property: read-only
+    type: number
+  AGENT_ATTACHMENTS:
+    property: read-only
+    type: number
+    description: The agent has attachments.
+  AGENT_AUTOMATED:
+    property: read-only
+    type: number
+    description: The agent has been identified as a scripted agent
+  AGENT_AUTOPILOT:
+    property: read-only
+    type: number
+  AGENT_AWAY:
+    property: read-only
+    type: number
+  AGENT_BUSY:
+    property: read-only
+    type: number
+  AGENT_BY_LEGACY_NAME:
+    property: read-only
+    type: number
+  AGENT_BY_USERNAME:
+    property: read-only
+    type: number
+  AGENT_CROUCHING:
+    property: read-only
+    type: number
+  AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT:
+    property: read-only
+    type: number
+    description: The agent is floating via scripted attachment.
+  AGENT_FLYING:
+    property: read-only
+    type: number
+    description: The agent is flying.
+  AGENT_IN_AIR:
+    property: read-only
+    type: number
+  AGENT_LIST_PARCEL:
+    property: read-only
+    type: number
+    description: Agents on the same parcel where the script is running.
+  AGENT_LIST_PARCEL_OWNER:
+    property: read-only
+    type: number
+    description: >-
+      Agents on any parcel in the region where the parcel owner is the same as
+      the owner of the parcel under the scripted object.
+  AGENT_LIST_REGION:
+    property: read-only
+    type: number
+    description: All agents in the region.
+  AGENT_MOUSELOOK:
+    property: read-only
+    type: number
+  AGENT_ON_OBJECT:
+    property: read-only
+    type: number
+  AGENT_SCRIPTED:
+    property: read-only
+    type: number
+    description: The agent has scripted attachments.
+  AGENT_SITTING:
+    property: read-only
+    type: number
+  AGENT_TYPING:
+    property: read-only
+    type: number
+  AGENT_WALKING:
+    property: read-only
+    type: number
+  ALL_SIDES:
+    property: read-only
+    type: number
+  ANIM_ON:
+    property: read-only
+    type: number
+    description: Texture animation is on.
+  ATTACH_ANY_HUD:
+    property: read-only
+    type: number
+    description: Filtering for any HUD attachment.
+  ATTACH_AVATAR_CENTER:
+    property: read-only
+    type: number
+    description: Attach to the avatar's geometric centre.
+  ATTACH_BACK:
+    property: read-only
+    type: number
+    description: Attach to the avatar's back.
+  ATTACH_BELLY:
+    property: read-only
+    type: number
+    description: Attach to the avatar's belly.
+  ATTACH_CHEST:
+    property: read-only
+    type: number
+    description: Attach to the avatar's chest.
+  ATTACH_CHIN:
+    property: read-only
+    type: number
+    description: Attach to the avatar's chin.
+  ATTACH_FACE_JAW:
+    property: read-only
+    type: number
+    description: Attach to the avatar's jaw.
+  ATTACH_FACE_LEAR:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left ear (extended).
+  ATTACH_FACE_LEYE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left eye (extended).
+  ATTACH_FACE_REAR:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right ear (extended).
+  ATTACH_FACE_REYE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right eye (extended).
+  ATTACH_FACE_TONGUE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's tongue.
+  ATTACH_GROIN:
+    property: read-only
+    type: number
+    description: Attach to the avatar's groin.
+  ATTACH_HEAD:
+    property: read-only
+    type: number
+    description: Attach to the avatar's head.
+  ATTACH_HIND_LFOOT:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left hind foot.
+  ATTACH_HIND_RFOOT:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right hind foot.
+  ATTACH_HUD_BOTTOM:
+    property: read-only
+    type: number
+  ATTACH_HUD_BOTTOM_LEFT:
+    property: read-only
+    type: number
+  ATTACH_HUD_BOTTOM_RIGHT:
+    property: read-only
+    type: number
+  ATTACH_HUD_CENTER_1:
+    property: read-only
+    type: number
+  ATTACH_HUD_CENTER_2:
+    property: read-only
+    type: number
+  ATTACH_HUD_TOP_CENTER:
+    property: read-only
+    type: number
+  ATTACH_HUD_TOP_LEFT:
+    property: read-only
+    type: number
+  ATTACH_HUD_TOP_RIGHT:
+    property: read-only
+    type: number
+  ATTACH_LEAR:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left ear.
+  ATTACH_LEFT_PEC:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left pectoral.
+  ATTACH_LEYE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left eye.
+  ATTACH_LFOOT:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left foot.
+  ATTACH_LHAND:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left hand.
+  ATTACH_LHAND_RING1:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left ring finger.
+  ATTACH_LHIP:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left hip.
+  ATTACH_LLARM:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left lower arm.
+  ATTACH_LLLEG:
+    property: read-only
+    type: number
+    description: Attach to the avatar's lower left leg.
+  ATTACH_LPEC:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)
+  ATTACH_LSHOULDER:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left shoulder.
+  ATTACH_LUARM:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left upper arm.
+  ATTACH_LULEG:
+    property: read-only
+    type: number
+    description: Attach to the avatar's lower upper leg.
+  ATTACH_LWING:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left wing.
+  ATTACH_MOUTH:
+    property: read-only
+    type: number
+    description: Attach to the avatar's mouth.
+  ATTACH_NECK:
+    property: read-only
+    type: number
+    description: Attach to the avatar's neck.
+  ATTACH_NOSE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's nose.
+  ATTACH_PELVIS:
+    property: read-only
+    type: number
+    description: Attach to the avatar's pelvis.
+  ATTACH_REAR:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right ear.
+  ATTACH_REYE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right eye.
+  ATTACH_RFOOT:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right foot.
+  ATTACH_RHAND:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right hand.
+  ATTACH_RHAND_RING1:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right ring finger.
+  ATTACH_RHIP:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right hip.
+  ATTACH_RIGHT_PEC:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right pectoral.
+  ATTACH_RLARM:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right lower arm.
+  ATTACH_RLLEG:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right lower leg.
+  ATTACH_RPEC:
+    property: read-only
+    type: number
+    description: Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)
+  ATTACH_RSHOULDER:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right shoulder.
+  ATTACH_RUARM:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right upper arm.
+  ATTACH_RULEG:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right upper leg.
+  ATTACH_RWING:
+    property: read-only
+    type: number
+    description: Attach to the avatar's right wing.
+  ATTACH_TAIL_BASE:
+    property: read-only
+    type: number
+    description: Attach to the avatar's tail base.
+  ATTACH_TAIL_TIP:
+    property: read-only
+    type: number
+    description: Attach to the avatar's tail tip.
+  AVOID_CHARACTERS:
+    property: read-only
+    type: number
+  AVOID_DYNAMIC_OBSTACLES:
+    property: read-only
+    type: number
+  AVOID_NONE:
+    property: read-only
+    type: number
+  BEACON_MAP:
+    property: read-only
+    type: number
+    description: >-
+      Cause llMapBeacon to optionally display and focus the world map on the
+      avatar's viewer.
+  CAMERA_ACTIVE:
+    property: read-only
+    type: number
+  CAMERA_BEHINDNESS_ANGLE:
+    property: read-only
+    type: number
+  CAMERA_BEHINDNESS_LAG:
+    property: read-only
+    type: number
+  CAMERA_DISTANCE:
+    property: read-only
+    type: number
+  CAMERA_FOCUS:
+    property: read-only
+    type: number
+  CAMERA_FOCUS_LAG:
+    property: read-only
+    type: number
+  CAMERA_FOCUS_LOCKED:
+    property: read-only
+    type: number
+  CAMERA_FOCUS_OFFSET:
+    property: read-only
+    type: number
+  CAMERA_FOCUS_THRESHOLD:
+    property: read-only
+    type: number
+  CAMERA_PITCH:
+    property: read-only
+    type: number
+  CAMERA_POSITION:
+    property: read-only
+    type: number
+  CAMERA_POSITION_LAG:
+    property: read-only
+    type: number
+  CAMERA_POSITION_LOCKED:
+    property: read-only
+    type: number
+  CAMERA_POSITION_THRESHOLD:
+    property: read-only
+    type: number
+  CHANGED_ALLOWED_DROP:
+    property: read-only
+    type: number
+    description: >-
+      The object inventory has changed because an item was added through the
+      llAllowInventoryDrop interface.
+  CHANGED_COLOR:
+    property: read-only
+    type: number
+    description: The object color has changed.
+  CHANGED_INVENTORY:
+    property: read-only
+    type: number
+    description: The object inventory has changed.
+  CHANGED_LINK:
+    property: read-only
+    type: number
+    description: The object has linked or its links were broken.
+  CHANGED_MEDIA:
+    property: read-only
+    type: number
+  CHANGED_OWNER:
+    property: read-only
+    type: number
+    description: The object has changed ownership.
+  CHANGED_REGION:
+    property: read-only
+    type: number
+    description: The object has changed region.
+  CHANGED_REGION_START:
+    property: read-only
+    type: number
+    description: The region this object is in has just come online.
+  CHANGED_RENDER_MATERIAL:
+    property: read-only
+    type: number
+    description: The render material has changed.
+  CHANGED_SCALE:
+    property: read-only
+    type: number
+    description: The object scale (size) has changed.
+  CHANGED_SHAPE:
+    property: read-only
+    type: number
+    description: The object base shape has changed, e.g., a box to a cylinder.
+  CHANGED_TELEPORT:
+    property: read-only
+    type: number
+    description: The avatar to whom this object is attached has teleported.
+  CHANGED_TEXTURE:
+    property: read-only
+    type: number
+    description: >-
+      The texture offset, scale rotation, or simply the object texture has
+      changed.
+  CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES:
+    property: read-only
+    type: number
+    description: >-
+      If set to false, character will not attempt to catch up on lost time when
+      pathfinding performance is low, potentially providing more reliable
+      movement (albeit while potentially appearing to be more stuttery). Default
+      is true to match pre-existing behavior.
+  CHARACTER_AVOIDANCE_MODE:
+    property: read-only
+    type: number
+    description: >-
+      Allows you to specify that a character should not try to avoid other
+      characters, should not try to avoid dynamic obstacles (relatively fast
+      moving objects and avatars), or both.
+  CHARACTER_CMD_JUMP:
+    property: read-only
+    type: number
+    description: >-
+      Makes the character jump. Requires an additional parameter, the height to
+      jump, between 0.1m and 2.0m. This must be provided as the first element of
+      the llExecCharacterCmd option list.
+  CHARACTER_CMD_SMOOTH_STOP:
+    property: read-only
+    type: number
+  CHARACTER_CMD_STOP:
+    property: read-only
+    type: number
+    description: Stops any current pathfinding operation.
+  CHARACTER_DESIRED_SPEED:
+    property: read-only
+    type: number
+    description: Speed of pursuit in meters per second.
+  CHARACTER_DESIRED_TURN_SPEED:
+    property: read-only
+    type: number
+    description: >-
+      The character's maximum speed while turning about the Z axis. - Note that
+      this is only loosely enforced.
+  CHARACTER_LENGTH:
+    property: read-only
+    type: number
+    description: Set collision capsule length - cannot be less than two times the radius.
+  CHARACTER_MAX_ACCEL:
+    property: read-only
+    type: number
+    description: The character's maximum acceleration rate.
+  CHARACTER_MAX_DECEL:
+    property: read-only
+    type: number
+    description: The character's maximum deceleration rate.
+  CHARACTER_MAX_SPEED:
+    property: read-only
+    type: number
+    description: The character's maximum speed.
+  CHARACTER_MAX_TURN_RADIUS:
+    property: read-only
+    type: number
+    description: The character's turn radius when travelling at CHARACTER_MAX_TURN_SPEED.
+  CHARACTER_ORIENTATION:
+    property: read-only
+    type: number
+    description: 'Valid options are: VERTICAL, HORIZONTAL.'
+  CHARACTER_RADIUS:
+    property: read-only
+    type: number
+    description: Set collision capsule radius.
+  CHARACTER_STAY_WITHIN_PARCEL:
+    property: read-only
+    type: number
+    description: >-
+      Determines whether a character can leave its starting parcel.\nTakes a
+      boolean parameter. If TRUE, the character cannot voluntarilly leave the
+      parcel, but can return to it.
+  CHARACTER_TYPE:
+    property: read-only
+    type: number
+    description: Specifies which walk-ability coefficient will be used by this character.
+  CHARACTER_TYPE_A:
+    property: read-only
+    type: number
+  CHARACTER_TYPE_B:
+    property: read-only
+    type: number
+  CHARACTER_TYPE_C:
+    property: read-only
+    type: number
+  CHARACTER_TYPE_D:
+    property: read-only
+    type: number
+  CHARACTER_TYPE_NONE:
+    property: read-only
+    type: number
+  CLICK_ACTION_BUY:
+    property: read-only
+    type: number
+    description: When the prim is clicked, the buy dialog is opened.
+  CLICK_ACTION_DISABLED:
+    property: read-only
+    type: number
+    description: No click action. No touches detected or passed.
+  CLICK_ACTION_IGNORE:
+    property: read-only
+    type: number
+    description: No click action. Object is invisible to the mouse.
+  CLICK_ACTION_NONE:
+    property: read-only
+    type: number
+    description: >-
+      Performs the default action: when the prim is clicked, touch events are
+      triggered.
+  CLICK_ACTION_OPEN:
+    property: read-only
+    type: number
+    description: When the prim is clicked, the object inventory dialog is opened.
+  CLICK_ACTION_OPEN_MEDIA:
+    property: read-only
+    type: number
+    description: When the prim is touched, the web media dialog is opened.
+  CLICK_ACTION_PAY:
+    property: read-only
+    type: number
+    description: When the prim is clicked, the pay dialog is opened.
+  CLICK_ACTION_PLAY:
+    property: read-only
+    type: number
+    description: When the prim is clicked, html-on-a-prim is enabled?
+  CLICK_ACTION_SIT:
+    property: read-only
+    type: number
+    description: When the prim is clicked, the avatar sits upon it.
+  CLICK_ACTION_TOUCH:
+    property: read-only
+    type: number
+    description: When the prim is clicked, touch events are triggered.
+  CLICK_ACTION_ZOOM:
+    property: read-only
+    type: number
+    description: Zoom in on object when clicked.
+  COMBAT_CHANNEL:
+    property: read-only
+    type: number
+    description: >-
+      COMBAT_CHANNEL is an integer constant that, when passed to llRegionSay
+      will add the message to the combat log. A script with a chat listen active
+      on COMBAT_CHANNEL may also monitor the combat log.
+  COMBAT_LOG_ID:
+    property: read-only
+    type:
+      display: uuid
+    description: >-
+      Messages from the region to the COMBAT_CHANNEL will all be from this ID.\n
+      Scripts may filter llListen calls on this ID to receive only system
+      generated combat log messages.
+  CONTENT_TYPE_ATOM:
+    property: read-only
+    type: number
+    description: '"application/atom+xml"'
+  CONTENT_TYPE_FORM:
+    property: read-only
+    type: number
+    description: '"application/x-www-form-urlencoded"'
+  CONTENT_TYPE_HTML:
+    property: read-only
+    type: number
+    description: >-
+      "text/html", only valid for embedded browsers on content owned by the
+      person viewing. Falls back to "text/plain" otherwise.
+  CONTENT_TYPE_JSON:
+    property: read-only
+    type: number
+    description: '"application/json"'
+  CONTENT_TYPE_LLSD:
+    property: read-only
+    type: number
+    description: '"application/llsd+xml"'
+  CONTENT_TYPE_RSS:
+    property: read-only
+    type: number
+    description: '"application/rss+xml"'
+  CONTENT_TYPE_TEXT:
+    property: read-only
+    type: number
+    description: '"text/plain"'
+  CONTENT_TYPE_XHTML:
+    property: read-only
+    type: number
+    description: '"application/xhtml+xml"'
+  CONTENT_TYPE_XML:
+    property: read-only
+    type: number
+    description: '"application/xml"'
+  CONTROL_BACK:
+    property: read-only
+    type: number
+    description: Test for the avatar move back control.
+  CONTROL_DOWN:
+    property: read-only
+    type: number
+    description: Test for the avatar move down control.
+  CONTROL_FWD:
+    property: read-only
+    type: number
+    description: Test for the avatar move forward control.
+  CONTROL_LBUTTON:
+    property: read-only
+    type: number
+    description: Test for the avatar left button control.
+  CONTROL_LEFT:
+    property: read-only
+    type: number
+    description: Test for the avatar move left control.
+  CONTROL_ML_LBUTTON:
+    property: read-only
+    type: number
+    description: Test for the avatar left button control while in mouse look.
+  CONTROL_RIGHT:
+    property: read-only
+    type: number
+    description: Test for the avatar move right control.
+  CONTROL_ROT_LEFT:
+    property: read-only
+    type: number
+    description: Test for the avatar rotate left control.
+  CONTROL_ROT_RIGHT:
+    property: read-only
+    type: number
+    description: Test for the avatar rotate right control.
+  CONTROL_UP:
+    property: read-only
+    type: number
+    description: Test for the avatar move up control.
+  DAMAGEABLE:
+    property: read-only
+    type: number
+    description: Objects in world that are able to process damage.
+  DAMAGE_TYPE_ACID:
+    property: read-only
+    type: number
+    description: Damage caused by a caustic substance, such as acid
+  DAMAGE_TYPE_BLUDGEONING:
+    property: read-only
+    type: number
+    description: Damage caused by a blunt object, such as a club.
+  DAMAGE_TYPE_COLD:
+    property: read-only
+    type: number
+    description: Damage inflicted by exposure to extreme cold
+  DAMAGE_TYPE_ELECTRIC:
+    property: read-only
+    type: number
+    description: Damage caused by electricity.
+  DAMAGE_TYPE_EMOTIONAL:
+    property: read-only
+    type: number
+  DAMAGE_TYPE_FIRE:
+    property: read-only
+    type: number
+    description: Damage inflicted by exposure to heat or flames.
+  DAMAGE_TYPE_FORCE:
+    property: read-only
+    type: number
+    description: Damage inflicted by a great force or impact.
+  DAMAGE_TYPE_GENERIC:
+    property: read-only
+    type: number
+    description: Generic or legacy damage.
+  DAMAGE_TYPE_IMPACT:
+    property: read-only
+    type: number
+    description: System damage generated by impact with land or a prim.
+  DAMAGE_TYPE_NECROTIC:
+    property: read-only
+    type: number
+    description: Damage caused by a direct assault on life-force
+  DAMAGE_TYPE_PIERCING:
+    property: read-only
+    type: number
+    description: Damage caused by a piercing object such as a bullet, spear, or arrow.
+  DAMAGE_TYPE_POISON:
+    property: read-only
+    type: number
+    description: Damage caused by poison.
+  DAMAGE_TYPE_PSYCHIC:
+    property: read-only
+    type: number
+    description: Damage caused by a direct assault on the mind.
+  DAMAGE_TYPE_RADIANT:
+    property: read-only
+    type: number
+    description: Damage caused by radiation or extreme light.
+  DAMAGE_TYPE_SLASHING:
+    property: read-only
+    type: number
+    description: Damage caused by a slashing object such as a sword or axe.
+  DAMAGE_TYPE_SONIC:
+    property: read-only
+    type: number
+    description: Damage caused by loud noises, like a Crash Worship concert.
+  DATA_BORN:
+    property: read-only
+    type: number
+    description: The date the agent was born, returned in ISO 8601 format of YYYY-MM-DD.
+  DATA_NAME:
+    property: read-only
+    type: number
+    description: The name of the agent.
+  DATA_ONLINE:
+    property: read-only
+    type: number
+    description: TRUE for online, FALSE for offline.
+  DATA_PAYINFO:
+    property: read-only
+    type: number
+  DATA_RATING:
+    property: read-only
+    type: number
+    description: "Returns the agent ratings as a comma separated string of six integers. They are:\n\t\t\t1) Positive rated behaviour\n\t\t\t2) Negative rated behaviour\n\t\t\t3) Positive rated appearance\n\t\t\t4) Negative rated appearance\n\t\t\t5) Positive rated building\n\t\t\t6) Negative rated building"
+  DATA_SIM_POS:
+    property: read-only
+    type: number
+  DATA_SIM_RATING:
+    property: read-only
+    type: number
+  DATA_SIM_STATUS:
+    property: read-only
+    type: number
+  DEBUG_CHANNEL:
+    property: read-only
+    type: number
+    description: >-
+      DEBUG_CHANNEL is an integer constant that, when passed to llSay,
+      llWhisper, or llShout as a channel parameter, will print text to the
+      Script Warning/Error Window.
+  DEG_TO_RAD:
+    property: read-only
+    type: number
+    description: "0.017453293 - Number of radians per degree.\n\t\t\tYou can use this to convert degrees to radians by multiplying the degrees by this number."
+  DENSITY:
+    property: read-only
+    type: number
+    description: >-
+      Used with llSetPhysicsMaterial to enable the density value. Must be
+      between 1.0 and 22587.0 (in Kg/m^3 -- see if you can figure out what 22587
+      represents)
+  DEREZ_DIE:
+    property: read-only
+    type: number
+    description: Causes the object to immediately die.
+  DEREZ_MAKE_TEMP:
+    property: read-only
+    type: number
+    description: The object is made temporary and will be cleaned up at some later timer.
+  DEREZ_TO_INVENTORY:
+    property: read-only
+    type: number
+    description: The object is returned to the inventory of the rezzer.
+  ENVIRONMENT_DAYINFO:
+    property: read-only
+    type: number
+    description: Day length, offset and progression.
+  ENV_INVALID_AGENT:
+    property: read-only
+    type: number
+    description: Could not find agent with the specified ID
+  ENV_INVALID_RULE:
+    property: read-only
+    type: number
+    description: Attempted to change an unknown property.
+  ENV_NOT_EXPERIENCE:
+    property: read-only
+    type: number
+    description: Attempt to change environments outside an experience.
+  ENV_NO_ENVIRONMENT:
+    property: read-only
+    type: number
+    description: Could not find environmental settings in object inventory.
+  ENV_NO_EXPERIENCE_LAND:
+    property: read-only
+    type: number
+    description: The experience has not been enabled on this land.
+  ENV_NO_EXPERIENCE_PERMISSION:
+    property: read-only
+    type: number
+    description: Agent has not granted permission to change environments.
+  ENV_NO_PERMISSIONS:
+    property: read-only
+    type: number
+    description: Script does not have permission to modify environment.
+  ENV_THROTTLE:
+    property: read-only
+    type: number
+    description: Could not validate values for environment.
+  ENV_VALIDATION_FAIL:
+    property: read-only
+    type: number
+    description: Could not validate values for environment.
+  EOF:
+    property: read-only
+    type: string
+    description: Indicates the last line of a notecard was read.
+  ERR_GENERIC:
+    property: read-only
+    type: number
+  ERR_MALFORMED_PARAMS:
+    property: read-only
+    type: number
+  ERR_PARCEL_PERMISSIONS:
+    property: read-only
+    type: number
+  ERR_RUNTIME_PERMISSIONS:
+    property: read-only
+    type: number
+  ERR_THROTTLED:
+    property: read-only
+    type: number
+  ESTATE_ACCESS_ALLOWED_AGENT_ADD:
+    property: read-only
+    type: number
+    description: Add the agent to this estate's Allowed Residents list.
+  ESTATE_ACCESS_ALLOWED_AGENT_REMOVE:
+    property: read-only
+    type: number
+    description: Remove the agent from this estate's Allowed Residents list.
+  ESTATE_ACCESS_ALLOWED_GROUP_ADD:
+    property: read-only
+    type: number
+    description: Add the group to this estate's Allowed groups list.
+  ESTATE_ACCESS_ALLOWED_GROUP_REMOVE:
+    property: read-only
+    type: number
+    description: Remove the group from this estate's Allowed groups list.
+  ESTATE_ACCESS_BANNED_AGENT_ADD:
+    property: read-only
+    type: number
+    description: Add the agent to this estate's Banned residents list.
+  ESTATE_ACCESS_BANNED_AGENT_REMOVE:
+    property: read-only
+    type: number
+    description: Remove the agent from this estate's Banned residents list.
+  FILTER_FLAGS:
+    property: read-only
+    type: number
+    description: Flags to control returned attachments.
+  FILTER_FLAG_HUDS:
+    property: read-only
+    type: number
+    description: Include HUDs with matching experience.
+  FILTER_INCLUDE:
+    property: read-only
+    type: number
+    description: Include attachment point.
+  FORCE_DIRECT_PATH:
+    property: read-only
+    type: number
+    description: >-
+      Makes character navigate in a straight line toward position. May be set to
+      TRUE or FALSE.
+  FRICTION:
+    property: read-only
+    type: number
+    description: >-
+      Used with llSetPhysicsMaterial to enable the friction value. Must be
+      between 0.0 and 255.0
+  GAME_CONTROL_AXIS_LEFTX:
+    property: read-only
+    type: number
+  GAME_CONTROL_AXIS_LEFTY:
+    property: read-only
+    type: number
+  GAME_CONTROL_AXIS_RIGHTX:
+    property: read-only
+    type: number
+  GAME_CONTROL_AXIS_RIGHTY:
+    property: read-only
+    type: number
+  GAME_CONTROL_AXIS_TRIGGERLEFT:
+    property: read-only
+    type: number
+  GAME_CONTROL_AXIS_TRIGGERRIGHT:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_A:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_B:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_BACK:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_DPAD_DOWN:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_DPAD_LEFT:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_DPAD_RIGHT:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_DPAD_UP:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_GUIDE:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_LEFTSHOULDER:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_LEFTSTICK:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_MISC1:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_PADDLE1:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_PADDLE2:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_PADDLE3:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_PADDLE4:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_RIGHTSHOULDER:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_RIGHTSTICK:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_START:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_TOUCHPAD:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_X:
+    property: read-only
+    type: number
+  GAME_CONTROL_BUTTON_Y:
+    property: read-only
+    type: number
+  GCNP_RADIUS:
+    property: read-only
+    type: number
+  GCNP_STATIC:
+    property: read-only
+    type: number
+  GRAVITY_MULTIPLIER:
+    property: read-only
+    type: number
+    description: >-
+      Used with llSetPhysicsMaterial to enable the gravity multiplier value.
+      Must be between -1.0 and +28.0
+  HORIZONTAL:
+    property: read-only
+    type: number
+  HTTP_ACCEPT:
+    property: read-only
+    type: number
+    description: |-
+      Provide a string value to be included in the HTTP
+                  accepts header value. This replaces the default Second Life HTTP accepts header.
+  HTTP_BODY_MAXLENGTH:
+    property: read-only
+    type: number
+  HTTP_BODY_TRUNCATED:
+    property: read-only
+    type: number
+  HTTP_CUSTOM_HEADER:
+    property: read-only
+    type: number
+    description: >-
+      Add an extra custom HTTP header to the request. The first string is the
+      name of the parameter to change, e.g. "Pragma", and the second string is
+      the value, e.g. "no-cache". Up to 8 custom headers may be configured per
+      request. Note that certain headers, such as the default headers, are
+      blocked for security reasons.
+  HTTP_EXTENDED_ERROR:
+    property: read-only
+    type: number
+    description: Report extended error information through http_response event.
+  HTTP_METHOD:
+    property: read-only
+    type: number
+  HTTP_MIMETYPE:
+    property: read-only
+    type: number
+  HTTP_PRAGMA_NO_CACHE:
+    property: read-only
+    type: number
+    description: >-
+      Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage:
+      [HTTP_PRAGMA_NO_CACHE, integer SendHeader]. When SendHeader is TRUE, the
+      "Pragma: no-cache" header is sent by the script. This matches the default
+      behavior. When SendHeader is FALSE, no "Pragma" header is sent by the
+      script.
+  HTTP_USER_AGENT:
+    property: read-only
+    type: number
+    description: |-
+      Provide a string value to be included in the HTTP
+                  User-Agent header value. This is appended to the default value.
+  HTTP_VERBOSE_THROTTLE:
+    property: read-only
+    type: number
+  HTTP_VERIFY_CERT:
+    property: read-only
+    type: number
+  IMG_USE_BAKED_AUX1:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_AUX2:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_AUX3:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_EYES:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_HAIR:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_HEAD:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_LEFTARM:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_LEFTLEG:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_LOWER:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_SKIRT:
+    property: read-only
+    type:
+      display: uuid
+  IMG_USE_BAKED_UPPER:
+    property: read-only
+    type:
+      display: uuid
+  INVENTORY_ALL:
+    property: read-only
+    type: number
+  INVENTORY_ANIMATION:
+    property: read-only
+    type: number
+  INVENTORY_BODYPART:
+    property: read-only
+    type: number
+  INVENTORY_CLOTHING:
+    property: read-only
+    type: number
+  INVENTORY_GESTURE:
+    property: read-only
+    type: number
+  INVENTORY_LANDMARK:
+    property: read-only
+    type: number
+  INVENTORY_MATERIAL:
+    property: read-only
+    type: number
+  INVENTORY_NONE:
+    property: read-only
+    type: number
+  INVENTORY_NOTECARD:
+    property: read-only
+    type: number
+  INVENTORY_OBJECT:
+    property: read-only
+    type: number
+  INVENTORY_SCRIPT:
+    property: read-only
+    type: number
+  INVENTORY_SETTING:
+    property: read-only
+    type: number
+  INVENTORY_SOUND:
+    property: read-only
+    type: number
+  INVENTORY_TEXTURE:
+    property: read-only
+    type: number
+  JSON_APPEND:
+    property: read-only
+    type: number
+  JSON_ARRAY:
+    property: read-only
+    type: string
+  JSON_DELETE:
+    property: read-only
+    type: string
+  JSON_FALSE:
+    property: read-only
+    type: string
+  JSON_INVALID:
+    property: read-only
+    type: string
+  JSON_NULL:
+    property: read-only
+    type: string
+  JSON_NUMBER:
+    property: read-only
+    type: string
+  JSON_OBJECT:
+    property: read-only
+    type: string
+  JSON_STRING:
+    property: read-only
+    type: string
+  JSON_TRUE:
+    property: read-only
+    type: string
+  KFM_CMD_PAUSE:
+    property: read-only
+    type: number
+    description: For use with KFM_COMMAND.
+  KFM_CMD_PLAY:
+    property: read-only
+    type: number
+    description: For use with KFM_COMMAND.
+  KFM_CMD_STOP:
+    property: read-only
+    type: number
+    description: For use with KFM_COMMAND.
+  KFM_COMMAND:
+    property: read-only
+    type: number
+  KFM_DATA:
+    property: read-only
+    type: number
+  KFM_FORWARD:
+    property: read-only
+    type: number
+    description: For use with KFM_MODE.
+  KFM_LOOP:
+    property: read-only
+    type: number
+    description: For use with KFM_MODE.
+  KFM_MODE:
+    property: read-only
+    type: number
+  KFM_PING_PONG:
+    property: read-only
+    type: number
+    description: For use with KFM_MODE.
+  KFM_REVERSE:
+    property: read-only
+    type: number
+    description: For use with KFM_MODE.
+  KFM_ROTATION:
+    property: read-only
+    type: number
+    description: For use with KFM_DATA.
+  KFM_TRANSLATION:
+    property: read-only
+    type: number
+    description: For use with KFM_DATA.
+  LAND_LARGE_BRUSH:
+    property: read-only
+    type: number
+    description: >-
+      Use a large brush size.\nNOTE: This value is incorrect, a large brush
+      should be 2.
+  LAND_LEVEL:
+    property: read-only
+    type: number
+    description: Action to level the land.
+  LAND_LOWER:
+    property: read-only
+    type: number
+    description: Action to lower the land.
+  LAND_MEDIUM_BRUSH:
+    property: read-only
+    type: number
+    description: >-
+      Use a medium brush size.\nNOTE: This value is incorrect, a medium brush
+      should be 1.
+  LAND_NOISE:
+    property: read-only
+    type: number
+  LAND_RAISE:
+    property: read-only
+    type: number
+    description: Action to raise the land.
+  LAND_REVERT:
+    property: read-only
+    type: number
+  LAND_SMALL_BRUSH:
+    property: read-only
+    type: number
+    description: >-
+      Use a small brush size.\nNOTE: This value is incorrect, a small brush
+      should be 0.
+  LAND_SMOOTH:
+    property: read-only
+    type: number
+  LINKSETDATA_DELETE:
+    property: read-only
+    type: number
+    description: A name:value pair has been removed from the linkset datastore.
+  LINKSETDATA_EMEMORY:
+    property: read-only
+    type: number
+    description: A name:value pair was too large to write to the linkset datastore.
+  LINKSETDATA_ENOKEY:
+    property: read-only
+    type: number
+    description: The key supplied was empty.
+  LINKSETDATA_EPROTECTED:
+    property: read-only
+    type: number
+    description: >-
+      The name:value pair has been protected from overwrite in the linkset
+      datastore.
+  LINKSETDATA_MULTIDELETE:
+    property: read-only
+    type: number
+    description: A CSV list of names removed from the linkset datastore.
+  LINKSETDATA_NOTFOUND:
+    property: read-only
+    type: number
+    description: The named key was not found in the datastore.
+  LINKSETDATA_NOUPDATE:
+    property: read-only
+    type: number
+    description: >-
+      The value written to a name in the keystore is the same as the value
+      already there.
+  LINKSETDATA_OK:
+    property: read-only
+    type: number
+    description: The name:value pair was written to the datastore.
+  LINKSETDATA_RESET:
+    property: read-only
+    type: number
+    description: The linkset datastore has been reset.
+  LINKSETDATA_UPDATE:
+    property: read-only
+    type: number
+    description: A name:value pair in the linkset datastore has been changed or created.
+  LINK_ALL_CHILDREN:
+    property: read-only
+    type: number
+    description: This targets every object except the root in the linked set.
+  LINK_ALL_OTHERS:
+    property: read-only
+    type: number
+    description: >-
+      This targets every object in the linked set except the object with the
+      script.
+  LINK_ROOT:
+    property: read-only
+    type: number
+    description: This targets the root of the linked set.
+  LINK_SET:
+    property: read-only
+    type: number
+    description: This targets every object in the linked set.
+  LINK_THIS:
+    property: read-only
+    type: number
+    description: The link number of the prim containing the script.
+  LIST_STAT_GEOMETRIC_MEAN:
+    property: read-only
+    type: number
+  LIST_STAT_MAX:
+    property: read-only
+    type: number
+  LIST_STAT_MEAN:
+    property: read-only
+    type: number
+  LIST_STAT_MEDIAN:
+    property: read-only
+    type: number
+  LIST_STAT_MIN:
+    property: read-only
+    type: number
+  LIST_STAT_NUM_COUNT:
+    property: read-only
+    type: number
+  LIST_STAT_RANGE:
+    property: read-only
+    type: number
+  LIST_STAT_STD_DEV:
+    property: read-only
+    type: number
+  LIST_STAT_SUM:
+    property: read-only
+    type: number
+  LIST_STAT_SUM_SQUARES:
+    property: read-only
+    type: number
+  LOOP:
+    property: read-only
+    type: number
+    description: Loop the texture animation.
+  MASK_BASE:
+    property: read-only
+    type: number
+  MASK_COMBINED:
+    property: read-only
+    type: number
+    description: Fold permissions for object inventory into results.
+  MASK_EVERYONE:
+    property: read-only
+    type: number
+  MASK_GROUP:
+    property: read-only
+    type: number
+  MASK_NEXT:
+    property: read-only
+    type: number
+  MASK_OWNER:
+    property: read-only
+    type: number
+  NAK:
+    property: read-only
+    type: string
+    description: >-
+      Indicates a notecard read was attempted and the notecard was not yet
+      cached on the server.
+  NULL_KEY:
+    property: read-only
+    type:
+      display: uuid
+  OBJECT_ACCOUNT_LEVEL:
+    property: read-only
+    type: number
+    description: >-
+      Retrieves the account level of an avatar.\nReturns 0 when the avatar has a
+      basic account,\n 1 when the avatar has a premium account,\n 10 when the
+      avatar has a premium plus account,\n or -1 if the object is not an avatar.
+  OBJECT_ANIMATED_COUNT:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the number of
+      associated animated objects
+  OBJECT_ANIMATED_SLOTS_AVAILABLE:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the number of
+      additional animated object attachments allowed.
+  OBJECT_ATTACHED_POINT:
+    property: read-only
+    type: number
+    description: >-
+      Gets the attachment point to which the object is attached.\nReturns 0 if
+      the object is not an attachment (or is an avatar, etc).
+  OBJECT_ATTACHED_SLOTS_AVAILABLE:
+    property: read-only
+    type: number
+    description: >-
+      Returns the number of attachment slots available.\nReturns 0 if the object
+      is not an avatar or none are available.
+  OBJECT_BODY_SHAPE_TYPE:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the body type of the
+      avatar, based on shape data.\nIf no data is available, -1.0 is
+      returned.\nThis is normally between 0 and 1.0, with 0.5 and larger
+      considered 'male'
+  OBJECT_CHARACTER_TIME:
+    property: read-only
+    type: number
+    description: Units in seconds
+  OBJECT_CLICK_ACTION:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the click action.\nThe
+      default is 0
+  OBJECT_CREATION_TIME:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the time this object
+      was created
+  OBJECT_CREATOR:
+    property: read-only
+    type: number
+    description: Gets the object's creator key. If id is an avatar, a NULL_KEY is returned.
+  OBJECT_DAMAGE:
+    property: read-only
+    type: number
+    description: Gets the damage value assigned to this object.
+  OBJECT_DAMAGE_TYPE:
+    property: read-only
+    type: number
+    description: Gets the damage type, if any, assigned to this object.
+  OBJECT_DESC:
+    property: read-only
+    type: number
+    description: >-
+      Gets the object's description. If id is an avatar, an empty string is
+      returned.
+  OBJECT_GROUP:
+    property: read-only
+    type: number
+    description: Gets the prims's group key. If id is an avatar, a NULL_KEY is returned.
+  OBJECT_GROUP_TAG:
+    property: read-only
+    type: number
+    description: >-
+      Gets the agent's current group role tag. If id is an object, an empty is
+      returned.
+  OBJECT_HEALTH:
+    property: read-only
+    type: number
+    description: Gets current health value for the object.
+  OBJECT_HOVER_HEIGHT:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get hover height of the
+      avatar\nIf no data is available, 0.0 is returned.
+  OBJECT_LAST_OWNER_ID:
+    property: read-only
+    type: number
+    description: Gets the object's last owner ID.
+  OBJECT_LINK_NUMBER:
+    property: read-only
+    type: number
+    description: Gets the object's link number or 0 if unlinked.
+  OBJECT_MASS:
+    property: read-only
+    type: number
+    description: Get the object's mass
+  OBJECT_MATERIAL:
+    property: read-only
+    type: number
+    description: Get an object's material setting.
+  OBJECT_NAME:
+    property: read-only
+    type: number
+    description: Gets the object's name.
+  OBJECT_OMEGA:
+    property: read-only
+    type: number
+    description: Gets an object's angular velocity.
+  OBJECT_OWNER:
+    property: read-only
+    type: number
+    description: >-
+      Gets an object's owner's key. If id is group owned, a NULL_KEY is
+      returned.
+  OBJECT_PATHFINDING_TYPE:
+    property: read-only
+    type: number
+    description: >-
+      Returns the pathfinding setting of any object in the region. It returns an
+      integer matching one of the OPT_* constants.
+  OBJECT_PERMS:
+    property: read-only
+    type: number
+    description: Gets the objects permissions
+  OBJECT_PERMS_COMBINED:
+    property: read-only
+    type: number
+    description: Gets the object's permissions including any inventory.
+  OBJECT_PHANTOM:
+    property: read-only
+    type: number
+    description: >-
+      Returns boolean, detailing if phantom is enabled or disabled on the
+      object.\nIf id is an avatar or attachment, 0 is returned.
+  OBJECT_PHYSICS:
+    property: read-only
+    type: number
+    description: >-
+      Returns boolean, detailing if physics is enabled or disabled on the
+      object.\nIf id is an avatar or attachment, 0 is returned.
+  OBJECT_PHYSICS_COST:
+    property: read-only
+    type: number
+  OBJECT_POS:
+    property: read-only
+    type: number
+    description: Gets the object's position in region coordinates.
+  OBJECT_PRIM_COUNT:
+    property: read-only
+    type: number
+    description: >-
+      Gets the prim count of the object.  The script and target object  must be
+      owned by the same owner
+  OBJECT_PRIM_EQUIVALENCE:
+    property: read-only
+    type: number
+  OBJECT_RENDER_WEIGHT:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the
+      Avatar_Rendering_Cost of an avatar, based on values reported by nearby
+      viewers.\nIf no data is available, -1 is returned.\nThe maximum render
+      weight stored by the simulator is 500000. When called against an object, 0
+      is returned.
+  OBJECT_RETURN_PARCEL:
+    property: read-only
+    type: number
+  OBJECT_RETURN_PARCEL_OWNER:
+    property: read-only
+    type: number
+  OBJECT_RETURN_REGION:
+    property: read-only
+    type: number
+  OBJECT_REZZER_KEY:
+    property: read-only
+    type: number
+  OBJECT_REZ_TIME:
+    property: read-only
+    type: number
+    description: Get the time when an object was rezzed.
+  OBJECT_ROOT:
+    property: read-only
+    type: number
+    description: >-
+      Gets the id of the root prim of the object requested.\nIf id is an avatar,
+      return the id of the root prim of the linkset the avatar is sitting on (or
+      the avatar's own id if the avatar is not sitting on an object within the
+      region).
+  OBJECT_ROT:
+    property: read-only
+    type: number
+    description: Gets the object's rotation.
+  OBJECT_RUNNING_SCRIPT_COUNT:
+    property: read-only
+    type: number
+  OBJECT_SCALE:
+    property: read-only
+    type: number
+    description: Gets the object's size.
+  OBJECT_SCRIPT_MEMORY:
+    property: read-only
+    type: number
+  OBJECT_SCRIPT_TIME:
+    property: read-only
+    type: number
+  OBJECT_SELECT_COUNT:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the number of avatars
+      selecting any part of the object
+  OBJECT_SERVER_COST:
+    property: read-only
+    type: number
+  OBJECT_SIT_COUNT:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag used with llGetObjectDetails to get the number of avatars
+      sitting on the object
+  OBJECT_STREAMING_COST:
+    property: read-only
+    type: number
+  OBJECT_TEMP_ATTACHED:
+    property: read-only
+    type: number
+    description: Returns boolean, indicating if object is a temp attachment.
+  OBJECT_TEMP_ON_REZ:
+    property: read-only
+    type: number
+    description: >-
+      Returns boolean, detailing if temporary is enabled or disabled on the
+      object.
+  OBJECT_TEXT:
+    property: read-only
+    type: number
+    description: Gets an objects hover text.
+  OBJECT_TEXT_ALPHA:
+    property: read-only
+    type: number
+    description: Gets the alpha of an objects hover text.
+  OBJECT_TEXT_COLOR:
+    property: read-only
+    type: number
+    description: Gets the color of an objects hover text.
+  OBJECT_TOTAL_INVENTORY_COUNT:
+    property: read-only
+    type: number
+    description: >-
+      Gets the total inventory count of the object.  The script and target
+      object must be owned by the same owner
+  OBJECT_TOTAL_SCRIPT_COUNT:
+    property: read-only
+    type: number
+  OBJECT_UNKNOWN_DETAIL:
+    property: read-only
+    type: number
+  OBJECT_VELOCITY:
+    property: read-only
+    type: number
+    description: Gets the object's velocity.
+  OPT_AVATAR:
+    property: read-only
+    type: number
+    description: Returned for avatars.
+  OPT_CHARACTER:
+    property: read-only
+    type: number
+    description: Returned for pathfinding characters.
+  OPT_EXCLUSION_VOLUME:
+    property: read-only
+    type: number
+    description: Returned for exclusion volumes.
+  OPT_LEGACY_LINKSET:
+    property: read-only
+    type: number
+    description: >-
+      Returned for movable obstacles, movable phantoms, physical, and
+      volumedetect objects.
+  OPT_MATERIAL_VOLUME:
+    property: read-only
+    type: number
+    description: Returned for material volumes.
+  OPT_OTHER:
+    property: read-only
+    type: number
+    description: Returned for attachments, Linden trees, and grass.
+  OPT_STATIC_OBSTACLE:
+    property: read-only
+    type: number
+    description: Returned for static obstacles.
+  OPT_WALKABLE:
+    property: read-only
+    type: number
+    description: Returned for walkable objects.
+  OVERRIDE_GLTF_BASE_ALPHA:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_BASE_ALPHA_MASK:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_BASE_ALPHA_MODE:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_BASE_COLOR_FACTOR:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_BASE_DOUBLE_SIDED:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_EMISSIVE_FACTOR:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_METALLIC_FACTOR:
+    property: read-only
+    type: number
+  OVERRIDE_GLTF_ROUGHNESS_FACTOR:
+    property: read-only
+    type: number
+  PARCEL_COUNT_GROUP:
+    property: read-only
+    type: number
+  PARCEL_COUNT_OTHER:
+    property: read-only
+    type: number
+  PARCEL_COUNT_OWNER:
+    property: read-only
+    type: number
+  PARCEL_COUNT_SELECTED:
+    property: read-only
+    type: number
+  PARCEL_COUNT_TEMP:
+    property: read-only
+    type: number
+  PARCEL_COUNT_TOTAL:
+    property: read-only
+    type: number
+  PARCEL_DETAILS_AREA:
+    property: read-only
+    type: number
+    description: The parcel's area, in square meters. (5 chars.).
+  PARCEL_DETAILS_DESC:
+    property: read-only
+    type: number
+    description: The description of the parcel. (127 chars).
+  PARCEL_DETAILS_FLAGS:
+    property: read-only
+    type: number
+    description: Flags set on the parcel
+  PARCEL_DETAILS_GROUP:
+    property: read-only
+    type: number
+    description: The parcel group's key. (36 chars.).
+  PARCEL_DETAILS_ID:
+    property: read-only
+    type: number
+    description: The parcel's key. (36 chars.).
+  PARCEL_DETAILS_LANDING_LOOKAT:
+    property: read-only
+    type: number
+    description: Lookat vector set for teleport routing.
+  PARCEL_DETAILS_LANDING_POINT:
+    property: read-only
+    type: number
+    description: The parcel's landing point, if any.
+  PARCEL_DETAILS_NAME:
+    property: read-only
+    type: number
+    description: The name of the parcel. (63 chars.).
+  PARCEL_DETAILS_OWNER:
+    property: read-only
+    type: number
+    description: The parcel owner's key. (36 chars.).
+  PARCEL_DETAILS_PRIM_CAPACITY:
+    property: read-only
+    type: number
+    description: The parcel's prim capacity.
+  PARCEL_DETAILS_PRIM_USED:
+    property: read-only
+    type: number
+    description: The number of prims used on this parcel.
+  PARCEL_DETAILS_SCRIPT_DANGER:
+    property: read-only
+    type: number
+    description: There are restrictions on this parcel that may impact script execution.
+  PARCEL_DETAILS_SEE_AVATARS:
+    property: read-only
+    type: number
+    description: The parcel's avatar visibility setting. (1 char.).
+  PARCEL_DETAILS_TP_ROUTING:
+    property: read-only
+    type: number
+    description: Parcel's teleport routing setting.
+  PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_CREATE_OBJECTS:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_DAMAGE:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_FLY:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_GROUP_SCRIPTS:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_LANDMARK:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_SCRIPTS:
+    property: read-only
+    type: number
+  PARCEL_FLAG_ALLOW_TERRAFORM:
+    property: read-only
+    type: number
+  PARCEL_FLAG_LOCAL_SOUND_ONLY:
+    property: read-only
+    type: number
+  PARCEL_FLAG_RESTRICT_PUSHOBJECT:
+    property: read-only
+    type: number
+  PARCEL_FLAG_USE_ACCESS_GROUP:
+    property: read-only
+    type: number
+  PARCEL_FLAG_USE_ACCESS_LIST:
+    property: read-only
+    type: number
+  PARCEL_FLAG_USE_BAN_LIST:
+    property: read-only
+    type: number
+  PARCEL_FLAG_USE_LAND_PASS_LIST:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_AGENT:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_AUTO_ALIGN:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_DESC:
+    property: read-only
+    type: number
+    description: Use this to get or set the parcel media description.
+  PARCEL_MEDIA_COMMAND_LOOP:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_LOOP_SET:
+    property: read-only
+    type: number
+    description: Used to get or set the parcel's media looping variable.
+  PARCEL_MEDIA_COMMAND_PAUSE:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_PLAY:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_SIZE:
+    property: read-only
+    type: number
+    description: Use this to get or set the parcel media pixel resolution.
+  PARCEL_MEDIA_COMMAND_STOP:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_TEXTURE:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_TIME:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_TYPE:
+    property: read-only
+    type: number
+    description: Use this to get or set the parcel media MIME type (e.g. "text/html").
+  PARCEL_MEDIA_COMMAND_UNLOAD:
+    property: read-only
+    type: number
+  PARCEL_MEDIA_COMMAND_URL:
+    property: read-only
+    type: number
+  PARCEL_SALE_AGENT:
+    property: read-only
+    type: number
+    description: The agent authorized to purchase the parcel.
+  PARCEL_SALE_ERROR_BAD_PARAMS:
+    property: read-only
+    type: number
+    description: The parameters provided to set the sale information are invalid.
+  PARCEL_SALE_ERROR_INVALID_PRICE:
+    property: read-only
+    type: number
+    description: The price set for the parcel is invalid (e.g., less than or equal to 0).
+  PARCEL_SALE_ERROR_IN_ESCROW:
+    property: read-only
+    type: number
+    description: The parcel is currently in escrow and cannot be set for sale.
+  PARCEL_SALE_ERROR_NO_PARCEL:
+    property: read-only
+    type: number
+    description: The parcel could not be found.
+  PARCEL_SALE_ERROR_NO_PERMISSIONS:
+    property: read-only
+    type: number
+    description: >-
+      The script does not have the required permissions to set the sale
+      information.
+  PARCEL_SALE_OBJECTS:
+    property: read-only
+    type: number
+    description: Are the objects on the parcel included in the sale?
+  PARCEL_SALE_OK:
+    property: read-only
+    type: number
+    description: The sale information was successfully set.
+  PARCEL_SALE_PRICE:
+    property: read-only
+    type: number
+    description: >-
+      The price of the parcel. If no authorized agent is set, must be greater
+      than 0.
+  PASSIVE:
+    property: read-only
+    type: number
+    description: Static in-world objects.
+  PASS_ALWAYS:
+    property: read-only
+    type: number
+    description: Always pass the event.
+  PASS_IF_NOT_HANDLED:
+    property: read-only
+    type: number
+    description: Pass the event if there is no script handling the event in the prim.
+  PASS_NEVER:
+    property: read-only
+    type: number
+    description: Always pass the event.
+  PATROL_PAUSE_AT_WAYPOINTS:
+    property: read-only
+    type: number
+  PAYMENT_INFO_ON_FILE:
+    property: read-only
+    type: number
+  PAYMENT_INFO_USED:
+    property: read-only
+    type: number
+  PAY_DEFAULT:
+    property: read-only
+    type: number
+  PAY_HIDE:
+    property: read-only
+    type: number
+  PERMISSION_ATTACH:
+    property: read-only
+    type: number
+    description: >-
+      If this permission is enabled, the object can successfully call
+      llAttachToAvatar to attach to the given avatar.
+  PERMISSION_CHANGE_JOINTS:
+    property: read-only
+    type: number
+    description: (not yet implemented)
+  PERMISSION_CHANGE_LINKS:
+    property: read-only
+    type: number
+    description: >-
+      If this permission is enabled, the object can successfully call
+      llCreateLink, llBreakLink, and llBreakAllLinks to change links to other
+      objects.
+  PERMISSION_CHANGE_PERMISSIONS:
+    property: read-only
+    type: number
+    description: (not yet implemented)
+  PERMISSION_CONTROL_CAMERA:
+    property: read-only
+    type: number
+  PERMISSION_DEBIT:
+    property: read-only
+    type: number
+    description: >-
+      If this permission is enabled, the object can successfully call
+      llGiveMoney or llTransferLindenDollars to debit the owners account.
+  PERMISSION_OVERRIDE_ANIMATIONS:
+    property: read-only
+    type: number
+    description: Permission to override default animations.
+  PERMISSION_RELEASE_OWNERSHIP:
+    property: read-only
+    type: number
+    description: (not yet implemented)
+  PERMISSION_REMAP_CONTROLS:
+    property: read-only
+    type: number
+    description: (not yet implemented)
+  PERMISSION_RETURN_OBJECTS:
+    property: read-only
+    type: number
+  PERMISSION_SILENT_ESTATE_MANAGEMENT:
+    property: read-only
+    type: number
+    description: >-
+      A script with this permission does not notify the object owner when it
+      modifies estate access rules via llManageEstateAccess.
+  PERMISSION_TAKE_CONTROLS:
+    property: read-only
+    type: number
+    description: >-
+      If this permission enabled, the object can successfully call the
+      llTakeControls libray call.
+  PERMISSION_TELEPORT:
+    property: read-only
+    type: number
+  PERMISSION_TRACK_CAMERA:
+    property: read-only
+    type: number
+  PERMISSION_TRIGGER_ANIMATION:
+    property: read-only
+    type: number
+    description: >-
+      If this permission is enabled, the object can successfully call
+      llStartAnimation for the avatar that owns this.
+  PERM_ALL:
+    property: read-only
+    type: number
+  PERM_COPY:
+    property: read-only
+    type: number
+  PERM_MODIFY:
+    property: read-only
+    type: number
+  PERM_MOVE:
+    property: read-only
+    type: number
+  PERM_TRANSFER:
+    property: read-only
+    type: number
+  PI:
+    property: read-only
+    type: number
+    description: 3.14159265 - The number of radians in a semi-circle.
+  PING_PONG:
+    property: read-only
+    type: number
+    description: Play animation going forwards, then backwards.
+  PI_BY_TWO:
+    property: read-only
+    type: number
+    description: 1.57079633 - The number of radians in a quarter circle.
+  PRIM_ALLOW_UNSIT:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for restricting manual standing for seated avatars in an
+      experience.\nIgnored if the avatar was not seated via a call to
+      llSitOnLink.
+  PRIM_ALPHA_MODE:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for materials using integer face, integer alpha_mode,
+      integer alpha_cutoff.\nDefines how the alpha channel of the diffuse
+      texture should be rendered.\nValid options for alpha_mode are
+      PRIM_ALPHA_MODE_BLEND, _NONE, _MASK, and _EMISSIVE.\nalpha_cutoff is used
+      only for PRIM_ALPHA_MODE_MASK.
+  PRIM_ALPHA_MODE_BLEND:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+      texture's alpha channel should be rendered as alpha-blended.
+  PRIM_ALPHA_MODE_EMISSIVE:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+      texture's alpha channel should be rendered as an emissivity mask.
+  PRIM_ALPHA_MODE_MASK:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+      texture's alpha channel should be rendered as fully opaque for alpha
+      values above alpha_cutoff and fully transparent otherwise.
+  PRIM_ALPHA_MODE_NONE:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
+      texture's alpha channel should be ignored.
+  PRIM_BUMP_BARK:
+    property: read-only
+    type: number
+  PRIM_BUMP_BLOBS:
+    property: read-only
+    type: number
+  PRIM_BUMP_BRICKS:
+    property: read-only
+    type: number
+  PRIM_BUMP_BRIGHT:
+    property: read-only
+    type: number
+  PRIM_BUMP_CHECKER:
+    property: read-only
+    type: number
+  PRIM_BUMP_CONCRETE:
+    property: read-only
+    type: number
+  PRIM_BUMP_DARK:
+    property: read-only
+    type: number
+  PRIM_BUMP_DISKS:
+    property: read-only
+    type: number
+  PRIM_BUMP_GRAVEL:
+    property: read-only
+    type: number
+  PRIM_BUMP_LARGETILE:
+    property: read-only
+    type: number
+  PRIM_BUMP_NONE:
+    property: read-only
+    type: number
+  PRIM_BUMP_SHINY:
+    property: read-only
+    type: number
+  PRIM_BUMP_SIDING:
+    property: read-only
+    type: number
+  PRIM_BUMP_STONE:
+    property: read-only
+    type: number
+  PRIM_BUMP_STUCCO:
+    property: read-only
+    type: number
+  PRIM_BUMP_SUCTION:
+    property: read-only
+    type: number
+  PRIM_BUMP_TILE:
+    property: read-only
+    type: number
+  PRIM_BUMP_WEAVE:
+    property: read-only
+    type: number
+  PRIM_BUMP_WOOD:
+    property: read-only
+    type: number
+  PRIM_CAST_SHADOWS:
+    property: read-only
+    type: number
+  PRIM_CLICK_ACTION:
+    property: read-only
+    type: number
+    description: '[PRIM_CLICK_ACTION, integer CLICK_ACTION_*]'
+  PRIM_COLLISION_SOUND:
+    property: read-only
+    type: number
+    description: Collision sound uuid and volume for this prim
+  PRIM_COLOR:
+    property: read-only
+    type: number
+    description: >-
+      [PRIM_COLOR, integer face, vector color, float alpha]
+
+      integer face – face number or ALL_SIDES vector color – color in RGB <R, G,
+      B> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white) float alpha – from
+      0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)
+  PRIM_DAMAGE:
+    property: read-only
+    type: number
+    description: Damage and damage type assigned to this prim.
+  PRIM_DESC:
+    property: read-only
+    type: number
+    description: '[PRIM_DESC, string description]'
+  PRIM_FLEXIBLE:
+    property: read-only
+    type: number
+    description: >-
+      [ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float
+      friction, float wind, float tension, vector force ] + +integer boolean –
+      TRUE enables, FALSE disables +integer softness – ranges from 0 to 3 +float
+      gravity – ranges from -10.0 to 10.0 +float friction – ranges from 0.0 to
+      10.0 +float wind – ranges from 0.0 to 10.0 +float tension – ranges from
+      0.0 to 10.0 +vector force
+  PRIM_FULLBRIGHT:
+    property: read-only
+    type: number
+    description: '[ PRIM_FULLBRIGHT, integer face, integer boolean ]'
+  PRIM_GLOW:
+    property: read-only
+    type: number
+    description: >-
+      PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW,
+      integer face, float intensity ]
+  PRIM_GLTF_ALPHA_MODE_BLEND:
+    property: read-only
+    type: number
+    description: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "BLEND".
+  PRIM_GLTF_ALPHA_MODE_MASK:
+    property: read-only
+    type: number
+    description: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "MASK".
+  PRIM_GLTF_ALPHA_MODE_OPAQUE:
+    property: read-only
+    type: number
+    description: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "OPAQUE".
+  PRIM_GLTF_BASE_COLOR:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for materials using integer face, string texture, vector
+      repeats, vector offsets, float rotation_in_radians, vector color, integer
+      alpha_mode, float alpha_cutoff, boolean double_sided.\nValid options for
+      alpha_mode are PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is
+      used only for PRIM_ALPHA_MODE_MASK.
+  PRIM_GLTF_EMISSIVE:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for GLTF materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians, vector color
+  PRIM_GLTF_METALLIC_ROUGHNESS:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for GLTF materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians, float
+      metallic_factor, float roughness_factor
+  PRIM_GLTF_NORMAL:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for GLTF materials using integer face, string texture,
+      vector repeats, vector offsets, float rotation_in_radians
+  PRIM_HEALTH:
+    property: read-only
+    type: number
+    description: Health value for this prim
+  PRIM_HOLE_CIRCLE:
+    property: read-only
+    type: number
+  PRIM_HOLE_DEFAULT:
+    property: read-only
+    type: number
+  PRIM_HOLE_SQUARE:
+    property: read-only
+    type: number
+  PRIM_HOLE_TRIANGLE:
+    property: read-only
+    type: number
+  PRIM_LINK_TARGET:
+    property: read-only
+    type: number
+    description: |-
+      [ PRIM_LINK_TARGET, integer link_target ]
+      Used to get or set multiple links with a single PrimParameters call.
+  PRIM_MATERIAL:
+    property: read-only
+    type: number
+    description: '[ PRIM_MATERIAL, integer PRIM_MATERIAL_* ]'
+  PRIM_MATERIAL_FLESH:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_GLASS:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_LIGHT:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_METAL:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_PLASTIC:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_RUBBER:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_STONE:
+    property: read-only
+    type: number
+  PRIM_MATERIAL_WOOD:
+    property: read-only
+    type: number
+  PRIM_MEDIA_ALT_IMAGE_ENABLE:
+    property: read-only
+    type: number
+    description: >-
+      Boolean. Gets/Sets the default image state (the image that the user sees
+      before a piece of media is active) for the chosen face. The default image
+      is specified by Second Life's server for that media type.
+  PRIM_MEDIA_AUTO_LOOP:
+    property: read-only
+    type: number
+    description: Boolean. Gets/Sets whether auto-looping is enabled.
+  PRIM_MEDIA_AUTO_PLAY:
+    property: read-only
+    type: number
+    description: >-
+      Boolean. Gets/Sets whether the media auto-plays when a Resident can view
+      it.
+  PRIM_MEDIA_AUTO_SCALE:
+    property: read-only
+    type: number
+    description: >-
+      Boolean. Gets/Sets whether auto-scaling is enabled. Auto-scaling forces
+      the media to the full size of the texture.
+  PRIM_MEDIA_AUTO_ZOOM:
+    property: read-only
+    type: number
+    description: >-
+      Boolean. Gets/Sets whether clicking the media triggers auto-zoom and
+      auto-focus on the media.
+  PRIM_MEDIA_CONTROLS:
+    property: read-only
+    type: number
+    description: >-
+      Integer. Gets/Sets the style of controls. Can be either
+      PRIM_MEDIA_CONTROLS_STANDARD or PRIM_MEDIA_CONTROLS_MINI.
+  PRIM_MEDIA_CONTROLS_MINI:
+    property: read-only
+    type: number
+    description: Mini web navigation controls; does not include an address bar.
+  PRIM_MEDIA_CONTROLS_STANDARD:
+    property: read-only
+    type: number
+    description: Standard web navigation controls.
+  PRIM_MEDIA_CURRENT_URL:
+    property: read-only
+    type: number
+    description: >-
+      String. Gets/Sets the current url displayed on the chosen face. Changing
+      this URL causes navigation. 1024 characters Maximum.
+  PRIM_MEDIA_FIRST_CLICK_INTERACT:
+    property: read-only
+    type: number
+    description: Boolean. Gets/Sets whether the first click interaction is enabled.
+  PRIM_MEDIA_HEIGHT_PIXELS:
+    property: read-only
+    type: number
+    description: Integer. Gets/Sets the height of the media in pixels.
+  PRIM_MEDIA_HOME_URL:
+    property: read-only
+    type: number
+    description: >-
+      String. Gets/Sets the home URL for the chosen face. 1024 characters
+      maximum.
+  PRIM_MEDIA_MAX_HEIGHT_PIXELS:
+    property: read-only
+    type: number
+  PRIM_MEDIA_MAX_URL_LENGTH:
+    property: read-only
+    type: number
+  PRIM_MEDIA_MAX_WHITELIST_COUNT:
+    property: read-only
+    type: number
+  PRIM_MEDIA_MAX_WHITELIST_SIZE:
+    property: read-only
+    type: number
+  PRIM_MEDIA_MAX_WIDTH_PIXELS:
+    property: read-only
+    type: number
+  PRIM_MEDIA_PARAM_MAX:
+    property: read-only
+    type: number
+  PRIM_MEDIA_PERMS_CONTROL:
+    property: read-only
+    type: number
+    description: >-
+      Integer. Gets/Sets the permissions mask that control who can see the media
+      control bar above the object:: PRIM_MEDIA_PERM_ANYONE,
+      PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER
+  PRIM_MEDIA_PERMS_INTERACT:
+    property: read-only
+    type: number
+    description: >-
+      Integer. Gets/Sets the permissions mask that control who can interact with
+      the object: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP,
+      PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER
+  PRIM_MEDIA_PERM_ANYONE:
+    property: read-only
+    type: number
+  PRIM_MEDIA_PERM_GROUP:
+    property: read-only
+    type: number
+  PRIM_MEDIA_PERM_NONE:
+    property: read-only
+    type: number
+  PRIM_MEDIA_PERM_OWNER:
+    property: read-only
+    type: number
+  PRIM_MEDIA_WHITELIST:
+    property: read-only
+    type: number
+    description: >-
+      String. Gets/Sets the white-list as a string of escaped, comma-separated
+      URLs. This string can hold up to 64 URLs or 1024 characters, whichever
+      comes first.
+  PRIM_MEDIA_WHITELIST_ENABLE:
+    property: read-only
+    type: number
+    description: >-
+      Boolean. Gets/Sets whether navigation is restricted to URLs in
+      PRIM_MEDIA_WHITELIST.
+  PRIM_MEDIA_WIDTH_PIXELS:
+    property: read-only
+    type: number
+    description: Integer. Gets/Sets the width of the media in pixels.
+  PRIM_NAME:
+    property: read-only
+    type: number
+    description: '[ PRIM_NAME, string name ]'
+  PRIM_NORMAL:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for materials using integer face, string texture, vector
+      repeats, vector offsets, float rotation_in_radians
+  PRIM_OMEGA:
+    property: read-only
+    type: number
+    description: >-
+      [ PRIM_OMEGA, vector axis, float spinrate, float gain ]
+
+      vector axis – arbitrary axis to rotate the object around float spinrate –
+      rate of rotation in radians per second float gain – also modulates the
+      final spinrate and disables the rotation behavior if zero
+  PRIM_PHANTOM:
+    property: read-only
+    type: number
+    description: '[ PRIM_PHANTOM, integer boolean ]'
+  PRIM_PHYSICS:
+    property: read-only
+    type: number
+    description: '[ PRIM_PHYSICS, integer boolean ]'
+  PRIM_PHYSICS_SHAPE_CONVEX:
+    property: read-only
+    type: number
+    description: >-
+      Use the convex hull of the prim shape for physics (this is the default for
+      mesh objects).
+  PRIM_PHYSICS_SHAPE_NONE:
+    property: read-only
+    type: number
+    description: >-
+      Ignore this prim in the physics shape. NB: This cannot be applied to the
+      root prim.
+  PRIM_PHYSICS_SHAPE_PRIM:
+    property: read-only
+    type: number
+    description: >-
+      Use the normal prim shape for physics (this is the default for all
+      non-mesh objects).
+  PRIM_PHYSICS_SHAPE_TYPE:
+    property: read-only
+    type: number
+    description: "Allows you to set the physics shape type of a prim via lsl. Permitted values are:\n\t\t\tPRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX"
+  PRIM_POINT_LIGHT:
+    property: read-only
+    type: number
+    description: >-
+      [ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity,
+      float radius, float falloff ]
+
+      integer boolean – TRUE enables, FALSE disables vector linear_color –
+      linear color in RGB <R, G, B&> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> =
+      white) float intensity – ranges from 0.0 to 1.0 float radius – ranges from
+      0.1 to 20.0 float falloff – ranges from 0.01 to 2.0
+  PRIM_POSITION:
+    property: read-only
+    type: number
+    description: >-
+      [ PRIM_POSITION, vector position ]
+
+      vector position – position in region or local coordinates depending upon
+      the situation
+  PRIM_POS_LOCAL:
+    property: read-only
+    type: number
+    description: |-
+      PRIM_POS_LOCAL, vector position ]
+      vector position - position in local coordinates
+  PRIM_PROJECTOR:
+    property: read-only
+    type: number
+    description: '[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]'
+  PRIM_REFLECTION_PROBE:
+    property: read-only
+    type: number
+    description: >-
+      Allows you to configure the object as a custom-placed reflection probe,
+      for image-based lighting (IBL). Only objects in the influence volume of
+      the reflection probe object are affected.
+  PRIM_REFLECTION_PROBE_BOX:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag option used with llGetPrimitiveParams and related functions
+      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+      probe is a box. When unset, the reflection probe is a sphere.
+  PRIM_REFLECTION_PROBE_DYNAMIC:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag option used with llGetPrimitiveParams and related functions
+      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+      probe includes avatars in IBL effects. When unset, the reflection probe
+      excludes avatars.
+  PRIM_REFLECTION_PROBE_MIRROR:
+    property: read-only
+    type: number
+    description: >-
+      This is a flag option used with llGetPrimitiveParams and related functions
+      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection
+      probe acts as a mirror.
+  PRIM_RENDER_MATERIAL:
+    property: read-only
+    type: number
+    description: '[ PRIM_RENDER_MATERIAL, integer face, string material ]'
+  PRIM_ROTATION:
+    property: read-only
+    type: number
+    description: '[ PRIM_ROT_LOCAL, rotation global_rot ]'
+  PRIM_ROT_LOCAL:
+    property: read-only
+    type: number
+    description: '[ PRIM_ROT_LOCAL, rotation local_rot ]'
+  PRIM_SCRIPTED_SIT_ONLY:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for restricting manual sitting on this prim.\nSitting must
+      be initiated via call to llSitOnLink.
+  PRIM_SCULPT_FLAG_ANIMESH:
+    property: read-only
+    type: number
+    description: Mesh is animated.
+  PRIM_SCULPT_FLAG_INVERT:
+    property: read-only
+    type: number
+    description: Render inside out (inverts the normals).
+  PRIM_SCULPT_FLAG_MIRROR:
+    property: read-only
+    type: number
+    description: Render an X axis mirror of the sculpty.
+  PRIM_SCULPT_TYPE_CYLINDER:
+    property: read-only
+    type: number
+  PRIM_SCULPT_TYPE_MASK:
+    property: read-only
+    type: number
+  PRIM_SCULPT_TYPE_MESH:
+    property: read-only
+    type: number
+  PRIM_SCULPT_TYPE_PLANE:
+    property: read-only
+    type: number
+  PRIM_SCULPT_TYPE_SPHERE:
+    property: read-only
+    type: number
+  PRIM_SCULPT_TYPE_TORUS:
+    property: read-only
+    type: number
+  PRIM_SHINY_HIGH:
+    property: read-only
+    type: number
+  PRIM_SHINY_LOW:
+    property: read-only
+    type: number
+  PRIM_SHINY_MEDIUM:
+    property: read-only
+    type: number
+  PRIM_SHINY_NONE:
+    property: read-only
+    type: number
+  PRIM_SIT_FLAGS:
+    property: read-only
+    type: number
+  PRIM_SIT_TARGET:
+    property: read-only
+    type: number
+    description: '[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]'
+  PRIM_SIZE:
+    property: read-only
+    type: number
+    description: '[ PRIM_SIZE, vector size ]'
+  PRIM_SLICE:
+    property: read-only
+    type: number
+    description: '[ PRIM_SLICE, vector slice ]'
+  PRIM_SPECULAR:
+    property: read-only
+    type: number
+    description: >-
+      Prim parameter for materials using integer face, string texture, vector
+      repeats, vector offsets, float rotation_in_radians, vector color, integer
+      glossy, integer environment
+  PRIM_TEMP_ON_REZ:
+    property: read-only
+    type: number
+  PRIM_TEXGEN:
+    property: read-only
+    type: number
+    description: '[ PRIM_TEXGEN, integer face, PRIM_TEXGEN_* ]'
+  PRIM_TEXGEN_DEFAULT:
+    property: read-only
+    type: number
+  PRIM_TEXGEN_PLANAR:
+    property: read-only
+    type: number
+  PRIM_TEXT:
+    property: read-only
+    type: number
+    description: '[ PRIM_TEXT, string text, vector color, float alpha ]'
+  PRIM_TEXTURE:
+    property: read-only
+    type: number
+    description: >-
+      [ PRIM_TEXTURE, integer face, string texture, vector repeats, vector
+      offsets, float rotation_in_radians ]
+  PRIM_TYPE:
+    property: read-only
+    type: number
+  PRIM_TYPE_BOX:
+    property: read-only
+    type: number
+  PRIM_TYPE_CYLINDER:
+    property: read-only
+    type: number
+  PRIM_TYPE_PRISM:
+    property: read-only
+    type: number
+  PRIM_TYPE_RING:
+    property: read-only
+    type: number
+  PRIM_TYPE_SCULPT:
+    property: read-only
+    type: number
+  PRIM_TYPE_SPHERE:
+    property: read-only
+    type: number
+  PRIM_TYPE_TORUS:
+    property: read-only
+    type: number
+  PRIM_TYPE_TUBE:
+    property: read-only
+    type: number
+  PROFILE_NONE:
+    property: read-only
+    type: number
+    description: Disables profiling
+  PROFILE_SCRIPT_MEMORY:
+    property: read-only
+    type: number
+    description: Enables memory profiling
+  PSYS_PART_BF_DEST_COLOR:
+    property: read-only
+    type: number
+  PSYS_PART_BF_ONE:
+    property: read-only
+    type: number
+  PSYS_PART_BF_ONE_MINUS_DEST_COLOR:
+    property: read-only
+    type: number
+  PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA:
+    property: read-only
+    type: number
+  PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR:
+    property: read-only
+    type: number
+  PSYS_PART_BF_SOURCE_ALPHA:
+    property: read-only
+    type: number
+  PSYS_PART_BF_SOURCE_COLOR:
+    property: read-only
+    type: number
+  PSYS_PART_BF_ZERO:
+    property: read-only
+    type: number
+  PSYS_PART_BLEND_FUNC_DEST:
+    property: read-only
+    type: number
+  PSYS_PART_BLEND_FUNC_SOURCE:
+    property: read-only
+    type: number
+  PSYS_PART_BOUNCE_MASK:
+    property: read-only
+    type: number
+    description: Particles bounce off of a plane at the objects Z height.
+  PSYS_PART_EMISSIVE_MASK:
+    property: read-only
+    type: number
+    description: The particle glows.
+  PSYS_PART_END_ALPHA:
+    property: read-only
+    type: number
+    description: A float which determines the ending alpha of the object.
+  PSYS_PART_END_COLOR:
+    property: read-only
+    type: number
+    description: A vector <r, g, b> which determines the ending color of the object.
+  PSYS_PART_END_GLOW:
+    property: read-only
+    type: number
+  PSYS_PART_END_SCALE:
+    property: read-only
+    type: number
+    description: >-
+      A vector <sx, sy, z>, which is the ending size of the particle billboard
+      in meters (z is ignored).
+  PSYS_PART_FLAGS:
+    property: read-only
+    type: number
+    description: >-
+      Each particle that is emitted by the particle system is simulated based on
+      the following flags. To use multiple flags, bitwise or (|) them together.
+  PSYS_PART_FOLLOW_SRC_MASK:
+    property: read-only
+    type: number
+    description: The particle position is relative to the source objects position.
+  PSYS_PART_FOLLOW_VELOCITY_MASK:
+    property: read-only
+    type: number
+    description: >-
+      The particle orientation is rotated so the vertical axis faces towards the
+      particle velocity.
+  PSYS_PART_INTERP_COLOR_MASK:
+    property: read-only
+    type: number
+    description: >-
+      Interpolate both the color and alpha from the start value to the end
+      value.
+  PSYS_PART_INTERP_SCALE_MASK:
+    property: read-only
+    type: number
+    description: Interpolate the particle scale from the start value to the end value.
+  PSYS_PART_MAX_AGE:
+    property: read-only
+    type: number
+    description: Age in seconds of a particle at which it dies.
+  PSYS_PART_RIBBON_MASK:
+    property: read-only
+    type: number
+  PSYS_PART_START_ALPHA:
+    property: read-only
+    type: number
+    description: A float which determines the starting alpha of the object.
+  PSYS_PART_START_COLOR:
+    property: read-only
+    type: number
+    description: A vector <r, g, b> which determines the starting color of the object.
+  PSYS_PART_START_GLOW:
+    property: read-only
+    type: number
+  PSYS_PART_START_SCALE:
+    property: read-only
+    type: number
+    description: >-
+      A vector <sx, sy, z>, which is the starting size of the particle billboard
+      in meters (z is ignored).
+  PSYS_PART_TARGET_LINEAR_MASK:
+    property: read-only
+    type: number
+  PSYS_PART_TARGET_POS_MASK:
+    property: read-only
+    type: number
+    description: >-
+      The particle heads towards the location of the target object as defined by
+      PSYS_SRC_TARGET_KEY.
+  PSYS_PART_WIND_MASK:
+    property: read-only
+    type: number
+    description: Particles have their velocity damped towards the wind velocity.
+  PSYS_SRC_ACCEL:
+    property: read-only
+    type: number
+    description: A vector <x, y, z> which is the acceleration to apply on particles.
+  PSYS_SRC_ANGLE_BEGIN:
+    property: read-only
+    type: number
+    description: >-
+      Area in radians specifying where particles will NOT be created (for ANGLE
+      patterns)
+  PSYS_SRC_ANGLE_END:
+    property: read-only
+    type: number
+    description: >-
+      Area in radians filled with particles (for ANGLE patterns) (if lower than
+      PSYS_SRC_ANGLE_BEGIN, acts as PSYS_SRC_ANGLE_BEGIN itself, and
+      PSYS_SRC_ANGLE_BEGIN acts as PSYS_SRC_ANGLE_END).
+  PSYS_SRC_BURST_PART_COUNT:
+    property: read-only
+    type: number
+    description: How many particles to release in a burst.
+  PSYS_SRC_BURST_RADIUS:
+    property: read-only
+    type: number
+    description: What distance from the center of the object to create the particles.
+  PSYS_SRC_BURST_RATE:
+    property: read-only
+    type: number
+    description: How often to release a particle burst (float seconds).
+  PSYS_SRC_BURST_SPEED_MAX:
+    property: read-only
+    type: number
+    description: Maximum speed that a particle should be moving.
+  PSYS_SRC_BURST_SPEED_MIN:
+    property: read-only
+    type: number
+    description: Minimum speed that a particle should be moving.
+  PSYS_SRC_INNERANGLE:
+    property: read-only
+    type: number
+    description: "Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area specified will NOT have particles in it."
+  PSYS_SRC_MAX_AGE:
+    property: read-only
+    type: number
+    description: How long this particle system should last, 0.0 means forever.
+  PSYS_SRC_OMEGA:
+    property: read-only
+    type: number
+    description: >-
+      Sets the angular velocity to rotate the axis that SRC_PATTERN_ANGLE and
+      SRC_PATTERN_ANGLE_CONE use.
+  PSYS_SRC_OUTERANGLE:
+    property: read-only
+    type: number
+    description: "Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area between the outer and inner angle will be filled with particles."
+  PSYS_SRC_PATTERN:
+    property: read-only
+    type: number
+    description: "The pattern which is used to generate particles.\n\t\t\tUse one of the following values: PSYS_SRC_PATTERN Values."
+  PSYS_SRC_PATTERN_ANGLE:
+    property: read-only
+    type: number
+    description: >-
+      Shoot particles across a 2 dimensional area defined by the arc created
+      from PSYS_SRC_OUTERANGLE. There will be an open area defined by
+      PSYS_SRC_INNERANGLE within the larger arc.
+  PSYS_SRC_PATTERN_ANGLE_CONE:
+    property: read-only
+    type: number
+    description: >-
+      Shoot particles out in a 3 dimensional cone with an outer arc of
+      PSYS_SRC_OUTERANGLE and an inner open area defined by PSYS_SRC_INNERANGLE.
+  PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY:
+    property: read-only
+    type: number
+  PSYS_SRC_PATTERN_DROP:
+    property: read-only
+    type: number
+    description: Drop particles at the source position.
+  PSYS_SRC_PATTERN_EXPLODE:
+    property: read-only
+    type: number
+    description: Shoot particles out in all directions, using the burst parameters.
+  PSYS_SRC_TARGET_KEY:
+    property: read-only
+    type: number
+    description: >-
+      The key of a target object to move towards if PSYS_PART_TARGET_POS_MASK is
+      enabled.
+  PSYS_SRC_TEXTURE:
+    property: read-only
+    type: number
+    description: An asset name for the texture to use for the particles.
+  PUBLIC_CHANNEL:
+    property: read-only
+    type: number
+    description: >-
+      PUBLIC_CHANNEL is an integer constant that, when passed to llSay,
+      llWhisper, or llShout as a channel parameter, will print text to the
+      publicly heard chat channel.
+  PURSUIT_FUZZ_FACTOR:
+    property: read-only
+    type: number
+    description: Selects a random destination near the offset.
+  PURSUIT_GOAL_TOLERANCE:
+    property: read-only
+    type: number
+  PURSUIT_INTERCEPT:
+    property: read-only
+    type: number
+    description: Define whether the character attempts to predict the target's location.
+  PURSUIT_OFFSET:
+    property: read-only
+    type: number
+    description: Go to a position offset from the target.
+  PU_EVADE_HIDDEN:
+    property: read-only
+    type: number
+    description: Triggered when an llEvade character thinks it has hidden from its pursuer.
+  PU_EVADE_SPOTTED:
+    property: read-only
+    type: number
+    description: Triggered when an llEvade character switches from hiding to running
+  PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED:
+    property: read-only
+    type: number
+  PU_FAILURE_INVALID_GOAL:
+    property: read-only
+    type: number
+    description: Goal is not on the navigation-mesh and cannot be reached.
+  PU_FAILURE_INVALID_START:
+    property: read-only
+    type: number
+    description: >-
+      Character cannot navigate from the current location - e.g., the character
+      is off the navmesh or too high above it.
+  PU_FAILURE_NO_NAVMESH:
+    property: read-only
+    type: number
+    description: >-
+      This is a fatal error reported to a character when there is no navmesh for
+      the region. This usually indicates a server failure and users should file
+      a bug report and include the time and region in which they received this
+      message.
+  PU_FAILURE_NO_VALID_DESTINATION:
+    property: read-only
+    type: number
+    description: >-
+      There is no good place for the character to go - e.g., it is patrolling
+      and all the patrol points are now unreachable.
+  PU_FAILURE_OTHER:
+    property: read-only
+    type: number
+  PU_FAILURE_PARCEL_UNREACHABLE:
+    property: read-only
+    type: number
+  PU_FAILURE_TARGET_GONE:
+    property: read-only
+    type: number
+    description: >-
+      Target (for llPursue or llEvade) can no longer be tracked - e.g., it left
+      the region or is an avatar that is now more than about 30m outside the
+      region.
+  PU_FAILURE_UNREACHABLE:
+    property: read-only
+    type: number
+    description: >-
+      Goal is no longer reachable for some reason - e.g., an obstacle blocks the
+      path.
+  PU_GOAL_REACHED:
+    property: read-only
+    type: number
+    description: >-
+      Character has reached the goal and will stop or choose a new goal (if
+      wandering).
+  PU_SLOWDOWN_DISTANCE_REACHED:
+    property: read-only
+    type: number
+    description: Character is near current goal.
+  RAD_TO_DEG:
+    property: read-only
+    type: number
+    description: >-
+      57.2957795 - Number of degrees per radian. You can use this number to
+      convert radians to degrees by multiplying the radians by this number.
+  RCERR_CAST_TIME_EXCEEDED:
+    property: read-only
+    type: number
+  RCERR_SIM_PERF_LOW:
+    property: read-only
+    type: number
+  RCERR_UNKNOWN:
+    property: read-only
+    type: number
+  RC_DATA_FLAGS:
+    property: read-only
+    type: number
+  RC_DETECT_PHANTOM:
+    property: read-only
+    type: number
+  RC_GET_LINK_NUM:
+    property: read-only
+    type: number
+  RC_GET_NORMAL:
+    property: read-only
+    type: number
+  RC_GET_ROOT_KEY:
+    property: read-only
+    type: number
+  RC_MAX_HITS:
+    property: read-only
+    type: number
+  RC_REJECT_AGENTS:
+    property: read-only
+    type: number
+  RC_REJECT_LAND:
+    property: read-only
+    type: number
+  RC_REJECT_NONPHYSICAL:
+    property: read-only
+    type: number
+  RC_REJECT_PHYSICAL:
+    property: read-only
+    type: number
+  RC_REJECT_TYPES:
+    property: read-only
+    type: number
+  REGION_FLAG_ALLOW_DAMAGE:
+    property: read-only
+    type: number
+  REGION_FLAG_ALLOW_DIRECT_TELEPORT:
+    property: read-only
+    type: number
+  REGION_FLAG_BLOCK_FLY:
+    property: read-only
+    type: number
+  REGION_FLAG_BLOCK_FLYOVER:
+    property: read-only
+    type: number
+  REGION_FLAG_BLOCK_TERRAFORM:
+    property: read-only
+    type: number
+  REGION_FLAG_DISABLE_COLLISIONS:
+    property: read-only
+    type: number
+  REGION_FLAG_DISABLE_PHYSICS:
+    property: read-only
+    type: number
+  REGION_FLAG_FIXED_SUN:
+    property: read-only
+    type: number
+  REGION_FLAG_RESTRICT_PUSHOBJECT:
+    property: read-only
+    type: number
+  REGION_FLAG_SANDBOX:
+    property: read-only
+    type: number
+  REMOTE_DATA_CHANNEL:
+    property: read-only
+    type: number
+  REMOTE_DATA_REPLY:
+    property: read-only
+    type: number
+  REMOTE_DATA_REQUEST:
+    property: read-only
+    type: number
+  REQUIRE_LINE_OF_SIGHT:
+    property: read-only
+    type: number
+    description: Define whether the character needs a line-of-sight to give chase.
+  RESTITUTION:
+    property: read-only
+    type: number
+    description: >-
+      Used with llSetPhysicsMaterial to enable the density value. Must be
+      between 0.0 and 1.0
+  REVERSE:
+    property: read-only
+    type: number
+    description: Play animation in reverse direction.
+  REZ_ACCEL:
+    property: read-only
+    type: number
+    description: >-
+      Acceleration forced applied to the rezzed object. [vector force, integer
+      rel]
+  REZ_DAMAGE:
+    property: read-only
+    type: number
+    description: >-
+      Damage applied by the object when it collides with an agent. [float
+      damage]
+  REZ_DAMAGE_TYPE:
+    property: read-only
+    type: number
+    description: >-
+      Set the damage type applied when this object collides. [integer
+      damage_type]
+  REZ_FLAGS:
+    property: read-only
+    type: number
+    description: Rez flags to set on the newly rezzed object. [integer flags]
+  REZ_FLAG_BLOCK_GRAB_OBJECT:
+    property: read-only
+    type: number
+    description: Prevent grabbing the object.
+  REZ_FLAG_DIE_ON_COLLIDE:
+    property: read-only
+    type: number
+    description: Object will die after its first collision.
+  REZ_FLAG_DIE_ON_NOENTRY:
+    property: read-only
+    type: number
+    description: Object will die if it attempts to enter a parcel that it can not.
+  REZ_FLAG_NO_COLLIDE_FAMILY:
+    property: read-only
+    type: number
+    description: >-
+      Object will not trigger collision events with other objects created by the
+      same rezzer.
+  REZ_FLAG_NO_COLLIDE_OWNER:
+    property: read-only
+    type: number
+    description: Object will not trigger collision events with its owner.
+  REZ_FLAG_PHANTOM:
+    property: read-only
+    type: number
+    description: Make the object phantom on rez.
+  REZ_FLAG_PHYSICAL:
+    property: read-only
+    type: number
+    description: Make the object physical on rez.
+  REZ_FLAG_TEMP:
+    property: read-only
+    type: number
+    description: Flag the object as temp on rez.
+  REZ_LOCK_AXES:
+    property: read-only
+    type: number
+    description: Prevent the object from rotating around some axes. [vector locks]
+  REZ_OMEGA:
+    property: read-only
+    type: number
+    description: >-
+      Omega applied to the rezzed object. [vector axis, integer rel, float spin,
+      float gain]
+  REZ_PARAM:
+    property: read-only
+    type: number
+    description: Integer value to pass to the object as its rez parameter. [integer param]
+  REZ_PARAM_STRING:
+    property: read-only
+    type: number
+    description: A string value to pass to the object as its rez parameter. [string param]
+  REZ_POS:
+    property: read-only
+    type: number
+    description: >-
+      Position at which to rez the new object. [vector position, integer rel,
+      integer atroot]
+  REZ_ROT:
+    property: read-only
+    type: number
+    description: Rotation applied to newly rezzed object. [rotation rot, integer rel]
+  REZ_SOUND:
+    property: read-only
+    type: number
+    description: >-
+      Sound attached to the rezzed object. [string name, float volume, integer
+      loop]
+  REZ_SOUND_COLLIDE:
+    property: read-only
+    type: number
+    description: Sound played by the object on a collision. [string name, float volume]
+  REZ_VEL:
+    property: read-only
+    type: number
+    description: >-
+      Initial velocity of rezzed object. [vector vel, integer rel, integer
+      inherit]
+  ROTATE:
+    property: read-only
+    type: number
+    description: Animate texture rotation.
+  SCALE:
+    property: read-only
+    type: number
+    description: Animate the texture scale.
+  SCRIPTED:
+    property: read-only
+    type: number
+    description: Scripted in-world objects.
+  SIM_STAT_ACTIVE_SCRIPT_COUNT:
+    property: read-only
+    type: number
+    description: Number of active scripts.
+  SIM_STAT_AGENT_COUNT:
+    property: read-only
+    type: number
+    description: Number of agents in region.
+  SIM_STAT_AGENT_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'agent' segment of simulation frame.
+  SIM_STAT_AGENT_UPDATES:
+    property: read-only
+    type: number
+    description: Agent updates per second.
+  SIM_STAT_AI_MS:
+    property: read-only
+    type: number
+    description: Time spent on AI step.
+  SIM_STAT_ASSET_DOWNLOADS:
+    property: read-only
+    type: number
+    description: Pending asset download count.
+  SIM_STAT_ASSET_UPLOADS:
+    property: read-only
+    type: number
+    description: Pending asset upload count.
+  SIM_STAT_CHILD_AGENT_COUNT:
+    property: read-only
+    type: number
+    description: Number of child agents in region.
+  SIM_STAT_FRAME_MS:
+    property: read-only
+    type: number
+    description: Total frame time.
+  SIM_STAT_IMAGE_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'image' segment of simulation frame.
+  SIM_STAT_IO_PUMP_MS:
+    property: read-only
+    type: number
+    description: Pump IO time.
+  SIM_STAT_NET_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'network' segment of simulation frame.
+  SIM_STAT_OTHER_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'other' segment of simulation frame.
+  SIM_STAT_PACKETS_IN:
+    property: read-only
+    type: number
+    description: Packets in per second.
+  SIM_STAT_PACKETS_OUT:
+    property: read-only
+    type: number
+    description: Packets out per second.
+  SIM_STAT_PCT_CHARS_STEPPED:
+    property: read-only
+    type: number
+    description: >-
+      Returns the % of pathfinding characters skipped each frame, averaged over
+      the last minute.\nThe returned value corresponds to the "Characters
+      Updated" stat in the viewer's Statistics Bar.
+  SIM_STAT_PHYSICS_FPS:
+    property: read-only
+    type: number
+    description: Physics simulation FPS.
+  SIM_STAT_PHYSICS_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'physics' segment of simulation frame.
+  SIM_STAT_PHYSICS_OTHER_MS:
+    property: read-only
+    type: number
+    description: Physics other time.
+  SIM_STAT_PHYSICS_SHAPE_MS:
+    property: read-only
+    type: number
+    description: Physics shape update time.
+  SIM_STAT_PHYSICS_STEP_MS:
+    property: read-only
+    type: number
+    description: Physics step time.
+  SIM_STAT_SCRIPT_EPS:
+    property: read-only
+    type: number
+    description: Script events per second.
+  SIM_STAT_SCRIPT_MS:
+    property: read-only
+    type: number
+    description: Time spent in 'script' segment of simulation frame.
+  SIM_STAT_SCRIPT_RUN_PCT:
+    property: read-only
+    type: number
+    description: Percent of scripts run during frame.
+  SIM_STAT_SLEEP_MS:
+    property: read-only
+    type: number
+    description: Time spent sleeping.
+  SIM_STAT_SPARE_MS:
+    property: read-only
+    type: number
+    description: Spare time left after frame.
+  SIM_STAT_UNACKED_BYTES:
+    property: read-only
+    type: number
+    description: Total unacknowledged bytes.
+  SIT_FLAG_ALLOW_UNSIT:
+    property: read-only
+    type: number
+    description: The prim allows a seated avatar to stand up.
+  SIT_FLAG_NO_COLLIDE:
+    property: read-only
+    type: number
+    description: The seated avatar's hit box is disabled when seated on this prim.
+  SIT_FLAG_NO_DAMAGE:
+    property: read-only
+    type: number
+    description: Damage will not be forwarded to an avatar seated on this prim.
+  SIT_FLAG_SCRIPTED_ONLY:
+    property: read-only
+    type: number
+    description: An avatar may not manually sit on this prim.
+  SIT_FLAG_SIT_TARGET:
+    property: read-only
+    type: number
+    description: The prim has an explicitly set sit target.
+  SIT_INVALID_AGENT:
+    property: read-only
+    type: number
+    description: Avatar ID did not specify a valid avatar.
+  SIT_INVALID_LINK:
+    property: read-only
+    type: number
+    description: >-
+      Link ID did not specify a valid prim in the linkset or resolved to
+      multiple prims.
+  SIT_INVALID_OBJECT:
+    property: read-only
+    type: number
+    description: >-
+      Attempt to force an avatar to sit on an attachment or other invalid
+      target.
+  SIT_NOT_EXPERIENCE:
+    property: read-only
+    type: number
+    description: Attempt to force an avatar to sit outside an experience.
+  SIT_NO_ACCESS:
+    property: read-only
+    type: number
+    description: >-
+      Avatar does not have access to the parcel containing the target linkset of
+      the forced sit.
+  SIT_NO_EXPERIENCE_PERMISSION:
+    property: read-only
+    type: number
+    description: Avatar has not granted permission to force sits.
+  SIT_NO_SIT_TARGET:
+    property: read-only
+    type: number
+    description: No available sit target in linkset for forced sit.
+  SKY_AMBIENT:
+    property: read-only
+    type: number
+    description: The ambient color of the environment
+  SKY_BLUE:
+    property: read-only
+    type: number
+    description: Blue settings for environment
+  SKY_CLOUDS:
+    property: read-only
+    type: number
+    description: Settings controlling cloud density and configuration
+  SKY_CLOUD_TEXTURE:
+    property: read-only
+    type: number
+    description: Texture ID used by clouds
+  SKY_DOME:
+    property: read-only
+    type: number
+    description: Sky dome information.
+  SKY_GAMMA:
+    property: read-only
+    type: number
+    description: The gamma value applied to the scene.
+  SKY_GLOW:
+    property: read-only
+    type: number
+    description: Glow color applied to the sun and moon.
+  SKY_HAZE:
+    property: read-only
+    type: number
+    description: Haze settings for environment
+  SKY_LIGHT:
+    property: read-only
+    type: number
+    description: Miscellaneous lighting values.
+  SKY_MOON:
+    property: read-only
+    type: number
+    description: Environmental moon details.
+  SKY_MOON_TEXTURE:
+    property: read-only
+    type: number
+    description: Environmental moon texture.
+  SKY_PLANET:
+    property: read-only
+    type: number
+    description: Planet information used in rendering the sky.
+  SKY_REFLECTION_PROBE_AMBIANCE:
+    property: read-only
+    type: number
+    description: Settings the ambience of the reflection probe.
+  SKY_REFRACTION:
+    property: read-only
+    type: number
+    description: Sky refraction parameters for rainbows and optical effects.
+  SKY_STAR_BRIGHTNESS:
+    property: read-only
+    type: number
+    description: Brightness value for the stars.
+  SKY_SUN:
+    property: read-only
+    type: number
+    description: Detailed sun information
+  SKY_SUN_TEXTURE:
+    property: read-only
+    type: number
+    description: Environmental sun texture
+  SKY_TEXTURE_DEFAULTS:
+    property: read-only
+    type: number
+    description: Is the environment using the default textures.
+  SKY_TRACKS:
+    property: read-only
+    type: number
+    description: Track elevations for this region.
+  SMOOTH:
+    property: read-only
+    type: number
+    description: Slide in the X direction, instead of playing separate frames.
+  SOUND_LOOP:
+    property: read-only
+    type: number
+    description: Sound will loop until stopped.
+  SOUND_PLAY:
+    property: read-only
+    type: number
+    description: Sound will play normally.
+  SOUND_SYNC:
+    property: read-only
+    type: number
+    description: Sound will be synchronized with the nearest master.
+  SOUND_TRIGGER:
+    property: read-only
+    type: number
+    description: Sound will be triggered at the prim's location and not attached.
+  SQRT2:
+    property: read-only
+    type: number
+    description: 1.41421356 - The square root of 2.
+  STATUS_BLOCK_GRAB:
+    property: read-only
+    type: number
+    description: >-
+      Controls whether the object can be grabbed.\nA grab is the default action
+      when in third person, and is available as the hand tool in build mode.
+      This is useful for physical objects that you don't want other people to be
+      able to trivially disturb. The default is FALSE
+  STATUS_BLOCK_GRAB_OBJECT:
+    property: read-only
+    type: number
+    description: Prevent click-and-drag movement on all prims in the object.
+  STATUS_BOUNDS_ERROR:
+    property: read-only
+    type: number
+    description: Argument(s) passed to function had a bounds error.
+  STATUS_CAST_SHADOWS:
+    property: read-only
+    type: number
+  STATUS_DIE_AT_EDGE:
+    property: read-only
+    type: number
+    description: >-
+      Controls whether the object is returned to the owner's inventory if it
+      wanders off the edge of the world.\nIt is useful to set this status TRUE
+      for things like bullets or rockets. The default is TRUE
+  STATUS_DIE_AT_NO_ENTRY:
+    property: read-only
+    type: number
+    description: >-
+      Controls whether the object dies if it attempts to enter a parcel that
+      does not allow object entry or does not have enough capacity.\nIt is
+      useful to set this status TRUE for things like bullets or rockets. The
+      default is FALSE
+  STATUS_INTERNAL_ERROR:
+    property: read-only
+    type: number
+    description: An internal error occurred.
+  STATUS_MALFORMED_PARAMS:
+    property: read-only
+    type: number
+    description: Function was called with malformed parameters.
+  STATUS_NOT_FOUND:
+    property: read-only
+    type: number
+    description: Object or other item was not found.
+  STATUS_NOT_SUPPORTED:
+    property: read-only
+    type: number
+    description: Feature not supported.
+  STATUS_OK:
+    property: read-only
+    type: number
+    description: Result of function call was a success.
+  STATUS_PHANTOM:
+    property: read-only
+    type: number
+    description: >-
+      Controls/indicates whether the object collides or not.\nSetting the value
+      to TRUE makes the object non-colliding with all objects. It is a good idea
+      to use this for most objects that move or rotate, but are non-physical. It
+      is also useful for simulating volumetric lighting. The default is FALSE.
+  STATUS_PHYSICS:
+    property: read-only
+    type: number
+    description: >-
+      Controls/indicates whether the object moves physically.\nThis controls the
+      same flag that the UI check-box for Physical controls. The default is
+      FALSE.
+  STATUS_RETURN_AT_EDGE:
+    property: read-only
+    type: number
+  STATUS_ROTATE_X:
+    property: read-only
+    type: number
+  STATUS_ROTATE_Y:
+    property: read-only
+    type: number
+  STATUS_ROTATE_Z:
+    property: read-only
+    type: number
+    description: "Controls/indicates whether the object can physically rotate around\n\t\t\tthe specific axis or not. This flag has no meaning\n\t\t\tfor non-physical objects. Set the value to FALSE\n\t\t\tif you want to disable rotation around that axis. The\n\t\t\tdefault is TRUE for a physical object.\n\t\t\tA useful example to think about when visualizing\n\t\t\tthe effect is a sit-and-spin device. They spin around the\n\t\t\tZ axis (up) but not around the X or Y axis."
+  STATUS_SANDBOX:
+    property: read-only
+    type: number
+    description: "Controls/indicates whether the object can cross region boundaries\n\t\t\tand move more than 20 meters from its creation\n\t\t\tpoint. The default if FALSE."
+  STATUS_TYPE_MISMATCH:
+    property: read-only
+    type: number
+    description: Argument(s) passed to function had a type mismatch.
+  STATUS_WHITELIST_FAILED:
+    property: read-only
+    type: number
+    description: Whitelist Failed.
+  STRING_TRIM:
+    property: read-only
+    type: number
+  STRING_TRIM_HEAD:
+    property: read-only
+    type: number
+  STRING_TRIM_TAIL:
+    property: read-only
+    type: number
+  TARGETED_EMAIL_OBJECT_OWNER:
+    property: read-only
+    type: number
+    description: Send email to the owner of the object
+  TARGETED_EMAIL_ROOT_CREATOR:
+    property: read-only
+    type: number
+    description: Send email to the creator of the root object
+  TERRAIN_DETAIL_1:
+    property: read-only
+    type: number
+  TERRAIN_DETAIL_2:
+    property: read-only
+    type: number
+  TERRAIN_DETAIL_3:
+    property: read-only
+    type: number
+  TERRAIN_DETAIL_4:
+    property: read-only
+    type: number
+  TERRAIN_HEIGHT_RANGE_NE:
+    property: read-only
+    type: number
+  TERRAIN_HEIGHT_RANGE_NW:
+    property: read-only
+    type: number
+  TERRAIN_HEIGHT_RANGE_SE:
+    property: read-only
+    type: number
+  TERRAIN_HEIGHT_RANGE_SW:
+    property: read-only
+    type: number
+  TERRAIN_PBR_OFFSET_1:
+    property: read-only
+    type: number
+  TERRAIN_PBR_OFFSET_2:
+    property: read-only
+    type: number
+  TERRAIN_PBR_OFFSET_3:
+    property: read-only
+    type: number
+  TERRAIN_PBR_OFFSET_4:
+    property: read-only
+    type: number
+  TERRAIN_PBR_ROTATION_1:
+    property: read-only
+    type: number
+  TERRAIN_PBR_ROTATION_2:
+    property: read-only
+    type: number
+  TERRAIN_PBR_ROTATION_3:
+    property: read-only
+    type: number
+  TERRAIN_PBR_ROTATION_4:
+    property: read-only
+    type: number
+  TERRAIN_PBR_SCALE_1:
+    property: read-only
+    type: number
+  TERRAIN_PBR_SCALE_2:
+    property: read-only
+    type: number
+  TERRAIN_PBR_SCALE_3:
+    property: read-only
+    type: number
+  TERRAIN_PBR_SCALE_4:
+    property: read-only
+    type: number
+  TEXTURE_BLANK:
+    property: read-only
+    type:
+      display: uuid
+  TEXTURE_DEFAULT:
+    property: read-only
+    type:
+      display: uuid
+  TEXTURE_MEDIA:
+    property: read-only
+    type:
+      display: uuid
+  TEXTURE_PLYWOOD:
+    property: read-only
+    type:
+      display: uuid
+  TEXTURE_TRANSPARENT:
+    property: read-only
+    type:
+      display: uuid
+  TOUCH_INVALID_FACE:
+    property: read-only
+    type: number
+  TOUCH_INVALID_TEXCOORD:
+    property: read-only
+    type:
+      display: vector
+  TOUCH_INVALID_VECTOR:
+    property: read-only
+    type:
+      display: vector
+  TP_ROUTING_BLOCKED:
+    property: read-only
+    type: number
+    description: Direct teleporting is blocked on this parcel.
+  TP_ROUTING_FREE:
+    property: read-only
+    type: number
+    description: Teleports are unrestricted on this parcel.
+  TP_ROUTING_LANDINGP:
+    property: read-only
+    type: number
+    description: Teleports are routed to a landing point if set on this parcel.
+  TRANSFER_BAD_OPTS:
+    property: read-only
+    type: number
+    description: Invalid inventory options.
+  TRANSFER_BAD_ROOT:
+    property: read-only
+    type: number
+    description: >-
+      The root path specified in TRANSFER_DEST contained an invalid directory or
+      was reduced to nothing.
+  TRANSFER_DEST:
+    property: read-only
+    type: number
+    description: The root folder to transfer inventory into.
+  TRANSFER_FLAGS:
+    property: read-only
+    type: number
+    description: Flags to control the behavior of inventory transfer.
+  TRANSFER_FLAG_COPY:
+    property: read-only
+    type: number
+    description: Gives a copy of the object being transfered. Implies TRANSFER_FLAG_TAKE.
+  TRANSFER_FLAG_RESERVED:
+    property: read-only
+    type: number
+    description: Reserved for future expansion.
+  TRANSFER_FLAG_TAKE:
+    property: read-only
+    type: number
+    description: On a successful transfer, automatically takes the object into inventory.
+  TRANSFER_NO_ATTACHMENT:
+    property: read-only
+    type: number
+    description: Can not transfer ownership of an attached object.
+  TRANSFER_NO_ITEMS:
+    property: read-only
+    type: number
+    description: No items in the inventory list are eligible for transfer.
+  TRANSFER_NO_PERMS:
+    property: read-only
+    type: number
+    description: The object does not have transfer permissions.
+  TRANSFER_NO_TARGET:
+    property: read-only
+    type: number
+    description: Could not find the receiver in the current region.
+  TRANSFER_OK:
+    property: read-only
+    type: number
+    description: Inventory transfer offer was successfully made.
+  TRANSFER_THROTTLE:
+    property: read-only
+    type: number
+    description: Inventory throttle hit.
+  TRAVERSAL_TYPE:
+    property: read-only
+    type: number
+    description: One of TRAVERSAL_TYPE_FAST, TRAVERSAL_TYPE_SLOW, and TRAVERSAL_TYPE_NONE.
+  TRAVERSAL_TYPE_FAST:
+    property: read-only
+    type: number
+  TRAVERSAL_TYPE_NONE:
+    property: read-only
+    type: number
+  TRAVERSAL_TYPE_SLOW:
+    property: read-only
+    type: number
+  TWO_PI:
+    property: read-only
+    type: number
+    description: 6.28318530 - The radians of a circle.
+  TYPE_FLOAT:
+    property: read-only
+    type: number
+    description: The list entry is a float.
+  TYPE_INTEGER:
+    property: read-only
+    type: number
+    description: The list entry is an integer.
+  TYPE_INVALID:
+    property: read-only
+    type: number
+    description: The list entry is invalid.
+  TYPE_KEY:
+    property: read-only
+    type: number
+    description: The list entry is a key.
+  TYPE_ROTATION:
+    property: read-only
+    type: number
+    description: The list entry is a rotation.
+  TYPE_STRING:
+    property: read-only
+    type: number
+    description: The list entry is a string.
+  TYPE_VECTOR:
+    property: read-only
+    type: number
+    description: The list entry is a vector.
+  URL_REQUEST_DENIED:
+    property: read-only
+    type: string
+  URL_REQUEST_GRANTED:
+    property: read-only
+    type: string
+  VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY:
+    property: read-only
+    type: number
+    description: >-
+      A slider between minimum (0.0) and maximum (1.0) deflection of angular
+      orientation. That is, its a simple scalar for modulating the strength of
+      angular deflection such that the vehicles preferred axis of motion points
+      toward its real velocity.
+  VEHICLE_ANGULAR_DEFLECTION_TIMESCALE:
+    property: read-only
+    type: number
+    description: >-
+      The time-scale for exponential success of linear deflection deflection.
+      Its another way to specify the strength of the vehicles tendency to
+      reorient itself so that its preferred axis of motion agrees with its true
+      velocity.
+  VEHICLE_ANGULAR_FRICTION_TIMESCALE:
+    property: read-only
+    type: number
+    description: "A vector of timescales for exponential decay of the vehicle's angular velocity about its preferred axes of motion (at, left, up).\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+  VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE:
+    property: read-only
+    type: number
+    description: The timescale for exponential decay of the angular motors magnitude.
+  VEHICLE_ANGULAR_MOTOR_DIRECTION:
+    property: read-only
+    type: number
+    description: >-
+      The direction and magnitude (in preferred frame) of the vehicle's angular
+      motor. The vehicle will accelerate (or decelerate if necessary) to match
+      its velocity to its motor.
+  VEHICLE_ANGULAR_MOTOR_TIMESCALE:
+    property: read-only
+    type: number
+    description: The timescale for exponential approach to full angular motor velocity.
+  VEHICLE_BANKING_EFFICIENCY:
+    property: read-only
+    type: number
+    description: >-
+      A slider between anti (-1.0), none (0.0), and maxmum (1.0) banking
+      strength.
+  VEHICLE_BANKING_MIX:
+    property: read-only
+    type: number
+    description: >-
+      A slider between static (0.0) and dynamic (1.0) banking. "Static" means
+      the banking scales only with the angle of roll, whereas "dynamic" is a
+      term that also scales with the vehicles linear speed.
+  VEHICLE_BANKING_TIMESCALE:
+    property: read-only
+    type: number
+    description: >-
+      The timescale for banking to exponentially approach its maximum effect.
+      This is another way to scale the strength of the banking effect, however
+      it affects the term that is proportional to the difference between what
+      the banking behavior is trying to do, and what the vehicle is actually
+      doing.
+  VEHICLE_BUOYANCY:
+    property: read-only
+    type: number
+    description: A slider between minimum (0.0) and maximum anti-gravity (1.0).
+  VEHICLE_FLAG_BLOCK_INTERFERENCE:
+    property: read-only
+    type: number
+    description: Prevent other scripts from pushing vehicle.
+  VEHICLE_FLAG_CAMERA_DECOUPLED:
+    property: read-only
+    type: number
+  VEHICLE_FLAG_HOVER_GLOBAL_HEIGHT:
+    property: read-only
+    type: number
+    description: Hover at global height.
+  VEHICLE_FLAG_HOVER_TERRAIN_ONLY:
+    property: read-only
+    type: number
+    description: Ignore water height when hovering.
+  VEHICLE_FLAG_HOVER_UP_ONLY:
+    property: read-only
+    type: number
+    description: >-
+      Hover does not push down. Use this flag for hovering vehicles that should
+      be able to jump above their hover height.
+  VEHICLE_FLAG_HOVER_WATER_ONLY:
+    property: read-only
+    type: number
+    description: Ignore terrain height when hovering.
+  VEHICLE_FLAG_LIMIT_MOTOR_UP:
+    property: read-only
+    type: number
+    description: Prevents ground vehicles from motoring into the sky.
+  VEHICLE_FLAG_LIMIT_ROLL_ONLY:
+    property: read-only
+    type: number
+    description: >-
+      For vehicles with vertical attractor that want to be able to climb/dive,
+      for instance, aeroplanes that want to use the banking feature.
+  VEHICLE_FLAG_MOUSELOOK_BANK:
+    property: read-only
+    type: number
+  VEHICLE_FLAG_MOUSELOOK_STEER:
+    property: read-only
+    type: number
+  VEHICLE_FLAG_NO_DEFLECTION_UP:
+    property: read-only
+    type: number
+    description: >-
+      This flag prevents linear deflection parallel to world z-axis. This is
+      useful for preventing ground vehicles with large linear deflection, like
+      bumper cars, from climbing their linear deflection into the sky.
+  VEHICLE_FLAG_NO_FLY_UP:
+    property: read-only
+    type: number
+    description: Old, changed to VEHICLE_FLAG_NO_DEFLECTION_UP
+  VEHICLE_HOVER_EFFICIENCY:
+    property: read-only
+    type: number
+    description: >-
+      A slider between minimum (0.0 = bouncy) and maximum (1.0 = fast as
+      possible) damped motion of the hover behavior. 
+  VEHICLE_HOVER_HEIGHT:
+    property: read-only
+    type: number
+    description: >-
+      The height (above the terrain or water, or global) at which the vehicle
+      will try to hover.
+  VEHICLE_HOVER_TIMESCALE:
+    property: read-only
+    type: number
+    description: Period of time (in seconds) for the vehicle to achieve its hover height.
+  VEHICLE_LINEAR_DEFLECTION_EFFICIENCY:
+    property: read-only
+    type: number
+    description: >-
+      A slider between minimum (0.0) and maximum (1.0) deflection of linear
+      velocity. That is, its a simple scalar for modulating the strength of
+      linear deflection.
+  VEHICLE_LINEAR_DEFLECTION_TIMESCALE:
+    property: read-only
+    type: number
+    description: >-
+      The timescale for exponential success of linear deflection deflection. It
+      is another way to specify how much time it takes for the vehicle's linear
+      velocity to be redirected to its preferred axis of motion.
+  VEHICLE_LINEAR_FRICTION_TIMESCALE:
+    property: read-only
+    type: number
+    description: "A vector of timescales for exponential decay of the vehicle's linear velocity along its preferred axes of motion (at, left, up).\n\t\t\tRange = [0.07, inf) seconds for each element of the vector."
+  VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE:
+    property: read-only
+    type: number
+    description: The timescale for exponential decay of the linear motors magnitude.
+  VEHICLE_LINEAR_MOTOR_DIRECTION:
+    property: read-only
+    type: number
+    description: "The direction and magnitude (in preferred frame) of the vehicle's linear motor. The vehicle will accelerate (or decelerate if necessary) to match its velocity to its motor.\n\t\t\tRange of magnitude = [0, 30] meters/second."
+  VEHICLE_LINEAR_MOTOR_OFFSET:
+    property: read-only
+    type: number
+  VEHICLE_LINEAR_MOTOR_TIMESCALE:
+    property: read-only
+    type: number
+    description: The timescale for exponential approach to full linear motor velocity.
+  VEHICLE_REFERENCE_FRAME:
+    property: read-only
+    type: number
+    description: >-
+      A rotation of the vehicle's preferred axes of motion and orientation (at,
+      left, up) with respect to the vehicle's local frame (x, y, z).
+  VEHICLE_TYPE_AIRPLANE:
+    property: read-only
+    type: number
+    description: >-
+      Uses linear deflection for lift, no hover, and banking to turn.\nSee
+      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_AIRPLANE
+  VEHICLE_TYPE_BALLOON:
+    property: read-only
+    type: number
+    description: >-
+      Hover, and friction, but no deflection.\nSee
+      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BALLOON
+  VEHICLE_TYPE_BOAT:
+    property: read-only
+    type: number
+    description: >-
+      Hovers over water with lots of friction and some anglar deflection.\nSee
+      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BOAT
+  VEHICLE_TYPE_CAR:
+    property: read-only
+    type: number
+    description: >-
+      Another vehicle that bounces along the ground but needs the motors to be
+      driven from external controls or timer events.\nSee
+      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_CAR
+  VEHICLE_TYPE_NONE:
+    property: read-only
+    type: number
+  VEHICLE_TYPE_SLED:
+    property: read-only
+    type: number
+    description: >-
+      Simple vehicle that bumps along the ground, and likes to move along its
+      local x-axis.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_SLED
+  VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY:
+    property: read-only
+    type: number
+    description: >-
+      A slider between minimum (0.0 = wobbly) and maximum (1.0 = firm as
+      possible) stability of the vehicle to keep itself upright.
+  VEHICLE_VERTICAL_ATTRACTION_TIMESCALE:
+    property: read-only
+    type: number
+    description: >-
+      The period of wobble, or timescale for exponential approach, of the
+      vehicle to rotate such that its preferred "up" axis is oriented along the
+      world's "up" axis.
+  VERTICAL:
+    property: read-only
+    type: number
+  WANDER_PAUSE_AT_WAYPOINTS:
+    property: read-only
+    type: number
+  WATER_BLUR_MULTIPLIER:
+    property: read-only
+    type: number
+    description: Blur factor.
+  WATER_FOG:
+    property: read-only
+    type: number
+    description: Fog properties when underwater.
+  WATER_FRESNEL:
+    property: read-only
+    type: number
+    description: Fresnel scattering applied to the surface of the water.
+  WATER_NORMAL_SCALE:
+    property: read-only
+    type: number
+    description: Scaling applied to the water normal map.
+  WATER_NORMAL_TEXTURE:
+    property: read-only
+    type: number
+    description: Normal map used for environmental waves.
+  WATER_REFRACTION:
+    property: read-only
+    type: number
+    description: Refraction factors when looking through the surface of the water.
+  WATER_TEXTURE_DEFAULTS:
+    property: read-only
+    type: number
+    description: Is the environment using the default wave map.
+  WATER_WAVE_DIRECTION:
+    property: read-only
+    type: number
+    description: Vectors for the directions of the waves.
+  XP_ERROR_EXPERIENCES_DISABLED:
+    property: read-only
+    type: number
+    description: The region currently has experiences disabled.
+  XP_ERROR_EXPERIENCE_DISABLED:
+    property: read-only
+    type: number
+    description: The experience owner has temporarily disabled the experience.
+  XP_ERROR_EXPERIENCE_SUSPENDED:
+    property: read-only
+    type: number
+    description: The experience has been suspended by Linden Customer Support.
+  XP_ERROR_INVALID_EXPERIENCE:
+    property: read-only
+    type: number
+    description: The script is associated with an experience that no longer exists.
+  XP_ERROR_INVALID_PARAMETERS:
+    property: read-only
+    type: number
+    description: One of the string arguments was too big to fit in the key-value store.
+  XP_ERROR_KEY_NOT_FOUND:
+    property: read-only
+    type: number
+    description: The requested key does not exist.
+  XP_ERROR_MATURITY_EXCEEDED:
+    property: read-only
+    type: number
+    description: The content rating of the experience exceeds that of the region.
+  XP_ERROR_NONE:
+    property: read-only
+    type: number
+    description: No error was detected.
+  XP_ERROR_NOT_FOUND:
+    property: read-only
+    type: number
+    description: >-
+      The sim was unable to verify the validity of the experience. Retrying
+      after a short wait is advised.
+  XP_ERROR_NOT_PERMITTED:
+    property: read-only
+    type: number
+    description: This experience is not allowed to run by the requested agent.
+  XP_ERROR_NOT_PERMITTED_LAND:
+    property: read-only
+    type: number
+    description: This experience is not allowed to run on the current region.
+  XP_ERROR_NO_EXPERIENCE:
+    property: read-only
+    type: number
+    description: This script is not associated with an experience.
+  XP_ERROR_QUOTA_EXCEEDED:
+    property: read-only
+    type: number
+    description: >-
+      An attempted write data to the key-value store failed due to the data
+      quota being met.
+  XP_ERROR_REQUEST_PERM_TIMEOUT:
+    property: read-only
+    type: number
+    description: Request timed out; permissions not modified.
+  XP_ERROR_RETRY_UPDATE:
+    property: read-only
+    type: number
+    description: A checked update failed due to an out of date request.
+  XP_ERROR_STORAGE_EXCEPTION:
+    property: read-only
+    type: number
+    description: Unable to communicate with the key-value store.
+  XP_ERROR_STORE_DISABLED:
+    property: read-only
+    type: number
+    description: The key-value store is currently disabled on this region.
+  XP_ERROR_THROTTLED:
+    property: read-only
+    type: number
+    description: The call failed due to too many recent calls.
+  XP_ERROR_UNKNOWN_ERROR:
+    property: read-only
+    type: number
+    description: Other unknown error.
+  ZERO_ROTATION:
+    property: read-only
+    type:
+      display: quaternion
+  ZERO_VECTOR:
+    property: read-only
+    type:
+      display: vector
+  default:
+    property: read-only
+    type: any
+    description: >-
+      All scripts must have a default state, which is the first state entered
+      when the script starts.
+
+      If another state is defined before the default state, the compiler will
+      report a syntax error.
+  quaternion:
+    type: any
+    description: Global 'quaternion' library table with callable metatable
+  rotation:
+    type: any
+    description: '''rotation'' global is an alias to the ''quaternion'' library'
+  uuid:
+    type: any
+    description: Global 'uuid' library table
+  vector:
+    type: any
+    description: Global 'vector' library table
+  LLEvents:
+    struct: LLEvents
+    description: Second Life event management and registration
+  LLTimers:
+    struct: LLTimers
+    description: Second Life timer management and scheduling
+  dangerouslyexecuterequiredmodule:
+    args:
+      - type: any
+    description: Dangerously executes a required module function
+  touuid:
+    args:
+      - type: any
+    description: Converts a string, buffer, or uuid to a uuid, returns nil if invalid
+  tovector:
+    args:
+      - type: any
+    description: Converts a value to a vector, returns nil if invalid
+  toquaternion:
+    args:
+      - type: any
+    description: Converts a value to a quaternion, returns nil if invalid
+  torotation:
+    args:
+      - type: any
+    description: Converts a value to a rotation (quaternion), returns nil if invalid
+  LLDetectedEvent:
+    any: true
+    description: >-
+      Event detection class providing access to detected object/avatar
+      information
+  bit32.arshift:
+    args:
+      - type: number
+      - type: number
+    description: Arithmetic right shift
+  bit32.band:
+    args:
+      - type: ...
+    description: Bitwise AND of all arguments
+  bit32.bnot:
+    args:
+      - type: number
+    description: Bitwise NOT
+  bit32.bor:
+    args:
+      - type: ...
+    description: Bitwise OR of all arguments
+  bit32.bxor:
+    args:
+      - type: ...
+    description: Bitwise XOR of all arguments
+  bit32.btest:
+    args:
+      - type: ...
+    description: Returns true if bitwise AND of all arguments is not zero
+  bit32.extract:
+    args:
+      - type: number
+      - type: number
+      - type: number
+        required: false
+    description: Extracts bits from n at position field with width
+  bit32.lrotate:
+    args:
+      - type: number
+      - type: number
+    description: Left rotate
+  bit32.lshift:
+    args:
+      - type: number
+      - type: number
+    description: Left shift
+  bit32.replace:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+        required: false
+    description: Replaces bits in n at position field with width using value v
+  bit32.rrotate:
+    args:
+      - type: number
+      - type: number
+    description: Right rotate
+  bit32.rshift:
+    args:
+      - type: number
+      - type: number
+    description: Right shift
+  bit32.countlz:
+    args:
+      - type: number
+    description: Count leading zeros
+  bit32.countrz:
+    args:
+      - type: number
+    description: Count trailing zeros
+  bit32.byteswap:
+    args:
+      - type: number
+    description: Swap byte order
+  buffer.create:
+    args:
+      - type: number
+    description: Creates a new buffer of the specified size
+  buffer.fromstring:
+    args:
+      - type: string
+    description: Creates a buffer from a string
+  buffer.tostring:
+    args:
+      - type: any
+    description: Converts buffer to string
+  buffer.readi8:
+    args:
+      - type: any
+      - type: number
+    description: Read signed 8-bit integer
+  buffer.readu8:
+    args:
+      - type: any
+      - type: number
+    description: Read unsigned 8-bit integer
+  buffer.readi16:
+    args:
+      - type: any
+      - type: number
+    description: Read signed 16-bit integer
+  buffer.readu16:
+    args:
+      - type: any
+      - type: number
+    description: Read unsigned 16-bit integer
+  buffer.readi32:
+    args:
+      - type: any
+      - type: number
+    description: Read signed 32-bit integer
+  buffer.readu32:
+    args:
+      - type: any
+      - type: number
+    description: Read unsigned 32-bit integer
+  buffer.readf32:
+    args:
+      - type: any
+      - type: number
+    description: Read 32-bit float
+  buffer.readf64:
+    args:
+      - type: any
+      - type: number
+    description: Read 64-bit float
+  buffer.writei8:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write signed 8-bit integer
+  buffer.writeu8:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write unsigned 8-bit integer
+  buffer.writei16:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write signed 16-bit integer
+  buffer.writeu16:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write unsigned 16-bit integer
+  buffer.writei32:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write signed 32-bit integer
+  buffer.writeu32:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write unsigned 32-bit integer
+  buffer.writef32:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write 32-bit float
+  buffer.writef64:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Write 64-bit float
+  buffer.readstring:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Read string from buffer
+  buffer.writestring:
+    args:
+      - type: any
+      - type: number
+      - type: string
+      - type: number
+        required: false
+    description: Write string to buffer
+  buffer.len:
+    args:
+      - type: any
+    description: Returns the length of the buffer
+  buffer.copy:
+    args:
+      - type: any
+      - type: number
+      - type: any
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Copy data from source buffer to target buffer
+  buffer.fill:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type: number
+        required: false
+    description: Fill buffer with a value
+  buffer.readbits:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: Read bits from buffer
+  buffer.writebits:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type: number
+    description: Write bits to buffer
+  coroutine.create:
+    args:
+      - type: any
+    description: Creates a new coroutine from a function
+  coroutine.resume:
+    args:
+      - type: any
+      - type: ...
+    description: Resumes a coroutine, returns success and results
+  coroutine.running:
+    args: []
+    description: Returns the running coroutine, or nil if called from main thread
+  coroutine.status:
+    args:
+      - type: any
+    description: Returns the status of a coroutine
+  coroutine.wrap:
+    args:
+      - type: any
+    description: Creates a coroutine and returns a function that resumes it
+  coroutine.yield:
+    args:
+      - type: ...
+    description: Suspends the coroutine and returns values to resume
+  coroutine.isyieldable:
+    args: []
+    description: Returns true if the coroutine can yield
+  coroutine.close:
+    args:
+      - type: any
+    description: Closes a coroutine, returns success and optional error message
+  debug.info:
+    args:
+      - type: any
+      - type: any
+      - type: string
+        required: false
+    description: 'OVERLOAD: Returns information about a function or stack level'
+  debug.traceback:
+    args:
+      - type: any
+        required: false
+      - type: any
+        required: false
+      - type: number
+        required: false
+    description: 'OVERLOAD: Returns a string with a traceback of the call stack'
+  llbase64.encode:
+    args:
+      - type: any
+    description: Encodes a string or buffer to base64
+  llbase64.decode:
+    args:
+      - type: string
+      - type: bool
+        required: false
+    description: 'OVERLOAD: Decodes a base64 string to a string'
+  lljson.encode:
+    args:
+      - type: any
+    description: Encodes a Lua value as JSON
+  lljson.decode:
+    args:
+      - type: string
+    description: Decodes a JSON string to a Lua value
+  lljson.slencode:
+    args:
+      - type: any
+      - type: bool
+        required: false
+    description: >-
+      Encodes a Lua value as JSON preserving SL types. Use tight to encode more
+      compactly.
+  lljson.sldecode:
+    args:
+      - type: string
+    description: Decodes a JSON string to a Lua value preserving SL types
+  math.abs:
+    args:
+      - type: number
+    description: Returns the absolute value of x
+  math.acos:
+    args:
+      - type: number
+    description: Returns the arc cosine of x (in radians)
+  math.asin:
+    args:
+      - type: number
+    description: Returns the arc sine of x (in radians)
+  math.atan:
+    args:
+      - type: number
+    description: Returns the arc tangent of x (in radians)
+  math.atan2:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Returns the arc tangent of y/x (in radians), using the signs to determine
+      the quadrant
+  math.ceil:
+    args:
+      - type: number
+    description: Returns the smallest integer larger than or equal to x
+  math.clamp:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: Returns n clamped between min and max
+  math.cos:
+    args:
+      - type: number
+    description: Returns the cosine of x (x in radians)
+  math.cosh:
+    args:
+      - type: number
+    description: Returns the hyperbolic cosine of x
+  math.deg:
+    args:
+      - type: number
+    description: Converts x from radians to degrees
+  math.exp:
+    args:
+      - type: number
+    description: Returns e^x
+  math.floor:
+    args:
+      - type: number
+    description: Returns the largest integer smaller than or equal to x
+  math.fmod:
+    args:
+      - type: number
+      - type: number
+    description: Returns the remainder of x/y that rounds towards zero
+  math.frexp:
+    args:
+      - type: number
+    description: Returns m and e such that x = m * 2^e
+  math.ldexp:
+    args:
+      - type: number
+      - type: number
+    description: Returns m * 2^e
+  math.lerp:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: Linear interpolation between a and b by t
+  math.log:
+    args:
+      - type: number
+      - type: number
+        required: false
+    description: Returns the logarithm of x in the given base (default e)
+  math.log10:
+    args:
+      - type: number
+    description: Returns the base-10 logarithm of x
+  math.map:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: Maps x from input range to output range
+  math.max:
+    args:
+      - type: number
+      - type: ...
+    description: Returns the maximum value among the arguments
+  math.min:
+    args:
+      - type: number
+      - type: ...
+    description: Returns the minimum value among the arguments
+  math.modf:
+    args:
+      - type: number
+    description: Returns the integer and fractional parts of x
+  math.noise:
+    args:
+      - type: number
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Returns Perlin noise value for the given coordinates
+  math.pow:
+    args:
+      - type: number
+      - type: number
+    description: Returns base^exponent
+  math.rad:
+    args:
+      - type: number
+    description: Converts x from degrees to radians
+  math.random:
+    args:
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Returns a pseudo-random number
+  math.randomseed:
+    args:
+      - type: number
+    description: Sets the seed for the pseudo-random generator
+  math.round:
+    args:
+      - type: number
+    description: Returns x rounded to the nearest integer
+  math.sign:
+    args:
+      - type: number
+    description: Returns -1, 0, or 1 depending on the sign of x
+  math.sin:
+    args:
+      - type: number
+    description: Returns the sine of x (x in radians)
+  math.sinh:
+    args:
+      - type: number
+    description: Returns the hyperbolic sine of x
+  math.sqrt:
+    args:
+      - type: number
+    description: Returns the square root of x
+  math.tan:
+    args:
+      - type: number
+    description: Returns the tangent of x (x in radians)
+  math.tanh:
+    args:
+      - type: number
+    description: Returns the hyperbolic tangent of x
+  math.isnan:
+    args:
+      - type: number
+    description: Returns true if x is NaN
+  math.isinf:
+    args:
+      - type: number
+    description: Returns true if x is infinite
+  math.isfinite:
+    args:
+      - type: number
+    description: Returns true if x is finite
+  os.clock:
+    args: []
+    description: Returns CPU time used by the program in seconds
+  os.date:
+    args:
+      - type: string
+        required: false
+      - type: number
+        required: false
+    description: Returns a string or table containing date and time
+  os.difftime:
+    args:
+      - type: number
+      - type: number
+        required: false
+    description: Returns the difference in seconds between two times
+  os.time:
+    args:
+      - type:
+          display: OsDateTime
+        required: false
+    description: Returns the current time or converts a table to time
+  string.byte:
+    args:
+      - type: string
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Returns the internal numeric codes of the characters
+  string.char:
+    args:
+      - type: ...
+    description: Returns a string from character codes
+  string.find:
+    args:
+      - type: string
+      - type: string
+      - type: number
+        required: false
+      - type: bool
+        required: false
+    description: Finds first match of pattern in string
+  string.format:
+    args:
+      - type: string
+      - type: ...
+    description: Returns a formatted string
+  string.gmatch:
+    args:
+      - type: string
+      - type: string
+    description: Returns an iterator function for pattern matches
+  string.gsub:
+    args:
+      - type: string
+      - type: string
+      - type: any
+      - type: number
+        required: false
+    description: Global substitution of pattern matches
+  string.len:
+    args:
+      - type: string
+    description: Returns the length of the string
+  string.lower:
+    args:
+      - type: string
+    description: Converts string to lowercase
+  string.match:
+    args:
+      - type: string
+      - type: string
+      - type: number
+        required: false
+    description: Returns captures from pattern match
+  string.pack:
+    args:
+      - type: string
+      - type: ...
+    description: Packs values into a binary string
+  string.packsize:
+    args:
+      - type: string
+    description: Returns the size of a packed string for the given format
+  string.rep:
+    args:
+      - type: string
+      - type: number
+    description: Returns a string repeated n times
+  string.reverse:
+    args:
+      - type: string
+    description: Reverses a string
+  string.split:
+    args:
+      - type: string
+      - type: string
+        required: false
+    description: Splits a string by separator
+  string.sub:
+    args:
+      - type: string
+      - type: number
+      - type: number
+        required: false
+    description: Returns a substring
+  string.unpack:
+    args:
+      - type: string
+      - type: string
+      - type: number
+        required: false
+    description: Unpacks values from a binary string
+  string.upper:
+    args:
+      - type: string
+    description: Converts string to uppercase
+  table.concat:
+    args:
+      - type: any
+      - type: string
+        required: false
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Concatenates table elements into a string
+  table.foreach:
+    args:
+      - type: any
+      - type: any
+    description: Iterates over table key-value pairs (deprecated)
+  table.foreachi:
+    args:
+      - type: any
+      - type: any
+    description: Iterates over array indices (deprecated)
+  table.getn:
+    args:
+      - type: any
+    description: 'Returns the length of a table (deprecated, use # operator)'
+  table.maxn:
+    args:
+      - type: any
+    description: Returns the largest positive numeric index
+  table.insert:
+    args:
+      - type: any
+      - type: any
+      - type: any
+        required: false
+    description: 'OVERLOAD: Inserts an element at the end of a list'
+  table.remove:
+    args:
+      - type: any
+      - type: number
+        required: false
+    description: Removes and returns an element from a list
+  table.sort:
+    args:
+      - type: any
+      - type: any
+        required: false
+    description: Sorts list elements in place
+  table.pack:
+    args:
+      - type: ...
+    description: Packs arguments into a table with length field n
+  table.unpack:
+    args:
+      - type: any
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Unpacks table elements as multiple return values
+  table.move:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type: number
+      - type: any
+        required: false
+    description: Moves elements from one table to another
+  table.create:
+    args:
+      - type: number
+      - type: any
+        required: false
+    description: Creates a new table with pre-allocated array slots
+  table.find:
+    args:
+      - type: any
+      - type: any
+      - type: number
+        required: false
+    description: Finds the index of a value in an array
+  table.clear:
+    args:
+      - type: any
+    description: Removes all elements from a table
+  table.freeze:
+    args:
+      - type: any
+    description: Makes a table read-only
+  table.isfrozen:
+    args:
+      - type: any
+    description: Returns true if a table is frozen
+  table.clone:
+    args:
+      - type: any
+    description: Creates a shallow copy of a table
+  utf8.char:
+    args:
+      - type: ...
+    description: Returns a string from UTF-8 codepoints
+  utf8.codes:
+    args:
+      - type: string
+    description: Returns an iterator for UTF-8 codepoints in a string
+  utf8.codepoint:
+    args:
+      - type: string
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: Returns the codepoints of characters in a string
+  utf8.len:
+    args:
+      - type: string
+      - type: number
+        required: false
+      - type: number
+        required: false
+    description: >-
+      Returns the number of UTF-8 characters in a string, or nil and error
+      position
+  utf8.offset:
+    args:
+      - type: string
+      - type: number
+      - type: number
+        required: false
+    description: Returns the byte position of the n-th character
+  ll.Abs:
+    args:
+      - type: number
+    description: Returns the absolute (positive) version of Value.
+  ll.Acos:
+    args:
+      - type: number
+    description: Returns the arc-cosine of Value, in radians.
+  ll.AddToLandBanList:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Add avatar ID to the parcel ban list for the specified number of Hours.\nA
+      value of 0 for Hours will add the agent indefinitely.\nThe smallest value
+      that Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen
+      values that small are used, it seems the function bans in approximately 30
+      second increments (Probably 36 second increments, as 0.01 of an hour is 36
+      seconds).\nResidents teleporting to a parcel where they are banned will be
+      redirected to a neighbouring parcel.
+  ll.AddToLandPassList:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: Add avatar ID to the land pass list, for a duration of Hours.
+  ll.AdjustSoundVolume:
+    args:
+      - type: number
+    description: >-
+      Adjusts the volume (0.0 - 1.0) of the currently playing attached
+      sound.\nThis function has no effect on sounds started with llTriggerSound.
+  ll.AgentInExperience:
+    args:
+      - type:
+          display: uuid
+    description: |2-
+
+                         Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
+                      
+  ll.AllowInventoryDrop:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      If Flag == TRUE, users without object modify permissions can still drop
+      inventory items into the object.
+  ll.AngleBetween:
+    args:
+      - type:
+          display: quaternion
+      - type:
+          display: quaternion
+    description: Returns the angle, in radians, between rotations Rot1 and Rot2.
+  ll.ApplyImpulse:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Applies impulse to the object.\nIf Local == TRUE, apply the Force in local
+      coordinates; otherwise, apply the Force in global coordinates.\nThis
+      function only works on physical objects.
+  ll.ApplyRotationalImpulse:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Applies rotational impulse to the object.\nIf Local == TRUE, apply the
+      Force in local coordinates; otherwise, apply the Force in global
+      coordinates.\nThis function only works on physical objects.
+  ll.Asin:
+    args:
+      - type: number
+    description: Returns the arc-sine, in radians, of Value.
+  ll.Atan2:
+    args:
+      - type: number
+      - type: number
+    description: Returns the arc-tangent2 of y, x.
+  ll.AttachToAvatar:
+    args:
+      - type: number
+    description: >-
+      Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH
+      runtime permission.
+  ll.AttachToAvatarTemp:
+    args:
+      - type: number
+    description: >-
+      Follows the same convention as llAttachToAvatar, with the exception that
+      the object will not create new inventory for the user, and will disappear
+      on detach or disconnect.
+  ll.AvatarOnLinkSitTarget:
+    args:
+      - type: number
+    description: >-
+      If an avatar is sitting on the link's sit target, return the avatar's key,
+      NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on
+      the specified link's prim.
+  ll.AvatarOnSitTarget:
+    args: []
+    description: >-
+      If an avatar is seated on the sit target, returns the avatar's key,
+      otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets
+      defined with llSitTarget.
+  ll.Axes2Rot:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: Returns the rotation represented by coordinate axes Forward, Left, and Up.
+  ll.AxisAngle2Rot:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: Returns the rotation that is a generated Angle about Axis.
+  ll.Base64ToInteger:
+    args:
+      - type: string
+    description: >-
+      Returns an integer that is the Text, Base64 decoded as a big endian
+      integer.\nReturns zero if Text is longer then 8 characters. If Text
+      contains fewer then 6 characters, the return value is unpredictable.
+  ll.Base64ToString:
+    args:
+      - type: string
+    description: >-
+      Converts a Base64 string to a conventional string.\nIf the conversion
+      creates any unprintable characters, they are converted to question marks.
+  ll.BreakAllLinks:
+    args: []
+    description: >-
+      De-links all prims in the link set (requires permission
+      PERMISSION_CHANGE_LINKS be set).
+  ll.BreakLink:
+    args:
+      - type: number
+    description: >-
+      De-links the prim with the given link number (requires permission
+      PERMISSION_CHANGE_LINKS be set).
+  ll.CSV2List:
+    args:
+      - type: string
+    description: Create a list from a string of comma separated values specified in Text.
+  ll.CastRay:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Casts a ray into the physics world from 'start' to 'end' and returns data
+      according to details in Options.\nReports collision data for intersections
+      with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1,
+      {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2},
+      ... , status_code] where {} indicates optional data.
+  ll.Ceil:
+    args:
+      - type: number
+    description: Returns smallest integer value >= Value.
+  ll.Char:
+    args:
+      - type: number
+    description: >-
+      Returns a single character string that is the representation of the
+      unicode value.
+  ll.ClearCameraParams:
+    args: []
+    description: >-
+      Resets all camera parameters to default values and turns off scripted
+      camera control.
+  ll.ClearLinkMedia:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Clears (deletes) the media and all parameters from the given Face on the
+      linked prim.\nReturns an integer that is a STATUS_* flag, which details
+      the success/failure of the operation.
+  ll.ClearPrimMedia:
+    args:
+      - type: number
+    description: >-
+      Clears (deletes) the media and all parameters from the given
+      Face.\nReturns an integer that is a STATUS_* flag which details the
+      success/failure of the operation.
+  ll.CloseRemoteDataChannel:
+    args:
+      - type:
+          display: uuid
+    description: This function is deprecated.
+  ll.Cloud:
+    args:
+      - type:
+          display: vector
+    description: Returns the cloud density at the object's position + Offset.
+  ll.CollisionFilter:
+    args:
+      - type: string
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Specify an empty string or NULL_KEY for Accept, to not filter on the
+      corresponding parameter.
+  ll.CollisionSound:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Suppress default collision sounds, replace default impact sounds with
+      ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply an
+      empty string to suppress collision sounds.
+  ll.CollisionSprite:
+    args:
+      - type: string
+    description: >-
+      Suppress default collision sprites, replace default impact sprite with
+      ImpactSprite; found in the object inventory (empty string to just
+      suppress).
+  ll.ComputeHash:
+    args:
+      - type: string
+      - type: string
+    description: Returns hex-encoded Hash string of Message using digest Algorithm.
+  ll.Cos:
+    args:
+      - type: number
+    description: Returns the cosine of Theta (Theta in radians).
+  ll.CreateCharacter:
+    args:
+      - type: table
+    description: >-
+      Convert link-set to AI/Physics character.\nCreates a path-finding entity,
+      known as a "character", from the object containing the script. Required to
+      activate use of path-finding functions.\nOptions is a list of key/value
+      pairs.
+  ll.CreateKeyValue:
+    args:
+      - type: string
+      - type: string
+    description: |2-
+
+                         Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
+                      
+  ll.CreateLink:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Attempt to link the object the script is in, to target (requires
+      permission PERMISSION_CHANGE_LINKS be set).\nRequires permission
+      PERMISSION_CHANGE_LINKS be set.
+  ll.Damage:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: number
+    description: Generates a damage event on the targeted agent or task.
+  ll.DataSizeKeyValue:
+    args: []
+    description: |2-
+
+                         Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
+                      
+  ll.DeleteCharacter:
+    args: []
+    description: >-
+      Convert link-set from AI/Physics character to Physics object.\nConvert the
+      current link-set back to a standard object, removing all path-finding
+      properties.
+  ll.DeleteKeyValue:
+    args:
+      - type: string
+    description: |2-
+
+                         Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                      
+  ll.DeleteSubList:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: >-
+      Removes the slice from start to end and returns the remainder of the
+      list.\nRemove a slice from the list and return the remainder, start and
+      end are inclusive.\nUsing negative numbers for start and/or end causes the
+      index to count backwards from the length of the list, so 0, -1 would
+      delete the entire list.\nIf Start is larger than End the list deleted is
+      the exclusion of the entries; so 6, 4 would delete the entire list except
+      for the 5th list entry.
+  ll.DeleteSubString:
+    args:
+      - type: string
+      - type: number
+      - type: number
+    description: >-
+      Removes the indicated sub-string and returns the result.\nStart and End
+      are inclusive.\nUsing negative numbers for Start and/or End causes the
+      index to count backwards from the length of the string, so 0, -1 would
+      delete the entire string.\nIf Start is larger than End, the sub-string is
+      the exclusion of the entries; so 6, 4 would delete the entire string
+      except for the 5th character.
+  ll.DerezObject:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Derezzes an object previously rezzed by a script in this region. Returns
+      TRUE on success or FALSE if the object could not be derezzed.
+  ll.DetachFromAvatar:
+    args: []
+    description: Remove the object containing the script from the avatar.
+  ll.Dialog:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: table
+      - type: number
+    description: |-
+      Shows a dialog box on the avatar's screen with the message.\n
+                          Up to 12 strings in the list form buttons.\n
+                          If a button is clicked, the name is chatted on Channel.\nOpens a "notify box" in the given avatars screen displaying the message.\n
+                      Up to twelve buttons can be specified in a list of strings. When the user clicks a button, the name of the button is said on the specified channel.\n
+                      Channels work just like llSay(), so channel 0 can be heard by everyone.\n
+                      The chat originates at the object's position, not the avatar's position, even though it is said as the avatar (uses avatar's UUID and Name etc.).\n
+                      Examples:\n
+                      llDialog(who, "Are you a boy or a girl?", [ "Boy", "Girl" ], -4913);\n
+                      llDialog(who, "This shows only an OK button.", [], -192);\n
+                      llDialog(who, "This chats so you can 'hear' it.", ["Hooray"], 0);
+  ll.Die:
+    args: []
+    description: Delete the object which holds the script.
+  ll.DumpList2String:
+    args:
+      - type: table
+      - type: string
+    description: >-
+      Returns the list as a single string, using Separator between the
+      entries.\nWrite the list out as a single string, using Separator between
+      values.
+  ll.EdgeOfWorld:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Checks to see whether the border hit by Direction from Position is the
+      edge of the world (has no neighboring region).\nReturns TRUE if the line
+      along Direction from Position hits the edge of the world in the current
+      simulator, returns FALSE if that edge crosses into another simulator.
+  ll.EjectFromLand:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Ejects AvatarID from land that you own.\nEjects AvatarID from land that
+      the object owner (group or resident) owns.
+  ll.Email:
+    args:
+      - type: string
+      - type: string
+      - type: string
+    description: >-
+      Sends email to Address with Subject and Message.\nSends an email to
+      Address with Subject and Message.
+  ll.EscapeURL:
+    args:
+      - type: string
+    description: >-
+      Returns an escaped/encoded version of url, replacing spaces with %20
+      etc.\nReturns the string that is the URL-escaped version of URL (replacing
+      spaces with %20, etc.).\n
+                      This function returns the UTF-8 encoded escape codes for selected characters.
+  ll.Euler2Rot:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the rotation representation of the Euler angles.\nReturns the
+      rotation represented by the Euler Angle.
+  ll.Evade:
+    args:
+      - type:
+          display: uuid
+      - type: table
+    description: >-
+      Evade a specified target.\nCharacters will (roughly) try to hide from
+      their pursuers if there is a good hiding spot along their fleeing path.
+      Hiding means no direct line of sight from the head of the character
+      (centre of the top of its physics bounding box) to the head of its pursuer
+      and no direct path between the two on the navigation-mesh.
+  ll.ExecCharacterCmd:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Execute a character command.\nSend a command to the path
+      system.\nCurrently only supports stopping the current path-finding
+      operation or causing the character to jump.
+  ll.Fabs:
+    args:
+      - type: number
+    description: >-
+      Returns the positive version of Value.\nReturns the absolute value of
+      Value.
+  ll.FindNotecardTextCount:
+    args:
+      - type: string
+      - type: string
+      - type: table
+    description: >-
+      Searches the text of a cached notecard for lines containing the given
+      pattern and returns the 
+                  number of matches found through a dataserver event.
+                  
+  ll.FindNotecardTextSync:
+    args:
+      - type: string
+      - type: string
+      - type: number
+      - type: number
+      - type: table
+    description: >-
+      Searches the text of a cached notecard for lines containing the given
+      pattern. 
+                  Returns a list of line numbers and column where a match is found. If the notecard is not in
+                  the cache it returns a list containing a single entry of NAK. If no matches are found an
+                  empty list is returned.
+  ll.FleeFrom:
+    args:
+      - type:
+          display: vector
+      - type: number
+      - type: table
+    description: >-
+      Flee from a point.\nDirects a character (llCreateCharacter) to keep away
+      from a defined position in the region or adjacent regions.
+  ll.Floor:
+    args:
+      - type: number
+    description: Returns largest integer value <= Value.
+  ll.ForceMouselook:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      If Enable is TRUE any avatar that sits on this object is forced into
+      mouse-look mode.\nAfter calling this function with Enable set to TRUE, any
+      agent sitting down on the prim will be forced into mouse-look.\nJust like
+      llSitTarget, this changes a permanent property of the prim (not the
+      object) and needs to be reset by calling this function with Enable set to
+      FALSE in order to disable it.
+  ll.Frand:
+    args:
+      - type: number
+    description: >-
+      Returns a pseudo random number in the range [0, Magnitude] or [Magnitude,
+      0].\nReturns a pseudo-random number between [0, Magnitude].
+  ll.GenerateKey:
+    args: []
+    description: >-
+      Generates a key (SHA-1 hash) using UUID generation to create a unique
+      key.\nAs the UUID produced is versioned, it should never return a value of
+      NULL_KEY.\nThe specific UUID version is an implementation detail that has
+      changed in the past and may change again in the future. Do not depend upon
+      the UUID that is returned to be version 5 SHA-1 hash.
+  ll.GetAccel:
+    args: []
+    description: >-
+      Returns the acceleration of the object relative to the region's
+      axes.\nGets the acceleration of the object.
+  ll.GetAgentInfo:
+    args:
+      - type:
+          display: uuid
+    description: |-
+      Returns an integer bit-field containing the agent information about id.\n
+                          Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.
+  ll.GetAgentLanguage:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the language code of the preferred interface language of the
+      avatar.\nReturns a string that is the language code of the preferred
+      interface language of the resident.
+  ll.GetAgentList:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Requests a list of agents currently in the region, limited by the scope
+      parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or
+      [string error_msg] - returns avatar keys for all agents in the region
+      limited to the area(s) specified by scope
+  ll.GetAgentSize:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      If the avatar is in the same region, returns the size of the bounding box
+      of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the
+      agent is in the same region as the object, returns the size of the avatar.
+  ll.GetAlpha:
+    args:
+      - type: number
+    description: >-
+      Returns the alpha value of Face.\nReturns the 'alpha' of the given face.
+      If face is ALL_SIDES the value returned is the mean average of all faces.
+  ll.GetAndResetTime:
+    args: []
+    description: >-
+      Returns the script time in seconds and then resets the script timer to
+      zero.\nGets the time in seconds since starting and resets the time to
+      zero.
+  ll.GetAnimation:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the name of the currently playing locomotion animation for the
+      avatar id.\nReturns the currently playing animation for the specified
+      avatar ID.
+  ll.GetAnimationList:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns a list of keys of playing animations for an avatar.\nReturns a
+      list of keys of all playing animations for the specified avatar ID.
+  ll.GetAnimationOverride:
+    args:
+      - type: string
+    description: >-
+      Returns a string that is the name of the animation that is used for the
+      specified animation state\nTo use this function the script must obtain
+      either the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION
+      permission (automatically granted to attached objects).
+  ll.GetAttached:
+    args: []
+    description: Returns the object's attachment point, or 0 if not attached.
+  ll.GetAttachedList:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns a list of keys of all visible (not HUD) attachments on the avatar
+      identified by the ID argument
+  ll.GetAttachedListFiltered:
+    args:
+      - type:
+          display: uuid
+      - type: table
+    description: Retrieves a list of attachments on an avatar.
+  ll.GetBoundingBox:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the bounding box around the object (including any linked prims)
+      relative to its root prim, as a list in the format [ (vector) min_corner,
+      (vector) max_corner ].
+  ll.GetCameraAspect:
+    args: []
+    description: >-
+      Returns the current camera aspect ratio (width / height) of the agent who
+      has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no
+      permissions have been granted: it returns zero.
+  ll.GetCameraFOV:
+    args: []
+    description: >-
+      Returns the current camera field of view of the agent who has granted the
+      scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions
+      have been granted: it returns zero.
+  ll.GetCameraPos:
+    args: []
+    description: >-
+      Returns the current camera position for the agent the task has permissions
+      for.\nReturns the position of the camera, of the user that granted the
+      script PERMISSION_TRACK_CAMERA. If no user has granted the permission, it
+      returns ZERO_VECTOR.
+  ll.GetCameraRot:
+    args: []
+    description: >-
+      Returns the current camera orientation for the agent the task has
+      permissions for. If no user has granted the PERMISSION_TRACK_CAMERA
+      permission, returns ZERO_ROTATION.
+  ll.GetCenterOfMass:
+    args: []
+    description: >-
+      Returns the prim's centre of mass (unless called from the root prim, where
+      it returns the object's centre of mass).
+  ll.GetClosestNavPoint:
+    args:
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Get the closest navigable point to the point provided.\nThe function
+      accepts a point in region-local space (like all the other path-finding
+      methods) and returns either an empty list or a list containing a single
+      vector which is the closest point on the navigation-mesh to the point
+      provided.
+  ll.GetColor:
+    args:
+      - type: number
+    description: >-
+      Returns the color on Face.\nReturns the color of Face as a vector of red,
+      green, and blue values between 0 and 1. If face is ALL_SIDES the color
+      returned is the mean average of each channel.
+  ll.GetCreator:
+    args: []
+    description: >-
+      Returns a key for the creator of the prim.\nReturns the key of the
+      object's original creator. Similar to llGetOwner.
+  ll.GetDate:
+    args: []
+    description: >-
+      Returns the current date in the UTC time zone in the format
+      YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.
+  ll.GetDayLength:
+    args: []
+    description: Returns the number of seconds in a day on this parcel.
+  ll.GetDayOffset:
+    args: []
+    description: >-
+      Returns the number of seconds in a day is offset from midnight in this
+      parcel.
+  ll.GetDisplayName:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the display name of an avatar, if the avatar is connected to the
+      current region, or if the name has been cached.  Otherwise, returns an
+      empty string. Use llRequestDisplayName if the avatar may be absent from
+      the region.
+  ll.GetEnergy:
+    args: []
+    description: Returns how much energy is in the object as a percentage of maximum.
+  ll.GetEnv:
+    args:
+      - type: string
+    description: Returns a string with the requested data about the region.
+  ll.GetEnvironment:
+    args:
+      - type:
+          display: vector
+      - type: table
+    description: Returns a string with the requested data about the region.
+  ll.GetExperienceDetails:
+    args:
+      - type:
+          display: uuid
+    description: |2-
+
+                         Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
+                      
+  ll.GetExperienceErrorMessage:
+    args:
+      - type: number
+    description: |2-
+
+                         Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
+                      
+  ll.GetForce:
+    args: []
+    description: >-
+      Returns the force (if the script is physical).\nReturns the current force
+      if the script is physical.
+  ll.GetFreeMemory:
+    args: []
+    description: >-
+      Returns the number of free bytes of memory the script can use.\nReturns
+      the available free space for the current script. This is inaccurate with
+      LSO.
+  ll.GetFreeURLs:
+    args: []
+    description: >-
+      Returns the number of available URLs for the current script.\nReturns an
+      integer that is the number of available URLs.
+  ll.GetGMTclock:
+    args: []
+    description: >-
+      Returns the time in seconds since midnight GMT.\nGets the time in seconds
+      since midnight in GMT/UTC.
+  ll.GetGeometricCenter:
+    args: []
+    description: >-
+      Returns the vector that is the geometric center of the object relative to
+      the root prim.
+  ll.GetHTTPHeader:
+    args:
+      - type:
+          display: uuid
+      - type: string
+    description: >-
+      Returns the value for header for request_id.\nReturns a string that is the
+      value of the Header for HTTPRequestID.
+  ll.GetHealth:
+    args:
+      - type:
+          display: uuid
+    description: Returns the current health of an avatar or object in the region.
+  ll.GetInventoryAcquireTime:
+    args:
+      - type: string
+    description: >-
+      Returns the time at which the item was placed into this prim's inventory
+      as a timestamp.
+  ll.GetInventoryCreator:
+    args:
+      - type: string
+    description: >-
+      Returns a key for the creator of the inventory item.\nThis function
+      returns the UUID of the creator of item. If item is not found in
+      inventory, the object says "No item named 'name'".
+  ll.GetInventoryDesc:
+    args:
+      - type: string
+    description: >-
+      Returns the item description of the item in inventory. If item is not
+      found in inventory, the object says "No item named 'name'" to the debug
+      channel and returns an empty string.
+  ll.GetInventoryKey:
+    args:
+      - type: string
+    description: >-
+      Returns the key that is the UUID of the inventory named.\nReturns the key
+      of the inventory named.
+  ll.GetInventoryName:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Returns the name of the inventory item of a given type, specified by index
+      number.\nUse the inventory constants INVENTORY_* to specify the type.
+  ll.GetInventoryNumber:
+    args:
+      - type: number
+    description: >-
+      Returns the quantity of items of a given type (INVENTORY_* flag) in the
+      prim's inventory.\nUse the inventory constants INVENTORY_* to specify the
+      type.
+  ll.GetInventoryPermMask:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Returns the requested permission mask for the inventory item.\nReturns the
+      requested permission mask for the inventory item defined by InventoryItem.
+      If item is not in the object's inventory, llGetInventoryPermMask returns
+      FALSE and causes the object to say "No item named '<item>'", where
+      "<item>" is item.
+  ll.GetInventoryType:
+    args:
+      - type: string
+    description: >-
+      Returns the type of the named inventory item.\nLike all inventory
+      functions, llGetInventoryType is case-sensitive.
+  ll.GetKey:
+    args: []
+    description: >-
+      Returns the key of the prim the script is attached to.\nGet the key for
+      the object which has this script.
+  ll.GetLandOwnerAt:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the key of the land owner, returns NULL_KEY if public.\nReturns
+      the key of the land owner at Position, or NULL_KEY if public.
+  ll.GetLinkKey:
+    args:
+      - type: number
+    description: >-
+      Returns the key of the linked prim LinkNumber.\nReturns the key of
+      LinkNumber in the link set.
+  ll.GetLinkMedia:
+    args:
+      - type: number
+      - type: number
+      - type: table
+    description: "Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.\tReturns an empty list if no media exists on the face."
+  ll.GetLinkName:
+    args:
+      - type: number
+    description: >-
+      Returns the name of LinkNumber in a link set.\nReturns the name of
+      LinkNumber the link set.
+  ll.GetLinkNumber:
+    args: []
+    description: >-
+      Returns the link number of the prim containing the script (0 means not
+      linked, 1 the prim is the root, 2 the prim is the first child,
+      etc.).\nReturns the link number of the prim containing the script. 0 means
+      no link, 1 the root, 2 for first child, etc.
+  ll.GetLinkNumberOfSides:
+    args:
+      - type: number
+    description: >-
+      Returns the number of sides of the specified linked prim.\nReturns an
+      integer that is the number of faces (or sides) of the prim link.
+  ll.GetLinkPrimitiveParams:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Returns the list of primitive attributes requested in the Parameters list
+      for LinkNumber.\nPRIM_* flags can be broken into three categories, face
+      flags, prim flags, and object flags.\n* Supplying a prim or object flag
+      will return that flag's attributes.\n* Face flags require the user to also
+      supply a face index parameter.
+  ll.GetLinkSitFlags:
+    args:
+      - type: number
+    description: Returns the sit flags set on the specified prim in a linkset.
+  ll.GetListEntryType:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT,
+      TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if
+      index is off list).\nReturns the type of the variable at Index in
+      ListVariable.
+  ll.GetListLength:
+    args:
+      - type: table
+    description: >-
+      Returns the number of elements in the list.\nReturns the number of
+      elements in ListVariable.
+  ll.GetLocalPos:
+    args: []
+    description: >-
+      Returns the position relative to the root.\nReturns the local position of
+      a child object relative to the root.
+  ll.GetLocalRot:
+    args: []
+    description: >-
+      Returns the rotation local to the root.\nReturns the local rotation of a
+      child object relative to the root.
+  ll.GetMass:
+    args: []
+    description: >-
+      Returns the mass of object that the script is attached to.\nReturns the
+      scripted object's mass. When called from a script in a link-set, the
+      parent will return the sum of the link-set weights, while a child will
+      return just its own mass. When called from a script inside an attachment,
+      this function will return the mass of the avatar it's attached to, not its
+      own.
+  ll.GetMassMKS:
+    args: []
+    description: Acts as llGetMass(), except that the units of the value returned are Kg.
+  ll.GetMaxScaleFactor:
+    args: []
+    description: >-
+      Returns the largest multiplicative uniform scale factor that can be
+      successfully applied (via llScaleByFactor()) to the object without
+      violating prim size or linkability rules.
+  ll.GetMemoryLimit:
+    args: []
+    description: Get the maximum memory a script can use, in bytes.
+  ll.GetMinScaleFactor:
+    args: []
+    description: >-
+      Returns the smallest multiplicative uniform scale factor that can be
+      successfully applied (via llScaleByFactor()) to the object without
+      violating prim size or linkability rules.
+  ll.GetMoonDirection:
+    args: []
+    description: >-
+      Returns a normalized vector of the direction of the moon in the
+      parcel.\nReturns the moon's direction on the simulator in the parcel.
+  ll.GetMoonRotation:
+    args: []
+    description: Returns the rotation applied to the moon in the parcel.
+  ll.GetNextEmail:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Fetch the next queued email with that matches the given address and/or
+      subject, via the email event.\nIf the parameters are blank, they are not
+      used for filtering.
+  ll.GetNotecardLine:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Returns LineNumber from NotecardName via the dataserver event. The line
+      index starts at zero in LSL, one in Lua.\nIf the requested line is passed
+      the end of the note-card the dataserver event will return the constant EOF
+      string.\nThe key returned by this function is a unique identifier which
+      will be supplied to the dataserver event in the requested parameter.
+  ll.GetNotecardLineSync:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Returns LineNumber from NotecardName. The line index starts at zero in
+      LSL, one in Lua.\nIf the requested line is past the end of the note-card
+      the return value will be set to the constant EOF string.\nIf the note-card
+      is not cached on the simulator the return value is the NAK string.
+  ll.GetNumberOfNotecardLines:
+    args:
+      - type: string
+    description: >-
+      Returns the number of lines contained within a notecard via the dataserver
+      event.\nThe key returned by this function is a query ID for identifying
+      the dataserver reply.
+  ll.GetNumberOfPrims:
+    args: []
+    description: >-
+      Returns the number of prims in a link set the script is attached
+      to.\nReturns the number of prims in (and avatars seated on) the object the
+      script is in.
+  ll.GetNumberOfSides:
+    args: []
+    description: >-
+      Returns the number of faces (or sides) of the prim.\nReturns the number of
+      sides of the prim which has the script.
+  ll.GetObjectAnimationNames:
+    args: []
+    description: >-
+      Returns a list of names of playing animations for an object.\nReturns a
+      list of names of all playing animations for the current object.
+  ll.GetObjectDesc:
+    args: []
+    description: >-
+      Returns the description of the prim the script is attached to.\nReturns
+      the description of the scripted object/prim. You can set the description
+      using llSetObjectDesc.
+  ll.GetObjectDetails:
+    args:
+      - type:
+          display: uuid
+      - type: table
+    description: >-
+      Returns a list of object details specified in the Parameters list for the
+      object or avatar in the region with key ID.\nParameters are specified by
+      the OBJECT_* constants.
+  ll.GetObjectLinkKey:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Returns the key of the linked prim link_no in a linkset.\nReturns the key
+      of link_no in the link set specified by id.
+  ll.GetObjectMass:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the mass of the avatar or object in the region.\nGets the mass of
+      the object or avatar corresponding to ID.
+  ll.GetObjectName:
+    args: []
+    description: >-
+      Returns the name of the prim which the script is attached to.\nReturns the
+      name of the prim (not object) which contains the script.
+  ll.GetObjectPermMask:
+    args:
+      - type: number
+    description: Returns the permission mask of the requested category for the object.
+  ll.GetObjectPrimCount:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the total number of prims for an object in the region.\nReturns
+      the prim count for any object id in the same region.
+  ll.GetOmega:
+    args: []
+    description: >-
+      Returns the rotation velocity in radians per second.\nReturns a vector
+      that is the rotation velocity of the object in radians per second.
+  ll.GetOwner:
+    args: []
+    description: >-
+      Returns the object owner's UUID.\nReturns the key for the owner of the
+      object.
+  ll.GetOwnerKey:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the owner of ObjectID.\nReturns the key for the owner of object
+      ObjectID.
+  ll.GetParcelDetails:
+    args:
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Returns a list of parcel details specified in the ParcelDetails list for
+      the parcel at Position.\nParameters is one or more of:
+      PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID,
+      _SEE_AVATARS.\nReturns a list that is the parcel details specified in
+      ParcelDetails (in the same order) for the parcel at Position.
+  ll.GetParcelFlags:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that
+      includes the point Position.\nReturns a bit-field specifying the parcel
+      flags (PARCEL_FLAG_*) for the parcel at Position.
+  ll.GetParcelMaxPrims:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Returns the maximum number of prims allowed on the parcel at Position for
+      a given scope.\nThe scope may be set to an individual parcel or the
+      combined resources of all parcels with the same ownership in the region.
+  ll.GetParcelMusicURL:
+    args: []
+    description: >-
+      Gets the streaming audio URL for the parcel object is on.\nThe object
+      owner, avatar or group, must also be the land owner.
+  ll.GetParcelPrimCount:
+    args:
+      - type:
+          display: vector
+      - type: number
+      - type:
+          display: numeric
+    description: >-
+      Returns the number of prims on the parcel at Position of the given
+      category.\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER,
+      _SELECTED, _TEMP.\nReturns the number of prims used on the parcel at
+      Position which are in Category.\nIf SimWide is TRUE, it returns the total
+      number of objects for all parcels with matching ownership in the category
+      specified.\nIf SimWide is FALSE, it returns the number of objects on this
+      specific parcel in the category specified
+  ll.GetParcelPrimOwners:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns a list of up to 100 residents who own objects on the parcel at
+      Position, with per-owner land impact totals.\nRequires owner-like
+      permissions for the parcel, and for the script owner to be present in the
+      region.\nThe list is formatted as [ key agentKey1, integer agentLI1, key
+      agentKey2, integer agentLI2, ... ], sorted by agent key.\nThe integers are
+      the combined land impacts of the objects owned by the corresponding
+      agents.
+  ll.GetPermissions:
+    args: []
+    description: >-
+      Returns an integer bitmask of the permissions that have been granted to
+      the script.  Individual permissions can be determined using a bit-wise
+      "and" operation against the PERMISSION_* constants
+  ll.GetPermissionsKey:
+    args: []
+    description: >-
+      Returns the key of the avatar that last granted or declined permissions to
+      the script.\nReturns NULL_KEY if permissions were never granted or
+      declined.
+  ll.GetPhysicsMaterial:
+    args: []
+    description: >-
+      Returns a list of the form [float gravity_multiplier, float restitution,
+      float friction, float density].
+  ll.GetPos:
+    args: []
+    description: >-
+      Returns the position of the task in region coordinates.\nReturns the
+      vector position of the task in region coordinates.
+  ll.GetPrimMediaParams:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Returns the media parameters for a particular face on an object, given the
+      desired list of parameter names, in the order requested. Returns an empty
+      list if no media exists on the face.
+  ll.GetPrimitiveParams:
+    args:
+      - type: table
+    description: >-
+      Returns the primitive parameters specified in the parameters
+      list.\nReturns primitive parameters specified in the Parameters list.
+  ll.GetRegionAgentCount:
+    args: []
+    description: >-
+      Returns the number of avatars in the region.\nReturns an integer that is
+      the number of avatars in the region.
+  ll.GetRegionCorner:
+    args: []
+    description: >-
+      Returns a vector, in meters, that is the global location of the south-west
+      corner of the region which the object is in.\nReturns the Region-Corner of
+      the simulator containing the task. The region-corner is a vector (values
+      in meters) representing distance from the first region.
+  ll.GetRegionDayLength:
+    args: []
+    description: Returns the number of seconds in a day in this region.
+  ll.GetRegionDayOffset:
+    args: []
+    description: >-
+      Returns the number of seconds in a day is offset from midnight in this
+      parcel.
+  ll.GetRegionFPS:
+    args: []
+    description: Returns the mean region frames per second.
+  ll.GetRegionFlags:
+    args: []
+    description: >-
+      Returns the region flags (REGION_FLAG_*) for the region the object is
+      in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for
+      the region the object is in.
+  ll.GetRegionMoonDirection:
+    args: []
+    description: >-
+      Returns a normalized vector of the direction of the moon in the
+      region.\nReturns the moon's direction on the simulator.
+  ll.GetRegionMoonRotation:
+    args: []
+    description: Returns the rotation applied to the moon in the region.
+  ll.GetRegionName:
+    args: []
+    description: Returns the current region name.
+  ll.GetRegionSunDirection:
+    args: []
+    description: >-
+      Returns a normalized vector of the direction of the sun in the
+      region.\nReturns the sun's direction on the simulator.
+  ll.GetRegionSunRotation:
+    args: []
+    description: Returns the rotation applied to the sun in the region.
+  ll.GetRegionTimeDilation:
+    args: []
+    description: >-
+      Returns the current time dilation as a float between 0.0 (full dilation)
+      and 1.0 (no dilation).\nReturns the current time dilation as a float
+      between 0.0 and 1.0.
+  ll.GetRegionTimeOfDay:
+    args: []
+    description: >-
+      Returns the time in seconds since environmental midnight for the entire
+      region.
+  ll.GetRenderMaterial:
+    args:
+      - type: number
+    description: >-
+      Returns a string that is the render material on face (the inventory name
+      if it is a material in the prim's inventory, otherwise the key).\nReturns
+      the render material of a face, if it is found in object inventory, its key
+      otherwise.
+  ll.GetRootPosition:
+    args: []
+    description: >-
+      Returns the position (in region coordinates) of the root prim of the
+      object which the script is attached to.\nThis is used to allow a child
+      prim to determine where the root is.
+  ll.GetRootRotation:
+    args: []
+    description: >-
+      Returns the rotation (relative to the region) of the root prim of the
+      object which the script is attached to.\nGets the global rotation of the
+      root object of the object script is attached to.
+  ll.GetRot:
+    args: []
+    description: Returns the rotation relative to the region's axes.\nReturns the rotation.
+  ll.GetSPMaxMemory:
+    args: []
+    description: >-
+      Returns the maximum used memory for the current script. Only valid after
+      using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns the
+      integer of the most bytes used while llScriptProfiler was last active.
+  ll.GetScale:
+    args: []
+    description: >-
+      Returns the scale of the prim.\nReturns a vector that is the scale
+      (dimensions) of the prim.
+  ll.GetScriptName:
+    args: []
+    description: >-
+      Returns the name of the script that this function is used in.\nReturns the
+      name of this script.
+  ll.GetScriptState:
+    args:
+      - type: string
+    description: >-
+      Returns TRUE if the script named is running.\nReturns TRUE if ScriptName
+      is running.
+  ll.GetSimStats:
+    args:
+      - type: number
+    description: Returns a float that is the requested statistic.
+  ll.GetSimulatorHostname:
+    args: []
+    description: >-
+      Returns the host-name of the machine which the script is running on.\nFor
+      example, "sim225.agni.lindenlab.com".
+  ll.GetStartParameter:
+    args: []
+    description: >-
+      Returns an integer that is the script rez parameter.\nIf the object was
+      rezzed by an agent, this function returns 0.
+  ll.GetStartString:
+    args: []
+    description: >-
+      Returns a string that is the value passed to llRezObjectWithParams with
+      REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function
+      returns an empty string.
+  ll.GetStaticPath:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type: number
+      - type: table
+  ll.GetStatus:
+    args:
+      - type: number
+    description: >-
+      Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the
+      object the script is attached to.
+  ll.GetSubString:
+    args:
+      - type: string
+      - type: number
+      - type: number
+    description: >-
+      Returns a sub-string from String, in a range specified by the Start and
+      End indices (inclusive).\nUsing negative numbers for Start and/or End
+      causes the index to count backwards from the length of the string, so 0,
+      -1 would capture the entire string.\nIf Start is greater than End, the sub
+      string is the exclusion of the entries.
+  ll.GetSunDirection:
+    args: []
+    description: >-
+      Returns a normalized vector of the direction of the sun in the
+      parcel.\nReturns the sun's direction on the simulator in the parcel.
+  ll.GetSunRotation:
+    args: []
+    description: Returns the rotation applied to the sun in the parcel.
+  ll.GetTexture:
+    args:
+      - type: number
+    description: >-
+      Returns a string that is the texture on face (the inventory name if it is
+      a texture in the prim's inventory, otherwise the key).\nReturns the
+      texture of a face, if it is found in object inventory, its key otherwise.
+  ll.GetTextureOffset:
+    args:
+      - type: number
+    description: Returns the texture offset of face in the x and y components of a vector.
+  ll.GetTextureRot:
+    args:
+      - type: number
+    description: Returns the texture rotation of side.
+  ll.GetTextureScale:
+    args:
+      - type: number
+    description: >-
+      Returns the texture scale of side in the x and y components of a
+      vector.\nReturns the texture scale of a side in the x and y components of
+      a vector.
+  ll.GetTime:
+    args: []
+    description: >-
+      Returns the time in seconds since the last region reset, script reset, or
+      call to either llResetTime or llGetAndResetTime.
+  ll.GetTimeOfDay:
+    args: []
+    description: Returns the time in seconds since environmental midnight on the parcel.
+  ll.GetTimestamp:
+    args: []
+    description: >-
+      Returns a time-stamp (UTC time zone) in the format:
+      YYYY-MM-DDThh:mm:ss.ff..fZ.
+  ll.GetTorque:
+    args: []
+    description: >-
+      Returns the torque (if the script is physical).\nReturns a vector that is
+      the torque (if the script is physical).
+  ll.GetUnixTime:
+    args: []
+    description: >-
+      Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC
+      from the system clock.
+  ll.GetUsedMemory:
+    args: []
+    description: >-
+      Returns the current used memory for the current script. Non-mono scripts
+      always use 16K.\nReturns the integer of the number of bytes of memory
+      currently in use by the script. Non-mono scripts always use 16K.
+  ll.GetUsername:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the username of an avatar, if the avatar is connected to the
+      current region, or if the name has been cached.  Otherwise, returns an
+      empty string. Use llRequestUsername if the avatar may be absent from the
+      region.
+  ll.GetVel:
+    args: []
+    description: >-
+      Returns the velocity of the object.\nReturns a vector that is the velocity
+      of the object.
+  ll.GetVisualParams:
+    args:
+      - type:
+          display: uuid
+      - type: table
+    description: Returns a list of the current value for each requested visual parameter.
+  ll.GetWallclock:
+    args: []
+    description: >-
+      Returns the time in seconds since midnight California Pacific time
+      (PST/PDT).\nReturns the time in seconds since simulator's time-zone
+      midnight (Pacific Time).
+  ll.GiveAgentInventory:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: table
+      - type: table
+    description: >-
+      Give InventoryItems to the specified agent as a new folder of items, as
+      permitted by the permissions system. The target must be an agent.
+  ll.GiveInventory:
+    args:
+      - type:
+          display: uuid
+      - type: string
+    description: >-
+      Give InventoryItem to destination represented by TargetID, as permitted by
+      the permissions system.\nTargetID may be any agent or an object in the
+      same region.
+  ll.GiveInventoryList:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: table
+    description: >-
+      Give InventoryItems to destination (represented by TargetID) as a new
+      folder of items, as permitted by the permissions system.\nTargetID may be
+      any agent or an object in the same region. If TargetID is an object, the
+      items are passed directly to the object inventory (no folder is created).
+  ll.GiveMoney:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Transfers Amount of L$ from script owner to AvatarID.\nThis call will
+      silently fail if PERMISSION_DEBIT has not been granted.
+  ll.GodLikeRezObject:
+    args:
+      - type:
+          display: uuid
+      - type:
+          display: vector
+    description: Rez directly off of a UUID if owner has god-bit set.
+  ll.Ground:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the ground height at the object position + offset.\nReturns the
+      ground height at the object's position + Offset.
+  ll.GroundContour:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the ground contour direction below the object position +
+      Offset.\nReturns the ground contour at the object's position + Offset.
+  ll.GroundNormal:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the ground normal below the object position + offset.\nReturns the
+      ground contour at the object's position + Offset.
+  ll.GroundRepel:
+    args:
+      - type: number
+      - type:
+          display: numeric
+      - type: number
+    description: >-
+      Critically damps to height if within height * 0.5 of level (either above
+      ground level or above the higher of land and water if water ==
+      TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or
+      water level.\n
+                          The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
+                          Do not use with vehicles. Only works in physics-enabled objects.
+  ll.GroundSlope:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the ground slope below the object position + Offset.\nReturns the
+      ground slope at the object position + Offset.
+  ll.HMAC:
+    args:
+      - type: string
+      - type: string
+      - type: string
+    description: >-
+      Returns the base64-encoded hashed message authentication code (HMAC), of
+      Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224,
+      sha256, sha384, sha512).
+  ll.HTTPRequest:
+    args:
+      - type: string
+      - type: table
+      - type: string
+    description: >-
+      Sends an HTTP request to the specified URL with the Body of the request
+      and Parameters.\nReturns a key that is a handle identifying the HTTP
+      request made.
+  ll.HTTPResponse:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: string
+    description: >-
+      Responds to an incoming HTTP request which was triggerd by an http_request
+      event within the script. HTTPRequestID specifies the request to respond to
+      (this ID is supplied in the http_request event handler).  Status and Body
+      specify the status code and message to respond with.
+  ll.Hash:
+    args:
+      - type: string
+    description: Calculates the 32bit hash value for the provided string.
+  ll.InsertString:
+    args:
+      - type: string
+      - type: number
+      - type: string
+    description: >-
+      Inserts SourceVariable into TargetVariable at Position, and returns the
+      result.\nInserts SourceVariable into TargetVariable at Position and
+      returns the result. Note this does not alter TargetVariable.
+  ll.InstantMessage:
+    args:
+      - type:
+          display: uuid
+      - type: string
+    description: >-
+      IMs Text to the user identified.\nSend Text to the user as an instant
+      message.
+  ll.IntegerToBase64:
+    args:
+      - type: number
+    description: >-
+      Returns a string that is a Base64 big endian encode of Value.\nEncodes the
+      Value as an 8-character Base64 string.
+  ll.IsFriend:
+    args:
+      - type:
+          display: uuid
+    description: Returns TRUE if avatar ID is a friend of the script owner.
+  ll.IsLinkGLTFMaterial:
+    args:
+      - type: number
+      - type: number
+    description: Checks the face for a PBR render material.
+  ll.Json2List:
+    args:
+      - type: string
+    description: Converts the top level of the JSON string to a list.
+  ll.JsonGetValue:
+    args:
+      - type: string
+      - type: table
+    description: Gets the value indicated by Specifiers from the JSON string.
+  ll.JsonSetValue:
+    args:
+      - type: string
+      - type: table
+      - type: string
+    description: >-
+      Returns a new JSON string that is the JSON given with the Value indicated
+      by Specifiers set to Value.
+  ll.JsonValueType:
+    args:
+      - type: string
+      - type: table
+    description: >-
+      Returns the type constant (JSON_*) for the value in JSON indicated by
+      Specifiers.
+  ll.Key2Name:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns the name of the prim or avatar specified by ID. The ID must be a
+      valid rezzed prim or avatar key in the current simulator, otherwise an
+      empty string is returned.\nFor avatars, the returned name is the legacy
+      name
+  ll.KeyCountKeyValue:
+    args: []
+    description: |2-
+
+                         Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
+                      
+  ll.KeysKeyValue:
+    args:
+      - type: number
+      - type: number
+    description: |2-
+
+                         Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
+                      
+  ll.Linear2sRGB:
+    args:
+      - type:
+          display: vector
+    description: Converts a color from the linear colorspace to sRGB.
+  ll.LinkAdjustSoundVolume:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Adjusts the volume (0.0 - 1.0) of the currently playing sound attached to
+      the link.\nThis function has no effect on sounds started with
+      llTriggerSound.
+  ll.LinkParticleSystem:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Creates a particle system in prim LinkNumber based on Rules. An empty list
+      removes a particle system from object.\nList format is [ rule-1, data-1,
+      rule-2, data-2 ... rule-n, data-n ].\nThis is identical to
+      llParticleSystem except that it applies to a specified linked prim and not
+      just the prim the script is in.
+  ll.LinkPlaySound:
+    args:
+      - type: number
+      - type: string
+      - type: number
+      - type: number
+    description: >-
+      Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be
+      attached to the link or triggered at its location.\nOnly one sound may be
+      attached to an object at a time, and attaching a new sound or calling
+      llStopSound will stop the previously attached sound.
+  ll.LinkSetSoundQueueing:
+    args:
+      - type: number
+      - type:
+          display: numeric
+    description: >-
+      Limits radius for audibility of scripted sounds (both attached and
+      triggered) to distance Radius around the link.
+  ll.LinkSetSoundRadius:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Limits radius for audibility of scripted sounds (both attached and
+      triggered) to distance Radius around the link.
+  ll.LinkSitTarget:
+    args:
+      - type: number
+      - type:
+          display: vector
+      - type:
+          display: quaternion
+    description: >-
+      Set the sit location for the linked prim(s). If Offset == <0,0,0> clear
+      it.\nSet the sit location for the linked prim(s). The sit location is
+      relative to the prim's position and rotation.
+  ll.LinkStopSound:
+    args:
+      - type: number
+    description: Stops playback of the currently attached sound on a link.
+  ll.LinksetDataAvailable:
+    args: []
+    description: Returns the number of bytes remaining in the linkset's datastore.
+  ll.LinksetDataCountFound:
+    args:
+      - type: string
+    description: >-
+      Returns the number of keys matching the regular expression passed in the
+      search parameter.
+  ll.LinksetDataCountKeys:
+    args: []
+    description: Returns the number of keys in the linkset's datastore.
+  ll.LinksetDataDelete:
+    args:
+      - type: string
+    description: Deletes a name:value pair from the linkset's datastore.
+  ll.LinksetDataDeleteFound:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Deletes all key value pairs in the linkset data where the key matches the
+      regular expression in search. Returns a list consisting of [ #deleted,
+      #not deleted ].
+  ll.LinksetDataDeleteProtected:
+    args:
+      - type: string
+      - type: string
+    description: Deletes a name:value pair from the linkset's datastore.
+  ll.LinksetDataFindKeys:
+    args:
+      - type: string
+      - type: number
+      - type: number
+    description: >-
+      Returns a list of keys from the linkset's data store matching the search
+      parameter.
+  ll.LinksetDataListKeys:
+    args:
+      - type: number
+      - type: number
+    description: Returns a list of all keys in the linkset datastore.
+  ll.LinksetDataRead:
+    args:
+      - type: string
+    description: Returns the value stored for a key in the linkset.
+  ll.LinksetDataReadProtected:
+    args:
+      - type: string
+      - type: string
+    description: Returns the value stored for a key in the linkset.
+  ll.LinksetDataReset:
+    args: []
+    description: Resets the linkset's data store, erasing all key-value pairs.
+  ll.LinksetDataWrite:
+    args:
+      - type: string
+      - type: string
+    description: Sets a name:value pair in the linkset's datastore
+  ll.LinksetDataWriteProtected:
+    args:
+      - type: string
+      - type: string
+      - type: string
+    description: Sets a name:value pair in the linkset's datastore
+  ll.List2CSV:
+    args:
+      - type: table
+    description: >-
+      Creates a string of comma separated values from the list.\nCreate a string
+      of comma separated values from the specified list.
+  ll.List2Float:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the float at Index in the list.\nReturns the value at Index in the
+      specified list. If Index describes a location not in the list, or the
+      value cannot be type-cast to a float, then zero is returned.
+  ll.List2Integer:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the integer at Index in the list.\nReturns the value at Index in
+      the specified list. If Index describes a location not in the list, or the
+      value cannot be type-cast to an integer, then zero is returned.
+  ll.List2Json:
+    args:
+      - type: string
+      - type: table
+    description: >-
+      Converts either a strided list of key:value pairs to a JSON_OBJECT, or a
+      list of values to a JSON_ARRAY.
+  ll.List2Key:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the key at Index in the list.\nReturns the value at Index in the
+      specified list. If Index describes a location not in the list, or the
+      value cannot be type-cast to a key, then null string is returned.
+  ll.List2List:
+    args:
+      - type: any
+      - type: number
+      - type: number
+    description: >-
+      Returns a subset of entries from ListVariable, in a range specified by the
+      Start and End indicies (inclusive).\nUsing negative numbers for Start
+      and/or End causes the index to count backwards from the length of the
+      string, so 0, -1 would capture the entire string.\nIf Start is greater
+      than End, the sub string is the exclusion of the entries.
+  ll.List2ListSlice:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Returns a subset of entries from ListVariable, in a range specified by
+      Start and End indices (inclusive) return the slice_index element of each
+      stride.\n Using negative numbers for Start and/or End causes the index to
+      count backwards from the length of the list. (e.g. 0, -1 captures entire
+      list)\nIf slice_index is less than 0, it is counted backwards from the end
+      of the stride.\n Stride must be a positive integer > 0 or an empy list is
+      returned.  If slice_index falls outside range of stride, an empty list is
+      returned. slice_index is zero-based. (e.g. A stride of 2 has valid indices
+      0,1)
+  ll.List2ListStrided:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Copies the strided slice of the list from Start to End.\nReturns a copy of
+      the strided slice of the specified list from Start to End.
+  ll.List2Rot:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the rotation at Index in the list.\nReturns the value at Index in
+      the specified list. If Index describes a location not in the list, or the
+      value cannot be type-cast to rotation, thenZERO_ROTATION is returned.
+  ll.List2String:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the string at Index in the list.\nReturns the value at Index in the
+      specified list as a string. If Index describes a location not in the list
+      then null string is returned.
+  ll.List2Vector:
+    args:
+      - type: table
+      - type: number
+    description: >-
+      Copies the vector at Index in the list.\nReturns the value at Index in the
+      specified list. If Index describes a location not in the list, or the
+      value cannot be type-cast to a vector, then ZERO_VECTOR is returned.
+  ll.ListFindList:
+    args:
+      - type: table
+      - type: table
+    description: >-
+      Returns the index of the first instance of Find in ListVariable. Returns
+      -1 if not found.\nReturns the position of the first instance of the Find
+      list in the ListVariable. Returns -1 if not found.
+  ll.ListFindListNext:
+    args:
+      - type: table
+      - type: table
+      - type: number
+    description: >-
+      Returns the index of the nth instance of Find in ListVariable. Returns -1
+      if not found.
+  ll.ListFindStrided:
+    args:
+      - type: table
+      - type: table
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Returns the index of the first instance of Find in ListVariable. Returns
+      -1 if not found.\nReturns the position of the first instance of the Find
+      list in the ListVariable after the start index and before the end index.
+      Steps through ListVariable by stride.  Returns -1 if not found.
+  ll.ListInsertList:
+    args:
+      - type: any
+      - type: any
+      - type: number
+    description: >-
+      Returns a list that contains all the elements from Target but with the
+      elements from ListVariable inserted at Position start.\nReturns a new
+      list, created by inserting ListVariable into the Target list at Position.
+      Note this does not alter the Target.
+  ll.ListRandomize:
+    args:
+      - type: any
+      - type: number
+    description: >-
+      Returns a version of the input ListVariable which has been randomized by
+      blocks of size Stride.\nIf the remainder from the length of the list,
+      divided by the stride is non-zero, this function does not randomize the
+      list.
+  ll.ListReplaceList:
+    args:
+      - type: any
+      - type: any
+      - type: number
+      - type: number
+    description: >-
+      Returns a list that is Target with Start through End removed and
+      ListVariable inserted at Start.\nReturns a list replacing the slice of the
+      Target list from Start to End with the specified ListVariable. Start and
+      End are inclusive, so 0, 1 would replace the first two entries and 0, 0
+      would replace only the first list entry.
+  ll.ListSort:
+    args:
+      - type: any
+      - type: number
+      - type:
+          display: numeric
+    description: >-
+      Returns the specified list, sorted into blocks of stride in ascending
+      order (if Ascending is TRUE, otherwise descending). Note that sort only
+      works if the first entry of each block is the same datatype.
+  ll.ListSortStrided:
+    args:
+      - type: any
+      - type: number
+      - type: number
+      - type:
+          display: numeric
+    description: >-
+      Returns the specified list, sorted by the specified element into blocks of
+      stride in ascending order (if Ascending is TRUE, otherwise descending).
+      Note that sort only works if the first entry of each block is the same
+      datatype.
+  ll.ListStatistics:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Performs a statistical aggregate function, specified by a LIST_STAT_*
+      constant, on ListVariables.\nThis function allows a script to perform a
+      statistical operation as defined by operation on a list composed of
+      integers and floats.
+  ll.Listen:
+    args:
+      - type: number
+      - type: string
+      - type:
+          display: uuid
+      - type: string
+    description: >-
+      Creates a listen callback for Text on Channel from SpeakersName and
+      SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and
+      returns an identifier that can be used to deactivate or remove the
+      listen.\nNon-empty values for SpeakersName, SpeakersID, and Text will
+      filter the results accordingly, while empty strings and NULL_KEY will not
+      filter the results, for string and key parameters
+      respectively.\nPUBLIC_CHANNEL is the public chat channel that all avatars
+      see as chat text. DEBUG_CHANNEL is the script debug channel, and is also
+      visible to nearby avatars. All other channels are are not sent to avatars,
+      but may be used to communicate with scripts.
+  ll.ListenControl:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Makes a listen event callback active or inactive. Pass in the value
+      returned from llListen to the iChannelHandle parameter to specify which
+      listener you are controlling.\nUse boolean values to specify Active
+  ll.ListenRemove:
+    args:
+      - type: number
+    description: >-
+      Removes a listen event callback. Pass in the value returned from llListen
+      to the iChannelHandle parameter to specify which listener to remove.
+  ll.LoadURL:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: string
+    description: "Shows dialog to avatar AvatarID offering to load web page at URL.\tIf user clicks yes, launches their web browser.\\nllLoadURL displays a dialogue box to the user, offering to load the specified web page using the default web browser."
+  ll.Log:
+    args:
+      - type: number
+    description: >-
+      Returns the natural logarithm of Value. Returns zero if Value <=
+      0.\nReturns the base e (natural) logarithm of the specified Value.
+  ll.Log10:
+    args:
+      - type: number
+    description: >-
+      Returns the base 10 logarithm of Value. Returns zero if Value <=
+      0.\nReturns the base 10 (common) logarithm of the specified Value.
+  ll.LookAt:
+    args:
+      - type:
+          display: vector
+      - type: number
+      - type: number
+    description: >-
+      Cause object name to point its forward axis towards Target, at a force
+      controlled by Strength and Damping.\nGood Strength values are around half
+      the mass of the object and good Damping values are less than 1/10th of the
+      Strength.\nAsymmetrical shapes require smaller Damping. A Strength of 0.0
+      cancels the look at.
+  ll.LoopSound:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly
+      one sound may be attached to an object at a time.\nA second call to
+      llLoopSound with the same key will not restart the sound, but the new
+      volume will be used. This allows control over the volume of already
+      playing sounds.\nSetting the volume to 0 is not the same as calling
+      llStopSound; a sound with 0 volume will continue to loop.\nTo restart the
+      sound from the beginning, call llStopSound before calling llLoopSound
+      again.
+  ll.LoopSoundMaster:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a
+      sync master.\nBehaviour is identical to llLoopSound, with the addition of
+      marking the source as a "Sync Master", causing "Slave" sounds to sync to
+      it. If there are multiple masters within a viewers interest area, the most
+      audible one (a function of both distance and volume) will win out as the
+      master.\nThe use of multiple masters within a small area is unlikely to
+      produce the desired effect.
+  ll.LoopSoundSlave:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays attached sound looping at volume (0.0 - 1.0), synced to most audible
+      sync master.\nBehaviour is identical to llLoopSound, unless there is a
+      "Sync Master" present.\nIf a Sync Master is already playing the Slave
+      sound will begin playing from the same point the master is in its loop
+      synchronizing the loop points of both sounds.\nIf a Sync Master is started
+      when the Slave is already playing, the Slave will skip to the correct
+      position to sync with the Master.
+  ll.MD5String:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Returns a string of 32 hex characters that is an RSA Data Security Inc.,
+      MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns
+      a 32-character hex string. (128-bit in binary.)
+  ll.MakeExplosion:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: string
+      - type:
+          display: vector
+    description: >-
+      Make a round explosion of particles. Deprecated: Use llParticleSystem
+      instead.\nMake a round explosion of particles using texture from the
+      objects inventory. Deprecated: Use llParticleSystem instead.
+  ll.MakeFire:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: string
+      - type:
+          display: vector
+    description: >-
+      Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake
+      fire particles using texture from the objects inventory. Deprecated: Use
+      llParticleSystem instead.
+  ll.MakeFountain:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: string
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Make a fountain of particles. Deprecated: Use llParticleSystem
+      instead.\nMake a fountain of particles using texture from the objects
+      inventory. Deprecated: Use llParticleSystem instead.
+  ll.MakeSmoke:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: string
+      - type:
+          display: vector
+    description: >-
+      Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake
+      smoky particles using texture from the objects inventory. Deprecated: Use
+      llParticleSystem instead.
+  ll.ManageEstateAccess:
+    args:
+      - type: number
+      - type:
+          display: uuid
+    description: >-
+      Adds or removes agents from the estate's agent access or ban lists, or
+      groups to the estate's group access list. Action is one of the
+      ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer
+      representing a boolean, TRUE if the call was successful; FALSE if
+      throttled, invalid action, invalid or null id or object owner is not
+      allowed to manage the estate.\nThe object owner is notified of any
+      changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to
+      the script.
+  ll.MapBeacon:
+    args:
+      - type: string
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Displays an in world beacon and optionally opens world map for avatar who
+      touched the object or is wearing the script, centered on RegionName with
+      Position highlighted. Only works for scripts attached to avatar, or during
+      touch events.
+  ll.MapDestination:
+    args:
+      - type: string
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Opens world map for avatar who touched it or is wearing the script,
+      centred on RegionName with Position highlighted. Only works for scripts
+      attached to avatar, or during touch events.\nDirection currently has no
+      effect.
+  ll.MessageLinked:
+    args:
+      - type: number
+      - type: number
+      - type: any
+      - type: any
+    description: >-
+      Sends Number, Text, and ID to members of the link set identified by
+      LinkNumber.\nLinkNumber is either a linked number (available through
+      llGetLinkNumber) or a LINK_* constant.
+  ll.MinEventDelay:
+    args:
+      - type: number
+    description: Set the minimum time between events being handled.
+  ll.ModPow:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped
+      at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised to
+      the Power, Modulus). Value is capped at 0xFFFF (16 bits).
+  ll.ModifyLand:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH,
+      LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x
+      4m, 8m x 8m).
+  ll.MoveToTarget:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Critically damp to Target in Tau seconds (if the script is
+      physical).\nCritically damp to position target in tau-seconds if the
+      script is physical. Good tau-values are greater than 0.2. A tau of 0.0
+      stops the critical damping.
+  ll.Name2Key:
+    args:
+      - type: string
+    description: Look up Agent ID for the named agent in the region.
+  ll.NavigateTo:
+    args:
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Navigate to destination.\nDirects an object to travel to a defined
+      position in the region or adjacent regions.
+  ll.OffsetTexture:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Sets the texture S and T offsets for the chosen Face.\nIf Face is
+      ALL_SIDES this function sets the texture offsets for all faces.
+  ll.OpenFloater:
+    args:
+      - type: string
+      - type: string
+      - type: table
+    description: >-
+      Returns the value for header for request_id.\nReturns a string that is the
+      value of the Header for HTTPRequestID.
+  ll.OpenRemoteDataChannel:
+    args: []
+    description: This function is deprecated.
+  ll.Ord:
+    args:
+      - type: string
+      - type: number
+    description: Returns the unicode value of the indicated character in the string.
+  ll.OverMyLand:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns TRUE if id ID over land owned by the script owner, otherwise
+      FALSE.\nReturns TRUE if key ID is over land owned by the object owner,
+      FALSE otherwise.
+  ll.OwnerSay:
+    args:
+      - type: string
+    description: >-
+      says Text to owner only (if owner is in region).\nSays Text to the owner
+      of the object running the script, if the owner has been within the
+      object's simulator since logging into Second Life, regardless of where
+      they may be in-world.
+  ll.ParcelMediaCommandList:
+    args:
+      - type: table
+    description: >-
+      Controls the playback of multimedia resources on a parcel or for an agent,
+      via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.
+  ll.ParcelMediaQuery:
+    args:
+      - type: table
+    description: >-
+      Queries the media properties of the parcel containing the script, via one
+      or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis
+      function will only work if the script is contained within an object owned
+      by the land-owner (or if the land is owned by a group, only if the object
+      has been deeded to the group).
+  ll.ParseString2List:
+    args:
+      - type: string
+      - type: any
+      - type: any
+    description: >-
+      Converts Text into a list, discarding Separators, keeping Spacers
+      (Separators and Spacers must be lists of strings, maximum of 8
+      each).\nSeparators and Spacers are lists of strings with a maximum of 8
+      entries each.
+  ll.ParseStringKeepNulls:
+    args:
+      - type: string
+      - type: any
+      - type: any
+    description: >-
+      Breaks Text into a list, discarding separators, keeping spacers, keeping
+      any null values generated. (separators and spacers must be lists of
+      strings, maximum of 8 each).\nllParseStringKeepNulls works almost exactly
+      like llParseString2List, except that if a null is found it will add a
+      null-string instead of discarding it like llParseString2List does.
+  ll.ParticleSystem:
+    args:
+      - type: table
+    description: >-
+      Creates a particle system in the prim the script is attached to, based on
+      Parameters. An empty list removes a particle system from object.\nList
+      format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].
+  ll.PassCollisions:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      Configures how collision events are passed to scripts in the linkset.\nIf
+      Pass == TRUE, collisions involving collision-handling scripted child prims
+      are also passed on to the root prim. If Pass == FALSE (default behavior),
+      such collisions will only trigger events in the affected child prim.
+  ll.PassTouches:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      Configures how touch events are passed to scripts in the linkset.\nIf Pass
+      == TRUE, touches involving touch-handling scripted child prims are also
+      passed on to the root prim. If Pass == FALSE (default behavior), such
+      touches will only trigger events in the affected child prim.
+  ll.PatrolPoints:
+    args:
+      - type: table
+      - type: table
+    description: >-
+      Patrol a list of points.\nSets the points for a character
+      (llCreateCharacter) to patrol along.
+  ll.PlaySound:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly
+      one sound may be attached to an object at a time, and attaching a new
+      sound or calling llStopSound will stop the previously attached sound.\nA
+      second call to llPlaySound with the same sound will not restart the sound,
+      but the new volume will be used, which allows control over the volume of
+      already playing sounds.\nTo restart the sound from the beginning, call
+      llStopSound before calling llPlaySound again.
+  ll.PlaySoundSlave:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of
+      most audible sync master.\nBehaviour is identical to llPlaySound, unless
+      there is a "Sync Master" present. If a Sync Master is already playing, the
+      Slave sound will not be played until the Master hits its loop point and
+      returns to the beginning.\nllPlaySoundSlave will play the sound exactly
+      once; if it is desired to have the sound play every time the Master loops,
+      either use llLoopSoundSlave with extra silence padded on the end of the
+      sound or ensure that llPlaySoundSlave is called at least once per loop of
+      the Master.
+  ll.Pow:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Returns the Value raised to the power Exponent, or returns 0 and triggers
+      Math Error for imaginary results.\nReturns the Value raised to the
+      Exponent.
+  ll.PreloadSound:
+    args:
+      - type: string
+    description: >-
+      Causes nearby viewers to preload the Sound from the object's
+      inventory.\nThis is intended to prevent delays in starting new sounds when
+      called upon.
+  ll.Pursue:
+    args:
+      - type:
+          display: uuid
+      - type: table
+    description: >-
+      Chase after a target.\nCauses the character (llCharacter) to pursue the
+      target defined by TargetID.
+  ll.PushObject:
+    args:
+      - type:
+          display: uuid
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied
+      impulse and angular impulse to the object specified.
+  ll.ReadKeyValue:
+    args:
+      - type: string
+    description: |2-
+
+                         Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
+                      
+  ll.RefreshPrimURL:
+    args: []
+    description: Reloads the web page shown on the sides of the object.
+  ll.RegionSay:
+    args:
+      - type: number
+      - type: string
+    description: Broadcasts Text to entire region on Channel (except for channel 0).
+  ll.RegionSayTo:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: string
+    description: >-
+      Says Text, on Channel, to avatar or object indicated by TargetID (if
+      within region).\nIf TargetID is an avatar and Channel is nonzero, Text can
+      be heard by any attachment on the avatar.
+  ll.ReleaseCamera:
+    args:
+      - type:
+          display: uuid
+    description: 'Return camera to agent.\nDeprecated: Use llClearCameraParams instead.'
+  ll.ReleaseControls:
+    args: []
+    description: Stop taking inputs.\nStop taking inputs from the avatar.
+  ll.ReleaseURL:
+    args:
+      - type: string
+    description: >-
+      Releases the specified URL, which was previously obtained using
+      llRequestURL.  Once released, the URL will no longer be usable.
+  ll.RemoteDataReply:
+    args:
+      - type:
+          display: uuid
+      - type:
+          display: uuid
+      - type: string
+      - type: number
+    description: This function is deprecated.
+  ll.RemoteDataSetRegion:
+    args: []
+    description: This function is deprecated.
+  ll.RemoteLoadScriptPin:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: number
+      - type:
+          display: numeric
+      - type: number
+    description: >-
+      If the owner of the object containing this script can modify the object
+      identified by the specified object key, and if the PIN matches the PIN
+      previously set using llSetRemoteScriptAccessPin (on the target prim), then
+      the script will be copied into target. Running is a boolean specifying
+      whether the script should be enabled once copied into the target object.
+  ll.RemoveFromLandBanList:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Remove avatar from the land ban list.\nRemove specified avatar from the
+      land parcel ban list.
+  ll.RemoveFromLandPassList:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Remove avatar from the land pass list.\nRemove specified avatar from the
+      land parcel pass list.
+  ll.RemoveInventory:
+    args:
+      - type: string
+    description: >-
+      Remove the named inventory item.\nRemove the named inventory item from the
+      object inventory.
+  ll.RemoveVehicleFlags:
+    args:
+      - type: number
+    description: >-
+      Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE.
+      Valid parameters can be found in the vehicle flags constants section.
+  ll.ReplaceAgentEnvironment:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: string
+    description: >-
+      Replaces the entire environment for an agent. Must be used as part of an
+      experience.
+  ll.ReplaceEnvironment:
+    args:
+      - type:
+          display: vector
+      - type: string
+      - type: number
+      - type: number
+      - type: number
+    description: Replaces the environment for a parcel or region.
+  ll.ReplaceSubString:
+    args:
+      - type: string
+      - type: string
+      - type: string
+      - type: number
+    description: >-
+      Searches InitialString and replaces instances of SubString with
+      NewSubString. Zero Count means "replace all". Positive Count moves left to
+      right. Negative moves right to left.
+  ll.RequestAgentData:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Requests data about AvatarID. When data is available the dataserver event
+      will be raised.\nThis function requests data about an avatar. If and when
+      the information is collected, the dataserver event is triggered with the
+      key returned from this function passed in the requested parameter. See the
+      agent data constants (DATA_*) for details about valid values of data and
+      what each will return in the dataserver event.
+  ll.RequestDisplayName:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Requests the display name of the agent. When the display name is available
+      the dataserver event will be raised.\nThe avatar identified does not need
+      to be in the same region or online at the time of the request.\nReturns a
+      key that is used to identify the dataserver event when it is raised.
+  ll.RequestExperiencePermissions:
+    args:
+      - type:
+          display: uuid
+      - type: string
+    description: |2-
+
+                         Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
+                      
+  ll.RequestInventoryData:
+    args:
+      - type: string
+    description: >-
+      Requests data for the named InventoryItem.\nWhen data is available, the
+      dataserver event will be raised with the key returned from this function
+      in the requested parameter.\nThe only request currently implemented is to
+      request data from landmarks, where the data returned is in the form
+      "<float, float, float>" which can be cast to a vector. This position is in
+      region local coordinates.
+  ll.RequestPermissions:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Ask AvatarID to allow the script to perform certain actions, specified in
+      the PermissionMask bitmask. PermissionMask should be one or more
+      PERMISSION_* constants. Multiple permissions can be requested
+      simultaneously by ORing the constants together. Many of the permissions
+      requests can only go to object owner.\nThis call will not stop script
+      execution. If the avatar grants the requested permissions, the
+      run_time_permissions event will be called.
+  ll.RequestSecureURL:
+    args: []
+    description: >-
+      Requests one HTTPS:// (SSL) URL for use by this object. The http_request
+      event is triggered with results.\nReturns a key that is the handle used
+      for identifying the request in the http_request event.
+  ll.RequestSimulatorData:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Requests the specified Data about RegionName. When the specified data is
+      available, the dataserver event is raised.\nData should use one of the
+      DATA_SIM_* constants.\nReturns a dataserver query ID and triggers the
+      dataserver event when data is found.
+  ll.RequestURL:
+    args: []
+    description: >-
+      Requests one HTTP:// URL for use by this script. The http_request event is
+      triggered with the result of the request.\nReturns a key that is the
+      handle used for identifying the result in the http_request event.
+  ll.RequestUserKey:
+    args:
+      - type: string
+    description: Look up Agent ID for the named agent using a historical name.
+  ll.RequestUsername:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Requests single-word user-name of an avatar. When data is available the
+      dataserver event will be raised.\nRequests the user-name of the identified
+      agent. When the user-name is available the dataserver event is
+      raised.\nThe agent identified does not need to be in the same region or
+      online at the time of the request.\nReturns a key that is used to identify
+      the dataserver event when it is raised.
+  ll.ResetAnimationOverride:
+    args:
+      - type: string
+    description: >-
+      Resets the animation of the specified animation state to the default
+      value.\nIf animation state equals "ALL", then all animation states are
+      reset.
+  ll.ResetLandBanList:
+    args: []
+    description: Removes all residents from the land ban list.
+  ll.ResetLandPassList:
+    args: []
+    description: Removes all residents from the land access/pass list.
+  ll.ResetOtherScript:
+    args:
+      - type: string
+    description: Resets the named script.
+  ll.ResetScript:
+    args: []
+    description: Resets the script.
+  ll.ResetTime:
+    args: []
+    description: Sets the time to zero.\nSets the internal timer to zero.
+  ll.ReturnObjectsByID:
+    args:
+      - type: table
+    description: >-
+      Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS
+      permission and that the script owner owns the parcel the returned objects
+      are in, or is an estate manager or region owner.
+  ll.ReturnObjectsByOwner:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Return objects based upon their owner and a scope of parcel, parcel owner,
+      or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the
+      script owner owns the parcel the returned objects are in, or is an estate
+      manager or region owner.
+  ll.RezAtRoot:
+    args:
+      - type: string
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type:
+          display: quaternion
+      - type: number
+    description: >-
+      Instantiate owner's InventoryItem at Position with Velocity, Rotation and
+      with StartParameter. The last selected root object's location will be set
+      to Position.\nCreates object's inventory item at the given Position, with
+      Velocity, Rotation, and StartParameter.
+  ll.RezObject:
+    args:
+      - type: string
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type:
+          display: quaternion
+      - type: number
+    description: >-
+      Instantiate owners InventoryItem at Position with Velocity, Rotation and
+      with start StartParameter.\nCreates object's inventory item at Position
+      with Velocity and Rotation supplied. The StartParameter value will be
+      available to the newly created object in the on_rez event or through the
+      llGetStartParameter function.\nThe Velocity parameter is ignored if the
+      rezzed object is not physical.
+  ll.RezObjectWithParams:
+    args:
+      - type: string
+      - type: table
+    description: Instantiate owner's InventoryItem with the given parameters.
+  ll.Rot2Angle:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the rotation angle represented by Rotation.\nReturns the angle
+      represented by the Rotation.
+  ll.Rot2Axis:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the rotation axis represented by Rotation.\nReturns the axis
+      represented by the Rotation.
+  ll.Rot2Euler:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns
+      the Euler Angle representation of the Rotation.
+  ll.Rot2Fwd:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the forward vector defined by Rotation.\nReturns the forward axis
+      represented by the Rotation.
+  ll.Rot2Left:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the left vector defined by Rotation.\nReturns the left axis
+      represented by the Rotation.
+  ll.Rot2Up:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      Returns the up vector defined by Rotation.\nReturns the up axis
+      represented by the Rotation.
+  ll.RotBetween:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation
+      needed to rotate Vector1 to Vector2.
+  ll.RotLookAt:
+    args:
+      - type:
+          display: quaternion
+      - type: number
+      - type: number
+    description: >-
+      Cause object to rotate to Rotation, with a force function defined by
+      Strength and Damping parameters. Good strength values are around half the
+      mass of the object and good damping values are less than 1/10th of the
+      strength.\nAsymmetrical shapes require smaller damping.\nA strength of 0.0
+      cancels the look at.
+  ll.RotTarget:
+    args:
+      - type:
+          display: quaternion
+      - type: number
+    description: >-
+      Set rotations with error of LeeWay radians as a rotational target, and
+      return an ID for the rotational target.\nThe returned number is a handle
+      that can be used in at_rot_target and llRotTargetRemove.
+  ll.RotTargetRemove:
+    args:
+      - type: number
+    description: >-
+      Removes rotational target number.\nRemove rotational target indicated by
+      the handle.
+  ll.RotateTexture:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Sets the texture rotation for the specified Face to angle Radians.\nIf
+      Face is ALL_SIDES, rotates the texture of all sides.
+  ll.Round:
+    args:
+      - type: number
+    description: >-
+      Returns Value rounded to the nearest integer.\nReturns the Value rounded
+      to the nearest integer.
+  ll.SHA1String:
+    args:
+      - type: string
+    description: >-
+      Returns a string of 40 hex characters that is the SHA1 security hash of
+      text.
+  ll.SHA256String:
+    args:
+      - type: string
+    description: >-
+      Returns a string of 64 hex characters that is the SHA256 security hash of
+      text.
+  ll.SameGroup:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      Returns TRUE if avatar ID is in the same region and has the same active
+      group, otherwise FALSE.\nReturns TRUE if the object or agent identified is
+      in the same simulator and has the same active group as this object.
+      Otherwise, returns FALSE.
+  ll.Say:
+    args:
+      - type: number
+      - type: string
+    description: >-
+      Says Text on Channel.\nThis chat method has a range of 20m
+      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
+      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
+      to nearby avatars. All other channels are are not sent to avatars, but may
+      be used to communicate with scripts.
+  ll.ScaleByFactor:
+    args:
+      - type: number
+    description: >-
+      Attempts to resize the entire object by ScalingFactor, maintaining the
+      size-position ratios of the prims.\n\nResizing is subject to prim scale
+      limits and linkability limits. This function can not resize the object if
+      the linkset is physical, a pathfinding character, in a keyframed motion,
+      or if resizing would cause the parcel to overflow.\nReturns a boolean (an
+      integer) TRUE if it succeeds, FALSE if it fails.
+  ll.ScaleTexture:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Sets the diffuse texture Horizontal and Vertical repeats on Face of the
+      prim the script is attached to.\nIf Face == ALL_SIDES, all sides are set
+      in one call.\nNegative values for horizontal and vertical will flip the
+      texture.
+  ll.ScriptDanger:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns TRUE if Position is over public land, sandbox land, land that
+      doesn't allow everyone to edit and build, or land that doesn't allow
+      outside scripts.\nReturns true if the position is over public land, land
+      that doesn't allow everyone to edit and build, or land that doesn't allow
+      outside scripts.
+  ll.ScriptProfiler:
+    args:
+      - type: number
+    description: >-
+      Enables or disables script profiling options. Currently only supports
+      PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly
+      reduce script performance.
+  ll.SendRemoteData:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: number
+      - type: string
+    description: This function is deprecated.
+  ll.Sensor:
+    args:
+      - type: string
+      - type:
+          display: uuid
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE,
+      and/or SCRIPTED) within Range meters and Arc radians of forward
+      vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent
+      filtering results based on that parameter. A range of 0.0 does not perform
+      a scan.\nResults are returned in the sensor and no_sensor events.
+  ll.SensorRemove:
+    args: []
+    description: removes sensor.\nRemoves the sensor set by llSensorRepeat.
+  ll.SensorRepeat:
+    args:
+      - type: string
+      - type:
+          display: uuid
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Initiates a periodic scan every Rate seconds, for Name and ID with Type
+      (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc
+      radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY
+      ID will prevent filtering results based on that parameter. A range of 0.0
+      does not perform a scan.\nResults are returned in the sensor and no_sensor
+      events.
+  ll.SetAgentEnvironment:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: table
+    description: >-
+      Sets an agent's environmental values to the specified values. Must be used
+      as part of an experience.
+  ll.SetAgentRot:
+    args:
+      - type:
+          display: quaternion
+      - type: number
+    description: Sets the avatar rotation to the given value.
+  ll.SetAlpha:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value for
+      Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value
+      is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is
+      mostly transparent). This function will clamp alpha values less than 0.1
+      to 0.1 and greater than 1.0 to 1.
+  ll.SetAngularVelocity:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Sets an object's angular velocity to AngVel, in local coordinates if Local
+      == TRUE (if the script is physical).\nHas no effect on non-physical
+      objects.
+  ll.SetAnimationOverride:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Sets the animation (in object inventory) that will play for the given
+      animation state.\nTo use this function the script must obtain the
+      PERMISSION_OVERRIDE_ANIMATIONS permission.
+  ll.SetBuoyancy:
+    args:
+      - type: number
+    description: >-
+      Set the tasks buoyancy (0 is none, < 1.0 sinks, 1.0 floats, > 1.0
+      rises).\nSet the object buoyancy. A value of 0 is none, less than 1.0
+      sinks, 1.0 floats, and greater than 1.0 rises.
+  ll.SetCameraAtOffset:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Sets the camera used in this object, at offset, if an avatar sits on
+      it.\nSets the offset that an avatar's camera will be moved to if the
+      avatar sits on the object.
+  ll.SetCameraEyeOffset:
+    args:
+      - type:
+          display: vector
+    description: Sets the camera eye offset used in this object if an avatar sits on it.
+  ll.SetCameraParams:
+    args:
+      - type: table
+    description: >-
+      Sets multiple camera parameters at once. List format is [ rule-1, data-1,
+      rule-2, data-2 . . . rule-n, data-n ].
+  ll.SetClickAction:
+    args:
+      - type: number
+    description: Sets the action performed when a prim is clicked upon.
+  ll.SetColor:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Sets the color, for the face.\nSets the color of the side specified. If
+      Face is ALL_SIDES, sets the color on all faces.
+  ll.SetContentType:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Set the media type of an LSL HTTP server response to
+      ContentType.\nHTTPRequestID must be a valid http_request ID. ContentType
+      must be one of the CONTENT_TYPE_* constants.
+  ll.SetDamage:
+    args:
+      - type: number
+    description: "Sets the amount of damage that will be done to an avatar that this task hits.\tTask will be killed.\\nSets the amount of damage that will be done to an avatar that this object hits. This object will be destroyed on damaging an avatar, and no collision event is triggered."
+  ll.SetEnvironment:
+    args:
+      - type:
+          display: vector
+      - type: table
+    description: Returns a string with the requested data about the region.
+  ll.SetForce:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Sets Force on object, in object-local coordinates if Local == TRUE
+      (otherwise, the region reference frame is used).\nOnly works on physical
+      objects.
+  ll.SetForceAndTorque:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Sets the Force and Torque of object, in object-local coordinates if Local
+      == TRUE (otherwise, the region reference frame is used).\nOnly works on
+      physical objects.
+  ll.SetGroundTexture:
+    args:
+      - type: table
+    description: Changes terrain texture properties in the region.
+  ll.SetHoverHeight:
+    args:
+      - type: number
+      - type:
+          display: numeric
+      - type: number
+    description: >-
+      Critically damps a physical object to a Height (either above ground level
+      or above the higher of land and water if water == TRUE).\nDo not use with
+      vehicles. Use llStopHover to stop hovering.
+  ll.SetInventoryPermMask:
+    args:
+      - type: string
+      - type: number
+      - type: number
+    description: Sets the given permission mask to the new value on the inventory item.
+  ll.SetKeyframedMotion:
+    args:
+      - type: table
+      - type: table
+    description: >-
+      Requests that a non-physical object be key-framed according to key-frame
+      list.\nSpecify a list of times, positions, and orientations to be followed
+      by an object. The object will be smoothly moved between key-frames by the
+      simulator. Collisions with other non-physical or key-framed objects will
+      be ignored (no script events will fire and collision processing will not
+      occur). Collisions with physical objects will be computed and reported,
+      but the key-framed object will be unaffected by those
+      collisions.\nKeyframes is a strided list containing positional,
+      rotational, and time data for each step in the motion.  Options is a list
+      containing optional arguments and parameters (specified by KFM_*
+      constants).
+  ll.SetLinkAlpha:
+    args:
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      If a prim exists in the link chain at LinkNumber, set Face to
+      Opacity.\nSets the Face, on the linked prim specified, to the Opacity.
+  ll.SetLinkCamera:
+    args:
+      - type: number
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Sets the camera eye offset, and the offset that camera is looking at, for
+      avatars that sit on the linked prim.
+  ll.SetLinkColor:
+    args:
+      - type: number
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      If a task exists in the link chain at LinkNumber, set the Face to
+      color.\nSets the color of the linked child's side, specified by
+      LinkNumber.
+  ll.SetLinkGLTFOverrides:
+    args:
+      - type: number
+      - type: number
+      - type: table
+    description: Sets or changes GLTF Overrides set on the selected faces.
+  ll.SetLinkMedia:
+    args:
+      - type: number
+      - type: number
+      - type: table
+    description: >-
+      Set the media parameters for a particular face on linked prim, specified
+      by Link. Returns an integer that is a STATUS_* flag which details the
+      success/failure of the operation(s).\nMediaParameters is a set of
+      name/value pairs in no particular order. Parameters not specified are
+      unchanged, or if new media is added then set to the default specified.
+  ll.SetLinkPrimitiveParams:
+    args:
+      - type: number
+      - type: table
+    description: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
+  ll.SetLinkPrimitiveParamsFast:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Set primitive parameters for LinkNumber based on Parameters, without a
+      delay.\nSet parameters for link number, from the list of Parameters, with
+      no built-in script sleep. This function is identical to
+      llSetLinkPrimitiveParams, except without the delay.
+  ll.SetLinkRenderMaterial:
+    args:
+      - type: number
+      - type: string
+      - type: number
+    description: >-
+      Sets the Render Material of Face on a linked prim, specified by
+      LinkNumber. Render Material may be a UUID or name of a material in prim
+      inventory.
+  ll.SetLinkSitFlags:
+    args:
+      - type: number
+      - type: number
+    description: Sets the sit flags for the specified prim in a linkset.
+  ll.SetLinkTexture:
+    args:
+      - type: number
+      - type: string
+      - type: number
+    description: >-
+      Sets the Texture of Face on a linked prim, specified by LinkNumber.
+      Texture may be a UUID or name of a texture in prim inventory.
+  ll.SetLinkTextureAnim:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Animates a texture on the prim specified by LinkNumber, by setting the
+      texture scale and offset.\nMode is a bitmask of animation options.\nFace
+      specifies which object face to animate.\nSizeX and SizeY specify the
+      number of horizontal and vertical frames.Start specifes the animation
+      start point.\nLength specifies the animation duration.\nRate specifies the
+      animation playback rate.
+  ll.SetLocalRot:
+    args:
+      - type:
+          display: quaternion
+    description: Sets the rotation of a child prim relative to the root prim.
+  ll.SetMemoryLimit:
+    args:
+      - type: number
+    description: >-
+      Requests Limit bytes to be reserved for this script.\nReturns TRUE or
+      FALSE indicating whether the limit was set successfully.\nThis function
+      has no effect if the script is running in the LSO VM.
+  ll.SetObjectDesc:
+    args:
+      - type: string
+    description: >-
+      Sets the description of the prim to Description.\nThe description field is
+      limited to 127 characters.
+  ll.SetObjectName:
+    args:
+      - type: string
+    description: Sets the prim's name to Name.
+  ll.SetObjectPermMask:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Sets the specified PermissionFlag permission to the value specified by
+      PermissionMask on the object the script is attached to.
+  ll.SetParcelForSale:
+    args:
+      - type:
+          display: numeric
+      - type: table
+    description: >-
+      Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE
+      the parcel is put up for sale. Options is a list of options to set for the
+      sale, such as price, authorized buyer, and whether to include objects on
+      the parcel.\n Setting ForSale to FALSE will remove the parcel from sale
+      and clear any options that were set.
+  ll.SetParcelMusicURL:
+    args:
+      - type: string
+    description: >-
+      Sets the streaming audio URL for the parcel the object is on.\nThe object
+      must be owned by the owner of the parcel; if the parcel is group owned the
+      object must be owned by that group.
+  ll.SetPayPrice:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Sets the default amount when someone chooses to pay this object.\nPrice is
+      the default price shown in the text input field.  QuickButtons specifies
+      the 4 payment values shown in the payment dialog's buttons.\nInput field
+      and buttons may be hidden with PAY_HIDE constant, and may be set to their
+      default values using PAY_DEFAULT.
+  ll.SetPhysicsMaterial:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Sets the selected parameters of the object's physics
+      behavior.\nMaterialBits is a bitmask specifying which of the parameters in
+      the other arguments should be applied to the object. GravityMultiplier,
+      Restitution, Friction, and Density are the possible parameters to
+      manipulate.
+  ll.SetPos:
+    args:
+      - type:
+          display: vector
+    description: >-
+      If the object is not physical, this function sets the position of the
+      prim.\nIf the script is in a child prim, Position is treated as root
+      relative and the link-set is adjusted.\nIf the prim is the root prim, the
+      entire object is moved (up to 10m) to Position in region coordinates.
+  ll.SetPrimMediaParams:
+    args:
+      - type: number
+      - type: table
+    description: >-
+      Sets the MediaParameters for a particular Face on the prim. Returns an
+      integer that is a STATUS_* flag which details the success/failure of the
+      operation(s).\nMediaParameters is a set of name/value pairs in no
+      particular order. Parameters not specified are unchanged, or if new media
+      is added then set to the default specified.
+  ll.SetPrimURL:
+    args:
+      - type: string
+    description: 'Deprecated: Use llSetPrimMediaParams instead.'
+  ll.SetPrimitiveParams:
+    args:
+      - type: table
+    description: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
+  ll.SetRegionPos:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Attempts to move the object so that the root prim is within 0.1m of
+      Position.\nReturns an integer boolean, TRUE if the object is successfully
+      placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any
+      location within the region or up to 10m across a region border.\nIf the
+      position is below ground, it will be set to the ground level at that x,y
+      location.
+  ll.SetRemoteScriptAccessPin:
+    args:
+      - type: number
+    description: >-
+      If PIN is set to a non-zero number, the task will accept remote script
+      loads via llRemoteLoadScriptPin() if it passes in the correct PIN.
+      Othersise, llRemoteLoadScriptPin() is ignored.
+  ll.SetRenderMaterial:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Applies Render Material to Face of prim.\nRender Material may be a UUID or
+      name of a material in prim inventory.\nIf Face is ALL_SIDES, set the
+      render material on all faces.
+  ll.SetRot:
+    args:
+      - type:
+          display: quaternion
+    description: >-
+      If the object is not physical, this function sets the rotation of the
+      prim.\nIf the script is in a child prim, Rotation is treated as root
+      relative and the link-set is adjusted.\nIf the prim is the root prim, the
+      entire object is rotated to Rotation in the global reference frame.
+  ll.SetScale:
+    args:
+      - type:
+          display: vector
+    description: Sets the prim's scale (size) to Scale.
+  ll.SetScriptState:
+    args:
+      - type: string
+      - type:
+          display: numeric
+    description: Enable or disable the script Running state of Script in the prim.
+  ll.SetSitText:
+    args:
+      - type: string
+    description: Displays Text rather than 'Sit' in the viewer's context menu.
+  ll.SetSoundQueueing:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached
+      sounds) interrupt the currently playing sound.\nThe default for objects is
+      FALSE. Setting this value to TRUE will make the sound wait until the
+      current playing sound reaches its end. The queue is one level deep.
+  ll.SetSoundRadius:
+    args:
+      - type: number
+    description: >-
+      Limits radius for audibility of scripted sounds (both attached and
+      triggered) to distance Radius.
+  ll.SetStatus:
+    args:
+      - type: number
+      - type:
+          display: numeric
+    description: >-
+      Sets object status specified in Status bitmask (e.g.
+      STATUS_PHYSICS|STATUS_PHANTOM) to boolean Value.\nFor a full list of
+      STATUS_* constants, see wiki documentation.
+  ll.SetText:
+    args:
+      - type: string
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      Causes Text to float above the prim, using the specified Color and
+      Opacity.
+  ll.SetTexture:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Applies Texture to Face of prim.\nTexture may be a UUID or name of a
+      texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all
+      faces.
+  ll.SetTextureAnim:
+    args:
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Animates a texture by setting the texture scale and offset.\nMode is a
+      bitmask of animation options.\nFace specifies which object face to
+      animate.\nSizeX and SizeY specify the number of horizontal and vertical
+      frames.Start specifes the animation start point.\nLength specifies the
+      animation duration.\nRate specifies the animation playback rate.
+  ll.SetTimerEvent:
+    args:
+      - type: number
+    description: >-
+      Causes the timer event to be triggered every Rate seconds.\n Passing in
+      0.0 stops further timer events.
+  ll.SetTorque:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: numeric
+    description: >-
+      Sets the Torque acting on the script's object, in object-local coordinates
+      if Local == TRUE (otherwise, the region reference frame is used).\nOnly
+      works on physical objects.
+  ll.SetTouchText:
+    args:
+      - type: string
+    description: Displays Text in the viewer context menu that acts on a touch.
+  ll.SetVehicleFlags:
+    args:
+      - type: number
+    description: >-
+      Enables the vehicle flags specified in the Flags bitmask.\nValid
+      parameters can be found in the wiki documentation.
+  ll.SetVehicleFloatParam:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      Sets a vehicle float parameter.\nValid parameters can be found in the wiki
+      documentation.
+  ll.SetVehicleRotationParam:
+    args:
+      - type: number
+      - type:
+          display: quaternion
+    description: >-
+      Sets a vehicle rotation parameter.\nValid parameters can be found in the
+      wiki documentation.
+  ll.SetVehicleType:
+    args:
+      - type: number
+    description: >-
+      Activates the vehicle action on the object with vehicle preset
+      Type.\nValid Types and an explanation of their characteristics can be
+      found in wiki documentation.
+  ll.SetVehicleVectorParam:
+    args:
+      - type: number
+      - type:
+          display: vector
+    description: >-
+      Sets a vehicle vector parameter.\nValid parameters can be found in the
+      wiki documentation.
+  ll.SetVelocity:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      If the object is physics-enabled, sets the object's linear velocity to
+      Velocity.\nIf Local==TRUE, Velocity is treated as a local directional
+      vector; otherwise, Velocity is treated as a global directional vector.
+  ll.Shout:
+    args:
+      - type: number
+      - type: string
+    description: >-
+      Shouts Text on Channel.\nThis chat method has a range of 100m
+      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
+      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
+      to nearby avatars. All other channels are are not sent to avatars, but may
+      be used to communicate with scripts.
+  ll.SignRSA:
+    args:
+      - type: string
+      - type: string
+      - type: string
+    description: >-
+      Returns the base64-encoded RSA signature of Message using PEM-formatted
+      PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).
+  ll.Sin:
+    args:
+      - type: number
+    description: Returns the sine of Theta (Theta in radians).
+  ll.SitOnLink:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      If agent identified by AvatarID is participating in the experience, sit
+      them on the specified link's sit target.
+  ll.SitTarget:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: quaternion
+    description: >-
+      Set the sit location for this object. If offset == ZERO_VECTOR, clears the
+      sit target.
+  ll.Sleep:
+    args:
+      - type: number
+    description: Put script to sleep for Time seconds.
+  ll.Sound:
+    args:
+      - type: string
+      - type: number
+      - type: number
+      - type: number
+    description: >-
+      Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and specifies
+      whether the sound should loop and/or be enqueued.
+  ll.SoundPreload:
+    args:
+      - type: string
+    description: >-
+      Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers
+      within range.
+  ll.Sqrt:
+    args:
+      - type: number
+    description: >-
+      Returns the square root of Value.\nTriggers a math runtime error for
+      imaginary results (if Value < 0.0).
+  ll.StartAnimation:
+    args:
+      - type: string
+    description: >-
+      This function plays the specified animation from playing on the avatar who
+      received the script's most recent permissions request.\nAnimation may be
+      an animation in task inventory or a built-in animation.\nRequires
+      PERMISSION_TRIGGER_ANIMATION.
+  ll.StartObjectAnimation:
+    args:
+      - type: string
+    description: >-
+      This function plays the specified animation on the rigged mesh object
+      associated with the current script.\nAnimation may be an animation in task
+      inventory or a built-in animation.\n
+  ll.StopAnimation:
+    args:
+      - type: string
+    description: >-
+      This function stops the specified animation on the avatar who received the
+      script's most recent permissions request.\nAnimation may be an animation
+      in task inventory, a built-in animation, or the uuid of an
+      animation.\nRequires PERMISSION_TRIGGER_ANIMATION.
+  ll.StopHover:
+    args: []
+    description: Stop hovering to a height (due to llSetHoverHeight()).
+  ll.StopLookAt:
+    args: []
+    description: >-
+      Stop causing object to point at a target (due to llLookAt() or
+      llRotLookAt()).
+  ll.StopMoveToTarget:
+    args: []
+    description: Stops critically damped motion (due to llMoveToTarget()).
+  ll.StopObjectAnimation:
+    args:
+      - type: string
+    description: >-
+      This function stops the specified animation on the rigged mesh object
+      associated with the current script.\nAnimation may be an animation in task
+      inventory, a built-in animation, or the uuid of an animation.\n
+  ll.StopSound:
+    args: []
+    description: Stops playback of the currently attached sound.
+  ll.StringLength:
+    args:
+      - type: string
+    description: >-
+      Returns an integer that is the number of characters in Text (not counting
+      the null).
+  ll.StringToBase64:
+    args:
+      - type: string
+    description: Returns the string Base64 representation of the input string.
+  ll.StringTrim:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Outputs a string, eliminating white-space from the start and/or end of the
+      input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD: trim
+      all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces in
+      Text\nSTRING_TRIM: trim all leading and trailing spaces in Text.
+  ll.SubStringIndex:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Returns an integer that is the index in Text where string pattern Sequence
+      first appears. Returns -1 if not found.
+  ll.TakeCamera:
+    args:
+      - type:
+          display: uuid
+    description: 'Deprecated: Use llSetCameraParams instead.'
+  ll.TakeControls:
+    args:
+      - type: number
+      - type:
+          display: numeric
+      - type:
+          display: numeric
+    description: >-
+      Take controls from the agent the script has permissions for.\nIf (Accept
+      == (Controls & input)), send input to the script.  PassOn determines
+      whether Controls also perform their normal functions.\nRequires the
+      PERMISSION_TAKE_CONTROLS permission to run.
+  ll.Tan:
+    args:
+      - type: number
+    description: Returns the tangent of Theta (Theta in radians).
+  ll.Target:
+    args:
+      - type:
+          display: vector
+      - type: number
+    description: >-
+      This function is to have the script know when it has reached a
+      position.\nIt registers a Position with a Range that triggers at_target
+      and not_at_target events continuously until unregistered.
+  ll.TargetOmega:
+    args:
+      - type:
+          display: vector
+      - type: number
+      - type: number
+    description: >-
+      Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate of
+      0.0 cancels the spin. This function always works in object-local
+      coordinates.
+  ll.TargetRemove:
+    args:
+      - type: number
+    description: Removes positional target Handle registered with llTarget.
+  ll.TargetedEmail:
+    args:
+      - type: number
+      - type: string
+      - type: string
+    description: >-
+      Sends an email with Subject and Message to the owner or creator of an
+      object.
+  ll.TeleportAgent:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Requests a teleport of avatar to a landmark stored in the object's
+      inventory. If no landmark is provided (an empty string), the avatar is
+      teleported to the location position in the current region. In either case,
+      the avatar is turned to face the position given by look_at in local
+      coordinates.\nRequires the PERMISSION_TELEPORT permission. This function
+      can only teleport the owner of the object.
+  ll.TeleportAgentGlobalCoords:
+    args:
+      - type:
+          display: uuid
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Teleports an agent to the RegionPosition local coordinates within a region
+      which is specified by the GlobalPosition global coordinates. The agent
+      lands facing the position defined by LookAtPoint local
+      coordinates.\nRequires the PERMISSION_TELEPORT permission. This function
+      can only teleport the owner of the object.
+  ll.TeleportAgentHome:
+    args:
+      - type:
+          display: uuid
+    description: Teleport agent over the owner's land to agent's home location.
+  ll.TextBox:
+    args:
+      - type:
+          display: uuid
+      - type: string
+      - type: number
+    description: >-
+      Opens a dialog for the specified avatar with message Text, which contains
+      a text box for input. Any text that is entered is said on the specified
+      Channel (as if by the avatar) when the "OK" button is clicked.
+  ll.ToLower:
+    args:
+      - type: string
+    description: Returns a string that is Text with all lower-case characters.
+  ll.ToUpper:
+    args:
+      - type: string
+    description: Returns a string that is Text with all upper-case characters.
+  ll.TransferLindenDollars:
+    args:
+      - type:
+          display: uuid
+      - type: number
+    description: >-
+      Transfer Amount of linden dollars (L$) from script owner to AvatarID.
+      Returns a key to a corresponding transaction_result event for the success
+      of the transfer.\nAttempts to send the amount of money to the specified
+      avatar, and trigger a transaction_result event identified by the returned
+      key.
+  ll.TransferOwnership:
+    args:
+      - type:
+          display: uuid
+      - type: number
+      - type: table
+    description: Transfers ownership of an object, or a copy of the object to a new agent.
+  ll.TriggerSound:
+    args:
+      - type: string
+      - type: number
+    description: >-
+      Plays Sound at Volume (0.0 - 1.0), centered at but not attached to
+      object.\nThere is no limit to the number of triggered sounds which can be
+      generated by an object, and calling llTriggerSound does not affect the
+      attached sounds created by llPlaySound and llLoopSound. This is very
+      useful for things like collision noises, explosions, etc. There is no way
+      to stop or alter the volume of a sound triggered by this function.
+  ll.TriggerSoundLimited:
+    args:
+      - type: string
+      - type: number
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: >-
+      Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object,
+      limited to axis-aligned bounding box defined by vectors top-north-east
+      (TNE) and bottom-south-west (BSW).\nThere is no limit to the number of
+      triggered sounds which can be generated by an object, and calling
+      llTriggerSound does not affect the attached sounds created by llPlaySound
+      and llLoopSound. This is very useful for things like collision noises,
+      explosions, etc. There is no way to stop or alter the volume of a sound
+      triggered by this function.
+  ll.UnSit:
+    args:
+      - type:
+          display: uuid
+    description: >-
+      If agent identified by AvatarID is sitting on the object the script is
+      attached to or is over land owned by the object's owner, the agent is
+      forced to stand up.
+  ll.UnescapeURL:
+    args:
+      - type: string
+    description: >-
+      Returns the string that is the URL unescaped, replacing "%20" with spaces,
+      etc., version of URL.\nThis function can output raw UTF-8 strings.
+  ll.UpdateCharacter:
+    args:
+      - type: table
+    description: Updates settings for a pathfinding character.
+  ll.UpdateKeyValue:
+    args:
+      - type: string
+      - type: string
+      - type: number
+      - type: string
+    description: |2-
+
+                         Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
+                      
+  ll.VecDist:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+    description: Returns the distance between Location1 and Location2.
+  ll.VecMag:
+    args:
+      - type:
+          display: vector
+    description: Returns the magnitude of the vector.
+  ll.VecNorm:
+    args:
+      - type:
+          display: vector
+    description: Returns normalized vector.
+  ll.VerifyRSA:
+    args:
+      - type: string
+      - type: string
+      - type: string
+      - type: string
+    description: >-
+      Returns TRUE if PublicKey, Message, and Algorithm produce the same
+      base64-formatted Signature.
+  ll.VolumeDetect:
+    args:
+      - type:
+          display: numeric
+    description: >-
+      If DetectEnabled = TRUE, object becomes phantom but triggers
+      collision_start and collision_end events when other objects start and stop
+      interpenetrating.\nIf another object (including avatars) interpenetrates
+      it, it will get a collision_start event.\nWhen an object stops
+      interpenetrating, a collision_end event is generated. While the other is
+      inter-penetrating, collision events are NOT generated.
+  ll.WanderWithin:
+    args:
+      - type:
+          display: vector
+      - type:
+          display: vector
+      - type: table
+    description: >-
+      Wander within a specified volume.\nSets a character to wander about a
+      central spot within a specified area.
+  ll.Water:
+    args:
+      - type:
+          display: vector
+    description: Returns the water height below the object position + Offset.
+  ll.Whisper:
+    args:
+      - type: number
+      - type: string
+    description: >-
+      Whispers Text on Channel.\nThis chat method has a range of 10m
+      radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as
+      chat text. DEBUG_CHANNEL is the script debug channel, and is also visible
+      to nearby avatars. All other channels are are not sent to avatars, but may
+      be used to communicate with scripts.
+  ll.Wind:
+    args:
+      - type:
+          display: vector
+    description: Returns the wind velocity at the object position + Offset.
+  ll.WorldPosToHUD:
+    args:
+      - type:
+          display: vector
+    description: >-
+      Returns the local position that would put the origin of a HUD object
+      directly over world_pos as viewed by the current camera.
+  ll.XorBase64:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Performs an exclusive OR on two Base64 strings and returns a Base64
+      string. Text2 repeats if it is shorter than Text1.
+  ll.XorBase64Strings:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Deprecated: Please use llXorBase64 instead.\nIncorrectly performs an
+      exclusive OR on two Base64 strings and returns a Base64 string. Text2
+      repeats if it is shorter than Text1.\nRetained for backwards
+      compatibility.
+  ll.XorBase64StringsCorrect:
+    args:
+      - type: string
+      - type: string
+    description: >-
+      Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls are
+      present) performs an exclusive OR on two Base64 strings and returns a
+      Base64 string.\nText2 repeats if it is shorter than Text1.
+  ll.sRGB2Linear:
+    args:
+      - type:
+          display: vector
+    description: Converts a color from the sRGB to the linear colorspace.
+  llcompat.AdjustDamage:
+    args:
+      - type: number
+      - type: number
+    description: >-
+      (Index semantics) Changes the amount of damage to be delivered by this
+      damage event.
+  llcompat.DetectedDamage:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns a list containing the current damage for the
+      event, the damage type and the original damage delivered.
+  llcompat.DetectedGrab:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the grab offset of a user touching the
+      object.\nReturns <0.0, 0.0, 0.0> if Number is not a valid object.
+  llcompat.DetectedGroup:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns TRUE if detected object or agent Number has the
+      same user group active as this object.\nIt will return FALSE if the object
+      or agent is in the group, but the group is not active.
+  llcompat.DetectedKey:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the key of detected object or avatar
+      number.\nReturns NULL_KEY if Number is not a valid index.
+  llcompat.DetectedLinkNumber:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the link position of the triggered event for
+      touches and collisions only.\n0 for a non-linked object, 1 for the root of
+      a linked object, 2 for the first child, etc.
+  llcompat.DetectedName:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the name of detected object or avatar
+      number.\nReturns the name of detected object number.\nReturns empty string
+      if Number is not a valid index.
+  llcompat.DetectedOwner:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the key of detected object's owner.\nReturns
+      invalid key if Number is not a valid index.
+  llcompat.DetectedPos:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the position of detected object or avatar
+      number.\nReturns <0.0, 0.0, 0.0> if Number is not a valid index.
+  llcompat.DetectedRezzer:
+    args:
+      - type: number
+    description: (Index semantics) Returns the key for the rezzer of the detected object.
+  llcompat.DetectedRot:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the rotation of detected object or avatar
+      number.\nReturns <0.0, 0.0, 0.0, 1.0> if Number is not a valid offset.
+  llcompat.DetectedTouchBinormal:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the surface bi-normal for a triggered touch
+      event.\nReturns a vector that is the surface bi-normal (tangent to the
+      surface) where the touch event was triggered.
+  llcompat.DetectedTouchFace:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the index of the face where the avatar clicked
+      in a triggered touch event.
+  llcompat.DetectedTouchNormal:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the surface normal for a triggered touch
+      event.\nReturns a vector that is the surface normal (perpendicular to the
+      surface) where the touch event was triggered.
+  llcompat.DetectedTouchPos:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the position, in region coordinates, where the
+      object was touched in a triggered touch event.\nUnless it is a HUD, in
+      which case it returns the position relative to the attach point.
+  llcompat.DetectedTouchST:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns a vector that is the surface coordinates where
+      the prim was touched.\nThe X and Y vector positions contain the horizontal
+      (S) and vertical (T) face coordinates respectively.\nEach component is in
+      the interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD is returned if the
+      surface coordinates cannot be determined (e.g. when the viewer does not
+      support this function).
+  llcompat.DetectedTouchUV:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns a vector that is the texture coordinates for
+      where the prim was touched.\nThe X and Y vector positions contain the U
+      and V face coordinates respectively.\nTOUCH_INVALID_TEXCOORD is returned
+      if the touch UV coordinates cannot be determined (e.g. when the viewer
+      does not support this function).
+  llcompat.DetectedType:
+    args:
+      - type: number
+    description: "(Index semantics) Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\\nReturns 0 if number is not a valid index.\\nNote that number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\\ninteger iType = llDetectedType(0);\\n{\\n\t// ...do stuff with the agent\\n}"
+  llcompat.DetectedVel:
+    args:
+      - type: number
+    description: >-
+      (Index semantics) Returns the velocity of the detected object
+      Number.\nReturns<0.0, 0.0, 0.0> if Number is not a valid offset.
+structs:
+  LLEvents:
+    'on':
+      method: true
+      args:
+        - type:
+            - collision
+            - collision_end
+            - collision_start
+            - final_damage
+            - on_damage
+            - sensor
+            - touch
+            - touch_end
+            - touch_start
+            - at_rot_target
+            - at_target
+            - attach
+            - changed
+            - control
+            - dataserver
+            - email
+            - experience_permissions
+            - experience_permissions_denied
+            - game_control
+            - http_request
+            - http_response
+            - land_collision
+            - land_collision_end
+            - land_collision_start
+            - link_message
+            - linkset_data
+            - listen
+            - money
+            - moving_end
+            - moving_start
+            - no_sensor
+            - not_at_rot_target
+            - not_at_target
+            - object_rez
+            - on_death
+            - on_rez
+            - path_update
+            - remote_data
+            - run_time_permissions
+            - state_entry
+            - state_exit
+            - timer
+            - transaction_result
+        - type: function
+      description: Registers a callback for an event. Returns the callback.
+    'off':
+      method: true
+      args:
+        - type:
+            - collision
+            - collision_end
+            - collision_start
+            - final_damage
+            - on_damage
+            - sensor
+            - touch
+            - touch_end
+            - touch_start
+            - at_rot_target
+            - at_target
+            - attach
+            - changed
+            - control
+            - dataserver
+            - email
+            - experience_permissions
+            - experience_permissions_denied
+            - game_control
+            - http_request
+            - http_response
+            - land_collision
+            - land_collision_end
+            - land_collision_start
+            - link_message
+            - linkset_data
+            - listen
+            - money
+            - moving_end
+            - moving_start
+            - no_sensor
+            - not_at_rot_target
+            - not_at_target
+            - object_rez
+            - on_death
+            - on_rez
+            - path_update
+            - remote_data
+            - run_time_permissions
+            - state_entry
+            - state_exit
+            - timer
+            - transaction_result
+        - type: function
+      description: Unregisters a callback. Returns true if found and removed.
+    once:
+      method: true
+      args:
+        - type:
+            - collision
+            - collision_end
+            - collision_start
+            - final_damage
+            - on_damage
+            - sensor
+            - touch
+            - touch_end
+            - touch_start
+            - at_rot_target
+            - at_target
+            - attach
+            - changed
+            - control
+            - dataserver
+            - email
+            - experience_permissions
+            - experience_permissions_denied
+            - game_control
+            - http_request
+            - http_response
+            - land_collision
+            - land_collision_end
+            - land_collision_start
+            - link_message
+            - linkset_data
+            - listen
+            - money
+            - moving_end
+            - moving_start
+            - no_sensor
+            - not_at_rot_target
+            - not_at_target
+            - object_rez
+            - on_death
+            - on_rez
+            - path_update
+            - remote_data
+            - run_time_permissions
+            - state_entry
+            - state_exit
+            - timer
+            - transaction_result
+        - type: function
+      description: Registers a one-time callback. Returns the wrapper function.
+    listeners:
+      method: true
+      args:
+        - type:
+            - collision
+            - collision_end
+            - collision_start
+            - final_damage
+            - on_damage
+            - sensor
+            - touch
+            - touch_end
+            - touch_start
+            - at_rot_target
+            - at_target
+            - attach
+            - changed
+            - control
+            - dataserver
+            - email
+            - experience_permissions
+            - experience_permissions_denied
+            - game_control
+            - http_request
+            - http_response
+            - land_collision
+            - land_collision_end
+            - land_collision_start
+            - link_message
+            - linkset_data
+            - listen
+            - money
+            - moving_end
+            - moving_start
+            - no_sensor
+            - not_at_rot_target
+            - not_at_target
+            - object_rez
+            - on_death
+            - on_rez
+            - path_update
+            - remote_data
+            - run_time_permissions
+            - state_entry
+            - state_exit
+            - timer
+            - transaction_result
+      description: Returns a list of all listeners for a specific event.
+    eventNames:
+      method: true
+      args: []
+      description: Returns a list of all event names that have listeners.
+    at_rot_target:
+      property: read-only
+      type: any
+    at_target:
+      property: read-only
+      type: any
+    attach:
+      property: read-only
+      type: any
+    changed:
+      property: read-only
+      type: any
+    collision:
+      property: read-only
+      type: any
+    collision_end:
+      property: read-only
+      type: any
+    collision_start:
+      property: read-only
+      type: any
+    control:
+      property: read-only
+      type: any
+    dataserver:
+      property: read-only
+      type: any
+    email:
+      property: read-only
+      type: any
+    experience_permissions:
+      property: read-only
+      type: any
+    experience_permissions_denied:
+      property: read-only
+      type: any
+    final_damage:
+      property: read-only
+      type: any
+    game_control:
+      property: read-only
+      type: any
+    http_request:
+      property: read-only
+      type: any
+    http_response:
+      property: read-only
+      type: any
+    land_collision:
+      property: read-only
+      type: any
+    land_collision_end:
+      property: read-only
+      type: any
+    land_collision_start:
+      property: read-only
+      type: any
+    link_message:
+      property: read-only
+      type: any
+    linkset_data:
+      property: read-only
+      type: any
+    listen:
+      property: read-only
+      type: any
+    money:
+      property: read-only
+      type: any
+    moving_end:
+      property: read-only
+      type: any
+    moving_start:
+      property: read-only
+      type: any
+    no_sensor:
+      property: read-only
+      type: any
+    not_at_rot_target:
+      property: read-only
+      type: any
+    not_at_target:
+      property: read-only
+      type: any
+    object_rez:
+      property: read-only
+      type: any
+    on_damage:
+      property: read-only
+      type: any
+    on_death:
+      property: read-only
+      type: any
+    on_rez:
+      property: read-only
+      type: any
+    path_update:
+      property: read-only
+      type: any
+    remote_data:
+      property: read-only
+      type: any
+    run_time_permissions:
+      property: read-only
+      type: any
+    sensor:
+      property: read-only
+      type: any
+    state_entry:
+      property: read-only
+      type: any
+    state_exit:
+      property: read-only
+      type: any
+    timer:
+      property: read-only
+      type: any
+    touch:
+      property: read-only
+      type: any
+    touch_end:
+      property: read-only
+      type: any
+    touch_start:
+      property: read-only
+      type: any
+    transaction_result:
+      property: read-only
+      type: any
+  LLTimers:
+    every:
+      method: true
+      args:
+        - type: number
+        - type: function
+      description: Registers a callback to be called every N seconds. Returns the callback.
+    once:
+      method: true
+      args:
+        - type: number
+        - type: function
+      description: >-
+        Registers a callback to be called once after N seconds. Returns the
+        callback.
+    'off':
+      method: true
+      args:
+        - type: any
+      description: Unregisters a timer callback. Returns true if found and removed.


### PR DESCRIPTION
- Part of #5299 

These are the two files that any installation of [the Luau Language Server (luau-lsp)](https://github.com/JohnnyMorganz/luau-lsp) needs to make sense of slua code. Currently, vscode plugin builds these two files based on these two files it fetches from the viewer:
-  [types_lua_default.xml](https://github.com/secondlife/viewer/blob/project/lua_editor/indra/newview/app_settings/types_lua_default.xml)
- [keywords_lsl_default.xml](https://github.com/secondlife/viewer/blob/project/lua_editor/indra/newview/app_settings/keywords_lsl_default.xml) (except it uses the version from the simulator capability)

Instead, I propose the viewer and/or simulator keep these two files on-hand so that [the vscode plugin](https://github.com/secondlife/sl-vscode-plugin) and other editors (including the viewer's builtin editor) can handle slua without complex file transformation.

These two files were generated by [the latest unreleased version](https://github.com/secondlife/sl-vscode-plugin/commit/251f9b840647a49c3a8255e20ba64d1ba419f42b) of [the vscode plugin](https://github.com/secondlife/sl-vscode-plugin). Further auto-generated updates to these files will be in a seperate PR #5328 ([View the diff](https://github.com/tapple/viewer/pull/1/files))

---

Part of a set:
- https://github.com/secondlife/lsl-definitions/pull/42
- https://github.com/secondlife/viewer/pull/5327
- https://github.com/secondlife/viewer/pull/5328