### PR TITLE
secondlife/viewer#4958 Fix model upload options for SDL file picker

### DIFF
--- a/indra/newview/llfilepicker.cpp
+++ b/indra/newview/llfilepicker.cpp
@@ -210,7 +210,8 @@ namespace
             filter_vec.push_back({ "RAW files (*.raw)", "raw" });
             break;
         case LLFilePicker::FFLOAD_MODEL:
-            filter_vec.push_back({ "Model files (*.dae)", "dae" });
+            filter_vec.push_back({ "Model files (*.dae; *.gltf; *.glb)", "dae;gltf;glb" });
+            filter_vec.push_back({ "Collada files (*.dae)", "dae" });
             filter_vec.push_back({ "GLTF Files (*.gltf; *.glb)", "gltf;glb" });
             break;
         case LLFilePicker::FFLOAD_MATERIAL:


### PR DESCRIPTION
## Description

Fixes default filter for SDL/Linux file picker for model uploads to include gltf/glb files

## Related Issues

Issue Link: #4958

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] The PR is linked to a relevant issue with sufficient context.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/secondlife/viewer/blob/develop/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
