### PR TITLE
Change the keywords.xml generator from c to python

### DIFF
--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -112,7 +112,7 @@
          <key>AGENT_ALWAYS_RUN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -139,7 +139,7 @@
          <key>AGENT_AUTOPILOT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -148,7 +148,7 @@
          <key>AGENT_AWAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -157,7 +157,7 @@
          <key>AGENT_BUSY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -166,7 +166,7 @@
          <key>AGENT_BY_LEGACY_NAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -175,7 +175,7 @@
          <key>AGENT_BY_USERNAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -184,7 +184,7 @@
          <key>AGENT_CROUCHING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -211,7 +211,7 @@
          <key>AGENT_IN_AIR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -247,7 +247,7 @@
          <key>AGENT_MOUSELOOK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -256,7 +256,7 @@
          <key>AGENT_ON_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -274,7 +274,7 @@
          <key>AGENT_SITTING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -283,7 +283,7 @@
          <key>AGENT_TYPING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -292,7 +292,7 @@
          <key>AGENT_WALKING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -301,7 +301,7 @@
          <key>ALL_SIDES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -463,7 +463,7 @@
          <key>ATTACH_HUD_BOTTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -472,7 +472,7 @@
          <key>ATTACH_HUD_BOTTOM_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -481,7 +481,7 @@
          <key>ATTACH_HUD_BOTTOM_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -490,7 +490,7 @@
          <key>ATTACH_HUD_CENTER_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -499,7 +499,7 @@
          <key>ATTACH_HUD_CENTER_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -508,7 +508,7 @@
          <key>ATTACH_HUD_TOP_CENTER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -517,7 +517,7 @@
          <key>ATTACH_HUD_TOP_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -526,7 +526,7 @@
          <key>ATTACH_HUD_TOP_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -845,7 +845,7 @@
          <key>AVOID_CHARACTERS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -854,7 +854,7 @@
          <key>AVOID_DYNAMIC_OBSTACLES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -863,7 +863,7 @@
          <key>AVOID_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -881,7 +881,7 @@
          <key>CAMERA_ACTIVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -890,7 +890,7 @@
          <key>CAMERA_BEHINDNESS_ANGLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -899,7 +899,7 @@
          <key>CAMERA_BEHINDNESS_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -908,7 +908,7 @@
          <key>CAMERA_DISTANCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -917,7 +917,7 @@
          <key>CAMERA_FOCUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -926,7 +926,7 @@
          <key>CAMERA_FOCUS_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -935,7 +935,7 @@
          <key>CAMERA_FOCUS_LOCKED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -944,7 +944,7 @@
          <key>CAMERA_FOCUS_OFFSET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -953,7 +953,7 @@
          <key>CAMERA_FOCUS_THRESHOLD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -962,7 +962,7 @@
          <key>CAMERA_PITCH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -971,7 +971,7 @@
          <key>CAMERA_POSITION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -980,7 +980,7 @@
          <key>CAMERA_POSITION_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -989,7 +989,7 @@
          <key>CAMERA_POSITION_LOCKED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -998,7 +998,7 @@
          <key>CAMERA_POSITION_THRESHOLD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1043,7 +1043,7 @@
          <key>CHANGED_MEDIA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1151,7 +1151,7 @@
          <key>CHARACTER_CMD_SMOOTH_STOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1268,7 +1268,7 @@
          <key>CHARACTER_TYPE_A</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1277,7 +1277,7 @@
          <key>CHARACTER_TYPE_B</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1286,7 +1286,7 @@
          <key>CHARACTER_TYPE_C</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1295,7 +1295,7 @@
          <key>CHARACTER_TYPE_D</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1304,7 +1304,7 @@
          <key>CHARACTER_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1646,7 +1646,7 @@
          <key>DAMAGE_TYPE_EMOTIONAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1781,7 +1781,7 @@
          <key>DATA_PAYINFO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1805,7 +1805,7 @@
          <key>DATA_SIM_POS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1814,7 +1814,7 @@
          <key>DATA_SIM_RATING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1823,7 +1823,7 @@
          <key>DATA_SIM_STATUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1986,7 +1986,7 @@
          <key>ERR_GENERIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -1995,7 +1995,7 @@
          <key>ERR_MALFORMED_PARAMS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2004,7 +2004,7 @@
          <key>ERR_PARCEL_PERMISSIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2013,7 +2013,7 @@
          <key>ERR_RUNTIME_PERMISSIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2022,7 +2022,7 @@
          <key>ERR_THROTTLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2139,7 +2139,7 @@
          <key>GAME_CONTROL_AXIS_LEFTX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2148,7 +2148,7 @@
          <key>GAME_CONTROL_AXIS_LEFTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2157,7 +2157,7 @@
          <key>GAME_CONTROL_AXIS_RIGHTX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2166,7 +2166,7 @@
          <key>GAME_CONTROL_AXIS_RIGHTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2175,7 +2175,7 @@
          <key>GAME_CONTROL_AXIS_TRIGGERLEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2184,7 +2184,7 @@
          <key>GAME_CONTROL_AXIS_TRIGGERRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2193,7 +2193,7 @@
          <key>GAME_CONTROL_BUTTON_A</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2202,7 +2202,7 @@
          <key>GAME_CONTROL_BUTTON_B</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2211,7 +2211,7 @@
          <key>GAME_CONTROL_BUTTON_BACK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2220,7 +2220,7 @@
          <key>GAME_CONTROL_BUTTON_DPAD_DOWN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2229,7 +2229,7 @@
          <key>GAME_CONTROL_BUTTON_DPAD_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2238,7 +2238,7 @@
          <key>GAME_CONTROL_BUTTON_DPAD_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2247,7 +2247,7 @@
          <key>GAME_CONTROL_BUTTON_DPAD_UP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2256,7 +2256,7 @@
          <key>GAME_CONTROL_BUTTON_GUIDE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2265,7 +2265,7 @@
          <key>GAME_CONTROL_BUTTON_LEFTSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2274,7 +2274,7 @@
          <key>GAME_CONTROL_BUTTON_LEFTSTICK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2283,7 +2283,7 @@
          <key>GAME_CONTROL_BUTTON_MISC1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2292,7 +2292,7 @@
          <key>GAME_CONTROL_BUTTON_PADDLE1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2301,7 +2301,7 @@
          <key>GAME_CONTROL_BUTTON_PADDLE2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2310,7 +2310,7 @@
          <key>GAME_CONTROL_BUTTON_PADDLE3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2319,7 +2319,7 @@
          <key>GAME_CONTROL_BUTTON_PADDLE4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2328,7 +2328,7 @@
          <key>GAME_CONTROL_BUTTON_RIGHTSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2337,7 +2337,7 @@
          <key>GAME_CONTROL_BUTTON_RIGHTSTICK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2346,7 +2346,7 @@
          <key>GAME_CONTROL_BUTTON_START</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2355,7 +2355,7 @@
          <key>GAME_CONTROL_BUTTON_TOUCHPAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2364,7 +2364,7 @@
          <key>GAME_CONTROL_BUTTON_X</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2373,7 +2373,7 @@
          <key>GAME_CONTROL_BUTTON_Y</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2382,7 +2382,7 @@
          <key>GCNP_RADIUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2391,7 +2391,7 @@
          <key>GCNP_STATIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2409,7 +2409,7 @@
          <key>HORIZONTAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2428,7 +2428,7 @@
          <key>HTTP_BODY_MAXLENGTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2437,7 +2437,7 @@
          <key>HTTP_BODY_TRUNCATED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2464,7 +2464,7 @@
          <key>HTTP_METHOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2473,7 +2473,7 @@
          <key>HTTP_MIMETYPE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2501,7 +2501,7 @@
          <key>HTTP_VERBOSE_THROTTLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2510,7 +2510,7 @@
          <key>HTTP_VERIFY_CERT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2519,7 +2519,7 @@
          <key>IMG_USE_BAKED_AUX1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2528,7 +2528,7 @@
          <key>IMG_USE_BAKED_AUX2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2537,7 +2537,7 @@
          <key>IMG_USE_BAKED_AUX3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2546,7 +2546,7 @@
          <key>IMG_USE_BAKED_EYES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2555,7 +2555,7 @@
          <key>IMG_USE_BAKED_HAIR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2564,7 +2564,7 @@
          <key>IMG_USE_BAKED_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2573,7 +2573,7 @@
          <key>IMG_USE_BAKED_LEFTARM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2582,7 +2582,7 @@
          <key>IMG_USE_BAKED_LEFTLEG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2591,7 +2591,7 @@
          <key>IMG_USE_BAKED_LOWER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2600,7 +2600,7 @@
          <key>IMG_USE_BAKED_SKIRT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2609,7 +2609,7 @@
          <key>IMG_USE_BAKED_UPPER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2618,7 +2618,7 @@
          <key>INVENTORY_ALL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2627,7 +2627,7 @@
          <key>INVENTORY_ANIMATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2636,7 +2636,7 @@
          <key>INVENTORY_BODYPART</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2645,7 +2645,7 @@
          <key>INVENTORY_CLOTHING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2654,7 +2654,7 @@
          <key>INVENTORY_GESTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2663,7 +2663,7 @@
          <key>INVENTORY_LANDMARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2672,7 +2672,7 @@
          <key>INVENTORY_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2681,7 +2681,7 @@
          <key>INVENTORY_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2690,7 +2690,7 @@
          <key>INVENTORY_NOTECARD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2699,7 +2699,7 @@
          <key>INVENTORY_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2708,7 +2708,7 @@
          <key>INVENTORY_SCRIPT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2717,7 +2717,7 @@
          <key>INVENTORY_SETTING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2726,7 +2726,7 @@
          <key>INVENTORY_SOUND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2735,7 +2735,7 @@
          <key>INVENTORY_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2744,7 +2744,7 @@
          <key>JSON_APPEND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2753,7 +2753,7 @@
          <key>JSON_ARRAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2762,7 +2762,7 @@
          <key>JSON_DELETE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2771,7 +2771,7 @@
          <key>JSON_FALSE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2780,7 +2780,7 @@
          <key>JSON_INVALID</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2789,7 +2789,7 @@
          <key>JSON_NULL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2798,7 +2798,7 @@
          <key>JSON_NUMBER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2807,7 +2807,7 @@
          <key>JSON_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2816,7 +2816,7 @@
          <key>JSON_STRING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2825,7 +2825,7 @@
          <key>JSON_TRUE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -2861,7 +2861,7 @@
          <key>KFM_COMMAND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2870,7 +2870,7 @@
          <key>KFM_DATA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2897,7 +2897,7 @@
          <key>KFM_MODE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2978,7 +2978,7 @@
          <key>LAND_NOISE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -2996,7 +2996,7 @@
          <key>LAND_REVERT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3014,7 +3014,7 @@
          <key>LAND_SMOOTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3158,7 +3158,7 @@
          <key>LIST_STAT_GEOMETRIC_MEAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3167,7 +3167,7 @@
          <key>LIST_STAT_MAX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3176,7 +3176,7 @@
          <key>LIST_STAT_MEAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3185,7 +3185,7 @@
          <key>LIST_STAT_MEDIAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3194,7 +3194,7 @@
          <key>LIST_STAT_MIN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3203,7 +3203,7 @@
          <key>LIST_STAT_NUM_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3212,7 +3212,7 @@
          <key>LIST_STAT_RANGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3221,7 +3221,7 @@
          <key>LIST_STAT_STD_DEV</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3230,7 +3230,7 @@
          <key>LIST_STAT_SUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3239,7 +3239,7 @@
          <key>LIST_STAT_SUM_SQUARES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3257,7 +3257,7 @@
          <key>MASK_BASE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3275,7 +3275,7 @@
          <key>MASK_EVERYONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3284,7 +3284,7 @@
          <key>MASK_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3293,7 +3293,7 @@
          <key>MASK_NEXT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3302,7 +3302,7 @@
          <key>MASK_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3320,7 +3320,7 @@
          <key>NULL_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3590,7 +3590,7 @@
          <key>OBJECT_PHYSICS_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3617,7 +3617,7 @@
          <key>OBJECT_PRIM_EQUIVALENCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3635,7 +3635,7 @@
          <key>OBJECT_RETURN_PARCEL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3644,7 +3644,7 @@
          <key>OBJECT_RETURN_PARCEL_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3653,7 +3653,7 @@
          <key>OBJECT_RETURN_REGION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3662,7 +3662,7 @@
          <key>OBJECT_REZZER_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3698,7 +3698,7 @@
          <key>OBJECT_RUNNING_SCRIPT_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3716,7 +3716,7 @@
          <key>OBJECT_SCRIPT_MEMORY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3725,7 +3725,7 @@
          <key>OBJECT_SCRIPT_TIME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3743,7 +3743,7 @@
          <key>OBJECT_SERVER_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3761,7 +3761,7 @@
          <key>OBJECT_STREAMING_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3824,7 +3824,7 @@
          <key>OBJECT_TOTAL_SCRIPT_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3833,7 +3833,7 @@
          <key>OBJECT_UNKNOWN_DETAIL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3923,7 +3923,7 @@
          <key>OVERRIDE_GLTF_BASE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3932,7 +3932,7 @@
          <key>OVERRIDE_GLTF_BASE_ALPHA_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3941,7 +3941,7 @@
          <key>OVERRIDE_GLTF_BASE_ALPHA_MODE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3950,7 +3950,7 @@
          <key>OVERRIDE_GLTF_BASE_COLOR_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3959,7 +3959,7 @@
          <key>OVERRIDE_GLTF_BASE_DOUBLE_SIDED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3968,7 +3968,7 @@
          <key>OVERRIDE_GLTF_EMISSIVE_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3977,7 +3977,7 @@
          <key>OVERRIDE_GLTF_METALLIC_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3986,7 +3986,7 @@
          <key>OVERRIDE_GLTF_ROUGHNESS_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -3995,7 +3995,7 @@
          <key>PARCEL_COUNT_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4004,7 +4004,7 @@
          <key>PARCEL_COUNT_OTHER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4013,7 +4013,7 @@
          <key>PARCEL_COUNT_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4022,7 +4022,7 @@
          <key>PARCEL_COUNT_SELECTED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4031,7 +4031,7 @@
          <key>PARCEL_COUNT_TEMP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4040,7 +4040,7 @@
          <key>PARCEL_COUNT_TOTAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4175,7 +4175,7 @@
          <key>PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4184,7 +4184,7 @@
          <key>PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4193,7 +4193,7 @@
          <key>PARCEL_FLAG_ALLOW_CREATE_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4202,7 +4202,7 @@
          <key>PARCEL_FLAG_ALLOW_DAMAGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4211,7 +4211,7 @@
          <key>PARCEL_FLAG_ALLOW_FLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4220,7 +4220,7 @@
          <key>PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4229,7 +4229,7 @@
          <key>PARCEL_FLAG_ALLOW_GROUP_SCRIPTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4238,7 +4238,7 @@
          <key>PARCEL_FLAG_ALLOW_LANDMARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4247,7 +4247,7 @@
          <key>PARCEL_FLAG_ALLOW_SCRIPTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4256,7 +4256,7 @@
          <key>PARCEL_FLAG_ALLOW_TERRAFORM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4265,7 +4265,7 @@
          <key>PARCEL_FLAG_LOCAL_SOUND_ONLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4274,7 +4274,7 @@
          <key>PARCEL_FLAG_RESTRICT_PUSHOBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4283,7 +4283,7 @@
          <key>PARCEL_FLAG_USE_ACCESS_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4292,7 +4292,7 @@
          <key>PARCEL_FLAG_USE_ACCESS_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4301,7 +4301,7 @@
          <key>PARCEL_FLAG_USE_BAN_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4310,7 +4310,7 @@
          <key>PARCEL_FLAG_USE_LAND_PASS_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4319,7 +4319,7 @@
          <key>PARCEL_MEDIA_COMMAND_AGENT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4328,7 +4328,7 @@
          <key>PARCEL_MEDIA_COMMAND_AUTO_ALIGN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4346,7 +4346,7 @@
          <key>PARCEL_MEDIA_COMMAND_LOOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4364,7 +4364,7 @@
          <key>PARCEL_MEDIA_COMMAND_PAUSE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4373,7 +4373,7 @@
          <key>PARCEL_MEDIA_COMMAND_PLAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4391,7 +4391,7 @@
          <key>PARCEL_MEDIA_COMMAND_STOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4400,7 +4400,7 @@
          <key>PARCEL_MEDIA_COMMAND_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4409,7 +4409,7 @@
          <key>PARCEL_MEDIA_COMMAND_TIME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4427,7 +4427,7 @@
          <key>PARCEL_MEDIA_COMMAND_UNLOAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4436,7 +4436,7 @@
          <key>PARCEL_MEDIA_COMMAND_URL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4562,7 +4562,7 @@
          <key>PATROL_PAUSE_AT_WAYPOINTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4571,7 +4571,7 @@
          <key>PAYMENT_INFO_ON_FILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4580,7 +4580,7 @@
          <key>PAYMENT_INFO_USED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4589,7 +4589,7 @@
          <key>PAY_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4598,7 +4598,7 @@
          <key>PAY_HIDE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4643,7 +4643,7 @@
          <key>PERMISSION_CONTROL_CAMERA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4697,7 +4697,7 @@
          <key>PERMISSION_RETURN_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4724,7 +4724,7 @@
          <key>PERMISSION_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4733,7 +4733,7 @@
          <key>PERMISSION_TRACK_CAMERA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4751,7 +4751,7 @@
          <key>PERM_ALL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4760,7 +4760,7 @@
          <key>PERM_COPY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4769,7 +4769,7 @@
          <key>PERM_MODIFY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4778,7 +4778,7 @@
          <key>PERM_MOVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4787,7 +4787,7 @@
          <key>PERM_TRANSFER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4877,7 +4877,7 @@
          <key>PRIM_BUMP_BARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4886,7 +4886,7 @@
          <key>PRIM_BUMP_BLOBS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4895,7 +4895,7 @@
          <key>PRIM_BUMP_BRICKS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4904,7 +4904,7 @@
          <key>PRIM_BUMP_BRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4913,7 +4913,7 @@
          <key>PRIM_BUMP_CHECKER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4922,7 +4922,7 @@
          <key>PRIM_BUMP_CONCRETE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4931,7 +4931,7 @@
          <key>PRIM_BUMP_DARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4940,7 +4940,7 @@
          <key>PRIM_BUMP_DISKS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4949,7 +4949,7 @@
          <key>PRIM_BUMP_GRAVEL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4958,7 +4958,7 @@
          <key>PRIM_BUMP_LARGETILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4967,7 +4967,7 @@
          <key>PRIM_BUMP_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4976,7 +4976,7 @@
          <key>PRIM_BUMP_SHINY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4985,7 +4985,7 @@
          <key>PRIM_BUMP_SIDING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -4994,7 +4994,7 @@
          <key>PRIM_BUMP_STONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5003,7 +5003,7 @@
          <key>PRIM_BUMP_STUCCO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5012,7 +5012,7 @@
          <key>PRIM_BUMP_SUCTION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5021,7 +5021,7 @@
          <key>PRIM_BUMP_TILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5030,7 +5030,7 @@
          <key>PRIM_BUMP_WEAVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5039,7 +5039,7 @@
          <key>PRIM_BUMP_WOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5050,7 +5050,7 @@
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5217,7 +5217,7 @@ vector force
          <key>PRIM_HOLE_CIRCLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5226,7 +5226,7 @@ vector force
          <key>PRIM_HOLE_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5235,7 +5235,7 @@ vector force
          <key>PRIM_HOLE_SQUARE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5244,7 +5244,7 @@ vector force
          <key>PRIM_HOLE_TRIANGLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5274,7 +5274,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_FLESH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5283,7 +5283,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_GLASS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5292,7 +5292,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_LIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5301,7 +5301,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_METAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5310,7 +5310,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_PLASTIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5319,7 +5319,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_RUBBER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5328,7 +5328,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_STONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5337,7 +5337,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_WOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5454,7 +5454,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_HEIGHT_PIXELS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5463,7 +5463,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_URL_LENGTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5472,7 +5472,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WHITELIST_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5481,7 +5481,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WHITELIST_SIZE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5490,7 +5490,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WIDTH_PIXELS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5499,7 +5499,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PARAM_MAX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5526,7 +5526,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_ANYONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5535,7 +5535,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5544,7 +5544,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5553,7 +5553,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5824,7 +5824,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_CYLINDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5833,7 +5833,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5842,7 +5842,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_MESH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5851,7 +5851,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_PLANE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5860,7 +5860,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_SPHERE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5869,7 +5869,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_TORUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5878,7 +5878,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_HIGH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5887,7 +5887,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_LOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5896,7 +5896,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_MEDIUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5905,7 +5905,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5914,7 +5914,7 @@ vector position - position in local coordinates
          <key>PRIM_SIT_FLAGS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5959,7 +5959,7 @@ vector position - position in local coordinates
          <key>PRIM_TEMP_ON_REZ</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5977,7 +5977,7 @@ vector position - position in local coordinates
          <key>PRIM_TEXGEN_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -5986,7 +5986,7 @@ vector position - position in local coordinates
          <key>PRIM_TEXGEN_PLANAR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6013,7 +6013,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6022,7 +6022,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_BOX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6031,7 +6031,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_CYLINDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6040,7 +6040,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_PRISM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6049,7 +6049,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_RING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6058,7 +6058,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_SCULPT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6067,7 +6067,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_SPHERE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6076,7 +6076,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_TORUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6085,7 +6085,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_TUBE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6112,7 +6112,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_DEST_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6121,7 +6121,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6130,7 +6130,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_DEST_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6139,7 +6139,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6148,7 +6148,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6157,7 +6157,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_SOURCE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6166,7 +6166,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_SOURCE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6175,7 +6175,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ZERO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6184,7 +6184,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BLEND_FUNC_DEST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6193,7 +6193,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BLEND_FUNC_SOURCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6238,7 +6238,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_END_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6310,7 +6310,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_RIBBON_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6337,7 +6337,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_START_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6355,7 +6355,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_TARGET_LINEAR_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6520,7 +6520,7 @@ vector position - position in local coordinates
          <key>PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6583,7 +6583,7 @@ vector position - position in local coordinates
          <key>PURSUIT_GOAL_TOLERANCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6628,7 +6628,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6673,7 +6673,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_OTHER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6682,7 +6682,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_PARCEL_UNREACHABLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6736,7 +6736,7 @@ vector position - position in local coordinates
          <key>RCERR_CAST_TIME_EXCEEDED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6745,7 +6745,7 @@ vector position - position in local coordinates
          <key>RCERR_SIM_PERF_LOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6754,7 +6754,7 @@ vector position - position in local coordinates
          <key>RCERR_UNKNOWN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6763,7 +6763,7 @@ vector position - position in local coordinates
          <key>RC_DATA_FLAGS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6772,7 +6772,7 @@ vector position - position in local coordinates
          <key>RC_DETECT_PHANTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6781,7 +6781,7 @@ vector position - position in local coordinates
          <key>RC_GET_LINK_NUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6790,7 +6790,7 @@ vector position - position in local coordinates
          <key>RC_GET_NORMAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6799,7 +6799,7 @@ vector position - position in local coordinates
          <key>RC_GET_ROOT_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6808,7 +6808,7 @@ vector position - position in local coordinates
          <key>RC_MAX_HITS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6817,7 +6817,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_AGENTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6826,7 +6826,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_LAND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6835,7 +6835,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_NONPHYSICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6844,7 +6844,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_PHYSICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6853,7 +6853,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_TYPES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6862,7 +6862,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_ALLOW_DAMAGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6871,7 +6871,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_ALLOW_DIRECT_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6880,7 +6880,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_FLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6889,7 +6889,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_FLYOVER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6898,7 +6898,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_TERRAFORM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6907,7 +6907,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_DISABLE_COLLISIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6916,7 +6916,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_DISABLE_PHYSICS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6925,7 +6925,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_FIXED_SUN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6934,7 +6934,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_RESTRICT_PUSHOBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6943,7 +6943,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_SANDBOX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6954,7 +6954,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6965,7 +6965,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -6976,7 +6976,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7831,7 +7831,7 @@ vector position - position in local coordinates
          <key>STATUS_CAST_SHADOWS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7921,7 +7921,7 @@ vector position - position in local coordinates
          <key>STATUS_RETURN_AT_EDGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7930,7 +7930,7 @@ vector position - position in local coordinates
          <key>STATUS_ROTATE_X</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7939,7 +7939,7 @@ vector position - position in local coordinates
          <key>STATUS_ROTATE_Y</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -7993,7 +7993,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8002,7 +8002,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8011,7 +8011,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM_TAIL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8038,7 +8038,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8047,7 +8047,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8056,7 +8056,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8065,7 +8065,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8074,7 +8074,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_NE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8083,7 +8083,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_NW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8092,7 +8092,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_SE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8101,7 +8101,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_SW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8110,7 +8110,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8119,7 +8119,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8128,7 +8128,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8137,7 +8137,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8146,7 +8146,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8155,7 +8155,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8164,7 +8164,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8173,7 +8173,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8182,7 +8182,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8191,7 +8191,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8200,7 +8200,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8209,7 +8209,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8218,7 +8218,7 @@ vector position - position in local coordinates
          <key>TEXTURE_BLANK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8227,7 +8227,7 @@ vector position - position in local coordinates
          <key>TEXTURE_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8236,7 +8236,7 @@ vector position - position in local coordinates
          <key>TEXTURE_MEDIA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8245,7 +8245,7 @@ vector position - position in local coordinates
          <key>TEXTURE_PLYWOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8254,7 +8254,7 @@ vector position - position in local coordinates
          <key>TEXTURE_TRANSPARENT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8263,7 +8263,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_FACE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8272,7 +8272,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_TEXCOORD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -8281,7 +8281,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_VECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -8443,7 +8443,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_FAST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8452,7 +8452,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8461,7 +8461,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_SLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8551,7 +8551,7 @@ vector position - position in local coordinates
          <key>URL_REQUEST_DENIED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8560,7 +8560,7 @@ vector position - position in local coordinates
          <key>URL_REQUEST_GRANTED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8669,7 +8669,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_CAMERA_DECOUPLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8732,7 +8732,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_MOUSELOOK_BANK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8741,7 +8741,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_MOUSELOOK_STEER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8844,7 +8844,7 @@ vector position - position in local coordinates
          <key>VEHICLE_LINEAR_MOTOR_OFFSET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8907,7 +8907,7 @@ vector position - position in local coordinates
          <key>VEHICLE_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8943,7 +8943,7 @@ vector position - position in local coordinates
          <key>VERTICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -8952,7 +8952,7 @@ vector position - position in local coordinates
          <key>WANDER_PAUSE_AT_WAYPOINTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>integer</string>
             <key>value</key>
@@ -9204,7 +9204,7 @@ vector position - position in local coordinates
          <key>ZERO_ROTATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>rotation</string>
             <key>value</key>
@@ -9213,7 +9213,7 @@ vector position - position in local coordinates
          <key>ZERO_VECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -9236,7 +9236,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9245,7 +9245,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetRotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -9254,7 +9254,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>CurrentRotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -9271,7 +9271,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9280,7 +9280,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetPosition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9289,7 +9289,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>CurrentPosition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9306,7 +9306,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9323,7 +9323,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Changed</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9340,7 +9340,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfCollisions</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9358,7 +9358,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfCollisions</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9376,7 +9376,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfCollisions</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9394,7 +9394,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9403,7 +9403,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Levels</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9412,7 +9412,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Edges</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9430,7 +9430,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9439,7 +9439,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9457,7 +9457,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Time</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9466,7 +9466,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9475,7 +9475,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9484,7 +9484,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9493,7 +9493,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberRemaining</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9606,7 +9606,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>HTTPRequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9615,7 +9615,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>HTTPMethod</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9624,7 +9624,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9641,7 +9641,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>HTTPRequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9650,7 +9650,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Status</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9659,7 +9659,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Metadata</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -9668,7 +9668,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9685,7 +9685,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9702,7 +9702,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9719,7 +9719,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9736,7 +9736,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SendersLink</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9745,7 +9745,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9754,7 +9754,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9763,7 +9763,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9780,7 +9780,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>action</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9789,7 +9789,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9798,7 +9798,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9815,7 +9815,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9824,7 +9824,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9833,7 +9833,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9842,7 +9842,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9860,7 +9860,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Payer</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9869,7 +9869,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9921,7 +9921,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RezzedObjectsID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -9962,7 +9962,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9979,7 +9979,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Type</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -9988,7 +9988,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Reserved</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -10007,7 +10007,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>EventType</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10016,7 +10016,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -10025,7 +10025,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>MessageID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -10034,7 +10034,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sender</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10043,7 +10043,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>IData</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10052,7 +10052,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SData</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10069,7 +10069,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>PermissionFlags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10087,7 +10087,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberDetected</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10126,7 +10126,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfTouches</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10145,7 +10145,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfTouches</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10163,7 +10163,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NumberOfTouches</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10181,7 +10181,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -10190,7 +10190,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Success</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10199,7 +10199,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Message</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10384,7 +10384,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AgentID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -10585,7 +10585,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AttachmentPoint</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10740,7 +10740,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10763,7 +10763,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10799,7 +10799,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10822,7 +10822,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10845,7 +10845,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -10854,7 +10854,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -10863,7 +10863,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -10886,7 +10886,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -10945,7 +10945,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Link</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -10954,7 +10954,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11000,7 +11000,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -11025,7 +11025,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -11050,7 +11050,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ObjectName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11059,7 +11059,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -11091,7 +11091,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ImpactSound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11100,7 +11100,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ImpactVolume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -11123,7 +11123,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ImpactSprite</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11180,7 +11180,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -11203,7 +11203,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -11226,7 +11226,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11235,7 +11235,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11361,7 +11361,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11386,7 +11386,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -11395,7 +11395,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11404,7 +11404,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11427,7 +11427,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11436,7 +11436,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11445,7 +11445,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11515,7 +11515,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11538,7 +11538,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11561,7 +11561,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11586,7 +11586,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11609,7 +11609,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11632,7 +11632,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11655,7 +11655,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11678,7 +11678,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11701,7 +11701,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11724,7 +11724,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11885,7 +11885,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11908,7 +11908,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -11931,7 +11931,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -11940,7 +11940,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11949,7 +11949,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Buttons</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -11958,7 +11958,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -12003,7 +12003,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -12012,7 +12012,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Separator</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12035,7 +12035,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -12044,7 +12044,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Direction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -12069,7 +12069,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12092,7 +12092,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12101,7 +12101,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12110,7 +12110,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12133,7 +12133,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12157,7 +12157,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -12244,7 +12244,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -12267,7 +12267,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12310,7 +12310,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12413,7 +12413,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -12459,7 +12459,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Magnitude</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -12508,7 +12508,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12532,7 +12532,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12587,7 +12587,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12610,7 +12610,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -12646,7 +12646,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12669,7 +12669,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12692,7 +12692,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12783,7 +12783,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -12903,7 +12903,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13264,7 +13264,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13287,7 +13287,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13310,7 +13310,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13420,7 +13420,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13456,7 +13456,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -13479,7 +13479,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13545,7 +13545,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13661,7 +13661,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -13670,7 +13670,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13693,7 +13693,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -13833,7 +13833,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13842,7 +13842,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13865,7 +13865,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13874,7 +13874,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LineNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13897,7 +13897,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13906,7 +13906,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LineNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -13929,7 +13929,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -14070,7 +14070,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -14129,7 +14129,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -14178,7 +14178,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -14235,7 +14235,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -14344,7 +14344,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -14647,7 +14647,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -14748,7 +14748,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -14875,7 +14875,7 @@ If another state is defined before the default state, the compiler will report a
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string />
+            <string></string>
          </map>
          <key>llGetStatus</key>
          <map>
@@ -14910,7 +14910,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>String</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -14919,7 +14919,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -14928,7 +14928,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -14977,7 +14977,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15000,7 +15000,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15023,7 +15023,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15046,7 +15046,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15147,7 +15147,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15278,7 +15278,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15287,7 +15287,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15310,7 +15310,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15319,7 +15319,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>FolderName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15328,7 +15328,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItems</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -15351,7 +15351,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15360,7 +15360,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15383,7 +15383,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItemID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15392,7 +15392,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -15417,7 +15417,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -15440,7 +15440,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -15463,7 +15463,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -15529,7 +15529,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -15675,7 +15675,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15698,7 +15698,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TargetVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15707,7 +15707,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15716,7 +15716,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SourceVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15739,7 +15739,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -15748,7 +15748,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15771,7 +15771,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -15853,7 +15853,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15876,7 +15876,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15885,7 +15885,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -15908,7 +15908,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15917,7 +15917,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -15926,7 +15926,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15949,7 +15949,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -15958,7 +15958,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16149,7 +16149,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -16158,7 +16158,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -16167,7 +16167,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Flags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16668,7 +16668,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16691,7 +16691,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16700,7 +16700,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16723,7 +16723,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16732,7 +16732,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16787,7 +16787,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16796,7 +16796,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16819,7 +16819,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16828,7 +16828,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16837,7 +16837,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16860,7 +16860,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16869,7 +16869,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16878,7 +16878,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16887,7 +16887,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16896,7 +16896,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>slice_index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16919,7 +16919,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16928,7 +16928,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16937,7 +16937,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16946,7 +16946,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -16969,7 +16969,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -16978,7 +16978,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17001,7 +17001,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17010,7 +17010,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17033,7 +17033,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17042,7 +17042,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17065,7 +17065,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17074,7 +17074,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17097,7 +17097,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17106,7 +17106,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17115,7 +17115,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Instance</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17138,7 +17138,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17147,7 +17147,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17156,7 +17156,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17165,7 +17165,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17174,7 +17174,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17197,7 +17197,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17206,7 +17206,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17215,7 +17215,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17238,7 +17238,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17247,7 +17247,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17270,7 +17270,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17279,7 +17279,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17288,7 +17288,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17297,7 +17297,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17443,7 +17443,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17452,7 +17452,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SpeakersName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17461,7 +17461,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SpeakersID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -17470,7 +17470,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17493,7 +17493,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelHandle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17502,7 +17502,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Active</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17525,7 +17525,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelHandle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17548,7 +17548,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -17557,7 +17557,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17566,7 +17566,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17589,7 +17589,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17612,7 +17612,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17635,7 +17635,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17644,7 +17644,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Strength</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17653,7 +17653,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Damping</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17676,7 +17676,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17685,7 +17685,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17708,7 +17708,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17717,7 +17717,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17740,7 +17740,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17749,7 +17749,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17772,7 +17772,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17781,7 +17781,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Nonce</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17804,7 +17804,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17813,7 +17813,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17822,7 +17822,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17831,7 +17831,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17840,7 +17840,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17849,7 +17849,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17858,7 +17858,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17883,7 +17883,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17892,7 +17892,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17901,7 +17901,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17910,7 +17910,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17919,7 +17919,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17928,7 +17928,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17937,7 +17937,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17962,7 +17962,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -17971,7 +17971,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17980,7 +17980,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17989,7 +17989,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -17998,7 +17998,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18007,7 +18007,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Bounce</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18016,7 +18016,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18025,7 +18025,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18034,7 +18034,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Bounce_Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18059,7 +18059,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18068,7 +18068,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18077,7 +18077,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18086,7 +18086,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18095,7 +18095,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18104,7 +18104,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18113,7 +18113,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18213,7 +18213,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RegionName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18222,7 +18222,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18231,7 +18231,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Direction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18254,7 +18254,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18263,7 +18263,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18272,7 +18272,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18281,7 +18281,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -18304,7 +18304,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Delay</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18327,7 +18327,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18336,7 +18336,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Power</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18345,7 +18345,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Modulus</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18400,7 +18400,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18409,7 +18409,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Tau</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18487,7 +18487,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>OffsetS</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18496,7 +18496,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>OffsetT</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18505,7 +18505,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -18616,7 +18616,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -18641,7 +18641,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18687,7 +18687,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>QueryList</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18712,7 +18712,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18721,7 +18721,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Separators</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18730,7 +18730,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Spacers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18753,7 +18753,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18762,7 +18762,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Separators</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18771,7 +18771,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Spacers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18794,7 +18794,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18895,7 +18895,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18904,7 +18904,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18927,7 +18927,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18936,7 +18936,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18959,7 +18959,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18968,7 +18968,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Exponent</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -18991,7 +18991,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19046,7 +19046,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19055,7 +19055,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Impulse</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -19064,7 +19064,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AngularImpulse</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -19073,7 +19073,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Local</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19096,7 +19096,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19209,7 +19209,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19270,7 +19270,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19279,7 +19279,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>MessageID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19396,7 +19396,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19419,7 +19419,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19442,7 +19442,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19465,7 +19465,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vehiclelags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19488,7 +19488,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>agent_id</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19497,7 +19497,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>transition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -19506,7 +19506,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>environment</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19639,7 +19639,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19648,7 +19648,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19694,7 +19694,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AgentID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19728,7 +19728,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19751,7 +19751,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19760,7 +19760,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>PermissionMask</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19796,7 +19796,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RegionName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19805,7 +19805,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -19864,7 +19864,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -19887,7 +19887,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19936,7 +19936,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20017,7 +20017,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scope</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20040,7 +20040,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20049,7 +20049,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20058,7 +20058,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20067,7 +20067,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20076,7 +20076,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20099,7 +20099,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20108,7 +20108,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20117,7 +20117,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20126,7 +20126,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20135,7 +20135,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20158,7 +20158,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20167,7 +20167,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Params</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -20190,7 +20190,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20213,7 +20213,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20236,7 +20236,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20259,7 +20259,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20282,7 +20282,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20305,7 +20305,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20328,7 +20328,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vector1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20337,7 +20337,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vector2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20360,7 +20360,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20369,7 +20369,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Strength</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20378,7 +20378,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Damping</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20401,7 +20401,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -20410,7 +20410,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LeeWay</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20433,7 +20433,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Handle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20456,7 +20456,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Radians</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20465,7 +20465,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20488,7 +20488,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20511,7 +20511,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20534,7 +20534,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20557,7 +20557,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -20639,7 +20639,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Horizontal</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20648,7 +20648,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vertical</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -20657,7 +20657,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20680,7 +20680,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20728,7 +20728,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -20737,7 +20737,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Destination</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20746,7 +20746,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -20755,7 +20755,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20993,7 +20993,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -21002,7 +21002,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21057,7 +21057,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21066,7 +21066,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AnimationName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21089,7 +21089,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Buoyancy</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -21112,7 +21112,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21135,7 +21135,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21158,7 +21158,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21204,7 +21204,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Color</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21213,7 +21213,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21268,7 +21268,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Damage</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -21512,7 +21512,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21535,7 +21535,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21544,7 +21544,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -21553,7 +21553,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21749,7 +21749,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21783,7 +21783,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21806,7 +21806,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21815,7 +21815,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>RenderMaterial</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21824,7 +21824,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21879,7 +21879,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -21888,7 +21888,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21897,7 +21897,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22006,7 +22006,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -22054,7 +22054,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Description</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22077,7 +22077,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22166,7 +22166,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22230,7 +22230,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>GravityMultiplier</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22239,7 +22239,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Restitution</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22248,7 +22248,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Friction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22257,7 +22257,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Density</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22335,7 +22335,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22410,7 +22410,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>PIN</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22433,7 +22433,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Material</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22442,7 +22442,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22465,7 +22465,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -22488,7 +22488,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -22511,7 +22511,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22520,7 +22520,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Running</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22543,7 +22543,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22612,7 +22612,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Status</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22621,7 +22621,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22644,7 +22644,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22653,7 +22653,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Color</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -22662,7 +22662,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22685,7 +22685,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22694,7 +22694,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22794,7 +22794,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rate</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22849,7 +22849,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22872,7 +22872,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Flags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22895,7 +22895,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22904,7 +22904,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -22927,7 +22927,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22936,7 +22936,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -22959,7 +22959,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Type</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22982,7 +22982,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -22991,7 +22991,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -23046,7 +23046,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23055,7 +23055,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23119,7 +23119,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23142,7 +23142,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -23151,7 +23151,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>LinkID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23174,7 +23174,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -23183,7 +23183,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>rotation</string>
                   </map>
