### PR TITLE
#2997 Fix Reset Skeleton not working on animesh objects

### DIFF
--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -8712,6 +8712,12 @@ LLVOAvatar* find_avatar_from_object(LLViewerObject* object)
         }
         else if( !object->isAvatar() )
         {
+            // Check for animesh objects (animated objects with a control avatar)
+            LLVOAvatar* avatar = object->getAvatar();
+            if (avatar)
+            {
+                return avatar;
+            }
             object = NULL;
         }
     }


### PR DESCRIPTION
The menu option was visible but non-functional because find_avatar_from_object() did not handle animesh objects. Now it checks for control avatars via getAvatar(), matching the enable check in LLAvatarEnableResetSkeleton.