### PR TITLE
#2639 Fix benchmarked render level being too high for Apple Silicon

### DIFF
--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -495,7 +495,9 @@ bool LLFeatureManager::loadGPUClass()
         {
             mGPUClass = GPU_CLASS_2;
         }
-        else if (gbps <= class1_gbps*4.f)
+        else if ((gbps <= class1_gbps*4.f)
+                 // Cap silicon's GPUs at med+ as they have high throughput, low capability
+                 || gGLManager.mIsApple)
         {
             mGPUClass = GPU_CLASS_3;
         }


### PR DESCRIPTION
After benchmark fixes, render level jumped from lowest to high+, cap it at med+ until shadows get fixed to have less of an impact