@@ -23206,7 +23206,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Time</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23229,7 +23229,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23238,7 +23238,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23247,7 +23247,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Queue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23256,7 +23256,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Loop</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23281,7 +23281,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23306,7 +23306,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23329,7 +23329,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23352,7 +23352,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23375,7 +23375,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23437,7 +23437,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23473,7 +23473,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23496,7 +23496,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23551,7 +23551,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23560,7 +23560,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sequence</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23583,7 +23583,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -23649,7 +23649,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23672,7 +23672,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -23681,7 +23681,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Range</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23704,7 +23704,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Axis</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -23713,7 +23713,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>SpinRate</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23722,7 +23722,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Gain</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -23745,7 +23745,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23768,7 +23768,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23777,7 +23777,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23786,7 +23786,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23909,7 +23909,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -23932,7 +23932,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -23941,7 +23941,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23950,7 +23950,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -23973,7 +23973,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23996,7 +23996,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24019,7 +24019,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -24028,7 +24028,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -24092,7 +24092,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24101,7 +24101,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -24124,7 +24124,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24133,7 +24133,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>float</string>
                   </map>
@@ -24142,7 +24142,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>TNE</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24151,7 +24151,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>BSW</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24174,7 +24174,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>key</string>
                   </map>
@@ -24197,7 +24197,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24243,7 +24243,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24252,7 +24252,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24261,7 +24261,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Checked</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -24270,7 +24270,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>OriginalValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24295,7 +24295,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Location1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24304,7 +24304,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Location2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24327,7 +24327,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24350,7 +24350,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24489,7 +24489,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24512,7 +24512,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>integer</string>
                   </map>
@@ -24521,7 +24521,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24544,7 +24544,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24590,7 +24590,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24599,7 +24599,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24622,7 +24622,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24631,7 +24631,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24656,7 +24656,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24665,7 +24665,7 @@ If another state is defined before the default state, the compiler will report a
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -9881,35 +9881,40 @@ If another state is defined before the default state, the compiler will report a
          <key>moving_end</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered whenever an object with this script stops moving.</string>
          </map>
          <key>moving_start</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered whenever an object with this script starts moving.</string>
          </map>
          <key>no_sensor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>This event is raised when sensors are active, via the llSensor function call, but are not sensing anything.</string>
          </map>
          <key>not_at_rot_target</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>When a target is set via the llRotTarget function call, but the script is outside the specified angle this event is raised.</string>
          </map>
          <key>not_at_target</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>When a target is set via the llTarget library call, but the script is outside the specified range this event is raised.</string>
          </map>
@@ -9950,7 +9955,8 @@ If another state is defined before the default state, the compiler will report a
          <key>on_death</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered when an avatar reaches 0 health.</string>
          </map>
@@ -10100,21 +10106,24 @@ If another state is defined before the default state, the compiler will report a
          <key>state_entry</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>The state_entry event occurs whenever a new state is entered, including at program start, and is always the first event handled.</string>
          </map>
          <key>state_exit</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>The state_exit event occurs whenever the state command is used to transition to another state. It is handled before the new states state_entry event.</string>
          </map>
          <key>timer</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>This event is raised at regular intervals set by the llSetTimerEvent library function.</string>
          </map>
@@ -10649,7 +10658,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llAvatarOnSitTarget</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -10781,7 +10791,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llBreakAllLinks</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -10927,7 +10938,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llClearCameraParams</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11328,7 +11340,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llDataSizeKeyValue</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11343,7 +11356,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llDeleteCharacter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11497,7 +11511,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llDetachFromAvatar</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11985,7 +12000,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llDie</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>0.0</real>
             <key>return</key>
@@ -12477,7 +12493,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGenerateKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12490,7 +12507,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetAccel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12628,7 +12646,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetAndResetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12710,7 +12729,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetAttached</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12801,7 +12821,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCameraAspect</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12814,7 +12835,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCameraFOV</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12827,7 +12849,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCameraPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12840,7 +12863,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCameraRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12853,7 +12877,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCenterOfMass</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12921,7 +12946,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetCreator</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12934,7 +12960,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetDate</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12947,7 +12974,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetDayLength</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12960,7 +12988,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetDayOffset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12996,7 +13025,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetEnergy</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13116,7 +13146,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetForce</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13129,7 +13160,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetFreeMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13142,7 +13174,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetFreeURLs</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13155,7 +13188,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetGMTclock</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13168,7 +13202,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetGeometricCenter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13438,7 +13473,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13563,7 +13599,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetLinkNumber</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13711,7 +13748,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetLocalPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13724,7 +13762,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetLocalRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13737,7 +13776,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMass</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13750,7 +13790,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMassMKS</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13763,7 +13804,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMaxScaleFactor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13776,7 +13818,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMemoryLimit</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13789,7 +13832,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMinScaleFactor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13802,7 +13846,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMoonDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13815,7 +13860,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetMoonRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13947,7 +13993,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetNumberOfPrims</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13960,7 +14007,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetNumberOfSides</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13973,7 +14021,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetObjectAnimationNames</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -13986,7 +14035,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetObjectDesc</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14088,7 +14138,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetObjectName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14147,7 +14198,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetOmega</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14160,7 +14212,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetOwner</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14285,7 +14338,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetParcelMusicURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14362,7 +14416,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetPermissions</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14375,7 +14430,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetPermissionsKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14388,7 +14444,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetPhysicsMaterial</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14401,7 +14458,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14473,7 +14531,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionAgentCount</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14486,7 +14545,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionCorner</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14499,7 +14559,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionDayLength</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14512,7 +14573,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionDayOffset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14525,7 +14587,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionFPS</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14538,7 +14601,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionFlags</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14551,7 +14615,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionMoonDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14564,7 +14629,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionMoonRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14577,7 +14643,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14590,7 +14657,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionSunDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14603,7 +14671,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionSunRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14616,7 +14685,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionTimeDilation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14629,7 +14699,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRegionTimeOfDay</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14665,7 +14736,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRootPosition</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14678,7 +14750,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRootRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14691,7 +14764,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14704,7 +14778,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetSPMaxMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14717,7 +14792,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetScale</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14730,7 +14806,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetScriptName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14791,7 +14868,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetSimulatorHostname</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14804,7 +14882,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetStartParameter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14817,7 +14896,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetStartString</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14946,7 +15026,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetSunDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14959,7 +15040,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetSunRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15064,7 +15146,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15077,7 +15160,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetTimeOfDay</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15090,7 +15174,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetTimestamp</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15103,7 +15188,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetTorque</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15116,7 +15202,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetUnixTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15129,7 +15216,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetUsedMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15165,7 +15253,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetVel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15210,7 +15299,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llGetWallclock</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15999,7 +16089,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llKeyCountKeyValue</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -16313,7 +16404,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llLinksetDataAvailable</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -16349,7 +16441,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llLinksetDataCountKeys</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -16577,7 +16670,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llLinksetDataReset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18564,7 +18658,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llOpenRemoteDataChannel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -19116,7 +19211,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llRefreshPrimURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -19229,7 +19325,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llReleaseControls</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19317,7 +19414,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llRemoteDataSetRegion</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -19778,7 +19876,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llRequestSecureURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19823,7 +19922,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llRequestURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19905,7 +20005,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llResetLandBanList</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19918,7 +20019,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llResetLandPassList</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19954,7 +20056,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llResetScript</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19967,7 +20070,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llResetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20834,7 +20938,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llSensorRemove</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23393,7 +23498,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llStopHover</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23406,7 +23512,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llStopLookAt</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23419,7 +23526,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llStopMoveToTarget</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23455,7 +23563,8 @@ If another state is defined before the default state, the compiler will report a
          <key>llStopSound</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -69,7 +69,7 @@
          <key>quaternion</key>
          <map>
             <key>private</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>The quaternion type is a left over from way back when LSL was created. It was later renamed to &lt;rotation&gt; to make it more user friendly, but it appears someone forgot to remove it ;-)</string>
          </map>
@@ -616,7 +616,7 @@
          <key>ATTACH_LPEC</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
             <key>type</key>
@@ -780,7 +780,7 @@
          <key>ATTACH_RPEC</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
             <key>type</key>
@@ -5048,7 +5048,7 @@
          <key>PRIM_CAST_SHADOWS</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6952,7 +6952,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_CHANNEL</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6963,7 +6963,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_REPLY</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -6974,7 +6974,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_REQUEST</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -8759,7 +8759,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_NO_FLY_UP</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Old, changed to VEHICLE_FLAG_NO_DEFLECTION_UP</string>
             <key>type</key>
@@ -10000,7 +10000,7 @@ If another state is defined before the default state, the compiler will report a
          <key>remote_data</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>arguments</key>
             <array>
                <map>
@@ -10401,7 +10401,7 @@ If another state is defined before the default state, the compiler will report a
                    Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
                 </string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llAllowInventoryDrop</key>
          <map>
@@ -11007,7 +11007,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11032,7 +11032,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11130,7 +11130,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -11492,7 +11492,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Derezzes an object previously rezzed by a script in this region. Returns TRUE on success or FALSE if the object could not be derezzed.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llDetachFromAvatar</key>
          <map>
@@ -11576,7 +11576,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if detected object or agent Number has the same user group active as this object.\nIt will return FALSE if the object or agent is in the group, but the group is not active.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llDetectedKey</key>
          <map>
@@ -12059,7 +12059,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Checks to see whether the border hit by Direction from Position is the edge of the world (has no neighboring region).\nReturns TRUE if the line along Direction from Position hits the edge of the world in the current simulator, returns FALSE if that edge crosses into another simulator.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llEjectFromLand</key>
          <map>
@@ -13061,7 +13061,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetExperienceDetails</key>
          <map>
@@ -13535,7 +13535,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.	Returns an empty list if no media exists on the face.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetLinkName</key>
          <map>
@@ -13628,7 +13628,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flag's attributes.\n* Face flags require the user to also supply a face index parameter.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetLinkSitFlags</key>
          <map>
@@ -14028,7 +14028,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns a list of object details specified in the Parameters list for the object or avatar in the region with key ID.\nParameters are specified by the OBJECT_* constants.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetObjectLinkKey</key>
          <map>
@@ -14225,7 +14225,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns a list of parcel details specified in the ParcelDetails list for the parcel at Position.\nParameters is one or more of: PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\nReturns a list that is the parcel details specified in ParcelDetails (in the same order) for the parcel at Position.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetParcelFlags</key>
          <map>
@@ -14443,7 +14443,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns the media parameters for a particular face on an object, given the desired list of parameter names, in the order requested. Returns an empty list if no media exists on the face.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetPrimitiveParams</key>
          <map>
@@ -14468,7 +14468,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns the primitive parameters specified in the parameters list.\nReturns primitive parameters specified in the Parameters list.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetRegionAgentCount</key>
          <map>
@@ -14763,7 +14763,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if the script named is running.\nReturns TRUE if ScriptName is running.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetSimStats</key>
          <map>
@@ -14900,7 +14900,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the object the script is attached to.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llGetSubString</key>
          <map>
@@ -15401,7 +15401,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
@@ -15809,7 +15809,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is a friend of the script owner.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llIsLinkGLTFMaterial</key>
          <map>
@@ -15843,7 +15843,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Checks the face for a PBR render material.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llJson2List</key>
          <map>
@@ -17865,7 +17865,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17944,7 +17944,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18041,7 +18041,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18120,7 +18120,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18162,7 +18162,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llMapBeacon</key>
          <map>
@@ -18566,7 +18566,7 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18631,7 +18631,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if id ID over land owned by the script owner, otherwise FALSE.\nReturns TRUE if key ID is over land owned by the object owner, FALSE otherwise.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llOwnerSay</key>
          <map>
@@ -18702,7 +18702,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Queries the media properties of the parcel containing the script, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis function will only work if the script is contained within an object owned by the land-owner (or if the land is owned by a group, only if the object has been deeded to the group).</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llParseString2List</key>
          <map>
@@ -19118,7 +19118,7 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19216,7 +19216,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19304,7 +19304,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19319,7 +19319,7 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20572,7 +20572,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is in the same region and has the same active group, otherwise FALSE.\nReturns TRUE if the object or agent identified is in the same simulator and has the same active group as this object. Otherwise, returns FALSE.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llSay</key>
          <map>
@@ -20629,7 +20629,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Attempts to resize the entire object by ScalingFactor, maintaining the size-position ratios of the prims.\n\nResizing is subject to prim scale limits and linkability limits. This function can not resize the object if the linkset is physical, a pathfinding character, in a keyframed motion, or if resizing would cause the parcel to overflow.\nReturns a boolean (an integer) TRUE if it succeeds, FALSE if it fails.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llScaleTexture</key>
          <map>
@@ -20695,7 +20695,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llScriptProfiler</key>
          <map>
@@ -20762,7 +20762,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21487,7 +21487,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
@@ -21756,7 +21756,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22044,7 +22044,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Requests Limit bytes to be reserved for this script.\nReturns TRUE or FALSE indicating whether the limit was set successfully.\nThis function has no effect if the script is running in the LSO VM.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llSetObjectDesc</key>
          <map>
@@ -22118,7 +22118,7 @@ If another state is defined before the default state, the compiler will report a
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
@@ -22342,7 +22342,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22367,7 +22367,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22400,7 +22400,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Attempts to move the object so that the root prim is within 0.1m of Position.\nReturns an integer boolean, TRUE if the object is successfully placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any location within the region or up to 10m across a region border.\nIf the position is below ground, it will be set to the ground level at that x,y location.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llSetRemoteScriptAccessPin</key>
          <map>
@@ -23263,7 +23263,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23288,7 +23288,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -23590,7 +23590,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24415,7 +24415,7 @@ If another state is defined before the default state, the compiler will report a
             <key>tooltip</key>
             <string>Returns TRUE if PublicKey, Message, and Algorithm produce the same base64-formatted Signature.</string>
             <key>bool_semantics</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
          </map>
          <key>llVolumeDetect</key>
          <map>
@@ -24638,7 +24638,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24672,7 +24672,7 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>

--- a/indra/newview/app_settings/keywords_lsl_default.xml
+++ b/indra/newview/app_settings/keywords_lsl_default.xml
@@ -10226,11 +10226,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the absolute (positive) version of Value.</string>
          </map>
@@ -10249,11 +10249,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-cosine of Value, in radians.</string>
          </map>
@@ -10281,11 +10281,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Add avatar ID to the parcel ban list for the specified number of Hours.\nA value of 0 for Hours will add the agent indefinitely.\nThe smallest value that Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen values that small are used, it seems the function bans in approximately 30 second increments (Probably 36 second increments, as 0.01 of an hour is 36 seconds).\nResidents teleporting to a parcel where they are banned will be redirected to a neighbouring parcel.</string>
          </map>
@@ -10313,11 +10313,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Add avatar ID to the land pass list, for a duration of Hours.</string>
          </map>
@@ -10345,11 +10345,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Changes the amount of damage to be delivered by this damage event.</string>
          </map>
@@ -10368,11 +10368,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Adjusts the volume (0.0 - 1.0) of the currently playing attached sound.\nThis function has no effect on sounds started with llTriggerSound.</string>
          </map>
@@ -10391,11 +10391,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
@@ -10418,11 +10418,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If Flag == TRUE, users without object modify permissions can still drop inventory items into the object.</string>
          </map>
@@ -10450,11 +10450,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the angle, in radians, between rotations Rot1 and Rot2.</string>
          </map>
@@ -10482,11 +10482,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies impulse to the object.\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis function only works on physical objects.</string>
          </map>
@@ -10514,11 +10514,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies rotational impulse to the object.\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis function only works on physical objects.</string>
          </map>
@@ -10537,11 +10537,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-sine, in radians, of Value.</string>
          </map>
@@ -10569,11 +10569,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-tangent2 of y, x.</string>
          </map>
@@ -10592,11 +10592,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH runtime permission.</string>
          </map>
@@ -10615,11 +10615,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Follows the same convention as llAttachToAvatar, with the exception that the object will not create new inventory for the user, and will disappear on detach or disconnect.</string>
          </map>
@@ -10638,11 +10638,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If an avatar is sitting on the link's sit target, return the avatar's key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link's prim.</string>
          </map>
@@ -10651,11 +10651,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If an avatar is seated on the sit target, returns the avatar's key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
          </map>
@@ -10692,11 +10692,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation represented by coordinate axes Forward, Left, and Up.</string>
          </map>
@@ -10724,11 +10724,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation that is a generated Angle about Axis.</string>
          </map>
@@ -10747,11 +10747,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the Text, Base64 decoded as a big endian integer.\nReturns zero if Text is longer then 8 characters. If Text contains fewer then 6 characters, the return value is unpredictable.</string>
          </map>
@@ -10770,11 +10770,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a Base64 string to a conventional string.\nIf the conversion creates any unprintable characters, they are converted to question marks.</string>
          </map>
@@ -10783,11 +10783,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>De-links all prims in the link set (requires permission PERMISSION_CHANGE_LINKS be set).</string>
          </map>
@@ -10806,11 +10806,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>De-links the prim with the given link number (requires permission PERMISSION_CHANGE_LINKS be set).</string>
          </map>
@@ -10829,11 +10829,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Create a list from a string of comma separated values specified in Text.</string>
          </map>
@@ -10870,11 +10870,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Casts a ray into the physics world from 'start' to 'end' and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
          </map>
@@ -10893,11 +10893,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns smallest integer value &gt;= Value.</string>
          </map>
@@ -10916,11 +10916,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a single character string that is the representation of the unicode value.</string>
          </map>
@@ -10929,11 +10929,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets all camera parameters to default values and turns off scripted camera control.</string>
          </map>
@@ -10961,11 +10961,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Clears (deletes) the media and all parameters from the given Face on the linked prim.\nReturns an integer that is a STATUS_* flag, which details the success/failure of the operation.</string>
          </map>
@@ -10984,11 +10984,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Clears (deletes) the media and all parameters from the given Face.\nReturns an integer that is a STATUS_* flag which details the success/failure of the operation.</string>
          </map>
@@ -11009,11 +11009,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -11034,11 +11034,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the cloud density at the object's position + Offset.</string>
          </map>
@@ -11075,11 +11075,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Specify an empty string or NULL_KEY for Accept, to not filter on the corresponding parameter.</string>
          </map>
@@ -11107,11 +11107,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Suppress default collision sounds, replace default impact sounds with ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply an empty string to suppress collision sounds.</string>
          </map>
@@ -11132,11 +11132,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Suppress default collision sprites, replace default impact sprite with ImpactSprite; found in the object inventory (empty string to just suppress).</string>
          </map>
@@ -11164,11 +11164,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns hex-encoded Hash string of Message using digest Algorithm.</string>
          </map>
@@ -11187,11 +11187,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the cosine of Theta (Theta in radians).</string>
          </map>
@@ -11210,11 +11210,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a "character", from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
          </map>
@@ -11242,11 +11242,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
@@ -11276,11 +11276,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Attempt to link the object the script is in, to target (requires permission PERMISSION_CHANGE_LINKS be set).\nRequires permission PERMISSION_CHANGE_LINKS be set.</string>
          </map>
@@ -11317,11 +11317,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Generates a damage event on the targeted agent or task.</string>
          </map>
@@ -11330,11 +11330,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
@@ -11345,11 +11345,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Convert link-set from AI/Physics character to Physics object.\nConvert the current link-set back to a standard object, removing all path-finding properties.</string>
          </map>
@@ -11368,11 +11368,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
@@ -11411,11 +11411,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th list entry.</string>
          </map>
@@ -11452,11 +11452,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th character.</string>
          </map>
@@ -11484,11 +11484,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Derezzes an object previously rezzed by a script in this region. Returns TRUE on success or FALSE if the object could not be derezzed.</string>
             <key>bool_semantics</key>
@@ -11499,11 +11499,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Remove the object containing the script from the avatar.</string>
          </map>
@@ -11522,11 +11522,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list containing the current damage for the event, the damage type and the original damage delivered.</string>
          </map>
@@ -11545,11 +11545,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the grab offset of a user touching the object.\nReturns &lt;0.0, 0.0, 0.0&gt; if Number is not a valid object.</string>
          </map>
@@ -11568,11 +11568,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if detected object or agent Number has the same user group active as this object.\nIt will return FALSE if the object or agent is in the group, but the group is not active.</string>
             <key>bool_semantics</key>
@@ -11593,11 +11593,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of detected object or avatar number.\nReturns NULL_KEY if Number is not a valid index.</string>
          </map>
@@ -11616,11 +11616,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the link position of the triggered event for touches and collisions only.\n0 for a non-linked object, 1 for the root of a linked object, 2 for the first child, etc.</string>
          </map>
@@ -11639,11 +11639,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of detected object or avatar number.\nReturns the name of detected object number.\nReturns empty string if Number is not a valid index.</string>
          </map>
@@ -11662,11 +11662,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of detected object's owner.\nReturns invalid key if Number is not a valid index.</string>
          </map>
@@ -11685,11 +11685,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position of detected object or avatar number.\nReturns &lt;0.0, 0.0, 0.0&gt; if Number is not a valid index.</string>
          </map>
@@ -11708,11 +11708,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key for the rezzer of the detected object.</string>
          </map>
@@ -11731,11 +11731,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation of detected object or avatar number.\nReturns &lt;0.0, 0.0, 0.0, 1.0&gt; if Number is not a valid offset.</string>
          </map>
@@ -11754,11 +11754,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the surface bi-normal for a triggered touch event.\nReturns a vector that is the surface bi-normal (tangent to the surface) where the touch event was triggered.</string>
          </map>
@@ -11777,11 +11777,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the face where the avatar clicked in a triggered touch event.</string>
          </map>
@@ -11800,11 +11800,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the surface normal for a triggered touch event.\nReturns a vector that is the surface normal (perpendicular to the surface) where the touch event was triggered.</string>
          </map>
@@ -11823,11 +11823,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position, in region coordinates, where the object was touched in a triggered touch event.\nUnless it is a HUD, in which case it returns the position relative to the attach point.</string>
          </map>
@@ -11846,11 +11846,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector that is the surface coordinates where the prim was touched.\nThe X and Y vector positions contain the horizontal (S) and vertical (T) face coordinates respectively.\nEach component is in the interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD is returned if the surface coordinates cannot be determined (e.g. when the viewer does not support this function).</string>
          </map>
@@ -11869,11 +11869,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector that is the texture coordinates for where the prim was touched.\nThe X and Y vector positions contain the U and V face coordinates respectively.\nTOUCH_INVALID_TEXCOORD is returned if the touch UV coordinates cannot be determined (e.g. when the viewer does not support this function).</string>
          </map>
@@ -11892,11 +11892,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\nReturns 0 if number is not a valid index.\nNote that number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\ninteger iType = llDetectedType(0);\n{\n	// ...do stuff with the agent\n}</string>
          </map>
@@ -11915,11 +11915,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the velocity of the detected object Number.\nReturns&lt;0.0, 0.0, 0.0&gt; if Number is not a valid offset.</string>
          </map>
@@ -11965,11 +11965,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Shows a dialog box on the avatar's screen with the message.\n
                     Up to 12 strings in the list form buttons.\n
@@ -11987,11 +11987,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Delete the object which holds the script.</string>
          </map>
@@ -12019,11 +12019,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the list as a single string, using Separator between the entries.\nWrite the list out as a single string, using Separator between values.</string>
          </map>
@@ -12051,11 +12051,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Checks to see whether the border hit by Direction from Position is the edge of the world (has no neighboring region).\nReturns TRUE if the line along Direction from Position hits the edge of the world in the current simulator, returns FALSE if that edge crosses into another simulator.</string>
             <key>bool_semantics</key>
@@ -12076,11 +12076,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Ejects AvatarID from land that you own.\nEjects AvatarID from land that the object owner (group or resident) owns.</string>
          </map>
@@ -12117,11 +12117,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Sends email to Address with Subject and Message.\nSends an email to Address with Subject and Message.</string>
          </map>
@@ -12140,11 +12140,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
                 This function returns the UTF-8 encoded escape codes for selected characters.</string>
@@ -12164,11 +12164,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation representation of the Euler angles.\nReturns the rotation represented by the Euler Angle.</string>
          </map>
@@ -12196,11 +12196,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Evade a specified target.\nCharacters will (roughly) try to hide from their pursuers if there is a good hiding spot along their fleeing path. Hiding means no direct line of sight from the head of the character (centre of the top of its physics bounding box) to the head of its pursuer and no direct path between the two on the navigation-mesh.</string>
          </map>
@@ -12228,11 +12228,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Execute a character command.\nSend a command to the path system.\nCurrently only supports stopping the current path-finding operation or causing the character to jump.</string>
          </map>
@@ -12251,11 +12251,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the positive version of Value.\nReturns the absolute value of Value.</string>
          </map>
@@ -12292,11 +12292,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches the text of a cached notecard for lines containing the given pattern and returns the 
             number of matches found through a dataserver event.
@@ -12353,11 +12353,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches the text of a cached notecard for lines containing the given pattern. 
             Returns a list of line numbers and column where a match is found. If the notecard is not in
@@ -12397,11 +12397,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Flee from a point.\nDirects a character (llCreateCharacter) to keep away from a defined position in the region or adjacent regions.</string>
          </map>
@@ -12420,11 +12420,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns largest integer value &lt;= Value.</string>
          </map>
@@ -12443,11 +12443,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If Enable is TRUE any avatar that sits on this object is forced into mouse-look mode.\nAfter calling this function with Enable set to TRUE, any agent sitting down on the prim will be forced into mouse-look.\nJust like llSitTarget, this changes a permanent property of the prim (not the object) and needs to be reset by calling this function with Enable set to FALSE in order to disable it.</string>
          </map>
@@ -12466,11 +12466,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a pseudo random number in the range [0, Magnitude] or [Magnitude, 0].\nReturns a pseudo-random number between [0, Magnitude].</string>
          </map>
@@ -12479,11 +12479,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Generates a key (SHA-1 hash) using UUID generation to create a unique key.\nAs the UUID produced is versioned, it should never return a value of NULL_KEY.\nThe specific UUID version is an implementation detail that has changed in the past and may change again in the future. Do not depend upon the UUID that is returned to be version 5 SHA-1 hash.</string>
          </map>
@@ -12492,11 +12492,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the acceleration of the object relative to the region's axes.\nGets the acceleration of the object.</string>
          </map>
@@ -12515,11 +12515,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer bit-field containing the agent information about id.\n
                     Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.</string>
@@ -12539,11 +12539,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the language code of the preferred interface language of the avatar.\nReturns a string that is the language code of the preferred interface language of the resident.</string>
          </map>
@@ -12571,11 +12571,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests a list of agents currently in the region, limited by the scope parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or [string error_msg] - returns avatar keys for all agents in the region limited to the area(s) specified by scope</string>
          </map>
@@ -12594,11 +12594,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If the avatar is in the same region, returns the size of the bounding box of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the agent is in the same region as the object, returns the size of the avatar.</string>
          </map>
@@ -12617,11 +12617,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the alpha value of Face.\nReturns the 'alpha' of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
          </map>
@@ -12630,11 +12630,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the script time in seconds and then resets the script timer to zero.\nGets the time in seconds since starting and resets the time to zero.</string>
          </map>
@@ -12653,11 +12653,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the currently playing locomotion animation for the avatar id.\nReturns the currently playing animation for the specified avatar ID.</string>
          </map>
@@ -12676,11 +12676,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys of playing animations for an avatar.\nReturns a list of keys of all playing animations for the specified avatar ID.</string>
          </map>
@@ -12699,11 +12699,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the name of the animation that is used for the specified animation state\nTo use this function the script must obtain either the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION permission (automatically granted to attached objects).</string>
          </map>
@@ -12712,11 +12712,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the object's attachment point, or 0 if not attached.</string>
          </map>
@@ -12735,11 +12735,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys of all visible (not HUD) attachments on the avatar identified by the ID argument</string>
          </map>
@@ -12767,11 +12767,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Retrieves a list of attachments on an avatar.</string>
          </map>
@@ -12790,11 +12790,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the bounding box around the object (including any linked prims) relative to its root prim, as a list in the format [ (vector) min_corner, (vector) max_corner ].</string>
          </map>
@@ -12803,11 +12803,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera aspect ratio (width / height) of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.</string>
          </map>
@@ -12816,11 +12816,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera field of view of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.</string>
          </map>
@@ -12829,11 +12829,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera position for the agent the task has permissions for.\nReturns the position of the camera, of the user that granted the script PERMISSION_TRACK_CAMERA. If no user has granted the permission, it returns ZERO_VECTOR.</string>
          </map>
@@ -12842,11 +12842,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera orientation for the agent the task has permissions for. If no user has granted the PERMISSION_TRACK_CAMERA permission, returns ZERO_ROTATION.</string>
          </map>
@@ -12855,11 +12855,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the prim's centre of mass (unless called from the root prim, where it returns the object's centre of mass).</string>
          </map>
@@ -12887,11 +12887,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the closest navigable point to the point provided.\nThe function accepts a point in region-local space (like all the other path-finding methods) and returns either an empty list or a list containing a single vector which is the closest point on the navigation-mesh to the point provided.</string>
          </map>
@@ -12910,11 +12910,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the color on Face.\nReturns the color of Face as a vector of red, green, and blue values between 0 and 1. If face is ALL_SIDES the color returned is the mean average of each channel.</string>
          </map>
@@ -12923,11 +12923,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a key for the creator of the prim.\nReturns the key of the object's original creator. Similar to llGetOwner.</string>
          </map>
@@ -12936,11 +12936,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.</string>
          </map>
@@ -12949,11 +12949,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day on this parcel.</string>
          </map>
@@ -12962,11 +12962,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day is offset from midnight in this parcel.</string>
          </map>
@@ -12985,11 +12985,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the display name of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestDisplayName if the avatar may be absent from the region.</string>
          </map>
@@ -12998,11 +12998,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns how much energy is in the object as a percentage of maximum.</string>
          </map>
@@ -13021,11 +13021,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
          </map>
@@ -13053,11 +13053,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
             <key>bool_semantics</key>
@@ -13078,11 +13078,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
@@ -13103,11 +13103,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
@@ -13118,11 +13118,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the force (if the script is physical).\nReturns the current force if the script is physical.</string>
          </map>
@@ -13131,11 +13131,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of free bytes of memory the script can use.\nReturns the available free space for the current script. This is inaccurate with LSO.</string>
          </map>
@@ -13144,11 +13144,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of available URLs for the current script.\nReturns an integer that is the number of available URLs.</string>
          </map>
@@ -13157,11 +13157,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since midnight GMT.\nGets the time in seconds since midnight in GMT/UTC.</string>
          </map>
@@ -13170,11 +13170,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the vector that is the geometric center of the object relative to the root prim.</string>
          </map>
@@ -13202,11 +13202,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value for header for request_id.\nReturns a string that is the value of the Header for HTTPRequestID.</string>
          </map>
@@ -13225,11 +13225,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current health of an avatar or object in the region.</string>
          </map>
@@ -13248,11 +13248,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time at which the item was placed into this prim's inventory as a timestamp.</string>
          </map>
@@ -13271,11 +13271,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says "No item named 'name'".</string>
          </map>
@@ -13294,11 +13294,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says "No item named 'name'" to the debug channel and returns an empty string.</string>
          </map>
@@ -13317,11 +13317,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key that is the UUID of the inventory named.\nReturns the key of the inventory named.</string>
          </map>
@@ -13349,11 +13349,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the inventory item of a given type, specified by index number.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
@@ -13372,11 +13372,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim's inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
@@ -13404,11 +13404,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object's inventory, llGetInventoryPermMask returns FALSE and causes the object to say "No item named '&lt;item&gt;'", where "&lt;item&gt;" is item.</string>
          </map>
@@ -13427,11 +13427,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the named inventory item.\nLike all inventory functions, llGetInventoryType is case-sensitive.</string>
          </map>
@@ -13440,11 +13440,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the prim the script is attached to.\nGet the key for the object which has this script.</string>
          </map>
@@ -13463,11 +13463,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the land owner, returns NULL_KEY if public.\nReturns the key of the land owner at Position, or NULL_KEY if public.</string>
          </map>
@@ -13486,11 +13486,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the linked prim LinkNumber.\nReturns the key of LinkNumber in the link set.</string>
          </map>
@@ -13527,11 +13527,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.	Returns an empty list if no media exists on the face.</string>
             <key>bool_semantics</key>
@@ -13552,11 +13552,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of LinkNumber in a link set.\nReturns the name of LinkNumber the link set.</string>
          </map>
@@ -13565,11 +13565,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the link number of the prim containing the script (0 means not linked, 1 the prim is the root, 2 the prim is the first child, etc.).\nReturns the link number of the prim containing the script. 0 means no link, 1 the root, 2 for first child, etc.</string>
          </map>
@@ -13588,11 +13588,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of sides of the specified linked prim.\nReturns an integer that is the number of faces (or sides) of the prim link.</string>
          </map>
@@ -13620,11 +13620,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flag's attributes.\n* Face flags require the user to also supply a face index parameter.</string>
             <key>bool_semantics</key>
@@ -13645,11 +13645,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the sit flags set on the specified prim in a linkset.</string>
          </map>
@@ -13677,11 +13677,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT, TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if index is off list).\nReturns the type of the variable at Index in ListVariable.</string>
          </map>
@@ -13700,11 +13700,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of elements in the list.\nReturns the number of elements in ListVariable.</string>
          </map>
@@ -13713,11 +13713,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position relative to the root.\nReturns the local position of a child object relative to the root.</string>
          </map>
@@ -13726,11 +13726,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation local to the root.\nReturns the local rotation of a child object relative to the root.</string>
          </map>
@@ -13739,11 +13739,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mass of object that the script is attached to.\nReturns the scripted object's mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it's attached to, not its own.</string>
          </map>
@@ -13752,11 +13752,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Acts as llGetMass(), except that the units of the value returned are Kg.</string>
          </map>
@@ -13765,11 +13765,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the largest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.</string>
          </map>
@@ -13778,11 +13778,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the maximum memory a script can use, in bytes.</string>
          </map>
@@ -13791,11 +13791,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the smallest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.</string>
          </map>
@@ -13804,11 +13804,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon's direction on the simulator in the parcel.</string>
          </map>
@@ -13817,11 +13817,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the moon in the parcel.</string>
          </map>
@@ -13849,11 +13849,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Fetch the next queued email with that matches the given address and/or subject, via the email event.\nIf the parameters are blank, they are not used for filtering.</string>
          </map>
@@ -13881,11 +13881,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero in LSL, one in Lua.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
          </map>
@@ -13913,11 +13913,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns LineNumber from NotecardName. The line index starts at zero in LSL, one in Lua.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
          </map>
@@ -13936,11 +13936,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Returns the number of lines contained within a notecard via the dataserver event.\nThe key returned by this function is a query ID for identifying the dataserver reply.</string>
          </map>
@@ -13949,11 +13949,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of prims in a link set the script is attached to.\nReturns the number of prims in (and avatars seated on) the object the script is in.</string>
          </map>
