### PR TITLE
#3502 fix using non-existing "cookies_enabled" control

### DIFF
--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -620,8 +620,6 @@ void LLFloaterPreference::apply()
     std::string cache_location = gDirUtilp->getExpandedFilename(LL_PATH_CACHE, "");
     setCacheLocation(cache_location);
 
-    LLViewerMedia::getInstance()->setCookiesEnabled(getChild<LLUICtrl>("cookies_enabled")->getValue());
-
     if (hasChild("web_proxy_enabled", true) &&hasChild("web_proxy_editor", true) && hasChild("web_proxy_port", true))
     {
         bool proxy_enable = getChild<LLUICtrl>("web_proxy_enabled")->getValue();


### PR DESCRIPTION
"cookies_enabled" checkbox no longer exists, so we shouldn't use it to override the setting(currently "CookiesEnabled" debug setting is used for that).