### PR TITLE
Use new suspendUntilNextFrame() to fix wait logic

### DIFF
--- a/indra/llcommon/lleventcoro.cpp
+++ b/indra/llcommon/lleventcoro.cpp
@@ -137,6 +137,18 @@ void llcoro::suspendUntilTimeout(float seconds)
     suspendUntilEventOnWithTimeout(bogus, seconds, timedout);
 }
 
+void llcoro::suspendUntilNextFrame()
+{
+    LLCoros::checkStop();
+    LLCoros::TempStatus st("waiting for next frame");
+
+    // Listen for the next event on the "mainloop" event pump.
+    // Once per frame we get mainloop.post(newFrame);
+    LLEventPumpOrPumpName mainloop_pump("mainloop");
+    // Wait for the next event (the event data is ignored).
+    suspendUntilEventOn(mainloop_pump);
+}
+
 namespace
 {
 

--- a/indra/llcommon/lleventcoro.h
+++ b/indra/llcommon/lleventcoro.h
@@ -85,6 +85,11 @@ void suspend();
 void suspendUntilTimeout(float seconds);
 
 /**
+ * Yield control from a coroutine until the next mainloop's newFrame event.
+ */
+void suspendUntilNextFrame();
+
+/**
  * Post specified LLSD event on the specified LLEventPump, then suspend for a
  * response on specified other LLEventPump. This is more than mere
  * convenience: the difference between this function and the sequence

--- a/indra/newview/llaisapi.cpp
+++ b/indra/newview/llaisapi.cpp
@@ -1060,7 +1060,12 @@ void AISUpdate::checkTimeout()
 {
     if (mTimer.hasExpired())
     {
-        llcoro::suspend();
+        // If we are taking too long, don't starve other tasks,
+        // yield to mainloop.
+        // If we use normal suspend(), there will be a chance of
+        // waking up from other suspends, before main coro had
+        // a chance, so wait for a frame tick instead.
+        llcoro::suspendUntilNextFrame();
         LLCoros::checkStop();
         mTimer.setTimerExpirySec(AIS_EXPIRY_SECONDS);
     }

--- a/indra/newview/llfloater360capture.cpp
+++ b/indra/newview/llfloater360capture.cpp
@@ -403,7 +403,7 @@ void LLFloater360Capture::suspendForAFrame()
     U32 curr_frame_count = LLFrameTimer::getFrameCount();
     while (LLFrameTimer::getFrameCount() <= curr_frame_count + frame_count_delta)
     {
-        llcoro::suspend();
+        llcoro::suspendUntilNextFrame();
     }
 }
 

--- a/indra/newview/llvoicevivox.cpp
+++ b/indra/newview/llvoicevivox.cpp
@@ -1107,7 +1107,7 @@ bool LLVivoxVoiceClient::startAndLaunchDaemon()
 
     while (!sPump && !sShuttingDown)
     {   // Can't use the pump until we have it available.
-        llcoro::suspend();
+        llcoro::suspendUntilNextFrame();
     }
 
     if (sShuttingDown)


### PR DESCRIPTION
Since 'suspend' can cycle to other coros then back to itself without passing back to main loop, decided to go over other uses of suspend and fix them to avoid potential deadlocks or feedback loops like we had with inventory.