@@ -13962,11 +13962,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of faces (or sides) of the prim.\nReturns the number of sides of the prim which has the script.</string>
          </map>
@@ -13975,11 +13975,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of names of playing animations for an object.\nReturns a list of names of all playing animations for the current object.</string>
          </map>
@@ -13988,11 +13988,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the description of the prim the script is attached to.\nReturns the description of the scripted object/prim. You can set the description using llSetObjectDesc.</string>
          </map>
@@ -14020,11 +14020,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of object details specified in the Parameters list for the object or avatar in the region with key ID.\nParameters are specified by the OBJECT_* constants.</string>
             <key>bool_semantics</key>
@@ -14054,11 +14054,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the linked prim link_no in a linkset.\nReturns the key of link_no in the link set specified by id.</string>
          </map>
@@ -14077,11 +14077,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mass of the avatar or object in the region.\nGets the mass of the object or avatar corresponding to ID.</string>
          </map>
@@ -14090,11 +14090,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the prim which the script is attached to.\nReturns the name of the prim (not object) which contains the script.</string>
          </map>
@@ -14113,11 +14113,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the permission mask of the requested category for the object.</string>
          </map>
@@ -14136,11 +14136,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the total number of prims for an object in the region.\nReturns the prim count for any object id in the same region.</string>
          </map>
@@ -14149,11 +14149,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation velocity in radians per second.\nReturns a vector that is the rotation velocity of the object in radians per second.</string>
          </map>
@@ -14162,11 +14162,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the object owner's UUID.\nReturns the key for the owner of the object.</string>
          </map>
@@ -14185,11 +14185,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the owner of ObjectID.\nReturns the key for the owner of object ObjectID.</string>
          </map>
@@ -14217,11 +14217,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of parcel details specified in the ParcelDetails list for the parcel at Position.\nParameters is one or more of: PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\nReturns a list that is the parcel details specified in ParcelDetails (in the same order) for the parcel at Position.</string>
             <key>bool_semantics</key>
@@ -14242,11 +14242,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that includes the point Position.\nReturns a bit-field specifying the parcel flags (PARCEL_FLAG_*) for the parcel at Position.</string>
          </map>
@@ -14274,11 +14274,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the maximum number of prims allowed on the parcel at Position for a given scope.\nThe scope may be set to an individual parcel or the combined resources of all parcels with the same ownership in the region.</string>
          </map>
@@ -14287,11 +14287,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Gets the streaming audio URL for the parcel object is on.\nThe object owner, avatar or group, must also be the land owner.</string>
          </map>
@@ -14328,11 +14328,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of prims on the parcel at Position of the given category.\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER, _SELECTED, _TEMP.\nReturns the number of prims used on the parcel at Position which are in Category.\nIf SimWide is TRUE, it returns the total number of objects for all parcels with matching ownership in the category specified.\nIf SimWide is FALSE, it returns the number of objects on this specific parcel in the category specified</string>
          </map>
@@ -14351,11 +14351,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Returns a list of up to 100 residents who own objects on the parcel at Position, with per-owner land impact totals.\nRequires owner-like permissions for the parcel, and for the script owner to be present in the region.\nThe list is formatted as [ key agentKey1, integer agentLI1, key agentKey2, integer agentLI2, ... ], sorted by agent key.\nThe integers are the combined land impacts of the objects owned by the corresponding agents.</string>
          </map>
@@ -14364,11 +14364,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise "and" operation against the PERMISSION_* constants</string>
          </map>
@@ -14377,11 +14377,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the avatar that last granted or declined permissions to the script.\nReturns NULL_KEY if permissions were never granted or declined.</string>
          </map>
@@ -14390,11 +14390,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of the form [float gravity_multiplier, float restitution, float friction, float density].</string>
          </map>
@@ -14403,11 +14403,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position of the task in region coordinates.\nReturns the vector position of the task in region coordinates.</string>
          </map>
@@ -14435,11 +14435,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Returns the media parameters for a particular face on an object, given the desired list of parameter names, in the order requested. Returns an empty list if no media exists on the face.</string>
             <key>bool_semantics</key>
@@ -14460,11 +14460,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Returns the primitive parameters specified in the parameters list.\nReturns primitive parameters specified in the Parameters list.</string>
             <key>bool_semantics</key>
@@ -14475,11 +14475,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of avatars in the region.\nReturns an integer that is the number of avatars in the region.</string>
          </map>
@@ -14488,11 +14488,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector, in meters, that is the global location of the south-west corner of the region which the object is in.\nReturns the Region-Corner of the simulator containing the task. The region-corner is a vector (values in meters) representing distance from the first region.</string>
          </map>
@@ -14501,11 +14501,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day in this region.</string>
          </map>
@@ -14514,11 +14514,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day is offset from midnight in this parcel.</string>
          </map>
@@ -14527,11 +14527,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mean region frames per second.</string>
          </map>
@@ -14540,11 +14540,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the region flags (REGION_FLAG_*) for the region the object is in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for the region the object is in.</string>
          </map>
@@ -14553,11 +14553,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon's direction on the simulator.</string>
          </map>
@@ -14566,11 +14566,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the moon in the region.</string>
          </map>
@@ -14579,11 +14579,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current region name.</string>
          </map>
@@ -14592,11 +14592,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun's direction on the simulator.</string>
          </map>
@@ -14605,11 +14605,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the sun in the region.</string>
          </map>
@@ -14618,11 +14618,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current time dilation as a float between 0.0 (full dilation) and 1.0 (no dilation).\nReturns the current time dilation as a float between 0.0 and 1.0.</string>
          </map>
@@ -14631,11 +14631,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since environmental midnight for the entire region.</string>
          </map>
@@ -14654,11 +14654,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim's inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
@@ -14667,11 +14667,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position (in region coordinates) of the root prim of the object which the script is attached to.\nThis is used to allow a child prim to determine where the root is.</string>
          </map>
@@ -14680,11 +14680,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation (relative to the region) of the root prim of the object which the script is attached to.\nGets the global rotation of the root object of the object script is attached to.</string>
          </map>
@@ -14693,11 +14693,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation relative to the region's axes.\nReturns the rotation.</string>
          </map>
@@ -14706,11 +14706,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the maximum used memory for the current script. Only valid after using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns the integer of the most bytes used while llScriptProfiler was last active.</string>
          </map>
@@ -14719,11 +14719,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the scale of the prim.\nReturns a vector that is the scale (dimensions) of the prim.</string>
          </map>
@@ -14732,11 +14732,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the script that this function is used in.\nReturns the name of this script.</string>
          </map>
@@ -14755,11 +14755,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if the script named is running.\nReturns TRUE if ScriptName is running.</string>
             <key>bool_semantics</key>
@@ -14780,11 +14780,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a float that is the requested statistic.</string>
          </map>
@@ -14793,11 +14793,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>tooltip</key>
             <string>Returns the host-name of the machine which the script is running on.\nFor example, "sim225.agni.lindenlab.com".</string>
          </map>
@@ -14806,11 +14806,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the script rez parameter.\nIf the object was rezzed by an agent, this function returns 0.</string>
          </map>
@@ -14819,11 +14819,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
          </map>
@@ -14869,11 +14869,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string />
          </map>
@@ -14892,11 +14892,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the object the script is attached to.</string>
             <key>bool_semantics</key>
@@ -14935,11 +14935,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a sub-string from String, in a range specified by the Start and End indices (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
@@ -14948,11 +14948,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun's direction on the simulator in the parcel.</string>
          </map>
@@ -14961,11 +14961,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the sun in the parcel.</string>
          </map>
@@ -14984,11 +14984,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim's inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
@@ -15007,11 +15007,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture offset of face in the x and y components of a vector.</string>
          </map>
@@ -15030,11 +15030,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture rotation of side.</string>
          </map>
@@ -15053,11 +15053,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture scale of side in the x and y components of a vector.\nReturns the texture scale of a side in the x and y components of a vector.</string>
          </map>
@@ -15066,11 +15066,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.</string>
          </map>
@@ -15079,11 +15079,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since environmental midnight on the parcel.</string>
          </map>
@@ -15092,11 +15092,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.</string>
          </map>
@@ -15105,11 +15105,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the torque (if the script is physical).\nReturns a vector that is the torque (if the script is physical).</string>
          </map>
@@ -15118,11 +15118,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC from the system clock.</string>
          </map>
@@ -15131,11 +15131,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current used memory for the current script. Non-mono scripts always use 16K.\nReturns the integer of the number of bytes of memory currently in use by the script. Non-mono scripts always use 16K.</string>
          </map>
@@ -15154,11 +15154,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the username of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestUsername if the avatar may be absent from the region.</string>
          </map>
@@ -15167,11 +15167,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the velocity of the object.\nReturns a vector that is the velocity of the object.</string>
          </map>
@@ -15199,11 +15199,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of the current value for each requested visual parameter.</string>
          </map>
@@ -15212,11 +15212,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator's time-zone midnight (Pacific Time).</string>
          </map>
@@ -15262,11 +15262,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>Give InventoryItems to the specified agent as a new folder of items, as permitted by the permissions system. The target must be an agent.</string>
          </map>
@@ -15294,11 +15294,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Give InventoryItem to destination represented by TargetID, as permitted by the permissions system.\nTargetID may be any agent or an object in the same region.</string>
          </map>
@@ -15335,11 +15335,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>Give InventoryItems to destination (represented by TargetID) as a new folder of items, as permitted by the permissions system.\nTargetID may be any agent or an object in the same region. If TargetID is an object, the items are passed directly to the object inventory (no folder is created).</string>
          </map>
@@ -15367,11 +15367,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfers Amount of L$ from script owner to AvatarID.\nThis call will silently fail if PERMISSION_DEBIT has not been granted.</string>
          </map>
@@ -15399,13 +15399,13 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Rez directly off of a UUID if owner has god-bit set.</string>
          </map>
@@ -15424,11 +15424,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object's position + Offset.</string>
          </map>
@@ -15447,11 +15447,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
@@ -15470,11 +15470,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
@@ -15511,11 +15511,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
                     The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
@@ -15536,11 +15536,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground slope below the object position + Offset.\nReturns the ground slope at the object position + Offset.</string>
          </map>
@@ -15577,11 +15577,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base64-encoded hashed message authentication code (HMAC), of Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224, sha256, sha384, sha512).</string>
          </map>
@@ -15618,11 +15618,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sends an HTTP request to the specified URL with the Body of the request and Parameters.\nReturns a key that is a handle identifying the HTTP request made.</string>
          </map>
@@ -15659,11 +15659,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Responds to an incoming HTTP request which was triggerd by an http_request event within the script. HTTPRequestID specifies the request to respond to (this ID is supplied in the http_request event handler).  Status and Body specify the status code and message to respond with.</string>
          </map>
@@ -15682,11 +15682,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Calculates the 32bit hash value for the provided string.</string>
          </map>
@@ -15723,11 +15723,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Inserts SourceVariable into TargetVariable at Position, and returns the result.\nInserts SourceVariable into TargetVariable at Position and returns the result. Note this does not alter TargetVariable.</string>
          </map>
@@ -15755,11 +15755,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>IMs Text to the user identified.\nSend Text to the user as an instant message.</string>
          </map>
@@ -15778,11 +15778,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is a Base64 big endian encode of Value.\nEncodes the Value as an 8-character Base64 string.</string>
          </map>
@@ -15801,11 +15801,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is a friend of the script owner.</string>
             <key>bool_semantics</key>
@@ -15835,11 +15835,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Checks the face for a PBR render material.</string>
             <key>bool_semantics</key>
@@ -15860,11 +15860,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts the top level of the JSON string to a list.</string>
          </map>
@@ -15892,11 +15892,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Gets the value indicated by Specifiers from the JSON string.</string>
          </map>
@@ -15933,11 +15933,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a new JSON string that is the JSON given with the Value indicated by Specifiers set to Value.</string>
          </map>
@@ -15965,11 +15965,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type constant (JSON_*) for the value in JSON indicated by Specifiers.</string>
          </map>
@@ -15988,11 +15988,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the prim or avatar specified by ID. The ID must be a valid rezzed prim or avatar key in the current simulator, otherwise an empty string is returned.\nFor avatars, the returned name is the legacy name</string>
          </map>
@@ -16001,11 +16001,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
@@ -16035,11 +16035,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
@@ -16060,11 +16060,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a color from the linear colorspace to sRGB.</string>
          </map>
@@ -16092,11 +16092,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Adjusts the volume (0.0 - 1.0) of the currently playing sound attached to the link.\nThis function has no effect on sounds started with llTriggerSound.</string>
          </map>
@@ -16124,11 +16124,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a particle system in prim LinkNumber based on Rules. An empty list removes a particle system from object.\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].\nThis is identical to llParticleSystem except that it applies to a specified linked prim and not just the prim the script is in.</string>
          </map>
@@ -16174,11 +16174,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be attached to the link or triggered at its location.\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.</string>
          </map>
@@ -16206,11 +16206,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.</string>
          </map>
@@ -16238,11 +16238,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.</string>
          </map>
@@ -16279,11 +16279,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim's position and rotation.</string>
          </map>
@@ -16302,11 +16302,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops playback of the currently attached sound on a link.</string>
          </map>
@@ -16315,11 +16315,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of bytes remaining in the linkset's datastore.</string>
          </map>
@@ -16338,11 +16338,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of keys matching the regular expression passed in the search parameter.</string>
          </map>
@@ -16351,11 +16351,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of keys in the linkset's datastore.</string>
          </map>
@@ -16374,11 +16374,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
@@ -16406,11 +16406,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes all key value pairs in the linkset data where the key matches the regular expression in search. Returns a list consisting of [ #deleted, #not deleted ].</string>
          </map>
@@ -16438,11 +16438,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
@@ -16479,11 +16479,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys from the linkset's data store matching the search parameter.</string>
          </map>
@@ -16511,11 +16511,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of all keys in the linkset datastore.</string>
          </map>
@@ -16534,11 +16534,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value stored for a key in the linkset.</string>
          </map>
@@ -16566,11 +16566,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value stored for a key in the linkset.</string>
          </map>
@@ -16579,11 +16579,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the linkset's data store, erasing all key-value pairs.</string>
          </map>
@@ -16611,11 +16611,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
@@ -16652,11 +16652,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
@@ -16675,11 +16675,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a string of comma separated values from the list.\nCreate a string of comma separated values from the specified list.</string>
          </map>
@@ -16707,11 +16707,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the float at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a float, then zero is returned.</string>
          </map>
@@ -16739,11 +16739,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the integer at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to an integer, then zero is returned.</string>
          </map>
@@ -16771,11 +16771,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts either a strided list of key:value pairs to a JSON_OBJECT, or a list of values to a JSON_ARRAY.</string>
          </map>
@@ -16803,11 +16803,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the key at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a key, then null string is returned.</string>
          </map>
@@ -16844,11 +16844,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a subset of entries from ListVariable, in a range specified by the Start and End indicies (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
@@ -16903,11 +16903,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a subset of entries from ListVariable, in a range specified by Start and End indices (inclusive) return the slice_index element of each stride.\n Using negative numbers for Start and/or End causes the index to count backwards from the length of the list. (e.g. 0, -1 captures entire list)\nIf slice_index is less than 0, it is counted backwards from the end of the stride.\n Stride must be a positive integer &gt; 0 or an empy list is returned.  If slice_index falls outside range of stride, an empty list is returned. slice_index is zero-based. (e.g. A stride of 2 has valid indices 0,1)</string>
          </map>
@@ -16953,11 +16953,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the strided slice of the list from Start to End.\nReturns a copy of the strided slice of the specified list from Start to End.</string>
          </map>
@@ -16985,11 +16985,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the rotation at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to rotation, thenZERO_ROTATION is returned.</string>
          </map>
@@ -17017,11 +17017,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the string at Index in the list.\nReturns the value at Index in the specified list as a string. If Index describes a location not in the list then null string is returned.</string>
          </map>
@@ -17049,11 +17049,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the vector at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a vector, then ZERO_VECTOR is returned.</string>
          </map>
@@ -17081,11 +17081,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\nReturns the position of the first instance of the Find list in the ListVariable. Returns -1 if not found.</string>
          </map>
@@ -17122,11 +17122,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the nth instance of Find in ListVariable. Returns -1 if not found.</string>
          </map>
@@ -17181,11 +17181,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\nReturns the position of the first instance of the Find list in the ListVariable after the start index and before the end index. Steps through ListVariable by stride.  Returns -1 if not found.</string>
          </map>
@@ -17222,11 +17222,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list that contains all the elements from Target but with the elements from ListVariable inserted at Position start.\nReturns a new list, created by inserting ListVariable into the Target list at Position. Note this does not alter the Target.</string>
          </map>
@@ -17254,11 +17254,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a version of the input ListVariable which has been randomized by blocks of size Stride.\nIf the remainder from the length of the list, divided by the stride is non-zero, this function does not randomize the list.</string>
          </map>
@@ -17304,11 +17304,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list that is Target with Start through End removed and ListVariable inserted at Start.\nReturns a list replacing the slice of the Target list from Start to End with the specified ListVariable. Start and End are inclusive, so 0, 1 would replace the first two entries and 0, 0 would replace only the first list entry.</string>
          </map>
@@ -17345,11 +17345,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the specified list, sorted into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.</string>
          </map>
@@ -17395,11 +17395,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the specified list, sorted by the specified element into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.</string>
          </map>
@@ -17427,11 +17427,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a statistical aggregate function, specified by a LIST_STAT_* constant, on ListVariables.\nThis function allows a script to perform a statistical operation as defined by operation on a list composed of integers and floats.</string>
          </map>
@@ -17477,11 +17477,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a listen callback for Text on Channel from SpeakersName and SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and returns an identifier that can be used to deactivate or remove the listen.\nNon-empty values for SpeakersName, SpeakersID, and Text will filter the results accordingly, while empty strings and NULL_KEY will not filter the results, for string and key parameters respectively.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -17509,11 +17509,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Makes a listen event callback active or inactive. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener you are controlling.\nUse boolean values to specify Active</string>
          </map>
@@ -17532,11 +17532,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes a listen event callback. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener to remove.</string>
          </map>
@@ -17573,11 +17573,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Shows dialog to avatar AvatarID offering to load web page at URL.	If user clicks yes, launches their web browser.\nllLoadURL displays a dialogue box to the user, offering to load the specified web page using the default web browser.</string>
          </map>
@@ -17596,11 +17596,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the natural logarithm of Value. Returns zero if Value &lt;= 0.\nReturns the base e (natural) logarithm of the specified Value.</string>
          </map>
@@ -17619,11 +17619,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base 10 logarithm of Value. Returns zero if Value &lt;= 0.\nReturns the base 10 (common) logarithm of the specified Value.</string>
          </map>
@@ -17660,11 +17660,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Cause object name to point its forward axis towards Target, at a force controlled by Strength and Damping.\nGood Strength values are around half the mass of the object and good Damping values are less than 1/10th of the Strength.\nAsymmetrical shapes require smaller Damping. A Strength of 0.0 cancels the look at.</string>
          </map>
@@ -17692,11 +17692,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly one sound may be attached to an object at a time.\nA second call to llLoopSound with the same key will not restart the sound, but the new volume will be used. This allows control over the volume of already playing sounds.\nSetting the volume to 0 is not the same as calling llStopSound; a sound with 0 volume will continue to loop.\nTo restart the sound from the beginning, call llStopSound before calling llLoopSound again.</string>
          </map>
@@ -17724,11 +17724,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a "Sync Master", causing "Slave" sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
          </map>
@@ -17756,11 +17756,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a "Sync Master" present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
          </map>
@@ -17788,11 +17788,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 32 hex characters that is an RSA Data Security Inc., MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns a 32-character hex string. (128-bit in binary.)</string>
          </map>
@@ -17867,11 +17867,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make a round explosion of particles. Deprecated: Use llParticleSystem instead.\nMake a round explosion of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -17946,11 +17946,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake fire particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -18043,11 +18043,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make a fountain of particles. Deprecated: Use llParticleSystem instead.\nMake a fountain of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -18122,11 +18122,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake smoky particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -18154,11 +18154,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
             <key>bool_semantics</key>
@@ -18197,11 +18197,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Displays an in world beacon and optionally opens world map for avatar who touched the object or is wearing the script, centered on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.</string>
          </map>
@@ -18238,11 +18238,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Opens world map for avatar who touched it or is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
          </map>
@@ -18288,11 +18288,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sends Number, Text, and ID to members of the link set identified by LinkNumber.\nLinkNumber is either a linked number (available through llGetLinkNumber) or a LINK_* constant.</string>
          </map>
@@ -18311,11 +18311,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the minimum time between events being handled.</string>
          </map>
@@ -18352,11 +18352,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised to the Power, Modulus). Value is capped at 0xFFFF (16 bits).</string>
          </map>
@@ -18384,11 +18384,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH, LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x 4m, 8m x 8m).</string>
          </map>
@@ -18416,11 +18416,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damp to Target in Tau seconds (if the script is physical).\nCritically damp to position target in tau-seconds if the script is physical. Good tau-values are greater than 0.2. A tau of 0.0 stops the critical damping.</string>
          </map>
@@ -18439,11 +18439,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Look up Agent ID for the named agent in the region.</string>
          </map>
@@ -18471,11 +18471,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Navigate to destination.\nDirects an object to travel to a defined position in the region or adjacent regions.</string>
          </map>
@@ -18512,11 +18512,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the texture S and T offsets for the chosen Face.\nIf Face is ALL_SIDES this function sets the texture offsets for all faces.</string>
          </map>
@@ -18553,11 +18553,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value for header for request_id.\nReturns a string that is the value of the Header for HTTPRequestID.</string>
          </map>
@@ -18568,11 +18568,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -18600,11 +18600,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the unicode value of the indicated character in the string.</string>
          </map>
@@ -18623,11 +18623,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if id ID over land owned by the script owner, otherwise FALSE.\nReturns TRUE if key ID is over land owned by the object owner, FALSE otherwise.</string>
             <key>bool_semantics</key>
@@ -18648,11 +18648,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object's simulator since logging into Second Life, regardless of where they may be in-world.</string>
          </map>
@@ -18671,11 +18671,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Controls the playback of multimedia resources on a parcel or for an agent, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.</string>
          </map>
@@ -18694,11 +18694,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Queries the media properties of the parcel containing the script, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis function will only work if the script is contained within an object owned by the land-owner (or if the land is owned by a group, only if the object has been deeded to the group).</string>
             <key>bool_semantics</key>
@@ -18737,11 +18737,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts Text into a list, discarding Separators, keeping Spacers (Separators and Spacers must be lists of strings, maximum of 8 each).\nSeparators and Spacers are lists of strings with a maximum of 8 entries each.</string>
          </map>
@@ -18778,11 +18778,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Breaks Text into a list, discarding separators, keeping spacers, keeping any null values generated. (separators and spacers must be lists of strings, maximum of 8 each).\nllParseStringKeepNulls works almost exactly like llParseString2List, except that if a null is found it will add a null-string instead of discarding it like llParseString2List does.</string>
          </map>
@@ -18801,11 +18801,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a particle system in the prim the script is attached to, based on Parameters. An empty list removes a particle system from object.\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].</string>
          </map>
@@ -18824,11 +18824,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Configures how collision events are passed to scripts in the linkset.\nIf Pass == TRUE, collisions involving collision-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such collisions will only trigger events in the affected child prim.</string>
          </map>
@@ -18847,11 +18847,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Configures how touch events are passed to scripts in the linkset.\nIf Pass == TRUE, touches involving touch-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such touches will only trigger events in the affected child prim.</string>
          </map>
@@ -18879,11 +18879,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Patrol a list of points.\nSets the points for a character (llCreateCharacter) to patrol along.</string>
          </map>
@@ -18911,11 +18911,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.\nA second call to llPlaySound with the same sound will not restart the sound, but the new volume will be used, which allows control over the volume of already playing sounds.\nTo restart the sound from the beginning, call llStopSound before calling llPlaySound again.</string>
          </map>
@@ -18943,11 +18943,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a "Sync Master" present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
          </map>
@@ -18975,11 +18975,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the Value raised to the power Exponent, or returns 0 and triggers Math Error for imaginary results.\nReturns the Value raised to the Exponent.</string>
          </map>
@@ -18998,11 +18998,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Causes nearby viewers to preload the Sound from the object's inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
          </map>
@@ -19030,11 +19030,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Chase after a target.\nCauses the character (llCharacter) to pursue the target defined by TargetID.</string>
          </map>
@@ -19080,11 +19080,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied impulse and angular impulse to the object specified.</string>
          </map>
@@ -19103,11 +19103,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
@@ -19120,11 +19120,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Reloads the web page shown on the sides of the object.</string>
          </map>
@@ -19152,11 +19152,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Broadcasts Text to entire region on Channel (except for channel 0).</string>
          </map>
@@ -19193,11 +19193,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Says Text, on Channel, to avatar or object indicated by TargetID (if within region).\nIf TargetID is an avatar and Channel is nonzero, Text can be heard by any attachment on the avatar.</string>
          </map>
@@ -19218,11 +19218,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return camera to agent.\nDeprecated: Use llClearCameraParams instead.</string>
          </map>
@@ -19231,11 +19231,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop taking inputs.\nStop taking inputs from the avatar.</string>
          </map>
@@ -19254,11 +19254,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Releases the specified URL, which was previously obtained using llRequestURL.  Once released, the URL will no longer be usable.</string>
          </map>
@@ -19306,11 +19306,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -19321,11 +19321,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -19380,11 +19380,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>If the owner of the object containing this script can modify the object identified by the specified object key, and if the PIN matches the PIN previously set using llSetRemoteScriptAccessPin (on the target prim), then the script will be copied into target. Running is a boolean specifying whether the script should be enabled once copied into the target object.</string>
          </map>
@@ -19403,11 +19403,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Remove avatar from the land ban list.\nRemove specified avatar from the land parcel ban list.</string>
          </map>
@@ -19426,11 +19426,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Remove avatar from the land pass list.\nRemove specified avatar from the land parcel pass list.</string>
          </map>
@@ -19449,11 +19449,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Remove the named inventory item.\nRemove the named inventory item from the object inventory.</string>
          </map>
@@ -19472,11 +19472,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
          </map>
@@ -19513,11 +19513,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Replaces the entire environment for an agent. Must be used as part of an experience.</string>
          </map>
@@ -19573,11 +19573,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Replaces the environment for a parcel or region.</string>
          </map>
@@ -19623,11 +19623,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
          </map>
@@ -19655,11 +19655,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Requests data about AvatarID. When data is available the dataserver event will be raised.\nThis function requests data about an avatar. If and when the information is collected, the dataserver event is triggered with the key returned from this function passed in the requested parameter. See the agent data constants (DATA_*) for details about valid values of data and what each will return in the dataserver event.</string>
          </map>
@@ -19678,11 +19678,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests the display name of the agent. When the display name is available the dataserver event will be raised.\nThe avatar identified does not need to be in the same region or online at the time of the request.\nReturns a key that is used to identify the dataserver event when it is raised.</string>
          </map>
@@ -19710,11 +19710,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
@@ -19735,11 +19735,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form "&lt;float, float, float&gt;" which can be cast to a vector. This position is in region local coordinates.</string>
          </map>
@@ -19767,11 +19767,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Ask AvatarID to allow the script to perform certain actions, specified in the PermissionMask bitmask. PermissionMask should be one or more PERMISSION_* constants. Multiple permissions can be requested simultaneously by ORing the constants together. Many of the permissions requests can only go to object owner.\nThis call will not stop script execution. If the avatar grants the requested permissions, the run_time_permissions event will be called.</string>
          </map>
@@ -19780,11 +19780,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests one HTTPS:// (SSL) URL for use by this object. The http_request event is triggered with results.\nReturns a key that is the handle used for identifying the request in the http_request event.</string>
          </map>
@@ -19812,11 +19812,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Requests the specified Data about RegionName. When the specified data is available, the dataserver event is raised.\nData should use one of the DATA_SIM_* constants.\nReturns a dataserver query ID and triggers the dataserver event when data is found.</string>
          </map>
@@ -19825,11 +19825,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests one HTTP:// URL for use by this script. The http_request event is triggered with the result of the request.\nReturns a key that is the handle used for identifying the result in the http_request event.</string>
          </map>
@@ -19848,11 +19848,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Look up Agent ID for the named agent using a historical name.</string>
          </map>
@@ -19871,11 +19871,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests single-word user-name of an avatar. When data is available the dataserver event will be raised.\nRequests the user-name of the identified agent. When the user-name is available the dataserver event is raised.\nThe agent identified does not need to be in the same region or online at the time of the request.\nReturns a key that is used to identify the dataserver event when it is raised.</string>
          </map>
@@ -19894,11 +19894,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals "ALL", then all animation states are reset.</string>
          </map>
@@ -19907,11 +19907,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Removes all residents from the land ban list.</string>
          </map>
@@ -19920,11 +19920,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Removes all residents from the land access/pass list.</string>
          </map>
@@ -19943,11 +19943,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the named script.</string>
          </map>
@@ -19956,11 +19956,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the script.</string>
          </map>
@@ -19969,11 +19969,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the time to zero.\nSets the internal timer to zero.</string>
          </map>
@@ -19992,11 +19992,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.</string>
          </map>
@@ -20024,11 +20024,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return objects based upon their owner and a scope of parcel, parcel owner, or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.</string>
          </map>
@@ -20083,11 +20083,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owner's InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object's location will be set to Position.\nCreates object's inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
          </map>
@@ -20142,11 +20142,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object's inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
          </map>
@@ -20174,11 +20174,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owner's InventoryItem with the given parameters.</string>
          </map>
@@ -20197,11 +20197,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation angle represented by Rotation.\nReturns the angle represented by the Rotation.</string>
          </map>
@@ -20220,11 +20220,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation axis represented by Rotation.\nReturns the axis represented by the Rotation.</string>
          </map>
@@ -20243,11 +20243,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns the Euler Angle representation of the Rotation.</string>
          </map>
@@ -20266,11 +20266,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the forward vector defined by Rotation.\nReturns the forward axis represented by the Rotation.</string>
          </map>
@@ -20289,11 +20289,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the left vector defined by Rotation.\nReturns the left axis represented by the Rotation.</string>
          </map>
@@ -20312,11 +20312,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the up vector defined by Rotation.\nReturns the up axis represented by the Rotation.</string>
          </map>
@@ -20344,11 +20344,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>rotation</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation needed to rotate Vector1 to Vector2.</string>
          </map>
@@ -20385,11 +20385,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Cause object to rotate to Rotation, with a force function defined by Strength and Damping parameters. Good strength values are around half the mass of the object and good damping values are less than 1/10th of the strength.\nAsymmetrical shapes require smaller damping.\nA strength of 0.0 cancels the look at.</string>
          </map>
@@ -20417,11 +20417,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set rotations with error of LeeWay radians as a rotational target, and return an ID for the rotational target.\nThe returned number is a handle that can be used in at_rot_target and llRotTargetRemove.</string>
          </map>
@@ -20440,11 +20440,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes rotational target number.\nRemove rotational target indicated by the handle.</string>
          </map>
@@ -20472,11 +20472,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the texture rotation for the specified Face to angle Radians.\nIf Face is ALL_SIDES, rotates the texture of all sides.</string>
          </map>
@@ -20495,11 +20495,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns Value rounded to the nearest integer.\nReturns the Value rounded to the nearest integer.</string>
          </map>
@@ -20518,11 +20518,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 40 hex characters that is the SHA1 security hash of text.</string>
          </map>
@@ -20541,11 +20541,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 64 hex characters that is the SHA256 security hash of text.</string>
          </map>
@@ -20564,11 +20564,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is in the same region and has the same active group, otherwise FALSE.\nReturns TRUE if the object or agent identified is in the same simulator and has the same active group as this object. Otherwise, returns FALSE.</string>
             <key>bool_semantics</key>
@@ -20598,11 +20598,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Says Text on Channel.\nThis chat method has a range of 20m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -20621,11 +20621,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempts to resize the entire object by ScalingFactor, maintaining the size-position ratios of the prims.\n\nResizing is subject to prim scale limits and linkability limits. This function can not resize the object if the linkset is physical, a pathfinding character, in a keyframed motion, or if resizing would cause the parcel to overflow.\nReturns a boolean (an integer) TRUE if it succeeds, FALSE if it fails.</string>
             <key>bool_semantics</key>
@@ -20664,11 +20664,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the diffuse texture Horizontal and Vertical repeats on Face of the prim the script is attached to.\nIf Face == ALL_SIDES, all sides are set in one call.\nNegative values for horizontal and vertical will flip the texture.</string>
          </map>
@@ -20687,11 +20687,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.</string>
             <key>bool_semantics</key>
@@ -20712,11 +20712,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enables or disables script profiling options. Currently only supports PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly reduce script performance.</string>
          </map>
@@ -20764,11 +20764,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -20823,11 +20823,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\nResults are returned in the sensor and no_sensor events.</string>
          </map>
@@ -20836,11 +20836,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>removes sensor.\nRemoves the sensor set by llSensorRepeat.</string>
          </map>
@@ -20904,11 +20904,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Initiates a periodic scan every Rate seconds, for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\nResults are returned in the sensor and no_sensor events.</string>
          </map>
@@ -20945,11 +20945,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets an agent's environmental values to the specified values. Must be used as part of an experience.</string>
          </map>
@@ -20977,11 +20977,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the avatar rotation to the given value.</string>
          </map>
@@ -21009,11 +21009,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value for Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is mostly transparent). This function will clamp alpha values less than 0.1 to 0.1 and greater than 1.0 to 1.</string>
          </map>
@@ -21041,11 +21041,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets an object's angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
          </map>
@@ -21073,11 +21073,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the animation (in object inventory) that will play for the given animation state.\nTo use this function the script must obtain the PERMISSION_OVERRIDE_ANIMATIONS permission.</string>
          </map>
@@ -21096,11 +21096,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the tasks buoyancy (0 is none, &lt; 1.0 sinks, 1.0 floats, &gt; 1.0 rises).\nSet the object buoyancy. A value of 0 is none, less than 1.0 sinks, 1.0 floats, and greater than 1.0 rises.</string>
          </map>
@@ -21119,11 +21119,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar's camera will be moved to if the avatar sits on the object.</string>
          </map>
@@ -21142,11 +21142,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera eye offset used in this object if an avatar sits on it.</string>
          </map>
@@ -21165,11 +21165,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets multiple camera parameters at once. List format is [ rule-1, data-1, rule-2, data-2 . . . rule-n, data-n ].</string>
          </map>
@@ -21188,11 +21188,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the action performed when a prim is clicked upon.</string>
          </map>
@@ -21220,11 +21220,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the color, for the face.\nSets the color of the side specified. If Face is ALL_SIDES, sets the color on all faces.</string>
          </map>
@@ -21252,11 +21252,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the media type of an LSL HTTP server response to ContentType.\nHTTPRequestID must be a valid http_request ID. ContentType must be one of the CONTENT_TYPE_* constants.</string>
          </map>
@@ -21275,11 +21275,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the amount of damage that will be done to an avatar that this task hits.	Task will be killed.\nSets the amount of damage that will be done to an avatar that this object hits. This object will be destroyed on damaging an avatar, and no collision event is triggered.</string>
          </map>
@@ -21307,11 +21307,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
          </map>
@@ -21339,11 +21339,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets Force on object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -21380,11 +21380,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the Force and Torque of object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -21403,11 +21403,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Changes terrain texture properties in the region.</string>
          </map>
@@ -21444,11 +21444,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damps a physical object to a Height (either above ground level or above the higher of land and water if water == TRUE).\nDo not use with vehicles. Use llStopHover to stop hovering.</string>
          </map>
@@ -21485,13 +21485,13 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the given permission mask to the new value on the inventory item.</string>
          </map>
@@ -21519,11 +21519,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests that a non-physical object be key-framed according to key-frame list.\nSpecify a list of times, positions, and orientations to be followed by an object. The object will be smoothly moved between key-frames by the simulator. Collisions with other non-physical or key-framed objects will be ignored (no script events will fire and collision processing will not occur). Collisions with physical objects will be computed and reported, but the key-framed object will be unaffected by those collisions.\nKeyframes is a strided list containing positional, rotational, and time data for each step in the motion.  Options is a list containing optional arguments and parameters (specified by KFM_* constants).</string>
          </map>
@@ -21560,11 +21560,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If a prim exists in the link chain at LinkNumber, set Face to Opacity.\nSets the Face, on the linked prim specified, to the Opacity.</string>
          </map>
@@ -21601,11 +21601,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera eye offset, and the offset that camera is looking at, for avatars that sit on the linked prim.</string>
          </map>
@@ -21642,11 +21642,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child's side, specified by LinkNumber.</string>
          </map>
@@ -21683,11 +21683,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets or changes GLTF Overrides set on the selected faces.</string>
          </map>
@@ -21724,11 +21724,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the media parameters for a particular face on linked prim, specified by Link. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.</string>
          </map>
@@ -21758,11 +21758,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
@@ -21790,11 +21790,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set primitive parameters for LinkNumber based on Parameters, without a delay.\nSet parameters for link number, from the list of Parameters, with no built-in script sleep. This function is identical to llSetLinkPrimitiveParams, except without the delay.</string>
          </map>
@@ -21831,11 +21831,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Material may be a UUID or name of a material in prim inventory.</string>
          </map>
@@ -21863,11 +21863,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the sit flags for the specified prim in a linkset.</string>
          </map>
@@ -21904,11 +21904,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the Texture of Face on a linked prim, specified by LinkNumber. Texture may be a UUID or name of a texture in prim inventory.</string>
          </map>
@@ -21990,11 +21990,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Animates a texture on the prim specified by LinkNumber, by setting the texture scale and offset.\nMode is a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\nLength specifies the animation duration.\nRate specifies the animation playback rate.</string>
          </map>
@@ -22013,11 +22013,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the rotation of a child prim relative to the root prim.</string>
          </map>
@@ -22036,11 +22036,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests Limit bytes to be reserved for this script.\nReturns TRUE or FALSE indicating whether the limit was set successfully.\nThis function has no effect if the script is running in the LSO VM.</string>
             <key>bool_semantics</key>
@@ -22061,11 +22061,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the description of the prim to Description.\nThe description field is limited to 127 characters.</string>
          </map>
@@ -22084,11 +22084,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the prim's name to Name.</string>
          </map>
@@ -22116,13 +22116,13 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the specified PermissionFlag permission to the value specified by PermissionMask on the object the script is attached to.</string>
          </map>
@@ -22150,11 +22150,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE the parcel is put up for sale. Options is a list of options to set for the sale, such as price, authorized buyer, and whether to include objects on the parcel.\n Setting ForSale to FALSE will remove the parcel from sale and clear any options that were set.</string>
          </map>
@@ -22173,11 +22173,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Sets the streaming audio URL for the parcel the object is on.\nThe object must be owned by the owner of the parcel; if the parcel is group owned the object must be owned by that group.</string>
          </map>
@@ -22205,11 +22205,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the text input field.  QuickButtons specifies the 4 payment values shown in the payment dialog's buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
          </map>
@@ -22264,11 +22264,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the selected parameters of the object's physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
          </map>
@@ -22287,11 +22287,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If the object is not physical, this function sets the position of the prim.\nIf the script is in a child prim, Position is treated as root relative and the link-set is adjusted.\nIf the prim is the root prim, the entire object is moved (up to 10m) to Position in region coordinates.</string>
          </map>
@@ -22319,11 +22319,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Sets the MediaParameters for a particular Face on the prim. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.</string>
          </map>
@@ -22344,11 +22344,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetPrimMediaParams instead.</string>
          </map>
@@ -22369,11 +22369,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
@@ -22392,11 +22392,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempts to move the object so that the root prim is within 0.1m of Position.\nReturns an integer boolean, TRUE if the object is successfully placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any location within the region or up to 10m across a region border.\nIf the position is below ground, it will be set to the ground level at that x,y location.</string>
             <key>bool_semantics</key>
@@ -22417,11 +22417,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If PIN is set to a non-zero number, the task will accept remote script loads via llRemoteLoadScriptPin() if it passes in the correct PIN. Othersise, llRemoteLoadScriptPin() is ignored.</string>
          </map>
@@ -22449,11 +22449,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Applies Render Material to Face of prim.\nRender Material may be a UUID or name of a material in prim inventory.\nIf Face is ALL_SIDES, set the render material on all faces.</string>
          </map>
@@ -22472,11 +22472,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If the object is not physical, this function sets the rotation of the prim.\nIf the script is in a child prim, Rotation is treated as root relative and the link-set is adjusted.\nIf the prim is the root prim, the entire object is rotated to Rotation in the global reference frame.</string>
          </map>
@@ -22495,11 +22495,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the prim's scale (size) to Scale.</string>
          </map>
@@ -22527,11 +22527,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enable or disable the script Running state of Script in the prim.</string>
          </map>
@@ -22550,11 +22550,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Displays Text rather than 'Sit' in the viewer's context menu.</string>
          </map>
@@ -22573,11 +22573,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached sounds) interrupt the currently playing sound.\nThe default for objects is FALSE. Setting this value to TRUE will make the sound wait until the current playing sound reaches its end. The queue is one level deep.</string>
          </map>
@@ -22596,11 +22596,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius.</string>
          </map>
@@ -22628,11 +22628,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets object status specified in Status bitmask (e.g. STATUS_PHYSICS|STATUS_PHANTOM) to boolean Value.\nFor a full list of STATUS_* constants, see wiki documentation.</string>
          </map>
@@ -22669,11 +22669,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Causes Text to float above the prim, using the specified Color and Opacity.</string>
          </map>
@@ -22701,11 +22701,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Applies Texture to Face of prim.\nTexture may be a UUID or name of a texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all faces.</string>
          </map>
@@ -22778,11 +22778,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Animates a texture by setting the texture scale and offset.\nMode is a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\nLength specifies the animation duration.\nRate specifies the animation playback rate.</string>
          </map>
@@ -22801,11 +22801,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Causes the timer event to be triggered every Rate seconds.\n Passing in 0.0 stops further timer events.</string>
          </map>
@@ -22833,11 +22833,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the Torque acting on the script's object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -22856,11 +22856,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Displays Text in the viewer context menu that acts on a touch.</string>
          </map>
@@ -22879,11 +22879,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enables the vehicle flags specified in the Flags bitmask.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -22911,11 +22911,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle float parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -22943,11 +22943,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle rotation parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -22966,11 +22966,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Activates the vehicle action on the object with vehicle preset Type.\nValid Types and an explanation of their characteristics can be found in wiki documentation.</string>
          </map>
@@ -22998,11 +22998,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle vector parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -23030,11 +23030,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If the object is physics-enabled, sets the object's linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
          </map>
@@ -23062,11 +23062,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Shouts Text on Channel.\nThis chat method has a range of 100m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -23103,11 +23103,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base64-encoded RSA signature of Message using PEM-formatted PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).</string>
          </map>
@@ -23126,11 +23126,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the sine of Theta (Theta in radians).</string>
          </map>
@@ -23158,11 +23158,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link's sit target.</string>
          </map>
@@ -23190,11 +23190,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the sit location for this object. If offset == ZERO_VECTOR, clears the sit target.</string>
          </map>
@@ -23213,11 +23213,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Put script to sleep for Time seconds.</string>
          </map>
@@ -23265,11 +23265,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and specifies whether the sound should loop and/or be enqueued.</string>
          </map>
@@ -23290,11 +23290,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers within range.</string>
          </map>
@@ -23313,11 +23313,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the square root of Value.\nTriggers a math runtime error for imaginary results (if Value &lt; 0.0).</string>
          </map>
@@ -23336,11 +23336,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function plays the specified animation from playing on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
@@ -23359,11 +23359,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function plays the specified animation on the rigged mesh object associated with the current script.\nAnimation may be an animation in task inventory or a built-in animation.\n</string>
          </map>
@@ -23382,11 +23382,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function stops the specified animation on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
@@ -23395,11 +23395,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop hovering to a height (due to llSetHoverHeight()).</string>
          </map>
@@ -23408,11 +23408,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop causing object to point at a target (due to llLookAt() or llRotLookAt()).</string>
          </map>
@@ -23421,11 +23421,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops critically damped motion (due to llMoveToTarget()).</string>
          </map>
@@ -23444,11 +23444,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function stops the specified animation on the rigged mesh object associated with the current script.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\n</string>
          </map>
@@ -23457,11 +23457,11 @@ If another state is defined before the default state, the compiler will report a
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops playback of the currently attached sound.</string>
          </map>
@@ -23480,11 +23480,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the number of characters in Text (not counting the null).</string>
          </map>
@@ -23503,11 +23503,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the string Base64 representation of the input string.</string>
          </map>
@@ -23535,11 +23535,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Outputs a string, eliminating white-space from the start and/or end of the input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD: trim all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces in Text\nSTRING_TRIM: trim all leading and trailing spaces in Text.</string>
          </map>
@@ -23567,11 +23567,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the index in Text where string pattern Sequence first appears. Returns -1 if not found.</string>
          </map>
@@ -23592,11 +23592,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetCameraParams instead.</string>
          </map>
@@ -23633,11 +23633,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Take controls from the agent the script has permissions for.\nIf (Accept == (Controls &amp; input)), send input to the script.  PassOn determines whether Controls also perform their normal functions.\nRequires the PERMISSION_TAKE_CONTROLS permission to run.</string>
          </map>
@@ -23656,11 +23656,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the tangent of Theta (Theta in radians).</string>
          </map>
@@ -23688,11 +23688,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function is to have the script know when it has reached a position.\nIt registers a Position with a Range that triggers at_target and not_at_target events continuously until unregistered.</string>
          </map>
@@ -23729,11 +23729,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate of 0.0 cancels the spin. This function always works in object-local coordinates.</string>
          </map>
@@ -23752,11 +23752,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes positional target Handle registered with llTarget.</string>
          </map>
@@ -23793,11 +23793,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Sends an email with Subject and Message to the owner or creator of an object.</string>
          </map>
@@ -23843,11 +23843,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests a teleport of avatar to a landmark stored in the object's inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
@@ -23893,11 +23893,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Teleports an agent to the RegionPosition local coordinates within a region which is specified by the GlobalPosition global coordinates. The agent lands facing the position defined by LookAtPoint local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
@@ -23916,11 +23916,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>100</real>
+            <real>100.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>5</real>
+            <real>5.0</real>
             <key>tooltip</key>
             <string>Teleport agent over the owner's land to agent's home location.</string>
          </map>
@@ -23957,11 +23957,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the "OK" button is clicked.</string>
          </map>
@@ -23980,11 +23980,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is Text with all lower-case characters.</string>
          </map>
@@ -24003,11 +24003,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is Text with all upper-case characters.</string>
          </map>
@@ -24035,11 +24035,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfer Amount of linden dollars (L$) from script owner to AvatarID. Returns a key to a corresponding transaction_result event for the success of the transfer.\nAttempts to send the amount of money to the specified avatar, and trigger a transaction_result event identified by the returned key.</string>
          </map>
@@ -24076,11 +24076,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfers ownership of an object, or a copy of the object to a new agent.</string>
          </map>
@@ -24108,11 +24108,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object.\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.</string>
          </map>
@@ -24158,11 +24158,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object, limited to axis-aligned bounding box defined by vectors top-north-east (TNE) and bottom-south-west (BSW).\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.</string>
          </map>
@@ -24181,11 +24181,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the object's owner, the agent is forced to stand up.</string>
          </map>
@@ -24204,11 +24204,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the string that is the URL unescaped, replacing "%20" with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
          </map>
@@ -24227,11 +24227,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Updates settings for a pathfinding character.</string>
          </map>
@@ -24277,11 +24277,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>key</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
@@ -24311,11 +24311,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the distance between Location1 and Location2.</string>
          </map>
@@ -24334,11 +24334,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the magnitude of the vector.</string>
          </map>
@@ -24357,11 +24357,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns normalized vector.</string>
          </map>
@@ -24407,11 +24407,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>integer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if PublicKey, Message, and Algorithm produce the same base64-formatted Signature.</string>
             <key>bool_semantics</key>
@@ -24432,11 +24432,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If DetectEnabled = TRUE, object becomes phantom but triggers collision_start and collision_end events when other objects start and stop interpenetrating.\nIf another object (including avatars) interpenetrates it, it will get a collision_start event.\nWhen an object stops interpenetrating, a collision_end event is generated. While the other is inter-penetrating, collision events are NOT generated.</string>
          </map>
@@ -24473,11 +24473,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Wander within a specified volume.\nSets a character to wander about a central spot within a specified area.</string>
          </map>
@@ -24496,11 +24496,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>float</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the water height below the object position + Offset.</string>
          </map>
@@ -24528,11 +24528,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>void</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Whispers Text on Channel.\nThis chat method has a range of 10m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -24551,11 +24551,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the wind velocity at the object position + Offset.</string>
          </map>
@@ -24574,11 +24574,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the local position that would put the origin of a HUD object directly over world_pos as viewed by the current camera.</string>
          </map>
@@ -24606,11 +24606,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.</string>
          </map>
@@ -24640,11 +24640,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0.2999999999999999888977698</real>
+            <real>0.3</real>
             <key>tooltip</key>
             <string>Deprecated: Please use llXorBase64 instead.\nIncorrectly performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.\nRetained for backwards compatibility.</string>
          </map>
@@ -24674,11 +24674,11 @@ If another state is defined before the default state, the compiler will report a
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls are present) performs an exclusive OR on two Base64 strings and returns a Base64 string.\nText2 repeats if it is shorter than Text1.</string>
          </map>
@@ -24697,11 +24697,11 @@ If another state is defined before the default state, the compiler will report a
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a color from the sRGB to the linear colorspace.</string>
          </map>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -10456,11 +10456,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>T</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Checks if the value is truthy; if not, raises an error with the optional message.</string>
          </map>
@@ -10488,11 +10488,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>never</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Raises an error with the specified object and optional call stack level.</string>
          </map>
@@ -10501,11 +10501,11 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the total heap size in kilobytes.</string>
          </map>
@@ -10524,11 +10524,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{[any]: any}?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the metatable for the specified object.</string>
          </map>
@@ -10561,11 +10561,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(K, V)?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the next key-value pair in the table traversal order.</string>
          </map>
@@ -10584,11 +10584,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new untyped userdata object with an optional metatable.</string>
          </map>
@@ -10607,11 +10607,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Prints all arguments to standard output using Tab as a separator.</string>
          </map>
@@ -10639,11 +10639,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if a and b have the same type and value.</string>
          </map>
@@ -10676,11 +10676,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>V?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a table lookup bypassing metatables.</string>
          </map>
@@ -10722,11 +10722,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{[K]: V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Assigns a value to a table field bypassing metatables.</string>
          </map>
@@ -10750,11 +10750,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the length of a table or string bypassing metatables.</string>
          </map>
@@ -10782,11 +10782,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a subset of arguments or the number of arguments.</string>
          </map>
@@ -10814,11 +10814,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Changes the metatable for the given table.</string>
          </map>
@@ -10846,11 +10846,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts the input string to a number in the specified base.</string>
          </map>
@@ -10869,11 +10869,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts the input object to a string.</string>
          </map>
@@ -10892,11 +10892,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the object as a string.</string>
          </map>
@@ -10915,11 +10915,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the object, including custom userdata types.</string>
          </map>
@@ -10942,11 +10942,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(({V}, number) -&gt; (number?, V), {V}, number)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an iterator for numeric key-value pairs in the table.</string>
          </map>
@@ -10970,11 +10970,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(({[K], V}, K) -&gt; (K?, V), {[K], V}, K)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an iterator for all key-value pairs in the table.</string>
          </map>
@@ -11007,11 +11007,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(boolean, R...)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Calls function f with parameters args, returning success and function results or an error.</string>
          </map>
@@ -11055,11 +11055,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(boolean, R1...)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Calls function f with parameters args, handling errors with e if they occur.</string>
          </map>
@@ -11078,11 +11078,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Execute the named external module.</string>
          </map>
@@ -11123,11 +11123,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...V</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns values from an array in the specified index range.</string>
          </map>
@@ -11147,11 +11147,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Dangerously executes a required module function</string>
          </map>
@@ -11170,11 +11170,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a value to a quaternion, returns nil if invalid</string>
          </map>
@@ -11193,11 +11193,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a value to a rotation (quaternion), returns nil if invalid</string>
          </map>
@@ -11216,11 +11216,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a string, buffer, or uuid to a uuid, returns nil if invalid</string>
          </map>
@@ -11239,11 +11239,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a value to a vector, returns nil if invalid</string>
          </map>
@@ -11251,7 +11251,7 @@ vector position - position in local coordinates
          <key>bit32</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Bitwise operations library.</string>
          </map>
@@ -11279,11 +11279,11 @@ vector position - position in local coordinates
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Shifts n by i bits to the right. If i is negative, a left shift is performed.
 Does an arithmetic shift: The most significant bit of n is propagated during the shift.</string>
@@ -11303,11 +11303,11 @@ Does an arithmetic shift: The most significant bit of n is propagated during the
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a bitwise AND operation on input numbers.</string>
          </map>
@@ -11326,11 +11326,11 @@ Does an arithmetic shift: The most significant bit of n is propagated during the
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the bitwise negation of the input number.</string>
          </map>
@@ -11349,11 +11349,11 @@ Does an arithmetic shift: The most significant bit of n is propagated during the
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a bitwise OR operation on input numbers.</string>
          </map>
@@ -11372,11 +11372,11 @@ Does an arithmetic shift: The most significant bit of n is propagated during the
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a bitwise AND operation on input numbers.
 Returns true if result is non-zero.</string>
@@ -11396,11 +11396,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a bitwise XOR operation on input numbers.</string>
          </map>
@@ -11419,11 +11419,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Swap byte order</string>
          </map>
@@ -11442,11 +11442,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Count leading zeros</string>
          </map>
@@ -11465,11 +11465,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Count trailing zeros</string>
          </map>
@@ -11506,11 +11506,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Extracts bits from n at position field with width</string>
          </map>
@@ -11538,11 +11538,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Rotates n by i bits to the left. If i is negative, a right rotate is performed.</string>
          </map>
@@ -11570,11 +11570,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Shifts n by i bits to the left. If i is negative, a right shift is performed.</string>
          </map>
@@ -11620,11 +11620,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Replaces bits in n at position field with width using value v</string>
          </map>
@@ -11652,11 +11652,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Rotates n by i bits to the right. If i is negative, a left rotate is performed.</string>
          </map>
@@ -11684,11 +11684,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Shifts n by i bits to the right. If i is negative, a left shift is performed.</string>
          </map>
@@ -11696,7 +11696,7 @@ Returns true if result is non-zero.</string>
          <key>buffer</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Buffer manipulation library for binary data.</string>
          </map>
@@ -11751,11 +11751,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies bytes from the source buffer into the target buffer.</string>
          </map>
@@ -11774,11 +11774,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>buffer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a buffer of the requested size with all bytes initialized to 0.</string>
          </map>
@@ -11824,11 +11824,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Fills the buffer with the specified value starting at the given offset.</string>
          </map>
@@ -11847,11 +11847,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>buffer</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a buffer initialized to the contents of the string.</string>
          </map>
@@ -11870,11 +11870,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the size of the buffer in bytes.</string>
          </map>
@@ -11911,11 +11911,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads up to 32 bits from the buffer at the given offset.</string>
          </map>
@@ -11943,11 +11943,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a 32-bit floating-point number from the buffer at the given offset.</string>
          </map>
@@ -11975,11 +11975,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a 64-bit floating-point number from the buffer at the given offset.</string>
          </map>
@@ -12007,11 +12007,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a signed 16-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12039,11 +12039,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a signed 32-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12071,11 +12071,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a signed 8-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12112,11 +12112,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads a string of the given length from the buffer at the specified offset.</string>
          </map>
@@ -12144,11 +12144,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads an unsigned 16-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12176,11 +12176,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads an unsigned 32-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12208,11 +12208,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reads an unsigned 8-bit integer from the buffer at the given offset.</string>
          </map>
@@ -12231,11 +12231,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the buffer data as a string.</string>
          </map>
@@ -12281,11 +12281,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes up to 32 bits to the buffer at the given offset.</string>
          </map>
@@ -12322,11 +12322,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes a 32-bit floating-point number to the buffer at the given offset.</string>
          </map>
@@ -12363,11 +12363,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes a 64-bit floating-point number to the buffer at the given offset.</string>
          </map>
@@ -12404,11 +12404,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes a signed 16-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12445,11 +12445,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes a signed 32-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12486,11 +12486,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes a signed 8-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12536,11 +12536,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes data from a string into the buffer at the specified offset.</string>
          </map>
@@ -12577,11 +12577,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes an unsigned 16-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12618,11 +12618,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes an unsigned 32-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12659,11 +12659,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Writes an unsigned 8-bit integer to the buffer at the given offset.</string>
          </map>
@@ -12671,7 +12671,7 @@ Returns true if result is non-zero.</string>
          <key>coroutine</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Coroutine manipulation library.</string>
          </map>
@@ -12690,11 +12690,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(boolean, string?)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Closes a coroutine, returning true if successful or false and an error.</string>
          </map>
@@ -12713,11 +12713,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>thread</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a new coroutine that, when resumed, will run function f.</string>
          </map>
@@ -12726,11 +12726,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if the currently running coroutine can yield.</string>
          </map>
@@ -12758,11 +12758,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(boolean, ...any)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resumes a coroutine, returning true and results if successful, or false and an error.</string>
          </map>
@@ -12771,11 +12771,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>thread?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the currently running coroutine, or nil if called from in the main coroutine.</string>
          </map>
@@ -12794,11 +12794,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>"running" | "suspended" | "normal" | "dead"</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the status of the coroutine: "running", "suspended", "normal", or "dead".</string>
          </map>
@@ -12817,11 +12817,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(...any) -&gt; ...any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a coroutine and returns a function that resumes it.</string>
          </map>
@@ -12840,11 +12840,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Yields the current coroutine, passing arguments to the resuming code.</string>
          </map>
@@ -12852,7 +12852,7 @@ Returns true if result is non-zero.</string>
          <key>debug</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Debug library for introspection.</string>
          </map>
@@ -12889,11 +12889,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns information about a stack frame or function based on specified format.</string>
          </map>
@@ -12930,11 +12930,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a human-readable call stack starting from the specified level.</string>
          </map>
@@ -12942,7 +12942,7 @@ Returns true if result is non-zero.</string>
          <key>llbase64</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Base64 encoding/decoding library.</string>
          </map>
@@ -12961,11 +12961,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Decodes a base64 string to a string</string>
          </map>
@@ -12984,11 +12984,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Encodes a string or buffer to base64</string>
          </map>
@@ -12996,7 +12996,7 @@ Returns true if result is non-zero.</string>
          <key>lljson</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>JSON encoding/decoding library for Second Life.</string>
          </map>
@@ -13015,11 +13015,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Decodes a JSON string to a Lua value</string>
          </map>
@@ -13038,11 +13038,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Encodes a Lua value as JSON</string>
          </map>
@@ -13061,11 +13061,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Decodes a JSON string to a Lua value preserving SL types</string>
          </map>
@@ -13093,11 +13093,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Encodes a Lua value as JSON preserving SL types. Use tight to encode more compactly.</string>
          </map>
@@ -13105,7 +13105,7 @@ Returns true if result is non-zero.</string>
          <key>math</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Mathematical functions library.</string>
          </map>
@@ -13124,11 +13124,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the absolute value of n.</string>
          </map>
@@ -13147,11 +13147,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc cosine of n in radians.</string>
          </map>
@@ -13170,11 +13170,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc sine of n in radians.</string>
          </map>
@@ -13193,11 +13193,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc tangent of n in radians.</string>
          </map>
@@ -13225,11 +13225,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc tangent of y/x in radians, using the signs to determine the quadrant.</string>
          </map>
@@ -13248,11 +13248,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the smallest integer larger than or equal to n.</string>
          </map>
@@ -13289,11 +13289,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns n clamped between min and max.</string>
          </map>
@@ -13312,11 +13312,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the cosine of n (n is in radians).</string>
          </map>
@@ -13335,11 +13335,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the hyperbolic cosine of n.</string>
          </map>
@@ -13358,11 +13358,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts n from radians to degrees.</string>
          </map>
@@ -13381,11 +13381,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base-e exponent of n.</string>
          </map>
@@ -13404,11 +13404,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the largest integer smaller than or equal to n.</string>
          </map>
@@ -13436,11 +13436,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the remainder of x modulo y, rounded towards zero.</string>
          </map>
@@ -13459,11 +13459,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(number, number)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns m and e such that n = m * 2^e.</string>
          </map>
@@ -13482,11 +13482,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if n is finite.</string>
          </map>
@@ -13505,11 +13505,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if n is infinite.</string>
          </map>
@@ -13528,11 +13528,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if n is NaN.</string>
          </map>
@@ -13560,11 +13560,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns s * 2^e.</string>
          </map>
@@ -13601,11 +13601,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Linearly interpolates between a and b using factor t.</string>
          </map>
@@ -13633,11 +13633,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the logarithm of n in the given base (default e).</string>
          </map>
@@ -13656,11 +13656,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base-10 logarithm of n.</string>
          </map>
@@ -13715,11 +13715,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Maps n from input range to output range.</string>
          </map>
@@ -13747,11 +13747,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the maximum value from the given numbers.</string>
          </map>
@@ -13779,11 +13779,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the minimum value from the given numbers.</string>
          </map>
@@ -13802,11 +13802,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(number, number)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the integer and fractional parts of n.</string>
          </map>
@@ -13843,11 +13843,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns Perlin noise value for the point (x, y, z).</string>
          </map>
@@ -13875,11 +13875,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns base to the power of exponent.</string>
          </map>
@@ -13898,11 +13898,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts n from degrees to radians.</string>
          </map>
@@ -13930,11 +13930,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a random number within the given range.</string>
          </map>
@@ -13953,11 +13953,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the seed for the random number generator.</string>
          </map>
@@ -13976,11 +13976,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Rounds n to the nearest integer.</string>
          </map>
@@ -13999,11 +13999,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns -1 if n is negative, 1 if positive, and 0 if zero.</string>
          </map>
@@ -14022,11 +14022,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the sine of n (n is in radians).</string>
          </map>
@@ -14045,11 +14045,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the hyperbolic sine of n.</string>
          </map>
@@ -14068,11 +14068,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the square root of n.</string>
          </map>
@@ -14091,11 +14091,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the tangent of n (n is in radians).</string>
          </map>
@@ -14114,11 +14114,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the hyperbolic tangent of n.</string>
          </map>
@@ -14126,7 +14126,7 @@ Returns true if result is non-zero.</string>
          <key>os</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Operating system facilities library.</string>
          </map>
@@ -14135,11 +14135,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a high-precision timestamp in seconds for measuring durations.</string>
          </map>
@@ -14167,11 +14167,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(string | OsDateTime)?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a table or string representation of the time based on the provided format.</string>
          </map>
@@ -14199,11 +14199,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the difference in seconds between two timestamps.</string>
          </map>
@@ -14222,11 +14222,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current Unix timestamp or the timestamp of the given date.</string>
          </map>
@@ -14273,11 +14273,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new quaternion with the given component values. Alias of quaternion.create.</string>
          </map>
@@ -14296,11 +14296,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the conjugate of the quaternion.</string>
          </map>
@@ -14346,11 +14346,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new quaternion with the given component values.</string>
          </map>
@@ -14378,11 +14378,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the dot product of two quaternions.</string>
          </map>
@@ -14401,11 +14401,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the magnitude of the quaternion.</string>
          </map>
@@ -14424,11 +14424,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the normalized version (unit quaternion) of the quaternion.</string>
          </map>
@@ -14465,11 +14465,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Spherical linear interpolation from a to b using factor t.</string>
          </map>
@@ -14488,11 +14488,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the forward vector from the quaternion.</string>
          </map>
@@ -14511,11 +14511,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the left vector from the quaternion.</string>
          </map>
@@ -14534,11 +14534,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the up vector from the quaternion.</string>
          </map>
@@ -14546,7 +14546,7 @@ Returns true if result is non-zero.</string>
          <key>string</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>String manipulation library.</string>
          </map>
@@ -14583,11 +14583,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the numeric code of every byte in the input string within the given range.</string>
          </map>
@@ -14606,11 +14606,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string containing characters for the given byte values.</string>
          </map>
@@ -14656,11 +14656,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(number?, number?, ...string)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Finds the first instance of the pattern in the string.</string>
          </map>
@@ -14688,11 +14688,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Formats input values into a string using printf-style format specifiers.</string>
          </map>
@@ -14720,11 +14720,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>() -&gt; ...string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an iterator function for pattern matches</string>
          </map>
@@ -14770,11 +14770,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(string, number)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs pattern-based substitution in a string.</string>
          </map>
@@ -14793,11 +14793,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of bytes in the string. Identical to #s</string>
          </map>
@@ -14816,11 +14816,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a lowercase version of the input string.</string>
          </map>
@@ -14857,11 +14857,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Finds and returns matches for a pattern in the input string.</string>
          </map>
@@ -14889,11 +14889,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Packs values into a binary string.</string>
          </map>
@@ -14912,11 +14912,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the size of a packed string for the given format.</string>
          </map>
@@ -14944,11 +14944,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the input string repeated a given number of times.</string>
          </map>
@@ -14967,11 +14967,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the input string with bytes in reverse order.</string>
          </map>
@@ -14999,11 +14999,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{string}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Splits a string by separator. Returns a list of substrings.</string>
          </map>
@@ -15040,11 +15040,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a substring from the given range.</string>
          </map>
@@ -15081,11 +15081,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...any</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Decodes a binary string using a pack format.</string>
          </map>
@@ -15104,11 +15104,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an uppercase version of the input string.</string>
          </map>
@@ -15116,7 +15116,7 @@ Returns true if result is non-zero.</string>
          <key>table</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Table manipulation library. Tables are collections of key-value pairs.</string>
          </map>
@@ -15135,11 +15135,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Clears all elements from a table while keeping its capacity.</string>
          </map>
@@ -15163,11 +15163,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{[K]: V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a shallow copy of the table.</string>
          </map>
@@ -15213,11 +15213,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Joins an array of strings into one string, with an optional separator.</string>
          </map>
@@ -15249,11 +15249,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new table with pre-allocated array capacity, optionally filled.</string>
          </map>
@@ -15294,11 +15294,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Finds the first occurrence of a value in the array and returns its index.</string>
          </map>
@@ -15334,11 +15334,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>R?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Iterates over all key-value pairs in the table (deprecated).</string>
          </map>
@@ -15373,11 +15373,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>R?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Iterates over all index-value pairs in the array (deprecated).</string>
          </map>
@@ -15401,11 +15401,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{[K]: V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Freezes a table, making it read-only.</string>
          </map>
@@ -15426,11 +15426,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the length of an array (deprecated; use # instead).</string>
          </map>
@@ -15471,11 +15471,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Inserts an element at the specified index, or at the end of the array.</string>
          </map>
@@ -15494,11 +15494,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns true if a table is frozen.</string>
          </map>
@@ -15517,11 +15517,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the highest numeric key in the table.</string>
          </map>
@@ -15580,11 +15580,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Inserts elements [i..j] from src array into dest array at [d].</string>
          </map>
@@ -15607,11 +15607,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{ n: number, [number]: V }</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Packs multiple arguments into a new array with length field n.</string>
          </map>
@@ -15643,11 +15643,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>V?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes and returns the element at the specified index from the array, or from the end of the array.</string>
          </map>
@@ -15680,11 +15680,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{[K]: V}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Reduces the memory usage of the table to the minimum necessary.</string>
          </map>
@@ -15716,11 +15716,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sorts an array in place.</string>
          </map>
@@ -15761,11 +15761,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...V</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Unpacks array elements into multiple return values.</string>
          </map>
@@ -15773,7 +15773,7 @@ Returns true if result is non-zero.</string>
          <key>utf8</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>UTF-8 support library.</string>
          </map>
@@ -15792,11 +15792,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a string from Unicode codepoints.</string>
          </map>
@@ -15833,11 +15833,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>...number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the Unicode codepoints in the specified range of the string.</string>
          </map>
@@ -15856,11 +15856,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>((string, number) -&gt; (number, number), string, number)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an iterator that produces the byte offset and Unicode codepoint for each character in the string.</string>
          </map>
@@ -15897,11 +15897,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>(number?, number?)</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of Unicode codepoints in the specified range of the string, or nil and error index.</string>
          </map>
@@ -15938,11 +15938,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the byte offset of the nth Unicode codepoint in the string.</string>
          </map>
@@ -15962,11 +15962,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new uuid from a string, buffer, or existing uuid. Returns nil if the string is not a valid UUID. Throws an error if the buffer is shorter than 16 bytes. Alias of uuid.create</string>
          </map>
@@ -15985,11 +15985,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid?</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new uuid from a string, buffer, or existing uuid. Returns nil if the string is not a valid UUID. Throws an error if the buffer is shorter than 16 bytes.</string>
          </map>
@@ -16027,11 +16027,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new vector with the given component values. Alias of vector.create.</string>
          </map>
@@ -16050,11 +16050,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.abs to each component of the vector.</string>
          </map>
@@ -16091,11 +16091,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the angle between two vectors in radians. The axis, if specified, is used to determine the sign of the angle.</string>
          </map>
@@ -16114,11 +16114,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.ceil to each component of the vector.</string>
          </map>
@@ -16155,11 +16155,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Clamps each component of the vector between min and max values.</string>
          </map>
@@ -16196,11 +16196,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a new vector with the given component values.</string>
          </map>
@@ -16228,11 +16228,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the cross product of two vectors.</string>
          </map>
@@ -16260,11 +16260,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the dot product of two vectors.</string>
          </map>
@@ -16283,11 +16283,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.floor to each component of the vector.</string>
          </map>
@@ -16324,11 +16324,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Linearly interpolates between a and b using factor t.</string>
          </map>
@@ -16347,11 +16347,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the magnitude of the vector.</string>
          </map>
@@ -16379,11 +16379,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.max to each component of the vectors.</string>
          </map>
@@ -16411,11 +16411,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.max to each component of the vectors.</string>
          </map>
@@ -16434,11 +16434,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Computes the normalized version (unit vector) of the vector.</string>
          </map>
@@ -16457,11 +16457,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies math.sign to each component of the vector.</string>
          </map>
@@ -16469,7 +16469,7 @@ Returns true if result is non-zero.</string>
          <key>ll</key>
          <map>
             <key>energy</key>
-            <real>-1</real>
+            <real>-1.0</real>
             <key>tooltip</key>
             <string>Library for functions shared between LSL and SLua.</string>
          </map>
@@ -16488,11 +16488,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the absolute (positive) version of Value.</string>
          </map>
@@ -16511,11 +16511,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-cosine of Value, in radians.</string>
          </map>
@@ -16543,11 +16543,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Add avatar ID to the parcel ban list for the specified number of Hours.\nA value of 0 for Hours will add the agent indefinitely.\nThe smallest value that Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen values that small are used, it seems the function bans in approximately 30 second increments (Probably 36 second increments, as 0.01 of an hour is 36 seconds).\nResidents teleporting to a parcel where they are banned will be redirected to a neighbouring parcel.</string>
          </map>
@@ -16575,11 +16575,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Add avatar ID to the land pass list, for a duration of Hours.</string>
          </map>
@@ -16609,11 +16609,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Changes the amount of damage to be delivered by this damage event.</string>
          </map>
@@ -16632,11 +16632,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Adjusts the volume (0.0 - 1.0) of the currently playing attached sound.\nThis function has no effect on sounds started with llTriggerSound.</string>
          </map>
@@ -16655,11 +16655,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns TRUE if the agent is in the Experience and the Experience can run in the current location.
@@ -16680,11 +16680,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If Flag == TRUE, users without object modify permissions can still drop inventory items into the object.</string>
          </map>
@@ -16712,11 +16712,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the angle, in radians, between rotations Rot1 and Rot2.</string>
          </map>
@@ -16744,11 +16744,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies impulse to the object.\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis function only works on physical objects.</string>
          </map>
@@ -16776,11 +16776,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies rotational impulse to the object.\nIf Local == TRUE, apply the Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis function only works on physical objects.</string>
          </map>
@@ -16799,11 +16799,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-sine, in radians, of Value.</string>
          </map>
@@ -16831,11 +16831,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the arc-tangent2 of y, x.</string>
          </map>
@@ -16854,11 +16854,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH runtime permission.</string>
          </map>
@@ -16877,11 +16877,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Follows the same convention as llAttachToAvatar, with the exception that the object will not create new inventory for the user, and will disappear on detach or disconnect.</string>
          </map>
@@ -16900,11 +16900,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If an avatar is sitting on the link's sit target, return the avatar's key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated on the specified link's prim.</string>
          </map>
@@ -16913,11 +16913,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If an avatar is seated on the sit target, returns the avatar's key, otherwise NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with llSitTarget.</string>
          </map>
@@ -16954,11 +16954,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation represented by coordinate axes Forward, Left, and Up.</string>
          </map>
@@ -16986,11 +16986,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation that is a generated Angle about Axis.</string>
          </map>
@@ -17009,11 +17009,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the Text, Base64 decoded as a big endian integer.\nReturns zero if Text is longer then 8 characters. If Text contains fewer then 6 characters, the return value is unpredictable.</string>
          </map>
@@ -17032,11 +17032,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a Base64 string to a conventional string.\nIf the conversion creates any unprintable characters, they are converted to question marks.</string>
          </map>
@@ -17045,11 +17045,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>De-links all prims in the link set (requires permission PERMISSION_CHANGE_LINKS be set).</string>
          </map>
@@ -17068,11 +17068,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>De-links the prim with the given link number (requires permission PERMISSION_CHANGE_LINKS be set).</string>
          </map>
@@ -17091,11 +17091,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{string}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Create a list from a string of comma separated values specified in Text.</string>
          </map>
@@ -17132,11 +17132,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Casts a ray into the physics world from 'start' to 'end' and returns data according to details in Options.\nReports collision data for intersections with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code] where {} indicates optional data.</string>
          </map>
@@ -17155,11 +17155,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns smallest integer value &gt;= Value.</string>
          </map>
@@ -17178,11 +17178,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a single character string that is the representation of the unicode value.</string>
          </map>
@@ -17191,11 +17191,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets all camera parameters to default values and turns off scripted camera control.</string>
          </map>
@@ -17223,11 +17223,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Clears (deletes) the media and all parameters from the given Face on the linked prim.\nReturns an integer that is a STATUS_* flag, which details the success/failure of the operation.</string>
          </map>
@@ -17246,11 +17246,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Clears (deletes) the media and all parameters from the given Face.\nReturns an integer that is a STATUS_* flag which details the success/failure of the operation.</string>
          </map>
@@ -17271,11 +17271,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -17296,11 +17296,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the cloud density at the object's position + Offset.</string>
          </map>
@@ -17337,11 +17337,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Specify an empty string or NULL_KEY for Accept, to not filter on the corresponding parameter.</string>
          </map>
@@ -17369,11 +17369,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Suppress default collision sounds, replace default impact sounds with ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply an empty string to suppress collision sounds.</string>
          </map>
@@ -17394,11 +17394,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Suppress default collision sprites, replace default impact sprite with ImpactSprite; found in the object inventory (empty string to just suppress).</string>
          </map>
@@ -17426,11 +17426,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns hex-encoded Hash string of Message using digest Algorithm.</string>
          </map>
@@ -17449,11 +17449,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the cosine of Theta (Theta in radians).</string>
          </map>
@@ -17472,11 +17472,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Convert link-set to AI/Physics character.\nCreates a path-finding entity, known as a "character", from the object containing the script. Required to activate use of path-finding functions.\nOptions is a list of key/value pairs.</string>
          </map>
@@ -17504,11 +17504,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to create a key-value pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value passed to the function.
@@ -17538,11 +17538,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Attempt to link the object the script is in, to target (requires permission PERMISSION_CHANGE_LINKS be set).\nRequires permission PERMISSION_CHANGE_LINKS be set.</string>
          </map>
@@ -17579,11 +17579,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Generates a damage event on the targeted agent or task.</string>
          </map>
@@ -17592,11 +17592,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request the used and total amount of data allocated for the Experience. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the the amount in use and the third item will be the total available.
@@ -17607,11 +17607,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Convert link-set from AI/Physics character to Physics object.\nConvert the current link-set back to a standard object, removing all path-finding properties.</string>
          </map>
@@ -17630,11 +17630,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to delete a key-value pair. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
@@ -17677,11 +17677,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the slice from start to end and returns the remainder of the list.\nRemove a slice from the list and return the remainder, start and end are inclusive.\nUsing negative numbers for start and/or end causes the index to count backwards from the length of the list, so 0, -1 would delete the entire list.\nIf Start is larger than End the list deleted is the exclusion of the entries; so 6, 4 would delete the entire list except for the 5th list entry.</string>
          </map>
@@ -17718,11 +17718,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the indicated sub-string and returns the result.\nStart and End are inclusive.\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would delete the entire string.\nIf Start is larger than End, the sub-string is the exclusion of the entries; so 6, 4 would delete the entire string except for the 5th character.</string>
          </map>
@@ -17750,11 +17750,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Derezzes an object previously rezzed by a script in this region. Returns TRUE on success or FALSE if the object could not be derezzed.</string>
          </map>
@@ -17763,11 +17763,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Remove the object containing the script from the avatar.</string>
          </map>
@@ -17788,11 +17788,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list containing the current damage for the event, the damage type and the original damage delivered.</string>
          </map>
@@ -17813,11 +17813,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the grab offset of a user touching the object.\nReturns &lt;0.0, 0.0, 0.0&gt; if Number is not a valid object.</string>
          </map>
@@ -17838,11 +17838,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if detected object or agent Number has the same user group active as this object.\nIt will return FALSE if the object or agent is in the group, but the group is not active.</string>
          </map>
@@ -17863,11 +17863,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of detected object or avatar number.\nReturns NULL_KEY if Number is not a valid index.</string>
          </map>
@@ -17888,11 +17888,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the link position of the triggered event for touches and collisions only.\n0 for a non-linked object, 1 for the root of a linked object, 2 for the first child, etc.</string>
          </map>
@@ -17913,11 +17913,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of detected object or avatar number.\nReturns the name of detected object number.\nReturns empty string if Number is not a valid index.</string>
          </map>
@@ -17938,11 +17938,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of detected object's owner.\nReturns invalid key if Number is not a valid index.</string>
          </map>
@@ -17963,11 +17963,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position of detected object or avatar number.\nReturns &lt;0.0, 0.0, 0.0&gt; if Number is not a valid index.</string>
          </map>
@@ -17988,11 +17988,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key for the rezzer of the detected object.</string>
          </map>
@@ -18013,11 +18013,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation of detected object or avatar number.\nReturns &lt;0.0, 0.0, 0.0, 1.0&gt; if Number is not a valid offset.</string>
          </map>
@@ -18038,11 +18038,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the surface bi-normal for a triggered touch event.\nReturns a vector that is the surface bi-normal (tangent to the surface) where the touch event was triggered.</string>
          </map>
@@ -18063,11 +18063,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the face where the avatar clicked in a triggered touch event.</string>
          </map>
@@ -18088,11 +18088,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the surface normal for a triggered touch event.\nReturns a vector that is the surface normal (perpendicular to the surface) where the touch event was triggered.</string>
          </map>
@@ -18113,11 +18113,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position, in region coordinates, where the object was touched in a triggered touch event.\nUnless it is a HUD, in which case it returns the position relative to the attach point.</string>
          </map>
@@ -18138,11 +18138,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector that is the surface coordinates where the prim was touched.\nThe X and Y vector positions contain the horizontal (S) and vertical (T) face coordinates respectively.\nEach component is in the interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD is returned if the surface coordinates cannot be determined (e.g. when the viewer does not support this function).</string>
          </map>
@@ -18163,11 +18163,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector that is the texture coordinates for where the prim was touched.\nThe X and Y vector positions contain the U and V face coordinates respectively.\nTOUCH_INVALID_TEXCOORD is returned if the touch UV coordinates cannot be determined (e.g. when the viewer does not support this function).</string>
          </map>
@@ -18188,11 +18188,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\nReturns 0 if number is not a valid index.\nNote that number is a bit-field, so comparisons need to be a bitwise checked. e.g.:\ninteger iType = llDetectedType(0);\n{\n	// ...do stuff with the agent\n}</string>
          </map>
@@ -18213,11 +18213,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the velocity of the detected object Number.\nReturns&lt;0.0, 0.0, 0.0&gt; if Number is not a valid offset.</string>
          </map>
@@ -18263,11 +18263,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Shows a dialog box on the avatar's screen with the message.\n
                     Up to 12 strings in the list form buttons.\n
@@ -18285,11 +18285,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Delete the object which holds the script.</string>
          </map>
@@ -18317,11 +18317,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the list as a single string, using Separator between the entries.\nWrite the list out as a single string, using Separator between values.</string>
          </map>
@@ -18349,11 +18349,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Checks to see whether the border hit by Direction from Position is the edge of the world (has no neighboring region).\nReturns TRUE if the line along Direction from Position hits the edge of the world in the current simulator, returns FALSE if that edge crosses into another simulator.</string>
          </map>
@@ -18372,11 +18372,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Ejects AvatarID from land that you own.\nEjects AvatarID from land that the object owner (group or resident) owns.</string>
          </map>
@@ -18413,11 +18413,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Sends email to Address with Subject and Message.\nSends an email to Address with Subject and Message.</string>
          </map>
@@ -18436,11 +18436,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an escaped/encoded version of url, replacing spaces with %20 etc.\nReturns the string that is the URL-escaped version of URL (replacing spaces with %20, etc.).\n
                 This function returns the UTF-8 encoded escape codes for selected characters.</string>
@@ -18460,11 +18460,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation representation of the Euler angles.\nReturns the rotation represented by the Euler Angle.</string>
          </map>
@@ -18492,11 +18492,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Evade a specified target.\nCharacters will (roughly) try to hide from their pursuers if there is a good hiding spot along their fleeing path. Hiding means no direct line of sight from the head of the character (centre of the top of its physics bounding box) to the head of its pursuer and no direct path between the two on the navigation-mesh.</string>
          </map>
@@ -18524,11 +18524,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Execute a character command.\nSend a command to the path system.\nCurrently only supports stopping the current path-finding operation or causing the character to jump.</string>
          </map>
@@ -18547,11 +18547,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the positive version of Value.\nReturns the absolute value of Value.</string>
          </map>
@@ -18588,11 +18588,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches the text of a cached notecard for lines containing the given pattern and returns the 
             number of matches found through a dataserver event.
@@ -18649,11 +18649,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches the text of a cached notecard for lines containing the given pattern. 
             Returns a list of line numbers and column where a match is found. If the notecard is not in
@@ -18693,11 +18693,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Flee from a point.\nDirects a character (llCreateCharacter) to keep away from a defined position in the region or adjacent regions.</string>
          </map>
@@ -18716,11 +18716,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns largest integer value &lt;= Value.</string>
          </map>
@@ -18739,11 +18739,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If Enable is TRUE any avatar that sits on this object is forced into mouse-look mode.\nAfter calling this function with Enable set to TRUE, any agent sitting down on the prim will be forced into mouse-look.\nJust like llSitTarget, this changes a permanent property of the prim (not the object) and needs to be reset by calling this function with Enable set to FALSE in order to disable it.</string>
          </map>
@@ -18762,11 +18762,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a pseudo random number in the range [0, Magnitude] or [Magnitude, 0].\nReturns a pseudo-random number between [0, Magnitude].</string>
          </map>
@@ -18775,11 +18775,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Generates a key (SHA-1 hash) using UUID generation to create a unique key.\nAs the UUID produced is versioned, it should never return a value of NULL_KEY.\nThe specific UUID version is an implementation detail that has changed in the past and may change again in the future. Do not depend upon the UUID that is returned to be version 5 SHA-1 hash.</string>
          </map>
@@ -18788,11 +18788,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the acceleration of the object relative to the region's axes.\nGets the acceleration of the object.</string>
          </map>
@@ -18811,11 +18811,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer bit-field containing the agent information about id.\n
                     Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED, AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING, AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\nReturns information about the given agent ID as a bit-field of agent info constants.</string>
@@ -18835,11 +18835,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the language code of the preferred interface language of the avatar.\nReturns a string that is the language code of the preferred interface language of the resident.</string>
          </map>
@@ -18867,11 +18867,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests a list of agents currently in the region, limited by the scope parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or [string error_msg] - returns avatar keys for all agents in the region limited to the area(s) specified by scope</string>
          </map>
@@ -18890,11 +18890,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If the avatar is in the same region, returns the size of the bounding box of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the agent is in the same region as the object, returns the size of the avatar.</string>
          </map>
@@ -18913,11 +18913,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the alpha value of Face.\nReturns the 'alpha' of the given face. If face is ALL_SIDES the value returned is the mean average of all faces.</string>
          </map>
@@ -18928,11 +18928,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the script time in seconds and then resets the script timer to zero.\nGets the time in seconds since starting and resets the time to zero.</string>
          </map>
@@ -18951,11 +18951,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the currently playing locomotion animation for the avatar id.\nReturns the currently playing animation for the specified avatar ID.</string>
          </map>
@@ -18974,11 +18974,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys of playing animations for an avatar.\nReturns a list of keys of all playing animations for the specified avatar ID.</string>
          </map>
@@ -18997,11 +18997,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the name of the animation that is used for the specified animation state\nTo use this function the script must obtain either the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION permission (automatically granted to attached objects).</string>
          </map>
@@ -19010,11 +19010,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the object's attachment point, or 0 if not attached.</string>
          </map>
@@ -19033,11 +19033,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{uuid}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys of all visible (not HUD) attachments on the avatar identified by the ID argument</string>
          </map>
@@ -19065,11 +19065,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{uuid}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Retrieves a list of attachments on an avatar.</string>
          </map>
@@ -19088,11 +19088,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{vector}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the bounding box around the object (including any linked prims) relative to its root prim, as a list in the format [ (vector) min_corner, (vector) max_corner ].</string>
          </map>
@@ -19101,11 +19101,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera aspect ratio (width / height) of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.</string>
          </map>
@@ -19114,11 +19114,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera field of view of the agent who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have been granted: it returns zero.</string>
          </map>
@@ -19127,11 +19127,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera position for the agent the task has permissions for.\nReturns the position of the camera, of the user that granted the script PERMISSION_TRACK_CAMERA. If no user has granted the permission, it returns ZERO_VECTOR.</string>
          </map>
@@ -19140,11 +19140,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current camera orientation for the agent the task has permissions for. If no user has granted the PERMISSION_TRACK_CAMERA permission, returns ZERO_ROTATION.</string>
          </map>
@@ -19153,11 +19153,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the prim's centre of mass (unless called from the root prim, where it returns the object's centre of mass).</string>
          </map>
@@ -19185,11 +19185,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the closest navigable point to the point provided.\nThe function accepts a point in region-local space (like all the other path-finding methods) and returns either an empty list or a list containing a single vector which is the closest point on the navigation-mesh to the point provided.</string>
          </map>
@@ -19208,11 +19208,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the color on Face.\nReturns the color of Face as a vector of red, green, and blue values between 0 and 1. If face is ALL_SIDES the color returned is the mean average of each channel.</string>
          </map>
@@ -19221,11 +19221,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a key for the creator of the prim.\nReturns the key of the object's original creator. Similar to llGetOwner.</string>
          </map>
@@ -19234,11 +19234,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.</string>
          </map>
@@ -19247,11 +19247,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day on this parcel.</string>
          </map>
@@ -19260,11 +19260,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day is offset from midnight in this parcel.</string>
          </map>
@@ -19283,11 +19283,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the display name of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestDisplayName if the avatar may be absent from the region.</string>
          </map>
@@ -19296,11 +19296,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns how much energy is in the object as a percentage of maximum.</string>
          </map>
@@ -19319,11 +19319,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
          </map>
@@ -19351,11 +19351,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
          </map>
@@ -19374,11 +19374,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns a list with the following Experience properties: [Experience Name, Owner ID, Group ID, Experience ID, State, State Message]. State is an integer corresponding to one of the constants XP_ERROR_... and State Message is the string returned by llGetExperienceErrorMessage for that integer.
@@ -19399,11 +19399,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Returns a string describing the error code passed or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not a valid Experience error code.
@@ -19414,11 +19414,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the force (if the script is physical).\nReturns the current force if the script is physical.</string>
          </map>
@@ -19427,11 +19427,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of free bytes of memory the script can use.\nReturns the available free space for the current script. This is inaccurate with LSO.</string>
          </map>
@@ -19440,11 +19440,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of available URLs for the current script.\nReturns an integer that is the number of available URLs.</string>
          </map>
@@ -19453,11 +19453,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since midnight GMT.\nGets the time in seconds since midnight in GMT/UTC.</string>
          </map>
@@ -19466,11 +19466,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the vector that is the geometric center of the object relative to the root prim.</string>
          </map>
@@ -19498,11 +19498,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value for header for request_id.\nReturns a string that is the value of the Header for HTTPRequestID.</string>
          </map>
@@ -19521,11 +19521,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current health of an avatar or object in the region.</string>
          </map>
@@ -19544,11 +19544,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time at which the item was placed into this prim's inventory as a timestamp.</string>
          </map>
@@ -19567,11 +19567,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a key for the creator of the inventory item.\nThis function returns the UUID of the creator of item. If item is not found in inventory, the object says "No item named 'name'".</string>
          </map>
@@ -19590,11 +19590,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the item description of the item in inventory. If item is not found in inventory, the object says "No item named 'name'" to the debug channel and returns an empty string.</string>
          </map>
@@ -19613,11 +19613,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key that is the UUID of the inventory named.\nReturns the key of the inventory named.</string>
          </map>
@@ -19645,11 +19645,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the inventory item of a given type, specified by index number.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
@@ -19668,11 +19668,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the quantity of items of a given type (INVENTORY_* flag) in the prim's inventory.\nUse the inventory constants INVENTORY_* to specify the type.</string>
          </map>
@@ -19700,11 +19700,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the requested permission mask for the inventory item.\nReturns the requested permission mask for the inventory item defined by InventoryItem. If item is not in the object's inventory, llGetInventoryPermMask returns FALSE and causes the object to say "No item named '&lt;item&gt;'", where "&lt;item&gt;" is item.</string>
          </map>
@@ -19723,11 +19723,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the named inventory item.\nLike all inventory functions, llGetInventoryType is case-sensitive.</string>
          </map>
@@ -19736,11 +19736,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the prim the script is attached to.\nGet the key for the object which has this script.</string>
          </map>
@@ -19759,11 +19759,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the land owner, returns NULL_KEY if public.\nReturns the key of the land owner at Position, or NULL_KEY if public.</string>
          </map>
@@ -19782,11 +19782,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the linked prim LinkNumber.\nReturns the key of LinkNumber in the link set.</string>
          </map>
@@ -19823,11 +19823,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the media parameters for a particular face on linked prim, given the desired list of parameter names. Returns a list of values in the order requested.	Returns an empty list if no media exists on the face.</string>
          </map>
@@ -19846,11 +19846,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of LinkNumber in a link set.\nReturns the name of LinkNumber the link set.</string>
          </map>
@@ -19859,11 +19859,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the link number of the prim containing the script (0 means not linked, 1 the prim is the root, 2 the prim is the first child, etc.).\nReturns the link number of the prim containing the script. 0 means no link, 1 the root, 2 for first child, etc.</string>
          </map>
@@ -19882,11 +19882,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of sides of the specified linked prim.\nReturns an integer that is the number of faces (or sides) of the prim link.</string>
          </map>
@@ -19914,11 +19914,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the list of primitive attributes requested in the Parameters list for LinkNumber.\nPRIM_* flags can be broken into three categories, face flags, prim flags, and object flags.\n* Supplying a prim or object flag will return that flag's attributes.\n* Face flags require the user to also supply a face index parameter.</string>
          </map>
@@ -19937,11 +19937,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the sit flags set on the specified prim in a linkset.</string>
          </map>
@@ -19969,11 +19969,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT, TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if index is off list).\nReturns the type of the variable at Index in ListVariable.</string>
          </map>
@@ -19992,11 +19992,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of elements in the list.\nReturns the number of elements in ListVariable.</string>
          </map>
@@ -20005,11 +20005,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position relative to the root.\nReturns the local position of a child object relative to the root.</string>
          </map>
@@ -20018,11 +20018,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation local to the root.\nReturns the local rotation of a child object relative to the root.</string>
          </map>
@@ -20031,11 +20031,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mass of object that the script is attached to.\nReturns the scripted object's mass. When called from a script in a link-set, the parent will return the sum of the link-set weights, while a child will return just its own mass. When called from a script inside an attachment, this function will return the mass of the avatar it's attached to, not its own.</string>
          </map>
@@ -20044,11 +20044,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Acts as llGetMass(), except that the units of the value returned are Kg.</string>
          </map>
@@ -20057,11 +20057,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the largest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.</string>
          </map>
@@ -20070,11 +20070,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Get the maximum memory a script can use, in bytes.</string>
          </map>
@@ -20083,11 +20083,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the smallest multiplicative uniform scale factor that can be successfully applied (via llScaleByFactor()) to the object without violating prim size or linkability rules.</string>
          </map>
@@ -20096,11 +20096,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the moon in the parcel.\nReturns the moon's direction on the simulator in the parcel.</string>
          </map>
@@ -20109,11 +20109,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the moon in the parcel.</string>
          </map>
@@ -20141,11 +20141,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Fetch the next queued email with that matches the given address and/or subject, via the email event.\nIf the parameters are blank, they are not used for filtering.</string>
          </map>
@@ -20173,11 +20173,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Returns LineNumber from NotecardName via the dataserver event. The line index starts at zero in LSL, one in Lua.\nIf the requested line is passed the end of the note-card the dataserver event will return the constant EOF string.\nThe key returned by this function is a unique identifier which will be supplied to the dataserver event in the requested parameter.</string>
          </map>
@@ -20205,11 +20205,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns LineNumber from NotecardName. The line index starts at zero in LSL, one in Lua.\nIf the requested line is past the end of the note-card the return value will be set to the constant EOF string.\nIf the note-card is not cached on the simulator the return value is the NAK string.</string>
          </map>
@@ -20228,11 +20228,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Returns the number of lines contained within a notecard via the dataserver event.\nThe key returned by this function is a query ID for identifying the dataserver reply.</string>
          </map>
@@ -20241,11 +20241,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of prims in a link set the script is attached to.\nReturns the number of prims in (and avatars seated on) the object the script is in.</string>
          </map>
@@ -20254,11 +20254,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of faces (or sides) of the prim.\nReturns the number of sides of the prim which has the script.</string>
          </map>
@@ -20267,11 +20267,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of names of playing animations for an object.\nReturns a list of names of all playing animations for the current object.</string>
          </map>
@@ -20280,11 +20280,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the description of the prim the script is attached to.\nReturns the description of the scripted object/prim. You can set the description using llSetObjectDesc.</string>
          </map>
@@ -20312,11 +20312,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of object details specified in the Parameters list for the object or avatar in the region with key ID.\nParameters are specified by the OBJECT_* constants.</string>
          </map>
@@ -20344,11 +20344,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the linked prim link_no in a linkset.\nReturns the key of link_no in the link set specified by id.</string>
          </map>
@@ -20367,11 +20367,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mass of the avatar or object in the region.\nGets the mass of the object or avatar corresponding to ID.</string>
          </map>
@@ -20380,11 +20380,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the prim which the script is attached to.\nReturns the name of the prim (not object) which contains the script.</string>
          </map>
@@ -20403,11 +20403,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the permission mask of the requested category for the object.</string>
          </map>
@@ -20426,11 +20426,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the total number of prims for an object in the region.\nReturns the prim count for any object id in the same region.</string>
          </map>
@@ -20439,11 +20439,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation velocity in radians per second.\nReturns a vector that is the rotation velocity of the object in radians per second.</string>
          </map>
@@ -20452,11 +20452,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the object owner's UUID.\nReturns the key for the owner of the object.</string>
          </map>
@@ -20475,11 +20475,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the owner of ObjectID.\nReturns the key for the owner of object ObjectID.</string>
          </map>
@@ -20507,11 +20507,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of parcel details specified in the ParcelDetails list for the parcel at Position.\nParameters is one or more of: PARCEL_DETAILS_NAME, _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\nReturns a list that is the parcel details specified in ParcelDetails (in the same order) for the parcel at Position.</string>
          </map>
@@ -20530,11 +20530,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that includes the point Position.\nReturns a bit-field specifying the parcel flags (PARCEL_FLAG_*) for the parcel at Position.</string>
          </map>
@@ -20562,11 +20562,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the maximum number of prims allowed on the parcel at Position for a given scope.\nThe scope may be set to an individual parcel or the combined resources of all parcels with the same ownership in the region.</string>
          </map>
@@ -20575,11 +20575,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Gets the streaming audio URL for the parcel object is on.\nThe object owner, avatar or group, must also be the land owner.</string>
          </map>
@@ -20616,11 +20616,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of prims on the parcel at Position of the given category.\nCategories: PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER, _SELECTED, _TEMP.\nReturns the number of prims used on the parcel at Position which are in Category.\nIf SimWide is TRUE, it returns the total number of objects for all parcels with matching ownership in the category specified.\nIf SimWide is FALSE, it returns the number of objects on this specific parcel in the category specified</string>
          </map>
@@ -20639,11 +20639,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Returns a list of up to 100 residents who own objects on the parcel at Position, with per-owner land impact totals.\nRequires owner-like permissions for the parcel, and for the script owner to be present in the region.\nThe list is formatted as [ key agentKey1, integer agentLI1, key agentKey2, integer agentLI2, ... ], sorted by agent key.\nThe integers are the combined land impacts of the objects owned by the corresponding agents.</string>
          </map>
@@ -20652,11 +20652,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer bitmask of the permissions that have been granted to the script.  Individual permissions can be determined using a bit-wise "and" operation against the PERMISSION_* constants</string>
          </map>
@@ -20665,11 +20665,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the key of the avatar that last granted or declined permissions to the script.\nReturns NULL_KEY if permissions were never granted or declined.</string>
          </map>
@@ -20678,11 +20678,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of the form [float gravity_multiplier, float restitution, float friction, float density].</string>
          </map>
@@ -20691,11 +20691,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position of the task in region coordinates.\nReturns the vector position of the task in region coordinates.</string>
          </map>
@@ -20723,11 +20723,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Returns the media parameters for a particular face on an object, given the desired list of parameter names, in the order requested. Returns an empty list if no media exists on the face.</string>
          </map>
@@ -20746,11 +20746,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Returns the primitive parameters specified in the parameters list.\nReturns primitive parameters specified in the Parameters list.</string>
          </map>
@@ -20759,11 +20759,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of avatars in the region.\nReturns an integer that is the number of avatars in the region.</string>
          </map>
@@ -20772,11 +20772,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a vector, in meters, that is the global location of the south-west corner of the region which the object is in.\nReturns the Region-Corner of the simulator containing the task. The region-corner is a vector (values in meters) representing distance from the first region.</string>
          </map>
@@ -20785,11 +20785,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day in this region.</string>
          </map>
@@ -20798,11 +20798,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds in a day is offset from midnight in this parcel.</string>
          </map>
@@ -20811,11 +20811,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the mean region frames per second.</string>
          </map>
@@ -20824,11 +20824,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the region flags (REGION_FLAG_*) for the region the object is in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for the region the object is in.</string>
          </map>
@@ -20837,11 +20837,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the moon in the region.\nReturns the moon's direction on the simulator.</string>
          </map>
@@ -20850,11 +20850,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the moon in the region.</string>
          </map>
@@ -20863,11 +20863,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current region name.</string>
          </map>
@@ -20876,11 +20876,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the sun in the region.\nReturns the sun's direction on the simulator.</string>
          </map>
@@ -20889,11 +20889,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the sun in the region.</string>
          </map>
@@ -20902,11 +20902,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current time dilation as a float between 0.0 (full dilation) and 1.0 (no dilation).\nReturns the current time dilation as a float between 0.0 and 1.0.</string>
          </map>
@@ -20915,11 +20915,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since environmental midnight for the entire region.</string>
          </map>
@@ -20938,11 +20938,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the render material on face (the inventory name if it is a material in the prim's inventory, otherwise the key).\nReturns the render material of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
@@ -20951,11 +20951,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the position (in region coordinates) of the root prim of the object which the script is attached to.\nThis is used to allow a child prim to determine where the root is.</string>
          </map>
@@ -20964,11 +20964,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation (relative to the region) of the root prim of the object which the script is attached to.\nGets the global rotation of the root object of the object script is attached to.</string>
          </map>
@@ -20977,11 +20977,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation relative to the region's axes.\nReturns the rotation.</string>
          </map>
@@ -20990,11 +20990,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the maximum used memory for the current script. Only valid after using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns the integer of the most bytes used while llScriptProfiler was last active.</string>
          </map>
@@ -21003,11 +21003,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the scale of the prim.\nReturns a vector that is the scale (dimensions) of the prim.</string>
          </map>
@@ -21016,11 +21016,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the script that this function is used in.\nReturns the name of this script.</string>
          </map>
@@ -21039,11 +21039,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if the script named is running.\nReturns TRUE if ScriptName is running.</string>
          </map>
@@ -21062,11 +21062,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a float that is the requested statistic.</string>
          </map>
@@ -21075,11 +21075,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>tooltip</key>
             <string>Returns the host-name of the machine which the script is running on.\nFor example, "sim225.agni.lindenlab.com".</string>
          </map>
@@ -21088,11 +21088,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the script rez parameter.\nIf the object was rezzed by an agent, this function returns 0.</string>
          </map>
@@ -21101,11 +21101,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the value passed to llRezObjectWithParams with REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns an empty string.</string>
          </map>
@@ -21151,11 +21151,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string />
          </map>
@@ -21174,11 +21174,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of the object the script is attached to.</string>
          </map>
@@ -21215,11 +21215,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a sub-string from String, in a range specified by the Start and End indices (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
@@ -21228,11 +21228,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a normalized vector of the direction of the sun in the parcel.\nReturns the sun's direction on the simulator in the parcel.</string>
          </map>
@@ -21241,11 +21241,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation applied to the sun in the parcel.</string>
          </map>
@@ -21264,11 +21264,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is the texture on face (the inventory name if it is a texture in the prim's inventory, otherwise the key).\nReturns the texture of a face, if it is found in object inventory, its key otherwise.</string>
          </map>
@@ -21287,11 +21287,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture offset of face in the x and y components of a vector.</string>
          </map>
@@ -21310,11 +21310,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture rotation of side.</string>
          </map>
@@ -21333,11 +21333,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the texture scale of side in the x and y components of a vector.\nReturns the texture scale of a side in the x and y components of a vector.</string>
          </map>
@@ -21346,11 +21346,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.</string>
          </map>
@@ -21359,11 +21359,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since environmental midnight on the parcel.</string>
          </map>
@@ -21372,11 +21372,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.</string>
          </map>
@@ -21385,11 +21385,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the torque (if the script is physical).\nReturns a vector that is the torque (if the script is physical).</string>
          </map>
@@ -21398,11 +21398,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC from the system clock.</string>
          </map>
@@ -21411,11 +21411,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the current used memory for the current script. Non-mono scripts always use 16K.\nReturns the integer of the number of bytes of memory currently in use by the script. Non-mono scripts always use 16K.</string>
          </map>
@@ -21434,11 +21434,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the username of an avatar, if the avatar is connected to the current region, or if the name has been cached.  Otherwise, returns an empty string. Use llRequestUsername if the avatar may be absent from the region.</string>
          </map>
@@ -21447,11 +21447,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the velocity of the object.\nReturns a vector that is the velocity of the object.</string>
          </map>
@@ -21479,11 +21479,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of the current value for each requested visual parameter.</string>
          </map>
@@ -21492,11 +21492,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns the time in seconds since simulator's time-zone midnight (Pacific Time).</string>
          </map>
@@ -21542,11 +21542,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>Give InventoryItems to the specified agent as a new folder of items, as permitted by the permissions system. The target must be an agent.</string>
          </map>
@@ -21574,11 +21574,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Give InventoryItem to destination represented by TargetID, as permitted by the permissions system.\nTargetID may be any agent or an object in the same region.</string>
          </map>
@@ -21615,11 +21615,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>Give InventoryItems to destination (represented by TargetID) as a new folder of items, as permitted by the permissions system.\nTargetID may be any agent or an object in the same region. If TargetID is an object, the items are passed directly to the object inventory (no folder is created).</string>
          </map>
@@ -21647,11 +21647,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfers Amount of L$ from script owner to AvatarID.\nThis call will silently fail if PERMISSION_DEBIT has not been granted.</string>
          </map>
@@ -21679,13 +21679,13 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Rez directly off of a UUID if owner has god-bit set.</string>
          </map>
@@ -21704,11 +21704,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground height at the object position + offset.\nReturns the ground height at the object's position + Offset.</string>
          </map>
@@ -21727,11 +21727,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground contour direction below the object position + Offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
@@ -21750,11 +21750,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground normal below the object position + offset.\nReturns the ground contour at the object's position + Offset.</string>
          </map>
@@ -21791,11 +21791,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damps to height if within height * 0.5 of level (either above ground level or above the higher of land and water if water == TRUE).\nCritically damps to fHeight if within fHeight * 0.5 of ground or water level.\n
                     The height is above ground level if iWater is FALSE or above the higher of land and water if iWater is TRUE.\n
@@ -21816,11 +21816,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the ground slope below the object position + Offset.\nReturns the ground slope at the object position + Offset.</string>
          </map>
@@ -21857,11 +21857,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base64-encoded hashed message authentication code (HMAC), of Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224, sha256, sha384, sha512).</string>
          </map>
@@ -21898,11 +21898,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sends an HTTP request to the specified URL with the Body of the request and Parameters.\nReturns a key that is a handle identifying the HTTP request made.</string>
          </map>
@@ -21939,11 +21939,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Responds to an incoming HTTP request which was triggerd by an http_request event within the script. HTTPRequestID specifies the request to respond to (this ID is supplied in the http_request event handler).  Status and Body specify the status code and message to respond with.</string>
          </map>
@@ -21962,11 +21962,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Calculates the 32bit hash value for the provided string.</string>
          </map>
@@ -22003,11 +22003,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Inserts SourceVariable into TargetVariable at Position, and returns the result.\nInserts SourceVariable into TargetVariable at Position and returns the result. Note this does not alter TargetVariable.</string>
          </map>
@@ -22035,11 +22035,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>IMs Text to the user identified.\nSend Text to the user as an instant message.</string>
          </map>
@@ -22058,11 +22058,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is a Base64 big endian encode of Value.\nEncodes the Value as an 8-character Base64 string.</string>
          </map>
@@ -22081,11 +22081,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is a friend of the script owner.</string>
          </map>
@@ -22113,11 +22113,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Checks the face for a PBR render material.</string>
          </map>
@@ -22136,11 +22136,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts the top level of the JSON string to a list.</string>
          </map>
@@ -22168,11 +22168,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Gets the value indicated by Specifiers from the JSON string.</string>
          </map>
@@ -22209,11 +22209,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a new JSON string that is the JSON given with the Value indicated by Specifiers set to Value.</string>
          </map>
@@ -22241,11 +22241,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the type constant (JSON_*) for the value in JSON indicated by Specifiers.</string>
          </map>
@@ -22264,11 +22264,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the name of the prim or avatar specified by ID. The ID must be a valid rezzed prim or avatar key in the current simulator, otherwise an empty string is returned.\nFor avatars, the returned name is the legacy name</string>
          </map>
@@ -22277,11 +22277,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request the number of keys in the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will the the number of keys in the system.
@@ -22311,11 +22311,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction the request a number of keys from the data store. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal to the number of keys in the data store. In the success case the subsequent items will be the keys requested. The number of keys returned may be less than requested if the return value is too large or if there is not enough keys remaining. The order keys are returned is not guaranteed but is stable between subsequent calls as long as no keys are added or removed. Because the keys are returned in a comma-delimited list it is not recommended to use commas in key names if this function is used.
@@ -22336,11 +22336,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a color from the linear colorspace to sRGB.</string>
          </map>
@@ -22368,11 +22368,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Adjusts the volume (0.0 - 1.0) of the currently playing sound attached to the link.\nThis function has no effect on sounds started with llTriggerSound.</string>
          </map>
@@ -22400,11 +22400,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a particle system in prim LinkNumber based on Rules. An empty list removes a particle system from object.\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].\nThis is identical to llParticleSystem except that it applies to a specified linked prim and not just the prim the script is in.</string>
          </map>
@@ -22450,11 +22450,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be attached to the link or triggered at its location.\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.</string>
          </map>
@@ -22482,11 +22482,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.</string>
          </map>
@@ -22514,11 +22514,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius around the link.</string>
          </map>
@@ -22555,11 +22555,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the sit location for the linked prim(s). If Offset == &lt;0,0,0&gt; clear it.\nSet the sit location for the linked prim(s). The sit location is relative to the prim's position and rotation.</string>
          </map>
@@ -22578,11 +22578,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops playback of the currently attached sound on a link.</string>
          </map>
@@ -22591,11 +22591,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of bytes remaining in the linkset's datastore.</string>
          </map>
@@ -22614,11 +22614,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of keys matching the regular expression passed in the search parameter.</string>
          </map>
@@ -22627,11 +22627,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the number of keys in the linkset's datastore.</string>
          </map>
@@ -22650,11 +22650,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
@@ -22682,11 +22682,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes all key value pairs in the linkset data where the key matches the regular expression in search. Returns a list consisting of [ #deleted, #not deleted ].</string>
          </map>
@@ -22714,11 +22714,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deletes a name:value pair from the linkset's datastore.</string>
          </map>
@@ -22755,11 +22755,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of keys from the linkset's data store matching the search parameter.</string>
          </map>
@@ -22787,11 +22787,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list of all keys in the linkset datastore.</string>
          </map>
@@ -22810,11 +22810,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value stored for a key in the linkset.</string>
          </map>
@@ -22842,11 +22842,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value stored for a key in the linkset.</string>
          </map>
@@ -22855,11 +22855,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the linkset's data store, erasing all key-value pairs.</string>
          </map>
@@ -22887,11 +22887,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
@@ -22928,11 +22928,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a name:value pair in the linkset's datastore</string>
          </map>
@@ -22951,11 +22951,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a string of comma separated values from the list.\nCreate a string of comma separated values from the specified list.</string>
          </map>
@@ -22983,11 +22983,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the float at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a float, then zero is returned.</string>
          </map>
@@ -23015,11 +23015,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the integer at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to an integer, then zero is returned.</string>
          </map>
@@ -23047,11 +23047,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts either a strided list of key:value pairs to a JSON_OBJECT, or a list of values to a JSON_ARRAY.</string>
          </map>
@@ -23079,11 +23079,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the key at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a key, then null string is returned.</string>
          </map>
@@ -23124,11 +23124,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a subset of entries from ListVariable, in a range specified by the Start and End indicies (inclusive).\nUsing negative numbers for Start and/or End causes the index to count backwards from the length of the string, so 0, -1 would capture the entire string.\nIf Start is greater than End, the sub string is the exclusion of the entries.</string>
          </map>
@@ -23187,11 +23187,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a subset of entries from ListVariable, in a range specified by Start and End indices (inclusive) return the slice_index element of each stride.\n Using negative numbers for Start and/or End causes the index to count backwards from the length of the list. (e.g. 0, -1 captures entire list)\nIf slice_index is less than 0, it is counted backwards from the end of the stride.\n Stride must be a positive integer &gt; 0 or an empy list is returned.  If slice_index falls outside range of stride, an empty list is returned. slice_index is zero-based. (e.g. A stride of 2 has valid indices 0,1)</string>
          </map>
@@ -23241,11 +23241,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the strided slice of the list from Start to End.\nReturns a copy of the strided slice of the specified list from Start to End.</string>
          </map>
@@ -23273,11 +23273,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the rotation at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to rotation, thenZERO_ROTATION is returned.</string>
          </map>
@@ -23305,11 +23305,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the string at Index in the list.\nReturns the value at Index in the specified list as a string. If Index describes a location not in the list then null string is returned.</string>
          </map>
@@ -23337,11 +23337,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Copies the vector at Index in the list.\nReturns the value at Index in the specified list. If Index describes a location not in the list, or the value cannot be type-cast to a vector, then ZERO_VECTOR is returned.</string>
          </map>
@@ -23369,11 +23369,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\nReturns the position of the first instance of the Find list in the ListVariable. Returns -1 if not found.</string>
          </map>
@@ -23410,11 +23410,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the nth instance of Find in ListVariable. Returns -1 if not found.</string>
          </map>
@@ -23469,11 +23469,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the index of the first instance of Find in ListVariable. Returns -1 if not found.\nReturns the position of the first instance of the Find list in the ListVariable after the start index and before the end index. Steps through ListVariable by stride.  Returns -1 if not found.</string>
          </map>
@@ -23514,11 +23514,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list that contains all the elements from Target but with the elements from ListVariable inserted at Position start.\nReturns a new list, created by inserting ListVariable into the Target list at Position. Note this does not alter the Target.</string>
          </map>
@@ -23550,11 +23550,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a version of the input ListVariable which has been randomized by blocks of size Stride.\nIf the remainder from the length of the list, divided by the stride is non-zero, this function does not randomize the list.</string>
          </map>
@@ -23604,11 +23604,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a list that is Target with Start through End removed and ListVariable inserted at Start.\nReturns a list replacing the slice of the Target list from Start to End with the specified ListVariable. Start and End are inclusive, so 0, 1 would replace the first two entries and 0, 0 would replace only the first list entry.</string>
          </map>
@@ -23649,11 +23649,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the specified list, sorted into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.</string>
          </map>
@@ -23703,11 +23703,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{T}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the specified list, sorted by the specified element into blocks of stride in ascending order (if Ascending is TRUE, otherwise descending). Note that sort only works if the first entry of each block is the same datatype.</string>
          </map>
@@ -23735,11 +23735,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a statistical aggregate function, specified by a LIST_STAT_* constant, on ListVariables.\nThis function allows a script to perform a statistical operation as defined by operation on a list composed of integers and floats.</string>
          </map>
@@ -23785,11 +23785,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a listen callback for Text on Channel from SpeakersName and SpeakersID (SpeakersName, SpeakersID, and/or Text can be empty) and returns an identifier that can be used to deactivate or remove the listen.\nNon-empty values for SpeakersName, SpeakersID, and Text will filter the results accordingly, while empty strings and NULL_KEY will not filter the results, for string and key parameters respectively.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -23817,11 +23817,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Makes a listen event callback active or inactive. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener you are controlling.\nUse boolean values to specify Active</string>
          </map>
@@ -23840,11 +23840,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes a listen event callback. Pass in the value returned from llListen to the iChannelHandle parameter to specify which listener to remove.</string>
          </map>
@@ -23881,11 +23881,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Shows dialog to avatar AvatarID offering to load web page at URL.	If user clicks yes, launches their web browser.\nllLoadURL displays a dialogue box to the user, offering to load the specified web page using the default web browser.</string>
          </map>
@@ -23904,11 +23904,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the natural logarithm of Value. Returns zero if Value &lt;= 0.\nReturns the base e (natural) logarithm of the specified Value.</string>
          </map>
@@ -23927,11 +23927,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base 10 logarithm of Value. Returns zero if Value &lt;= 0.\nReturns the base 10 (common) logarithm of the specified Value.</string>
          </map>
@@ -23968,11 +23968,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Cause object name to point its forward axis towards Target, at a force controlled by Strength and Damping.\nGood Strength values are around half the mass of the object and good Damping values are less than 1/10th of the Strength.\nAsymmetrical shapes require smaller Damping. A Strength of 0.0 cancels the look at.</string>
          </map>
@@ -24000,11 +24000,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly one sound may be attached to an object at a time.\nA second call to llLoopSound with the same key will not restart the sound, but the new volume will be used. This allows control over the volume of already playing sounds.\nSetting the volume to 0 is not the same as calling llStopSound; a sound with 0 volume will continue to loop.\nTo restart the sound from the beginning, call llStopSound before calling llLoopSound again.</string>
          </map>
@@ -24032,11 +24032,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached Sound, looping at volume (0.0 - 1.0), and declares it a sync master.\nBehaviour is identical to llLoopSound, with the addition of marking the source as a "Sync Master", causing "Slave" sounds to sync to it. If there are multiple masters within a viewers interest area, the most audible one (a function of both distance and volume) will win out as the master.\nThe use of multiple masters within a small area is unlikely to produce the desired effect.</string>
          </map>
@@ -24064,11 +24064,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached sound looping at volume (0.0 - 1.0), synced to most audible sync master.\nBehaviour is identical to llLoopSound, unless there is a "Sync Master" present.\nIf a Sync Master is already playing the Slave sound will begin playing from the same point the master is in its loop synchronizing the loop points of both sounds.\nIf a Sync Master is started when the Slave is already playing, the Slave will skip to the correct position to sync with the Master.</string>
          </map>
@@ -24096,11 +24096,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 32 hex characters that is an RSA Data Security Inc., MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns a 32-character hex string. (128-bit in binary.)</string>
          </map>
@@ -24175,11 +24175,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make a round explosion of particles. Deprecated: Use llParticleSystem instead.\nMake a round explosion of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -24254,11 +24254,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake fire particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -24351,11 +24351,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make a fountain of particles. Deprecated: Use llParticleSystem instead.\nMake a fountain of particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -24430,11 +24430,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake smoky particles using texture from the objects inventory. Deprecated: Use llParticleSystem instead.</string>
          </map>
@@ -24462,11 +24462,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Adds or removes agents from the estate's agent access or ban lists, or groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_* operations to perform.\nReturns an integer representing a boolean, TRUE if the call was successful; FALSE if throttled, invalid action, invalid or null id or object owner is not allowed to manage the estate.\nThe object owner is notified of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted to the script.</string>
          </map>
@@ -24503,11 +24503,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Displays an in world beacon and optionally opens world map for avatar who touched the object or is wearing the script, centered on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.</string>
          </map>
@@ -24544,11 +24544,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Opens world map for avatar who touched it or is wearing the script, centred on RegionName with Position highlighted. Only works for scripts attached to avatar, or during touch events.\nDirection currently has no effect.</string>
          </map>
@@ -24594,11 +24594,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sends Number, Text, and ID to members of the link set identified by LinkNumber.\nLinkNumber is either a linked number (available through llGetLinkNumber) or a LINK_* constant.</string>
          </map>
@@ -24617,11 +24617,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the minimum time between events being handled.</string>
          </map>
@@ -24658,11 +24658,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised to the Power, Modulus). Value is capped at 0xFFFF (16 bits).</string>
          </map>
@@ -24690,11 +24690,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH, LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x 4m, 8m x 8m).</string>
          </map>
@@ -24722,11 +24722,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damp to Target in Tau seconds (if the script is physical).\nCritically damp to position target in tau-seconds if the script is physical. Good tau-values are greater than 0.2. A tau of 0.0 stops the critical damping.</string>
          </map>
@@ -24745,11 +24745,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Look up Agent ID for the named agent in the region.</string>
          </map>
@@ -24777,11 +24777,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Navigate to destination.\nDirects an object to travel to a defined position in the region or adjacent regions.</string>
          </map>
@@ -24818,11 +24818,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the texture S and T offsets for the chosen Face.\nIf Face is ALL_SIDES this function sets the texture offsets for all faces.</string>
          </map>
@@ -24859,11 +24859,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the value for header for request_id.\nReturns a string that is the value of the Header for HTTPRequestID.</string>
          </map>
@@ -24874,11 +24874,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -24906,11 +24906,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the unicode value of the indicated character in the string.</string>
          </map>
@@ -24929,11 +24929,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if id ID over land owned by the script owner, otherwise FALSE.\nReturns TRUE if key ID is over land owned by the object owner, FALSE otherwise.</string>
          </map>
@@ -24952,11 +24952,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>says Text to owner only (if owner is in region).\nSays Text to the owner of the object running the script, if the owner has been within the object's simulator since logging into Second Life, regardless of where they may be in-world.</string>
          </map>
@@ -24975,11 +24975,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Controls the playback of multimedia resources on a parcel or for an agent, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.</string>
          </map>
@@ -24998,11 +24998,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>list</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Queries the media properties of the parcel containing the script, via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis function will only work if the script is contained within an object owned by the land-owner (or if the land is owned by a group, only if the object has been deeded to the group).</string>
          </map>
@@ -25039,11 +25039,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{string}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts Text into a list, discarding Separators, keeping Spacers (Separators and Spacers must be lists of strings, maximum of 8 each).\nSeparators and Spacers are lists of strings with a maximum of 8 entries each.</string>
          </map>
@@ -25080,11 +25080,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>{string}</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Breaks Text into a list, discarding separators, keeping spacers, keeping any null values generated. (separators and spacers must be lists of strings, maximum of 8 each).\nllParseStringKeepNulls works almost exactly like llParseString2List, except that if a null is found it will add a null-string instead of discarding it like llParseString2List does.</string>
          </map>
@@ -25103,11 +25103,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Creates a particle system in the prim the script is attached to, based on Parameters. An empty list removes a particle system from object.\nList format is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].</string>
          </map>
@@ -25126,11 +25126,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Configures how collision events are passed to scripts in the linkset.\nIf Pass == TRUE, collisions involving collision-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such collisions will only trigger events in the affected child prim.</string>
          </map>
@@ -25149,11 +25149,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Configures how touch events are passed to scripts in the linkset.\nIf Pass == TRUE, touches involving touch-handling scripted child prims are also passed on to the root prim. If Pass == FALSE (default behavior), such touches will only trigger events in the affected child prim.</string>
          </map>
@@ -25181,11 +25181,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Patrol a list of points.\nSets the points for a character (llCreateCharacter) to patrol along.</string>
          </map>
@@ -25213,11 +25213,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly one sound may be attached to an object at a time, and attaching a new sound or calling llStopSound will stop the previously attached sound.\nA second call to llPlaySound with the same sound will not restart the sound, but the new volume will be used, which allows control over the volume of already playing sounds.\nTo restart the sound from the beginning, call llStopSound before calling llPlaySound again.</string>
          </map>
@@ -25245,11 +25245,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop of most audible sync master.\nBehaviour is identical to llPlaySound, unless there is a "Sync Master" present. If a Sync Master is already playing, the Slave sound will not be played until the Master hits its loop point and returns to the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is desired to have the sound play every time the Master loops, either use llLoopSoundSlave with extra silence padded on the end of the sound or ensure that llPlaySoundSlave is called at least once per loop of the Master.</string>
          </map>
@@ -25277,11 +25277,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the Value raised to the power Exponent, or returns 0 and triggers Math Error for imaginary results.\nReturns the Value raised to the Exponent.</string>
          </map>
@@ -25300,11 +25300,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Causes nearby viewers to preload the Sound from the object's inventory.\nThis is intended to prevent delays in starting new sounds when called upon.</string>
          </map>
@@ -25332,11 +25332,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Chase after a target.\nCauses the character (llCharacter) to pursue the target defined by TargetID.</string>
          </map>
@@ -25382,11 +25382,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied impulse and angular impulse to the object specified.</string>
          </map>
@@ -25405,11 +25405,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to retrieve the value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND if the key does not exist. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key.
@@ -25422,11 +25422,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Reloads the web page shown on the sides of the object.</string>
          </map>
@@ -25454,11 +25454,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Broadcasts Text to entire region on Channel (except for channel 0).</string>
          </map>
@@ -25495,11 +25495,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Says Text, on Channel, to avatar or object indicated by TargetID (if within region).\nIf TargetID is an avatar and Channel is nonzero, Text can be heard by any attachment on the avatar.</string>
          </map>
@@ -25520,11 +25520,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return camera to agent.\nDeprecated: Use llClearCameraParams instead.</string>
          </map>
@@ -25533,11 +25533,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop taking inputs.\nStop taking inputs from the avatar.</string>
          </map>
@@ -25556,11 +25556,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Releases the specified URL, which was previously obtained using llRequestURL.  Once released, the URL will no longer be usable.</string>
          </map>
@@ -25608,11 +25608,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -25623,11 +25623,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -25682,11 +25682,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>If the owner of the object containing this script can modify the object identified by the specified object key, and if the PIN matches the PIN previously set using llSetRemoteScriptAccessPin (on the target prim), then the script will be copied into target. Running is a boolean specifying whether the script should be enabled once copied into the target object.</string>
          </map>
@@ -25705,11 +25705,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Remove avatar from the land ban list.\nRemove specified avatar from the land parcel ban list.</string>
          </map>
@@ -25728,11 +25728,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Remove avatar from the land pass list.\nRemove specified avatar from the land parcel pass list.</string>
          </map>
@@ -25751,11 +25751,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Remove the named inventory item.\nRemove the named inventory item from the object inventory.</string>
          </map>
@@ -25774,11 +25774,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE. Valid parameters can be found in the vehicle flags constants section.</string>
          </map>
@@ -25815,11 +25815,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Replaces the entire environment for an agent. Must be used as part of an experience.</string>
          </map>
@@ -25875,11 +25875,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Replaces the environment for a parcel or region.</string>
          </map>
@@ -25925,11 +25925,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Searches InitialString and replaces instances of SubString with NewSubString. Zero Count means "replace all". Positive Count moves left to right. Negative moves right to left.</string>
          </map>
@@ -25957,11 +25957,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Requests data about AvatarID. When data is available the dataserver event will be raised.\nThis function requests data about an avatar. If and when the information is collected, the dataserver event is triggered with the key returned from this function passed in the requested parameter. See the agent data constants (DATA_*) for details about valid values of data and what each will return in the dataserver event.</string>
          </map>
@@ -25980,11 +25980,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests the display name of the agent. When the display name is available the dataserver event will be raised.\nThe avatar identified does not need to be in the same region or online at the time of the request.\nReturns a key that is used to identify the dataserver event when it is raised.</string>
          </map>
@@ -26012,11 +26012,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Ask the agent for permission to participate in an experience. This request is similar to llRequestPermissions with the following permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH, PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT. However, unlike llRequestPermissions the decision to allow or block the request is persistent and applies to all scripts using the experience grid wide. Subsequent calls to llRequestExperiencePermissions from scripts in the experience will receive the same response automatically with no user interaction. One of experience_permissions or experience_permissions_denied will be generated in response to this call. Outstanding permission requests will be lost if the script is derezzed, moved to another region or reset.
@@ -26037,11 +26037,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Requests data for the named InventoryItem.\nWhen data is available, the dataserver event will be raised with the key returned from this function in the requested parameter.\nThe only request currently implemented is to request data from landmarks, where the data returned is in the form "&lt;float, float, float&gt;" which can be cast to a vector. This position is in region local coordinates.</string>
          </map>
@@ -26069,11 +26069,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Ask AvatarID to allow the script to perform certain actions, specified in the PermissionMask bitmask. PermissionMask should be one or more PERMISSION_* constants. Multiple permissions can be requested simultaneously by ORing the constants together. Many of the permissions requests can only go to object owner.\nThis call will not stop script execution. If the avatar grants the requested permissions, the run_time_permissions event will be called.</string>
          </map>
@@ -26082,11 +26082,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests one HTTPS:// (SSL) URL for use by this object. The http_request event is triggered with results.\nReturns a key that is the handle used for identifying the request in the http_request event.</string>
          </map>
@@ -26114,11 +26114,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Requests the specified Data about RegionName. When the specified data is available, the dataserver event is raised.\nData should use one of the DATA_SIM_* constants.\nReturns a dataserver query ID and triggers the dataserver event when data is found.</string>
          </map>
@@ -26127,11 +26127,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests one HTTP:// URL for use by this script. The http_request event is triggered with the result of the request.\nReturns a key that is the handle used for identifying the result in the http_request event.</string>
          </map>
@@ -26150,11 +26150,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Look up Agent ID for the named agent using a historical name.</string>
          </map>
@@ -26173,11 +26173,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests single-word user-name of an avatar. When data is available the dataserver event will be raised.\nRequests the user-name of the identified agent. When the user-name is available the dataserver event is raised.\nThe agent identified does not need to be in the same region or online at the time of the request.\nReturns a key that is used to identify the dataserver event when it is raised.</string>
          </map>
@@ -26196,11 +26196,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the animation of the specified animation state to the default value.\nIf animation state equals "ALL", then all animation states are reset.</string>
          </map>
@@ -26209,11 +26209,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Removes all residents from the land ban list.</string>
          </map>
@@ -26222,11 +26222,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Removes all residents from the land access/pass list.</string>
          </map>
@@ -26245,11 +26245,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the named script.</string>
          </map>
@@ -26258,11 +26258,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Resets the script.</string>
          </map>
@@ -26273,11 +26273,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the time to zero.\nSets the internal timer to zero.</string>
          </map>
@@ -26296,11 +26296,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.</string>
          </map>
@@ -26328,11 +26328,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Return objects based upon their owner and a scope of parcel, parcel owner, or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script owner owns the parcel the returned objects are in, or is an estate manager or region owner.</string>
          </map>
@@ -26387,11 +26387,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owner's InventoryItem at Position with Velocity, Rotation and with StartParameter. The last selected root object's location will be set to Position.\nCreates object's inventory item at the given Position, with Velocity, Rotation, and StartParameter.</string>
          </map>
@@ -26446,11 +26446,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owners InventoryItem at Position with Velocity, Rotation and with start StartParameter.\nCreates object's inventory item at Position with Velocity and Rotation supplied. The StartParameter value will be available to the newly created object in the on_rez event or through the llGetStartParameter function.\nThe Velocity parameter is ignored if the rezzed object is not physical.</string>
          </map>
@@ -26478,11 +26478,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>200</real>
+            <real>200.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0.1000000000000000055511151</real>
+            <real>0.1</real>
             <key>tooltip</key>
             <string>Instantiate owner's InventoryItem with the given parameters.</string>
          </map>
@@ -26501,11 +26501,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation angle represented by Rotation.\nReturns the angle represented by the Rotation.</string>
          </map>
@@ -26524,11 +26524,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation axis represented by Rotation.\nReturns the axis represented by the Rotation.</string>
          </map>
@@ -26547,11 +26547,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns the Euler Angle representation of the Rotation.</string>
          </map>
@@ -26570,11 +26570,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the forward vector defined by Rotation.\nReturns the forward axis represented by the Rotation.</string>
          </map>
@@ -26593,11 +26593,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the left vector defined by Rotation.\nReturns the left axis represented by the Rotation.</string>
          </map>
@@ -26616,11 +26616,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the up vector defined by Rotation.\nReturns the up axis represented by the Rotation.</string>
          </map>
@@ -26648,11 +26648,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>quaternion</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation needed to rotate Vector1 to Vector2.</string>
          </map>
@@ -26689,11 +26689,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Cause object to rotate to Rotation, with a force function defined by Strength and Damping parameters. Good strength values are around half the mass of the object and good damping values are less than 1/10th of the strength.\nAsymmetrical shapes require smaller damping.\nA strength of 0.0 cancels the look at.</string>
          </map>
@@ -26721,11 +26721,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set rotations with error of LeeWay radians as a rotational target, and return an ID for the rotational target.\nThe returned number is a handle that can be used in at_rot_target and llRotTargetRemove.</string>
          </map>
@@ -26744,11 +26744,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes rotational target number.\nRemove rotational target indicated by the handle.</string>
          </map>
@@ -26776,11 +26776,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the texture rotation for the specified Face to angle Radians.\nIf Face is ALL_SIDES, rotates the texture of all sides.</string>
          </map>
@@ -26799,11 +26799,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns Value rounded to the nearest integer.\nReturns the Value rounded to the nearest integer.</string>
          </map>
@@ -26822,11 +26822,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 40 hex characters that is the SHA1 security hash of text.</string>
          </map>
@@ -26845,11 +26845,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string of 64 hex characters that is the SHA256 security hash of text.</string>
          </map>
@@ -26868,11 +26868,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if avatar ID is in the same region and has the same active group, otherwise FALSE.\nReturns TRUE if the object or agent identified is in the same simulator and has the same active group as this object. Otherwise, returns FALSE.</string>
          </map>
@@ -26900,11 +26900,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Says Text on Channel.\nThis chat method has a range of 20m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -26923,11 +26923,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempts to resize the entire object by ScalingFactor, maintaining the size-position ratios of the prims.\n\nResizing is subject to prim scale limits and linkability limits. This function can not resize the object if the linkset is physical, a pathfinding character, in a keyframed motion, or if resizing would cause the parcel to overflow.\nReturns a boolean (an integer) TRUE if it succeeds, FALSE if it fails.</string>
          </map>
@@ -26964,11 +26964,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the diffuse texture Horizontal and Vertical repeats on Face of the prim the script is attached to.\nIf Face == ALL_SIDES, all sides are set in one call.\nNegative values for horizontal and vertical will flip the texture.</string>
          </map>
@@ -26987,11 +26987,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if Position is over public land, sandbox land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.\nReturns true if the position is over public land, land that doesn't allow everyone to edit and build, or land that doesn't allow outside scripts.</string>
          </map>
@@ -27010,11 +27010,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enables or disables script profiling options. Currently only supports PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly reduce script performance.</string>
          </map>
@@ -27062,11 +27062,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>3</real>
+            <real>3.0</real>
             <key>tooltip</key>
             <string>This function is deprecated.</string>
          </map>
@@ -27121,11 +27121,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\nResults are returned in the sensor and no_sensor events.</string>
          </map>
@@ -27134,11 +27134,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>removes sensor.\nRemoves the sensor set by llSensorRepeat.</string>
          </map>
@@ -27202,11 +27202,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Initiates a periodic scan every Rate seconds, for Name and ID with Type (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on that parameter. A range of 0.0 does not perform a scan.\nResults are returned in the sensor and no_sensor events.</string>
          </map>
@@ -27243,11 +27243,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets an agent's environmental values to the specified values. Must be used as part of an experience.</string>
          </map>
@@ -27275,11 +27275,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the avatar rotation to the given value.</string>
          </map>
@@ -27307,11 +27307,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value for Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value is interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is mostly transparent). This function will clamp alpha values less than 0.1 to 0.1 and greater than 1.0 to 1.</string>
          </map>
@@ -27339,11 +27339,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets an object's angular velocity to AngVel, in local coordinates if Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.</string>
          </map>
@@ -27371,11 +27371,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the animation (in object inventory) that will play for the given animation state.\nTo use this function the script must obtain the PERMISSION_OVERRIDE_ANIMATIONS permission.</string>
          </map>
@@ -27394,11 +27394,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the tasks buoyancy (0 is none, &lt; 1.0 sinks, 1.0 floats, &gt; 1.0 rises).\nSet the object buoyancy. A value of 0 is none, less than 1.0 sinks, 1.0 floats, and greater than 1.0 rises.</string>
          </map>
@@ -27417,11 +27417,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera used in this object, at offset, if an avatar sits on it.\nSets the offset that an avatar's camera will be moved to if the avatar sits on the object.</string>
          </map>
@@ -27440,11 +27440,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera eye offset used in this object if an avatar sits on it.</string>
          </map>
@@ -27463,11 +27463,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets multiple camera parameters at once. List format is [ rule-1, data-1, rule-2, data-2 . . . rule-n, data-n ].</string>
          </map>
@@ -27486,11 +27486,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the action performed when a prim is clicked upon.</string>
          </map>
@@ -27518,11 +27518,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the color, for the face.\nSets the color of the side specified. If Face is ALL_SIDES, sets the color on all faces.</string>
          </map>
@@ -27550,11 +27550,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the media type of an LSL HTTP server response to ContentType.\nHTTPRequestID must be a valid http_request ID. ContentType must be one of the CONTENT_TYPE_* constants.</string>
          </map>
@@ -27573,11 +27573,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the amount of damage that will be done to an avatar that this task hits.	Task will be killed.\nSets the amount of damage that will be done to an avatar that this object hits. This object will be destroyed on damaging an avatar, and no collision event is triggered.</string>
          </map>
@@ -27605,11 +27605,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string with the requested data about the region.</string>
          </map>
@@ -27637,11 +27637,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets Force on object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -27678,11 +27678,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the Force and Torque of object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -27701,11 +27701,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Changes terrain texture properties in the region.</string>
          </map>
@@ -27742,11 +27742,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Critically damps a physical object to a Height (either above ground level or above the higher of land and water if water == TRUE).\nDo not use with vehicles. Use llStopHover to stop hovering.</string>
          </map>
@@ -27783,13 +27783,13 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the given permission mask to the new value on the inventory item.</string>
          </map>
@@ -27817,11 +27817,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests that a non-physical object be key-framed according to key-frame list.\nSpecify a list of times, positions, and orientations to be followed by an object. The object will be smoothly moved between key-frames by the simulator. Collisions with other non-physical or key-framed objects will be ignored (no script events will fire and collision processing will not occur). Collisions with physical objects will be computed and reported, but the key-framed object will be unaffected by those collisions.\nKeyframes is a strided list containing positional, rotational, and time data for each step in the motion.  Options is a list containing optional arguments and parameters (specified by KFM_* constants).</string>
          </map>
@@ -27858,11 +27858,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If a prim exists in the link chain at LinkNumber, set Face to Opacity.\nSets the Face, on the linked prim specified, to the Opacity.</string>
          </map>
@@ -27899,11 +27899,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the camera eye offset, and the offset that camera is looking at, for avatars that sit on the linked prim.</string>
          </map>
@@ -27940,11 +27940,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If a task exists in the link chain at LinkNumber, set the Face to color.\nSets the color of the linked child's side, specified by LinkNumber.</string>
          </map>
@@ -27981,11 +27981,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets or changes GLTF Overrides set on the selected faces.</string>
          </map>
@@ -28022,11 +28022,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the media parameters for a particular face on linked prim, specified by Link. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.</string>
          </map>
@@ -28056,11 +28056,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
@@ -28088,11 +28088,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set primitive parameters for LinkNumber based on Parameters, without a delay.\nSet parameters for link number, from the list of Parameters, with no built-in script sleep. This function is identical to llSetLinkPrimitiveParams, except without the delay.</string>
          </map>
@@ -28129,11 +28129,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the Render Material of Face on a linked prim, specified by LinkNumber. Render Material may be a UUID or name of a material in prim inventory.</string>
          </map>
@@ -28161,11 +28161,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the sit flags for the specified prim in a linkset.</string>
          </map>
@@ -28202,11 +28202,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the Texture of Face on a linked prim, specified by LinkNumber. Texture may be a UUID or name of a texture in prim inventory.</string>
          </map>
@@ -28288,11 +28288,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Animates a texture on the prim specified by LinkNumber, by setting the texture scale and offset.\nMode is a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\nLength specifies the animation duration.\nRate specifies the animation playback rate.</string>
          </map>
@@ -28311,11 +28311,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Sets the rotation of a child prim relative to the root prim.</string>
          </map>
@@ -28336,11 +28336,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests Limit bytes to be reserved for this script.\nReturns TRUE or FALSE indicating whether the limit was set successfully.\nThis function has no effect if the script is running in the LSO VM.</string>
          </map>
@@ -28359,11 +28359,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the description of the prim to Description.\nThe description field is limited to 127 characters.</string>
          </map>
@@ -28382,11 +28382,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the prim's name to Name.</string>
          </map>
@@ -28414,13 +28414,13 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>god-mode</key>
             <boolean>1</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the specified PermissionFlag permission to the value specified by PermissionMask on the object the script is attached to.</string>
          </map>
@@ -28448,11 +28448,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE the parcel is put up for sale. Options is a list of options to set for the sale, such as price, authorized buyer, and whether to include objects on the parcel.\n Setting ForSale to FALSE will remove the parcel from sale and clear any options that were set.</string>
          </map>
@@ -28471,11 +28471,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>2</real>
+            <real>2.0</real>
             <key>tooltip</key>
             <string>Sets the streaming audio URL for the parcel the object is on.\nThe object must be owned by the owner of the parcel; if the parcel is group owned the object must be owned by that group.</string>
          </map>
@@ -28503,11 +28503,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the default amount when someone chooses to pay this object.\nPrice is the default price shown in the text input field.  QuickButtons specifies the 4 payment values shown in the payment dialog's buttons.\nInput field and buttons may be hidden with PAY_HIDE constant, and may be set to their default values using PAY_DEFAULT.</string>
          </map>
@@ -28562,11 +28562,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the selected parameters of the object's physics behavior.\nMaterialBits is a bitmask specifying which of the parameters in the other arguments should be applied to the object. GravityMultiplier, Restitution, Friction, and Density are the possible parameters to manipulate.</string>
          </map>
@@ -28585,11 +28585,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If the object is not physical, this function sets the position of the prim.\nIf the script is in a child prim, Position is treated as root relative and the link-set is adjusted.\nIf the prim is the root prim, the entire object is moved (up to 10m) to Position in region coordinates.</string>
          </map>
@@ -28617,11 +28617,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Sets the MediaParameters for a particular Face on the prim. Returns an integer that is a STATUS_* flag which details the success/failure of the operation(s).\nMediaParameters is a set of name/value pairs in no particular order. Parameters not specified are unchanged, or if new media is added then set to the default specified.</string>
          </map>
@@ -28642,11 +28642,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetPrimMediaParams instead.</string>
          </map>
@@ -28667,11 +28667,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetLinkPrimitiveParamsFast instead.</string>
          </map>
@@ -28690,11 +28690,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempts to move the object so that the root prim is within 0.1m of Position.\nReturns an integer boolean, TRUE if the object is successfully placed within 0.1 m of Position, FALSE otherwise.\nPosition may be any location within the region or up to 10m across a region border.\nIf the position is below ground, it will be set to the ground level at that x,y location.</string>
          </map>
@@ -28713,11 +28713,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If PIN is set to a non-zero number, the task will accept remote script loads via llRemoteLoadScriptPin() if it passes in the correct PIN. Othersise, llRemoteLoadScriptPin() is ignored.</string>
          </map>
@@ -28745,11 +28745,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Applies Render Material to Face of prim.\nRender Material may be a UUID or name of a material in prim inventory.\nIf Face is ALL_SIDES, set the render material on all faces.</string>
          </map>
@@ -28768,11 +28768,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>If the object is not physical, this function sets the rotation of the prim.\nIf the script is in a child prim, Rotation is treated as root relative and the link-set is adjusted.\nIf the prim is the root prim, the entire object is rotated to Rotation in the global reference frame.</string>
          </map>
@@ -28791,11 +28791,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the prim's scale (size) to Scale.</string>
          </map>
@@ -28823,11 +28823,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enable or disable the script Running state of Script in the prim.</string>
          </map>
@@ -28846,11 +28846,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Displays Text rather than 'Sit' in the viewer's context menu.</string>
          </map>
@@ -28869,11 +28869,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached sounds) interrupt the currently playing sound.\nThe default for objects is FALSE. Setting this value to TRUE will make the sound wait until the current playing sound reaches its end. The queue is one level deep.</string>
          </map>
@@ -28892,11 +28892,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Limits radius for audibility of scripted sounds (both attached and triggered) to distance Radius.</string>
          </map>
@@ -28924,11 +28924,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets object status specified in Status bitmask (e.g. STATUS_PHYSICS|STATUS_PHANTOM) to boolean Value.\nFor a full list of STATUS_* constants, see wiki documentation.</string>
          </map>
@@ -28965,11 +28965,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Causes Text to float above the prim, using the specified Color and Opacity.</string>
          </map>
@@ -28997,11 +28997,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0.2000000000000000111022302</real>
+            <real>0.2</real>
             <key>tooltip</key>
             <string>Applies Texture to Face of prim.\nTexture may be a UUID or name of a texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all faces.</string>
          </map>
@@ -29074,11 +29074,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Animates a texture by setting the texture scale and offset.\nMode is a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX and SizeY specify the number of horizontal and vertical frames.Start specifes the animation start point.\nLength specifies the animation duration.\nRate specifies the animation playback rate.</string>
          </map>
@@ -29099,11 +29099,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Causes the timer event to be triggered every Rate seconds.\n Passing in 0.0 stops further timer events.</string>
          </map>
@@ -29131,11 +29131,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets the Torque acting on the script's object, in object-local coordinates if Local == TRUE (otherwise, the region reference frame is used).\nOnly works on physical objects.</string>
          </map>
@@ -29154,11 +29154,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Displays Text in the viewer context menu that acts on a touch.</string>
          </map>
@@ -29177,11 +29177,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Enables the vehicle flags specified in the Flags bitmask.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -29209,11 +29209,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle float parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -29241,11 +29241,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle rotation parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -29264,11 +29264,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Activates the vehicle action on the object with vehicle preset Type.\nValid Types and an explanation of their characteristics can be found in wiki documentation.</string>
          </map>
@@ -29296,11 +29296,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Sets a vehicle vector parameter.\nValid parameters can be found in the wiki documentation.</string>
          </map>
@@ -29328,11 +29328,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If the object is physics-enabled, sets the object's linear velocity to Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector; otherwise, Velocity is treated as a global directional vector.</string>
          </map>
@@ -29360,11 +29360,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Shouts Text on Channel.\nThis chat method has a range of 100m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -29401,11 +29401,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the base64-encoded RSA signature of Message using PEM-formatted PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).</string>
          </map>
@@ -29424,11 +29424,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the sine of Theta (Theta in radians).</string>
          </map>
@@ -29456,11 +29456,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If agent identified by AvatarID is participating in the experience, sit them on the specified link's sit target.</string>
          </map>
@@ -29488,11 +29488,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Set the sit location for this object. If offset == ZERO_VECTOR, clears the sit target.</string>
          </map>
@@ -29511,11 +29511,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Put script to sleep for Time seconds.</string>
          </map>
@@ -29563,11 +29563,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and specifies whether the sound should loop and/or be enqueued.</string>
          </map>
@@ -29588,11 +29588,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers within range.</string>
          </map>
@@ -29611,11 +29611,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the square root of Value.\nTriggers a math runtime error for imaginary results (if Value &lt; 0.0).</string>
          </map>
@@ -29634,11 +29634,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function plays the specified animation from playing on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory or a built-in animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
@@ -29657,11 +29657,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function plays the specified animation on the rigged mesh object associated with the current script.\nAnimation may be an animation in task inventory or a built-in animation.\n</string>
          </map>
@@ -29680,11 +29680,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function stops the specified animation on the avatar who received the script's most recent permissions request.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\nRequires PERMISSION_TRIGGER_ANIMATION.</string>
          </map>
@@ -29693,11 +29693,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop hovering to a height (due to llSetHoverHeight()).</string>
          </map>
@@ -29706,11 +29706,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stop causing object to point at a target (due to llLookAt() or llRotLookAt()).</string>
          </map>
@@ -29719,11 +29719,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops critically damped motion (due to llMoveToTarget()).</string>
          </map>
@@ -29742,11 +29742,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function stops the specified animation on the rigged mesh object associated with the current script.\nAnimation may be an animation in task inventory, a built-in animation, or the uuid of an animation.\n</string>
          </map>
@@ -29755,11 +29755,11 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Stops playback of the currently attached sound.</string>
          </map>
@@ -29778,11 +29778,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the number of characters in Text (not counting the null).</string>
          </map>
@@ -29801,11 +29801,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the string Base64 representation of the input string.</string>
          </map>
@@ -29833,11 +29833,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Outputs a string, eliminating white-space from the start and/or end of the input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD: trim all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces in Text\nSTRING_TRIM: trim all leading and trailing spaces in Text.</string>
          </map>
@@ -29865,11 +29865,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns an integer that is the index in Text where string pattern Sequence first appears. Returns -1 if not found.</string>
          </map>
@@ -29890,11 +29890,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Use llSetCameraParams instead.</string>
          </map>
@@ -29931,11 +29931,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Take controls from the agent the script has permissions for.\nIf (Accept == (Controls &amp; input)), send input to the script.  PassOn determines whether Controls also perform their normal functions.\nRequires the PERMISSION_TAKE_CONTROLS permission to run.</string>
          </map>
@@ -29954,11 +29954,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the tangent of Theta (Theta in radians).</string>
          </map>
@@ -29986,11 +29986,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>This function is to have the script know when it has reached a position.\nIt registers a Position with a Range that triggers at_target and not_at_target events continuously until unregistered.</string>
          </map>
@@ -30027,11 +30027,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate of 0.0 cancels the spin. This function always works in object-local coordinates.</string>
          </map>
@@ -30050,11 +30050,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Removes positional target Handle registered with llTarget.</string>
          </map>
@@ -30091,11 +30091,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>20</real>
+            <real>20.0</real>
             <key>tooltip</key>
             <string>Sends an email with Subject and Message to the owner or creator of an object.</string>
          </map>
@@ -30141,11 +30141,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Requests a teleport of avatar to a landmark stored in the object's inventory. If no landmark is provided (an empty string), the avatar is teleported to the location position in the current region. In either case, the avatar is turned to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
@@ -30191,11 +30191,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Teleports an agent to the RegionPosition local coordinates within a region which is specified by the GlobalPosition global coordinates. The agent lands facing the position defined by LookAtPoint local coordinates.\nRequires the PERMISSION_TELEPORT permission. This function can only teleport the owner of the object.</string>
          </map>
@@ -30214,11 +30214,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>100</real>
+            <real>100.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>5</real>
+            <real>5.0</real>
             <key>tooltip</key>
             <string>Teleport agent over the owner's land to agent's home location.</string>
          </map>
@@ -30255,11 +30255,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>1</real>
+            <real>1.0</real>
             <key>tooltip</key>
             <string>Opens a dialog for the specified avatar with message Text, which contains a text box for input. Any text that is entered is said on the specified Channel (as if by the avatar) when the "OK" button is clicked.</string>
          </map>
@@ -30278,11 +30278,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is Text with all lower-case characters.</string>
          </map>
@@ -30301,11 +30301,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns a string that is Text with all upper-case characters.</string>
          </map>
@@ -30333,11 +30333,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfer Amount of linden dollars (L$) from script owner to AvatarID. Returns a key to a corresponding transaction_result event for the success of the transfer.\nAttempts to send the amount of money to the specified avatar, and trigger a transaction_result event identified by the returned key.</string>
          </map>
@@ -30374,11 +30374,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Transfers ownership of an object, or a copy of the object to a new agent.</string>
          </map>
@@ -30406,11 +30406,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object.\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.</string>
          </map>
@@ -30456,11 +30456,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object, limited to axis-aligned bounding box defined by vectors top-north-east (TNE) and bottom-south-west (BSW).\nThere is no limit to the number of triggered sounds which can be generated by an object, and calling llTriggerSound does not affect the attached sounds created by llPlaySound and llLoopSound. This is very useful for things like collision noises, explosions, etc. There is no way to stop or alter the volume of a sound triggered by this function.</string>
          </map>
@@ -30479,11 +30479,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If agent identified by AvatarID is sitting on the object the script is attached to or is over land owned by the object's owner, the agent is forced to stand up.</string>
          </map>
@@ -30502,11 +30502,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the string that is the URL unescaped, replacing "%20" with spaces, etc., version of URL.\nThis function can output raw UTF-8 strings.</string>
          </map>
@@ -30525,11 +30525,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Updates settings for a pathfinding character.</string>
          </map>
@@ -30575,11 +30575,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>uuid</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>
                    Starts an asychronous transaction to update the value associated with the key given. The dataserver callback will be executed with the key returned from this call and a string describing the result. The result is a two element commma-delimited list. The first item is an integer specifying if the transaction succeeded (1) or not (0). In the failure case, the second item will be an integer corresponding to one of the XP_ERROR_... constants. In the success case the second item will be the value associated with the key. If Checked is 1 the existing value in the data store must match the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked is 0 the key will be created if necessary.
@@ -30609,11 +30609,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the distance between Location1 and Location2.</string>
          </map>
@@ -30632,11 +30632,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the magnitude of the vector.</string>
          </map>
@@ -30655,11 +30655,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns normalized vector.</string>
          </map>
@@ -30705,11 +30705,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>boolean</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns TRUE if PublicKey, Message, and Algorithm produce the same base64-formatted Signature.</string>
          </map>
@@ -30728,11 +30728,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>If DetectEnabled = TRUE, object becomes phantom but triggers collision_start and collision_end events when other objects start and stop interpenetrating.\nIf another object (including avatars) interpenetrates it, it will get a collision_start event.\nWhen an object stops interpenetrating, a collision_end event is generated. While the other is inter-penetrating, collision events are NOT generated.</string>
          </map>
@@ -30769,11 +30769,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Wander within a specified volume.\nSets a character to wander about a central spot within a specified area.</string>
          </map>
@@ -30792,11 +30792,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>number</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the water height below the object position + Offset.</string>
          </map>
@@ -30824,11 +30824,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Whispers Text on Channel.\nThis chat method has a range of 10m radius.\nPUBLIC_CHANNEL is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL is the script debug channel, and is also visible to nearby avatars. All other channels are are not sent to avatars, but may be used to communicate with scripts.</string>
          </map>
@@ -30847,11 +30847,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the wind velocity at the object position + Offset.</string>
          </map>
@@ -30870,11 +30870,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Returns the local position that would put the origin of a HUD object directly over world_pos as viewed by the current camera.</string>
          </map>
@@ -30902,11 +30902,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.</string>
          </map>
@@ -30936,11 +30936,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0.2999999999999999888977698</real>
+            <real>0.3</real>
             <key>tooltip</key>
             <string>Deprecated: Please use llXorBase64 instead.\nIncorrectly performs an exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats if it is shorter than Text1.\nRetained for backwards compatibility.</string>
          </map>
@@ -30970,11 +30970,11 @@ Returns true if result is non-zero.</string>
             <key>deprecated</key>
             <boolean>1</boolean>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>string</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls are present) performs an exclusive OR on two Base64 strings and returns a Base64 string.\nText2 repeats if it is shorter than Text1.</string>
          </map>
@@ -30993,11 +30993,11 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>energy</key>
-            <real>10</real>
+            <real>10.0</real>
             <key>return</key>
             <string>vector</string>
             <key>sleep</key>
-            <real>0</real>
+            <real>0.0</real>
             <key>tooltip</key>
             <string>Converts a color from the sRGB to the linear colorspace.</string>
          </map>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -868,7 +868,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_LPEC</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)</string>
             <key>type</key>
@@ -1032,7 +1032,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_RPEC</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)</string>
             <key>type</key>
@@ -5291,7 +5291,7 @@ export type rotation = quaternion</string>
          <key>PRIM_CAST_SHADOWS</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -7195,7 +7195,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_CHANNEL</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -7206,7 +7206,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_REPLY</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -7217,7 +7217,7 @@ vector position - position in local coordinates
          <key>REMOTE_DATA_REQUEST</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string />
             <key>type</key>
@@ -8993,7 +8993,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_NO_FLY_UP</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Old, changed to VEHICLE_FLAG_NO_DEFLECTION_UP</string>
             <key>type</key>
@@ -10228,7 +10228,7 @@ vector position - position in local coordinates
          <key>remote_data</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>arguments</key>
             <array>
                <map>
@@ -10328,7 +10328,7 @@ vector position - position in local coordinates
          <key>timer</key>
          <map>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>arguments</key>
             <array />
             <key>tooltip</key>
@@ -15332,7 +15332,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15371,7 +15371,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -15424,7 +15424,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -16607,7 +16607,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17269,7 +17269,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17294,7 +17294,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17392,7 +17392,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17786,7 +17786,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17811,7 +17811,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17836,7 +17836,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17861,7 +17861,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17886,7 +17886,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17911,7 +17911,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17936,7 +17936,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17961,7 +17961,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17986,7 +17986,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18011,7 +18011,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18036,7 +18036,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18061,7 +18061,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18086,7 +18086,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18111,7 +18111,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18136,7 +18136,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18161,7 +18161,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18186,7 +18186,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18211,7 +18211,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18926,7 +18926,7 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21681,7 +21681,7 @@ Returns true if result is non-zero.</string>
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
@@ -24173,7 +24173,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24252,7 +24252,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24349,7 +24349,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24428,7 +24428,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24872,7 +24872,7 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -25420,7 +25420,7 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -25518,7 +25518,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -25606,7 +25606,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -25621,7 +25621,7 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26271,7 +26271,7 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array />
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -27060,7 +27060,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -27785,7 +27785,7 @@ Returns true if result is non-zero.</string>
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
@@ -28054,7 +28054,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -28334,7 +28334,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -28416,7 +28416,7 @@ Returns true if result is non-zero.</string>
             <key>energy</key>
             <real>10.0</real>
             <key>god-mode</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>return</key>
             <string>()</string>
             <key>sleep</key>
@@ -28640,7 +28640,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -28665,7 +28665,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29097,7 +29097,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29561,7 +29561,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29586,7 +29586,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29888,7 +29888,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -30934,7 +30934,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -30968,7 +30968,7 @@ Returns true if result is non-zero.</string>
                </map>
             </array>
             <key>deprecated</key>
-            <boolean>1</boolean>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -364,7 +364,7 @@ export type rotation = quaternion</string>
          <key>AGENT_ALWAYS_RUN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -391,7 +391,7 @@ export type rotation = quaternion</string>
          <key>AGENT_AUTOPILOT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -400,7 +400,7 @@ export type rotation = quaternion</string>
          <key>AGENT_AWAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -409,7 +409,7 @@ export type rotation = quaternion</string>
          <key>AGENT_BUSY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -418,7 +418,7 @@ export type rotation = quaternion</string>
          <key>AGENT_BY_LEGACY_NAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -427,7 +427,7 @@ export type rotation = quaternion</string>
          <key>AGENT_BY_USERNAME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -436,7 +436,7 @@ export type rotation = quaternion</string>
          <key>AGENT_CROUCHING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -463,7 +463,7 @@ export type rotation = quaternion</string>
          <key>AGENT_IN_AIR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -499,7 +499,7 @@ export type rotation = quaternion</string>
          <key>AGENT_MOUSELOOK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -508,7 +508,7 @@ export type rotation = quaternion</string>
          <key>AGENT_ON_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -526,7 +526,7 @@ export type rotation = quaternion</string>
          <key>AGENT_SITTING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -535,7 +535,7 @@ export type rotation = quaternion</string>
          <key>AGENT_TYPING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -544,7 +544,7 @@ export type rotation = quaternion</string>
          <key>AGENT_WALKING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -553,7 +553,7 @@ export type rotation = quaternion</string>
          <key>ALL_SIDES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -715,7 +715,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_BOTTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -724,7 +724,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_BOTTOM_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -733,7 +733,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_BOTTOM_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -742,7 +742,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_CENTER_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -751,7 +751,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_CENTER_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -760,7 +760,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_TOP_CENTER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -769,7 +769,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_TOP_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -778,7 +778,7 @@ export type rotation = quaternion</string>
          <key>ATTACH_HUD_TOP_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1097,7 +1097,7 @@ export type rotation = quaternion</string>
          <key>AVOID_CHARACTERS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1106,7 +1106,7 @@ export type rotation = quaternion</string>
          <key>AVOID_DYNAMIC_OBSTACLES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1115,7 +1115,7 @@ export type rotation = quaternion</string>
          <key>AVOID_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1133,7 +1133,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_ACTIVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1142,7 +1142,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_BEHINDNESS_ANGLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1151,7 +1151,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_BEHINDNESS_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1160,7 +1160,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_DISTANCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1169,7 +1169,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_FOCUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1178,7 +1178,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_FOCUS_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1187,7 +1187,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_FOCUS_LOCKED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1196,7 +1196,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_FOCUS_OFFSET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1205,7 +1205,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_FOCUS_THRESHOLD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1214,7 +1214,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_PITCH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1223,7 +1223,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_POSITION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1232,7 +1232,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_POSITION_LAG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1241,7 +1241,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_POSITION_LOCKED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1250,7 +1250,7 @@ export type rotation = quaternion</string>
          <key>CAMERA_POSITION_THRESHOLD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1295,7 +1295,7 @@ export type rotation = quaternion</string>
          <key>CHANGED_MEDIA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1403,7 +1403,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_CMD_SMOOTH_STOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1520,7 +1520,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_TYPE_A</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1529,7 +1529,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_TYPE_B</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1538,7 +1538,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_TYPE_C</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1547,7 +1547,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_TYPE_D</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1556,7 +1556,7 @@ export type rotation = quaternion</string>
          <key>CHARACTER_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -1898,7 +1898,7 @@ export type rotation = quaternion</string>
          <key>DAMAGE_TYPE_EMOTIONAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2033,7 +2033,7 @@ export type rotation = quaternion</string>
          <key>DATA_PAYINFO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2057,7 +2057,7 @@ export type rotation = quaternion</string>
          <key>DATA_SIM_POS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2066,7 +2066,7 @@ export type rotation = quaternion</string>
          <key>DATA_SIM_RATING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2075,7 +2075,7 @@ export type rotation = quaternion</string>
          <key>DATA_SIM_STATUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2238,7 +2238,7 @@ export type rotation = quaternion</string>
          <key>ERR_GENERIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2247,7 +2247,7 @@ export type rotation = quaternion</string>
          <key>ERR_MALFORMED_PARAMS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2256,7 +2256,7 @@ export type rotation = quaternion</string>
          <key>ERR_PARCEL_PERMISSIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2265,7 +2265,7 @@ export type rotation = quaternion</string>
          <key>ERR_RUNTIME_PERMISSIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2274,7 +2274,7 @@ export type rotation = quaternion</string>
          <key>ERR_THROTTLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2382,7 +2382,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_LEFTX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2391,7 +2391,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_LEFTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2400,7 +2400,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_RIGHTX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2409,7 +2409,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_RIGHTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2418,7 +2418,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_TRIGGERLEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2427,7 +2427,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_AXIS_TRIGGERRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2436,7 +2436,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_A</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2445,7 +2445,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_B</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2454,7 +2454,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_BACK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2463,7 +2463,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_DPAD_DOWN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2472,7 +2472,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_DPAD_LEFT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2481,7 +2481,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_DPAD_RIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2490,7 +2490,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_DPAD_UP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2499,7 +2499,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_GUIDE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2508,7 +2508,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_LEFTSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2517,7 +2517,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_LEFTSTICK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2526,7 +2526,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_MISC1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2535,7 +2535,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_PADDLE1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2544,7 +2544,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_PADDLE2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2553,7 +2553,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_PADDLE3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2562,7 +2562,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_PADDLE4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2571,7 +2571,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_RIGHTSHOULDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2580,7 +2580,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_RIGHTSTICK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2589,7 +2589,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_START</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2598,7 +2598,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_TOUCHPAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2607,7 +2607,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_X</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2616,7 +2616,7 @@ export type rotation = quaternion</string>
          <key>GAME_CONTROL_BUTTON_Y</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2625,7 +2625,7 @@ export type rotation = quaternion</string>
          <key>GCNP_RADIUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2634,7 +2634,7 @@ export type rotation = quaternion</string>
          <key>GCNP_STATIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2652,7 +2652,7 @@ export type rotation = quaternion</string>
          <key>HORIZONTAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2671,7 +2671,7 @@ export type rotation = quaternion</string>
          <key>HTTP_BODY_MAXLENGTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2680,7 +2680,7 @@ export type rotation = quaternion</string>
          <key>HTTP_BODY_TRUNCATED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2707,7 +2707,7 @@ export type rotation = quaternion</string>
          <key>HTTP_METHOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2716,7 +2716,7 @@ export type rotation = quaternion</string>
          <key>HTTP_MIMETYPE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2744,7 +2744,7 @@ export type rotation = quaternion</string>
          <key>HTTP_VERBOSE_THROTTLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2753,7 +2753,7 @@ export type rotation = quaternion</string>
          <key>HTTP_VERIFY_CERT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2762,7 +2762,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_AUX1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2771,7 +2771,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_AUX2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2780,7 +2780,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_AUX3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2789,7 +2789,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_EYES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2798,7 +2798,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_HAIR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2807,7 +2807,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2816,7 +2816,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_LEFTARM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2825,7 +2825,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_LEFTLEG</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2834,7 +2834,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_LOWER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2843,7 +2843,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_SKIRT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2852,7 +2852,7 @@ export type rotation = quaternion</string>
          <key>IMG_USE_BAKED_UPPER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -2861,7 +2861,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_ALL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2870,7 +2870,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_ANIMATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2879,7 +2879,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_BODYPART</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2888,7 +2888,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_CLOTHING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2897,7 +2897,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_GESTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2906,7 +2906,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_LANDMARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2915,7 +2915,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_MATERIAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2924,7 +2924,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2933,7 +2933,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_NOTECARD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2942,7 +2942,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2951,7 +2951,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_SCRIPT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2960,7 +2960,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_SETTING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2969,7 +2969,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_SOUND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2978,7 +2978,7 @@ export type rotation = quaternion</string>
          <key>INVENTORY_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2987,7 +2987,7 @@ export type rotation = quaternion</string>
          <key>JSON_APPEND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -2996,7 +2996,7 @@ export type rotation = quaternion</string>
          <key>JSON_ARRAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3005,7 +3005,7 @@ export type rotation = quaternion</string>
          <key>JSON_DELETE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3014,7 +3014,7 @@ export type rotation = quaternion</string>
          <key>JSON_FALSE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3023,7 +3023,7 @@ export type rotation = quaternion</string>
          <key>JSON_INVALID</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3032,7 +3032,7 @@ export type rotation = quaternion</string>
          <key>JSON_NULL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3041,7 +3041,7 @@ export type rotation = quaternion</string>
          <key>JSON_NUMBER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3050,7 +3050,7 @@ export type rotation = quaternion</string>
          <key>JSON_OBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3059,7 +3059,7 @@ export type rotation = quaternion</string>
          <key>JSON_STRING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3068,7 +3068,7 @@ export type rotation = quaternion</string>
          <key>JSON_TRUE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -3104,7 +3104,7 @@ export type rotation = quaternion</string>
          <key>KFM_COMMAND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3113,7 +3113,7 @@ export type rotation = quaternion</string>
          <key>KFM_DATA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3140,7 +3140,7 @@ export type rotation = quaternion</string>
          <key>KFM_MODE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3221,7 +3221,7 @@ export type rotation = quaternion</string>
          <key>LAND_NOISE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3239,7 +3239,7 @@ export type rotation = quaternion</string>
          <key>LAND_REVERT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3257,7 +3257,7 @@ export type rotation = quaternion</string>
          <key>LAND_SMOOTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3401,7 +3401,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_GEOMETRIC_MEAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3410,7 +3410,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_MAX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3419,7 +3419,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_MEAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3428,7 +3428,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_MEDIAN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3437,7 +3437,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_MIN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3446,7 +3446,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_NUM_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3455,7 +3455,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_RANGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3464,7 +3464,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_STD_DEV</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3473,7 +3473,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_SUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3482,7 +3482,7 @@ export type rotation = quaternion</string>
          <key>LIST_STAT_SUM_SQUARES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3500,7 +3500,7 @@ export type rotation = quaternion</string>
          <key>MASK_BASE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3518,7 +3518,7 @@ export type rotation = quaternion</string>
          <key>MASK_EVERYONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3527,7 +3527,7 @@ export type rotation = quaternion</string>
          <key>MASK_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3536,7 +3536,7 @@ export type rotation = quaternion</string>
          <key>MASK_NEXT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3545,7 +3545,7 @@ export type rotation = quaternion</string>
          <key>MASK_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3563,7 +3563,7 @@ export type rotation = quaternion</string>
          <key>NULL_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -3833,7 +3833,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_PHYSICS_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3860,7 +3860,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_PRIM_EQUIVALENCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3878,7 +3878,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_RETURN_PARCEL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3887,7 +3887,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_RETURN_PARCEL_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3896,7 +3896,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_RETURN_REGION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3905,7 +3905,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_REZZER_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3941,7 +3941,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_RUNNING_SCRIPT_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3959,7 +3959,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_SCRIPT_MEMORY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3968,7 +3968,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_SCRIPT_TIME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -3986,7 +3986,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_SERVER_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4004,7 +4004,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_STREAMING_COST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4067,7 +4067,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_TOTAL_SCRIPT_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4076,7 +4076,7 @@ export type rotation = quaternion</string>
          <key>OBJECT_UNKNOWN_DETAIL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4166,7 +4166,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_BASE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4175,7 +4175,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_BASE_ALPHA_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4184,7 +4184,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_BASE_ALPHA_MODE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4193,7 +4193,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_BASE_COLOR_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4202,7 +4202,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_BASE_DOUBLE_SIDED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4211,7 +4211,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_EMISSIVE_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4220,7 +4220,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_METALLIC_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4229,7 +4229,7 @@ export type rotation = quaternion</string>
          <key>OVERRIDE_GLTF_ROUGHNESS_FACTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4238,7 +4238,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4247,7 +4247,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_OTHER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4256,7 +4256,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4265,7 +4265,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_SELECTED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4274,7 +4274,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_TEMP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4283,7 +4283,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_COUNT_TOTAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4418,7 +4418,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4427,7 +4427,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4436,7 +4436,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_CREATE_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4445,7 +4445,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_DAMAGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4454,7 +4454,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_FLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4463,7 +4463,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4472,7 +4472,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_GROUP_SCRIPTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4481,7 +4481,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_LANDMARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4490,7 +4490,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_SCRIPTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4499,7 +4499,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_ALLOW_TERRAFORM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4508,7 +4508,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_LOCAL_SOUND_ONLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4517,7 +4517,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_RESTRICT_PUSHOBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4526,7 +4526,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_USE_ACCESS_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4535,7 +4535,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_USE_ACCESS_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4544,7 +4544,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_USE_BAN_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4553,7 +4553,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_FLAG_USE_LAND_PASS_LIST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4562,7 +4562,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_AGENT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4571,7 +4571,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_AUTO_ALIGN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4589,7 +4589,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_LOOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4607,7 +4607,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_PAUSE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4616,7 +4616,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_PLAY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4634,7 +4634,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_STOP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4643,7 +4643,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_TEXTURE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4652,7 +4652,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_TIME</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4670,7 +4670,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_UNLOAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4679,7 +4679,7 @@ export type rotation = quaternion</string>
          <key>PARCEL_MEDIA_COMMAND_URL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4805,7 +4805,7 @@ export type rotation = quaternion</string>
          <key>PATROL_PAUSE_AT_WAYPOINTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4814,7 +4814,7 @@ export type rotation = quaternion</string>
          <key>PAYMENT_INFO_ON_FILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4823,7 +4823,7 @@ export type rotation = quaternion</string>
          <key>PAYMENT_INFO_USED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4832,7 +4832,7 @@ export type rotation = quaternion</string>
          <key>PAY_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4841,7 +4841,7 @@ export type rotation = quaternion</string>
          <key>PAY_HIDE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4886,7 +4886,7 @@ export type rotation = quaternion</string>
          <key>PERMISSION_CONTROL_CAMERA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4940,7 +4940,7 @@ export type rotation = quaternion</string>
          <key>PERMISSION_RETURN_OBJECTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4967,7 +4967,7 @@ export type rotation = quaternion</string>
          <key>PERMISSION_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4976,7 +4976,7 @@ export type rotation = quaternion</string>
          <key>PERMISSION_TRACK_CAMERA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -4994,7 +4994,7 @@ export type rotation = quaternion</string>
          <key>PERM_ALL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5003,7 +5003,7 @@ export type rotation = quaternion</string>
          <key>PERM_COPY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5012,7 +5012,7 @@ export type rotation = quaternion</string>
          <key>PERM_MODIFY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5021,7 +5021,7 @@ export type rotation = quaternion</string>
          <key>PERM_MOVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5030,7 +5030,7 @@ export type rotation = quaternion</string>
          <key>PERM_TRANSFER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5120,7 +5120,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_BARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5129,7 +5129,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_BLOBS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5138,7 +5138,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_BRICKS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5147,7 +5147,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_BRIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5156,7 +5156,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_CHECKER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5165,7 +5165,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_CONCRETE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5174,7 +5174,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_DARK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5183,7 +5183,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_DISKS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5192,7 +5192,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_GRAVEL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5201,7 +5201,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_LARGETILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5210,7 +5210,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5219,7 +5219,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_SHINY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5228,7 +5228,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_SIDING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5237,7 +5237,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_STONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5246,7 +5246,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_STUCCO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5255,7 +5255,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_SUCTION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5264,7 +5264,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_TILE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5273,7 +5273,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_WEAVE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5282,7 +5282,7 @@ export type rotation = quaternion</string>
          <key>PRIM_BUMP_WOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5293,7 +5293,7 @@ export type rotation = quaternion</string>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5460,7 +5460,7 @@ vector force
          <key>PRIM_HOLE_CIRCLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5469,7 +5469,7 @@ vector force
          <key>PRIM_HOLE_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5478,7 +5478,7 @@ vector force
          <key>PRIM_HOLE_SQUARE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5487,7 +5487,7 @@ vector force
          <key>PRIM_HOLE_TRIANGLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5517,7 +5517,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_FLESH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5526,7 +5526,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_GLASS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5535,7 +5535,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_LIGHT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5544,7 +5544,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_METAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5553,7 +5553,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_PLASTIC</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5562,7 +5562,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_RUBBER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5571,7 +5571,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_STONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5580,7 +5580,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MATERIAL_WOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5697,7 +5697,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_HEIGHT_PIXELS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5706,7 +5706,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_URL_LENGTH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5715,7 +5715,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WHITELIST_COUNT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5724,7 +5724,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WHITELIST_SIZE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5733,7 +5733,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_MAX_WIDTH_PIXELS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5742,7 +5742,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PARAM_MAX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5769,7 +5769,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_ANYONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5778,7 +5778,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_GROUP</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5787,7 +5787,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -5796,7 +5796,7 @@ Used to get or set multiple links with a single PrimParameters call.
          <key>PRIM_MEDIA_PERM_OWNER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6067,7 +6067,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_CYLINDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6076,7 +6076,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6085,7 +6085,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_MESH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6094,7 +6094,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_PLANE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6103,7 +6103,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_SPHERE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6112,7 +6112,7 @@ vector position - position in local coordinates
          <key>PRIM_SCULPT_TYPE_TORUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6121,7 +6121,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_HIGH</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6130,7 +6130,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_LOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6139,7 +6139,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_MEDIUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6148,7 +6148,7 @@ vector position - position in local coordinates
          <key>PRIM_SHINY_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6157,7 +6157,7 @@ vector position - position in local coordinates
          <key>PRIM_SIT_FLAGS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6202,7 +6202,7 @@ vector position - position in local coordinates
          <key>PRIM_TEMP_ON_REZ</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6220,7 +6220,7 @@ vector position - position in local coordinates
          <key>PRIM_TEXGEN_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6229,7 +6229,7 @@ vector position - position in local coordinates
          <key>PRIM_TEXGEN_PLANAR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6256,7 +6256,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6265,7 +6265,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_BOX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6274,7 +6274,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_CYLINDER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6283,7 +6283,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_PRISM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6292,7 +6292,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_RING</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6301,7 +6301,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_SCULPT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6310,7 +6310,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_SPHERE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6319,7 +6319,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_TORUS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6328,7 +6328,7 @@ vector position - position in local coordinates
          <key>PRIM_TYPE_TUBE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6355,7 +6355,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_DEST_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6364,7 +6364,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6373,7 +6373,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_DEST_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6382,7 +6382,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6391,7 +6391,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6400,7 +6400,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_SOURCE_ALPHA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6409,7 +6409,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_SOURCE_COLOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6418,7 +6418,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BF_ZERO</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6427,7 +6427,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BLEND_FUNC_DEST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6436,7 +6436,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_BLEND_FUNC_SOURCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6481,7 +6481,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_END_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6553,7 +6553,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_RIBBON_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6580,7 +6580,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_START_GLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6598,7 +6598,7 @@ vector position - position in local coordinates
          <key>PSYS_PART_TARGET_LINEAR_MASK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6763,7 +6763,7 @@ vector position - position in local coordinates
          <key>PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6826,7 +6826,7 @@ vector position - position in local coordinates
          <key>PURSUIT_GOAL_TOLERANCE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6871,7 +6871,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6916,7 +6916,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_OTHER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6925,7 +6925,7 @@ vector position - position in local coordinates
          <key>PU_FAILURE_PARCEL_UNREACHABLE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6979,7 +6979,7 @@ vector position - position in local coordinates
          <key>RCERR_CAST_TIME_EXCEEDED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6988,7 +6988,7 @@ vector position - position in local coordinates
          <key>RCERR_SIM_PERF_LOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -6997,7 +6997,7 @@ vector position - position in local coordinates
          <key>RCERR_UNKNOWN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7006,7 +7006,7 @@ vector position - position in local coordinates
          <key>RC_DATA_FLAGS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7015,7 +7015,7 @@ vector position - position in local coordinates
          <key>RC_DETECT_PHANTOM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7024,7 +7024,7 @@ vector position - position in local coordinates
          <key>RC_GET_LINK_NUM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7033,7 +7033,7 @@ vector position - position in local coordinates
          <key>RC_GET_NORMAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7042,7 +7042,7 @@ vector position - position in local coordinates
          <key>RC_GET_ROOT_KEY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7051,7 +7051,7 @@ vector position - position in local coordinates
          <key>RC_MAX_HITS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7060,7 +7060,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_AGENTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7069,7 +7069,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_LAND</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7078,7 +7078,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_NONPHYSICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7087,7 +7087,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_PHYSICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7096,7 +7096,7 @@ vector position - position in local coordinates
          <key>RC_REJECT_TYPES</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7105,7 +7105,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_ALLOW_DAMAGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7114,7 +7114,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_ALLOW_DIRECT_TELEPORT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7123,7 +7123,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_FLY</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7132,7 +7132,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_FLYOVER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7141,7 +7141,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_BLOCK_TERRAFORM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7150,7 +7150,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_DISABLE_COLLISIONS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7159,7 +7159,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_DISABLE_PHYSICS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7168,7 +7168,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_FIXED_SUN</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7177,7 +7177,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_RESTRICT_PUSHOBJECT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7186,7 +7186,7 @@ vector position - position in local coordinates
          <key>REGION_FLAG_SANDBOX</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7197,7 +7197,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7208,7 +7208,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -7219,7 +7219,7 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8074,7 +8074,7 @@ vector position - position in local coordinates
          <key>STATUS_CAST_SHADOWS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8164,7 +8164,7 @@ vector position - position in local coordinates
          <key>STATUS_RETURN_AT_EDGE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8173,7 +8173,7 @@ vector position - position in local coordinates
          <key>STATUS_ROTATE_X</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8182,7 +8182,7 @@ vector position - position in local coordinates
          <key>STATUS_ROTATE_Y</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8236,7 +8236,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8245,7 +8245,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM_HEAD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8254,7 +8254,7 @@ vector position - position in local coordinates
          <key>STRING_TRIM_TAIL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8281,7 +8281,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8290,7 +8290,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8299,7 +8299,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8308,7 +8308,7 @@ vector position - position in local coordinates
          <key>TERRAIN_DETAIL_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8317,7 +8317,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_NE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8326,7 +8326,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_NW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8335,7 +8335,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_SE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8344,7 +8344,7 @@ vector position - position in local coordinates
          <key>TERRAIN_HEIGHT_RANGE_SW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8353,7 +8353,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8362,7 +8362,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8371,7 +8371,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8380,7 +8380,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_OFFSET_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8389,7 +8389,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8398,7 +8398,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8407,7 +8407,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8416,7 +8416,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_ROTATION_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8425,7 +8425,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_1</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8434,7 +8434,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_2</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8443,7 +8443,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_3</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8452,7 +8452,7 @@ vector position - position in local coordinates
          <key>TERRAIN_PBR_SCALE_4</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8461,7 +8461,7 @@ vector position - position in local coordinates
          <key>TEXTURE_BLANK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -8470,7 +8470,7 @@ vector position - position in local coordinates
          <key>TEXTURE_DEFAULT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -8479,7 +8479,7 @@ vector position - position in local coordinates
          <key>TEXTURE_MEDIA</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -8488,7 +8488,7 @@ vector position - position in local coordinates
          <key>TEXTURE_PLYWOOD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -8497,7 +8497,7 @@ vector position - position in local coordinates
          <key>TEXTURE_TRANSPARENT</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>uuid</string>
             <key>value</key>
@@ -8506,7 +8506,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_FACE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8515,7 +8515,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_TEXCOORD</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -8524,7 +8524,7 @@ vector position - position in local coordinates
          <key>TOUCH_INVALID_VECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -8686,7 +8686,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_FAST</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8695,7 +8695,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8704,7 +8704,7 @@ vector position - position in local coordinates
          <key>TRAVERSAL_TYPE_SLOW</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8785,7 +8785,7 @@ vector position - position in local coordinates
          <key>URL_REQUEST_DENIED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8794,7 +8794,7 @@ vector position - position in local coordinates
          <key>URL_REQUEST_GRANTED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>string</string>
             <key>value</key>
@@ -8903,7 +8903,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_CAMERA_DECOUPLED</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8966,7 +8966,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_MOUSELOOK_BANK</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -8975,7 +8975,7 @@ vector position - position in local coordinates
          <key>VEHICLE_FLAG_MOUSELOOK_STEER</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -9078,7 +9078,7 @@ vector position - position in local coordinates
          <key>VEHICLE_LINEAR_MOTOR_OFFSET</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -9141,7 +9141,7 @@ vector position - position in local coordinates
          <key>VEHICLE_TYPE_NONE</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -9177,7 +9177,7 @@ vector position - position in local coordinates
          <key>VERTICAL</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -9186,7 +9186,7 @@ vector position - position in local coordinates
          <key>WANDER_PAUSE_AT_WAYPOINTS</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>number</string>
             <key>value</key>
@@ -9438,7 +9438,7 @@ vector position - position in local coordinates
          <key>ZERO_ROTATION</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>quaternion</string>
             <key>value</key>
@@ -9447,7 +9447,7 @@ vector position - position in local coordinates
          <key>ZERO_VECTOR</key>
          <map>
             <key>tooltip</key>
-            <string />
+            <string></string>
             <key>type</key>
             <string>vector</string>
             <key>value</key>
@@ -9464,7 +9464,7 @@ vector position - position in local coordinates
                   <key>TargetNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9473,7 +9473,7 @@ vector position - position in local coordinates
                   <key>TargetRotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -9482,7 +9482,7 @@ vector position - position in local coordinates
                   <key>CurrentRotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -9499,7 +9499,7 @@ vector position - position in local coordinates
                   <key>TargetNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9508,7 +9508,7 @@ vector position - position in local coordinates
                   <key>TargetPosition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9517,7 +9517,7 @@ vector position - position in local coordinates
                   <key>CurrentPosition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9534,7 +9534,7 @@ vector position - position in local coordinates
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -9551,7 +9551,7 @@ vector position - position in local coordinates
                   <key>Changed</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9622,7 +9622,7 @@ vector position - position in local coordinates
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -9631,7 +9631,7 @@ vector position - position in local coordinates
                   <key>Levels</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9640,7 +9640,7 @@ vector position - position in local coordinates
                   <key>Edges</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9658,7 +9658,7 @@ vector position - position in local coordinates
                   <key>RequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -9667,7 +9667,7 @@ vector position - position in local coordinates
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9685,7 +9685,7 @@ vector position - position in local coordinates
                   <key>Time</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9694,7 +9694,7 @@ vector position - position in local coordinates
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9703,7 +9703,7 @@ vector position - position in local coordinates
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9712,7 +9712,7 @@ vector position - position in local coordinates
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9721,7 +9721,7 @@ vector position - position in local coordinates
                   <key>NumberRemaining</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9834,7 +9834,7 @@ vector position - position in local coordinates
                   <key>HTTPRequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -9843,7 +9843,7 @@ vector position - position in local coordinates
                   <key>HTTPMethod</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9852,7 +9852,7 @@ vector position - position in local coordinates
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9869,7 +9869,7 @@ vector position - position in local coordinates
                   <key>HTTPRequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -9878,7 +9878,7 @@ vector position - position in local coordinates
                   <key>Status</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9887,7 +9887,7 @@ vector position - position in local coordinates
                   <key>Metadata</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -9896,7 +9896,7 @@ vector position - position in local coordinates
                   <key>Body</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9913,7 +9913,7 @@ vector position - position in local coordinates
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9930,7 +9930,7 @@ vector position - position in local coordinates
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9947,7 +9947,7 @@ vector position - position in local coordinates
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -9964,7 +9964,7 @@ vector position - position in local coordinates
                   <key>SendersLink</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9973,7 +9973,7 @@ vector position - position in local coordinates
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -9982,7 +9982,7 @@ vector position - position in local coordinates
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -9991,7 +9991,7 @@ vector position - position in local coordinates
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10008,7 +10008,7 @@ vector position - position in local coordinates
                   <key>action</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10017,7 +10017,7 @@ vector position - position in local coordinates
                   <key>name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10026,7 +10026,7 @@ vector position - position in local coordinates
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10043,7 +10043,7 @@ vector position - position in local coordinates
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10052,7 +10052,7 @@ vector position - position in local coordinates
                   <key>Name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10061,7 +10061,7 @@ vector position - position in local coordinates
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10070,7 +10070,7 @@ vector position - position in local coordinates
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10088,7 +10088,7 @@ vector position - position in local coordinates
                   <key>Payer</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10097,7 +10097,7 @@ vector position - position in local coordinates
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10149,7 +10149,7 @@ vector position - position in local coordinates
                   <key>RezzedObjectsID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10190,7 +10190,7 @@ vector position - position in local coordinates
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10207,7 +10207,7 @@ vector position - position in local coordinates
                   <key>Type</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10216,7 +10216,7 @@ vector position - position in local coordinates
                   <key>Reserved</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -10235,7 +10235,7 @@ vector position - position in local coordinates
                   <key>EventType</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10244,7 +10244,7 @@ vector position - position in local coordinates
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10253,7 +10253,7 @@ vector position - position in local coordinates
                   <key>MessageID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10262,7 +10262,7 @@ vector position - position in local coordinates
                   <key>Sender</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10271,7 +10271,7 @@ vector position - position in local coordinates
                   <key>IData</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10280,7 +10280,7 @@ vector position - position in local coordinates
                   <key>SData</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -10297,7 +10297,7 @@ vector position - position in local coordinates
                   <key>PermissionFlags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10397,7 +10397,7 @@ vector position - position in local coordinates
                   <key>RequestID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -10406,7 +10406,7 @@ vector position - position in local coordinates
                   <key>Success</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -10415,7 +10415,7 @@ vector position - position in local coordinates
                   <key>Message</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -11140,7 +11140,7 @@ vector position - position in local coordinates
                   <key>f</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>(...any) -&gt; ...any</string>
                   </map>
@@ -11163,7 +11163,7 @@ vector position - position in local coordinates
                   <key>val</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>any</string>
                   </map>
@@ -11186,7 +11186,7 @@ vector position - position in local coordinates
                   <key>val</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>any</string>
                   </map>
@@ -11209,7 +11209,7 @@ vector position - position in local coordinates
                   <key>val</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | buffer | uuid</string>
                   </map>
@@ -11232,7 +11232,7 @@ vector position - position in local coordinates
                   <key>val</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>any</string>
                   </map>
@@ -11412,7 +11412,7 @@ Returns true if result is non-zero.</string>
                   <key>n</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11435,7 +11435,7 @@ Returns true if result is non-zero.</string>
                   <key>n</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11458,7 +11458,7 @@ Returns true if result is non-zero.</string>
                   <key>n</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11481,7 +11481,7 @@ Returns true if result is non-zero.</string>
                   <key>n</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11490,7 +11490,7 @@ Returns true if result is non-zero.</string>
                   <key>field</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11499,7 +11499,7 @@ Returns true if result is non-zero.</string>
                   <key>width</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number?</string>
                   </map>
@@ -11586,7 +11586,7 @@ Returns true if result is non-zero.</string>
                   <key>n</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11595,7 +11595,7 @@ Returns true if result is non-zero.</string>
                   <key>v</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11604,7 +11604,7 @@ Returns true if result is non-zero.</string>
                   <key>field</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -11613,7 +11613,7 @@ Returns true if result is non-zero.</string>
                   <key>width</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number?</string>
                   </map>
@@ -12954,7 +12954,7 @@ Returns true if result is non-zero.</string>
                   <key>data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -12977,7 +12977,7 @@ Returns true if result is non-zero.</string>
                   <key>data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | buffer</string>
                   </map>
@@ -13008,7 +13008,7 @@ Returns true if result is non-zero.</string>
                   <key>json</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13031,7 +13031,7 @@ Returns true if result is non-zero.</string>
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>any</string>
                   </map>
@@ -13054,7 +13054,7 @@ Returns true if result is non-zero.</string>
                   <key>json</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -13077,7 +13077,7 @@ Returns true if result is non-zero.</string>
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>any</string>
                   </map>
@@ -13086,7 +13086,7 @@ Returns true if result is non-zero.</string>
                   <key>tight</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean?</string>
                   </map>
@@ -15955,7 +15955,7 @@ Returns true if result is non-zero.</string>
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | buffer | uuid</string>
                   </map>
@@ -15978,7 +15978,7 @@ Returns true if result is non-zero.</string>
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | buffer | uuid</string>
                   </map>
@@ -16648,7 +16648,7 @@ Returns true if result is non-zero.</string>
                   <key>AgentID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -16847,7 +16847,7 @@ Returns true if result is non-zero.</string>
                   <key>AttachmentPoint</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17002,7 +17002,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17025,7 +17025,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17061,7 +17061,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17084,7 +17084,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17107,7 +17107,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17116,7 +17116,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17125,7 +17125,7 @@ Returns true if result is non-zero.</string>
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17148,7 +17148,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17207,7 +17207,7 @@ Returns true if result is non-zero.</string>
                   <key>Link</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17216,7 +17216,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17262,7 +17262,7 @@ Returns true if result is non-zero.</string>
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -17287,7 +17287,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -17312,7 +17312,7 @@ Returns true if result is non-zero.</string>
                   <key>ObjectName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17321,7 +17321,7 @@ Returns true if result is non-zero.</string>
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -17353,7 +17353,7 @@ Returns true if result is non-zero.</string>
                   <key>ImpactSound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17362,7 +17362,7 @@ Returns true if result is non-zero.</string>
                   <key>ImpactVolume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17385,7 +17385,7 @@ Returns true if result is non-zero.</string>
                   <key>ImpactSprite</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17442,7 +17442,7 @@ Returns true if result is non-zero.</string>
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17465,7 +17465,7 @@ Returns true if result is non-zero.</string>
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -17488,7 +17488,7 @@ Returns true if result is non-zero.</string>
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17497,7 +17497,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17623,7 +17623,7 @@ Returns true if result is non-zero.</string>
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17652,7 +17652,7 @@ Returns true if result is non-zero.</string>
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -17661,7 +17661,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17670,7 +17670,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17693,7 +17693,7 @@ Returns true if result is non-zero.</string>
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -17702,7 +17702,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17711,7 +17711,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17779,7 +17779,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17804,7 +17804,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17829,7 +17829,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17854,7 +17854,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17879,7 +17879,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17904,7 +17904,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17929,7 +17929,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17954,7 +17954,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -17979,7 +17979,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18004,7 +18004,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18179,7 +18179,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18204,7 +18204,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18229,7 +18229,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18238,7 +18238,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18247,7 +18247,7 @@ Returns true if result is non-zero.</string>
                   <key>Buttons</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18256,7 +18256,7 @@ Returns true if result is non-zero.</string>
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18301,7 +18301,7 @@ Returns true if result is non-zero.</string>
                   <key>Source</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -18310,7 +18310,7 @@ Returns true if result is non-zero.</string>
                   <key>Separator</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18333,7 +18333,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18342,7 +18342,7 @@ Returns true if result is non-zero.</string>
                   <key>Direction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18365,7 +18365,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18388,7 +18388,7 @@ Returns true if result is non-zero.</string>
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18397,7 +18397,7 @@ Returns true if result is non-zero.</string>
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18406,7 +18406,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18429,7 +18429,7 @@ Returns true if result is non-zero.</string>
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18453,7 +18453,7 @@ Returns true if result is non-zero.</string>
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -18540,7 +18540,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18563,7 +18563,7 @@ Returns true if result is non-zero.</string>
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18606,7 +18606,7 @@ Returns true if result is non-zero.</string>
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -18709,7 +18709,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18755,7 +18755,7 @@ Returns true if result is non-zero.</string>
                   <key>Magnitude</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18804,7 +18804,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18828,7 +18828,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18883,7 +18883,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18906,7 +18906,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -18944,7 +18944,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18967,7 +18967,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -18990,7 +18990,7 @@ Returns true if result is non-zero.</string>
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19081,7 +19081,7 @@ Returns true if result is non-zero.</string>
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -19201,7 +19201,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -19560,7 +19560,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19583,7 +19583,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19606,7 +19606,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19716,7 +19716,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -19752,7 +19752,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -19775,7 +19775,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -19839,7 +19839,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -19953,7 +19953,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -19962,7 +19962,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -19985,7 +19985,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -20125,7 +20125,7 @@ Returns true if result is non-zero.</string>
                   <key>Address</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20134,7 +20134,7 @@ Returns true if result is non-zero.</string>
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20157,7 +20157,7 @@ Returns true if result is non-zero.</string>
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20166,7 +20166,7 @@ Returns true if result is non-zero.</string>
                   <key>LineNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -20189,7 +20189,7 @@ Returns true if result is non-zero.</string>
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20198,7 +20198,7 @@ Returns true if result is non-zero.</string>
                   <key>LineNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -20221,7 +20221,7 @@ Returns true if result is non-zero.</string>
                   <key>NotecardName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -20360,7 +20360,7 @@ Returns true if result is non-zero.</string>
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -20419,7 +20419,7 @@ Returns true if result is non-zero.</string>
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -20468,7 +20468,7 @@ Returns true if result is non-zero.</string>
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -20523,7 +20523,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20632,7 +20632,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -20931,7 +20931,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21032,7 +21032,7 @@ Returns true if result is non-zero.</string>
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21157,7 +21157,7 @@ Returns true if result is non-zero.</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string />
+            <string></string>
          </map>
          <key>ll.GetStatus</key>
          <map>
@@ -21190,7 +21190,7 @@ Returns true if result is non-zero.</string>
                   <key>String</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21199,7 +21199,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21208,7 +21208,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21257,7 +21257,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21280,7 +21280,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21303,7 +21303,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21326,7 +21326,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21427,7 +21427,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -21558,7 +21558,7 @@ Returns true if result is non-zero.</string>
                   <key>TargetID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -21567,7 +21567,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21590,7 +21590,7 @@ Returns true if result is non-zero.</string>
                   <key>TargetID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -21599,7 +21599,7 @@ Returns true if result is non-zero.</string>
                   <key>FolderName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21608,7 +21608,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItems</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -21631,7 +21631,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -21640,7 +21640,7 @@ Returns true if result is non-zero.</string>
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21663,7 +21663,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItemID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -21672,7 +21672,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21697,7 +21697,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21720,7 +21720,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21743,7 +21743,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21809,7 +21809,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -21955,7 +21955,7 @@ Returns true if result is non-zero.</string>
                   <key>value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21978,7 +21978,7 @@ Returns true if result is non-zero.</string>
                   <key>TargetVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -21987,7 +21987,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -21996,7 +21996,7 @@ Returns true if result is non-zero.</string>
                   <key>SourceVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22019,7 +22019,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -22028,7 +22028,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22051,7 +22051,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -22129,7 +22129,7 @@ Returns true if result is non-zero.</string>
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22152,7 +22152,7 @@ Returns true if result is non-zero.</string>
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22161,7 +22161,7 @@ Returns true if result is non-zero.</string>
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -22184,7 +22184,7 @@ Returns true if result is non-zero.</string>
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22193,7 +22193,7 @@ Returns true if result is non-zero.</string>
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -22202,7 +22202,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22225,7 +22225,7 @@ Returns true if result is non-zero.</string>
                   <key>JSON</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22234,7 +22234,7 @@ Returns true if result is non-zero.</string>
                   <key>Specifiers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -22425,7 +22425,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -22434,7 +22434,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -22443,7 +22443,7 @@ Returns true if result is non-zero.</string>
                   <key>Flags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -22944,7 +22944,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -22967,7 +22967,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -22976,7 +22976,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -22999,7 +22999,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23008,7 +23008,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23063,7 +23063,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23072,7 +23072,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23099,7 +23099,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23108,7 +23108,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23117,7 +23117,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23144,7 +23144,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23153,7 +23153,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23162,7 +23162,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23171,7 +23171,7 @@ Returns true if result is non-zero.</string>
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23180,7 +23180,7 @@ Returns true if result is non-zero.</string>
                   <key>slice_index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23207,7 +23207,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23216,7 +23216,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23225,7 +23225,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23234,7 +23234,7 @@ Returns true if result is non-zero.</string>
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23257,7 +23257,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23266,7 +23266,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23289,7 +23289,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23298,7 +23298,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23321,7 +23321,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23330,7 +23330,7 @@ Returns true if result is non-zero.</string>
                   <key>Index</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23353,7 +23353,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23362,7 +23362,7 @@ Returns true if result is non-zero.</string>
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23385,7 +23385,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23394,7 +23394,7 @@ Returns true if result is non-zero.</string>
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23403,7 +23403,7 @@ Returns true if result is non-zero.</string>
                   <key>Instance</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23426,7 +23426,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23435,7 +23435,7 @@ Returns true if result is non-zero.</string>
                   <key>Find</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -23444,7 +23444,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23453,7 +23453,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23462,7 +23462,7 @@ Returns true if result is non-zero.</string>
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23489,7 +23489,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23498,7 +23498,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23507,7 +23507,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23534,7 +23534,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23543,7 +23543,7 @@ Returns true if result is non-zero.</string>
                   <key>Stride</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23570,7 +23570,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23579,7 +23579,7 @@ Returns true if result is non-zero.</string>
                   <key>ListVariable</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{T}</string>
                   </map>
@@ -23588,7 +23588,7 @@ Returns true if result is non-zero.</string>
                   <key>Start</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23597,7 +23597,7 @@ Returns true if result is non-zero.</string>
                   <key>End</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23751,7 +23751,7 @@ Returns true if result is non-zero.</string>
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23760,7 +23760,7 @@ Returns true if result is non-zero.</string>
                   <key>SpeakersName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23769,7 +23769,7 @@ Returns true if result is non-zero.</string>
                   <key>SpeakersID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -23778,7 +23778,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23801,7 +23801,7 @@ Returns true if result is non-zero.</string>
                   <key>ChannelHandle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23810,7 +23810,7 @@ Returns true if result is non-zero.</string>
                   <key>Active</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -23833,7 +23833,7 @@ Returns true if result is non-zero.</string>
                   <key>ChannelHandle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23856,7 +23856,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -23865,7 +23865,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23874,7 +23874,7 @@ Returns true if result is non-zero.</string>
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23897,7 +23897,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23920,7 +23920,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23943,7 +23943,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -23952,7 +23952,7 @@ Returns true if result is non-zero.</string>
                   <key>Strength</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23961,7 +23961,7 @@ Returns true if result is non-zero.</string>
                   <key>Damping</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -23984,7 +23984,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -23993,7 +23993,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24016,7 +24016,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24025,7 +24025,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24048,7 +24048,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24057,7 +24057,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24080,7 +24080,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24089,7 +24089,7 @@ Returns true if result is non-zero.</string>
                   <key>Nonce</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24112,7 +24112,7 @@ Returns true if result is non-zero.</string>
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24121,7 +24121,7 @@ Returns true if result is non-zero.</string>
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24130,7 +24130,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24139,7 +24139,7 @@ Returns true if result is non-zero.</string>
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24148,7 +24148,7 @@ Returns true if result is non-zero.</string>
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24157,7 +24157,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24166,7 +24166,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24191,7 +24191,7 @@ Returns true if result is non-zero.</string>
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24200,7 +24200,7 @@ Returns true if result is non-zero.</string>
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24209,7 +24209,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24218,7 +24218,7 @@ Returns true if result is non-zero.</string>
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24227,7 +24227,7 @@ Returns true if result is non-zero.</string>
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24236,7 +24236,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24245,7 +24245,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24270,7 +24270,7 @@ Returns true if result is non-zero.</string>
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24279,7 +24279,7 @@ Returns true if result is non-zero.</string>
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24288,7 +24288,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24297,7 +24297,7 @@ Returns true if result is non-zero.</string>
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24306,7 +24306,7 @@ Returns true if result is non-zero.</string>
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24315,7 +24315,7 @@ Returns true if result is non-zero.</string>
                   <key>Bounce</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24324,7 +24324,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24333,7 +24333,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24342,7 +24342,7 @@ Returns true if result is non-zero.</string>
                   <key>Bounce_Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24367,7 +24367,7 @@ Returns true if result is non-zero.</string>
                   <key>Particles</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24376,7 +24376,7 @@ Returns true if result is non-zero.</string>
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24385,7 +24385,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24394,7 +24394,7 @@ Returns true if result is non-zero.</string>
                   <key>Lifetime</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24403,7 +24403,7 @@ Returns true if result is non-zero.</string>
                   <key>Arc</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24412,7 +24412,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24421,7 +24421,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24519,7 +24519,7 @@ Returns true if result is non-zero.</string>
                   <key>RegionName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24528,7 +24528,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24537,7 +24537,7 @@ Returns true if result is non-zero.</string>
                   <key>Direction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24560,7 +24560,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24569,7 +24569,7 @@ Returns true if result is non-zero.</string>
                   <key>Number</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24578,7 +24578,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | uuid</string>
                   </map>
@@ -24587,7 +24587,7 @@ Returns true if result is non-zero.</string>
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string | uuid</string>
                   </map>
@@ -24610,7 +24610,7 @@ Returns true if result is non-zero.</string>
                   <key>Delay</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24633,7 +24633,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24642,7 +24642,7 @@ Returns true if result is non-zero.</string>
                   <key>Power</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24651,7 +24651,7 @@ Returns true if result is non-zero.</string>
                   <key>Modulus</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24706,7 +24706,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -24715,7 +24715,7 @@ Returns true if result is non-zero.</string>
                   <key>Tau</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24793,7 +24793,7 @@ Returns true if result is non-zero.</string>
                   <key>OffsetS</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24802,7 +24802,7 @@ Returns true if result is non-zero.</string>
                   <key>OffsetT</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24811,7 +24811,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -24922,7 +24922,7 @@ Returns true if result is non-zero.</string>
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -24945,7 +24945,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -24991,7 +24991,7 @@ Returns true if result is non-zero.</string>
                   <key>QueryList</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -25014,7 +25014,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25023,7 +25023,7 @@ Returns true if result is non-zero.</string>
                   <key>Separators</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{string}</string>
                   </map>
@@ -25032,7 +25032,7 @@ Returns true if result is non-zero.</string>
                   <key>Spacers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{string}</string>
                   </map>
@@ -25055,7 +25055,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25064,7 +25064,7 @@ Returns true if result is non-zero.</string>
                   <key>Separators</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{string}</string>
                   </map>
@@ -25073,7 +25073,7 @@ Returns true if result is non-zero.</string>
                   <key>Spacers</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>{string}</string>
                   </map>
@@ -25096,7 +25096,7 @@ Returns true if result is non-zero.</string>
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -25197,7 +25197,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25206,7 +25206,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25229,7 +25229,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25238,7 +25238,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25261,7 +25261,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25270,7 +25270,7 @@ Returns true if result is non-zero.</string>
                   <key>Exponent</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25293,7 +25293,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25348,7 +25348,7 @@ Returns true if result is non-zero.</string>
                   <key>ObjectID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25357,7 +25357,7 @@ Returns true if result is non-zero.</string>
                   <key>Impulse</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -25366,7 +25366,7 @@ Returns true if result is non-zero.</string>
                   <key>AngularImpulse</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -25375,7 +25375,7 @@ Returns true if result is non-zero.</string>
                   <key>Local</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -25398,7 +25398,7 @@ Returns true if result is non-zero.</string>
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25511,7 +25511,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25572,7 +25572,7 @@ Returns true if result is non-zero.</string>
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25581,7 +25581,7 @@ Returns true if result is non-zero.</string>
                   <key>MessageID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25698,7 +25698,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25721,7 +25721,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25744,7 +25744,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25767,7 +25767,7 @@ Returns true if result is non-zero.</string>
                   <key>Vehiclelags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25790,7 +25790,7 @@ Returns true if result is non-zero.</string>
                   <key>agent_id</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25799,7 +25799,7 @@ Returns true if result is non-zero.</string>
                   <key>transition</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25808,7 +25808,7 @@ Returns true if result is non-zero.</string>
                   <key>environment</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -25941,7 +25941,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -25950,7 +25950,7 @@ Returns true if result is non-zero.</string>
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -25996,7 +25996,7 @@ Returns true if result is non-zero.</string>
                   <key>AgentID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -26030,7 +26030,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26053,7 +26053,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -26062,7 +26062,7 @@ Returns true if result is non-zero.</string>
                   <key>PermissionMask</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26098,7 +26098,7 @@ Returns true if result is non-zero.</string>
                   <key>RegionName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26107,7 +26107,7 @@ Returns true if result is non-zero.</string>
                   <key>Data</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26166,7 +26166,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -26189,7 +26189,7 @@ Returns true if result is non-zero.</string>
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26238,7 +26238,7 @@ Returns true if result is non-zero.</string>
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26321,7 +26321,7 @@ Returns true if result is non-zero.</string>
                   <key>Scope</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26344,7 +26344,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26353,7 +26353,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26362,7 +26362,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26371,7 +26371,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26380,7 +26380,7 @@ Returns true if result is non-zero.</string>
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26403,7 +26403,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26412,7 +26412,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26421,7 +26421,7 @@ Returns true if result is non-zero.</string>
                   <key>Velocity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26430,7 +26430,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26439,7 +26439,7 @@ Returns true if result is non-zero.</string>
                   <key>StartParameter</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26462,7 +26462,7 @@ Returns true if result is non-zero.</string>
                   <key>InventoryItem</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26471,7 +26471,7 @@ Returns true if result is non-zero.</string>
                   <key>Params</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -26494,7 +26494,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26517,7 +26517,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26540,7 +26540,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26563,7 +26563,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26586,7 +26586,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26609,7 +26609,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26632,7 +26632,7 @@ Returns true if result is non-zero.</string>
                   <key>Vector1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26641,7 +26641,7 @@ Returns true if result is non-zero.</string>
                   <key>Vector2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -26664,7 +26664,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26673,7 +26673,7 @@ Returns true if result is non-zero.</string>
                   <key>Strength</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26682,7 +26682,7 @@ Returns true if result is non-zero.</string>
                   <key>Damping</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26705,7 +26705,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -26714,7 +26714,7 @@ Returns true if result is non-zero.</string>
                   <key>LeeWay</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26737,7 +26737,7 @@ Returns true if result is non-zero.</string>
                   <key>Handle</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26760,7 +26760,7 @@ Returns true if result is non-zero.</string>
                   <key>Radians</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26769,7 +26769,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26792,7 +26792,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26815,7 +26815,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26838,7 +26838,7 @@ Returns true if result is non-zero.</string>
                   <key>text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -26861,7 +26861,7 @@ Returns true if result is non-zero.</string>
                   <key>ID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -26939,7 +26939,7 @@ Returns true if result is non-zero.</string>
                   <key>Horizontal</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26948,7 +26948,7 @@ Returns true if result is non-zero.</string>
                   <key>Vertical</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26957,7 +26957,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -26980,7 +26980,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -27026,7 +27026,7 @@ Returns true if result is non-zero.</string>
                   <key>ChannelID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -27035,7 +27035,7 @@ Returns true if result is non-zero.</string>
                   <key>Destination</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -27044,7 +27044,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27053,7 +27053,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -27291,7 +27291,7 @@ Returns true if result is non-zero.</string>
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27300,7 +27300,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27355,7 +27355,7 @@ Returns true if result is non-zero.</string>
                   <key>AnimationState</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -27364,7 +27364,7 @@ Returns true if result is non-zero.</string>
                   <key>AnimationName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -27387,7 +27387,7 @@ Returns true if result is non-zero.</string>
                   <key>Buoyancy</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27410,7 +27410,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -27433,7 +27433,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -27456,7 +27456,7 @@ Returns true if result is non-zero.</string>
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -27502,7 +27502,7 @@ Returns true if result is non-zero.</string>
                   <key>Color</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -27511,7 +27511,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27566,7 +27566,7 @@ Returns true if result is non-zero.</string>
                   <key>Damage</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27810,7 +27810,7 @@ Returns true if result is non-zero.</string>
                   <key>Options</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -27833,7 +27833,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27842,7 +27842,7 @@ Returns true if result is non-zero.</string>
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -27851,7 +27851,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28047,7 +28047,7 @@ Returns true if result is non-zero.</string>
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -28081,7 +28081,7 @@ Returns true if result is non-zero.</string>
                   <key>Parameters</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>list</string>
                   </map>
@@ -28104,7 +28104,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28113,7 +28113,7 @@ Returns true if result is non-zero.</string>
                   <key>RenderMaterial</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28122,7 +28122,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28177,7 +28177,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkNumber</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28186,7 +28186,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28195,7 +28195,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28304,7 +28304,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -28352,7 +28352,7 @@ Returns true if result is non-zero.</string>
                   <key>Description</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28375,7 +28375,7 @@ Returns true if result is non-zero.</string>
                   <key>Name</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28464,7 +28464,7 @@ Returns true if result is non-zero.</string>
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28528,7 +28528,7 @@ Returns true if result is non-zero.</string>
                   <key>GravityMultiplier</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28537,7 +28537,7 @@ Returns true if result is non-zero.</string>
                   <key>Restitution</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28546,7 +28546,7 @@ Returns true if result is non-zero.</string>
                   <key>Friction</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28555,7 +28555,7 @@ Returns true if result is non-zero.</string>
                   <key>Density</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28633,7 +28633,7 @@ Returns true if result is non-zero.</string>
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28706,7 +28706,7 @@ Returns true if result is non-zero.</string>
                   <key>PIN</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28729,7 +28729,7 @@ Returns true if result is non-zero.</string>
                   <key>Material</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28738,7 +28738,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28761,7 +28761,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -28784,7 +28784,7 @@ Returns true if result is non-zero.</string>
                   <key>Scale</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -28807,7 +28807,7 @@ Returns true if result is non-zero.</string>
                   <key>ScriptName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28816,7 +28816,7 @@ Returns true if result is non-zero.</string>
                   <key>Running</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -28839,7 +28839,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28908,7 +28908,7 @@ Returns true if result is non-zero.</string>
                   <key>Status</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28917,7 +28917,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -28940,7 +28940,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28949,7 +28949,7 @@ Returns true if result is non-zero.</string>
                   <key>Color</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -28958,7 +28958,7 @@ Returns true if result is non-zero.</string>
                   <key>Opacity</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -28981,7 +28981,7 @@ Returns true if result is non-zero.</string>
                   <key>Texture</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -28990,7 +28990,7 @@ Returns true if result is non-zero.</string>
                   <key>Face</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29090,7 +29090,7 @@ Returns true if result is non-zero.</string>
                   <key>Rate</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29147,7 +29147,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29170,7 +29170,7 @@ Returns true if result is non-zero.</string>
                   <key>Flags</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29193,7 +29193,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29202,7 +29202,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29225,7 +29225,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29234,7 +29234,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -29257,7 +29257,7 @@ Returns true if result is non-zero.</string>
                   <key>Type</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29280,7 +29280,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterName</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29289,7 +29289,7 @@ Returns true if result is non-zero.</string>
                   <key>ParameterValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -29344,7 +29344,7 @@ Returns true if result is non-zero.</string>
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29353,7 +29353,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29417,7 +29417,7 @@ Returns true if result is non-zero.</string>
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29440,7 +29440,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -29449,7 +29449,7 @@ Returns true if result is non-zero.</string>
                   <key>LinkID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29472,7 +29472,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -29481,7 +29481,7 @@ Returns true if result is non-zero.</string>
                   <key>Rotation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>quaternion</string>
                   </map>
@@ -29504,7 +29504,7 @@ Returns true if result is non-zero.</string>
                   <key>Time</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29527,7 +29527,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29536,7 +29536,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29545,7 +29545,7 @@ Returns true if result is non-zero.</string>
                   <key>Queue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -29554,7 +29554,7 @@ Returns true if result is non-zero.</string>
                   <key>Loop</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -29579,7 +29579,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29604,7 +29604,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29627,7 +29627,7 @@ Returns true if result is non-zero.</string>
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29650,7 +29650,7 @@ Returns true if result is non-zero.</string>
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29673,7 +29673,7 @@ Returns true if result is non-zero.</string>
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29735,7 +29735,7 @@ Returns true if result is non-zero.</string>
                   <key>Animation</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29771,7 +29771,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29794,7 +29794,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29849,7 +29849,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29858,7 +29858,7 @@ Returns true if result is non-zero.</string>
                   <key>Sequence</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -29881,7 +29881,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -29947,7 +29947,7 @@ Returns true if result is non-zero.</string>
                   <key>Theta</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -29970,7 +29970,7 @@ Returns true if result is non-zero.</string>
                   <key>Position</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -29979,7 +29979,7 @@ Returns true if result is non-zero.</string>
                   <key>Range</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30002,7 +30002,7 @@ Returns true if result is non-zero.</string>
                   <key>Axis</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30011,7 +30011,7 @@ Returns true if result is non-zero.</string>
                   <key>SpinRate</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30020,7 +30020,7 @@ Returns true if result is non-zero.</string>
                   <key>Gain</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30043,7 +30043,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30066,7 +30066,7 @@ Returns true if result is non-zero.</string>
                   <key>Target</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30075,7 +30075,7 @@ Returns true if result is non-zero.</string>
                   <key>Subject</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30084,7 +30084,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30207,7 +30207,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -30230,7 +30230,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -30239,7 +30239,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30248,7 +30248,7 @@ Returns true if result is non-zero.</string>
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30271,7 +30271,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30294,7 +30294,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30317,7 +30317,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -30326,7 +30326,7 @@ Returns true if result is non-zero.</string>
                   <key>Amount</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30390,7 +30390,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30399,7 +30399,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30422,7 +30422,7 @@ Returns true if result is non-zero.</string>
                   <key>Sound</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30431,7 +30431,7 @@ Returns true if result is non-zero.</string>
                   <key>Volume</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30440,7 +30440,7 @@ Returns true if result is non-zero.</string>
                   <key>TNE</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30449,7 +30449,7 @@ Returns true if result is non-zero.</string>
                   <key>BSW</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30472,7 +30472,7 @@ Returns true if result is non-zero.</string>
                   <key>AvatarID</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>uuid</string>
                   </map>
@@ -30495,7 +30495,7 @@ Returns true if result is non-zero.</string>
                   <key>URL</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30541,7 +30541,7 @@ Returns true if result is non-zero.</string>
                   <key>Key</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30550,7 +30550,7 @@ Returns true if result is non-zero.</string>
                   <key>Value</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30559,7 +30559,7 @@ Returns true if result is non-zero.</string>
                   <key>Checked</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>boolean | number</string>
                   </map>
@@ -30568,7 +30568,7 @@ Returns true if result is non-zero.</string>
                   <key>OriginalValue</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30593,7 +30593,7 @@ Returns true if result is non-zero.</string>
                   <key>Location1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30602,7 +30602,7 @@ Returns true if result is non-zero.</string>
                   <key>Location2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30625,7 +30625,7 @@ Returns true if result is non-zero.</string>
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30648,7 +30648,7 @@ Returns true if result is non-zero.</string>
                   <key>Vector</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30785,7 +30785,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30808,7 +30808,7 @@ Returns true if result is non-zero.</string>
                   <key>Channel</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>number</string>
                   </map>
@@ -30817,7 +30817,7 @@ Returns true if result is non-zero.</string>
                   <key>Text</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30840,7 +30840,7 @@ Returns true if result is non-zero.</string>
                   <key>Offset</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>vector</string>
                   </map>
@@ -30886,7 +30886,7 @@ Returns true if result is non-zero.</string>
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30895,7 +30895,7 @@ Returns true if result is non-zero.</string>
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30918,7 +30918,7 @@ Returns true if result is non-zero.</string>
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30927,7 +30927,7 @@ Returns true if result is non-zero.</string>
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30952,7 +30952,7 @@ Returns true if result is non-zero.</string>
                   <key>Text1</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>
@@ -30961,7 +30961,7 @@ Returns true if result is non-zero.</string>
                   <key>Text2</key>
                   <map>
                      <key>tooltip</key>
-                     <string />
+                     <string></string>
                      <key>type</key>
                      <string>string</string>
                   </map>

--- a/indra/newview/app_settings/keywords_lua_default.xml
+++ b/indra/newview/app_settings/keywords_lua_default.xml
@@ -10109,35 +10109,40 @@ vector position - position in local coordinates
          <key>moving_end</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered whenever an object with this script stops moving.</string>
          </map>
          <key>moving_start</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered whenever an object with this script starts moving.</string>
          </map>
          <key>no_sensor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>This event is raised when sensors are active, via the llSensor function call, but are not sensing anything.</string>
          </map>
          <key>not_at_rot_target</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>When a target is set via the llRotTarget function call, but the script is outside the specified angle this event is raised.</string>
          </map>
          <key>not_at_target</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>When a target is set via the llTarget library call, but the script is outside the specified range this event is raised.</string>
          </map>
@@ -10178,7 +10183,8 @@ vector position - position in local coordinates
          <key>on_death</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>Triggered when an avatar reaches 0 health.</string>
          </map>
@@ -10330,7 +10336,8 @@ vector position - position in local coordinates
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>tooltip</key>
             <string>This event is raised at regular intervals set by the llSetTimerEvent library function.</string>
          </map>
@@ -10499,7 +10506,8 @@ vector position - position in local coordinates
          <key>gcinfo</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12724,7 +12732,8 @@ Returns true if result is non-zero.</string>
          <key>coroutine.isyieldable</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -12769,7 +12778,8 @@ Returns true if result is non-zero.</string>
          <key>coroutine.running</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -14133,7 +14143,8 @@ Returns true if result is non-zero.</string>
          <key>os.clock</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -16911,7 +16922,8 @@ Returns true if result is non-zero.</string>
          <key>ll.AvatarOnSitTarget</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17043,7 +17055,8 @@ Returns true if result is non-zero.</string>
          <key>ll.BreakAllLinks</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17189,7 +17202,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ClearCameraParams</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17590,7 +17604,8 @@ Returns true if result is non-zero.</string>
          <key>ll.DataSizeKeyValue</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17605,7 +17620,8 @@ Returns true if result is non-zero.</string>
          <key>ll.DeleteCharacter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -17761,7 +17777,8 @@ Returns true if result is non-zero.</string>
          <key>ll.DetachFromAvatar</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18283,7 +18300,8 @@ Returns true if result is non-zero.</string>
          <key>ll.Die</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>0.0</real>
             <key>return</key>
@@ -18773,7 +18791,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GenerateKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18786,7 +18805,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetAccel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -18924,7 +18944,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetAndResetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -19008,7 +19029,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetAttached</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19099,7 +19121,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCameraAspect</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19112,7 +19135,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCameraFOV</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19125,7 +19149,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCameraPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19138,7 +19163,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCameraRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19151,7 +19177,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCenterOfMass</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19219,7 +19246,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetCreator</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19232,7 +19260,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetDate</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19245,7 +19274,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetDayLength</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19258,7 +19288,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetDayOffset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19294,7 +19325,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetEnergy</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19412,7 +19444,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetForce</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19425,7 +19458,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetFreeMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19438,7 +19472,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetFreeURLs</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19451,7 +19486,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetGMTclock</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19464,7 +19500,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetGeometricCenter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19734,7 +19771,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -19857,7 +19895,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetLinkNumber</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20003,7 +20042,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetLocalPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20016,7 +20056,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetLocalRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20029,7 +20070,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMass</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20042,7 +20084,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMassMKS</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20055,7 +20098,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMaxScaleFactor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20068,7 +20112,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMemoryLimit</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20081,7 +20126,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMinScaleFactor</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20094,7 +20140,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMoonDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20107,7 +20154,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetMoonRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20239,7 +20287,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetNumberOfPrims</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20252,7 +20301,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetNumberOfSides</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20265,7 +20315,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetObjectAnimationNames</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20278,7 +20329,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetObjectDesc</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20378,7 +20430,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetObjectName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20437,7 +20490,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetOmega</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20450,7 +20504,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetOwner</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20573,7 +20628,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetParcelMusicURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20650,7 +20706,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetPermissions</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20663,7 +20720,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetPermissionsKey</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20676,7 +20734,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetPhysicsMaterial</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20689,7 +20748,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetPos</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20757,7 +20817,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionAgentCount</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20770,7 +20831,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionCorner</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20783,7 +20845,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionDayLength</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20796,7 +20859,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionDayOffset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20809,7 +20873,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionFPS</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20822,7 +20887,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionFlags</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20835,7 +20901,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionMoonDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20848,7 +20915,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionMoonRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20861,7 +20929,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20874,7 +20943,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionSunDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20887,7 +20957,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionSunRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20900,7 +20971,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionTimeDilation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20913,7 +20985,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRegionTimeOfDay</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20949,7 +21022,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRootPosition</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20962,7 +21036,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRootRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20975,7 +21050,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetRot</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -20988,7 +21064,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetSPMaxMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21001,7 +21078,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetScale</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21014,7 +21092,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetScriptName</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21073,7 +21152,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetSimulatorHostname</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21086,7 +21166,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetStartParameter</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21099,7 +21180,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetStartString</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21226,7 +21308,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetSunDirection</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21239,7 +21322,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetSunRotation</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21344,7 +21428,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21357,7 +21442,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetTimeOfDay</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21370,7 +21456,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetTimestamp</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21383,7 +21470,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetTorque</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21396,7 +21484,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetUnixTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21409,7 +21498,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetUsedMemory</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21445,7 +21535,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetVel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -21490,7 +21581,8 @@ Returns true if result is non-zero.</string>
          <key>ll.GetWallclock</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22275,7 +22367,8 @@ Returns true if result is non-zero.</string>
          <key>ll.KeyCountKeyValue</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22589,7 +22682,8 @@ Returns true if result is non-zero.</string>
          <key>ll.LinksetDataAvailable</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22625,7 +22719,8 @@ Returns true if result is non-zero.</string>
          <key>ll.LinksetDataCountKeys</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -22853,7 +22948,8 @@ Returns true if result is non-zero.</string>
          <key>ll.LinksetDataReset</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -24870,7 +24966,8 @@ Returns true if result is non-zero.</string>
          <key>ll.OpenRemoteDataChannel</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -25418,7 +25515,8 @@ Returns true if result is non-zero.</string>
          <key>ll.RefreshPrimURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -25531,7 +25629,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ReleaseControls</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -25619,7 +25718,8 @@ Returns true if result is non-zero.</string>
          <key>ll.RemoteDataSetRegion</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -26080,7 +26180,8 @@ Returns true if result is non-zero.</string>
          <key>ll.RequestSecureURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26125,7 +26226,8 @@ Returns true if result is non-zero.</string>
          <key>ll.RequestURL</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26207,7 +26309,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ResetLandBanList</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26220,7 +26323,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ResetLandPassList</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26256,7 +26360,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ResetScript</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -26269,7 +26374,8 @@ Returns true if result is non-zero.</string>
          <key>ll.ResetTime</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>deprecated</key>
             <boolean>true</boolean>
             <key>energy</key>
@@ -27132,7 +27238,8 @@ Returns true if result is non-zero.</string>
          <key>ll.SensorRemove</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29691,7 +29798,8 @@ Returns true if result is non-zero.</string>
          <key>ll.StopHover</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29704,7 +29812,8 @@ Returns true if result is non-zero.</string>
          <key>ll.StopLookAt</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29717,7 +29826,8 @@ Returns true if result is non-zero.</string>
          <key>ll.StopMoveToTarget</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
@@ -29753,7 +29863,8 @@ Returns true if result is non-zero.</string>
          <key>ll.StopSound</key>
          <map>
             <key>arguments</key>
-            <array />
+            <array>
+            </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>


### PR DESCRIPTION
- Part of https://github.com/secondlife/viewer/issues/5299
- Converts real, boolean, string, and array fields in the keywords file from c's llsd format to python's llsd format
- As requested by @HaroldCindy: https://github.com/secondlife/lsl-definitions/pull/38#issuecomment-3798608711